### PR TITLE
LSRA delete a custom logic to get a tree type, use a general one.

### DIFF
--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -7002,30 +7002,30 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
             // 8-byte non-GC items, and 16-byte or 32-byte SIMD vectors.
             // LSRA is agnostic to those choices but needs
             // to know what they are here.
-            var_types typ;
+            var_types type;
             if (!treeNode->IsMultiRegNode())
             {
-                typ = getDefType(treeNode);
+                type = getDefType(treeNode);
             }
             else
             {
-                typ = treeNode->GetRegTypeByIndex(refPosition->getMultiRegIdx());
+                type = treeNode->GetRegTypeByIndex(refPosition->getMultiRegIdx());
             }
 
-            typ = RegSet::tmpNormalizeType(typ);
+            type = RegSet::tmpNormalizeType(type);
 
             if (refPosition->spillAfter && !refPosition->reload)
             {
-                currentSpill[typ]++;
-                if (currentSpill[typ] > maxSpill[typ])
+                currentSpill[type]++;
+                if (currentSpill[type] > maxSpill[type])
                 {
-                    maxSpill[typ] = currentSpill[typ];
+                    maxSpill[type] = currentSpill[type];
                 }
             }
             else if (refPosition->reload)
             {
-                assert(currentSpill[typ] > 0);
-                currentSpill[typ]--;
+                assert(currentSpill[type] > 0);
+                currentSpill[type]--;
             }
             else if (refPosition->RegOptional() && refPosition->assignedReg() == REG_NA)
             {
@@ -7034,10 +7034,10 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
                 // memory location.  To properly account max spill for typ we
                 // decrement spill count.
                 assert(RefTypeIsUse(refType));
-                assert(currentSpill[typ] > 0);
-                currentSpill[typ]--;
+                assert(currentSpill[type] > 0);
+                currentSpill[type]--;
             }
-            JITDUMP("  Max spill for %s is %d\n", varTypeName(typ), maxSpill[typ]);
+            JITDUMP("  Max spill for %s is %d\n", varTypeName(type), maxSpill[type]);
         }
     }
 }

--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -6994,7 +6994,7 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
             // 8-byte non-GC items, and 16-byte or 32-byte SIMD vectors.
             // LSRA is agnostic to those choices but needs
             // to know what they are here.
-            var_types typ;
+            var_types typ; // first variant
 
             GenTree* treeNode = refPosition->treeNode;
             if (treeNode == nullptr)
@@ -7030,7 +7030,20 @@ void LinearScan::updateMaxSpill(RefPosition* refPosition)
             {
                 typ = treeNode->TypeGet();
             }
-            typ = RegSet::tmpNormalizeType(typ);
+            var_types type1BeforeNormalize = typ;
+            typ                            = RegSet::tmpNormalizeType(typ);
+
+            var_types type2;
+            if (!treeNode->IsMultiRegNode())
+            {
+                type2 = getDefType(treeNode);
+            }
+            else
+            {
+                type2 = treeNode->GetRegTypeByIndex(refPosition->getMultiRegIdx());
+            }
+
+            assert(type2 == type1BeforeNormalize);
 
             if (refPosition->spillAfter && !refPosition->reload)
             {

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -2604,7 +2604,7 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, regMaskTP dstCandidates, int mu
         assert((tree->GetRegNum() == REG_NA) || (dstCandidates == genRegMask(tree->GetRegByIndex(multiRegIdx))));
     }
 
-    RegisterType type;
+    RegisterType type; // second variant
     if (!tree->IsMultiRegNode())
     {
         type = getDefType(tree);

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -2604,7 +2604,7 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, regMaskTP dstCandidates, int mu
         assert((tree->GetRegNum() == REG_NA) || (dstCandidates == genRegMask(tree->GetRegByIndex(multiRegIdx))));
     }
 
-    RegisterType type; // second variant
+    RegisterType type;
     if (!tree->IsMultiRegNode())
     {
         type = getDefType(tree);


### PR DESCRIPTION
Use 
```
            if (!treeNode->IsMultiRegNode()) {
                type = getDefType(treeNode);
            } else {
                type = treeNode->GetRegTypeByIndex(refPosition->getMultiRegIdx());
            }         
```
when we need type in LSRA, so if we need a special logic for bitcasts we will need to update only `getDefType`.

[jitstressregs](https://dev.azure.com/dnceng/public/_build/results?buildId=616324&view=ms.vss-test-web.build-test-results-tab ) run did not show any assert failures, so the different logics were producing the same result.