### PR TITLE
Fix SuperPmi MCS tool

### DIFF
--- a/src/coreclr/src/ToolBox/superpmi/mcs/verbildump.cpp
+++ b/src/coreclr/src/ToolBox/superpmi/mcs/verbildump.cpp
@@ -915,12 +915,9 @@ char* DumpAttributeToConsoleBare(DWORD attribute)
 
     if (0)
         ;
-    ifPrint(CORINFO_FLG_STATIC, s_static) ifPrint(CORINFO_FLG_DONT_INLINE, s_dontInline)
-        ifPrint(CORINFO_FLG_CONSTRUCTOR, s_constructor) else
-    {
-        LogError("unknown attribute %x", attribute);
-        __debugbreak();
-    }
+    ifPrint(CORINFO_FLG_STATIC, s_static)
+    ifPrint(CORINFO_FLG_DONT_INLINE, s_dontInline)
+    ifPrint(CORINFO_FLG_CONSTRUCTOR, s_constructor)
     return nullptr;
 
 #undef ifPrint


### PR DESCRIPTION
It currently errors out if it finds a method without `CORINFO_FLG_STATIC`, `CORINFO_FLG_DONT_INLINE` or `CORINFO_FLG_CONSTRUCTOR`. Also, it only prints the first attribute it encounters.
It's unclear to me how this ever worked, but in any case it isn't useful to fail to generate a map or IL dump.