### PR TITLE
Improve char.ToUpperInvariant / ToLowerInvariant perf

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -354,10 +354,7 @@ namespace System
         }
 
         // Converts a character to upper-case for invariant culture.
-        public static char ToUpperInvariant(char c)
-        {
-            return TextInfo.Invariant.ToUpper(c);
-        }
+        public static char ToUpperInvariant(char c) => TextInfo.ToUpperInvariant(c);
 
         /*===================================ToLower====================================
         **
@@ -383,10 +380,7 @@ namespace System
         }
 
         // Converts a character to lower-case for invariant culture.
-        public static char ToLowerInvariant(char c)
-        {
-            return TextInfo.Invariant.ToLower(c);
-        }
+        public static char ToLowerInvariant(char c) => TextInfo.ToLowerInvariant(c);
 
         //
         // IConvertible implementation


### PR DESCRIPTION
Somewhat inspired by Steve's PR at https://github.com/dotnet/runtime/pull/35185. Turns out we call `char.ToUpperInvariant` / `char.ToLowerInvariant` in a few dozen places within the runtime.

This PR improves these code paths by: (a) not bouncing through the `TextInfo.Invariant` indirection for ASCII data or when `GlobalizationMode.Invariant` is enabled; (b) inlining small methods that the JIT wasn't already inlining; and (c) tweaking the bit twiddling to get more efficient codegen.

|               Method | Toolchain |         args |     Mean |    Error |   StdDev | Ratio | Code Size |
|--------------------- |---------- |------------- |---------:|---------:|---------:|------:|----------:|
| CharToUpperInvariant |    master | Hello World! | 51.98 ns | 0.615 ns | 0.545 ns |  1.00 |     147 B |
| CharToUpperInvariant |  textinfo | Hello World! | 22.71 ns | 0.436 ns | 0.408 ns |  0.44 |     105 B |
|                      |           |              |          |          |          |       |           |
| CharToLowerInvariant |    master | Hello World! | 49.15 ns | 0.295 ns | 0.247 ns |  1.00 |     144 B |
| CharToLowerInvariant |  textinfo | Hello World! | 22.68 ns | 0.242 ns | 0.215 ns |  0.46 |     105 B |

```cs
[Benchmark]
[Arguments("Hello World!")]
public int CharToUpperInvariant(string args)
{
    int accum = 0;
    for (int i = 0; i < args.Length; i++)
    {
        accum += char.ToUpperInvariant(args[i]);
    }
    return accum;
}

[Benchmark]
[Arguments("Hello World!")]
public int CharToLowerInvariant(string args)
{
    int accum = 0;
    for (int i = 0; i < args.Length; i++)
    {
        accum += char.ToLowerInvariant(args[i]);
    }
    return accum;
}
```