### PR TITLE
Remove needed use of mono product build from CI

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -100,25 +100,14 @@ jobs:
           artifactName: '$(librariesBuildArtifactName)'
           displayName: 'live-built libraries'
 
-    - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:  
-      # We need to explictly download CoreCLR for Mono because the CoreCLR tests depend on it
-      - template: /eng/pipelines/common/download-artifact-step.yml
-        parameters:
-          unpackFolder: $(coreClrProductRootFolderPath)
-          artifactFileName: '$(coreClrProductArtifactName)$(archiveExtension)'
-          artifactName: '$(coreClrProductArtifactName)'
-          displayName: 'CoreCLR product build for Mono'
-
-
-    # Download product binaries directory
+    # We need to explictly download CoreCLR, even if building Mono because the CoreCLR tests depend on it
     - template: /eng/pipelines/common/download-artifact-step.yml
       parameters:
-        unpackFolder: $(buildProductRootFolderPath)
-        artifactFileName: '$(buildProductArtifactName)$(archiveExtension)'
-        artifactName: '$(buildProductArtifactName)'
-        displayName: 'product build'
-
-
+        unpackFolder: $(coreClrProductRootFolderPath)
+        artifactFileName: '$(coreClrProductArtifactName)$(archiveExtension)'
+        artifactName: '$(coreClrProductArtifactName)'
+        displayName: 'CoreCLR product build'
+    
     # Build managed test components
     - script: $(coreClrRepoRootDir)build-test$(scriptExt) skipnative skipgeneratelayout skiptestwrappers $(buildConfig) $(archType) $(crossArg) $(priorityArg) ci $(librariesOverrideArg)
       displayName: Build managed test components

--- a/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
+++ b/eng/pipelines/coreclr/templates/xplat-pipeline-job.yml
@@ -68,11 +68,19 @@ jobs:
 
     - name: binTestsPath
       value: '$(Build.SourcesDirectory)/artifacts/tests/coreclr'
-
+     
+    # Build product defines what we are trying to build, either coreclr or mono
     - name: buildProductArtifactName
       value: 'CoreCLRProduct_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
 
     - name: buildProductRootFolderPath
+      value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)'
+
+    # We need this because both mono and coreclr build currently depends on CoreClr
+    - name: coreClrProductArtifactName
+      value: 'CoreCLRProduct_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)'
+
+    - name: coreClrProductRootFolderPath
       value: '$(Build.SourcesDirectory)/artifacts/bin/coreclr/$(osGroup).$(archType).$(buildConfigUpper)'
 
     - name: corelibProductArtifactName


### PR DESCRIPTION
Mono pri0 tests build pulls the mono build,  but it is not actually needed for that stage.