### PR TITLE
Ping timeout in SendPingWithIPAddress test increased to 10 seconds

### DIFF
--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -140,7 +140,7 @@ namespace System.Net.NetworkInformation.Tests
             }
 
             SendBatchPing(
-                (ping) => ping.Send(localIpAddress, 10000),
+                (ping) => ping.Send(localIpAddress, TestSettings.PingTimeout),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddress);

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -140,7 +140,7 @@ namespace System.Net.NetworkInformation.Tests
             }
 
             SendBatchPing(
-                (ping) => ping.Send(localIpAddress),
+                (ping) => ping.Send(localIpAddress, 10000),
                 (pingReply) =>
                 {
                     PingResultValidator(pingReply, localIpAddress);


### PR DESCRIPTION
Ping timeout in SendPingWithIPAddress test increased to 10 seconds to prevent failures.