### PR TITLE
Fix PAL test build on non-Linux Unix platforms

### DIFF
--- a/src/coreclr/src/pal/tests/palsuite/common/palsuite.h
+++ b/src/coreclr/src/pal/tests/palsuite/common/palsuite.h
@@ -17,7 +17,10 @@
 #ifndef __PALSUITE_H__
 #define __PALSUITE_H__
 
-#include <uchar.h>
+#ifndef __cplusplus
+typedef unsigned short char16_t;
+#endif
+
 #include <pal_assert.h>
 #include <pal.h>
 #include <palprivate.h>


### PR DESCRIPTION
A step towards re-enabling PAL tests in the CI: https://github.com/dotnet/runtime/issues/34776.

On macOS and Illumos/SmartOS, currently the C11's [non-optional](https://en.wikichip.org/wiki/c/c11#New_headers) header `<uchar.h>` (not to be confused with ICU's `unicode/uchar.h`) is not available.

This PR removes the `uchar.h` usage from PAL tests (which is used for the definition of `char16_t`) and conditionally declare `char16_t` for "C sources in PAL tests".

All tests are passing on macOS baremetal, one test failed on Ubuntu x64 virtual machine:

```xml
<test name="miscellaneous.queryperformancecounter.test1" type="miscellaneous.queryperformancecounter" method="test1" result="Fail" >
  <failure exception-type="Exit code: 1">
    <message><![CDATA[ERROR:  average diff 59 acceptable 15.]]></message>
  </failure>
</test>
```

There are currently six failures on SmartOS x64 VM (http://sprunge.us/3eVz48 - file: `/tmp/PalTestOutput/default/pal_tests.xml`) with #35173 (and libunwind) changes.

cc @janvorli, @rmustacc