### PR TITLE
Updated assert statement to include a check for Timeout in FileSystem…

### DIFF
--- a/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
@@ -81,7 +81,7 @@ namespace System.IO
                         )
                     {
                         // Assert so we can track down other cases (if any) to add to our test suite
-                        Debug.Assert(errorCode == Interop.Errors.ERROR_ACCESS_DENIED || errorCode == Interop.Errors.ERROR_SHARING_VIOLATION,
+                        Debug.Assert(errorCode == Interop.Errors.ERROR_ACCESS_DENIED || errorCode == Interop.Errors.ERROR_SHARING_VIOLATION || Interop.Errors.ERROR_SEM_TIMEOUT,
                             $"Unexpected error code getting attributes {errorCode} from path {path}");
 
                         // Files that are marked for deletion will not let you GetFileAttributes,

--- a/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
+++ b/src/libraries/Common/src/System/IO/FileSystem.Attributes.Windows.cs
@@ -81,7 +81,7 @@ namespace System.IO
                         )
                     {
                         // Assert so we can track down other cases (if any) to add to our test suite
-                        Debug.Assert(errorCode == Interop.Errors.ERROR_ACCESS_DENIED || errorCode == Interop.Errors.ERROR_SHARING_VIOLATION || Interop.Errors.ERROR_SEM_TIMEOUT,
+                        Debug.Assert(errorCode == Interop.Errors.ERROR_ACCESS_DENIED || errorCode == Interop.Errors.ERROR_SHARING_VIOLATION || errorCode == Interop.Errors.ERROR_SEM_TIMEOUT,
                             $"Unexpected error code getting attributes {errorCode} from path {path}");
 
                         // Files that are marked for deletion will not let you GetFileAttributes,


### PR DESCRIPTION
Fixes #28831
There is a test failure in System.IO.FileSystem.Tests and since the root cause appears to be OS specific, the instruction is to update the assert statement to  catch the semaphore timeout case.