### PR TITLE
Optimize CoreCLR Helix runs by pruning the CORE_ROOT folder content

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -156,6 +156,9 @@ set "__BinDir=%__RootBinDir%\bin\coreclr\%__TargetOS%.%__BuildArch%.%__BuildType
 set "__TestRootDir=%__RootBinDir%\tests\coreclr"
 set "__TestBinDir=%__TestRootDir%\%__TargetOS%.%__BuildArch%.%__BuildType%"
 
+if not defined XunitTestBinBase set XunitTestBinBase=%__TestBinDir%\
+set "CORE_ROOT=%XunitTestBinBase%\Tests\Core_Root"
+
 REM We have different managed and native intermediate dirs because the managed bits will include
 REM the configuration information deeper in the intermediates path.
 REM These variables are used by the msbuild project files.
@@ -288,9 +291,6 @@ REM ============================================================================
 if "%__SkipRestorePackages%" == "1" goto SkipRestoreProduct
 
 echo %__MsgPrefix%Restoring CoreCLR product from packages
-
-if not defined XunitTestBinBase set XunitTestBinBase=%__TestBinDir%\
-set "CORE_ROOT=%XunitTestBinBase%\Tests\Core_Root"
 
 set __BuildLogRootName=Restore_Product
 set __BuildLog=%__LogsDir%\%__BuildLogRootName%_%__TargetOS%__%__BuildArch%__%__BuildType%.log
@@ -436,12 +436,8 @@ REM Remove any lock folder used for synchronization from previous runs.
 powershell -NoProfile "Get-ChildItem -path %__TestBinDir% -Include 'lock' -Recurse -Force |  where {$_.Attributes -eq 'Directory'}| Remove-Item -force -Recurse"
 
 set CORE_ROOT=%__TestBinDir%\Tests\Core_Root
-set CORE_ROOT_STAGE=%__TestBinDir%\Tests\Core_Root_Stage
 if exist "%CORE_ROOT%" rd /s /q "%CORE_ROOT%"
-if exist "%CORE_ROOT_STAGE%" rd /s /q "%CORE_ROOT_STAGE%"
 md "%CORE_ROOT%"
-md "%CORE_ROOT_STAGE%"
-xcopy /s "%__BinDir%" "%CORE_ROOT_STAGE%"
 
 REM =========================================================================================
 REM ===
@@ -478,8 +474,6 @@ if errorlevel 1 (
     echo     %__BuildErr%
     exit /b 1
 )
-
-xcopy /s /y /i "%CORE_ROOT_STAGE%" "%CORE_ROOT%"
 
 REM =========================================================================================
 REM ===
@@ -557,8 +551,6 @@ if defined __DoCrossgen2 (
 )
 
 :SkipCrossgen
-
-rd /s /q "%CORE_ROOT_STAGE%"
 
 REM =========================================================================================
 REM ===

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -119,13 +119,10 @@ generate_layout()
 
     mkdir -p "$CORE_ROOT"
 
-    build_MSBuild_projects "Tests_Overlay_Managed" "${__ProjectDir}/tests/src/runtest.proj" "Creating test overlay" "/t:CreateTestOverlay"
-
     chmod +x "$__BinDir"/corerun
     chmod +x "$__CrossgenExe"
 
-    # Make sure to copy over the pulled down packages
-    cp -r "$__BinDir"/* "$CORE_ROOT/" > /dev/null
+    build_MSBuild_projects "Tests_Overlay_Managed" "${__ProjectDir}/tests/src/runtest.proj" "Creating test overlay" "/t:CreateTestOverlay"
 
     if [[ "$__TargetOS" != "OSX" ]]; then
         nextCommand="\"$__TestDir/setup-stress-dependencies.sh\" --arch=$__BuildArch --outputDir=$CORE_ROOT"

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -34,6 +34,7 @@
       <RunTimeArtifactsExcludeFiles Include="linuxonjit.dll" />
       
       <RunTimeArtifactsIncludeFolders Include="/" />
+      <RunTimeArtifactsIncludeFolders Include="IL/" />
       <RunTimeArtifactsIncludeFolders Include="crossgen2/" />
       <RunTimeArtifactsIncludeFolders Include="PDB/" />
       <RunTimeArtifactsIncludeFolders Include="R2RTest/" />

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -40,10 +40,9 @@
 
       <!-- Add binary dependencies to copy-local items -->
       <RunTimeDependencyCopyLocal
-          Include="$(CoreCLRArtifactsPath)/%(RunTimeArtifactsIncludeFolders.Identity)*"
-          Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)/%(Identity)')">
-        <TargetDir>%(RunTimeArtifactsIncludeFolders.Identity)</TargetDir>
-      </RunTimeDependencyCopyLocal>
+          Include="$(CoreCLRArtifactsPath)%(RunTimeArtifactsIncludeFolders.Identity)*"
+          Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)%(Identity)')"
+          TargetDir="%(RunTimeArtifactsIncludeFolders.Identity)" />
     </ItemGroup>
 
     <Copy

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -21,17 +21,34 @@
       <RunTimeDependencyExcludeFiles Include="@(RunTimeDependencyExclude -> '%(FileName)%(Extension)')" />
       <RunTimeDependencyExcludeFiles Include="@(RunTimeDependencyExclude -> '%(FileName).ni%(Extension)')" />
       <RunTimeDependencyExcludeFiles Include="@(RunTimeDependencyExclude -> '%(FileName).pdb')" />
+
       <AllResolvedRuntimeDependencies Include="@(RuntimeCopyLocalItems -> '%(FileName)%(Extension)');@(NativeCopyLocalItems -> '%(FileName)%(Extension)')">
         <File>%(Identity)</File>
       </AllResolvedRuntimeDependencies>
+      
       <RunTimeDependencyCopyLocalFile Include="@(AllResolvedRuntimeDependencies)"  Exclude="@(RunTimeDependencyExcludeFiles)"/>
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
+      
+      <RunTimeArtifactsExcludeFiles Include="protononjit.dll" />
+      <RunTimeArtifactsExcludeFiles Include="linuxonjit.dll" />
+      
+      <RunTimeArtifactsIncludeFolders Include="/" />
+      <RunTimeArtifactsIncludeFolders Include="crossgen2/" />
+      <RunTimeArtifactsIncludeFolders Include="PDB/" />
+      <RunTimeArtifactsIncludeFolders Include="R2RTest/" />
+
+      <!-- Add binary dependencies to copy-local items -->
+      <RunTimeDependencyCopyLocal
+          Include="$(CoreCLRArtifactsPath)/%(RunTimeArtifactsIncludeFolders.Identity)*"
+          Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)/%(Identity)')">
+        <TargetDir>%(RunTimeArtifactsIncludeFolders.Identity)</TargetDir>
+      </RunTimeDependencyCopyLocal>
     </ItemGroup>
 
     <Copy
       SourceFiles="@(RunTimeDependencyCopyLocal)"
-      DestinationFolder="$(CORE_ROOT)"
+      DestinationFiles="@(RunTimeDependencyCopyLocal -> '$(CORE_ROOT)/%(TargetDir)%(Filename)%(Extension)')"
       SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
       OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
       Retries="$(CopyRetryCount)"


### PR DESCRIPTION
This change limits the content of CORE_ROOT by removing some of the
unused artifacts, most notably the sharedFramework subfolder that
is not used by CoreCLR tests at all. The aim of this change is
to optimize the execution of CoreCLR tests in Helix where according
to Jarret's findings a large amount of time gets spent just
downloading and unpacking the test payloads.

In technical terms I have slightly changed the semantics of the target
CreateTestOverlay (or rather of its dependent target
CopyDependencyToCoreRoot) so that it also copies over
the appropriate binary artifacts. This let me simplify the cmd / sh
script logic and introduce common filtering at the MSBuild level.

Thanks

Tomas