### PR TITLE
[meta] Add embedding API function to get the default ALC

### DIFF
--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -9,6 +9,7 @@
 #include "mono/metadata/icall-decl.h"
 #include "mono/metadata/loader-internals.h"
 #include "mono/metadata/loaded-images-internals.h"
+#include "mono/metadata/mono-private-unstable.h"
 #include "mono/utils/mono-error-internals.h"
 #include "mono/utils/mono-logger-internals.h"
 
@@ -178,6 +179,13 @@ mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
 	return alc;
+}
+
+MonoGCHandle
+mono_alc_get_default_gchandle (void)
+{
+	// Because the default domain is never unloadable, this should be a strong handle and never change
+	return mono_domain_default_alc (mono_domain_get ())->gchandle;
 }
 
 static MonoAssembly*

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -16,10 +16,12 @@
 
 typedef MonoGCHandle MonoAssemblyLoadContextGCHandle;
 
-MONO_API MONO_RT_EXTERNAL_ONLY
-MonoAssembly *mono_assembly_load_full_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status);
+MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *
+mono_assembly_load_full_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status);
 
 typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle *alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
-void mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append);
+
+MONO_API MONO_RT_EXTERNAL_ONLY void
+mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append);
 
 #endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/

--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -24,4 +24,7 @@ typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHa
 MONO_API MONO_RT_EXTERNAL_ONLY void
 mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append);
 
+MONO_API MONO_RT_EXTERNAL_ONLY MonoAssemblyLoadContextGCHandle
+mono_alc_get_default_gchandle (void);
+
 #endif /*__MONO_METADATA_MONO_PRIVATE_UNSTABLE_H__*/


### PR DESCRIPTION
Also formatting fixes to the unstable header.

We can just return the stored GCHandle for the default ALC because it's both strong and should never change.

cc: @garuma 