### PR TITLE
Add build argument to suppress PGO

### DIFF
--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -12,9 +12,14 @@
       <_CoreClrBuildArg Condition="'$(CrossBuild)' == 'true'" Include="-cross" />
       <_CoreClrBuildArg Condition="!$([MSBuild]::IsOsPlatform(Windows))" Include="-os $(TargetOS)" />
 
-      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and ('$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'x64') and '$(Configuration)' == 'Release'" Include="-enforcepgo" />
+      <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and
+                                   ('$(TargetArchitecture)' == 'x86' or '$(TargetArchitecture)' == 'x64') and
+                                   '$(Configuration)' == 'Release' and
+                                   '$(NoPgoOptimize)' != 'true'"
+                                   Include="-enforcepgo" />
       <_CoreClrBuildArg Condition="$([MSBuild]::IsOsPlatform(Windows)) and '$(CrossDac)' != ''" Include="-$(CrossDac)dac" />
       <_CoreClrBuildArg Condition="'$(OfficialBuildId)' != ''" Include="/p:OfficialBuildId=$(OfficialBuildId)" />
+      <_CoreClrBuildArg Condition="'$(NoPgoOptimize)' == 'true'" Include="-nopgooptimize" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
Fixes #34069.
You can now specify build.cmd/sh /p:NoPgoOptimize=true which has the effect of passing -nopgooptimize to src/coreclr/build-runtime.sh/cmd.
On windows this also removes the -enforcepgo option that would otherwise be added by default on release x86/x64 builds.

I tested the change manually by logging the parameters received by build-runtime.sh/cmd. There was suggestion in #34069 that Linux scripts didn't support automatically converting build.sh args into msbuild args, but when I went to investigate it was already working.

@jashook 