### PR TITLE
[CBOR] Implement Conformance Levels

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
@@ -71,9 +71,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.NotNull(length);
-            Assert.Equal(0u, length!.Value);
+            Assert.Equal(0, length!.Value);
         }
 
         [Theory]
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Null(length);
         }
 
@@ -124,7 +124,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < expectedLength; i++)
@@ -145,13 +145,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < expectedLength; i++)
             {
-                ulong? nestedLength = reader.ReadStartArray();
-                Assert.Equal(1, (int)nestedLength!.Value);
+                int? nestedLength = reader.ReadStartArray();
+                Assert.Equal(1, nestedLength!.Value);
                 reader.ReadInt64();
                 reader.ReadEndArray();
             }
@@ -203,7 +203,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 1; i < expectedLength; i++)
@@ -224,13 +224,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 1; i < expectedLength; i++)
             {
-                ulong? nestedLength = reader.ReadStartArray();
-                Assert.Equal(1, (int)nestedLength!.Value);
+                int? nestedLength = reader.ReadStartArray();
+                Assert.Equal(1, nestedLength!.Value);
                 reader.ReadInt64();
                 reader.ReadEndArray();
             }
@@ -256,7 +256,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < actualLength; i++)
@@ -277,13 +277,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartArray();
+            int? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < actualLength; i++)
             {
-                ulong? innerLength = reader.ReadStartArray();
-                Assert.Equal(1, (int)innerLength!.Value);
+                int? innerLength = reader.ReadStartArray();
+                Assert.Equal(1, innerLength!.Value);
                 reader.ReadInt64();
                 reader.ReadEndArray();
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
@@ -94,6 +94,28 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.Lax, "9fff")]
+        [InlineData(CborConformanceLevel.Strict, "9fff")]
+        internal static void ReadArray_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            uint? length = reader.ReadStartArray();
+            Assert.Null(length);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9fff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "9fff")]
+        internal static void ReadArray_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadStartArray());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
         [InlineData("80", 0)]
         [InlineData("8101", 1)]
         [InlineData("83010203", 3)]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
@@ -59,6 +59,41 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.Lax, "9800")]
+        [InlineData(CborConformanceLevel.Lax, "990000")]
+        [InlineData(CborConformanceLevel.Lax, "9a00000000")]
+        [InlineData(CborConformanceLevel.Lax, "9b0000000000000000")]
+        [InlineData(CborConformanceLevel.Strict, "9800")]
+        [InlineData(CborConformanceLevel.Strict, "990000")]
+        [InlineData(CborConformanceLevel.Strict, "9a00000000")]
+        [InlineData(CborConformanceLevel.Strict, "9b0000000000000000")]
+        internal static void ReadArray_NonCanonicalLengths_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            uint? length = reader.ReadStartArray();
+            Assert.NotNull(length);
+            Assert.Equal(0u, length!.Value);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9800")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "990000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9a00000000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9b0000000000000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "9800")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "990000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "9a00000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "9b0000000000000000")]
+        internal static void ReadArray_NonCanonicalLengths_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadStartArray());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
         [InlineData("80", 0)]
         [InlineData("8101", 1)]
         [InlineData("83010203", 3)]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            ulong? length = reader.ReadStartArray();
+            uint? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < expectedLength; i++)
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            ulong? length = reader.ReadStartArray();
+            uint? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < expectedLength; i++)
@@ -146,7 +146,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            ulong? length = reader.ReadStartArray();
+            uint? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 1; i < expectedLength; i++)
@@ -167,7 +167,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            ulong? length = reader.ReadStartArray();
+            uint? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 1; i < expectedLength; i++)
@@ -199,7 +199,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            ulong? length = reader.ReadStartArray();
+            uint? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < actualLength; i++)
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            ulong? length = reader.ReadStartArray();
+            uint? length = reader.ReadStartArray();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < actualLength; i++)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -157,7 +157,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 Assert.Equal(CborReaderState.StartArray, reader.PeekState());
 
-                uint? length = reader.ReadStartArray();
+                int? length = reader.ReadStartArray();
 
                 if (expectDefiniteLengthCollections)
                 {
@@ -187,7 +187,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 Assert.Equal(CborReaderState.StartMap, reader.PeekState());
 
-                uint? length = reader.ReadStartMap();
+                int? length = reader.ReadStartMap();
 
                 if (expectDefiniteLengthCollections)
                 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 Assert.Equal(CborReaderState.StartArray, reader.PeekState());
 
-                ulong? length = reader.ReadStartArray();
+                uint? length = reader.ReadStartArray();
 
                 if (expectDefiniteLengthCollections)
                 {
@@ -137,7 +137,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 Assert.Equal(CborReaderState.StartMap, reader.PeekState());
 
-                ulong? length = reader.ReadStartMap();
+                uint? length = reader.ReadStartMap();
 
                 if (expectDefiniteLengthCollections)
                 {
@@ -151,7 +151,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 foreach (object value in expectedValues.Skip(1))
                 {
-                    VerifyValue(reader, value);
+                    VerifyValue(reader, value, expectDefiniteLengthCollections);
                 }
 
                 Assert.Equal(CborReaderState.EndMap, reader.PeekState());

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -267,9 +267,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 "4201",
                 "61",
                 "6261",
-                // invalid utf8 strings
-                "61ff",
-                "62f090",
                 // indefinite-length strings with missing break byte
                 "5f41ab40",
                 "7f62616260",

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -89,6 +89,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                         Assert.Equal(expected.ByteArrayToHex(), bytes.ByteArrayToHex());
                         break;
 
+                    case string[] expectedChunks when CborWriterTests.Helpers.IsIndefiniteLengthByteString(expectedChunks):
+                        byte[][] expectedByteChunks = expectedChunks.Skip(1).Select(ch => ch.HexToByteArray()).ToArray();
+                        VerifyValue(reader, expectedByteChunks, expectDefiniteLengthCollections);
+                        break;
+
                     case string[] expectedChunks:
                         Assert.Equal(CborReaderState.StartTextString, reader.PeekState());
                         reader.ReadStartTextStringIndefiniteLength();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -69,6 +69,42 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.Lax, "b800")]
+        [InlineData(CborConformanceLevel.Lax, "b90000")]
+        [InlineData(CborConformanceLevel.Lax, "ba00000000")]
+        [InlineData(CborConformanceLevel.Lax, "bb0000000000000000")]
+        [InlineData(CborConformanceLevel.Strict, "b800")]
+        [InlineData(CborConformanceLevel.Strict, "b90000")]
+        [InlineData(CborConformanceLevel.Strict, "ba00000000")]
+        [InlineData(CborConformanceLevel.Strict, "bb0000000000000000")]
+        internal static void ReadMap_NonCanonicalLengths_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            uint? length = reader.ReadStartMap();
+            Assert.NotNull(length);
+            Assert.Equal(0u, length!.Value);
+            reader.ReadEndMap();
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "b800")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "b90000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "ba00000000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "bb0000000000000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "b800")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "b90000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "ba00000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "bb0000000000000000")]
+        internal static void ReadMap_NonCanonicalLengths_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadStartMap());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "a3010102020303")]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.Null(length);
         }
 
@@ -103,9 +103,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.NotNull(length);
-            Assert.Equal(0u, length!.Value);
+            Assert.Equal(0, length!.Value);
             reader.ReadEndMap();
         }
 
@@ -259,7 +259,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < expectedLength; i++)
@@ -281,7 +281,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < expectedLength; i++)
@@ -289,7 +289,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 reader.ReadInt64(); // key
 
                 // value
-                ulong? nestedLength = reader.ReadStartMap();
+                int? nestedLength = reader.ReadStartMap();
                 Assert.Equal(1, (int)nestedLength!.Value);
                 reader.ReadInt64();
                 reader.ReadInt64();
@@ -309,8 +309,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartMap();
-            Assert.Equal(expectedLength, (int)length!.Value);
+            int? length = reader.ReadStartMap();
+            Assert.Equal(expectedLength, length!.Value);
 
             for (int i = 1; i < expectedLength; i++)
             {
@@ -331,15 +331,15 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 1; i < expectedLength; i++)
             {
                 reader.ReadInt64(); // key
 
-                ulong? nestedLength = reader.ReadStartMap();
-                Assert.Equal(1, (int)nestedLength!.Value);
+                int? nestedLength = reader.ReadStartMap();
+                Assert.Equal(1, nestedLength!.Value);
                 reader.ReadInt64();
                 reader.ReadInt64();
                 reader.ReadEndMap();
@@ -376,7 +376,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < actualLength; i++)
@@ -459,15 +459,15 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            uint? length = reader.ReadStartMap();
+            int? length = reader.ReadStartMap();
             Assert.Equal(expectedLength, (int)length!.Value);
 
             for (int i = 0; i < actualLength; i++)
             {
                 reader.ReadInt64(); // key
 
-                ulong? innerLength = reader.ReadStartArray();
-                Assert.Equal(1, (int)innerLength!.Value);
+                int? innerLength = reader.ReadStartArray();
+                Assert.Equal(1, innerLength!.Value);
                 reader.ReadInt64();
                 reader.ReadEndArray();
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -154,10 +154,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, "a", 0, 256, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a4200061610019010000a301010202030300")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 256, 0, -1, 0, "a", 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a4190100002000616100a301010202030300")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0, new object[] { Map, 2, 2, 1, 1 }, 0 }, "a52000a30303020201010061610019010000a20202010100")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0, new object[] { Map, 2, 2, 1, 1 }, 0 }, "a52000a30303020201010061610019010000a20202010100")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, "a", 0, 256, 0, new object[] { Map, 1, 1, 2, 2 }, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a5200061610019010000a20101020200a301010202030300")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 256, 0, -1, 0, "a", 0, new object[] { Map, 1, 1, 2, 2 }, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a5190100002000616100a20101020200a301010202030300")]
         internal static void ReadMap_NestedValues_ShouldAcceptKeysSortedAccordingToConformanceLevel(CborConformanceLevel level, object expectedValue, string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -191,7 +191,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             reader.ReadStartMap();
             Helpers.VerifyValue(reader, dupeKey);
             reader.ReadInt32();
+
+            int bytesRead = reader.BytesRead;
+            int bytesRemaining = reader.BytesRemaining;
+            CborReaderState state = reader.PeekState();
+
             Assert.Throws<FormatException>(() => Helpers.VerifyValue(reader, dupeKey));
+
+            // ensure reader state is preserved
+            Assert.Equal(bytesRead, reader.BytesRead);
+            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(state, reader.PeekState());
         }
 
         [Theory]
@@ -227,8 +237,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 reader.ReadInt32(); // value is always an integer
             }
 
+            int bytesRead = reader.BytesRead;
+            int bytesRemaining = reader.BytesRemaining;
+            CborReaderState state = reader.PeekState();
+
             // the final element violates sorting invariant
             Assert.Throws<FormatException>(() => Helpers.VerifyValue(reader, keySequence.Last()));
+
+            // ensure reader state is preserved
+            Assert.Equal(bytesRead, reader.BytesRead);
+            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(state, reader.PeekState());
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -69,22 +69,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "a3010102020303")]
         // indefinite length string payload
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new string[] { "c", "" }, 0 }, "a5010002006161006162007f616360ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new string[] { "c", "" }, 0 }, "a5010002006161006162007f616360ff00")]
         // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "z", 0, "aa", 0 }, "a2617a0062616100")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "z", 0, "aa", 0 }, "a2617a0062616100")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 255, 0, "", 0 }, "a218ff006000")]
@@ -96,7 +96,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, "a", 0, 256, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a4200061610019010000a301010202030300")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 256, 0, -1, 0, "a", 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a4190100002000616100a301010202030300")]
@@ -108,22 +108,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "bf010102020303ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "bf010102020303ff")]
         // indefinite length string payload
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new string[] { "c", "" }, 0 }, "bf010002006161006162007f616360ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new string[] { "c", "" }, 0 }, "bf010002006161006162007f616360ff00ff")]
         // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "z", 0, "aa", 0 }, "bf617a0062616100ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "z", 0, "aa", 0 }, "bf617a0062616100ff")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 255, 0, "", 0 }, "bf18ff006000ff")]
@@ -135,7 +135,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, "a", 0, 256, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "bf200061610019010000bf010102020303ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 256, 0, -1, 0, "a", 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "bf190100002000616100bf010102020303ff00ff")]
@@ -176,9 +176,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { 1, 2, 3, 0 }, "a40101020203030000")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { 1, 2, 3, 0 }, "a40101020203030000")]
         [InlineData(CborConformanceLevel.Strict, new object[] { 1, 2, 3, 0 }, "a40101020203030000")]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { 1, "", 25, "a", 2 }, "a5010060001819006161000200")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { 1, "", 25, "a", 2 }, "a5010060001819006161000200")]
         [InlineData(CborConformanceLevel.Strict, new object[] { 1, 25, "", "a", 2 }, "a5010018190060006161000200")]
         internal static void ReadMap_UnsortedKeys_ConformanceNotRequiringSortedKeys_ShouldSucceed(CborConformanceLevel level, object[] keySequence, string hexEncoding)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -140,6 +140,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }.Select(l => new object[] { l.Level, l.Encoding });
 
         [Fact]
+        internal static void SkipValue_SkippedValueFollowedByNonConformingValue_ShouldThrowFormatException()
+        {
+            byte[] encoding = "827fff7fff".HexToByteArray();
+            var reader = new CborReader(encoding, CborConformanceLevel.Ctap2Canonical);
+
+            reader.ReadStartArray();
+            reader.SkipValue();
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
+        }
+
+        [Fact]
         public static void SkipValue_NestedFormatException_ShouldPreserveOriginalReaderState()
         {
             string hexEncoding = "820181bf01ff"; // [1, [ {_ 1 : <missing value> } ]]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -296,6 +296,76 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.Lax, "5800")]
+        [InlineData(CborConformanceLevel.Lax, "590000")]
+        [InlineData(CborConformanceLevel.Lax, "5a00000000")]
+        [InlineData(CborConformanceLevel.Lax, "5b0000000000000000")]
+        [InlineData(CborConformanceLevel.Strict, "5800")]
+        [InlineData(CborConformanceLevel.Strict, "590000")]
+        [InlineData(CborConformanceLevel.Strict, "5a00000000")]
+        [InlineData(CborConformanceLevel.Strict, "5b0000000000000000")]
+        internal static void ReadByteString_NonCanonicalLengths_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            byte[] value = reader.ReadByteString();
+            Assert.Equal(Array.Empty<byte>(), value);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5800")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "590000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5a00000000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5b0000000000000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "5800")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "590000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "5a00000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "5b0000000000000000")]
+        internal static void ReadByteString_NonCanonicalLengths_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadByteString());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax, "7800")]
+        [InlineData(CborConformanceLevel.Lax, "790000")]
+        [InlineData(CborConformanceLevel.Lax, "7a00000000")]
+        [InlineData(CborConformanceLevel.Lax, "7b0000000000000000")]
+        [InlineData(CborConformanceLevel.Strict, "7800")]
+        [InlineData(CborConformanceLevel.Strict, "790000")]
+        [InlineData(CborConformanceLevel.Strict, "7a00000000")]
+        [InlineData(CborConformanceLevel.Strict, "7b0000000000000000")]
+        internal static void ReadTextString_NonCanonicalLengths_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            string value = reader.ReadTextString();
+            Assert.Equal("", value);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7800")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "790000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7a00000000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7b0000000000000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "7800")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "790000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "7a00000000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "7b0000000000000000")]
+        internal static void ReadTextString_NonCanonicalLengths_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
         [InlineData("00")] // 0
         [InlineData("20")] // -1
         [InlineData("60")] // empty text string

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -366,6 +366,94 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.Lax, "5f40ff")]
+        [InlineData(CborConformanceLevel.Strict, "5f40ff")]
+        internal static void ReadByteString_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            reader.ReadStartByteStringIndefiniteLength();
+            reader.ReadByteString();
+            reader.ReadEndByteStringIndefiniteLength();
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax, "5f40ff")]
+        [InlineData(CborConformanceLevel.Strict, "5f40ff")]
+        internal static void ReadByteString_IndefiniteLength_AsSingleItem_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            reader.ReadByteString();
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5f40ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "5f40ff")]
+        internal static void ReadByteString_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatExceptoin(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadStartByteStringIndefiniteLength());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5f40ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "5f40ff")]
+        internal static void ReadByteString_IndefiniteLength_AsSingleItem_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadByteString());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax, "7f60ff")]
+        [InlineData(CborConformanceLevel.Strict, "7f60ff")]
+        internal static void ReadTextString_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            reader.ReadStartTextStringIndefiniteLength();
+            reader.ReadTextString();
+            reader.ReadEndTextStringIndefiniteLength();
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax, "7f60ff")]
+        [InlineData(CborConformanceLevel.Strict, "7f60ff")]
+        internal static void ReadTextString_IndefiniteLength_AsSingleItem_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            reader.ReadTextString();
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7f60ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "7f60ff")]
+        internal static void ReadTextString_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatExceptoin(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadStartTextStringIndefiniteLength());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7f60ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "7f60ff")]
+        internal static void ReadTextString_IndefiniteLength_AsSingleItem_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, level);
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
+            Assert.Equal(0, reader.BytesRead);
+        }
+
+        [Theory]
         [InlineData("00")] // 0
         [InlineData("20")] // -1
         [InlineData("60")] // empty text string

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -116,6 +116,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(encoding.Length, reader.BytesRemaining);
         }
 
+        [Theory]
+        [InlineData((CborConformanceLevel)(-1))]
+        internal static void InvalidConformanceLevel_ShouldThrowArgumentOutOfRangeException(CborConformanceLevel level)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborReader(Array.Empty<byte>(), conformanceLevel: level));
+        }
+
         public static IEnumerable<object[]> EncodedValueInputs => CborReaderTests.SampleCborValues.Select(x => new[] { x });
         public static IEnumerable<object[]> EncodedValueInvalidInputs => CborReaderTests.InvalidCborValues.Select(x => new[] { x });
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -51,6 +51,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(0, reader.BytesRemaining);
         }
 
+        [Fact]
+        public static void ConformanceLevel_DefaultValue_ShouldEqualLax()
+        {
+            var reader = new CborReader(Array.Empty<byte>());
+            Assert.Equal(CborConformanceLevel.Lax, reader.ConformanceLevel);
+        }
+
         [Theory]
         [InlineData(CborMajorType.UnsignedInteger, CborReaderState.UnsignedInteger)]
         [InlineData(CborMajorType.NegativeInteger, CborReaderState.NegativeInteger)]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -75,16 +75,66 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Fact]
-        public static void CborReader_ReadingTwoPrimitiveValues_ShouldThrowInvalidOperationException()
+        public static void Read_EmptyBuffer_ShouldThrowFormatException()
+        {
+            var reader = new CborReader(ReadOnlyMemory<byte>.Empty);
+            Assert.Throws<FormatException>(() => reader.ReadInt64());
+        }
+
+        [Fact]
+        public static void Read_BeyondEndOfFirstValue_ShouldThrowInvalidOperationException()
+        {
+            var reader = new CborReader("01".HexToByteArray());
+            reader.ReadInt64();
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
+        }
+
+        [Fact]
+        public static void CborReader_ReadingTwoRootLevelValues_ShouldThrowInvalidOperationException()
         {
             ReadOnlyMemory<byte> buffer = new byte[] { 0, 0 };
             var reader = new CborReader(buffer);
             reader.ReadInt64();
-            Assert.Equal(CborReaderState.Finished, reader.PeekState());
 
             int bytesRemaining = reader.BytesRemaining;
+            Assert.Equal(CborReaderState.FinishedWithTrailingBytes, reader.PeekState());
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
             Assert.Equal(bytesRemaining, reader.BytesRemaining);
+        }
+
+        [Theory]
+        [InlineData(1, 2, "0101")]
+        [InlineData(10, 10, "0a0a0a0a0a0a0a0a0a0a")]
+        [InlineData(new object[] { 1, 2 }, 3, "820102820102820102")]
+        public static void CborReader_MultipleRootValuesAllowed_ReadingMultipleValues_HappyPath(object expectedValue, int repetitions, string hexEncoding)
+        {
+            var reader = new CborReader(hexEncoding.HexToByteArray(), allowMultipleRootLevelValues: true);
+
+            for (int i = 0; i < repetitions; i++)
+            {
+                Helpers.VerifyValue(reader, expectedValue);
+            }
+
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Fact]
+        public static void CborReader_MultipleRootValuesAllowed_ReadingBeyondEndOfBuffer_ShouldThrowInvalidOperationException()
+        {
+            string hexEncoding = "810102";
+            var reader = new CborReader(hexEncoding.HexToByteArray(), allowMultipleRootLevelValues: true);
+
+            Assert.Equal(CborReaderState.StartArray, reader.PeekState());
+            reader.ReadStartArray();
+            reader.ReadInt32();
+            reader.ReadEndArray();
+
+            Assert.Equal(CborReaderState.UnsignedInteger, reader.PeekState());
+            reader.ReadInt32();
+
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborRoundtripTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborRoundtripTests.cs
@@ -58,7 +58,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter();
             writer.WriteInt64(input);
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
 
             var reader = new CborReader(encoding);
             long result = reader.ReadInt64();
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter();
             writer.WriteUInt64(input);
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
 
             var reader = new CborReader(encoding);
             ulong result = reader.ReadUInt64();
@@ -115,7 +115,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 #endif
             using var writer = new CborWriter();
             writer.WriteByteString(input);
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
 
             var reader = new CborReader(encoding);
             byte[] result = reader.ReadByteString();
@@ -139,7 +139,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter();
             writer.WriteTextString(input);
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
 
             var reader = new CborReader(encoding);
             string result = reader.ReadTextString();
@@ -162,7 +162,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 #endif
             using var writer = new CborWriter();
             writer.WriteByteString(input);
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
 
             int length = input?.Length ?? 0;
             int lengthEncodingLength = GetLengthEncodingLength(length);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -52,11 +52,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "9f0120604107ff")]
         [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "9f656c6f72656d65697073756d65646f6c6f72ff")]
         [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "9ff4f6faffc00000fb7ff0000000000000ff")]
-        public static void WriteArray_IndefiniteLength_HappyPath(object[] values, string expectedHexEncoding)
+        public static void WriteArray_IndefiniteLength_NoPatching_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -67,11 +67,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new object[] { new object[] { } }, "9f9fffff")]
         [InlineData(new object[] { 1, new object[] { 2, 3 }, new object[] { 4, 5 } }, "9f019f0203ff9f0405ffff")]
         [InlineData(new object[] { "", new object[] { new object[] { }, new object[] { 1, new byte[] { 10 } } } }, "9f609f9fff9f01410affffff")]
-        public static void WriteArray_IndefiniteLength_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
+        public static void WriteArray_IndefiniteLength_NoPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -86,11 +86,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "840120604107")]
         [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "83656c6f72656d65697073756d65646f6c6f72")]
         [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "84f4f6faffc00000fb7ff0000000000000")]
-        public static void WriteArray_IndefiniteLengthWithPatching_HappyPath(object[] values, string expectedHexEncoding)
+        public static void WriteArray_IndefiniteLength_WithPatching_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter(patchIndefiniteLengthItems: true);
+            using var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -101,11 +101,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new object[] { new object[] { } }, "8180")]
         [InlineData(new object[] { 1, new object[] { 2, 3 }, new object[] { 4, 5 } }, "8301820203820405")]
         [InlineData(new object[] { "", new object[] { new object[] { }, new object[] { 1, new byte[] { 10 } } } }, "826082808201410a")]
-        public static void WriteArray_IndefiniteLengthWithPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
+        public static void WriteArray_IndefiniteLength_WithPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter(patchIndefiniteLengthItems: true);
+            using var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -219,24 +219,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             writer.WriteStartMap(definiteLength: 0);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndArray());
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
-        [InlineData(CborConformanceLevel.Ctap2Canonical)]
-        internal static void WriteArray_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
-        {
-            using var writer = new CborWriter(level);
-            Assert.Throws<InvalidOperationException>(() => writer.WriteStartArrayIndefiniteLength());
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Lax)]
-        [InlineData(CborConformanceLevel.Strict)]
-        internal static void WriteArray_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
-        {
-            using var writer = new CborWriter(level);
-            writer.WriteStartArrayIndefiniteLength();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -79,6 +79,40 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(new object[] { }, "80")]
+        [InlineData(new object[] { 42 }, "81182a")]
+        [InlineData(new object[] { 1, 2, 3 }, "83010203")]
+        [InlineData(new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }, "98190102030405060708090a0b0c0d0e0f101112131415161718181819")]
+        [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "840120604107")]
+        [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "83656c6f72656d65697073756d65646f6c6f72")]
+        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "84f4f6faffc00000fb7ff0000000000000")]
+        public static void WriteArray_IndefiniteLengthWithPatching_HappyPath(object[] values, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+
+            using var writer = new CborWriter(patchIndefiniteLengthItems: true);
+            Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
+
+            byte[] actualEncoding = writer.GetEncoding();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(new object[] { new object[] { } }, "8180")]
+        [InlineData(new object[] { 1, new object[] { 2, 3 }, new object[] { 4, 5 } }, "8301820203820405")]
+        [InlineData(new object[] { "", new object[] { new object[] { }, new object[] { 1, new byte[] { 10 } } } }, "826082808201410a")]
+        public static void WriteArray_IndefiniteLengthWithPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+
+            using var writer = new CborWriter(patchIndefiniteLengthItems: true);
+            Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
+
+            byte[] actualEncoding = writer.GetEncoding();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -186,5 +186,23 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             writer.WriteStartMap(definiteLength: 0);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndArray());
         }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        internal static void WriteArray_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartArrayIndefiniteLength());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax)]
+        [InlineData(CborConformanceLevel.Strict)]
+        internal static void WriteArray_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            writer.WriteStartArrayIndefiniteLength();
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteArray(writer, values);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteArray(writer, values);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Helpers.cs
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
                 else
                 {
-                    writer.WriteStartArrayIndefiniteLength();
+                    writer.WriteStartArray();
                 }
 
                 foreach (object value in values)
@@ -116,7 +116,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
                 else
                 {
-                    writer.WriteStartMapIndefiniteLength();
+                    writer.WriteStartMap();
                 }
 
                 foreach (object value in keyValuePairs.Skip(1))
@@ -129,22 +129,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public static void WriteChunkedByteString(CborWriter writer, byte[][] chunks)
             {
-                writer.WriteStartByteStringIndefiniteLength();
+                writer.WriteStartByteString();
                 foreach (byte[] chunk in chunks)
                 {
                     writer.WriteByteString(chunk);
                 }
-                writer.WriteEndByteStringIndefiniteLength();
+                writer.WriteEndByteString();
             }
 
             public static void WriteChunkedTextString(CborWriter writer, string[] chunks)
             {
-                writer.WriteStartTextStringIndefiniteLength();
+                writer.WriteStartTextString();
                 foreach (string chunk in chunks)
                 {
                     writer.WriteTextString(chunk);
                 }
-                writer.WriteEndTextStringIndefiniteLength();
+                writer.WriteEndTextString();
             }
 
             public static void ExecOperation(CborWriter writer, string op)
@@ -154,12 +154,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     case nameof(writer.WriteInt64): writer.WriteInt64(42); break;
                     case nameof(writer.WriteByteString): writer.WriteByteString(Array.Empty<byte>()); break;
                     case nameof(writer.WriteTextString): writer.WriteTextString(""); break;
-                    case nameof(writer.WriteStartTextStringIndefiniteLength): writer.WriteStartTextStringIndefiniteLength(); break;
-                    case nameof(writer.WriteStartByteStringIndefiniteLength): writer.WriteStartByteStringIndefiniteLength(); break;
-                    case nameof(writer.WriteStartArray): writer.WriteStartArrayIndefiniteLength(); break;
-                    case nameof(writer.WriteStartMap): writer.WriteStartMapIndefiniteLength(); break;
-                    case nameof(writer.WriteEndByteStringIndefiniteLength): writer.WriteEndByteStringIndefiniteLength(); break;
-                    case nameof(writer.WriteEndTextStringIndefiniteLength): writer.WriteEndTextStringIndefiniteLength(); break;
+                    case nameof(writer.WriteStartTextString): writer.WriteStartTextString(); break;
+                    case nameof(writer.WriteStartByteString): writer.WriteStartByteString(); break;
+                    case nameof(writer.WriteStartArray): writer.WriteStartArray(); break;
+                    case nameof(writer.WriteStartMap): writer.WriteStartMap(); break;
+                    case nameof(writer.WriteEndByteString): writer.WriteEndByteString(); break;
+                    case nameof(writer.WriteEndTextString): writer.WriteEndTextString(); break;
                     case nameof(writer.WriteEndArray): writer.WriteEndArray(); break;
                     case nameof(writer.WriteEndMap): writer.WriteEndMap(); break;
                     default: throw new Exception($"Unrecognized CborWriter operation name {op}");

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Integer.cs
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteInt64(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteInt32(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -107,7 +107,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteUInt64(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -131,7 +131,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteUInt32(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteCborNegativeIntegerEncoding(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
     }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -86,19 +86,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         // indefinite length string payload
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
         // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "a218ff006000")]
         internal static void WriteMap_SimpleValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
@@ -111,7 +111,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4200061610019010000a301010202030300")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4190100002000616100a301010202030300")]
         internal static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
@@ -124,19 +124,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
         // indefinite length string payload
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
         // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "bf18ff006000ff")]
         internal static void WriteMap_SimpleValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
+        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf200061610019010000bf010102020303ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf190100002000616100bf010102020303ff00ff")]
         internal static void WriteMap_NestedValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -90,11 +90,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
-        // indefinite length string payload
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
+        // nested array payload
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5616200020061610082616360000100")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5616200020061610082616360000100")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162008261636000")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162008261636000")]
         // CBOR sorting rules do not match canonical string sorting
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
@@ -129,49 +129,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
-        // indefinite length string payload
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
-        // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
-        // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "bf18ff006000ff")]
-        internal static void WriteMap_SimpleValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
-        {
-            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(level);
-            Helpers.WriteValue(writer, value, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.ToArray();
-            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf200061610019010000bf010102020303ff00ff")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf190100002000616100bf010102020303ff00ff")]
-        internal static void WriteMap_NestedValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
-        {
-            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(level);
-            Helpers.WriteValue(writer, value, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.ToArray();
-            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
-        }
-
-        [Theory]
         [InlineData(new object[] { Map, "a", 1, "a", 2 }, "a2616101616102")]
         public static void WriteMap_DuplicateKeys_ShouldSucceed(object[] values, string expectedHexEncoding)
         {
@@ -189,9 +146,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(CborConformanceLevel.Strict, "foobar")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, "foobar")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "foobar")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { new string[] { "x", "y" } })]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new string[] { "x", "y" } })]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new string[] { "x", "y" } })]
+        [InlineData(CborConformanceLevel.Strict, new object[] { new object[] { "x", "y" } })]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new object[] { "x", "y" } })]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new object[] { "x", "y" } })]
         internal static void WriteMap_DuplicateKeys_StrictConformance_ShouldFail(CborConformanceLevel level, object dupeKey)
         {
             using var writer = new CborWriter(level);
@@ -341,6 +298,24 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             writer.WriteStartArray(definiteLength: 0);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndMap());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        internal static void WriteMap_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartMapIndefiniteLength());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax)]
+        [InlineData(CborConformanceLevel.Strict)]
+        internal static void WriteMap_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            writer.WriteStartMapIndefiniteLength();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -110,7 +110,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -125,7 +125,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
-            byte[] actualEncoding = writer.ToArray();
+            byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -192,7 +192,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 writer.WriteInt32(0);
                 writer.WriteEndMap();
 
-                return writer.ToArray();
+                return writer.GetEncoding();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -115,12 +115,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
-        [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4200061610019010000a301010202030300")]
-        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4190100002000616100a301010202030300")]
-        internal static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
+        [InlineData("a42000a30303020201010061610019010000", CborConformanceLevel.Lax)]
+        [InlineData("a42000a30303020201010061610019010000", CborConformanceLevel.Strict)]
+        [InlineData("a4200061610019010000a301010202030300", CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData("a4190100002000616100a301010202030300", CborConformanceLevel.Ctap2Canonical)]
+        internal static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(string expectedHexEncoding, CborConformanceLevel level)
         {
+            object[] value = new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 };
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -321,7 +321,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public static void EndWriteMap_IndefiniteLength_OddItems_ShouldThrowInvalidOperationException(int length)
         {
             using var writer = new CborWriter();
-            writer.WriteStartMapIndefiniteLength();
+            writer.WriteStartMap();
 
             for (int i = 1; i < length; i++)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -87,18 +87,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         [Theory]
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         // indefinite length string payload
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
         // CBOR sorting rules do not match canonical string sorting
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "a218ff006000")]
         internal static void WriteMap_SimpleValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
@@ -112,6 +116,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         [Theory]
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4200061610019010000a301010202030300")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4190100002000616100a301010202030300")]
         internal static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -125,18 +125,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         [Theory]
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
         // indefinite length string payload
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
         // CBOR sorting rules do not match canonical string sorting
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "bf18ff006000ff")]
         internal static void WriteMap_SimpleValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
@@ -150,6 +154,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         [Theory]
         [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf200061610019010000bf010102020303ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf190100002000616100bf010102020303ff00ff")]
         internal static void WriteMap_NestedValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
@@ -173,10 +178,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.Strict, 42)]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, 42)]
         [InlineData(CborConformanceLevel.Ctap2Canonical, 42)]
+        [InlineData(CborConformanceLevel.Strict, "foobar")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, "foobar")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "foobar")]
+        [InlineData(CborConformanceLevel.Strict, new object[] { new string[] { "x", "y" } })]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new string[] { "x", "y" } })]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new string[] { "x", "y" } })]
         internal static void WriteMap_DuplicateKeys_StrictConformance_ShouldFail(CborConformanceLevel level, object dupeKey)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -86,6 +86,82 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
+        // indefinite length string payload
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
+        // CBOR sorting rules do not match canonical string sorting
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
+        // Test case distinguishing between RFC7049 and CTAP2 sorting rules
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "a218ff006000")]
+        internal static void WriteMap_SimpleValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            using var writer = new CborWriter(level);
+            Helpers.WriteValue(writer, value);
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4200061610019010000a301010202030300")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4190100002000616100a301010202030300")]
+        internal static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            using var writer = new CborWriter(level);
+            Helpers.WriteValue(writer, value);
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
+        // indefinite length string payload
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
+        // CBOR sorting rules do not match canonical string sorting
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
+        // Test case distinguishing between RFC7049 and CTAP2 sorting rules
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "bf18ff006000ff")]
+        internal static void WriteMap_SimpleValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            using var writer = new CborWriter(level);
+            Helpers.WriteValue(writer, value, useDefiniteLengthCollections: false);
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.NoConformance, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf200061610019010000bf010102020303ff00ff")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf190100002000616100bf010102020303ff00ff")]
+        internal static void WriteMap_NestedValues_IndefiniteLength_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            using var writer = new CborWriter(level);
+            Helpers.WriteValue(writer, value, useDefiniteLengthCollections: false);
+            byte[] actualEncoding = writer.ToArray();
+            AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
         [InlineData(new object[] { Map, "a", 1, "a", 2 }, "a2616101616102")]
         public static void WriteMap_DuplicateKeys_ShouldSucceed(object[] values, string expectedHexEncoding)
         {
@@ -94,6 +170,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Helpers.WriteMap(writer, values);
             byte[] actualEncoding = writer.ToArray();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, 42)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, 42)]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, "foobar")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "foobar")]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new string[] { "x", "y" } })]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new string[] { "x", "y" } })]
+        internal static void WriteMap_DuplicateKeys_StrictConformance_ShouldFail(CborConformanceLevel level, object dupeKey)
+        {
+            using var writer = new CborWriter(level);
+            writer.WriteStartMap(2);
+            Helpers.WriteValue(writer, dupeKey);
+            writer.WriteInt32(0);
+            Assert.Throws<InvalidOperationException>(() => Helpers.WriteValue(writer, dupeKey));
         }
 
         [Theory]
@@ -176,7 +268,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(0)]
         [InlineData(3)]
         [InlineData(10)]
-        public static void EndWriteMap_IndefiniteLength_EvenItems_ShouldThrowInvalidOperationException(int length)
+        public static void EndWriteMap_IndefiniteLength_OddItems_ShouldThrowInvalidOperationException(int length)
         {
             using var writer = new CborWriter();
             writer.WriteStartMapIndefiniteLength();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -157,13 +157,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData("a42000a30303020201010061610019010000", CborConformanceLevel.Lax)]
-        [InlineData("a42000a30303020201010061610019010000", CborConformanceLevel.Strict)]
-        [InlineData("a4200061610019010000a301010202030300", CborConformanceLevel.Rfc7049Canonical)]
-        [InlineData("a4190100002000616100a301010202030300", CborConformanceLevel.Ctap2Canonical)]
+        [InlineData("a52000a30303020201010061610019010000a20202010100", CborConformanceLevel.Lax)]
+        [InlineData("a52000a30303020201010061610019010000a20202010100", CborConformanceLevel.Strict)]
+        [InlineData("a5200061610019010000a20101020200a301010202030300", CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData("a5190100002000616100a20101020200a301010202030300", CborConformanceLevel.Ctap2Canonical)]
         internal static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(string expectedHexEncoding, CborConformanceLevel level)
         {
-            object[] value = new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 };
+            object[] value = new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0, new object[] { Map, 2, 2, 1, 1 }, 0 };
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             using var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -86,22 +86,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         // indefinite length string payload
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a561620002006161007f616360ff000100")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162007f616360ff00")]
         // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "a218ff006000")]
@@ -115,7 +115,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a42000a30303020201010061610019010000")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4200061610019010000a301010202030300")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "a4190100002000616100a301010202030300")]
@@ -129,22 +129,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf030302020101ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "bf010102020303ff")]
         // indefinite length string payload
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf61620002006161007f616360ff000100ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new string[] { "c", "" }, 0, 1, 0 }, "bf010002006161006162007f616360ff00ff")]
         // CBOR sorting rules do not match canonical string sorting
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "bf62616100617a00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "bf617a0062616100ff")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "bf600018ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "bf18ff006000ff")]
@@ -158,7 +158,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.NonStrict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
+        [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf2000bf030302020101ff0061610019010000ff")]
         [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf200061610019010000bf010102020303ff00ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0 }, "bf190100002000616100bf010102020303ff00ff")]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteSingle(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteDouble(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = "f6".HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteNull();
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteBoolean(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteSimpleValue(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] input = hexInput.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteByteString(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             using var writer = new CborWriter();
             Helpers.WriteChunkedByteString(writer, chunkInputs);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             writer.WriteTextString(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             using var writer = new CborWriter();
             Helpers.WriteChunkedTextString(writer, chunkInputs);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -32,12 +32,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new string[] { "" }, "5f40ff")]
         [InlineData(new string[] { "ab", "" }, "5f41ab40ff")]
         [InlineData(new string[] { "ab", "bc", "" }, "5f41ab41bc40ff")]
-        public static void WriteByteString_IndefiniteLength_SingleValue_HappyPath(string[] hexChunkInputs, string hexExpectedEncoding)
+        public static void WriteByteString_IndefiniteLength_NoPatching_SingleValue_HappyPath(string[] hexChunkInputs, string hexExpectedEncoding)
         {
             byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
 
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteChunkedByteString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
 
-            using var writer = new CborWriter(patchIndefiniteLengthItems: true);
+            using var writer = new CborWriter();
             Helpers.WriteChunkedByteString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -78,10 +78,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new string[] { "" }, "7f60ff")]
         [InlineData(new string[] { "ab", "" }, "7f62616260ff")]
         [InlineData(new string[] { "ab", "bc", "" }, "7f62616262626360ff")]
-        public static void WriteTextString_IndefiniteLength_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
+        public static void WriteTextString_IndefiniteLength_NoPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -91,10 +91,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [InlineData(new string[] { "" }, "60")]
         [InlineData(new string[] { "ab", "" }, "626162")]
         [InlineData(new string[] { "ab", "bc", "" }, "6461626263")]
-        public static void WriteTextString_IndefiniteLengthWithPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
+        public static void WriteTextString_IndefiniteLength_WithPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter(patchIndefiniteLengthItems: true);
+            using var writer = new CborWriter(encodeIndefiniteLengths: false);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -161,42 +161,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             writer.WriteStartByteStringIndefiniteLength();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
-        [InlineData(CborConformanceLevel.Ctap2Canonical)]
-        internal static void WriteTextString_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
-        {
-            using var writer = new CborWriter(level);
-            Assert.Throws<InvalidOperationException>(() => writer.WriteStartTextStringIndefiniteLength());
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Lax)]
-        [InlineData(CborConformanceLevel.Strict)]
-        internal static void WriteTextString_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
-        {
-            using var writer = new CborWriter(level);
-            writer.WriteStartTextStringIndefiniteLength();
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
-        [InlineData(CborConformanceLevel.Ctap2Canonical)]
-        internal static void WriteByteString_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
-        {
-            using var writer = new CborWriter(level);
-            Assert.Throws<InvalidOperationException>(() => writer.WriteStartByteStringIndefiniteLength());
-        }
-
-        [Theory]
-        [InlineData(CborConformanceLevel.Lax)]
-        [InlineData(CborConformanceLevel.Strict)]
-        internal static void WriteByteString_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
-        {
-            using var writer = new CborWriter(level);
-            writer.WriteStartByteStringIndefiniteLength();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -113,53 +113,53 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [Theory]
         [InlineData(nameof(CborWriter.WriteInt64))]
         [InlineData(nameof(CborWriter.WriteByteString))]
-        [InlineData(nameof(CborWriter.WriteStartTextStringIndefiniteLength))]
-        [InlineData(nameof(CborWriter.WriteStartByteStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteStartTextString))]
+        [InlineData(nameof(CborWriter.WriteStartByteString))]
         [InlineData(nameof(CborWriter.WriteStartArray))]
         [InlineData(nameof(CborWriter.WriteStartMap))]
         public static void WriteTextString_IndefiniteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartTextStringIndefiniteLength();
+            writer.WriteStartTextString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
 
         [Theory]
-        [InlineData(nameof(CborWriter.WriteEndByteStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteEndByteString))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteTextString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartTextStringIndefiniteLength();
+            writer.WriteStartTextString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
 
         [Theory]
         [InlineData(nameof(CborWriter.WriteInt64))]
         [InlineData(nameof(CborWriter.WriteTextString))]
-        [InlineData(nameof(CborWriter.WriteStartTextStringIndefiniteLength))]
-        [InlineData(nameof(CborWriter.WriteStartByteStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteStartTextString))]
+        [InlineData(nameof(CborWriter.WriteStartByteString))]
         [InlineData(nameof(CborWriter.WriteStartArray))]
         [InlineData(nameof(CborWriter.WriteStartMap))]
-        [InlineData(nameof(CborWriter.WriteEndTextStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteEndTextString))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteByteString_IndefiniteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartByteStringIndefiniteLength();
+            writer.WriteStartByteString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
 
         [Theory]
-        [InlineData(nameof(CborWriter.WriteEndTextStringIndefiniteLength))]
+        [InlineData(nameof(CborWriter.WriteEndTextString))]
         [InlineData(nameof(CborWriter.WriteEndArray))]
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteByteString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
             using var writer = new CborWriter();
-            writer.WriteStartByteStringIndefiniteLength();
+            writer.WriteStartByteString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -134,5 +134,41 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             writer.WriteStartByteStringIndefiniteLength();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        internal static void WriteTextString_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartTextStringIndefiniteLength());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax)]
+        [InlineData(CborConformanceLevel.Strict)]
+        internal static void WriteTextString_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            writer.WriteStartTextStringIndefiniteLength();
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        internal static void WriteByteString_IndefiniteLength_UnsupportedConformanceLevel_ShouldThrowInvalidOperationException(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartByteStringIndefiniteLength());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Lax)]
+        [InlineData(CborConformanceLevel.Strict)]
+        internal static void WriteByteString_IndefiniteLength_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level)
+        {
+            using var writer = new CborWriter(level);
+            writer.WriteStartByteStringIndefiniteLength();
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -210,7 +210,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             new object[]
             {
                 new object[] { CborTag.MimeMessage, 42 },
-                42m,
+                42.0m,
+                (BigInteger)1,
                 DateTimeOffset.UnixEpoch,
             };
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter();
 
-            writer.WriteStartArrayIndefiniteLength();
+            writer.WriteStartArray();
             writer.WriteTag(CborTag.Uri);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndArray());
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             writer.WriteTag((CborTag)tag);
             Helpers.WriteValue(writer, value);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 writer.WriteTag((CborTag)tag);
             }
             Helpers.WriteValue(writer, value);
-            AssertHelper.HexEqual(expectedEncoding, writer.ToArray());
+            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 writer.WriteTag((CborTag)tag);
             }
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => writer.ToArray());
+            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => writer.GetEncoding());
 
             Assert.Equal("Buffer contains incomplete CBOR document.", exn.Message);
         }
@@ -90,7 +90,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             writer.WriteDateTimeOffset(value);
 
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -105,7 +105,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             writer.WriteUnixTimeSeconds(value);
 
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             writer.WriteUnixTimeSeconds(value);
 
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -155,7 +155,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             using var writer = new CborWriter();
             writer.WriteBigInteger(value);
 
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -175,7 +175,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             decimal value = decimal.Parse(stringValue, Globalization.CultureInfo.InvariantCulture);
             using var writer = new CborWriter();
             writer.WriteDecimal(value);
-            byte[] encoding = writer.ToArray();
+            byte[] encoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -46,6 +46,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Equal(5, writer.BytesWritten);
         }
 
+        [Fact]
+        public static void ConformanceLevel_DefaultValue_ShouldEqualLax()
+        {
+            using var writer = new CborWriter();
+            Assert.Equal(CborConformanceLevel.Lax, writer.ConformanceLevel);
+        }
+
         [Theory]
         [MemberData(nameof(EncodedValueInputs))]
         public static void WriteEncodedValue_RootValue_HappyPath(string hexEncodedValue)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -149,10 +149,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter(encodeIndefiniteLengths: true);
 
-            writer.WriteStartTextStringIndefiniteLength();
+            writer.WriteStartTextString();
             writer.WriteTextString("foo");
             writer.WriteEncodedValue("63626172".HexToByteArray());
-            writer.WriteEndTextStringIndefiniteLength();
+            writer.WriteEndTextString();
 
             byte[] encoding = writer.GetEncoding();
             Assert.Equal("7f63666f6f63626172ff", encoding.ByteArrayToHex().ToLower());
@@ -163,10 +163,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter(encodeIndefiniteLengths: true);
 
-            writer.WriteStartByteStringIndefiniteLength();
+            writer.WriteStartByteString();
             writer.WriteByteString(new byte[] { 1, 1, 1 });
             writer.WriteEncodedValue("43020202".HexToByteArray());
-            writer.WriteEndByteStringIndefiniteLength();
+            writer.WriteEndByteString();
 
             byte[] encoding = writer.GetEncoding();
             Assert.Equal("5f4301010143020202ff", encoding.ByteArrayToHex().ToLower());
@@ -176,7 +176,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public static void WriteEncodedValue_BadIndefiniteLengthStringValue_ShouldThrowInvalidOperationException()
         {
             using var writer = new CborWriter();
-            writer.WriteStartTextStringIndefiniteLength();
+            writer.WriteStartTextString();
             Assert.Throws<InvalidOperationException>(() => writer.WriteEncodedValue(new byte[] { 0x01 }));
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -156,6 +156,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             Assert.Throws<ArgumentException>(() => writer.WriteEncodedValue(new byte[] { 0x01, 0x01 }));
         }
 
+        [Theory]
+        [InlineData((CborConformanceLevel)(-1))]
+        internal static void InvalidConformanceLevel_ShouldThrowArgumentOutOfRangeException(CborConformanceLevel level)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new CborWriter(conformanceLevel: level));
+        }
+
         public static IEnumerable<object[]> EncodedValueInputs => CborReaderTests.SampleCborValues.Select(x => new [] { x });
         public static IEnumerable<object[]> EncodedValueBadInputs => CborReaderTests.InvalidCborValues.Select(x => new[] { x });
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         [Fact]
-        public static void ToArray_OnInCompleteValue_ShouldThrowInvalidOperationExceptoin()
+        public static void GetEncoding_OnInCompleteValue_ShouldThrowInvalidOperationExceptoin()
         {
             using var writer = new CborWriter();
             Assert.Throws<InvalidOperationException>(() => writer.GetEncoding());
@@ -34,7 +34,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             using var writer = new CborWriter();
             writer.WriteInt64(42);
+            int bytesWritten = writer.BytesWritten;
             Assert.Throws<InvalidOperationException>(() => writer.WriteTextString("lorem ipsum"));
+            Assert.Equal(bytesWritten, writer.BytesWritten);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public static void WriteEncodedValue_ContextScenaria_HappyPath(object value, bool useDefiniteLength, string hexExpectedEncoding)
         {
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: !useDefiniteLength);
 
             Helpers.WriteValue(writer, value, useDefiniteLengthCollections: useDefiniteLength);
 
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [Fact]
         public static void WriteEncodedValue_IndefiniteLengthTextString_HappyPath()
         {
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: true);
 
             writer.WriteStartTextStringIndefiniteLength();
             writer.WriteTextString("foo");
@@ -161,7 +161,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         [Fact]
         public static void WriteEncodedValue_IndefiniteLengthByteString_HappyPath()
         {
-            using var writer = new CborWriter();
+            using var writer = new CborWriter(encodeIndefiniteLengths: true);
 
             writer.WriteStartByteStringIndefiniteLength();
             writer.WriteByteString(new byte[] { 1, 1, 1 });
@@ -209,6 +209,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         internal static void InvalidConformanceLevel_ShouldThrowArgumentOutOfRangeException(CborConformanceLevel level)
         {
             Assert.Throws<ArgumentOutOfRangeException>(() => new CborWriter(conformanceLevel: level));
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        internal static void EncodeIndefiniteLengths_UnsupportedConformanceLevel_ShouldThrowArgumentException(CborConformanceLevel level)
+        {
+            Assert.Throws<ArgumentException>(() => new CborWriter(level, encodeIndefiniteLengths: true));
         }
 
         public static IEnumerable<object[]> EncodedValueInputs => CborReaderTests.SampleCborValues.Select(x => new [] { x });

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -18,7 +18,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     {
         public static void Validate(CborConformanceLevel conformanceLevel)
         {
-            if (!Enum.IsDefined(typeof(CborConformanceLevel), conformanceLevel))
+            if (conformanceLevel < CborConformanceLevel.Lax ||
+                conformanceLevel > CborConformanceLevel.Ctap2Canonical)
             {
                 throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
@@ -34,23 +33,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     return false;
 
                 case CborConformanceLevel.Rfc7049Canonical:
-                case CborConformanceLevel.Ctap2Canonical:
-                    return true;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
-            };
-        }
-
-        public static bool RequiresPreservedFloatRepresentation(CborConformanceLevel conformanceLevel)
-        {
-            switch (conformanceLevel)
-            {
-                case CborConformanceLevel.Lax:
-                case CborConformanceLevel.Strict:
-                case CborConformanceLevel.Rfc7049Canonical:
-                    return false;
-
                 case CborConformanceLevel.Ctap2Canonical:
                     return true;
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -17,27 +17,33 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
     internal static class CborConformanceLevelHelpers
     {
+        public static void Validate(CborConformanceLevel conformanceLevel)
+        {
+            if (!Enum.IsDefined(typeof(CborConformanceLevel), conformanceLevel))
+            {
+                throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            }
+        }
+
         public static bool RequiresUniqueKeys(CborConformanceLevel level)
         {
-            return level switch
-            {
-                CborConformanceLevel.Rfc7049Canonical => true,
-                CborConformanceLevel.Ctap2Canonical => true,
-                CborConformanceLevel.Strict => true,
-                CborConformanceLevel.NonStrict => false,
-                _ => false,
-            };
+            return level != CborConformanceLevel.NonStrict;
         }
 
         public static bool RequiresSortedKeys(CborConformanceLevel level)
         {
-            return level switch
+            switch (level)
             {
-                CborConformanceLevel.Rfc7049Canonical => true,
-                CborConformanceLevel.Ctap2Canonical => true,
-                CborConformanceLevel.Strict => false,
-                CborConformanceLevel.NonStrict => false,
-                _ => false,
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.NonStrict:
+                    return false;
+
+                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    return false;
             };
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -109,15 +109,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             };
         }
 
-        public static int CompareEncodings(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right, CborConformanceLevel level)
+        public static int GetKeyEncodingHashCode(ReadOnlySpan<byte> encoding)
+        {
+            return System.Marvin.ComputeHash32(encoding, System.Marvin.DefaultSeed);
+        }
+
+        public static bool AreEqualKeyEncodings(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+        {
+            return left.SequenceEqual(right);
+        }
+
+        public static int CompareKeyEncodings(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right, CborConformanceLevel level)
         {
             Debug.Assert(!left.IsEmpty && !right.IsEmpty);
 
             switch (level)
             {
-                // Strict mode only concerns itself with uniqueness, not sorting.
-                // Any total order for buffers should do.
-                case CborConformanceLevel.Strict:
                 case CborConformanceLevel.Rfc7049Canonical:
                     // Implements key sorting according to
                     // https://tools.ietf.org/html/rfc7049#section-3.9

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal enum CborConformanceLevel
     {
-        NonStrict = 0,
+        Lax = 0,
         Strict = 1,
         Rfc7049Canonical = 2,
         Ctap2Canonical = 3,
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public static bool RequiresUniqueKeys(CborConformanceLevel level)
         {
-            return level != CborConformanceLevel.NonStrict;
+            return level != CborConformanceLevel.Lax;
         }
 
         public static bool RequiresSortedKeys(CborConformanceLevel level)
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             switch (level)
             {
                 case CborConformanceLevel.Strict:
-                case CborConformanceLevel.NonStrict:
+                case CborConformanceLevel.Lax:
                     return false;
 
                 case CborConformanceLevel.Rfc7049Canonical:

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -25,14 +25,111 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
         }
 
-        public static bool RequiresUniqueKeys(CborConformanceLevel level)
+        public static bool RequiresMinimalIntegerRepresentation(CborConformanceLevel conformanceLevel)
         {
-            return level != CborConformanceLevel.Lax;
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                case CborConformanceLevel.Strict:
+                    return false;
+
+                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
         }
 
-        public static bool RequiresSortedKeys(CborConformanceLevel level)
+        public static bool RequiresPreservedFloatRepresentation(CborConformanceLevel conformanceLevel)
         {
-            switch (level)
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.Rfc7049Canonical:
+                    return false;
+
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
+        }
+
+        public static bool RequiresDefiniteLengthItems(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                case CborConformanceLevel.Strict:
+                    return false;
+
+                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
+        }
+
+        public static bool RequiresSkipSemanticValidation(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Strict:
+                    return true;
+
+                case CborConformanceLevel.Lax:
+                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return false;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
+        }
+
+        public static bool AllowsTags(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.Rfc7049Canonical:
+                    return true;
+
+                case CborConformanceLevel.Ctap2Canonical:
+                    return false;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
+        }
+
+        public static bool RequiresUniqueKeys(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                    return false;
+
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
+        }
+
+        public static bool RequiresSortedKeys(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
             {
                 case CborConformanceLevel.Strict:
                 case CborConformanceLevel.Lax:
@@ -43,7 +140,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     return true;
 
                 default:
-                    return false;
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
             };
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -58,23 +58,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             };
         }
 
-        public static bool RequiresSkipSemanticValidation(CborConformanceLevel conformanceLevel)
-        {
-            switch (conformanceLevel)
-            {
-                case CborConformanceLevel.Strict:
-                    return true;
-
-                case CborConformanceLevel.Lax:
-                case CborConformanceLevel.Rfc7049Canonical:
-                case CborConformanceLevel.Ctap2Canonical:
-                    return false;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
-            };
-        }
-
         public static bool AllowsTags(CborConformanceLevel conformanceLevel)
         {
             switch (conformanceLevel)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Security.Cryptography.Encoding.Tests.Cbor
+{
+    internal enum CborConformanceLevel
+    {
+        NonStrict = 0,
+        Strict = 1,
+        Rfc7049Canonical = 2,
+        Ctap2Canonical = 3,
+    }
+
+    internal static class CborConformanceLevelHelpers
+    {
+        public static bool RequiresUniqueKeys(CborConformanceLevel level)
+        {
+            return level switch
+            {
+                CborConformanceLevel.Rfc7049Canonical => true,
+                CborConformanceLevel.Ctap2Canonical => true,
+                CborConformanceLevel.Strict => true,
+                CborConformanceLevel.NonStrict => false,
+                _ => false,
+            };
+        }
+
+        public static bool RequiresSortedKeys(CborConformanceLevel level)
+        {
+            return level switch
+            {
+                CborConformanceLevel.Rfc7049Canonical => true,
+                CborConformanceLevel.Ctap2Canonical => true,
+                CborConformanceLevel.Strict => false,
+                CborConformanceLevel.NonStrict => false,
+                _ => false,
+            };
+        }
+
+        public static int CompareEncodings(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right, CborConformanceLevel level)
+        {
+            Debug.Assert(!left.IsEmpty && !right.IsEmpty);
+
+            switch (level)
+            {
+                // Strict mode only concerns itself with uniqueness, not sorting
+                // so any total order for buffers should do.
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.Rfc7049Canonical:
+                    // Implements key sorting according to
+                    // https://tools.ietf.org/html/rfc7049#section-3.9
+
+                    if (left.Length != right.Length)
+                    {
+                        return left.Length - right.Length;
+                    }
+
+                    return left.SequenceCompareTo(right);
+
+                case CborConformanceLevel.Ctap2Canonical:
+                    // Implements key sorting according to
+                    // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding
+
+                    int leftMt = (int)new CborInitialByte(left[0]).MajorType;
+                    int rightMt = (int)new CborInitialByte(right[0]).MajorType;
+
+                    if (leftMt != rightMt)
+                    {
+                        return leftMt - rightMt;
+                    }
+
+                    if (left.Length != right.Length)
+                    {
+                        return left.Length - right.Length;
+                    }
+
+                    return left.SequenceCompareTo(right);
+
+                default:
+                    Debug.Fail("Invalid conformance level used in encoding sort.");
+                    throw new Exception("Invalid conformance level used in encoding sort.");
+            }
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -115,8 +115,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             switch (level)
             {
-                // Strict mode only concerns itself with uniqueness, not sorting
-                // so any total order for buffers should do.
+                // Strict mode only concerns itself with uniqueness, not sorting.
+                // Any total order for buffers should do.
                 case CborConformanceLevel.Strict:
                 case CborConformanceLevel.Rfc7049Canonical:
                     // Implements key sorting according to

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
@@ -8,9 +8,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal enum CborConformanceLevel
     {
-        NoConformance = 0,
-        Rfc7049Canonical = 1,
-        Ctap2Canonical = 2,
+        NonStrict = 0,
+        Strict = 1,
+        Rfc7049Canonical = 2,
+        Ctap2Canonical = 3,
     }
 
     internal enum CborMajorType : byte

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
@@ -6,14 +6,6 @@ using System.Diagnostics;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
-    internal enum CborConformanceLevel
-    {
-        NonStrict = 0,
-        Strict = 1,
-        Rfc7049Canonical = 2,
-        Ctap2Canonical = 3,
-    }
-
     internal enum CborMajorType : byte
     {
         UnsignedInteger = 0,

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
@@ -6,6 +6,13 @@ using System.Diagnostics;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
+    internal enum CborConformanceLevel
+    {
+        NoConformance = 0,
+        Rfc7049Canonical = 1,
+        Ctap2Canonical = 2,
+    }
+
     internal enum CborMajorType : byte
     {
         UnsignedInteger = 0,

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -15,6 +15,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
+                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                {
+                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                }
+
                 AdvanceBuffer(1);
                 PushDataItem(CborMajorType.Array, null);
                 return null;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                    throw new FormatException("Indefinite-length items are not supported under the current conformance level.");
                 }
 
                 AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
                     throw new FormatException("Indefinite-length items not support under the current conformance level.");
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal partial class CborReader
     {
-        public uint? ReadStartArray()
+        public int? ReadStartArray()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Array);
 
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 AdvanceBuffer(1 + additionalBytes);
                 PushDataItem(CborMajorType.Array, (uint)arrayLength);
-                return (uint)arrayLength;
+                return (int)arrayLength;
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
 
                 AdvanceBuffer(1 + additionalBytes);
-                PushDataItem(CborMajorType.Array, (uint)arrayLength);
+                PushDataItem(CborMajorType.Array, (int)arrayLength);
                 return (int)arrayLength;
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
                 }
 
                 AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -159,7 +159,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (CborConformanceLevelHelpers.RequiresMinimalIntegerRepresentation(ConformanceLevel))
                 {
-                    throw new FormatException("Non-minimal integer representation  are not permitted under the current conformance level.");
+                    throw new FormatException("Non-minimal integer representations are not permitted under the current conformance level.");
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -157,7 +157,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             void ValidateIsNonStandardIntegerRepresentationSupported()
             {
-                if (CborConformanceLevelHelpers.RequiresMinimalIntegerRepresentation(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresMinimalIntegerRepresentation(ConformanceLevel))
                 {
                     throw new FormatException("Non-minimal integer representations are not permitted under the current conformance level.");
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers.Binary;
+using System.Xml;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
@@ -92,8 +93,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         }
 
         // Unsigned integer decoding https://tools.ietf.org/html/rfc7049#section-2.1
-        private static ulong ReadUnsignedInteger(ReadOnlySpan<byte> buffer, CborInitialByte header, out int additionalBytes)
+        private ulong ReadUnsignedInteger(ReadOnlySpan<byte> buffer, CborInitialByte header, out int additionalBytes)
         {
+            ulong result;
+
             switch (header.AdditionalInfo)
             {
                 case CborAdditionalInfo x when (x < CborAdditionalInfo.Additional8BitData):
@@ -102,26 +105,62 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 case CborAdditionalInfo.Additional8BitData:
                     EnsureBuffer(buffer, 2);
+                    result = buffer[1];
+
+                    if (result < (int)CborAdditionalInfo.Additional8BitData)
+                    {
+                        ValidateIsNonStandardIntegerRepresentationSupported();
+                    }
+
                     additionalBytes = 1;
-                    return buffer[1];
+                    return result;
 
                 case CborAdditionalInfo.Additional16BitData:
                     EnsureBuffer(buffer, 3);
+                    result = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(1));
+
+                    if (result <= byte.MaxValue)
+                    {
+                        ValidateIsNonStandardIntegerRepresentationSupported();
+                    }
+
                     additionalBytes = 2;
-                    return BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(1));
+                    return result;
 
                 case CborAdditionalInfo.Additional32BitData:
                     EnsureBuffer(buffer, 5);
+                    result = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(1));
+
+                    if (result <= ushort.MaxValue)
+                    {
+                        ValidateIsNonStandardIntegerRepresentationSupported();
+                    }
+
                     additionalBytes = 4;
-                    return BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(1));
+                    return result;
 
                 case CborAdditionalInfo.Additional64BitData:
                     EnsureBuffer(buffer, 9);
+                    result = BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(1));
+
+                    if (result <= uint.MaxValue)
+                    {
+                        ValidateIsNonStandardIntegerRepresentationSupported();
+                    }
+
                     additionalBytes = 8;
-                    return BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(1));
+                    return result;
 
                 default:
                     throw new FormatException("initial byte contains invalid integer encoding data.");
+            }
+
+            void ValidateIsNonStandardIntegerRepresentationSupported()
+            {
+                if (CborConformanceLevelHelpers.RequiresMinimalIntegerRepresentation(ConformanceLevel))
+                {
+                    throw new FormatException("Non-minimal integer representation  are not permitted under the current conformance level.");
+                }
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -129,7 +128,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (!previousKeys.Add(currentKeyRange))
             {
-                throw new FormatException("CBOR map contain duplicate keys.");
+                throw new FormatException("CBOR map contains duplicate keys.");
             }
         }
 
@@ -149,7 +148,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             return _originalBuffer.Span.Slice(range.offset, range.length);
         }
 
-        private class KeyEncodingComparer : IComparer<(int, int)>
+        private class KeyEncodingComparer : IComparer<(int offset, int length)>
         {
             private readonly CborReader _reader;
 
@@ -158,7 +157,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 _reader = reader;
             }
 
-            public int Compare((int, int) x, (int, int) y)
+            public int Compare((int offset, int length) x, (int offset, int length) y)
             {
                 return CborConformanceLevelHelpers.CompareEncodings(_reader.GetKeyEncoding(x), _reader.GetKeyEncoding(y), _reader.ConformanceLevel);
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -115,10 +115,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 int cmp = CborConformanceLevelHelpers.CompareEncodings(previousKeyEncoding, currentKeyEncoding, ConformanceLevel);
                 if (cmp > 0)
                 {
+                    ResetBuffer(currentKeyRange.Offset);
                     throw new FormatException("CBOR map keys are not in sorted encoding order.");
                 }
                 else if (cmp == 0 && CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
                 {
+                    ResetBuffer(currentKeyRange.Offset);
                     throw new FormatException("CBOR map contains duplicate keys.");
                 }
             }
@@ -134,6 +136,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (!previousKeys.Add(currentKeyRange))
             {
+                ResetBuffer(currentKeyRange.Offset);
                 throw new FormatException("CBOR map contains duplicate keys.");
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -164,7 +164,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             return _keyEncodingRanges = new HashSet<(int Offset, int Length)>(_keyEncodingComparer);
         }
 
-        private void ReturnKeyEncodingRangeSet()
+        private void ReturnKeyEncodingRangeAllocation()
         {
             if (_keyEncodingRanges != null)
             {
@@ -172,11 +172,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 _pooledKeyEncodingRangeSets.Push(_keyEncodingRanges);
                 _keyEncodingRanges = null;
             }
-        }
-
-        private ReadOnlySpan<byte> GetKeyEncoding(in (int Offset, int Length) range)
-        {
-            return _originalBuffer.Span.Slice(range.Offset, range.Length);
         }
 
         private class KeyEncodingComparer : IEqualityComparer<(int Offset, int Length)>
@@ -188,14 +183,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 _reader = reader;
             }
 
+            private ReadOnlySpan<byte> GetKeyEncoding((int Offset, int Length) range)
+            {
+                return _reader._originalBuffer.Span.Slice(range.Offset, range.Length);
+            }
+
             public int GetHashCode((int Offset, int Length) value)
             {
-                return CborConformanceLevelHelpers.GetKeyEncodingHashCode(_reader.GetKeyEncoding(in value));
+                return CborConformanceLevelHelpers.GetKeyEncodingHashCode(GetKeyEncoding(value));
             }
 
             public bool Equals((int Offset, int Length) x, (int Offset, int Length) y)
             {
-                return CborConformanceLevelHelpers.AreEqualKeyEncodings(_reader.GetKeyEncoding(in x), _reader.GetKeyEncoding(in y));
+                return CborConformanceLevelHelpers.AreEqualKeyEncodings(GetKeyEncoding(x), GetKeyEncoding(y));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 ReadOnlySpan<byte> previousKeyEncoding = originalBuffer.Slice(previousKeyRange.Offset, previousKeyRange.Length);
                 ReadOnlySpan<byte> currentKeyEncoding = originalBuffer.Slice(currentKeyRange.Offset, currentKeyRange.Length);
 
-                int cmp = CborConformanceLevelHelpers.CompareEncodings(previousKeyEncoding, currentKeyEncoding, ConformanceLevel);
+                int cmp = CborConformanceLevelHelpers.CompareKeyEncodings(previousKeyEncoding, currentKeyEncoding, ConformanceLevel);
                 if (cmp > 0)
                 {
                     ResetBuffer(currentKeyRange.Offset);
@@ -152,7 +152,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             return _previousKeyRanges;
         }
 
-        private ReadOnlySpan<byte> GetKeyEncoding((int Offset, int Length) range)
+        private ReadOnlySpan<byte> GetKeyEncoding(in (int Offset, int Length) range)
         {
             return _originalBuffer.Span.Slice(range.Offset, range.Length);
         }
@@ -168,12 +168,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public int GetHashCode((int Offset, int Length) value)
             {
-                return System.Marvin.ComputeHash32(_reader.GetKeyEncoding(value), System.Marvin.DefaultSeed);
+                return CborConformanceLevelHelpers.GetKeyEncodingHashCode(_reader.GetKeyEncoding(in value));
             }
 
             public bool Equals((int Offset, int Length) x, (int Offset, int Length) y)
             {
-                return _reader.GetKeyEncoding(x).SequenceEqual(_reader.GetKeyEncoding(y));
+                return CborConformanceLevelHelpers.AreEqualKeyEncodings(_reader.GetKeyEncoding(in x), _reader.GetKeyEncoding(in y));
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     {
         private KeyEncodingComparer? _keyComparer;
 
-        public uint? ReadStartMap()
+        public int? ReadStartMap()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Map);
 
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 AdvanceBuffer(1 + additionalBytes);
                 PushDataItem(CborMajorType.Map, 2 * (uint)mapSize);
-                return (uint)mapSize;
+                return (int)mapSize;
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public int? ReadStartMap()
         {
+            int? length;
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Map);
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
@@ -28,7 +29,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 AdvanceBuffer(1);
                 PushDataItem(CborMajorType.Map, null);
-                return null;
+                length = null;
             }
             else
             {
@@ -41,8 +42,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
                 AdvanceBuffer(1 + additionalBytes);
                 PushDataItem(CborMajorType.Map, 2 * (int)mapSize);
-                return (int)mapSize;
+                length = (int)mapSize;
             }
+
+            _currentKeyOffset = _bytesRead;
+            _currentItemIsKey = true;
+            return length;
         }
 
         public void ReadEndMap()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 }
 
                 AdvanceBuffer(1 + additionalBytes);
-                PushDataItem(CborMajorType.Map, 2 * (uint)mapSize);
+                PushDataItem(CborMajorType.Map, 2 * (int)mapSize);
                 return (int)mapSize;
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
                 }
 
                 AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -78,7 +78,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             Debug.Assert(_currentKeyOffset != null && _curentItemIsKey);
 
-            (int offset, int length) currentKeyRange = (_currentKeyOffset.Value, _bytesRead - _currentKeyOffset.Value);
+            (int Offset, int Length) currentKeyRange = (_currentKeyOffset.Value, _bytesRead - _currentKeyOffset.Value);
 
             if (CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
             {
@@ -100,17 +100,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             _curentItemIsKey = true;
         }
 
-        private void ValidateSortedKeyEncoding((int offset, int length) currentKeyRange)
+        private void ValidateSortedKeyEncoding((int Offset, int Length) currentKeyRange)
         {
             Debug.Assert(_currentKeyOffset != null);
 
             if (_previousKeyRange != null)
             {
-                (int offset, int length) previousKeyRange = _previousKeyRange.Value;
+                (int Offset, int Length) previousKeyRange = _previousKeyRange.Value;
 
                 ReadOnlySpan<byte> originalBuffer = _originalBuffer.Span;
-                ReadOnlySpan<byte> previousKeyEncoding = originalBuffer.Slice(previousKeyRange.offset, previousKeyRange.length);
-                ReadOnlySpan<byte> currentKeyEncoding = originalBuffer.Slice(currentKeyRange.offset, currentKeyRange.length);
+                ReadOnlySpan<byte> previousKeyEncoding = originalBuffer.Slice(previousKeyRange.Offset, previousKeyRange.Length);
+                ReadOnlySpan<byte> currentKeyEncoding = originalBuffer.Slice(currentKeyRange.Offset, currentKeyRange.Length);
 
                 int cmp = CborConformanceLevelHelpers.CompareEncodings(previousKeyEncoding, currentKeyEncoding, ConformanceLevel);
                 if (cmp > 0)
@@ -126,11 +126,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             _previousKeyRange = currentKeyRange;
         }
 
-        private void ValidateKeyUniqueness((int offset, int length) currentKeyRange)
+        private void ValidateKeyUniqueness((int Offset, int Length) currentKeyRange)
         {
             Debug.Assert(_currentKeyOffset != null);
 
-            HashSet<(int offset, int length)> previousKeys = GetPreviousKeyRanges();
+            HashSet<(int Offset, int Length)> previousKeys = GetPreviousKeyRanges();
 
             if (!previousKeys.Add(currentKeyRange))
             {
@@ -138,23 +138,23 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
         }
 
-        private HashSet<(int offset, int length)> GetPreviousKeyRanges()
+        private HashSet<(int Offset, int Length)> GetPreviousKeyRanges()
         {
             if (_previousKeyRanges == null)
             {
                 _keyComparer ??= new KeyEncodingComparer(this);
-                _previousKeyRanges = new HashSet<(int offset, int length)>(_keyComparer);
+                _previousKeyRanges = new HashSet<(int Offset, int Length)>(_keyComparer);
             }
 
             return _previousKeyRanges;
         }
 
-        private ReadOnlySpan<byte> GetKeyEncoding((int offset, int length) range)
+        private ReadOnlySpan<byte> GetKeyEncoding((int Offset, int Length) range)
         {
-            return _originalBuffer.Span.Slice(range.offset, range.length);
+            return _originalBuffer.Span.Slice(range.Offset, range.Length);
         }
 
-        private class KeyEncodingComparer : IEqualityComparer<(int offset, int length)>
+        private class KeyEncodingComparer : IEqualityComparer<(int Offset, int Length)>
         {
             private readonly CborReader _reader;
 
@@ -163,12 +163,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 _reader = reader;
             }
 
-            public int GetHashCode((int offset, int length) value)
+            public int GetHashCode((int Offset, int Length) value)
             {
                 return System.Marvin.ComputeHash32(_reader.GetKeyEncoding(value), System.Marvin.DefaultSeed);
             }
 
-            public bool Equals((int offset, int length) x, (int offset, int length) y)
+            public bool Equals((int Offset, int Length) x, (int Offset, int Length) y)
             {
                 return _reader.GetKeyEncoding(x).SequenceEqual(_reader.GetKeyEncoding(y));
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
                     throw new FormatException("Indefinite-length items not support under the current conformance level.");
                 }
@@ -80,11 +80,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             (int Offset, int Length) currentKeyRange = (_currentKeyOffset.Value, _bytesRead - _currentKeyOffset.Value);
 
-            if (CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
+            if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
             {
                 ValidateSortedKeyEncoding(currentKeyRange);
             }
-            else if (CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
+            else if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
             {
                 ValidateKeyUniqueness(currentKeyRange);
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     throw new InvalidOperationException("Not at end of indefinite-length map.");
                 }
 
-                if (!_curentItemIsKey)
+                if (!_currentItemIsKey)
                 {
                     throw new FormatException("CBOR map key is missing a value.");
                 }
@@ -78,28 +78,31 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private void HandleMapKeyAdded()
         {
-            Debug.Assert(_currentKeyOffset != null && _curentItemIsKey);
+            Debug.Assert(_currentKeyOffset != null && _currentItemIsKey);
 
             (int Offset, int Length) currentKeyRange = (_currentKeyOffset.Value, _bytesRead - _currentKeyOffset.Value);
 
-            if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
+            if (_isConformanceLevelCheckEnabled)
             {
-                ValidateSortedKeyEncoding(currentKeyRange);
-            }
-            else if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
-            {
-                ValidateKeyUniqueness(currentKeyRange);
+                if (CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
+                {
+                    ValidateSortedKeyEncoding(currentKeyRange);
+                }
+                else if (CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
+                {
+                    ValidateKeyUniqueness(currentKeyRange);
+                }
             }
 
-            _curentItemIsKey = false;
+            _currentItemIsKey = false;
         }
 
         private void HandleMapValueAdded()
         {
-            Debug.Assert(_currentKeyOffset != null && !_curentItemIsKey);
+            Debug.Assert(_currentKeyOffset != null && !_currentItemIsKey);
 
             _currentKeyOffset = _bytesRead;
-            _curentItemIsKey = true;
+            _currentItemIsKey = true;
         }
 
         private void ValidateSortedKeyEncoding((int Offset, int Length) currentKeyRange)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -4,33 +4,37 @@
 
 #nullable enable
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal partial class CborReader
     {
-        public ulong? ReadStartMap()
+        private KeyEncodingComparer? _keyComparer;
+
+        public uint? ReadStartMap()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Map);
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                PushDataItem(CborMajorType.Map, null);
                 AdvanceBuffer(1);
+                PushDataItem(CborMajorType.Map, null);
                 return null;
             }
             else
             {
                 ulong mapSize = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
 
-                if (mapSize > long.MaxValue)
+                if (mapSize > int.MaxValue || 2 * mapSize > (ulong)_buffer.Length)
                 {
-                    throw new OverflowException("Read CBOR map field count exceeds supported size.");
+                    throw new FormatException("Insufficient buffer size for declared definite length in CBOR data item.");
                 }
 
-                PushDataItem(CborMajorType.Map, 2 * mapSize);
                 AdvanceBuffer(1 + additionalBytes);
-                return mapSize;
+                PushDataItem(CborMajorType.Map, 2 * (uint)mapSize);
+                return (uint)mapSize;
             }
         }
 
@@ -45,9 +49,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     throw new InvalidOperationException("Not at end of indefinite-length map.");
                 }
 
-                if (!_isEvenNumberOfDataItemsRead)
+                if (!_curentItemIsKey)
                 {
-                    throw new FormatException("CBOR Map types require an even number of key/value combinations");
+                    throw new FormatException("CBOR map key is missing a value.");
                 }
 
                 PopDataItem(expectedType: CborMajorType.Map);
@@ -58,6 +62,105 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 PopDataItem(expectedType: CborMajorType.Map);
                 AdvanceDataItemCounters();
+            }
+        }
+
+        //
+        // Map decoding conformance
+        //
+
+        private void HandleMapKeyAdded()
+        {
+            Debug.Assert(_currentKeyOffset != null && _curentItemIsKey);
+
+            (int offset, int length) currentKeyRange = (_currentKeyOffset.Value, _bytesRead - _currentKeyOffset.Value);
+
+            if (CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
+            {
+                ValidateSortedKeyEncoding(currentKeyRange);
+            }
+            else if (CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
+            {
+                ValidateKeyUniqueness(currentKeyRange);
+            }
+
+            _curentItemIsKey = false;
+        }
+
+        private void HandleMapValueAdded()
+        {
+            Debug.Assert(_currentKeyOffset != null && !_curentItemIsKey);
+
+            _currentKeyOffset = _bytesRead;
+            _curentItemIsKey = true;
+        }
+
+        private void ValidateSortedKeyEncoding((int offset, int length) currentKeyRange)
+        {
+            Debug.Assert(_currentKeyOffset != null);
+
+            if (_previousKeyRange != null)
+            {
+                (int offset, int length) previousKeyRange = _previousKeyRange.Value;
+
+                ReadOnlySpan<byte> originalBuffer = _originalBuffer.Span;
+                ReadOnlySpan<byte> previousKeyEncoding = originalBuffer.Slice(previousKeyRange.offset, previousKeyRange.length);
+                ReadOnlySpan<byte> currentKeyEncoding = originalBuffer.Slice(currentKeyRange.offset, currentKeyRange.length);
+
+                int cmp = CborConformanceLevelHelpers.CompareEncodings(previousKeyEncoding, currentKeyEncoding, ConformanceLevel);
+                if (cmp > 0)
+                {
+                    throw new FormatException("CBOR map keys are not in sorted encoding order.");
+                }
+                else if (cmp == 0 && CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
+                {
+                    throw new FormatException("CBOR map contains duplicate keys.");
+                }
+            }
+
+            _previousKeyRange = currentKeyRange;
+        }
+
+        private void ValidateKeyUniqueness((int offset, int length) currentKeyRange)
+        {
+            Debug.Assert(_currentKeyOffset != null);
+
+            SortedSet<(int offset, int length)> previousKeys = GetPreviousKeyRanges();
+
+            if (!previousKeys.Add(currentKeyRange))
+            {
+                throw new FormatException("CBOR map contain duplicate keys.");
+            }
+        }
+
+        private SortedSet<(int offset, int length)> GetPreviousKeyRanges()
+        {
+            if (_previousKeyRanges == null)
+            {
+                _keyComparer ??= new KeyEncodingComparer(this);
+                _previousKeyRanges = new SortedSet<(int offset, int length)>(_keyComparer);
+            }
+
+            return _previousKeyRanges;
+        }
+
+        private ReadOnlySpan<byte> GetKeyEncoding((int offset, int length) range)
+        {
+            return _originalBuffer.Span.Slice(range.offset, range.length);
+        }
+
+        private class KeyEncodingComparer : IComparer<(int, int)>
+        {
+            private readonly CborReader _reader;
+
+            public KeyEncodingComparer(CborReader reader)
+            {
+                _reader = reader;
+            }
+
+            public int Compare((int, int) x, (int, int) y)
+            {
+                return CborConformanceLevelHelpers.CompareEncodings(_reader.GetKeyEncoding(x), _reader.GetKeyEncoding(y), _reader.ConformanceLevel);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -18,6 +18,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
+                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                {
+                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                }
+
                 AdvanceBuffer(1);
                 PushDataItem(CborMajorType.Map, null);
                 return null;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -9,10 +9,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal partial class CborReader
     {
-        // flag used to temporarily disable conformance level checks,
-        // e.g. during a skip operation over nonconforming encodings.
-        private bool _isConformanceLevelCheckEnabled = true;
-
         public void SkipValue(bool validateConformance = false) => SkipToAncestor(0, validateConformance);
         public void SkipToParent(bool validateConformance = false)
         {
@@ -44,7 +40,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             finally
             {
-                _isConformanceLevelCheckEnabled = false;
+                _isConformanceLevelCheckEnabled = true;
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public void SkipValue(bool validateConformance = false) => SkipToAncestor(0, validateConformance);
         public void SkipToParent(bool validateConformance = false)
         {
-            if ((_nestedDataItems?.Count ?? 0) == 0)
+            if (_currentMajorType is null)
             {
                 throw new InvalidOperationException("CBOR reader is at the root context.");
             }
@@ -22,7 +22,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private void SkipToAncestor(int depth, bool validateConformance)
         {
-            Debug.Assert(0 <= depth && depth <= (_nestedDataItems?.Count ?? 0));
+            Debug.Assert(0 <= depth && depth <= Depth);
             Checkpoint checkpoint = CreateCheckpoint();
             _isConformanceLevelCheckEnabled = validateConformance;
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -8,7 +8,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     {
         public void SkipValue()
         {
-            CborReaderCheckpoint checkpoint = CreateCheckpoint();
+            Checkpoint checkpoint = CreateCheckpoint();
 
             try
             {
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             catch
             {
-                RestoreCheckpoint(checkpoint);
+                RestoreCheckpoint(in checkpoint);
                 throw;
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -2,18 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#nullable enable
+using System.Diagnostics;
+
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal partial class CborReader
     {
-        public void SkipValue()
+        public void SkipValue() => SkipToAncestor(0);
+        public void SkipToParent()
         {
+            if ((_nestedDataItems?.Count ?? 0) == 0)
+            {
+                throw new InvalidOperationException("CBOR reader is at the root context.");
+            }
+
+            SkipToAncestor(1);
+        }
+
+        private void SkipToAncestor(int depth)
+        {
+            Debug.Assert(0 <= depth && depth <= (_nestedDataItems?.Count ?? 0));
             Checkpoint checkpoint = CreateCheckpoint();
 
             try
             {
-                int depth = 0;
-
                 do
                 {
                     SkipNextNode(ref depth);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -125,8 +125,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("CBOR text string is not of indefinite length.");
             }
 
-            PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
             AdvanceBuffer(1);
+            PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
         }
 
         public void ReadEndTextStringIndefiniteLength()
@@ -146,8 +146,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("CBOR text string is not of indefinite length.");
             }
 
-            PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
             AdvanceBuffer(1);
+            PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
         }
 
         public void ReadEndByteStringIndefiniteLength()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -190,7 +190,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private bool TryReadChunkedByteStringConcatenated(Span<byte> destination, out int bytesWritten)
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int encodingLength, out int concatenatedBufferSize);
+            List<(int Offset, int Length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int encodingLength, out int concatenatedBufferSize);
 
             if (concatenatedBufferSize > destination.Length)
             {
@@ -215,7 +215,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private bool TryReadChunkedTextStringConcatenated(Span<char> destination, out int charsWritten)
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int encodingLength, out int _);
+            List<(int Offset, int Length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int encodingLength, out int _);
             ReadOnlySpan<byte> buffer = _buffer.Span;
 
             int concatenatedStringSize = 0;
@@ -245,7 +245,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private byte[] ReadChunkedByteStringConcatenated()
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int encodingLength, out int concatenatedBufferSize);
+            List<(int Offset, int Length)> ranges = ReadChunkedStringRanges(CborMajorType.ByteString, out int encodingLength, out int concatenatedBufferSize);
             var output = new byte[concatenatedBufferSize];
 
             ReadOnlySpan<byte> source = _buffer.Span;
@@ -266,7 +266,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private string ReadChunkedTextStringConcatenated()
         {
-            List<(int offset, int length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int encodingLength, out int concatenatedBufferSize);
+            List<(int Offset, int Length)> ranges = ReadChunkedStringRanges(CborMajorType.TextString, out int encodingLength, out int concatenatedBufferSize);
             ReadOnlySpan<byte> buffer = _buffer.Span;
             int concatenatedStringSize = 0;
 
@@ -282,7 +282,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             ReturnRangeList(ranges);
             return output;
 
-            static void BuildString(Span<char> target, (List<(int offset, int length)> ranges, ReadOnlyMemory<byte> source) input)
+            static void BuildString(Span<char> target, (List<(int Offset, int Length)> ranges, ReadOnlyMemory<byte> source) input)
             {
                 ReadOnlySpan<byte> source = input.source.Span;
 
@@ -298,9 +298,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         // reads a buffer starting with an indefinite-length string,
         // performing validation and returning a list of ranges containing the individual chunk payloads
-        private List<(int offset, int length)> ReadChunkedStringRanges(CborMajorType type, out int encodingLength, out int concatenatedBufferSize)
+        private List<(int Offset, int Length)> ReadChunkedStringRanges(CborMajorType type, out int encodingLength, out int concatenatedBufferSize)
         {
-            var ranges = AcquireRangeList();
+            List<(int Offset, int Length)> ranges = AcquireRangeList();
             ReadOnlySpan<byte> buffer = _buffer.Span;
             concatenatedBufferSize = 0;
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
                     throw new FormatException("Indefinite-length items not support under the current conformance level.");
                 }
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
                     throw new FormatException("Indefinite-length items not support under the current conformance level.");
                 }
@@ -79,7 +79,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
                     throw new FormatException("Indefinite-length items not support under the current conformance level.");
                 }
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
-                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
                     throw new FormatException("Indefinite-length items not support under the current conformance level.");
                 }
@@ -149,7 +149,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("CBOR text string is not of indefinite length.");
             }
 
-            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
                 throw new FormatException("Indefinite-length items not support under the current conformance level.");
             }
@@ -175,7 +175,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("CBOR text string is not of indefinite length.");
             }
 
-            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
                 throw new FormatException("Indefinite-length items not support under the current conformance level.");
             }
@@ -351,8 +351,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             int byteLength = checked((int)ReadUnsignedInteger(buffer, header, out int additionalBytes));
             EnsureBuffer(1 + additionalBytes + byteLength);
 
-            // force any utf8 decoding errors if text string
-            if (type == CborMajorType.TextString)
+            // Force any UTF8 decoding errors if text string
+            if (_isConformanceLevelCheckEnabled && type == CborMajorType.TextString)
             {
                 ReadOnlySpan<byte> encodedSlice = buffer.Slice(1 + additionalBytes, byteLength);
                 ValidateUtf8AndGetCharCount(encodedSlice);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -20,6 +20,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
+                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                {
+                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                }
+
                 return ReadChunkedByteStringConcatenated();
             }
 
@@ -38,6 +43,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
+                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                {
+                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                }
+
                 return TryReadChunkedByteStringConcatenated(destination, out bytesWritten);
             }
 
@@ -65,6 +75,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
+                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                {
+                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                }
+
                 return ReadChunkedTextStringConcatenated();
             }
 
@@ -93,6 +108,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (header.AdditionalInfo == CborAdditionalInfo.IndefiniteLength)
             {
+                if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+                {
+                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                }
+
                 return TryReadChunkedTextStringConcatenated(destination, out charsWritten);
             }
 
@@ -125,6 +145,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("CBOR text string is not of indefinite length.");
             }
 
+            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new FormatException("Indefinite-length items not support under the current conformance level.");
+            }
+
             AdvanceBuffer(1);
             PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
         }
@@ -144,6 +169,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             if (header.AdditionalInfo != CborAdditionalInfo.IndefiniteLength)
             {
                 throw new InvalidOperationException("CBOR text string is not of indefinite length.");
+            }
+
+            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new FormatException("Indefinite-length items not support under the current conformance level.");
             }
 
             AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
                 }
 
                 return ReadChunkedByteStringConcatenated();
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
                 }
 
                 return TryReadChunkedByteStringConcatenated(destination, out bytesWritten);
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
                 }
 
                 return ReadChunkedTextStringConcatenated();
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
                 }
 
                 return TryReadChunkedTextStringConcatenated(destination, out charsWritten);
@@ -151,7 +151,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
-                throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                throw new FormatException("Indefinite-length items not supported under the current conformance level.");
             }
 
             AdvanceBuffer(1);
@@ -177,7 +177,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
-                throw new FormatException("Indefinite-length items not support under the current conformance level.");
+                throw new FormatException("Indefinite-length items not supported under the current conformance level.");
             }
 
             AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -45,7 +45,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1
 
-            CborReaderCheckpoint checkpoint = CreateCheckpoint();
+            Checkpoint checkpoint = CreateCheckpoint();
 
             try
             {
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             catch
             {
-                RestoreCheckpoint(checkpoint);
+                RestoreCheckpoint(in checkpoint);
                 throw;
             }
         }
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.1
 
-            CborReaderCheckpoint checkpoint = CreateCheckpoint();
+            Checkpoint checkpoint = CreateCheckpoint();
 
             try
             {
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             catch
             {
-                RestoreCheckpoint(checkpoint);
+                RestoreCheckpoint(in checkpoint);
                 throw;
             }
         }
@@ -121,7 +121,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.2
 
-            CborReaderCheckpoint checkpoint = CreateCheckpoint();
+            Checkpoint checkpoint = CreateCheckpoint();
 
             try
             {
@@ -147,7 +147,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             catch
             {
-                RestoreCheckpoint(checkpoint);
+                RestoreCheckpoint(in checkpoint);
                 throw;
             }
         }
@@ -156,7 +156,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.3
 
-            CborReaderCheckpoint checkpoint = CreateCheckpoint();
+            Checkpoint checkpoint = CreateCheckpoint();
 
             try
             {
@@ -215,7 +215,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             catch
             {
-                RestoreCheckpoint(checkpoint);
+                RestoreCheckpoint(in checkpoint);
                 throw;
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             CborTag tag = PeekTagCore(out int additionalBytes);
 
-            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel) && _isConformanceLevelCheckEnabled)
+            if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
                 throw new FormatException("Tagged items are not permitted under the current conformance level.");
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -13,6 +13,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             CborTag tag = PeekTagCore(out int additionalBytes);
 
+            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
+            {
+                throw new FormatException("Tagged items are not permitted under the current conformance level.");
+            }
+
             AdvanceBuffer(1 + additionalBytes);
             _isTagContext = true;
             return tag;
@@ -21,6 +26,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         public void ReadTag(CborTag expectedTag)
         {
             CborTag tag = PeekTagCore(out int additionalBytes);
+
+            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
+            {
+                throw new FormatException("Tagged items are not permitted under the current conformance level.");
+            }
 
             if (expectedTag != tag)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -13,7 +13,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             CborTag tag = PeekTagCore(out int additionalBytes);
 
-            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
+            if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
                 throw new FormatException("Tagged items are not permitted under the current conformance level.");
             }
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             CborTag tag = PeekTagCore(out int additionalBytes);
 
-            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
+            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel) && _isConformanceLevelCheckEnabled)
             {
                 throw new FormatException("Tagged items are not permitted under the current conformance level.");
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -412,8 +412,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private readonly struct StackFrame
         {
             public StackFrame(CborMajorType type, int frameOffset, int? remainingDataItems,
-                              int? currentKeyOffset, bool currentItemIsKey,
-                              (int Offset, int Length)? previousKeyRange, HashSet<(int Offset, int Length)>? previousKeyRanges)
+                int? currentKeyOffset, bool currentItemIsKey,
+                (int Offset, int Length)? previousKeyRange, HashSet<(int Offset, int Length)>? previousKeyRanges)
             {
                 MajorType = type;
                 FrameOffset = frameOffset;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -345,7 +345,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (frame.MajorType == CborMajorType.Map)
             {
-                ReturnKeyEncodingRangeSet();
+                ReturnKeyEncodingRangeAllocation();
             }
 
             _nestedDataItems.Pop();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -63,7 +63,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // keeps a cached copy of the reader state; 'Unknown' denotes uncomputed state
         private CborReaderState _cachedState = CborReaderState.Unknown;
 
-        internal CborReader(ReadOnlyMemory<byte> buffer, CborConformanceLevel conformanceLevel = CborConformanceLevel.NonStrict)
+        internal CborReader(ReadOnlyMemory<byte> buffer, CborConformanceLevel conformanceLevel = CborConformanceLevel.Lax)
         {
             CborConformanceLevelHelpers.Validate(conformanceLevel);
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -57,9 +57,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private (int Offset, int Length)? _previousKeyRange;
         private HashSet<(int Offset, int Length)>? _previousKeyRanges;
 
-        // stores a reusable List allocation for keeping ranges in the buffer
-        private List<(int Offset, int Length)>? _rangeListAllocation = null;
-
         // keeps a cached copy of the reader state; 'Unknown' denotes uncomputed state
         private CborReaderState _cachedState = CborReaderState.Unknown;
 
@@ -383,24 +380,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 throw new FormatException("Unexpected end of buffer.");
             }
-        }
-
-        private List<(int Offset, int Length)> AcquireRangeList()
-        {
-            List<(int Offset, int Length)>? ranges = Interlocked.Exchange(ref _rangeListAllocation, null);
-
-            if (ranges != null)
-            {
-                ranges.Clear();
-                return ranges;
-            }
-
-            return new List<(int Offset, int Length)>();
-        }
-
-        private void ReturnRangeList(List<(int Offset, int Length)> ranges)
-        {
-            _rangeListAllocation = ranges;
         }
 
         private readonly struct StackFrame

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -361,6 +361,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             _cachedState = CborReaderState.Unknown;
         }
 
+        private void ResetBuffer(int position)
+        {
+            _buffer = _originalBuffer.Slice(position);
+            _bytesRead = position;
+            // invalidate the state cache
+            _cachedState = CborReaderState.Unknown;
+        }
+
         private void EnsureBuffer(int length)
         {
             if (_buffer.Length < length)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -317,6 +317,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new FormatException("CBOR tag should be followed by a data item.");
             }
 
+            if (frame.MajorType == CborMajorType.Map)
+            {
+                ReturnKeyEncodingRangeSet();
+            }
+
             _nestedDataItems.Pop();
 
             _frameOffset = frame.FrameOffset;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -54,11 +54,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Map-specific bookkeeping
         private int? _currentKeyOffset = null;
         private bool _curentItemIsKey = false;
-        private (int offset, int length)? _previousKeyRange;
-        private HashSet<(int offset, int length)>? _previousKeyRanges;
+        private (int Offset, int Length)? _previousKeyRange;
+        private HashSet<(int Offset, int Length)>? _previousKeyRanges;
 
         // stores a reusable List allocation for keeping ranges in the buffer
-        private List<(int offset, int length)>? _rangeListAllocation = null;
+        private List<(int Offset, int Length)>? _rangeListAllocation = null;
 
         // keeps a cached copy of the reader state; 'Unknown' denotes uncomputed state
         private CborReaderState _cachedState = CborReaderState.Unknown;
@@ -377,9 +377,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
         }
 
-        private List<(int offset, int length)> AcquireRangeList()
+        private List<(int Offset, int Length)> AcquireRangeList()
         {
-            List<(int offset, int length)>? ranges = Interlocked.Exchange(ref _rangeListAllocation, null);
+            List<(int Offset, int Length)>? ranges = Interlocked.Exchange(ref _rangeListAllocation, null);
 
             if (ranges != null)
             {
@@ -387,10 +387,10 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 return ranges;
             }
 
-            return new List<(int, int)>();
+            return new List<(int Offset, int Length)>();
         }
 
-        private void ReturnRangeList(List<(int offset, int length)> ranges)
+        private void ReturnRangeList(List<(int Offset, int Length)> ranges)
         {
             _rangeListAllocation = ranges;
         }
@@ -399,7 +399,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             public StackFrame(CborMajorType type, int frameOffset, uint? remainingDataItems,
                               int? currentKeyOffset, bool currentItemIsKey,
-                              (int offset, int length)? previousKeyRange, HashSet<(int offset, int length)>? previousKeyRanges)
+                              (int Offset, int Length)? previousKeyRange, HashSet<(int Offset, int Length)>? previousKeyRanges)
             {
                 MajorType = type;
                 FrameOffset = frameOffset;
@@ -417,8 +417,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public int? CurrentKeyOffset { get; }
             public bool CurrentItemIsKey { get; }
-            public (int offset, int length)? PreviousKeyRange { get; }
-            public HashSet<(int offset, int length)>? PreviousKeyRanges { get; }
+            public (int Offset, int Length)? PreviousKeyRange { get; }
+            public HashSet<(int Offset, int Length)>? PreviousKeyRanges { get; }
         }
 
         // Struct containing checkpoint data for rolling back reader state in the event of a failure
@@ -427,8 +427,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private readonly struct Checkpoint
         {
             public Checkpoint(int bytesRead, int stackDepth, int frameOffset, uint? remainingDataItems,
-                              int? currentKeyOffset, bool currentItemIsKey, (int offset, int length)? previousKeyRange,
-                              HashSet<(int offset, int length)>? previousKeyRanges)
+                              int? currentKeyOffset, bool currentItemIsKey, (int Offset, int Length)? previousKeyRange,
+                              HashSet<(int Offset, int Length)>? previousKeyRanges)
             {
                 BytesRead = bytesRead;
                 StackDepth = stackDepth;
@@ -448,8 +448,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public int? CurrentKeyOffset { get; }
             public bool CurrentItemIsKey { get; }
-            public (int offset, int length)? PreviousKeyRange { get; }
-            public HashSet<(int offset, int length)>? PreviousKeyRanges { get; }
+            public (int Offset, int Length)? PreviousKeyRange { get; }
+            public HashSet<(int Offset, int Length)>? PreviousKeyRanges { get; }
         }
 
         private Checkpoint CreateCheckpoint()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private int? _currentKeyOffset = null;
         private bool _curentItemIsKey = false;
         private (int offset, int length)? _previousKeyRange;
-        private SortedSet<(int offset, int length)>? _previousKeyRanges;
+        private HashSet<(int offset, int length)>? _previousKeyRanges;
 
         // stores a reusable List allocation for keeping ranges in the buffer
         private List<(int offset, int length)>? _rangeListAllocation = null;
@@ -399,7 +399,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             public StackFrame(CborMajorType type, int frameOffset, uint? remainingDataItems,
                               int? currentKeyOffset, bool currentItemIsKey,
-                              (int offset, int length)? previousKeyRange, SortedSet<(int offset, int length)>? previousKeyRanges)
+                              (int offset, int length)? previousKeyRange, HashSet<(int offset, int length)>? previousKeyRanges)
             {
                 MajorType = type;
                 FrameOffset = frameOffset;
@@ -418,7 +418,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             public int? CurrentKeyOffset { get; }
             public bool CurrentItemIsKey { get; }
             public (int offset, int length)? PreviousKeyRange { get; }
-            public SortedSet<(int offset, int length)>? PreviousKeyRanges { get; }
+            public HashSet<(int offset, int length)>? PreviousKeyRanges { get; }
         }
 
         // Struct containing checkpoint data for rolling back reader state in the event of a failure
@@ -428,7 +428,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             public Checkpoint(int bytesRead, int stackDepth, int frameOffset, uint? remainingDataItems,
                               int? currentKeyOffset, bool currentItemIsKey, (int offset, int length)? previousKeyRange,
-                              SortedSet<(int offset, int length)>? previousKeyRanges)
+                              HashSet<(int offset, int length)>? previousKeyRanges)
             {
                 BytesRead = bytesRead;
                 StackDepth = stackDepth;
@@ -449,7 +449,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             public int? CurrentKeyOffset { get; }
             public bool CurrentItemIsKey { get; }
             public (int offset, int length)? PreviousKeyRange { get; }
-            public SortedSet<(int offset, int length)>? PreviousKeyRanges { get; }
+            public HashSet<(int offset, int length)>? PreviousKeyRanges { get; }
         }
 
         private Checkpoint CreateCheckpoint()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -18,7 +18,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
 
             WriteUnsignedInteger(CborMajorType.Array, (ulong)definiteLength);
-            AdvanceDataItemCounters();
             PushDataItem(CborMajorType.Array, (uint)definiteLength);
         }
 
@@ -33,13 +32,14 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 EnsureWriteCapacity(1);
                 _buffer[_offset++] = CborInitialByte.IndefiniteLengthBreakByte;
             }
+
+            AdvanceDataItemCounters();
         }
 
         public void WriteStartArrayIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));
-            AdvanceDataItemCounters();
             PushDataItem(CborMajorType.Array, expectedNestedItems: null);
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -38,6 +38,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartArrayIndefiniteLength()
         {
+            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
+            }
+
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Array, expectedNestedItems: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -22,17 +22,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.Array, definiteLength);
         }
 
-        public void WriteEndArray()
-        {
-            PopDataItem(CborMajorType.Array);
-            AdvanceDataItemCounters();
-        }
-
-        public void WriteStartArrayIndefiniteLength()
+        public void WriteStartArray()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Array, definiteLength: null);
+        }
+
+        public void WriteEndArray()
+        {
+            PopDataItem(CborMajorType.Array);
+            AdvanceDataItemCounters();
         }
 
         private void PatchIndefiniteLengthCollection(CborMajorType majorType, int count)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -30,11 +30,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartArrayIndefiniteLength()
         {
-            if (!PatchIndefiniteLengthItems && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
-            {
-                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
-            }
-
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Array, definiteLength: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -52,30 +52,30 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             else if (value <= byte.MaxValue)
             {
-                EnsureWriteCapacity(2);
+                EnsureWriteCapacity(1 + sizeof(byte));
                 WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional8BitData));
                 _buffer[_offset++] = (byte)value;
             }
             else if (value <= ushort.MaxValue)
             {
-                EnsureWriteCapacity(3);
+                EnsureWriteCapacity(1 + sizeof(ushort));
                 WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional16BitData));
                 BinaryPrimitives.WriteUInt16BigEndian(_buffer.AsSpan(_offset), (ushort)value);
-                _offset += 2;
+                _offset += sizeof(ushort);
             }
             else if (value <= uint.MaxValue)
             {
-                EnsureWriteCapacity(5);
+                EnsureWriteCapacity(1 + sizeof(uint));
                 WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional32BitData));
                 BinaryPrimitives.WriteUInt32BigEndian(_buffer.AsSpan(_offset), (uint)value);
-                _offset += 4;
+                _offset += sizeof(uint);
             }
             else
             {
-                EnsureWriteCapacity(9);
+                EnsureWriteCapacity(1 + sizeof(ulong));
                 WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional64BitData));
                 BinaryPrimitives.WriteUInt64BigEndian(_buffer.AsSpan(_offset), value);
-                _offset += 8;
+                _offset += sizeof(ulong);
             }
         }
 
@@ -87,19 +87,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
             else if (value <= byte.MaxValue)
             {
-                return 2;
+                return 1 + sizeof(byte);
             }
             else if (value <= ushort.MaxValue)
             {
-                return 3;
+                return 1 + sizeof(ushort);
             }
             else if (value <= uint.MaxValue)
             {
-                return 5;
+                return 1 + sizeof(uint);
             }
             else
             {
-                return 9;
+                return 1 + sizeof(ulong);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -45,7 +45,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Unsigned integer encoding https://tools.ietf.org/html/rfc7049#section-2.1
         private void WriteUnsignedInteger(CborMajorType type, ulong value)
         {
-            if (value < 24)
+            if (value < (byte)CborAdditionalInfo.Additional8BitData)
             {
                 EnsureWriteCapacity(1);
                 WriteInitialByte(new CborInitialByte(type, (CborAdditionalInfo)value));
@@ -76,6 +76,30 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 WriteInitialByte(new CborInitialByte(type, CborAdditionalInfo.Additional64BitData));
                 BinaryPrimitives.WriteUInt64BigEndian(_buffer.AsSpan(_offset), value);
                 _offset += 8;
+            }
+        }
+
+        private int GetIntegerEncodingLength(ulong value)
+        {
+            if (value < (byte)CborAdditionalInfo.Additional8BitData)
+            {
+                return 1;
+            }
+            else if (value <= byte.MaxValue)
+            {
+                return 2;
+            }
+            else if (value <= ushort.MaxValue)
+            {
+                return 3;
+            }
+            else if (value <= uint.MaxValue)
+            {
+                return 5;
+            }
+            else
+            {
+                return 9;
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -94,8 +94,8 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     keyLength: _currentValueOffset.Value - _currentKeyOffset.Value,
                     totalLength: _offset - _currentKeyOffset.Value);
 
-                Debug.Assert(!(CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel) && ranges.Contains(currentKeyRange)));
-                ranges.Add(currentKeyRange);
+                bool unique = ranges.Add(currentKeyRange);
+                Debug.Assert(unique || !CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel));
             }
 
             // reset state to new key

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -37,11 +37,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartMapIndefiniteLength()
         {
-            if (!PatchIndefiniteLengthItems && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
-            {
-                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
-            }
-
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Map, definiteLength: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -26,6 +26,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             WriteUnsignedInteger(CborMajorType.Map, (ulong)definiteLength);
             PushDataItem(CborMajorType.Map, definiteLength: checked(2 * definiteLength));
+            _currentKeyOffset = _offset;
         }
 
         public void WriteStartMap()
@@ -34,7 +35,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Map, definiteLength: null);
             _currentKeyOffset = _offset;
-            _currentValueOffset = null;
         }
 
         public void WriteEndMap()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 CborConformanceLevel.Rfc7049Canonical => true,
                 CborConformanceLevel.Ctap2Canonical => true,
-                CborConformanceLevel.NoConformance => false,
+                CborConformanceLevel.NonStrict => false,
                 _ => false,
             };
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -24,6 +24,15 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.Map, definiteLength: checked(2 * definiteLength));
         }
 
+        public void WriteStartMap()
+        {
+            EnsureWriteCapacity(1);
+            WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
+            PushDataItem(CborMajorType.Map, definiteLength: null);
+            _currentKeyOffset = _offset;
+            _currentValueOffset = null;
+        }
+
         public void WriteEndMap()
         {
             if (_itemsWritten % 2 == 1)
@@ -33,15 +42,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             PopDataItem(CborMajorType.Map);
             AdvanceDataItemCounters();
-        }
-
-        public void WriteStartMapIndefiniteLength()
-        {
-            EnsureWriteCapacity(1);
-            WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
-            PushDataItem(CborMajorType.Map, definiteLength: null);
-            _currentKeyOffset = _offset;
-            _currentValueOffset = null;
         }
 
         //

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -47,6 +47,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartMapIndefiniteLength()
         {
+            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
+            }
+
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Map, expectedNestedItems: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -115,7 +115,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             // copy sorted ranges to temporary buffer
             Span<byte> s = tmpSpan;
-            foreach((int, int, int) range in _keyValueEncodingRanges)
+            foreach((int offset, int keyLength, int valueLength) range in _keyValueEncodingRanges)
             {
                 ReadOnlySpan<byte> kvEnc = GetKeyValueEncoding(range);
                 kvEnc.CopyTo(s);
@@ -139,7 +139,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             return _buffer.AsSpan(keyValueRange.offset, keyValueRange.keyValueLength);
         }
 
-        private class KeyEncodingComparer : IComparer<(int, int, int)>
+        private class KeyEncodingComparer : IComparer<(int offset, int keyLength, int keyValueLength)>
         {
             private readonly CborWriter _writer;
 
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 _writer = writer;
             }
 
-            public int Compare((int, int, int) x, (int, int, int) y)
+            public int Compare((int offset, int keyLength, int keyValueLength) x, (int offset, int keyLength, int keyValueLength) y)
             {
                 return CborConformanceLevelHelpers.CompareEncodings(_writer.GetKeyEncoding(x), _writer.GetKeyEncoding(y), _writer.ConformanceLevel);
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -60,19 +60,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
             {
-                HashSet<KeyValueEncodingRange> ranges = GetKeyValueEncodingRanges();
+                HashSet<KeyValueEncodingRange> keys = GetKeyValueEncodingRanges();
 
-                var currentKeyRange = new KeyValueEncodingRange(
+                var newKey = new KeyValueEncodingRange(
                     offset: _currentKeyOffset.Value,
                     keyLength: currentValueOffset - _currentKeyOffset.Value,
-                    totalLength: 0 // totalLength not known, but is not significant w.r.t. key equality semantics
+                    totalLength: -1 // totalLength not known, but is not significant w.r.t. key equality semantics
                 );
 
-                if (ranges.Contains(currentKeyRange))
+                if (keys.Contains(newKey))
                 {
                     // reset writer state to what existed before the offending key write
-                    _buffer.AsSpan(currentKeyRange.Offset, _offset).Fill(0);
-                    _offset = currentKeyRange.Offset;
+                    _buffer.AsSpan(newKey.Offset, _offset).Fill(0);
+                    _offset = newKey.Offset;
 
                     throw new InvalidOperationException("Duplicate key encoding in CBOR map.");
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -58,19 +58,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Map encoding conformance
         //
 
-        private SortedSet<(int offset, int keyLength, int keyValueLength)> GetKeyValueEncodingRanges()
-        {
-            // TODO consider pooling set allocations?
-
-            if (_keyValueEncodingRanges == null)
-            {
-                _comparer ??= new KeyEncodingComparer(this);
-                return _keyValueEncodingRanges = new SortedSet<(int offset, int keyLength, int keyValueLength)>(_comparer);
-            }
-
-            return _keyValueEncodingRanges;
-        }
-
         private void HandleKeyWritten()
         {
             Debug.Assert(_currentKeyOffset != null && _currentValueOffset == null);
@@ -165,6 +152,19 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 return CborConformanceLevelHelpers.CompareEncodings(_writer.GetKeyEncoding(x), _writer.GetKeyEncoding(y), _writer.ConformanceLevel);
             }
+        }
+
+        private SortedSet<(int offset, int keyLength, int keyValueLength)> GetKeyValueEncodingRanges()
+        {
+            // TODO consider pooling set allocations?
+
+            if (_keyValueEncodingRanges == null)
+            {
+                _comparer ??= new KeyEncodingComparer(this);
+                return _keyValueEncodingRanges = new SortedSet<(int offset, int keyLength, int keyValueLength)>(_comparer);
+            }
+
+            return _keyValueEncodingRanges;
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -73,7 +73,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             {
                 SortedSet<(int offset, int keyLength, int keyValueLength)> ranges = GetKeyValueEncodingRanges();
 
-                (int offset, int keyLength, int valueLength) currentKeyRange =
+                (int offset, int keyLength, int keyValueLength) currentKeyRange =
                     (_currentKeyOffset.Value,
                      _currentValueOffset.Value - _currentKeyOffset.Value,
                      0);
@@ -120,7 +120,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             // copy sorted ranges to temporary buffer
             Span<byte> s = tmpSpan;
-            foreach((int offset, int keyLength, int valueLength) range in _keyValueEncodingRanges)
+            foreach((int offset, int keyLength, int keyValueLength) range in _keyValueEncodingRanges)
             {
                 ReadOnlySpan<byte> kvEnc = GetKeyValueEncoding(range);
                 kvEnc.CopyTo(s);
@@ -134,7 +134,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             s_bufferPool.Return(tempBuffer, clearArray: true);
         }
 
-        private ReadOnlySpan<byte> GetKeyEncoding((int offset, int keyLength, int valueLength) keyValueRange)
+        private ReadOnlySpan<byte> GetKeyEncoding((int offset, int keyLength, int keyValueLength) keyValueRange)
         {
             return _buffer.AsSpan(keyValueRange.offset, keyValueRange.keyLength);
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -3,12 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System.Text;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
     internal partial class CborWriter
     {
+        private KeyEncodingComparer? _comparer;
+
         public void WriteStartMap(int definiteLength)
         {
             if (definiteLength < 0)
@@ -17,13 +21,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
 
             WriteUnsignedInteger(CborMajorType.Map, (ulong)definiteLength);
-            AdvanceDataItemCounters();
             PushDataItem(CborMajorType.Map, 2 * (uint)definiteLength);
         }
 
         public void WriteEndMap()
         {
-            if (!_isEvenNumberOfDataItemsWritten)
+            if (_currentValueOffset != null)
             {
                 throw new InvalidOperationException("CBOR Map types require an even number of key/value combinations");
             }
@@ -38,14 +41,184 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 EnsureWriteCapacity(1);
                 _buffer[_offset++] = CborInitialByte.IndefiniteLengthBreakByte;
             }
+
+            AdvanceDataItemCounters();
         }
 
         public void WriteStartMapIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
-            AdvanceDataItemCounters();
             PushDataItem(CborMajorType.Map, expectedNestedItems: null);
+            _currentKeyOffset = _offset;
+            _currentValueOffset = null;
+        }
+
+        //
+        // Map encoding conformance
+        //
+
+        private bool ConformanceRequiresSortedKeys()
+        {
+            return ConformanceLevel switch
+            {
+                CborConformanceLevel.Rfc7049Canonical => true,
+                CborConformanceLevel.Ctap2Canonical => true,
+                CborConformanceLevel.NoConformance => false,
+                _ => false,
+            };
+        }
+
+        private SortedSet<(int offset, int keyLength, int keyValueLength)> GetKeyValueEncodingRanges()
+        {
+            // TODO consider pooling set allocations?
+
+            if (_keyValueEncodingRanges == null)
+            {
+                _comparer ??= new KeyEncodingComparer(this);
+                return _keyValueEncodingRanges = new SortedSet<(int offset, int keyLength, int keyValueLength)>(_comparer);
+            }
+
+            return _keyValueEncodingRanges;
+        }
+
+        private void HandleKeyWritten()
+        {
+            Debug.Assert(_currentKeyOffset != null && _currentValueOffset == null);
+
+            _currentValueOffset = _offset;
+
+            if (ConformanceRequiresSortedKeys())
+            {
+                // check for key uniqueness
+                SortedSet<(int offset, int keyLength, int keyValueLength)> ranges = GetKeyValueEncodingRanges();
+
+                (int offset, int keyLength, int valueLength) currentKeyRange =
+                    (_currentKeyOffset.Value,
+                     _currentValueOffset.Value - _currentKeyOffset.Value,
+                     0);
+
+                if (ranges.Contains(currentKeyRange))
+                {
+                    // TODO: check if rollback is necessary here
+                    throw new InvalidOperationException("Duplicate key encoding in CBOR map.");
+                }
+            }
+        }
+
+        private void HandleValueWritten()
+        {
+            Debug.Assert(_currentKeyOffset != null && _currentValueOffset != null);
+
+            if (ConformanceRequiresSortedKeys())
+            {
+                Debug.Assert(_keyValueEncodingRanges != null);
+
+                (int offset, int keyLength, int keyValueLength) currentKeyRange =
+                    (_currentKeyOffset.Value,
+                     _currentValueOffset.Value - _currentKeyOffset.Value,
+                     _offset - _currentKeyOffset.Value);
+
+                _keyValueEncodingRanges.Add(currentKeyRange);
+            }
+
+            // reset state
+            _currentKeyOffset = _offset;
+            _currentValueOffset = null;
+        }
+
+        private void SortKeyValuePairEncodings()
+        {
+            if (_keyValueEncodingRanges == null)
+            {
+                return;
+            }
+
+            int totalMapPayloadEncodingLength = _offset - _frameOffset;
+            byte[] tempBuffer = s_bufferPool.Rent(totalMapPayloadEncodingLength);
+            Span<byte> tmpSpan = tempBuffer.AsSpan(0, totalMapPayloadEncodingLength);
+
+            // copy sorted ranges to temporary buffer
+            Span<byte> s = tmpSpan;
+            foreach((int, int, int) range in _keyValueEncodingRanges)
+            {
+                ReadOnlySpan<byte> kvEnc = GetKeyValueEncoding(range);
+                kvEnc.CopyTo(s);
+                s = s.Slice(kvEnc.Length);
+            }
+            Debug.Assert(s.IsEmpty);
+
+            // now copy back to the original buffer segment
+            tmpSpan.CopyTo(_buffer.AsSpan(_frameOffset, totalMapPayloadEncodingLength));
+
+            s_bufferPool.Return(tempBuffer, clearArray: true);
+        }
+
+        private ReadOnlySpan<byte> GetKeyEncoding((int offset, int keyLength, int valueLength) keyValueRange)
+        {
+            return _buffer.AsSpan(keyValueRange.offset, keyValueRange.keyLength);
+        }
+
+        private ReadOnlySpan<byte> GetKeyValueEncoding((int offset, int keyLength, int keyValueLength) keyValueRange)
+        {
+            return _buffer.AsSpan(keyValueRange.offset, keyValueRange.keyValueLength);
+        }
+
+        private static int CompareEncodings(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right, CborConformanceLevel level)
+        {
+            Debug.Assert(!left.IsEmpty && !right.IsEmpty);
+
+            switch (level)
+            {
+                case CborConformanceLevel.Rfc7049Canonical:
+                    // Implements key sorting according to
+                    // https://tools.ietf.org/html/rfc7049#section-3.9
+
+                    if (left.Length != right.Length)
+                    {
+                        return left.Length - right.Length;
+                    }
+
+                    return left.SequenceCompareTo(right);
+
+                case CborConformanceLevel.Ctap2Canonical:
+                    // Implements key sorting according to
+                    // https://fidoalliance.org/specs/fido-v2.0-ps-20190130/fido-client-to-authenticator-protocol-v2.0-ps-20190130.html#message-encoding
+
+                    int leftMt = (int)new CborInitialByte(left[0]).MajorType;
+                    int rightMt = (int)new CborInitialByte(right[0]).MajorType;
+
+                    if (leftMt != rightMt)
+                    {
+                        return leftMt - rightMt;
+                    }
+
+                    if (left.Length != right.Length)
+                    {
+                        return left.Length - right.Length;
+                    }
+
+                    return left.SequenceCompareTo(right);
+
+                default:
+                    Debug.Fail("Invalid conformance level used in encoding sort.");
+                    throw new Exception("Invalid conformance level used in encoding sort.");
+            }
+        }
+
+        private class KeyEncodingComparer : IComparer<(int, int, int)>
+        {
+            private readonly CborWriter _writer;
+
+            public KeyEncodingComparer(CborWriter writer)
+            {
+                _writer = writer;
+            }
+
+            public int Compare((int, int, int) x, (int, int, int) y)
+            {
+                return CompareEncodings(_writer.GetKeyEncoding(x), _writer.GetKeyEncoding(y), _writer.ConformanceLevel);
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -71,9 +71,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
             {
-                SortedSet<(int offset, int keyLength, int keyValueLength)> ranges = GetKeyValueEncodingRanges();
+                SortedSet<(int Offset, int KeyLength, int TotalLength)> ranges = GetKeyValueEncodingRanges();
 
-                (int offset, int keyLength, int keyValueLength) currentKeyRange =
+                (int Offset, int KeyLength, int TotalLength) currentKeyRange =
                     (_currentKeyOffset.Value,
                      _currentValueOffset.Value - _currentKeyOffset.Value,
                      0);
@@ -92,9 +92,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             if (CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel) || CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
             {
-                SortedSet<(int offset, int keyLength, int keyValueLength)> ranges = GetKeyValueEncodingRanges();
+                SortedSet<(int Offset, int KeyLength, int TotalLength)> ranges = GetKeyValueEncodingRanges();
 
-                (int offset, int keyLength, int keyValueLength) currentKeyRange =
+                (int Offset, int KeyLength, int TotalLength) currentKeyRange =
                     (_currentKeyOffset.Value,
                      _currentValueOffset.Value - _currentKeyOffset.Value,
                      _offset - _currentKeyOffset.Value);
@@ -120,7 +120,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             // copy sorted ranges to temporary buffer
             Span<byte> s = tmpSpan;
-            foreach((int offset, int keyLength, int keyValueLength) range in _keyValueEncodingRanges)
+            foreach((int Offset, int KeyLength, int TotalLength) range in _keyValueEncodingRanges)
             {
                 ReadOnlySpan<byte> kvEnc = GetKeyValueEncoding(range);
                 kvEnc.CopyTo(s);
@@ -134,17 +134,17 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             s_bufferPool.Return(tempBuffer, clearArray: true);
         }
 
-        private ReadOnlySpan<byte> GetKeyEncoding((int offset, int keyLength, int keyValueLength) keyValueRange)
+        private ReadOnlySpan<byte> GetKeyEncoding((int Offset, int KeyLength, int TotalLength) keyValueRange)
         {
-            return _buffer.AsSpan(keyValueRange.offset, keyValueRange.keyLength);
+            return _buffer.AsSpan(keyValueRange.Offset, keyValueRange.KeyLength);
         }
 
-        private ReadOnlySpan<byte> GetKeyValueEncoding((int offset, int keyLength, int keyValueLength) keyValueRange)
+        private ReadOnlySpan<byte> GetKeyValueEncoding((int Offset, int KeyLength, int TotalLength) keyValueRange)
         {
-            return _buffer.AsSpan(keyValueRange.offset, keyValueRange.keyValueLength);
+            return _buffer.AsSpan(keyValueRange.Offset, keyValueRange.TotalLength);
         }
 
-        private class KeyEncodingComparer : IComparer<(int offset, int keyLength, int keyValueLength)>
+        private class KeyEncodingComparer : IComparer<(int Offset, int KeyLength, int TotalLength)>
         {
             private readonly CborWriter _writer;
 
@@ -153,20 +153,20 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 _writer = writer;
             }
 
-            public int Compare((int offset, int keyLength, int keyValueLength) x, (int offset, int keyLength, int keyValueLength) y)
+            public int Compare((int Offset, int KeyLength, int TotalLength) x, (int Offset, int KeyLength, int TotalLength) y)
             {
                 return CborConformanceLevelHelpers.CompareEncodings(_writer.GetKeyEncoding(x), _writer.GetKeyEncoding(y), _writer.ConformanceLevel);
             }
         }
 
-        private SortedSet<(int offset, int keyLength, int keyValueLength)> GetKeyValueEncodingRanges()
+        private SortedSet<(int Offset, int KeyLength, int TotalLength)> GetKeyValueEncodingRanges()
         {
             // TODO consider pooling set allocations?
 
             if (_keyValueEncodingRanges == null)
             {
                 _comparer ??= new KeyEncodingComparer(this);
-                return _keyValueEncodingRanges = new SortedSet<(int offset, int keyLength, int keyValueLength)>(_comparer);
+                return _keyValueEncodingRanges = new SortedSet<(int Offset, int KeyLength, int TotalLength)>(_comparer);
             }
 
             return _keyValueEncodingRanges;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length);
             EnsureWriteCapacity(value.Length);
 
-            if (!EncodeIndefiniteLengths && IsMajorTypeContext(CborMajorType.ByteString))
+            if (!EncodeIndefiniteLengths && _currentMajorType == CborMajorType.ByteString)
             {
                 // operation is writing chunk of an indefinite-length string
                 Debug.Assert(_currentIndefiniteLengthStringRanges != null);
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             WriteUnsignedInteger(CborMajorType.TextString, (ulong)length);
             EnsureWriteCapacity(length);
 
-            if (!EncodeIndefiniteLengths && IsMajorTypeContext(CborMajorType.TextString))
+            if (!EncodeIndefiniteLengths && _currentMajorType == CborMajorType.TextString)
             {
                 // operation is writing chunk of an indefinite-length string
                 Debug.Assert(_currentIndefiniteLengthStringRanges != null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -46,7 +46,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.ByteString, CborAdditionalInfo.IndefiniteLength));
-            AdvanceDataItemCounters();
             PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
         }
 
@@ -56,13 +55,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             // append break byte
             EnsureWriteCapacity(1);
             _buffer[_offset++] = CborInitialByte.IndefiniteLengthBreakByte;
+            AdvanceDataItemCounters();
         }
 
         public void WriteStartTextStringIndefiniteLength()
         {
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.TextString, CborAdditionalInfo.IndefiniteLength));
-            AdvanceDataItemCounters();
             PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
         }
 
@@ -72,6 +71,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             // append break byte
             EnsureWriteCapacity(1);
             _buffer[_offset++] = CborInitialByte.IndefiniteLengthBreakByte;
+            AdvanceDataItemCounters();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -4,7 +4,10 @@
 
 #nullable enable
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
+using System.Threading;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
 {
@@ -12,11 +15,22 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     {
         private static readonly System.Text.Encoding s_utf8Encoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
+        // keeps track of chunk offsets for written indefinite-length string ranges
+        private List<(int Offset, int Length)>? _currentIndefiniteLengthStringRanges = null;
+
         // Implements major type 2 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
         public void WriteByteString(ReadOnlySpan<byte> value)
         {
             WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length);
             EnsureWriteCapacity(value.Length);
+
+            if (PatchIndefiniteLengthItems && IsMajorTypeContext(CborMajorType.ByteString))
+            {
+                // operation is writing chunk of an indefinite-length string
+                Debug.Assert(_currentIndefiniteLengthStringRanges != null);
+                _currentIndefiniteLengthStringRanges.Add((_offset, value.Length));
+            }
+
             value.CopyTo(_buffer.AsSpan(_offset));
             _offset += value.Length;
             AdvanceDataItemCounters();
@@ -37,51 +51,99 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             WriteUnsignedInteger(CborMajorType.TextString, (ulong)length);
             EnsureWriteCapacity(length);
-            s_utf8Encoding.GetBytes(value, _buffer.AsSpan(_offset));
+
+            if (PatchIndefiniteLengthItems && IsMajorTypeContext(CborMajorType.TextString))
+            {
+                // operation is writing chunk of an indefinite-length string
+                Debug.Assert(_currentIndefiniteLengthStringRanges != null);
+                _currentIndefiniteLengthStringRanges.Add((_offset, value.Length));
+            }
+
+            s_utf8Encoding.GetBytes(value, _buffer.AsSpan(_offset, length));
             _offset += length;
             AdvanceDataItemCounters();
         }
 
         public void WriteStartByteStringIndefiniteLength()
         {
-            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            if (PatchIndefiniteLengthItems)
+            {
+                _currentIndefiniteLengthStringRanges ??= new List<(int, int)>();
+            }
+            else if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
                 throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
             }
 
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.ByteString, CborAdditionalInfo.IndefiniteLength));
-            PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
+            PushDataItem(CborMajorType.ByteString, definiteLength: null);
         }
 
         public void WriteEndByteStringIndefiniteLength()
         {
             PopDataItem(CborMajorType.ByteString);
-            // append break byte
-            EnsureWriteCapacity(1);
-            _buffer[_offset++] = CborInitialByte.IndefiniteLengthBreakByte;
             AdvanceDataItemCounters();
         }
 
         public void WriteStartTextStringIndefiniteLength()
         {
-            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            if (PatchIndefiniteLengthItems)
+            {
+                _currentIndefiniteLengthStringRanges ??= new List<(int, int)>();
+            }
+            else if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
                 throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
             }
 
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.TextString, CborAdditionalInfo.IndefiniteLength));
-            PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
+            PushDataItem(CborMajorType.TextString, definiteLength: null);
         }
 
         public void WriteEndTextStringIndefiniteLength()
         {
             PopDataItem(CborMajorType.TextString);
-            // append break byte
-            EnsureWriteCapacity(1);
-            _buffer[_offset++] = CborInitialByte.IndefiniteLengthBreakByte;
             AdvanceDataItemCounters();
+        }
+
+        private void PatchIndefiniteLengthString(CborMajorType type)
+        {
+            Debug.Assert(type == CborMajorType.ByteString || type == CborMajorType.TextString);
+            Debug.Assert(_currentIndefiniteLengthStringRanges != null);
+
+            int currentOffset = _offset;
+
+            // calculate the definite length of the concatenated string
+            int definiteLength = 0;
+            foreach ((int _, int length) in _currentIndefiniteLengthStringRanges)
+            {
+                definiteLength += length;
+            }
+
+            // copy chunks to a temporary buffer
+            byte[] tempBuffer = s_bufferPool.Rent(definiteLength);
+            Span<byte> tempSpan = tempBuffer.AsSpan(0, definiteLength);
+
+            Span<byte> s = tempSpan;
+            foreach ((int offset, int length) in _currentIndefiniteLengthStringRanges)
+            {
+                _buffer.AsSpan(offset, length).CopyTo(s);
+                s = s.Slice(length);
+            }
+            Debug.Assert(s.IsEmpty);
+
+            // write back to the original buffer
+            _offset = _frameOffset - 1;
+            WriteUnsignedInteger(type, (ulong)definiteLength);
+            tempSpan.CopyTo(_buffer.AsSpan(_offset, definiteLength));
+            _offset += definiteLength;
+
+            // zero out excess bytes & other cleanups
+            _buffer.AsSpan(_offset, currentOffset - _offset).Fill(0);
+            s_bufferPool.Return(tempBuffer, clearArray: true);
+            _currentIndefiniteLengthStringRanges.Clear();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -44,6 +44,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartByteStringIndefiniteLength()
         {
+            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
+            }
+
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.ByteString, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
@@ -60,6 +65,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartTextStringIndefiniteLength()
         {
+            if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
+            }
+
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.TextString, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.TextString, expectedNestedItems: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             AdvanceDataItemCounters();
         }
 
-        public void WriteStartByteStringIndefiniteLength()
+        public void WriteStartByteString()
         {
             if (!EncodeIndefiniteLengths)
             {
@@ -79,13 +79,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.ByteString, definiteLength: null);
         }
 
-        public void WriteEndByteStringIndefiniteLength()
+        public void WriteEndByteString()
         {
             PopDataItem(CborMajorType.ByteString);
             AdvanceDataItemCounters();
         }
 
-        public void WriteStartTextStringIndefiniteLength()
+        public void WriteStartTextString()
         {
             if (!EncodeIndefiniteLengths)
             {
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             PushDataItem(CborMajorType.TextString, definiteLength: null);
         }
 
-        public void WriteEndTextStringIndefiniteLength()
+        public void WriteEndTextString()
         {
             PopDataItem(CborMajorType.TextString);
             AdvanceDataItemCounters();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             WriteUnsignedInteger(CborMajorType.ByteString, (ulong)value.Length);
             EnsureWriteCapacity(value.Length);
 
-            if (PatchIndefiniteLengthItems && IsMajorTypeContext(CborMajorType.ByteString))
+            if (!EncodeIndefiniteLengths && IsMajorTypeContext(CborMajorType.ByteString))
             {
                 // operation is writing chunk of an indefinite-length string
                 Debug.Assert(_currentIndefiniteLengthStringRanges != null);
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             WriteUnsignedInteger(CborMajorType.TextString, (ulong)length);
             EnsureWriteCapacity(length);
 
-            if (PatchIndefiniteLengthItems && IsMajorTypeContext(CborMajorType.TextString))
+            if (!EncodeIndefiniteLengths && IsMajorTypeContext(CborMajorType.TextString))
             {
                 // operation is writing chunk of an indefinite-length string
                 Debug.Assert(_currentIndefiniteLengthStringRanges != null);
@@ -66,13 +66,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartByteStringIndefiniteLength()
         {
-            if (PatchIndefiniteLengthItems)
+            if (!EncodeIndefiniteLengths)
             {
+                // Writer does not allow indefinite-length encodings.
+                // We need to keep track of chunk offsets to convert to
+                // a definite-length encoding once writing is complete.
                 _currentIndefiniteLengthStringRanges ??= new List<(int, int)>();
-            }
-            else if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
-            {
-                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
             }
 
             EnsureWriteCapacity(1);
@@ -88,13 +87,12 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteStartTextStringIndefiniteLength()
         {
-            if (PatchIndefiniteLengthItems)
+            if (!EncodeIndefiniteLengths)
             {
+                // Writer does not allow indefinite-length encodings.
+                // We need to keep track of chunk offsets to convert to
+                // a definite-length encoding once writing is complete.
                 _currentIndefiniteLengthStringRanges ??= new List<(int, int)>();
-            }
-            else if (CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
-            {
-                throw new InvalidOperationException("Indefinite-length items are not permitted under the current conformance level.");
             }
 
             EnsureWriteCapacity(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -11,6 +11,11 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
     {
         public void WriteTag(CborTag tag)
         {
+            if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
+            {
+                throw new InvalidOperationException("Tagged items are not permitted under the current conformance level.");
+            }
+
             WriteUnsignedInteger(CborMajorType.Tag, (ulong)tag);
             _isTagContext = true;
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Map-specific bookkeeping
         private int? _currentKeyOffset = null;
         private int? _currentValueOffset = null;
-        private SortedSet<(int Offset, int KeyLength, int TotalLength)>? _keyValueEncodingRanges = null;
+        private HashSet<KeyValueEncodingRange>? _keyValueEncodingRanges = null;
 
         public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.Lax, bool encodeIndefiniteLengths = false)
         {
@@ -317,7 +317,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private readonly struct StackFrame
         {
             public StackFrame(CborMajorType type, int frameOffset, int? definiteLength, int itemsWritten,
-                              int? currentKeyOffset, int? currentValueOffset, SortedSet<(int, int, int)>? keyValueEncodingRanges)
+                              int? currentKeyOffset, int? currentValueOffset, HashSet<KeyValueEncodingRange>? keyValueEncodingRanges)
             {
                 MajorType = type;
                 FrameOffset = frameOffset;
@@ -335,7 +335,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             public int? CurrentKeyOffset { get; }
             public int? CurrentValueOffset { get; }
-            public SortedSet<(int, int, int)>? KeyValueEncodingRanges { get; }
+            public HashSet<KeyValueEncodingRange>? KeyValueEncodingRanges { get; }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private int? _currentValueOffset = null;
         private SortedSet<(int offset, int keyLength, int keyValueLength)>? _keyValueEncodingRanges = null;
 
-        public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.NonStrict)
+        public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.Lax)
         {
             CborConformanceLevelHelpers.Validate(conformanceLevel);
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -28,7 +28,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         // Map-specific bookkeeping
         private int? _currentKeyOffset = null;
         private int? _currentValueOffset = null;
-        private SortedSet<(int offset, int keyLength, int keyValueLength)>? _keyValueEncodingRanges = null;
+        private SortedSet<(int Offset, int KeyLength, int TotalLength)>? _keyValueEncodingRanges = null;
 
         public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.Lax)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -30,7 +30,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
         private int? _currentValueOffset = null;
         private SortedSet<(int offset, int keyLength, int keyValueLength)>? _keyValueEncodingRanges = null;
 
-        public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.NoConformance)
+        public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.NonStrict)
         {
             ConformanceLevel = conformanceLevel;
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -225,7 +225,24 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
             }
         }
 
-        public byte[] ToArray()
+        public byte[] GetEncoding() => GetSpanEncoding().ToArray();
+
+        public bool TryWriteEncoding(Span<byte> destination, out int bytesWritten)
+        {
+            ReadOnlySpan<byte> encoding = GetSpanEncoding();
+
+            if (encoding.Length > destination.Length)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            encoding.CopyTo(destination);
+            bytesWritten = encoding.Length;
+            return true;
+        }
+
+        private ReadOnlySpan<byte> GetSpanEncoding()
         {
             CheckDisposed();
 
@@ -234,7 +251,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("Buffer contains incomplete CBOR document.");
             }
 
-            return (_offset == 0) ? Array.Empty<byte>() : _buffer.AsSpan(0, _offset).ToArray();
+            return (_offset == 0) ? ReadOnlySpan<byte>.Empty : new ReadOnlySpan<byte>(_buffer, 0, _offset);
         }
 
         private readonly struct StackFrame

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -161,9 +161,6 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         private void AdvanceDataItemCounters()
         {
-            _remainingDataItems--;
-            _isTagContext = false;
-
             if (_currentKeyOffset != null) // this is a map context
             {
                 if (_currentValueOffset == null)
@@ -175,6 +172,9 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                     HandleValueWritten();
                 }
             }
+
+            _remainingDataItems--;
+            _isTagContext = false;
         }
 
         private void WriteInitialByte(CborInitialByte initialByte)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -6,7 +6,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing.Text;
 using System.Threading;
 
 namespace System.Security.Cryptography.Encoding.Tests.Cbor
@@ -49,7 +48,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
         public void WriteEncodedValue(ReadOnlyMemory<byte> encodedValue)
         {
-            ValidateEncoding(encodedValue);
+            ValidateEncoding(encodedValue, ConformanceLevel);
             ReadOnlySpan<byte> encodedValueSpan = encodedValue.Span;
             EnsureWriteCapacity(encodedValueSpan.Length);
 
@@ -70,13 +69,13 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
 
             AdvanceDataItemCounters();
 
-            static void ValidateEncoding(ReadOnlyMemory<byte> encodedValue)
+            static void ValidateEncoding(ReadOnlyMemory<byte> encodedValue, CborConformanceLevel conformanceLevel)
             {
-                var reader = new CborReader(encodedValue);
+                var reader = new CborReader(encodedValue, conformanceLevel: conformanceLevel);
 
                 try
                 {
-                    reader.SkipValue();
+                    reader.SkipValue(validateConformance: true);
                 }
                 catch (FormatException e)
                 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -144,7 +144,7 @@ namespace System.Security.Cryptography.Encoding.Tests.Cbor
                 throw new InvalidOperationException("Definite-length nested CBOR data item is incomplete.");
             }
 
-            if (expectedType == CborMajorType.Map && ConformanceRequiresSortedKeys())
+            if (expectedType == CborMajorType.Map && CborConformanceLevelHelpers.RequiresSortedKeys(ConformanceLevel))
             {
                 SortKeyValuePairEncodings();
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <ItemGroup>
+    <Compile Include="..\..\Common\src\System\Marvin.cs" Link="System\Marvin.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"
              Link="Common\System\Security\Cryptography\CryptoPool.cs" />
     <Compile Include="Asn1\Reader\Asn1ReaderTests.cs" />

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="AsnEncodedDataCollectionTests.cs" />
     <Compile Include="Base64TransformsTests.cs" />
     <Compile Include="Cbor\CborWriter.Tag.cs" />
+    <Compile Include="Cbor\CborConformanceLevel.cs" />
     <Compile Include="Oid.cs" />
     <Compile Include="OidCollectionTests.cs" />
     <Compile Include="PemEncodingFindTests.cs" />


### PR DESCRIPTION
Contributes to #32046 and #32047.

- [x] Define conformance levels for Strict mode, RFC7049 canonical mode and CTAP2 canonical mode.
- [x] Implement key sorting in CborWriter.
- [x] Implement conformance level validation for CborWriter.
- [x] Implement conformance level validation for CborReader.

Addendum:

- [x] Implement patching support for indefinite-length data items.
- [x] Fix `SkipValue()` conformance and implement a `SkipToParent()` method.
- [x] Implement writing and reading multiple root-level values.