### PR TITLE
Add default license header to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -156,6 +156,9 @@ csharp_space_between_square_brackets = false
 # Analyzers
 dotnet_code_quality.ca1802.api_surface = private, internal
 
+# License header
+file_header_template = Licensed to the .NET Foundation under one or more agreements.\nThe .NET Foundation licenses this file to you under the MIT license.\nSee the LICENSE file in the project root for more information.
+
 # C++ Files
 [*.{cpp,h,in}]
 curly_bracket_next_line = true


### PR DESCRIPTION
Visual Studio >= 16.6 Preview 2 supports adding license headers defined in the .editorconfig file. Adding the rule to our editorconfig.

https://devblogs.microsoft.com/visualstudio/visual-studio-2019-version-16-6-preview-2/ for more details.