### PR TITLE
Add prototype exception filter rewriter tool

### DIFF
--- a/src/mono/mono/mini/TestDriver.cs
+++ b/src/mono/mono/mini/TestDriver.cs
@@ -117,6 +117,11 @@ public class TestDriver {
 				for (j = 5; j < name.Length; ++j)
 					if (!Char.IsDigit (name [j]))
 						break;
+				if (methods[i].GetParameters().Length > 0) {
+					if (verbose)
+						Console.WriteLine ("Skipping '{0}' because it accepts parameters.", name);
+					continue;
+				}
 				if (verbose)
 					Console.WriteLine ("Running '{0}' ...", name);
 				expected = Int32.Parse (name.Substring (5, j - 5));


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19400,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This PR adds a tool that rewrites exception filters into non-filtered code so we can get code with filters working in fullaot. It also integrates it into packager.exe and runs it on all the BCL assemblies during the wasm sdk build.

A future PR will shift all this logic into the linker.