### PR TITLE
Fix incorrect path of the runincontext script in Helix

### DIFF
--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -130,8 +130,8 @@
     </ItemGroup>
 
     <Copy SourceFiles="@(_XUnitConsoleRunnerFiles)" DestinationFolder="$(CoreRootDirectory)" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)\..\scripts\runincontext.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TargetsWindows)' == 'true' and '$(_RunInUnloadableContext)' == 'true'" />
-    <Copy SourceFiles="$(MSBuildThisFileDirectory)/../scripts/runincontext.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TargetsWindows)' != 'true' and '$(_RunInUnloadableContext)' == 'true'" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts\runincontext.cmd" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TargetsWindows)' == 'true' and '$(_RunInUnloadableContext)' == 'true'" />
+    <Copy SourceFiles="$(MSBuildThisFileDirectory)scripts/runincontext.sh" DestinationFolder="$(CoreRootDirectory)" Condition=" '$(TargetsWindows)' != 'true' and '$(_RunInUnloadableContext)' == 'true'" />
   </Target>
 
   <Target Name="CreateTestEnvFiles">


### PR DESCRIPTION
The source path of the runincontext.cmd/sh script in
helixpublishwitharcade.proj is incorrectly referring to the parent
directory instead of the current one as the base for the scripts folder.
