### PR TITLE
System.Diagnostics Tracing APIs (#35220)

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -7,7 +7,7 @@
 
 namespace System.Diagnostics
 {
-    public partial class Activity
+    public partial class Activity : IDisposable
     {
         public Activity(string operationName) { }
         public System.Diagnostics.ActivityTraceFlags ActivityTraceFlags { get { throw null; } set { } }
@@ -33,8 +33,13 @@ namespace System.Diagnostics
 #endif
             get { throw null; }
         }
+
+        public bool IsAllDataRequested { get { throw null; } set { throw null; }}
         public System.Diagnostics.ActivityIdFormat IdFormat { get { throw null; } }
+        public System.Diagnostics.ActivityKind Kind  { get { throw null; } }
         public string OperationName { get { throw null; } }
+        public string DisplayName { get { throw null; } set { throw null; } }
+        public System.Diagnostics.ActivitySource Source { get { throw null; } }
         public System.Diagnostics.Activity? Parent { get { throw null; } }
         public string? ParentId { get { throw null; } }
         public System.Diagnostics.ActivitySpanId ParentSpanId { get { throw null; } }
@@ -43,9 +48,12 @@ namespace System.Diagnostics
         public System.Diagnostics.ActivitySpanId SpanId { get { throw null; } }
         public System.DateTime StartTimeUtc { get { throw null; } }
         public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string?>> Tags { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityEvent> Events { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityLink> Links { get { throw null; } }
         public System.Diagnostics.ActivityTraceId TraceId { get { throw null; } }
         public string? TraceStateString { get { throw null; } set { } }
         public System.Diagnostics.Activity AddBaggage(string key, string? value) { throw null; }
+        public System.Diagnostics.Activity AddEvent(System.Diagnostics.ActivityEvent e) { throw null; }
         public System.Diagnostics.Activity AddTag(string key, string? value) { throw null; }
         public string? GetBaggageItem(string key) { throw null; }
         public System.Diagnostics.Activity SetEndTime(System.DateTime endTimeUtc) { throw null; }
@@ -54,7 +62,12 @@ namespace System.Diagnostics
         public System.Diagnostics.Activity SetParentId(string parentId) { throw null; }
         public System.Diagnostics.Activity SetStartTime(System.DateTime startTimeUtc) { throw null; }
         public System.Diagnostics.Activity Start() { throw null; }
-        public void Stop() { }
+        public void Stop() { throw null; }
+        public void Dispose()  { throw null; }
+        protected virtual void Dispose(bool disposing) { throw null; }
+        public void SetCustomProperty(string propertyName, object? propertyValue) { throw null; }
+        public object? GetCustomProperty(string propertyName) { throw null; }
+        public ActivityContext Context { get { throw null; } }
     }
     public enum ActivityIdFormat
     {
@@ -81,6 +94,18 @@ namespace System.Diagnostics
         public static bool operator !=(System.Diagnostics.ActivitySpanId spanId1, System.Diagnostics.ActivitySpanId spandId2) { throw null; }
         public string ToHexString() { throw null; }
         public override string ToString() { throw null; }
+    }
+    public sealed class ActivitySource : IDisposable
+    {
+        public ActivitySource(string name, string? version = "") { throw null; }
+        public string Name { get { throw null; } }
+        public string? Version { get { throw null; } }
+        public bool HasListeners() { throw null; }
+        public System.Diagnostics.Activity? StartActivity(string name, System.Diagnostics.ActivityKind kind = ActivityKind.Internal)  { throw null; }
+        public System.Diagnostics.Activity? StartActivity(string name, System.Diagnostics.ActivityKind kind, System.Diagnostics.ActivityContext parentContext, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string?>>? tags = null, System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityLink>? links = null, System.DateTimeOffset startTime = default) { throw null; }
+        public System.Diagnostics.Activity? StartActivity(string name, System.Diagnostics.ActivityKind kind, string parentId, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string?>>? tags = null, System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityLink>? links = null, System.DateTimeOffset startTime = default) { throw null; }
+        public static void AddActivityListener(System.Diagnostics.ActivityListener listener) { throw null; }
+        public void Dispose() { throw null; }
     }
     [System.FlagsAttribute]
     public enum ActivityTraceFlags
@@ -121,4 +146,76 @@ namespace System.Diagnostics
         public System.Diagnostics.Activity StartActivity(System.Diagnostics.Activity activity, object? args) { throw null; }
         public void StopActivity(System.Diagnostics.Activity activity, object? args) { }
     }
+    public enum ActivityDataRequest
+    {
+        None,
+        PropagationData,
+        AllData,
+        AllDataAndRecorded
+    }
+    public enum ActivityKind
+    {
+        Internal = 0,
+        Server = 1,
+        Client = 2,
+        Producer = 3,
+        Consumer = 4,
+    }
+    public readonly struct ActivityEvent
+    {
+        public ActivityEvent(string name) {throw null; }
+        public ActivityEvent(string name, System.DateTimeOffset timestamp) { throw null; }
+        public ActivityEvent(string name, System.DateTimeOffset timestamp, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>? attributes) { throw null; }
+        public ActivityEvent(string name, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>? attributes) { throw null; }
+        public string Name { get { throw null; } }
+        public System.DateTimeOffset Timestamp { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>? Attributes { get { throw null; } }
+    }
+    public readonly struct ActivityContext : System.IEquatable<System.Diagnostics.ActivityContext>
+    {
+        public ActivityContext(System.Diagnostics.ActivityTraceId traceId, System.Diagnostics.ActivitySpanId spanId, System.Diagnostics.ActivityTraceFlags traceOptions, string? traceState = null) { throw null; }
+        public System.Diagnostics.ActivityTraceId TraceId  { get { throw null; } }
+        public System.Diagnostics.ActivitySpanId SpanId  { get { throw null; } }
+        public System.Diagnostics.ActivityTraceFlags TraceFlags  { get { throw null; } }
+        public string? TraceState  { get { throw null; } }
+        public static bool operator ==(System.Diagnostics.ActivityContext left, System.Diagnostics.ActivityContext right) { throw null; }
+        public static bool operator !=(System.Diagnostics.ActivityContext left, System.Diagnostics.ActivityContext right) { throw null; }
+        public bool Equals(System.Diagnostics.ActivityContext value) { throw null; }
+        public override bool Equals(object? obj) { throw null; }
+        public override int GetHashCode() { throw null; }
+    }
+    public readonly struct ActivityLink : IEquatable<ActivityLink>
+    {
+        public ActivityLink(System.Diagnostics.ActivityContext context) { throw null; }
+        public ActivityLink(System.Diagnostics.ActivityContext context, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>? attributes) { throw null; }
+        public System.Diagnostics.ActivityContext Context  { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object>>? Attributes  { get { throw null; } }
+
+        public override bool Equals(object? obj) { throw null; }
+        public bool Equals(System.Diagnostics.ActivityLink value) { throw null; }
+        public static bool operator ==(System.Diagnostics.ActivityLink left, System.Diagnostics.ActivityLink right) { throw null; }
+        public static bool operator !=(System.Diagnostics.ActivityLink left, System.Diagnostics.ActivityLink right) { throw null; }
+        public override int GetHashCode()  { throw null; }
+    }
+    public readonly struct ActivityCreationOptions<T>
+    {
+        public System.Diagnostics.ActivitySource Source  { get { throw null; } }
+        public string Name  { get { throw null; } }
+        public System.Diagnostics.ActivityKind Kind  { get { throw null; } }
+        public T Parent  { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string?>> Tags  { get { throw null; } }
+        public System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityLink> Links  { get { throw null; } }
+    }
+    public delegate System.Diagnostics.ActivityDataRequest GetRequestedData<T>(ref System.Diagnostics.ActivityCreationOptions<T> options);
+    public sealed class ActivityListener : IDisposable
+    {
+        public ActivityListener() { throw null; }
+        public System.Action<System.Diagnostics.Activity>? ActivityStarted { get { throw null; } set { } }
+        public System.Action<System.Diagnostics.Activity>? ActivityStopped { get { throw null; } set { } }
+        public System.Func<System.Diagnostics.ActivitySource, bool>? ShouldListenTo { get { throw null; } set { } }
+        public System.Diagnostics.GetRequestedData<string>? GetRequestedDataUsingParentId { get { throw null; } set { } }
+        public System.Diagnostics.GetRequestedData<ActivityContext>? GetRequestedDataUsingContext { get { throw null; } set { } }
+        public void Dispose() { throw null; }
+   }
 }
+

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/Resources/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -144,8 +144,14 @@
   <data name="SetFormatOnStartedActivity" xml:space="preserve">
     <value>"Can not change format for an activity that was already started"</value>
   </data>
+  <data name="SetLinkInvalid" xml:space="preserve">
+    <value>"Can not add link to activity after it has been started"</value>
+  </data>
   <data name="SetParentIdOnActivityWithParent" xml:space="preserve">
     <value>"Can not set ParentId on activity which has parent"</value>
+  </data>
+  <data name="SpanIdOrTraceIdInvalid" xml:space="preserve">
+    <value>"Invalid SpanId or TraceId"</value>
   </data>
   <data name="StartTimeNotUtc" xml:space="preserve">
     <value>"StartTime is not UTC"</value>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -32,6 +32,14 @@
       <Link>Common\System\HexConverter.cs</Link>
     </Compile>
     <Compile Include="System\Diagnostics\Activity.cs" />
+    <Compile Include="System\Diagnostics\ActivityContext.cs" />
+    <Compile Include="System\Diagnostics\ActivityCreationOptions.cs" />
+    <Compile Include="System\Diagnostics\ActivityDataRequest.cs" />
+    <Compile Include="System\Diagnostics\ActivityEvent.cs" />
+    <Compile Include="System\Diagnostics\ActivityKind.cs" />
+    <Compile Include="System\Diagnostics\ActivityLink.cs" />
+    <Compile Include="System\Diagnostics\ActivityListener.cs" />
+    <Compile Include="System\Diagnostics\ActivitySource.cs" />
     <Compile Include="System\Diagnostics\DiagnosticSourceActivity.cs" />
     <Reference Include="System.Memory" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -5,6 +5,7 @@
 using System.Buffers.Binary;
 using System.Buffers.Text;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -29,11 +30,14 @@ namespace System.Diagnostics
     /// but the exception is suppressed, and the operation does something reasonable (typically
     /// doing nothing).
     /// </summary>
-    public partial class Activity
+    public partial class Activity : IDisposable
     {
 #pragma warning disable CA1825 // Array.Empty<T>() doesn't exist in all configurations
         private static readonly IEnumerable<KeyValuePair<string, string?>> s_emptyBaggageTags = new KeyValuePair<string, string?>[0];
+        private static readonly IEnumerable<ActivityLink> s_emptyLinks = new ActivityLink[0];
+        private static readonly IEnumerable<ActivityEvent> s_emptyEvents = new ActivityEvent[0];
 #pragma warning restore CA1825
+        private static ActivitySource s_defaultSource = new ActivitySource(string.Empty);
 
         private const byte ActivityTraceFlagsIsSet = 0b_1_0000000; // Internal flag to indicate if flags have been set
         private const int RequestIdMaxLength = 1024;
@@ -70,8 +74,17 @@ namespace System.Diagnostics
 
         private byte _w3CIdFlags;
 
-        private KeyValueListNode? _tags;
-        private KeyValueListNode? _baggage;
+        private LinkedListNode<KeyValuePair<string, string?>>? _tags;
+        private LinkedListNode<KeyValuePair<string, string?>>? _baggage;
+        private LinkedListNode<ActivityLink>? _links;
+        private LinkedListNode<ActivityEvent>? _events;
+        private ConcurrentDictionary<string, object>? _customProperties;
+        private string? _displayName;
+
+        /// <summary>
+        /// Kind describes the relationship between the Activity, its parents, and its children in a Trace.
+        /// </summary>
+        public ActivityKind Kind { get; private set; } = ActivityKind.Internal;
 
         /// <summary>
         /// An operation name is a COARSEST name that is useful grouping/filtering.
@@ -80,6 +93,23 @@ namespace System.Diagnostics
         /// the name but rather in the tags.
         /// </summary>
         public string OperationName { get; } = null!;
+
+        /// <summary>
+        /// DisplayName is name mainly intended to be used in the UI and not necessary has to be
+        /// same as OperationName.
+        /// </summary>
+        public string DisplayName
+        {
+            get => _displayName ?? OperationName;
+            set => _displayName = value;
+        }
+
+        /// <summary>
+        /// Get the ActivitySource object associated with this Activity.
+        /// All Activities created from public constructors will have a singleton source where the source name is empty string.
+        /// Otherwise, the source will be holding the object that created the Activity through ActivitySource.StartActivity.
+        /// </summary>
+        public ActivitySource Source { get; private set; }
 
         /// <summary>
         /// If the Activity that created this activity is from the same process you can get
@@ -216,19 +246,65 @@ namespace System.Diagnostics
         {
             get
             {
-                KeyValueListNode? tags = _tags;
+                LinkedListNode<KeyValuePair<string, string?>>? tags = _tags;
                 return tags != null ?
                     Iterate(tags) :
                     s_emptyBaggageTags;
 
-                static IEnumerable<KeyValuePair<string, string?>> Iterate(KeyValueListNode? tags)
+                static IEnumerable<KeyValuePair<string, string?>> Iterate(LinkedListNode<KeyValuePair<string, string?>>? tags)
                 {
                     do
                     {
-                        yield return tags!.keyValue;
+                        yield return tags!.Value;
                         tags = tags.Next;
                     }
                     while (tags != null);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Events is the list of all <see cref="ActivityEvent" /> objects attached to this Activity object.
+        /// If there is not any <see cref="ActivityEvent" /> object attached to the Activity object, Events will return empty list.
+        /// </summary>
+        public IEnumerable<ActivityEvent> Events
+        {
+            get
+            {
+                LinkedListNode<ActivityEvent>? events = _events;
+                return events != null ? Iterate(events) : s_emptyEvents;
+
+                static IEnumerable<ActivityEvent> Iterate(LinkedListNode<ActivityEvent>? events)
+                {
+                    do
+                    {
+                        yield return events!.Value;
+                        events = events.Next;
+                    }
+                    while (events != null);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Links is the list of all <see cref="ActivityLink" /> objects attached to this Activity object.
+        /// If there is no any <see cref="ActivityLink" /> object attached to the Activity object, Links will return empty list.
+        /// </summary>
+        public IEnumerable<ActivityLink> Links
+        {
+            get
+            {
+                LinkedListNode<ActivityLink>? links = _links;
+                return links != null ? Iterate(links) : s_emptyLinks;
+
+                static IEnumerable<ActivityLink> Iterate(LinkedListNode<ActivityLink>? links)
+                {
+                    do
+                    {
+                        yield return links!.Value;
+                        links = links.Next;
+                    }
+                    while (links != null);
                 }
             }
         }
@@ -260,9 +336,9 @@ namespace System.Diagnostics
                     Debug.Assert(activity != null);
                     do
                     {
-                        for (KeyValueListNode? baggage = activity._baggage; baggage != null; baggage = baggage.Next)
+                        for (LinkedListNode<KeyValuePair<string, string?>>? baggage = activity._baggage; baggage != null; baggage = baggage.Next)
                         {
-                            yield return baggage.keyValue;
+                            yield return baggage.Value;
                         }
 
                         activity = activity.Parent;
@@ -293,6 +369,10 @@ namespace System.Diagnostics
         /// <param name="operationName">Operation's name <see cref="OperationName"/></param>
         public Activity(string operationName)
         {
+            Source = s_defaultSource;
+            // Allow data by default in the constructor to keep the compatability.
+            IsAllDataRequested = true;
+
             if (string.IsNullOrEmpty(operationName))
             {
                 NotifyError(new ArgumentException(SR.OperationNameInvalid));
@@ -310,13 +390,31 @@ namespace System.Diagnostics
         /// <returns>'this' for convenient chaining</returns>
         public Activity AddTag(string key, string? value)
         {
-            KeyValueListNode? currentTags = _tags;
-            KeyValueListNode newTags = new KeyValueListNode() { keyValue = new KeyValuePair<string, string?>(key, value) };
+            LinkedListNode<KeyValuePair<string, string?>>? currentTags = _tags;
+            LinkedListNode<KeyValuePair<string, string?>> newTags = new LinkedListNode<KeyValuePair<string, string?>>(new KeyValuePair<string, string?>(key, value));
             do
             {
                 newTags.Next = currentTags;
                 currentTags = Interlocked.CompareExchange(ref _tags, newTags, currentTags);
             } while (!ReferenceEquals(newTags.Next, currentTags));
+
+            return this;
+        }
+
+        /// <summary>
+        /// Add <see cref="ActivityEvent" /> object to the <see cref="Events" /> list.
+        /// </summary>
+        /// <param name="e"> object of <see cref="ActivityEvent"/> to add to the attached events list.</param>
+        /// <returns>'this' for convenient chaining</returns>
+        public Activity AddEvent(ActivityEvent e)
+        {
+            LinkedListNode<ActivityEvent>? currentEvents = _events;
+            LinkedListNode<ActivityEvent> newEvents = new LinkedListNode<ActivityEvent>(e);
+            do
+            {
+                newEvents.Next = currentEvents;
+                currentEvents = Interlocked.CompareExchange(ref _events, newEvents, currentEvents);
+            } while (!ReferenceEquals(newEvents.Next, currentEvents));
 
             return this;
         }
@@ -332,8 +430,8 @@ namespace System.Diagnostics
         /// <returns>'this' for convenient chaining</returns>
         public Activity AddBaggage(string key, string? value)
         {
-            KeyValueListNode? currentBaggage = _baggage;
-            KeyValueListNode newBaggage = new KeyValueListNode() { keyValue = new KeyValuePair<string, string?>(key, value) };
+            LinkedListNode<KeyValuePair<string, string?>>? currentBaggage = _baggage;
+            LinkedListNode<KeyValuePair<string, string?>> newBaggage = new LinkedListNode<KeyValuePair<string, string?>>(new KeyValuePair<string, string?>(key, value));
 
             do
             {
@@ -375,7 +473,7 @@ namespace System.Diagnostics
         }
 
         /// <summary>
-        /// Set the parent ID using the W3C convention using a TraceId and a SpanId.   This
+        /// Set the parent ID using the W3C convention using a TraceId and a SpanId. This
         /// constructor has the advantage that no string manipulation is needed to set the ID.
         /// </summary>
         public Activity SetParentId(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags activityTraceFlags = ActivityTraceFlags.None)
@@ -438,6 +536,12 @@ namespace System.Diagnostics
         }
 
         /// <summary>
+        /// Get the context of the activity. Context becomes valid only if the activity has been started.
+        /// otherwise will default context.
+        /// </summary>
+        public ActivityContext Context => new ActivityContext(TraceId, SpanId, ActivityTraceFlags, TraceStateString);
+
+        /// <summary>
         /// Starts activity
         /// <list type="bullet">
         /// <item>Sets <see cref="Parent"/> to hold <see cref="Current"/>.</item>
@@ -464,7 +568,7 @@ namespace System.Diagnostics
                     if (parent != null)
                     {
                         // The parent change should not form a loop.   We are actually guaranteed this because
-                        // 1. Unstarted activities can't be 'Current' (thus can't be 'parent'), we throw if you try.
+                        // 1. Un-started activities can't be 'Current' (thus can't be 'parent'), we throw if you try.
                         // 2. All started activities have a finite parent change (by inductive reasoning).
                         Parent = parent;
                     }
@@ -492,6 +596,8 @@ namespace System.Diagnostics
                     _id = GenerateHierarchicalId();
 
                 SetCurrent(this);
+
+                Source.NotifyActivityStart(this);
             }
             return this;
         }
@@ -521,6 +627,8 @@ namespace System.Diagnostics
                 }
 
                 SetCurrent(Parent);
+
+                Source.NotifyActivityStop(this);
             }
         }
 
@@ -603,6 +711,12 @@ namespace System.Diagnostics
         /// True if the W3CIdFlags.Recorded flag is set.
         /// </summary>
         public bool Recorded { get => (ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0; }
+
+        /// <summary>
+        /// Indicate if the this Activity object should be populated with all the propagation info and also all other
+        /// properties such as Links, Tags, and Events.
+        /// </summary>
+        public bool IsAllDataRequested { get; set;}
 
         /// <summary>
         /// Return the flags (defined by the W3C ID specification) associated with the activity.
@@ -716,6 +830,140 @@ namespace System.Diagnostics
             return id.Length == 55 &&
                    ('0' <= id[0] && id[0] <= '9' || 'a' <= id[0] && id[0] <= 'f') &&
                    ('0' <= id[1] && id[1] <= '9' || 'a' <= id[1] && id[1] <= 'e');
+        }
+
+        /// <summary>
+        /// Dispose will stop the Activity if it is already started and notify any event listeners. Nothing will happen otherwise.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!IsFinished)
+            {
+                Stop();
+            }
+
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+
+        }
+
+        /// <summary>
+        /// SetCustomProperty allow attaching any custom object to this Activity object.
+        /// If the property name was previously associated with other object, SetCustomProperty will update to use the new propert value instead.
+        /// </summary>
+        /// <param name="propertyName"> The name to associate the value with.<see cref="OperationName"/></param>
+        /// <param name="propertyValue">The object to attach and map to the property name.</param>
+        public void SetCustomProperty(string propertyName, object? propertyValue)
+        {
+            if (_customProperties == null)
+            {
+                Interlocked.CompareExchange(ref _customProperties, new ConcurrentDictionary<string, object>(), null);
+            }
+
+            if (propertyValue == null)
+            {
+                _customProperties.TryRemove(propertyName, out object _);
+            }
+            else
+            {
+                _customProperties[propertyName] = propertyValue!;
+            }
+        }
+
+        /// <summary>
+        /// GetCustomProperty retrieve previously attached object mapped to the property name.
+        /// </summary>
+        /// <param name="propertyName"> The name to get the associated object with.</param>
+        /// <returns>The object mapped to the property name. Or null if there is no mapping previously done with this property name.</returns>
+        public object? GetCustomProperty(string propertyName)
+        {
+            // We don't check null name here as the dictionary is performing this check anyway.
+
+            if (_customProperties == null)
+            {
+                return null;
+            }
+
+            return _customProperties.TryGetValue(propertyName, out object? o) ? o! : null;
+        }
+
+        internal static Activity CreateAndStart(ActivitySource source, string name, ActivityKind kind, string? parentId, ActivityContext parentContext,
+                                                IEnumerable<KeyValuePair<string, string?>>? tags, IEnumerable<ActivityLink>? links,
+                                                DateTimeOffset startTime, ActivityDataRequest request)
+        {
+            Activity activity = new Activity(name);
+
+            activity.Source = source;
+            activity.Kind = kind;
+
+            if (parentId != null)
+            {
+                activity._parentId = parentId;
+            }
+            else if (parentContext != default)
+            {
+                activity._traceId = parentContext.TraceId.ToString();
+                activity._parentSpanId = parentContext.SpanId.ToString();
+                activity.ActivityTraceFlags = parentContext.TraceFlags;
+                activity._traceState = parentContext.TraceState;
+            }
+            else
+            {
+                Activity? parent = Current;
+                if (parent != null)
+                {
+                    // The parent change should not form a loop. We are actually guaranteed this because
+                    // 1. Un-started activities can't be 'Current' (thus can't be 'parent'), we throw if you try.
+                    // 2. All started activities have a finite parent change (by inductive reasoning).
+                    activity.Parent = parent;
+                }
+            }
+
+            activity.IdFormat =
+                ForceDefaultIdFormat ? DefaultIdFormat :
+                activity.Parent != null ? activity.Parent.IdFormat :
+                activity._parentSpanId != null ? ActivityIdFormat.W3C :
+                activity._parentId == null ? DefaultIdFormat :
+                IsW3CId(activity._parentId) ? ActivityIdFormat.W3C :
+                ActivityIdFormat.Hierarchical;
+
+            if (activity.IdFormat == ActivityIdFormat.W3C)
+                activity.GenerateW3CId();
+            else
+                activity._id = activity.GenerateHierarchicalId();
+
+            if (links != null)
+            {
+                foreach (ActivityLink link in links)
+                {
+                     activity._links = new LinkedListNode<ActivityLink>(link, activity._links);
+                }
+            }
+
+            if (tags != null)
+            {
+                foreach (KeyValuePair<string, string?> tag in tags)
+                {
+                    activity._tags = new LinkedListNode<KeyValuePair<string, string?>>(tag, activity._tags);
+                }
+            }
+
+            activity.StartTimeUtc = startTime == default ? DateTime.UtcNow : startTime.DateTime;
+
+            activity.IsAllDataRequested = request == ActivityDataRequest.AllData || request == ActivityDataRequest.AllDataAndRecorded;
+
+            if (request == ActivityDataRequest.AllDataAndRecorded)
+            {
+                activity.ActivityTraceFlags |= ActivityTraceFlags.Recorded;
+            }
+
+            SetCurrent(activity);
+
+            return activity;
         }
 
         /// <summary>
@@ -946,10 +1194,16 @@ namespace System.Diagnostics
         /// <summary>
         /// Having our own key-value linked list allows us to be more efficient
         /// </summary>
-        private partial class KeyValueListNode
+        private partial class LinkedListNode<T>
         {
-            public KeyValuePair<string, string?> keyValue;
-            public KeyValueListNode? Next;
+            public LinkedListNode(T value) => Value = value;
+            public LinkedListNode(T value, LinkedListNode<T>? next)
+            {
+                Value = value;
+                Next = next;
+            }
+            public T Value;
+            public LinkedListNode<T>? Next;
         }
 
         [Flags]

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
@@ -1,0 +1,79 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// ActivityContext representation conforms to the w3c TraceContext specification. It contains two identifiers
+    /// a TraceId and a SpanId - along with a set of common TraceFlags and system-specific TraceState values.
+    /// </summary>
+    public readonly struct ActivityContext : IEquatable<ActivityContext>
+    {
+        /// <summary>
+        /// Construct a new object of ActivityContext.
+        /// </summary>
+        /// <param name="traceId"> A trace identifier.</param>
+        /// <param name="spanId"> A span identifier </param>
+        /// <param name="traceFlags">Contain details about the trace.</param>
+        /// <param name="traceState"> Carries system-specific configuration data.</param>
+        public ActivityContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags, string? traceState = null)
+        {
+            // We don't allow creating context with invalid span or trace Ids.
+            if (traceId == default || spanId == default)
+            {
+                throw new ArgumentException(SR.SpanIdOrTraceIdInvalid, traceId == default ? nameof(traceId) : nameof(spanId));
+            }
+
+            TraceId = traceId;
+            SpanId = spanId;
+            TraceFlags = traceFlags;
+            TraceState = traceState;
+        }
+
+        /// <summary>
+        /// The trace identifier
+        /// </summary>
+        public ActivityTraceId TraceId { get; }
+
+        /// <summary>
+        /// The span identifier
+        /// </summary>
+        public ActivitySpanId SpanId { get; }
+
+        /// <summary>
+        /// The flags for the details about the trace.
+        /// </summary>
+        public ActivityTraceFlags TraceFlags { get; }
+
+        /// <summary>
+        /// system-specific configuration data.
+        /// </summary>
+        public string? TraceState { get; }
+
+        public bool Equals(ActivityContext value) =>  SpanId.Equals(value.SpanId) && TraceId.Equals(value.TraceId) && TraceFlags == value.TraceFlags && TraceState == value.TraceState;
+
+        public override bool Equals(object? obj) => (obj is ActivityContext context) ? Equals(context) : false;
+        public static bool operator ==(ActivityContext left, ActivityContext right) => left.Equals(right);
+        public static bool operator !=(ActivityContext left, ActivityContext right) => !(left == right);
+
+        public override int GetHashCode()
+        {
+            if (this == default)
+                return 0;
+
+            // HashCode.Combine would be the best but we need to compile for the full framework which require adding dependency
+            // on the extensions package. Considering this simple type and hashing is not expected to be used much, we are implementing
+            // the hashing manually.
+            int hash = 5381;
+            hash = ((hash << 5) + hash) + TraceId.GetHashCode();
+            hash = ((hash << 5) + hash) + SpanId.GetHashCode();
+            hash = ((hash << 5) + hash) + (int) TraceFlags;
+            hash = ((hash << 5) + hash) + (TraceState == null ? 0 : TraceState.GetHashCode());
+
+            return hash;
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityCreationOptions.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityCreationOptions.cs
@@ -1,0 +1,63 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Collections.Generic;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// ActivityCreationOptions is encapsulating all needed information which will be sent to the ActivityListener to decide about creating the Activity object and with what state.
+    /// The possible generic type parameters is <see cref="ActivityContext"/> or <see cref="string"/>
+    /// </summary>
+    public readonly struct ActivityCreationOptions<T>
+    {
+        /// <summary>
+        /// Construct a new <see cref="ActivityCreationOptions{T}"/> object.
+        /// </summary>
+        /// <param name="source">The trace Activity source<see cref="ActivitySource"/> used to request creating the Activity object.</param>
+        /// <param name="name">The operation name of the Activity.</param>
+        /// <param name="parent">The requested parent to create the Activity object with. The parent either be a parent Id represented as string or it can be a parent context <see cref="ActivityContext"/>.</param>
+        /// <param name="kind"><see cref="ActivityKind"/> to create the Activity object with.</param>
+        /// <param name="tags">Key-value pairs list for the tags to create the Activity object with.<see cref="ActivityContext"/></param>
+        /// <param name="links"><see cref="ActivityLink"/> list to create the Activity object with.</param>
+        internal ActivityCreationOptions(ActivitySource source, string name, T parent, ActivityKind kind, IEnumerable<KeyValuePair<string, string?>>? tags, IEnumerable<ActivityLink>? links)
+        {
+            Source = source;
+            Name = name;
+            Kind = kind;
+            Parent = parent;
+            Tags = tags;
+            Links = links;
+        }
+
+        /// <summary>
+        /// Retrieve the <see cref="ActivitySource"/> object.
+        /// </summary>
+        public ActivitySource Source { get; }
+
+        /// <summary>
+        /// Retrieve the name which requested to create the Activity object with.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Retrieve the <see cref="ActivityKind"/> which requested to create the Activity object with.
+        /// </summary>
+        public ActivityKind Kind { get; }
+
+        /// <summary>
+        /// Retrieve the parent which requested to create the Activity object with. Parent will be either in form of string or <see cref="ActivityContext"/>.
+        /// </summary>
+        public T Parent { get; }
+
+        /// <summary>
+        /// Retrieve the tags which requested to create the Activity object with.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string?>>? Tags { get; }
+
+        /// <summary>
+        /// Retrieve the list of <see cref="ActivityLink"/> which requested to create the Activity object with.
+        /// </summary>
+        public IEnumerable<ActivityLink>? Links { get; }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityDataRequest.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityDataRequest.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Used by ActivityListener to indicate what amount of data should be collected for this Activity
+    /// Requesting more data causes greater performance overhead to collect it.
+    /// </summary>
+    public enum ActivityDataRequest
+    {
+        /// <summary>
+        /// The Activity object doesn't need to be created
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The Activity object needs to be created. It will have Name, Source, Id and Baggage.
+        /// Other properties are unnecessary and will be ignored by this listener.
+        /// </summary>
+        PropagationData,
+
+        /// <summary>
+        /// The activity object should be populated with all the propagation info and also all other
+        /// properties such as Links, Tags, and Events. Activity.IsAllDataRequested will return true.
+        /// </summary>
+        AllData,
+
+        /// <summary>
+        /// The activity object should be populated the same as the AllData case and additionally
+        /// Activity.IsRecorded is set true. For activities using W3C trace ids this sets a flag bit in the
+        /// ID that will be propagated downstream requesting that trace is recorded everywhere.
+        /// </summary>
+        AllDataAndRecorded
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityEvent.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityEvent.cs
@@ -1,0 +1,74 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// A text annotation associated with a collection of attributes.
+    /// </summary>
+    public readonly struct ActivityEvent
+    {
+        private static readonly IEnumerable<KeyValuePair<string, object>> s_emptyAttributes = new Dictionary<string, object>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityEvent"/> class.
+        /// </summary>
+        /// <param name="name">Event name.</param>
+        public ActivityEvent(string name) : this(name, DateTimeOffset.UtcNow, s_emptyAttributes)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityEvent"/> class.
+        /// </summary>
+        /// <param name="name">Event name.</param>
+        /// <param name="timestamp">Event timestamp. Timestamp MUST only be used for the events that happened in the past, not at the moment of this call.</param>
+        public ActivityEvent(string name, DateTimeOffset timestamp) : this(name, timestamp, s_emptyAttributes)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityEvent"/> class.
+        /// </summary>
+        /// <param name="name">Event name.</param>
+        /// <param name="attributes">Event attributes.</param>
+        public ActivityEvent(string name, IEnumerable<KeyValuePair<string, object>>? attributes)
+        {
+            this.Name = name ?? string.Empty;
+            this.Attributes = attributes ?? s_emptyAttributes;
+            this.Timestamp = DateTimeOffset.UtcNow;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityEvent"/> class.
+        /// </summary>
+        /// <param name="name">Event name.</param>
+        /// <param name="timestamp">Event timestamp. Timestamp MUST only be used for the events that happened in the past, not at the moment of this call.</param>
+        /// <param name="attributes">Event attributes.</param>
+        public ActivityEvent(string name, DateTimeOffset timestamp, IEnumerable<KeyValuePair<string, object>>? attributes)
+        {
+            this.Name = name ?? string.Empty;
+            this.Attributes = attributes ?? s_emptyAttributes;
+            this.Timestamp = timestamp != default ? timestamp : DateTimeOffset.UtcNow;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ActivityEvent"/> name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the <see cref="ActivityEvent"/> timestamp.
+        /// </summary>
+        public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// Gets the collection of attributes associated with the event.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>>? Attributes { get; }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityKind.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityKind.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Kind describes the relationship between the Activity, its parents, and its children in a Trace.
+    ///     --------------------------------------------------------------------------------
+    ///    ActivityKind    Synchronous  Asynchronous    Remote Incoming    Remote Outgoing
+    ///     --------------------------------------------------------------------------------
+    ///       Internal
+    ///       Client          yes                                               yes
+    ///       Server          yes                            yes
+    ///       Producer                     yes                                  maybe
+    ///       Consumer                     yes               maybe
+    ///     --------------------------------------------------------------------------------
+    /// </summary>
+    public enum ActivityKind
+    {
+        /// <summary>
+        /// Default value.
+        /// Indicates that the Activity represents an internal operation within an application, as opposed to an operations with remote parents or children.
+        /// </summary>
+        Internal = 0,
+
+        /// <summary>
+        /// Server activity represents request incoming from external component.
+        /// </summary>
+        Server = 1,
+
+        /// <summary>
+        /// Client activity represents outgoing request to the external component.
+        /// </summary>
+        Client = 2,
+
+        /// <summary>
+        /// Producer activity represents output provided to external components.
+        /// </summary>
+        Producer = 3,
+
+        /// <summary>
+        /// Consumer activity represents output received from an external component.
+        /// </summary>
+        Consumer = 4,
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityLink.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityLink.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Activity may be linked to zero or more other <see cref="ActivityContext"/> that are causally related.
+    /// Links can point to ActivityContexts inside a single Trace or across different Traces.
+    /// Links can be used to represent batched operations where a Activity was initiated by multiple initiating Activities,
+    /// each representing a single incoming item being processed in the batch.
+    /// </summary>
+    public readonly struct ActivityLink  : IEquatable<ActivityLink>
+    {
+        /// <summary>
+        /// Construct a new <see cref="ActivityLink"/> object which can be linked to an Activity object.
+        /// </summary>
+        /// <param name="context">The trace Activity context<see cref="ActivityContext"/></param>
+        public ActivityLink(ActivityContext context) : this(context, null) {}
+
+        /// <summary>
+        /// Construct a new <see cref="ActivityLink"/> object which can be linked to an Activity object.
+        /// </summary>
+        /// <param name="context">The trace Activity context<see cref="ActivityContext"/></param>
+        /// <param name="attributes">The key-value pair list of attributes which associated to the <see cref="ActivityContext"/></param>
+        public ActivityLink(ActivityContext context, IEnumerable<KeyValuePair<string, object>>? attributes)
+        {
+            Context = context;
+            Attributes = attributes;
+        }
+
+        /// <summary>
+        /// Retrieve the <see cref="ActivityContext"/> object inside this <see cref="ActivityLink"/> object.
+        /// </summary>
+        public ActivityContext Context { get; }
+
+        /// <summary>
+        /// Retrieve the key-value pair list of attributes attached with the <see cref="ActivityContext"/>.
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, object>>? Attributes { get; }
+
+        public override bool Equals(object? obj) => (obj is ActivityLink link) && this.Equals(link);
+
+        public bool Equals(ActivityLink value) => Context == value.Context && value.Attributes == Attributes;
+        public static bool operator ==(ActivityLink left, ActivityLink right) => left.Equals(right);
+        public static bool operator !=(ActivityLink left, ActivityLink right) => !left.Equals(right);
+
+        public override int GetHashCode()
+        {
+            if (this == default)
+                return 0;
+
+            // HashCode.Combine would be the best but we need to compile for the full framework which require adding dependency
+            // on the extensions package. Considering this simple type and hashing is not expected to be used, we are implementing
+            // the hashing manually.
+            int hash = 5381;
+            hash = ((hash << 5) + hash) + this.Context.GetHashCode();
+            if (Attributes != null)
+            {
+                foreach (KeyValuePair<string, object> kvp in Attributes)
+                {
+                    hash = ((hash << 5) + hash) + kvp.Key.GetHashCode();
+                    if (kvp.Value != null)
+                    {
+                        hash = ((hash << 5) + hash) + kvp.Value.GetHashCode();
+                    }
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityListener.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Diagnostics
+{
+    /// <summary>
+    /// Define the callback that can be used in <see cref="ActivityListener"/> to allow deciding to create the Activity objects and with what data state.
+    /// </summary>
+    public delegate ActivityDataRequest GetRequestedData<T>(ref ActivityCreationOptions<T> options);
+
+    /// <summary>
+    /// ActivityListener allows listening to the start and stop Activity events and give the oppertunity to decide creating the Activity for sampling scenarios.
+    /// </summary>
+    public sealed class ActivityListener : IDisposable
+    {
+        /// <summary>
+        /// Construct a new <see cref="ActivityListener"/> object to start listeneing to the <see cref="Activity"/> events.
+        /// </summary>
+        public ActivityListener()
+        {
+
+        }
+
+        /// <summary>
+        /// Set or get the callback used to listen to the <see cref="Activity"/> start event.
+        /// </summary>
+        public Action<Activity>? ActivityStarted { get; set; }
+
+        /// <summary>
+        /// Set or get the callback used to listen to the <see cref="Activity"/> stop event.
+        /// </summary>
+        public Action<Activity>? ActivityStopped { get; set; }
+
+        /// <summary>
+        /// Set or get the callback used to decide if want to listen to <see cref="Activity"/> objects events which created using <see cref="ActivitySource"/> object.
+        /// </summary>
+        public Func<ActivitySource, bool>? ShouldListenTo { get; set; }
+
+        /// <summary>
+        /// Set or get the callback used to decide allowing creating <see cref="Activity"/> objects with specific data state.
+        /// </summary>
+        public GetRequestedData<string>? GetRequestedDataUsingParentId { get; set; }
+
+        /// <summary>
+        /// Set or get the callback used to decide allowing creating <see cref="Activity"/> objects with specific data state.
+        /// </summary>
+        public GetRequestedData<ActivityContext>? GetRequestedDataUsingContext { get; set; }
+
+        /// <summary>
+        /// Dispose will unregister this <see cref="ActivityListener"/> object from listeneing to <see cref="Activity"/> events.
+        /// </summary>
+        public void Dispose() => ActivitySource.DetachListener(this);
+   }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -1,0 +1,357 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading;
+using System.Collections.Generic;
+
+namespace System.Diagnostics
+{
+    public sealed class ActivitySource : IDisposable
+    {
+        private static SynchronizedList<ActivitySource> s_activeSources = new SynchronizedList<ActivitySource>();
+        private static SynchronizedList<ActivityListener> s_allListeners = new SynchronizedList<ActivityListener>();
+        private SynchronizedList<ActivityListener>? _listeners;
+
+        private ActivitySource() { throw new InvalidOperationException(); }
+
+        /// <summary>
+        /// Construct an ActivitySource object with the input name
+        /// </summary>
+        /// <param name="name">The name of the ActivitySource object</param>
+        /// <param name="version">The version of the component publishing the tracing info.</param>
+        public ActivitySource(string name, string? version = "")
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            Name = name;
+            Version = version;
+
+            s_activeSources.Add(this);
+
+            if (s_allListeners.Count > 0)
+            {
+                s_allListeners.EnumWithAction(listener => {
+                    var shouldListenTo = listener.ShouldListenTo;
+                    if (shouldListenTo != null && shouldListenTo(this))
+                    {
+                        AddListener(listener);
+                    }
+                });
+            }
+        }
+
+        /// <summary>
+        /// Returns the ActivitySource name.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Returns the ActivitySource version.
+        /// </summary>
+        public string? Version { get; }
+
+        /// <summary>
+        /// Check if there is any listeners for this ActivitySource.
+        /// This property can be helpful to tell if there is no listener, then no need to create Activity object
+        /// and avoid creating the objects needed to create Activity (e.g. ActivityContext)
+        /// Example of that is http scenario which can avoid reading the context data from the wire.
+        /// </summary>
+        public bool HasListeners()
+        {
+            SynchronizedList<ActivityListener>? listeners = _listeners;
+            return listeners != null && listeners.Count > 0;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Activity"/> object if there is any listener to the Activity, returns null otherwise.
+        /// </summary>
+        /// <param name="name">The operation name of the Activity</param>
+        /// <param name="kind">The <see cref="ActivityKind"/></param>
+        /// <returns>The created <see cref="Activity"/> object or null if there is no any event listener.</returns>
+        public Activity? StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
+            => StartActivity(name, kind, default, null, null, null, default);
+
+        /// <summary>
+        /// Creates a new <see cref="Activity"/> object if there is any listener to the Activity events, returns null otherwise.
+        /// </summary>
+        /// <param name="name">The operation name of the Activity.</param>
+        /// <param name="kind">The <see cref="ActivityKind"/></param>
+        /// <param name="parentContext">The parent <see cref="ActivityContext"/> object to initialize the created Activity object with.</param>
+        /// <param name="tags">The optional tags list to initialize the created Activity object with.</param>
+        /// <param name="links">The optional <see cref="ActivityLink"/> list to initialize the created Activity object with.</param>
+        /// <param name="startTime">The optional start timestamp to set on the created Activity object.</param>
+        /// <returns>The created <see cref="Activity"/> object or null if there is no any listener.</returns>
+        public Activity? StartActivity(string name, ActivityKind kind, ActivityContext parentContext, IEnumerable<KeyValuePair<string, string?>>? tags = null, IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default)
+            => StartActivity(name, kind, parentContext, null, tags, links, startTime);
+
+        /// <summary>
+        /// Creates a new <see cref="Activity"/> object if there is any listener to the Activity events, returns null otherwise.
+        /// </summary>
+        /// <param name="name">The operation name of the Activity.</param>
+        /// <param name="kind">The <see cref="ActivityKind"/></param>
+        /// <param name="parentId">The parent Id to initialize the created Activity object with.</param>
+        /// <param name="tags">The optional tags list to initialize the created Activity object with.</param>
+        /// <param name="links">The optional <see cref="ActivityLink"/> list to initialize the created Activity object with.</param>
+        /// <param name="startTime">The optional start timestamp to set on the created Activity object.</param>
+        /// <returns>The created <see cref="Activity"/> object or null if there is no any listener.</returns>
+        public Activity? StartActivity(string name, ActivityKind kind, string parentId, IEnumerable<KeyValuePair<string, string?>>? tags = null, IEnumerable<ActivityLink>? links = null, DateTimeOffset startTime = default)
+            => StartActivity(name, kind, default, parentId, tags, links, startTime);
+
+        private Activity? StartActivity(string name, ActivityKind kind, ActivityContext context, string? parentId, IEnumerable<KeyValuePair<string, string?>>? tags, IEnumerable<ActivityLink>? links, DateTimeOffset startTime)
+        {
+            // _listeners can get assigned to null in Dispose.
+            SynchronizedList<ActivityListener>? listeners = _listeners;
+            if (listeners == null || listeners.Count == 0)
+            {
+                return null;
+            }
+
+            Activity? activity = null;
+
+            ActivityDataRequest dateRequest = ActivityDataRequest.None;
+
+            if (parentId != null)
+            {
+                listeners.EnumWithFunc(listener => {
+                    var getRequestedDataUsingParentId = listener.GetRequestedDataUsingParentId;
+                    if (getRequestedDataUsingParentId != null)
+                    {
+                        ActivityCreationOptions<string> aco = new ActivityCreationOptions<string>(this, name, parentId, kind, tags, links);
+                        ActivityDataRequest dr = getRequestedDataUsingParentId(ref aco);
+                        if (dr > dateRequest)
+                        {
+                            dateRequest = dr;
+                        }
+
+                        // Stop the enumeration if we get the max value RecordingAndSampling.
+                        return dateRequest != ActivityDataRequest.AllDataAndRecorded;
+                    }
+                    return true;
+                });
+            }
+            else
+            {
+                listeners.EnumWithFunc(listener => {
+                    var getRequestedDataUsingContext = listener.GetRequestedDataUsingContext;
+                    if (getRequestedDataUsingContext != null)
+                    {
+                        ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(this, name, context, kind, tags, links);
+                        ActivityDataRequest dr = getRequestedDataUsingContext(ref aco);
+                        if (dr > dateRequest)
+                        {
+                            dateRequest = dr;
+                        }
+
+                        // Stop the enumeration if we get the max value RecordingAndSampling.
+                        return dateRequest != ActivityDataRequest.AllDataAndRecorded;
+                    }
+                    return true;
+                });
+            }
+
+            if (dateRequest != ActivityDataRequest.None)
+            {
+                activity = Activity.CreateAndStart(this, name, kind, parentId, context, tags, links, startTime, dateRequest);
+                listeners.EnumWithAction(listener => {
+                    var activityStarted = listener.ActivityStarted;
+                    if (activityStarted != null)
+                    {
+                        activityStarted(activity);
+                    }
+                });
+            }
+
+            return activity;
+        }
+
+        /// <summary>
+        /// Dispose the ActivitySource object and remove the current instance from the global list. empty the listeners list too.
+        /// </summary>
+        public void Dispose()
+        {
+            _listeners = null;
+            s_activeSources.Remove(this);
+        }
+
+        /// <summary>
+        /// Add a listener to the <see cref="Activity"/> starting and stopping events.
+        /// </summary>
+        /// <param name="listener"> The <see cref="ActivityListener"/> object to use for listeneing to the <see cref="Activity"/> events.</param>
+        public static void AddActivityListener(ActivityListener listener)
+        {
+            if (listener == null)
+            {
+                throw new ArgumentNullException(nameof(listener));
+            }
+
+            if (s_allListeners.AddIfNotExist(listener))
+            {
+                s_activeSources.EnumWithAction(source => {
+                    var shouldListenTo = listener.ShouldListenTo;
+                    if (shouldListenTo != null && shouldListenTo(source))
+                    {
+                        source.AddListener(listener);
+                    }
+                });
+            }
+        }
+
+        internal void AddListener(ActivityListener listener)
+        {
+            if (_listeners == null)
+            {
+                Interlocked.CompareExchange(ref _listeners, new SynchronizedList<ActivityListener>(), null);
+            }
+
+            _listeners.AddIfNotExist(listener);
+        }
+
+        internal static void DetachListener(ActivityListener listener)
+        {
+            s_allListeners.Remove(listener);
+
+            s_activeSources.EnumWithAction(source => {
+                var listeners = source._listeners;
+                listeners?.Remove(listener);
+            });
+        }
+
+        internal void NotifyActivityStart(Activity activity)
+        {
+            Debug.Assert(activity != null);
+
+            // _listeners can get assigned to null in Dispose.
+            SynchronizedList<ActivityListener>? listeners = _listeners;
+            if (listeners != null &&  listeners.Count > 0)
+            {
+                listeners.EnumWithAction(listener => listener.ActivityStarted?.Invoke(activity));
+            }
+        }
+
+        internal void NotifyActivityStop(Activity activity)
+        {
+            Debug.Assert(activity != null);
+
+            // _listeners can get assigned to null in Dispose.
+            SynchronizedList<ActivityListener>? listeners = _listeners;
+            if (listeners != null &&  listeners.Count > 0)
+            {
+                listeners.EnumWithAction(listener => {
+                    listeners.EnumWithAction(listener => listener.ActivityStopped?.Invoke(activity));
+                });
+            }
+        }
+    }
+
+    // SynchronizedList<T> is a helper collection which ensure thread safety on the collection
+    // and allow enumerating the collection items and execute some action on the enumerated item and can detect any change in the collection
+    // during the enumeration which force restarting the enumeration again.
+    // Causion: We can have the action executed on the same item more than once which is ok in our scenarios.
+    internal class SynchronizedList<T>
+    {
+        private List<T> _list;
+        private uint _version;
+
+        public SynchronizedList() => _list = new List<T>();
+
+        public void Add(T item)
+        {
+            lock (_list)
+            {
+                _list.Add(item);
+                _version++;
+            }
+        }
+
+        public bool AddIfNotExist(T item)
+        {
+            lock (_list)
+            {
+                if (!_list.Contains(item))
+                {
+                    _list.Add(item);
+                    _version++;
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            lock (_list)
+            {
+                if (_list.Remove(item))
+                {
+                    _version++;
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        public int Count => _list.Count;
+
+        public void EnumWithFunc(Func<T, bool> func)
+        {
+            uint version = _version;
+            int index = 0;
+
+            while (index < _list.Count)
+            {
+                T item;
+                lock (_list)
+                {
+                    if (version != _version)
+                    {
+                        version = _version;
+                        index = 0;
+                        continue;
+                    }
+
+                    item = _list[index];
+                    index++;
+                }
+
+                // Important to call the func outside the lock.
+                // This is the whole point we are having this wrapper class.
+                if (!func(item))
+                {
+                    break;
+                }
+            }
+        }
+
+        public void EnumWithAction(Action<T> action)
+        {
+            uint version = _version;
+            int index = 0;
+
+            while (index < _list.Count)
+            {
+                T item;
+                lock (_list)
+                {
+                    if (version != _version)
+                    {
+                        version = _version;
+                        index = 0;
+                        continue;
+                    }
+
+                    item = _list[index];
+                    index++;
+                }
+
+                // Important to call the action outside the lock.
+                // This is the whole point we are having this wrapper class.
+                action(item);
+            }
+        }
+
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticListener.cs
@@ -279,7 +279,7 @@ namespace System.Diagnostics
             //    - IsEnabled1Arg invoked for DiagnosticSource.IsEnabled(string)
             //    - IsEnabled3Arg invoked for DiagnosticSource.IsEnabled(string, obj, obj)
             // Subscriber MUST set both IsEnabled1Arg and IsEnabled3Arg or none of them:
-            //     when Predicate<string> is provided in DiagosticListener.Subscribe,
+            //     when Predicate<string> is provided in DiagnosticListener.Subscribe,
             //       - IsEnabled1Arg is set to predicate
             //       - IsEnabled3Arg falls back to predicate ignoring extra arguments.
             //     similarly, when Func<string, obj, obj, bool> is provided,

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -1,0 +1,365 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Diagnostics.Tests
+{
+    public class ActivitySourceTests : IDisposable
+    {
+        [Fact]
+        public void TestConstruction()
+        {
+            RemoteExecutor.Invoke(() => {
+                using (ActivitySource as1 = new ActivitySource("Source1"))
+                {
+                    Assert.Equal("Source1", as1.Name);
+                    Assert.Equal(String.Empty, as1.Version);
+                    Assert.False(as1.HasListeners());
+                    using (ActivitySource as2 =  new ActivitySource("Source2", "1.1.1.2"))
+                    {
+                        Assert.Equal("Source2", as2.Name);
+                        Assert.Equal("1.1.1.2", as2.Version);
+                        Assert.False(as2.HasListeners());
+                    }
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestStartActivityWithNoListener()
+        {
+            RemoteExecutor.Invoke(() => {
+                using (ActivitySource aSource =  new ActivitySource("SourceActivity"))
+                {
+                    Assert.Equal("SourceActivity", aSource.Name);
+                    Assert.Equal(string.Empty, aSource.Version);
+                    Assert.False(aSource.HasListeners());
+
+                    Activity current = Activity.Current;
+                    using (Activity a1 = aSource.StartActivity("a1"))
+                    {
+                        // no listeners, we should get null activity.
+                        Assert.Null(a1);
+                        Assert.Equal(Activity.Current, current);
+                    }
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestActivityWithListenerNoActivityCreate()
+        {
+            RemoteExecutor.Invoke(() => {
+                using (ActivitySource aSource =  new ActivitySource("SourceActivityListener"))
+                {
+                    Assert.False(aSource.HasListeners());
+
+                    using (ActivityListener listener = new ActivityListener
+                        {
+                            ActivityStarted = activity => Assert.NotNull(activity),
+                            ActivityStopped = activity => Assert.NotNull(activity),
+                            ShouldListenTo = (activitySource) => object.ReferenceEquals(aSource, activitySource),
+                            GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.None,
+                            GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.None
+                        }
+                    )
+                    {
+                        ActivitySource.AddActivityListener(listener);
+                        Assert.True(aSource.HasListeners());
+
+                        // The listener is not allowing to create a new Activity.
+                        Assert.Null(aSource.StartActivity("nullActivity"));
+                    }
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestActivityWithListenerActivityCreateAndAllDataRequested()
+        {
+            RemoteExecutor.Invoke(() => {
+                using (ActivitySource aSource = new ActivitySource("SourceActivityListener"))
+                {
+                    int counter = 0;
+                    Assert.False(aSource.HasListeners());
+
+                    using (ActivityListener listener = new ActivityListener
+                        {
+                            ActivityStarted = activity => counter++,
+                            ActivityStopped = activity => counter--,
+                            ShouldListenTo = (activitySource) => object.ReferenceEquals(aSource, activitySource),
+                            GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllDataAndRecorded,
+                            GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllDataAndRecorded
+                        }
+                    )
+                    {
+                        ActivitySource.AddActivityListener(listener);
+
+                        Assert.True(aSource.HasListeners());
+
+                        using (Activity activity = aSource.StartActivity("AllDataRequestedActivity"))
+                        {
+                            Assert.NotNull(activity);
+                            Assert.True(activity.IsAllDataRequested);
+                            Assert.Equal(1, counter);
+
+                            Assert.Equal(0, activity.Tags.Count());
+                            Assert.Equal(0, activity.Baggage.Count());
+
+                            Assert.True(object.ReferenceEquals(activity, activity.AddTag("key", "value")));
+                            Assert.True(object.ReferenceEquals(activity, activity.AddBaggage("key", "value")));
+
+                            Assert.Equal(1, activity.Tags.Count());
+                            Assert.Equal(1, activity.Baggage.Count());
+
+                            using (Activity activity1 = aSource.StartActivity("AllDataRequestedActivity1"))
+                            {
+                                Assert.NotNull(activity1);
+                                Assert.True(activity1.IsAllDataRequested);
+                                Assert.Equal(2, counter);
+
+                                Assert.Equal(0, activity1.Links.Count());
+                                Assert.Equal(0, activity1.Events.Count());
+                                Assert.True(object.ReferenceEquals(activity1, activity1.AddEvent(new ActivityEvent("e1"))));
+                                Assert.Equal(1, activity1.Events.Count());
+                            }
+                            Assert.Equal(1, counter);
+                        }
+
+                        Assert.Equal(0, counter);
+                    }
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestActivitySourceAttachedObject()
+        {
+            RemoteExecutor.Invoke(() => {
+                // All Activities created through the constructor should have same source.
+                Assert.True(object.ReferenceEquals(new Activity("a1").Source, new Activity("a2").Source));
+                Assert.Equal("", new Activity("a3").Source.Name);
+                Assert.Equal(string.Empty, new Activity("a4").Source.Version);
+
+                using (ActivitySource aSource = new ActivitySource("SourceToTest", "1.2.3.4"))
+                {
+                    //Ensure at least we have a listener to allow Activity creation
+                    using (ActivityListener listener = new ActivityListener
+                        {
+                            ActivityStarted = activity => Assert.NotNull(activity),
+                            ActivityStopped = activity => Assert.NotNull(activity),
+                            ShouldListenTo = (activitySource) => object.ReferenceEquals(aSource, activitySource),
+                            GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
+                            GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData
+                        }
+                    )
+                    {
+                        ActivitySource.AddActivityListener(listener);
+
+                        using (Activity activity = aSource.StartActivity("ActivityToTest"))
+                        {
+                            Assert.True(object.ReferenceEquals(aSource, activity.Source));
+                        }
+                    }
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestListeningToConstructedActivityEvents()
+        {
+            RemoteExecutor.Invoke(() => {
+                int activityStartCount = 0;
+                int activityStopCount  = 0;
+
+                using (ActivityListener listener = new ActivityListener
+                    {
+                        ActivityStarted = activity => activityStartCount++,
+                        ActivityStopped = activity => activityStopCount++,
+                        ShouldListenTo = (activitySource) => activitySource.Name == "" && activitySource.Version == "",
+                        GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
+                        GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData
+                    }
+                )
+                {
+                    ActivitySource.AddActivityListener(listener);
+
+                    Assert.Equal(0, activityStartCount);
+                    Assert.Equal(0, activityStopCount);
+
+                    using (Activity a1 = new Activity("a1"))
+                    {
+                        Assert.Equal(0, activityStartCount);
+                        Assert.Equal(0, activityStopCount);
+
+                        a1.Start();
+
+                        Assert.Equal(1, activityStartCount);
+                        Assert.Equal(0, activityStopCount);
+                    }
+
+                    Assert.Equal(1, activityStartCount);
+                    Assert.Equal(1, activityStopCount);
+                }
+
+                // Ensure the listener is disposed
+                using (Activity a2 = new Activity("a2"))
+                {
+                    a2.Start();
+
+                    Assert.Equal(1, activityStartCount);
+                    Assert.Equal(1, activityStopCount);
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestExpectedListenersReturnValues()
+        {
+            RemoteExecutor.Invoke(() => {
+
+                ActivitySource source = new ActivitySource("MultipleListenerSource");
+                ActivityListener [] listeners = new ActivityListener[4];
+
+                listeners[0] = new ActivityListener
+                {
+                    ActivityStarted = activity => Assert.NotNull(activity),
+                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ShouldListenTo = (activitySource) => true,
+                    GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.None,
+                    GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.None
+                };
+                ActivitySource.AddActivityListener(listeners[0]);
+
+                Assert.Null(source.StartActivity("a1"));
+
+                listeners[1] = new ActivityListener
+                {
+                    ActivityStarted = activity => Assert.NotNull(activity),
+                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ShouldListenTo = (activitySource) => true,
+                    GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.PropagationData,
+                    GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.PropagationData
+                };
+                ActivitySource.AddActivityListener(listeners[1]);
+
+                using (Activity a2 = source.StartActivity("a2"))
+                {
+                    Assert.False(a2.IsAllDataRequested);
+                    Assert.True((a2.ActivityTraceFlags & ActivityTraceFlags.Recorded) == 0);
+                }
+
+                listeners[2] = new ActivityListener
+                {
+                    ActivityStarted = activity => Assert.NotNull(activity),
+                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ShouldListenTo = (activitySource) => true,
+                    GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
+                    GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData
+                };
+                ActivitySource.AddActivityListener(listeners[2]);
+
+                using (Activity a3 = source.StartActivity("a3"))
+                {
+                    Assert.True(a3.IsAllDataRequested);
+                    Assert.True((a3.ActivityTraceFlags & ActivityTraceFlags.Recorded) == 0);
+                }
+
+                listeners[3] = new ActivityListener
+                {
+                    ActivityStarted = activity => Assert.NotNull(activity),
+                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ShouldListenTo = (activitySource) => true,
+                    GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllDataAndRecorded,
+                    GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllDataAndRecorded
+                };
+                ActivitySource.AddActivityListener(listeners[3]);
+
+                using (Activity a4 = source.StartActivity("a4"))
+                {
+                    Assert.True(a4.IsAllDataRequested);
+                    Assert.True((a4.ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0, $"a4.ActivityTraceFlags failed: {a4.ActivityTraceFlags}");
+                }
+
+                foreach (IDisposable listener in listeners)
+                {
+                    listener.Dispose();
+                }
+
+                Assert.Null(source.StartActivity("a5"));
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestActivityCreationProperties()
+        {
+            RemoteExecutor.Invoke(() => {
+                ActivitySource source = new ActivitySource("MultipleListenerSource");
+
+                using (ActivityListener listener = new ActivityListener
+                    {
+                        ActivityStarted = activity => Assert.NotNull(activity),
+                        ActivityStopped = activity => Assert.NotNull(activity),
+                        ShouldListenTo = (activitySource) => true,
+                        GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
+                        GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData
+                    }
+                )
+                {
+                    ActivitySource.AddActivityListener(listener);
+
+                    ActivityContext ctx = new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.Recorded, "key0-value0");
+
+                    List<ActivityLink> links = new List<ActivityLink>();
+                    links.Add(new ActivityLink(new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None, "key1-value1")));
+                    links.Add(new ActivityLink(new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), ActivityTraceFlags.None, "key2-value2")));
+
+                    List<KeyValuePair<string, string>> attributes = new List<KeyValuePair<string, string>>();
+                    attributes.Add(new KeyValuePair<string, string>("tag1", "tagValue1"));
+                    attributes.Add(new KeyValuePair<string, string>("tag2", "tagValue2"));
+                    attributes.Add(new KeyValuePair<string, string>("tag3", "tagValue3"));
+
+                    using (Activity activity = source.StartActivity("a1", ActivityKind.Client, ctx, attributes, links))
+                    {
+                        Assert.NotNull(activity);
+                        Assert.Equal("a1", activity.OperationName);
+                        Assert.Equal("a1", activity.DisplayName);
+                        Assert.Equal(ActivityKind.Client, activity.Kind);
+
+                        Assert.Equal(ctx.TraceId, activity.TraceId);
+                        Assert.Equal(ctx.SpanId, activity.ParentSpanId);
+                        Assert.Equal(ctx.TraceFlags, activity.ActivityTraceFlags);
+                        Assert.Equal(ctx.TraceState, activity.TraceStateString);
+                        Assert.Equal(ActivityIdFormat.W3C, activity.IdFormat);
+
+                        foreach (KeyValuePair<string, string> pair in attributes)
+                        {
+                            Assert.NotEqual(default, activity.Tags.FirstOrDefault((p) => pair.Key == p.Key && pair.Value == pair.Value));
+                        }
+
+                        foreach (ActivityLink link in links)
+                        {
+                            Assert.NotEqual(default, activity.Links.FirstOrDefault((l) => link == l));
+                        }
+                    }
+
+                    using (Activity activity = source.StartActivity("a2", ActivityKind.Client, "NoW3CParentId", attributes, links))
+                    {
+                        Assert.Equal(ActivityIdFormat.Hierarchical, activity.IdFormat);
+                    }
+                }
+            }).Dispose();
+        }
+        public void Dispose() => Activity.Current = null;
+    }
+}

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivityTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
@@ -1345,6 +1346,88 @@ namespace System.Diagnostics.Tests
 
             Activity.Current = stopped;
             Assert.Same(started, Activity.Current);
+        }
+
+        [Fact]
+        public void TestDispose()
+        {
+            Activity current = Activity.Current;
+            using (Activity activity = new Activity("Mine").Start())
+            {
+                Assert.Same(activity, Activity.Current);
+                Assert.Same(current, activity.Parent);
+            }
+
+            Assert.Same(current, Activity.Current);
+        }
+
+        [Fact]
+        public void TestCustomProperties()
+        {
+            Activity activity = new Activity("Custom");
+            activity.SetCustomProperty("P1", "Prop1");
+            activity.SetCustomProperty("P2", "Prop2");
+            activity.SetCustomProperty("P3", null);
+
+            Assert.Equal("Prop1", activity.GetCustomProperty("P1"));
+            Assert.Equal("Prop2", activity.GetCustomProperty("P2"));
+            Assert.Null(activity.GetCustomProperty("P3"));
+            Assert.Null(activity.GetCustomProperty("P4"));
+
+            activity.SetCustomProperty("P1", "Prop5");
+            Assert.Equal("Prop5", activity.GetCustomProperty("P1"));
+
+        }
+
+        [Fact]
+        public void TestKind()
+        {
+            Activity activity = new Activity("Kind");
+            Assert.Equal(ActivityKind.Internal, activity.Kind);
+        }
+
+        [Fact]
+        public void TestDisplayName()
+        {
+            Activity activity = new Activity("Op1");
+            Assert.Equal("Op1", activity.OperationName);
+            Assert.Equal("Op1", activity.DisplayName);
+
+            activity.DisplayName = "Op2";
+            Assert.Equal("Op1", activity.OperationName);
+            Assert.Equal("Op2", activity.DisplayName);
+        }
+
+        [Fact]
+        public void TestEvent()
+        {
+            Activity activity = new Activity("EventTest");
+            Assert.Equal(0, activity.Events.Count());
+
+            DateTimeOffset ts1 = DateTimeOffset.UtcNow;
+            DateTimeOffset ts2 = ts1.AddMinutes(1);
+
+            Assert.True(object.ReferenceEquals(activity, activity.AddEvent(new ActivityEvent("Event1", ts1))));
+            Assert.True(object.ReferenceEquals(activity, activity.AddEvent(new ActivityEvent("Event2", ts2))));
+
+            Assert.Equal(2, activity.Events.Count());
+            Assert.Equal("Event2", activity.Events.ElementAt(0).Name);
+            Assert.Equal(ts2, activity.Events.ElementAt(0).Timestamp);
+            Assert.Equal(0, activity.Events.ElementAt(0).Attributes.Count());
+
+            Assert.Equal("Event1", activity.Events.ElementAt(1).Name);
+            Assert.Equal(ts1, activity.Events.ElementAt(1).Timestamp);
+            Assert.Equal(0, activity.Events.ElementAt(1).Attributes.Count());
+        }
+
+        [Fact]
+        public void TestIsAllDataRequested()
+        {
+            // Activity constructor allways set IsAllDataRequested to true for compatability.
+            Activity a1 = new Activity("a1");
+            Assert.True(a1.IsAllDataRequested);
+            Assert.True(object.ReferenceEquals(a1, a1.AddTag("k1", "v1")));
+            Assert.Equal(1, a1.Tags.Count());
         }
 
         public void Dispose()

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/System.Diagnostics.DiagnosticSource.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <Compile Include="DiagnosticSourceTests.cs" />
     <Compile Include="ActivityTests.cs" />
+    <Compile Include="ActivitySourceTests.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsNetFx)' == 'true'">
     <Compile Include="HttpHandlerDiagnosticListenerTests.cs" />


### PR DESCRIPTION
This change is porting the added System.Diagnostics APIs to preview 4. These APIs are very important to fill the gap between .NET Libraries and OpenTelemtry. There are some teams (application insight and Azure Monitoring) waiting to try the new APIs as early as we can provide it. It will be good if we can have these APIs included in preview 4 for early adaptors.

Original PR merged to master: https://github.com/dotnet/runtime/pull/35220
Original issue tracking the work:  #31373
The design issue for the APIs: dotnet/designs#98

CC @noahfalk 