### PR TITLE
[mono] Fix iOS sample

### DIFF
--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -1,62 +1,22 @@
 MONO_CONFIG=Debug
 MONO_ARCH=arm64
+DOTNET := ../../../../.././dotnet.sh
 
-ARTIFACTS_BIN=../../../../../artifacts/bin/
-ARTIFACTS_BCL=$(ARTIFACTS_BIN)runtime/netcoreapp5.0-iOS-$(MONO_CONFIG)-$(MONO_ARCH)
-ARTIFACTS_MONO=$(ARTIFACTS_BIN)/mono/iOS.$(MONO_ARCH).$(MONO_CONFIG)
-
-DOTNET := $(shell cd ../../ && bash init-tools.sh | tail -1)
-
-BCL_LIBS = \
-	System.Runtime.dll \
-	System.Runtime.Extensions.dll \
-	System.Collections.dll \
-	System.Core.dll \
-	System.Threading.dll \
-	System.Threading.Tasks.dll \
-	System.Linq.dll \
-	System.Memory.dll \
-	System.Runtime.InteropServices.dll \
-	System.Text.Encoding.Extensions.dll \
-	Microsoft.Win32.Primitives.dll \
-	System.Console.dll
-
-all: mono build
+# usage example:
+# 'make all MONO_ARCH=x64 MONO_CONFIG=Release' to build the app for simulator
+all: runtimepack bundle
 
 program:
-	$(DOTNET) build -c Debug Program.csproj
+	$(DOTNET) build -c $(MONO_CONFIG) Program.csproj
 
-# copy everything to bin/ and run BuildIosApp task
-build: clean program
-	cp $(ARTIFACTS_MONO)/System.Private.CoreLib.{dll,pdb} bin
-	cp $(ARTIFACTS_MONO)/libmono.a bin
-	for lib in $(BCL_LIBS); do cp $(ARTIFACTS_BCL)/$$lib bin; done
-	cp $(ARTIFACTS_BCL)/*.a bin
-	$(DOTNET) msbuild /t:BuildAppleApp /p:Configuration=$(MONO_CONFIG) \
-	/p:TargetArchitecture=$(MONO_ARCH) \
-	/p:TargetOS=iOS \
-	/p:OutputDirectory=bin \
-	/p:ProjectName=HelloiOS \
-	/p:Optimized=false \
-	/p:AppDir=$(CURDIR)/bin \
-	/p:NativeMainSource=$(CURDIR)/main.m \
-	/p:BuildAppBundle=true \
-	/p:GenerateXcodeProject=true \
-	/p:DevTeamProvisioning= \
-	/p:MainLibraryFileName=Program.dll \
-	../../../mono.proj
+bundle: clean program
+	$(DOTNET) msbuild /t:BuildAppBundle /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH)
 
 deploy-sim:
-	make build MONO_ARCH=x64
-	xcrun simctl shutdown "iPhone 11" || true
-	xcrun simctl boot "iPhone 11"
-	open -a Simulator
-	xcrun simctl install "iPhone 11" $(realpath ../../../../../artifacts/bin/mono/iOS.x64.$(MONO_CONFIG)/HelloiOS/HelloiOS/Debug-iphonesimulator/HelloiOS.app)
-	xcrun simctl launch booted net.dot.HelloiOS
+	$(DOTNET) msbuild /t:IosDeployToSimulator /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH)
 
-# rebuild mono for iOS-arm64 or x64
-mono:
-	../../../../.././build.sh -c $(MONO_CONFIG) -os iOS -arch $(MONO_ARCH) -subset Mono
+runtimepack:
+	../../../../.././build.sh -c $(MONO_CONFIG) -os iOS -arch $(MONO_ARCH) -subset Mono+Libs /p:DisableCrossgen=true
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -10,7 +10,8 @@ program:
 	$(DOTNET) build -c $(MONO_CONFIG) Program.csproj
 
 bundle: clean program
-	$(DOTNET) msbuild /t:BuildAppBundle /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH)
+	$(DOTNET) msbuild /t:BuildAppBundle /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH) \
+	/p:UseLlvm=$(UseLlvm) /p:LlvmPath=$(LlvmPath)
 
 deploy-sim:
 	$(DOTNET) msbuild /t:IosDeployToSimulator /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH)

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -1,9 +1,66 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <OutputPath>bin</OutputPath>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <TargetArchitecture Condition="'$(TargetArchitecture)'==''">x64</TargetArchitecture>
+    <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\runtimes\ios-$(TargetArchitecture)</RuntimePackDir>
+    <MonoRuntimeDir>$(ArtifactsDir)bin\mono\iOS.$(TargetArchitecture).$(Configuration)</MonoRuntimeDir>
+    <BundleDir>$(MSBuildThisFileDirectory)\bin\bundle</BundleDir>
   </PropertyGroup>
 
+  <Target Name="RebuildAppleAppBuilder">
+    <MSBuild Projects="$(RepoRoot)src\mono\msbuild\AppleAppBuilder\AppleAppBuilder.csproj"
+             Properties="Configuration=$(Configuration)" Targets="Restore;Build" />
+  </Target>
+
+  <UsingTask TaskName="AppleAppBuilderTask" 
+      AssemblyFile="$(ArtifactsObjDir)mono\AppleAppBuilder\$(TargetArchitecture)\$(Configuration)\AppleAppBuilder.dll" />
+
+  <Target Name="BuildAppBundle" DependsOnTargets="RebuildAppleAppBuilder">
+    <PropertyGroup>
+      <TargetArch Condition="$(RuntimeIdentifier.EndsWith('arm64'))">arm64</TargetArch>
+      <TargetArch Condition="'$(TargetArch)' == ''">x64</TargetArch>
+    </PropertyGroup>
+    <ItemGroup>
+      <AppBinaries Include="bin\*.*"/>
+      <BclBinaries Include="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.*" Exclude="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\System.Runtime.WindowsRuntime.dll" />
+      <BclBinaries Include="$(RuntimePackDir)\native\*.*" />
+      <MonoRuntimeBinaries Include="$(MonoRuntimeDir)\*.*" />
+    </ItemGroup>
+    <Error Condition="!Exists('$(RuntimePackDir)')" Text="RuntimePackDir=$(RuntimePackDir) doesn't exist" />
+    <RemoveDir Directories="$(BundleDir)" />
+    <Copy SourceFiles="@(AppBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
+    <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+    <!-- runtime pack contains all needed binaries but lets overwrite them from artifacts/bin/mono to sync runtime changes -->
+    <Copy SourceFiles="@(MonoRuntimeBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+    <AppleAppBuilderTask 
+        Arch="$(TargetArchitecture)"
+        ProjectName="HelloiOS"
+        MonoRuntimeHeaders="$(RuntimePackDir)\native\include\mono-2.0"
+        CrossCompiler="$(RuntimePackDir)\native\cross\mono-aot-cross"
+        MainLibraryFileName="Program.dll"
+        GenerateXcodeProject="True"
+        BuildAppBundle="True"
+        DevTeamProvisioning="$(DevTeamProvisioning)"
+        OutputDirectory="$(BundleDir)"
+        AppDir="$(BundleDir)">
+        <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
+        <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />
+    </AppleAppBuilderTask>
+    <Message Importance="High" Text="Xcode: $(XcodeProjectPath)"/>
+    <Message Importance="High" Text="App:   $(AppBundlePath)"/>
+  </Target>
+
+  <Target Name="IosDeployToSimulator">
+    <PropertyGroup>
+      <IosSimulator Condition="'$(IosSimulator)' == ''">iPhone 11</IosSimulator>
+    </PropertyGroup>
+    <Message Importance="High" Text="\nDeploying to '$(IosSimulator)' simulator..." />
+    <Exec Command="xcrun simctl shutdown &quot;$(IosSimulator)&quot;" ContinueOnError="WarnAndContinue" />
+    <Exec Command="xcrun simctl boot &quot;$(IosSimulator)&quot;" />
+    <Exec Command="open -a Simulator" />
+    <Exec Command="xcrun simctl install &quot;$(IosSimulator)&quot; $(BundleDir)/HelloiOS/Debug-iphonesimulator/HelloiOS.app" />
+    <Exec Command="xcrun simctl launch --console booted net.dot.HelloiOS" />
+  </Target>
 </Project>

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -44,6 +44,9 @@
         BuildAppBundle="True"
         DevTeamProvisioning="$(DevTeamProvisioning)"
         OutputDirectory="$(BundleDir)"
+        UseLlvm="$(UseLlvm)"
+        LlvmPath="$(LlvmPath)"
+        Optimized="False"
         AppDir="$(BundleDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />
         <Output TaskParameter="XcodeProjectPath" PropertyName="XcodeProjectPath" />


### PR DESCRIPTION
Recent ios test runner PRs broke it.

Steps to run the sample:
```
cd src/mono/netcore/sample/iOS
make all MONO_ARCH=x64 MONO_CONFIG=Debug
```
(or arm64 for device and FullAOT)