### PR TITLE
Avoid unnecessary ToLower calls in RegexCompiler generated code

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -839,6 +839,43 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets whether the specified character participates in case conversion.</summary>
+        /// <remarks>
+        /// This method is used to perform operations as if they were case-sensitive even if they're
+        /// specified as being case-insensitive.  Such a reduction can be applied when the only character
+        /// that would lower-case to the one being searched for / compared against is that character itself.
+        /// </remarks>
+        private static bool ParticipatesInCaseConversion(int comparison)
+        {
+            Debug.Assert((uint)comparison <= char.MaxValue);
+
+            switch (char.GetUnicodeCategory((char)comparison))
+            {
+                case UnicodeCategory.ClosePunctuation:
+                case UnicodeCategory.ConnectorPunctuation:
+                case UnicodeCategory.Control:
+                case UnicodeCategory.DashPunctuation:
+                case UnicodeCategory.DecimalDigitNumber:
+                case UnicodeCategory.FinalQuotePunctuation:
+                case UnicodeCategory.InitialQuotePunctuation:
+                case UnicodeCategory.LineSeparator:
+                case UnicodeCategory.OpenPunctuation:
+                case UnicodeCategory.OtherNumber:
+                case UnicodeCategory.OtherPunctuation:
+                case UnicodeCategory.ParagraphSeparator:
+                case UnicodeCategory.SpaceSeparator:
+                    // All chars in these categories meet the criteria that the only way
+                    // `char.ToLower(toTest, AnyCulture) == charInAboveCategory` is when
+                    // toTest == charInAboveCategory.
+                    return false;
+
+                default:
+                    // We don't know (without testing the character against every other
+                    // character), so assume it does.
+                    return true;
+            }
+        }
+
         /// <summary>
         /// Generates the first section of the MSIL. This section contains all
         /// the forward logic, and corresponds directly to the regex codes.
@@ -1311,7 +1348,7 @@ namespace System.Text.RegularExpressions
                 // ch = runtext[runtextpos];
                 // if (ch == lastChar) goto partialMatch;
                 Rightchar();
-                if (_boyerMoorePrefix.CaseInsensitive)
+                if (_boyerMoorePrefix.CaseInsensitive && ParticipatesInCaseConversion(chLast))
                 {
                     CallToLower();
                 }
@@ -1407,7 +1444,7 @@ namespace System.Text.RegularExpressions
                         Dup();
                         Stloc(testLocal);
                         Callvirt(s_stringGetCharsMethod);
-                        if (_boyerMoorePrefix.CaseInsensitive)
+                        if (_boyerMoorePrefix.CaseInsensitive && ParticipatesInCaseConversion(_boyerMoorePrefix.Pattern[charindex]))
                         {
                             CallToLower();
                         }
@@ -2439,14 +2476,20 @@ namespace System.Text.RegularExpressions
                     case RegexNode.Onelazy:
                     case RegexNode.Oneloop:
                     case RegexNode.Oneloopatomic:
-                        if (IsCaseInsensitive(node)) CallToLower();
+                        if (IsCaseInsensitive(node) && ParticipatesInCaseConversion(node.Ch))
+                        {
+                            CallToLower();
+                        }
                         Ldc(node.Ch);
                         BneFar(doneLabel);
                         break;
 
                     default:
                         Debug.Assert(node.Type == RegexNode.Notone || node.Type == RegexNode.Notonelazy || node.Type == RegexNode.Notoneloop || node.Type == RegexNode.Notoneloopatomic);
-                        if (IsCaseInsensitive(node)) CallToLower();
+                        if (IsCaseInsensitive(node) && ParticipatesInCaseConversion(node.Ch))
+                        {
+                            CallToLower();
+                        }
                         Ldc(node.Ch);
                         BeqFar(doneLabel);
                         break;
@@ -2667,7 +2710,10 @@ namespace System.Text.RegularExpressions
                     EmitTextSpanOffset();
                     textSpanPos++;
                     LdindU2();
-                    if (caseInsensitive) CallToLower();
+                    if (caseInsensitive && ParticipatesInCaseConversion(s[i]))
+                    {
+                        CallToLower();
+                    }
                     Ldc(s[i]);
                     BneFar(doneLabel);
                 }
@@ -2842,7 +2888,7 @@ namespace System.Text.RegularExpressions
 
                 if (node.Type == RegexNode.Notoneloopatomic &&
                     maxIterations == int.MaxValue &&
-                    !IsCaseInsensitive(node))
+                    (!IsCaseInsensitive(node) || !ParticipatesInCaseConversion(node.Ch)))
                 {
                     // For Notoneloopatomic, we're looking for a specific character, as everything until we find
                     // it is consumed by the loop.  If we're unbounded, such as with ".*" and if we're case-sensitive,
@@ -2976,12 +3022,18 @@ namespace System.Text.RegularExpressions
                     switch (node.Type)
                     {
                         case RegexNode.Oneloopatomic:
-                            if (IsCaseInsensitive(node)) CallToLower();
+                            if (IsCaseInsensitive(node) && ParticipatesInCaseConversion(node.Ch))
+                            {
+                                CallToLower();
+                            }
                             Ldc(node.Ch);
                             BneFar(doneLabel);
                             break;
                         case RegexNode.Notoneloopatomic:
-                            if (IsCaseInsensitive(node)) CallToLower();
+                            if (IsCaseInsensitive(node) && ParticipatesInCaseConversion(node.Ch))
+                            {
+                                CallToLower();
+                            }
                             Ldc(node.Ch);
                             BeqFar(doneLabel);
                             break;
@@ -3064,12 +3116,18 @@ namespace System.Text.RegularExpressions
                 switch (node.Type)
                 {
                     case RegexNode.Oneloopatomic:
-                        if (IsCaseInsensitive(node)) CallToLower();
+                        if (IsCaseInsensitive(node) && ParticipatesInCaseConversion(node.Ch))
+                        {
+                            CallToLower();
+                        }
                         Ldc(node.Ch);
                         BneFar(skipUpdatesLabel);
                         break;
                     case RegexNode.Notoneloopatomic:
-                        if (IsCaseInsensitive(node)) CallToLower();
+                        if (IsCaseInsensitive(node) && ParticipatesInCaseConversion(node.Ch))
+                        {
+                            CallToLower();
+                        }
                         Ldc(node.Ch);
                         BeqFar(skipUpdatesLabel);
                         break;
@@ -4136,7 +4194,7 @@ namespace System.Text.RegularExpressions
                     }
                     else
                     {
-                        if (IsCaseInsensitive())
+                        if (IsCaseInsensitive() && ParticipatesInCaseConversion(Operand(0)))
                         {
                             CallToLower();
                         }
@@ -4182,7 +4240,7 @@ namespace System.Text.RegularExpressions
                                 Add();
                             }
                             Callvirt(s_stringGetCharsMethod);
-                            if (IsCaseInsensitive())
+                            if (IsCaseInsensitive() && ParticipatesInCaseConversion(str[i]))
                             {
                                 CallToLower();
                             }
@@ -4225,7 +4283,7 @@ namespace System.Text.RegularExpressions
                             Ldc(str.Length - i);
                             Sub();
                             Callvirt(s_stringGetCharsMethod);
-                            if (IsCaseInsensitive())
+                            if (IsCaseInsensitive() && ParticipatesInCaseConversion(str[i]))
                             {
                                 CallToLower();
                             }
@@ -4428,7 +4486,7 @@ namespace System.Text.RegularExpressions
                         }
                         else
                         {
-                            if (IsCaseInsensitive())
+                            if (IsCaseInsensitive() && ParticipatesInCaseConversion(Operand(0)))
                             {
                                 CallToLower();
                             }
@@ -4537,7 +4595,7 @@ namespace System.Text.RegularExpressions
                         // we can use the vectorized IndexOf to search for the target character.
                         if ((Code() == RegexCode.Notoneloop || Code() == RegexCode.Notoneloopatomic) &&
                             !IsRightToLeft() &&
-                            !IsCaseInsensitive())
+                            (!IsCaseInsensitive() || !ParticipatesInCaseConversion(Operand(0))))
                         {
                             // i = runtext.AsSpan(runtextpos, len).IndexOf(ch);
                             Ldloc(_runtextLocal!);
@@ -4705,7 +4763,7 @@ namespace System.Text.RegularExpressions
                             }
                             else
                             {
-                                if (IsCaseInsensitive())
+                                if (IsCaseInsensitive() && ParticipatesInCaseConversion(Operand(0)))
                                 {
                                     CallToLower();
                                 }
@@ -4906,7 +4964,7 @@ namespace System.Text.RegularExpressions
                         }
                         else
                         {
-                            if (IsCaseInsensitive())
+                            if (IsCaseInsensitive() && ParticipatesInCaseConversion(Operand(0)))
                             {
                                 CallToLower();
                             }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -529,7 +529,7 @@ namespace System.Text.RegularExpressions
             _int32LocalsPool ??= new Stack<LocalBuilder>(),
             _int32LocalsPool.TryPop(out LocalBuilder? iterationLocal) ? iterationLocal : DeclareInt32());
 
-        /// <summary>Rents an ReadOnlySpan(char) local variable slot from the pool of locals.</summary>
+        /// <summary>Rents a ReadOnlySpan(char) local variable slot from the pool of locals.</summary>
         /// <remarks>
         /// Care must be taken to Dispose of the returned <see cref="RentedLocalBuilder"/> when it's no longer needed,
         /// and also not to jump into the middle of a block involving a rented local from outside of that block.

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.UnicodeChar.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.UnicodeChar.Tests.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
+using System.Tests;
 using Xunit;
 
 namespace System.Text.RegularExpressions.Tests
@@ -13,7 +14,7 @@ namespace System.Text.RegularExpressions.Tests
         private const int MaxUnicodeRange = 2 << 15;
 
         [Fact]
-        public static void RegexUnicodeChar()
+        public void RegexUnicodeChar()
         {
             // Regex engine is Unicode aware now for the \w and \d character classes
             // \s is not - i.e. it still only recognizes the ASCII space separators, not Unicode ones
@@ -221,6 +222,61 @@ namespace System.Text.RegularExpressions.Tests
 
                 match = match.NextMatch();
                 Assert.False(match.Success);
+            }
+        }
+
+        [OuterLoop("May take tens of seconds due to large number of cultures tested")]
+        [Fact]
+        public void ValidateCategoriesParticipatingInCaseConversion()
+        {
+            // Some optimizations in RegexCompiler rely on only some Unicode categories participating
+            // in case conversion.  If this test ever fails, that optimization needs to be revisited,
+            // as our assumptions about the Unicode spec may have been invalidated.
+
+            var nonParticipatingCategories = new HashSet<UnicodeCategory>()
+            {
+                UnicodeCategory.ClosePunctuation,
+                UnicodeCategory.ConnectorPunctuation,
+                UnicodeCategory.Control,
+                UnicodeCategory.DashPunctuation,
+                UnicodeCategory.DecimalDigitNumber,
+                UnicodeCategory.FinalQuotePunctuation,
+                UnicodeCategory.InitialQuotePunctuation,
+                UnicodeCategory.LineSeparator,
+                UnicodeCategory.OpenPunctuation,
+                UnicodeCategory.OtherNumber,
+                UnicodeCategory.OtherPunctuation,
+                UnicodeCategory.ParagraphSeparator,
+                UnicodeCategory.SpaceSeparator,
+            };
+
+            foreach (CultureInfo ci in CultureInfo.GetCultures(CultureTypes.AllCultures))
+            {
+                using (new ThreadCultureChange(ci))
+                {
+                    for (int i = 0; i <= char.MaxValue; i++)
+                    {
+                        char ch = (char)i;
+                        char upper = char.ToUpper(ch);
+                        char lower = char.ToLower(ch);
+
+                        if (nonParticipatingCategories.Contains(char.GetUnicodeCategory(ch)))
+                        {
+                            // If this character is in one of these categories, make sure it doesn't change case.
+                            Assert.Equal(ch, upper);
+                            Assert.Equal(ch, lower);
+                        }
+                        else
+                        {
+                            // If it's not in one of these categories, make sure it doesn't change case to
+                            // something in one of these categories.
+                            UnicodeCategory upperCategory = char.GetUnicodeCategory(upper);
+                            UnicodeCategory lowerCategory = char.GetUnicodeCategory(lower);
+                            Assert.False(nonParticipatingCategories.Contains(upperCategory));
+                            Assert.False(nonParticipatingCategories.Contains(lowerCategory));
+                        }
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
When `RegexOptions.IgnoreCase` is used, we can skip calling ToLower{Invariant} if the only character that could possibly lower-case to the character we're comparing against is that character itself.  This then also lets us employ optimizations like using IndexOf when searching for `\n` as part of expressions like `.*`.

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Text.RegularExpressions;

public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly Regex _many = new Regex("hello.*world", RegexOptions.Compiled | RegexOptions.IgnoreCase);
    private readonly Regex _single = new Regex("h.l", RegexOptions.Compiled | RegexOptions.IgnoreCase);
    private readonly string _input = "abcdHELLO" + new string('a', 128) + "WORLD123";

    [Benchmark] public bool Many() => _many.IsMatch(_input);
    [Benchmark] public bool Single() => _single.IsMatch(_input);
}
```

| Method |           Toolchain |      Mean |    Error |   StdDev | Ratio |
|------- |-------------------- |----------:|---------:|---------:|------:|
|   Many | \master\corerun.exe | 817.32 ns | 2.488 ns | 2.327 ns |  1.00 |
|   Many |     \pr\corerun.exe | 170.75 ns | 0.399 ns | 0.354 ns |  0.21 |
|        |                     |           |          |          |       |
| Single | \master\corerun.exe |  84.47 ns | 0.278 ns | 0.232 ns |  1.00 |
| Single |     \pr\corerun.exe |  81.94 ns | 0.220 ns | 0.195 ns |  0.97 |

cc: @GrabYourPitchforks, @tarekgh, @eerhardt, @pgovind 