### PR TITLE
Changes triggered by the CA1834 analyzer

### DIFF
--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0-beta3.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/Analyzers.props
+++ b/eng/Analyzers.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(EnableAnalyzers)' == 'true'">
     <PackageReference Include="Microsoft.DotNet.CodeAnalysis" Version="$(MicrosoftDotNetCodeAnalysisVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0-beta3.final" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -837,7 +837,7 @@ namespace System.Net
             {
                 result += SeparatorLiteral + CookieFields.VersionAttributeName + EqualsLiteral + m_version.ToString(NumberFormatInfo.InvariantInfo);
             }
-            return result == EqualsLiteral.ToString() ? null : result;
+            return result == "=" ? null : result;
         }
     }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-#pragma warning disable CA1834 // Prefer StringBuilder.Append(char) over Append(string) where applicable
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -39,7 +38,7 @@ namespace System.Net
         internal const string MaxSupportedVersionString = "1";
 
         internal const string SeparatorLiteral = "; ";
-        internal const string EqualsLiteral = "=";
+        internal const char EqualsLiteral = '=';
         internal const string QuotesLiteral = "\"";
         internal const string SpecialAttributeLiteral = "$";
 
@@ -838,7 +837,7 @@ namespace System.Net
             {
                 result += SeparatorLiteral + CookieFields.VersionAttributeName + EqualsLiteral + m_version.ToString(NumberFormatInfo.InvariantInfo);
             }
-            return result == EqualsLiteral ? null : result;
+            return result == EqualsLiteral.ToString() ? null : result;
         }
     }
 }

--- a/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
+#pragma warning disable CA1834 // Prefer StringBuilder.Append(char) over Append(string) where applicable
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaValidator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/XmlSchemaValidator.cs
@@ -139,7 +139,7 @@ namespace System.Xml.Schema
         private static readonly XmlSchemaDatatype s_dtStringArray = s_dtCDATA.DeriveByList(null);
 
         //Error message constants
-        private const string Quote = "'";
+        private const char Quote = '\'';
 
         //Empty arrays
         private static readonly XmlSchemaParticle[] s_emptyParticleArray = Array.Empty<XmlSchemaParticle>();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RecordBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RecordBuilder.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable CA1834 // Prefer StringBuilder.Append(char) over Append(string) where applicable
 using System.Diagnostics;
 using System.Text;
 using System.Xml.XPath;
@@ -44,7 +43,7 @@ namespace System.Xml.Xsl.XsltOld
         private const int HaveRecord = 2;      // Record was fully generated
 
         private const char s_Minus = '-';
-        private const string s_Space = " ";
+        private const char s_Space = ' ';
         private const string s_SpaceMinus = " -";
         private const char s_Question = '?';
         private const char s_Greater = '>';
@@ -656,7 +655,7 @@ namespace System.Xml.Xsl.XsltOld
             }
             else if (minus)
             {
-                _mainNode.ValueAppend(s_Space, false);
+                _mainNode.ValueAppend(s_Space.ToString(), false);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RecordBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RecordBuilder.cs
@@ -655,7 +655,7 @@ namespace System.Xml.Xsl.XsltOld
             }
             else if (minus)
             {
-                _mainNode.ValueAppend(s_Space.ToString(), false);
+                _mainNode.ValueAppend(" ", false);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RecordBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XsltOld/RecordBuilder.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#pragma warning disable CA1834 // Prefer StringBuilder.Append(char) over Append(string) where applicable
 using System.Diagnostics;
 using System.Text;
 using System.Xml.XPath;


### PR DESCRIPTION
https://github.com/dotnet/roslyn-analyzers/pull/3481 was updated to now detect const string fields. This is the accompanying set of runtime changes.