### PR TITLE
Enable more formerly-failing-on-mono tests.

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1391,15 +1391,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/Invoke/25params/25paramMixed_il_r/**">
             <Issue>https://github.com/dotnet/runtime/issues/34068</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/refany/_il_dbgarray2/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34378</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/refany/_il_dbgarray3/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34377</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/refany/_il_relarray3/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34381</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/refany/_il_rellcs/**">
             <Issue>https://github.com/dotnet/runtime/issues/34196</Issue>
         </ExcludeList>


### PR DESCRIPTION
See:
- https://github.com/dotnet/runtime/issues/34377,
- https://github.com/dotnet/runtime/issues/34378, and
- https://github.com/dotnet/runtime/issues/34381.