### PR TITLE
Build iOS AOT compiler against LLVM, always

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -178,7 +178,7 @@
   </ItemGroup>
 
   <!-- Mono sets -->
-  <ItemGroup Condition="$(_subset.Contains('+mono.llvm+'))">
+  <ItemGroup Condition="$(_subset.Contains('+mono.llvm+')) or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'">
     <MonoProject Include="$(MonoProjectRoot)llvm\llvm-init.proj" />
   </ItemGroup>
 

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -99,6 +99,6 @@
 
   <PropertyGroup>
     <MonoObjDir>$(ArtifactsObjDir)mono/$(PlatformConfigPathPart)/</MonoObjDir>
-    <MonoLLVMDir Condition="'$(MonoEnableLLVM)' == 'true' and '$(MonoLLVMDir)' == ''">$(MonoObjDir)llvm</MonoLLVMDir>  
+    <MonoLLVMDir Condition="('$(MonoEnableLLVM)' == 'true' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS') and '$(MonoLLVMDir)' == ''">$(MonoObjDir)llvm</MonoLLVMDir>  
   </PropertyGroup>
 </Project>

--- a/src/mono/llvm/llvm-init.proj
+++ b/src/mono/llvm/llvm-init.proj
@@ -9,8 +9,8 @@
     <PackageReference Condition="'$(TargetOS)' == 'Linux'" Include="runtime.linux-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
     <PackageReference Condition="'$(TargetOS)' == 'Windows_NT'" Include="runtime.win-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
     <PackageReference Condition="'$(TargetOS)' == 'Windows_NT'" Include="runtime.win-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'OSX'" Include="runtime.osx.10.12-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
-    <PackageReference Condition="'$(TargetOS)' == 'OSX'" Include="runtime.osx.10.12-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="runtime.osx.10.12-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Sdk" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)" />
+    <PackageReference Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="runtime.osx.10.12-$(HostArch).Microsoft.NETCore.Runtime.Mono.LLVM.Tools" Version="$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)" />
   </ItemGroup>
 
   <Target Name="CopyLLVMToTree" AfterTargets="Build">
@@ -19,8 +19,8 @@
       <LLVMFiles Condition="'$(TargetOS)' == 'Linux'" Include="$(NuGetPackageRoot)\runtime.linux-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimelinuxx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\linux-$(HostArch)\**" />
       <LLVMFiles Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(NuGetPackageRoot)\runtime.win-$(HostArch).microsoft.netcore.runtime.mono.llvm.sdk\$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\win-$(HostArch)\**" />
       <LLVMFiles Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(NuGetPackageRoot)\runtime.win-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimewinx64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\win-$(HostArch)\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'OSX'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-$(HostArch).microsoft.netcore.runtime.mono.llvm.sdk\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\osx.10.12-$(HostArch)\**" />
-      <LLVMFiles Condition="'$(TargetOS)' == 'OSX'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\osx.10.12-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-$(HostArch).microsoft.netcore.runtime.mono.llvm.sdk\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion)\tools\osx.10.12-$(HostArch)\**" />
+      <LLVMFiles Condition="'$(TargetOS)' == 'OSX' or '$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="$(NuGetPackageRoot)\runtime.osx.10.12-$(HostArch).microsoft.netcore.runtime.mono.llvm.tools\$(runtimeosx1012x64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion)\tools\osx.10.12-$(HostArch)\**" />
     </ItemGroup>
 
     <Copy SourceFiles="@(LLVMFiles)" DestinationFolder="$(MonoLLVMDir)\%(RecursiveDir)">

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -50,7 +50,7 @@
       <_MonoConfigureParams Include="--enable-maintainer-mode" />
       <_MonoConfigureParams Include="--enable-compile-warnings" />
       <_MonoConfigureParams Include="--prefix=$(MonoObjDir)out" />
-      <_MonoConfigureParams Condition="'$(MonoEnableLLVM)' == 'true'" Include="--with-llvm=$(MonoLLVMDir)" /> <!-- TODO: integrate for iOS/Android -->
+      <_MonoConfigureParams Condition="'$(MonoEnableLLVM)' == 'true'" Include="--with-llvm=$(MonoLLVMDir)" /> <!-- TODO: integrate for Android -->
       <_MonoConfigureParams Condition="'$(MonoEnableCXX)' == 'true'" Include="--enable-cxx" />
     </ItemGroup>
 
@@ -183,7 +183,7 @@
       <_MonoAotCrossConfigureParams Include="--enable-minimal=com,remoting" />
       <_MonoAotCrossConfigureParams Include="--enable-monotouch" />
       <_MonoAotCrossConfigureParams Include="--disable-crash-reporting" />
-      <!--<_MonoAotCrossConfigureParams Include="with-llvm=/Users/alexander/dev/mono2/sdks/out/llvm-llvm64" /> --> <!-- TODO -->
+      <_MonoAotCrossConfigureParams Include="--with-llvm=$(MonoLLVMDir)" />
 
       <_MonoAotCrossAC_VARS Include="ac_cv_func_shm_open_working_with_mmap=no" />
 
@@ -377,7 +377,7 @@
       <_MonoAotCrossConfigureParams Include="--enable-minimal=com,remoting" />
       <_MonoAotCrossConfigureParams Include="--enable-monotouch" />
       <_MonoAotCrossConfigureParams Include="--disable-crash-reporting" />
-      <!--<_MonoAotCrossConfigureParams Include="with-llvm=/Users/alexander/dev/mono2/sdks/out/llvm-llvm64" /> --> <!-- TODO -->
+      <_MonoAotCrossConfigureParams Include="--with-llvm=$(MonoLLVMDir)" />
 
       <_MonoAotCrossAC_VARS Include="ac_cv_func_shm_open_working_with_mmap=no" />
 
@@ -1038,6 +1038,12 @@
       </_MonoRuntimeArtifacts>
       <_MonoRuntimeArtifacts Include="$(_MonoAotCrossFilePath)">
         <Destination>$(BinDir)cross\mono-aot-cross</Destination>
+      </_MonoRuntimeArtifacts>
+      <_MonoRuntimeArtifacts Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="$(MonoLLVMDir)\bin\llc">
+        <Destination>$(BinDir)cross\llc</Destination>
+      </_MonoRuntimeArtifacts>
+      <_MonoRuntimeArtifacts Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" Include="$(MonoLLVMDir)\bin\opt">
+        <Destination>$(BinDir)cross\opt</Destination>
       </_MonoRuntimeArtifacts>
       <_MonoIncludeArtifacts Include="$(MonoObjDir)out\include\**" />
     </ItemGroup>


### PR DESCRIPTION
This is in line with our discussions about which platforms are JIT and which are AOT and which are LLVM AOT.

We can't just blithely use our MonoEnableLLVM logic, as we do not want the iOS JIT build with LLVM.

Probably need to double-check that the mono-aot-cross command is definitely consuming llc/opt from its own directory, not $PATH.