### PR TITLE
[docs] Helpful links when building the first time.

### DIFF
--- a/docs/workflow/building/mono/README.md
+++ b/docs/workflow/building/mono/README.md
@@ -1,5 +1,15 @@
 # Building Mono
 
+## Build Requirements
+
+| Windows  | Linux    | macOS    | FreeBSD  |
+| :------: | :------: | :------: | :------: |
+| [Requirements](../../requirements/windows-requirements.md) | [Requirements](../../requirements/linux-requirements.md) | [Requirements](../../requirements/macos-requirements.md) |
+
+Before proceeding further, please click on the link above that matches your machine and ensure you have installed all the prerequisites for the build to work.
+
+## Concept
+
 To build the Mono runtime, you must first do a complete runtime build (coreclr, libraries, and then mono).  At the repo root, simply execute:
 
 ```bash

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -14,7 +14,7 @@ endif(CMAKE_STATIC_LIB_LINK)
 
 find_package(OpenSSL)
 if(NOT OPENSSL_FOUND)
-    message(FATAL_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!")
+    message(FATAL_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!. See the requirements document for your specific operating system: https://github.com/dotnet/runtime/tree/master/docs/workflow/requirements.")
 endif(NOT OPENSSL_FOUND)
 
 include_directories(${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
PR should help reduce questions for first time builders by providing some helpful hints on where to look.

- Add requirements link to the mono build README.md.  
   - Those interested in building for mono may jump straight to that document without actually reading the main documents.  The first item to do is run the build for runtime with a command to run.  

- Add a link to the requirements document when missing openssl.
   - Again for those that jump straight to mono build.

/cc @CoffeeFlux 