### PR TITLE
Improve Array.Sort(T[]) performance

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -25,6 +26,11 @@ namespace System
         // We have different max sizes for arrays with elements of size 1 for backwards compatibility
         internal const int MaxArrayLength = 0X7FEFFFFF;
         internal const int MaxByteArrayLength = 0x7FFFFFC7;
+
+        // This is the threshold where Introspective sort switches to Insertion sort.
+        // Empirically, 16 seems to speed up most cases without slowing down others, at least for integers.
+        // Large value types may benefit from a smaller number.
+        internal const int IntrosortSizeThreshold = 16;
 
         // This ctor exists solely to prevent C# from generating a protected .ctor that violates the surface area.
         private protected Array() { }
@@ -1916,11 +1922,11 @@ namespace System
 
                 try
                 {
-                    IntroSort(left, length + left - 1, 2 * IntrospectiveSortUtilities.FloorLog2PlusOne(length));
+                    IntroSort(left, length + left - 1, 2 * (BitOperations.Log2((uint)length) + 1));
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    IntrospectiveSortUtilities.ThrowBadComparer(comparer);
+                    ThrowHelper.ThrowArgumentException_BadComparer(comparer);
                 }
                 catch (Exception e)
                 {
@@ -1930,20 +1936,22 @@ namespace System
 
             private void IntroSort(int lo, int hi, int depthLimit)
             {
+                Debug.Assert(hi > lo);
+                Debug.Assert(depthLimit >= 0);
+
                 while (hi > lo)
                 {
                     int partitionSize = hi - lo + 1;
-                    if (partitionSize <= IntrospectiveSortUtilities.IntrosortSizeThreshold)
+                    if (partitionSize <= IntrosortSizeThreshold)
                     {
-                        if (partitionSize == 1)
-                        {
-                            return;
-                        }
+                        Debug.Assert(partitionSize >= 2);
+
                         if (partitionSize == 2)
                         {
                             SwapIfGreater(lo, hi);
                             return;
                         }
+
                         if (partitionSize == 3)
                         {
                             SwapIfGreater(lo, hi - 1);
@@ -1971,8 +1979,11 @@ namespace System
 
             private int PickPivotAndPartition(int lo, int hi)
             {
+                Debug.Assert(hi - lo >= IntrosortSizeThreshold);
+
                 // Compute median-of-three.  But also partition them, since we've done the comparison.
                 int mid = lo + (hi - lo) / 2;
+
                 // Sort lo, mid and hi appropriately, then pick mid as the pivot.
                 SwapIfGreater(lo, mid);
                 SwapIfGreater(lo, hi);
@@ -1994,7 +2005,10 @@ namespace System
                 }
 
                 // Put pivot in the right location.
-                Swap(left, hi - 1);
+                if (left != hi - 1)
+                {
+                    Swap(left, hi - 1);
+                }
                 return left;
             }
 
@@ -2122,11 +2136,11 @@ namespace System
 
                 try
                 {
-                    IntroSort(left, length + left - 1, 2 * IntrospectiveSortUtilities.FloorLog2PlusOne(length));
+                    IntroSort(left, length + left - 1, 2 * (BitOperations.Log2((uint)length) + 1));
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    IntrospectiveSortUtilities.ThrowBadComparer(comparer);
+                    ThrowHelper.ThrowArgumentException_BadComparer(comparer);
                 }
                 catch (Exception e)
                 {
@@ -2136,20 +2150,22 @@ namespace System
 
             private void IntroSort(int lo, int hi, int depthLimit)
             {
+                Debug.Assert(hi > lo);
+                Debug.Assert(depthLimit >= 0);
+
                 while (hi > lo)
                 {
                     int partitionSize = hi - lo + 1;
-                    if (partitionSize <= IntrospectiveSortUtilities.IntrosortSizeThreshold)
+                    if (partitionSize <= IntrosortSizeThreshold)
                     {
-                        if (partitionSize == 1)
-                        {
-                            return;
-                        }
+                        Debug.Assert(partitionSize >= 2);
+
                         if (partitionSize == 2)
                         {
                             SwapIfGreater(lo, hi);
                             return;
                         }
+
                         if (partitionSize == 3)
                         {
                             SwapIfGreater(lo, hi - 1);
@@ -2177,6 +2193,8 @@ namespace System
 
             private int PickPivotAndPartition(int lo, int hi)
             {
+                Debug.Assert(hi - lo >= IntrosortSizeThreshold);
+
                 // Compute median-of-three.  But also partition them, since we've done the comparison.
                 int mid = lo + (hi - lo) / 2;
 
@@ -2200,7 +2218,10 @@ namespace System
                 }
 
                 // Put pivot in the right location.
-                Swap(left, hi - 1);
+                if (left != hi - 1)
+                {
+                    Swap(left, hi - 1);
+                }
                 return left;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1920,7 +1920,7 @@ namespace System
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
+                    IntrospectiveSortUtilities.ThrowBadComparer(comparer);
                 }
                 catch (Exception e)
                 {
@@ -2126,7 +2126,7 @@ namespace System
                 }
                 catch (IndexOutOfRangeException)
                 {
-                    IntrospectiveSortUtilities.ThrowOrIgnoreBadComparer(comparer);
+                    IntrospectiveSortUtilities.ThrowBadComparer(comparer);
                 }
                 catch (Exception e)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -97,6 +97,12 @@ namespace System
         }
 
         [DoesNotReturn]
+        internal static void ThrowArgumentException_BadComparer(object? comparer)
+        {
+            throw new ArgumentException(SR.Format(SR.Arg_BogusIComparer, comparer));
+        }
+
+        [DoesNotReturn]
         internal static void ThrowIndexArgumentOutOfRange_NeedNonNegNumException()
         {
             throw GetArgumentOutOfRangeException(ExceptionArgument.index,
@@ -428,9 +434,9 @@ namespace System
             return new ArgumentException(GetResourceString(resource));
         }
 
-        internal static InvalidOperationException GetInvalidOperationException(ExceptionResource resource, Exception? innerException = null)
+        private static InvalidOperationException GetInvalidOperationException(ExceptionResource resource)
         {
-            return new InvalidOperationException(GetResourceString(resource), innerException);
+            return new InvalidOperationException(GetResourceString(resource));
         }
 
         private static ArgumentException GetWrongKeyTypeArgumentException(object? key, Type targetType)

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -428,9 +428,9 @@ namespace System
             return new ArgumentException(GetResourceString(resource));
         }
 
-        private static InvalidOperationException GetInvalidOperationException(ExceptionResource resource)
+        internal static InvalidOperationException GetInvalidOperationException(ExceptionResource resource, Exception? innerException = null)
         {
-            return new InvalidOperationException(GetResourceString(resource));
+            return new InvalidOperationException(GetResourceString(resource), innerException);
         }
 
         private static ArgumentException GetWrongKeyTypeArgumentException(object? key, Type targetType)


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/35175 was opened about a 10% regression in sorting throughput (specifically looking just at `Int32[]`) from .NET Core 3.1 to .NET 5.

On my machine:
```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19041.207 (2004/?/20H1)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=5.0.100-preview.4.20211.5
```
our dotnet/performance tests don't show a regression anywhere near that, e.g.

|            Type |           Method |              Toolchain | Size |       Mean |     Error |    StdDev |     Median |        Min |        Max | Ratio | RatioSD |
|---------------- |----------------- |----------------------- |----- |-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|
| Sort&lt;BigStruct&gt; | Array_Comparison |    \master\corerun.exe |  128 |   4.028 us | 0.1816 us | 0.1783 us |   4.014 us |   3.805 us |   4.529 us |  0.93 |    0.07 |
| Sort&lt;BigStruct&gt; | Array_Comparison | \netcore31\corerun.exe |  128 |   4.333 us | 0.2711 us | 0.2663 us |   4.267 us |   4.089 us |   4.945 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|     Sort&lt;Int32&gt; | Array_Comparison |    \master\corerun.exe |  128 |   3.277 us | 0.7013 us | 0.8076 us |   2.822 us |   2.649 us |   4.951 us |  0.99 |    0.11 |
|     Sort&lt;Int32&gt; | Array_Comparison | \netcore31\corerun.exe |  128 |   3.327 us | 0.6240 us | 0.7186 us |   2.848 us |   2.668 us |   4.293 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|  Sort&lt;IntClass&gt; | Array_Comparison |    \master\corerun.exe |  128 |   6.481 us | 0.1237 us | 0.1033 us |   6.454 us |   6.336 us |   6.645 us |  1.05 |    0.02 |
|  Sort&lt;IntClass&gt; | Array_Comparison | \netcore31\corerun.exe |  128 |   6.167 us | 0.0816 us | 0.0637 us |   6.156 us |   6.078 us |   6.272 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
| Sort&lt;IntStruct&gt; | Array_Comparison |    \master\corerun.exe |  128 |   3.967 us | 1.4690 us | 1.6917 us |   3.002 us |   2.671 us |   6.633 us |  0.98 |    0.09 |
| Sort&lt;IntStruct&gt; | Array_Comparison | \netcore31\corerun.exe |  128 |   4.039 us | 1.3931 us | 1.6043 us |   3.026 us |   2.692 us |   6.397 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|    Sort&lt;String&gt; | Array_Comparison |    \master\corerun.exe |  128 |  41.962 us | 0.4130 us | 0.3449 us |  41.896 us |  41.473 us |  42.598 us |  0.78 |    0.01 |
|    Sort&lt;String&gt; | Array_Comparison | \netcore31\corerun.exe |  128 |  53.607 us | 0.2796 us | 0.2335 us |  53.682 us |  53.180 us |  53.989 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
| Sort&lt;BigStruct&gt; | Array_Comparison |    \master\corerun.exe |  256 |  10.402 us | 0.2142 us | 0.2200 us |  10.431 us |  10.121 us |  10.930 us |  0.91 |    0.04 |
| Sort&lt;BigStruct&gt; | Array_Comparison | \netcore31\corerun.exe |  256 |  11.442 us | 0.2745 us | 0.2819 us |  11.352 us |  11.102 us |  11.946 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|     Sort&lt;Int32&gt; | Array_Comparison |    \master\corerun.exe |  256 |   7.440 us | 0.0629 us | 0.0525 us |   7.430 us |   7.367 us |   7.532 us |  1.00 |    0.01 |
|     Sort&lt;Int32&gt; | Array_Comparison | \netcore31\corerun.exe |  256 |   7.449 us | 0.0787 us | 0.0658 us |   7.448 us |   7.349 us |   7.573 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|  Sort&lt;IntClass&gt; | Array_Comparison |    \master\corerun.exe |  256 |  16.090 us | 0.0999 us | 0.0835 us |  16.108 us |  15.961 us |  16.187 us |  1.04 |    0.01 |
|  Sort&lt;IntClass&gt; | Array_Comparison | \netcore31\corerun.exe |  256 |  15.492 us | 0.1317 us | 0.1100 us |  15.461 us |  15.367 us |  15.746 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
| Sort&lt;IntStruct&gt; | Array_Comparison |    \master\corerun.exe |  256 |   7.741 us | 0.0896 us | 0.0699 us |   7.722 us |   7.659 us |   7.892 us |  1.03 |    0.01 |
| Sort&lt;IntStruct&gt; | Array_Comparison | \netcore31\corerun.exe |  256 |   7.528 us | 0.1079 us | 0.0843 us |   7.524 us |   7.405 us |   7.679 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|    Sort&lt;String&gt; | Array_Comparison |    \master\corerun.exe |  256 |  95.722 us | 0.7744 us | 0.6467 us |  95.536 us |  94.978 us |  96.726 us |  0.79 |    0.01 |
|    Sort&lt;String&gt; | Array_Comparison | \netcore31\corerun.exe |  256 | 121.650 us | 0.5643 us | 0.5002 us | 121.748 us | 120.844 us | 122.655 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
| Sort&lt;BigStruct&gt; | Array_Comparison |    \master\corerun.exe | 1024 |  69.300 us | 0.7271 us | 0.6802 us |  69.153 us |  68.452 us |  70.507 us |  0.97 |    0.01 |
| Sort&lt;BigStruct&gt; | Array_Comparison | \netcore31\corerun.exe | 1024 |  71.688 us | 0.3637 us | 0.3224 us |  71.633 us |  71.268 us |  72.251 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|     Sort&lt;Int32&gt; | Array_Comparison |    \master\corerun.exe | 1024 |  48.195 us | 0.3197 us | 0.2991 us |  48.131 us |  47.767 us |  48.726 us |  1.00 |    0.01 |
|     Sort&lt;Int32&gt; | Array_Comparison | \netcore31\corerun.exe | 1024 |  48.023 us | 0.4813 us | 0.4266 us |  47.822 us |  47.539 us |  48.785 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|  Sort&lt;IntClass&gt; | Array_Comparison |    \master\corerun.exe | 1024 |  86.818 us | 0.4345 us | 0.4064 us |  86.950 us |  86.163 us |  87.711 us |  1.03 |    0.01 |
|  Sort&lt;IntClass&gt; | Array_Comparison | \netcore31\corerun.exe | 1024 |  84.631 us | 0.3439 us | 0.3048 us |  84.565 us |  84.260 us |  85.095 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
| Sort&lt;IntStruct&gt; | Array_Comparison |    \master\corerun.exe | 1024 |  49.627 us | 0.8809 us | 0.7356 us |  49.472 us |  48.783 us |  51.387 us |  0.96 |    0.02 |
| Sort&lt;IntStruct&gt; | Array_Comparison | \netcore31\corerun.exe | 1024 |  51.501 us | 0.6825 us | 0.6384 us |  51.372 us |  50.403 us |  52.402 us |  1.00 |    0.00 |
|                 |                  |                        |      |            |           |           |            |            |            |       |         |
|    Sort&lt;String&gt; | Array_Comparison |    \master\corerun.exe | 1024 | 551.786 us | 4.9619 us | 4.3986 us | 550.369 us | 546.377 us | 561.409 us |  0.82 |    0.01 |
|    Sort&lt;String&gt; | Array_Comparison | \netcore31\corerun.exe | 1024 | 670.227 us | 5.4861 us | 4.5811 us | 669.726 us | 662.498 us | 680.227 us |  1.00 |    0.00 |

However, the benchmarks shared in that PR do show a regression in some cases for Int32 on my machine, albeit not quite what was cited:

|    Method |        Job |           Toolchain |        N |      Mean[us] |    Error[us] |   StdDev[us] | Time / N[us] | Ratio | RatioSD | SpeedupMedian | Code Size[B] |
|---------- |----------- |-------------------- |--------- |---------------:|--------------:|--------------:|--------------:|------:|--------:|--------------:|--------------:|
| ArraySort | Job-RWQZQA |             Default |      100 |       2.123 us |     0.0490 us |     0.0733 us |    21.2333 ns |  1.13 |    0.07 |          0.89 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |      100 |       2.050 us |     0.0421 us |     0.0887 us |    20.5000 ns |  1.10 |    0.07 |          0.91 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |     1000 |      30.437 us |     0.5058 us |     0.7091 us |    30.4370 ns |  1.04 |    0.02 |          0.96 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |     1000 |      31.331 us |     0.2103 us |     0.1642 us |    31.3306 ns |  1.08 |    0.01 |          0.93 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |    10000 |     404.177 us |     0.6468 us |     0.9277 us |    40.4177 ns |  1.02 |    0.00 |          0.98 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |    10000 |     425.490 us |     3.3336 us |     2.9551 us |    42.5490 ns |  1.08 |    0.01 |          0.93 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |   100000 |   5,079.667 us |     4.6692 us |     6.6964 us |    50.7967 ns |  1.02 |    0.01 |          0.98 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |   100000 |   5,338.014 us |    20.5143 us |    16.0162 us |    53.3801 ns |  1.07 |    0.01 |          0.93 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |  1000000 |  60,104.120 us |    32.8821 us |    47.1586 us |    60.1041 ns |  1.01 |    0.00 |          0.99 |         306 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |  1000000 |  63,220.262 us |    93.8403 us |    87.7783 us |    63.2203 ns |  1.06 |    0.00 |          0.94 |          97 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default | 10000000 | 699,312.886 us |   755.2464 us | 1,107.0303 us |    69.9313 ns |  1.01 |    0.00 |          0.99 |         306 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe | 10000000 | 736,870.178 us | 1,700.3041 us | 1,590.4655 us |    73.6870 ns |  1.07 |    0.00 |          0.94 |         150 B |

Even so, a simple console app does sufficiently demonstrate a meaningful throughput regression:
```C#
using System;
using System.Diagnostics;
using System.Linq;

class Program
{
    static void Main()
    {
        const int Size = 1_000;
        int[][] arrays = Enumerable.Range(0, 100_000).Select(_ => new int[Size]).ToArray();
        var sw = new Stopwatch();

        var r = new Random(42);
        var unsorted = new int[Size];
        for (int i = 0; i < unsorted.Length; i++) unsorted[i] = r.Next();

        while (true)
        {
            foreach (int[] array in arrays) Array.Copy(unsorted, array, unsorted.Length);

            sw.Restart();
            foreach (int[] array in arrays) Array.Sort(array);
            sw.Stop();

            Console.WriteLine(sw.Elapsed.TotalSeconds);
        }
    }
}
```
On .NET Core 3.1 I get results like:
```
1.6084611
1.5947359
1.6061765
1.5940196
1.6140805
```
and with master I get results like:
```
1.9340624
1.9376759
1.9425619
1.936641
1.9411098
```
which is closer to a 20% regression.

Since even though our actual benchmarks aren’t showing anything close to that (and in some cases .NET 5 being meaningfully faster, especially with strings), this PR addresses the gap. It includes a variety of tweaks to improve `Array.Sort<T>(T[])` performance; the two most impactful are using `Unsafe.*` in `PickPivotAndPartition` to avoid bounds checks and aggressive inlining on `SwapIfGreater`.  A few other small improvements to codegen round it out. I only made the unsafe changes in the `Sort<T>(T[])` implementation, and not in the more complicated implementations, such as for `Sort<T>(T[], Comparer<T>)` and `Sort<TKey, TValue>(TKey[], TValue[])`, but I did make some of the smaller changes for consistency across the file.

Fixes https://github.com/dotnet/runtime/issues/35175
@jkotas, any visceral reaction to the `Unsafe.*` code here? :smile:
cc: @damageboy, @adamsitnik 

In terms of impact, here are my results from my running the benchmarks shared in #35175:

|    Method |        Job |           Toolchain |        N |       Mean[us] |     Error[us] |    StdDev[us] |  Time / N[us] | Ratio | RatioSD | SpeedupMedian |  Code Size[B] |
|---------- |----------- |-------------------- |--------- |---------------:|--------------:|--------------:|--------------:|------:|--------:|--------------:|--------------:|
| ArraySort | Job-RWQZQA |             Default |      100 |       2.123 us |     0.0490 us |     0.0733 us |    21.2333 ns |  1.13 |    0.07 |          0.89 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |      100 |       2.050 us |     0.0421 us |     0.0887 us |    20.5000 ns |  1.10 |    0.07 |          0.91 |         191 B |
| ArraySort | Job-KOZKWL |     \pr\corerun.exe |      100 |       1.868 us |     0.0386 us |     0.0933 us |    18.6812 ns |  1.00 |    0.00 |          1.00 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |     1000 |      30.437 us |     0.5058 us |     0.7091 us |    30.4370 ns |  1.04 |    0.02 |          0.96 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |     1000 |      31.331 us |     0.2103 us |     0.1642 us |    31.3306 ns |  1.08 |    0.01 |          0.93 |         191 B |
| ArraySort | Job-KOZKWL |     \pr\corerun.exe |     1000 |      28.990 us |     0.1958 us |     0.1635 us |    28.9897 ns |  1.00 |    0.00 |          1.00 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |    10000 |     404.177 us |     0.6468 us |     0.9277 us |    40.4177 ns |  1.02 |    0.00 |          0.98 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |    10000 |     425.490 us |     3.3336 us |     2.9551 us |    42.5490 ns |  1.08 |    0.01 |          0.93 |         191 B |
| ArraySort | Job-KOZKWL |     \pr\corerun.exe |    10000 |     394.917 us |     2.1902 us |     1.9415 us |    39.4917 ns |  1.00 |    0.00 |          1.00 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |   100000 |   5,079.667 us |     4.6692 us |     6.6964 us |    50.7967 ns |  1.02 |    0.01 |          0.98 |         336 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |   100000 |   5,338.014 us |    20.5143 us |    16.0162 us |    53.3801 ns |  1.07 |    0.01 |          0.93 |         191 B |
| ArraySort | Job-KOZKWL |     \pr\corerun.exe |   100000 |   4,975.340 us |    33.2037 us |    31.0588 us |    49.7534 ns |  1.00 |    0.00 |          1.00 |         191 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default |  1000000 |  60,104.120 us |    32.8821 us |    47.1586 us |    60.1041 ns |  1.01 |    0.00 |          0.99 |         306 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe |  1000000 |  63,220.262 us |    93.8403 us |    87.7783 us |    63.2203 ns |  1.06 |    0.00 |          0.94 |          97 B |
| ArraySort | Job-KOZKWL |     \pr\corerun.exe |  1000000 |  59,504.806 us |   102.7170 us |    80.1947 us |    59.5048 ns |  1.00 |    0.00 |          1.00 |          97 B |
|           |            |                     |          |                |               |               |               |       |         |               |               |
| ArraySort | Job-RWQZQA |             Default | 10000000 | 699,312.886 us |   755.2464 us | 1,107.0303 us |    69.9313 ns |  1.01 |    0.00 |          0.99 |         306 B |
| ArraySort | Job-WOYWHX | \master\corerun.exe | 10000000 | 736,870.178 us | 1,700.3041 us | 1,590.4655 us |    73.6870 ns |  1.07 |    0.00 |          0.94 |         150 B |
| ArraySort | Job-KOZKWL |     \pr\corerun.exe | 10000000 | 691,165.742 us |   442.2233 us |   413.6559 us |    69.1166 ns |  1.00 |    0.00 |          1.00 |         150 B |

For the simple command-line app, we now get results like:
```
1.6690784
1.659153
1.6788734
1.6582936
1.6734444
```

I also tweaked the above to remove the app  that copies the unsorted data over each array, such that we're then sorting an already sorted array each time.  With that, on .NET Core 3.1 I get:
```
0.4768374
0.4794121
0.4774386
0.4762099
0.477092
```
and on master I get:
```
0.641116
0.6407797
0.6416041
0.6469679
0.6616153
```
and with this PR I get:
```
0.4768012
0.4689296
0.4675659
0.470049
0.4719857
```

Finally, I checked GC pause times similar to what @jkotas did in https://github.com/dotnet/coreclr/pull/27642#issuecomment-549108085.  With .NET Core 3.1, we get average GC pause times around 500ms, and with .NET 5 (both master and this PR), we get average GC pause times around 15ms.  This highlights one of the benefits of moving the sorting into managed code, separate from all the other benefits.