### PR TITLE
EventSource does not write all events to EventPipe

### DIFF
--- a/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
+++ b/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
@@ -81,6 +81,7 @@ namespace Tracing.Tests.EventSourceError
             source.Dynamic.All += (TraceEvent traceEvent) =>
             {
                 if (traceEvent.ProviderName == "SentinelEventSource"
+                    || traceEvent.ProviderName == "Microsoft-Windows-DotNETRuntime"
                     || traceEvent.ProviderName == "Microsoft-Windows-DotNETRuntimeRundown"
                     || traceEvent.ProviderName == "Microsoft-DotNETCore-EventPipe")
                 {
@@ -90,7 +91,7 @@ namespace Tracing.Tests.EventSourceError
                 ++eventCount;
 
                 if (traceEvent.ProviderName == "IllegalTypesEventSource"
-                    && traceEvent.EventName == "WriteEventString"
+                    && traceEvent.EventName == "EventSourceMessage"
                     && traceEvent.FormattedMessage.StartsWith("ERROR: Exception in Command Processing for EventSource IllegalTypesEventSource", StringComparison.OrdinalIgnoreCase))
                 {
                     sawEvent = true;

--- a/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
+++ b/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+
+namespace Tracing.Tests.EventSourceError
+{
+    // This class tries to use IEnumerable<int> events with manifest based
+    // EventSource, which will cause an error. The test is validating we see
+    // that error over EventPipe.
+    class IllegalTypesEventSource : EventSource
+    {
+        public IllegalTypesEventSource()
+        {
+
+        }
+
+        [Event(1, Level = EventLevel.LogAlways)]
+        public void SimpleArrayEvent(int[] simpleArray)
+        {
+           WriteEvent(1, simpleArray);
+        }
+
+        [Event(2, Level = EventLevel.LogAlways)]
+        public void BasicEvent(int i)
+        {
+            WriteEvent(2, i);
+        }
+
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            Console.WriteLine($"command={command.Command}");
+        }
+    }
+
+    public class EventSourceError
+    {
+        public static int Main(string[] args)
+        {
+            // This test validates that if an EventSource generates an error
+            // during construction it gets emitted over EventPipe
+
+            List<Provider> providers = new List<Provider>
+            {
+                new Provider("IllegalTypesEventSource")
+            };
+
+            var configuration = new SessionConfiguration(circularBufferSizeMB: 1024, format: EventPipeSerializationFormat.NetTrace,  providers: providers);
+            return IpcTraceTest.RunAndValidateEventCounts(_expectedEventCounts, _eventGeneratingAction, configuration, _DoesRundownContainMethodEvents);
+        }
+
+        private static Dictionary<string, ExpectedEventCount> _expectedEventCounts = new Dictionary<string, ExpectedEventCount>()
+        {
+            { "IllegalTypesEventSource", 1 }
+        };
+
+        private static Action _eventGeneratingAction = () =>
+        {
+            // Constructing the EventSource should generate the error message
+            IllegalTypesEventSource eventSource = new IllegalTypesEventSource();
+
+            // This will be a no-op since the EventSource failed to construct
+            eventSource.SimpleArrayEvent(new int[] { 12 });
+        };
+
+        private static Func<EventPipeEventSource, Func<int>> _DoesRundownContainMethodEvents = (source) =>
+        {
+            int eventCount = 0;
+            bool sawEvent = false;
+            source.Dynamic.All += (TraceEvent traceEvent) =>
+            {
+                if (traceEvent.ProviderName == "SentinelEventSource"
+                    || traceEvent.ProviderName == "Microsoft-Windows-DotNETRuntimeRundown"
+                    || traceEvent.ProviderName == "Microsoft-DotNETCore-EventPipe")
+                {
+                    return;
+                }
+
+                ++eventCount;
+
+                if (traceEvent.ProviderName == "IllegalTypesEventSource"
+                    && traceEvent.EventName == "WriteEventString"
+                    && traceEvent.FormattedMessage.StartsWith("ERROR: Exception in Command Processing for EventSource IllegalTypesEventSource", StringComparison.OrdinalIgnoreCase))
+                {
+                    sawEvent = true;
+                }
+                else
+                {
+                    Console.WriteLine($"Saw unexpected event {traceEvent}");
+                }
+            };
+
+            return () => ((eventCount == 1) && sawEvent) ? 100 : -1;
+        };
+    }
+}

--- a/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -8,8 +8,6 @@ namespace System.Diagnostics.Tracing
     {
         // The EventPipeProvider handle.
         private IntPtr m_provHandle = IntPtr.Zero;
-        private object m_createEventLock = new object();
-        private IntPtr m_writeEventStringeEventHandle = IntPtr.Zero;
 
         // Register an event provider.
         unsafe uint IEventProvider.EventRegister(
@@ -52,7 +50,7 @@ namespace System.Diagnostics.Tracing
             int userDataCount,
             EventProvider.EventData* userData)
         {
-            if (eventDescriptor.EventId != 0 && eventHandle != IntPtr.Zero)
+            if (eventHandle != IntPtr.Zero)
             {
                 if (userDataCount == 0)
                 {
@@ -71,30 +69,7 @@ namespace System.Diagnostics.Tracing
                 }
                 EventPipeInternal.WriteEventData(eventHandle, userData, (uint)userDataCount, activityId, relatedActivityId);
             }
-            else
-            {
-                if (m_writeEventStringeEventHandle == IntPtr.Zero)
-                {
-                    lock (m_createEventLock)
-                    {
-                        if (m_writeEventStringeEventHandle == IntPtr.Zero)
-                        {
-                            string eventName = "WriteEventString";
-                            EventParameterInfo paramInfo = default(EventParameterInfo);
-                            paramInfo.SetInfo("message", typeof(string));
-                            byte[]? metadata = EventPipeMetadataGenerator.Instance.GenerateMetadata(0, eventName, 0, (uint)EventLevel.LogAlways, 0, new EventParameterInfo[] { paramInfo });
-                            uint metadataLength = (metadata != null) ? (uint)metadata.Length : 0;
 
-                            fixed (byte* pMetadata = metadata)
-                            {
-                                m_writeEventStringeEventHandle = ((IEventProvider)this).DefineEventHandle(0, eventName, 0, 0, (uint)EventLevel.LogAlways, pMetadata, metadataLength);
-                            }
-                        }
-                    }
-                }
-
-                EventPipeInternal.WriteEventData(m_writeEventStringeEventHandle, userData, (uint)userDataCount, activityId, relatedActivityId);
-            }
             return EventProvider.WriteEventErrorCode.NoError;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeMetadataGenerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeMetadataGenerator.cs
@@ -55,7 +55,7 @@ namespace System.Diagnostics.Tracing
             return GenerateMetadata(eventId, eventName, (long)keywords, (uint)level, version, eventParams);
         }
 
-        private unsafe byte[]? GenerateMetadata(
+        internal unsafe byte[]? GenerateMetadata(
             int eventId,
             string eventName,
             long keywords,

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2152,18 +2152,18 @@ namespace System.Diagnostics.Tracing
         private unsafe void WriteEventString(EventLevel level, long keywords, string msgString)
         {
 #if FEATURE_MANAGED_ETW || FEATURE_PERFTRACING
+            bool allAreNull = true;
 #if FEATURE_MANAGED_ETW
-            if (m_etwProvider == null)
-            {
-                return;
-            }
+            allAreNull &= (m_etwProvider == null);
 #endif // FEATURE_MANAGED_ETW
 #if FEATURE_PERFTRACING
-            if (m_eventPipeProvider == null)
+            allAreNull &= (m_eventPipeProvider == null);
+#endif // FEATURE_PERFTRACING
+            if (allAreNull)
             {
                 return;
             }
-#endif // FEATURE_PERFTRACING
+
             const string EventName = "EventSourceMessage";
             if (SelfDescribingEvents)
             {


### PR DESCRIPTION
Currently if an EventPipe session is enabled but an etw session is not, EventSource will not write any events that go through `WriteEventRaw` to EventPipe. The first line checks if m_etwProvider is null and bails if it is, so it never gets to the EventPipe call.

We also don't write any error messages through `ReportOutOfBandMessage` to EventPipe