### PR TITLE
[mono] Enable LLVM for iOS by default for AppleAppBuilder

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -174,6 +174,8 @@
         GenerateXcodeProject="True"
         BuildAppBundle="True"
         Optimized="True"
+        UseLlvm="$(MonoEnableLLVM)"
+        LlvmPath="$(RuntimePackDir)\native\cross"
         DevTeamProvisioning="$(DevTeamProvisioning)"
         OutputDirectory="$(BundleDir)"
         AppDir="$(BundleDir)">

--- a/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AotCompiler.cs
@@ -63,8 +63,7 @@ internal class AotCompiler
             //  TODO: enable direct-pinvokes (to get rid of -force_loads)
             //.Append("direct-pinvoke,")
             .Append("full,")
-            .Append("mattr=+crc,")   // enable System.Runtime.Intrinsics.Arm
-            .Append("mattr=+base,"); // (Crc32 and ArmBase for now)
+            .Append("mattr=+crc,");   // enable System.Runtime.Intrinsics.Arm (Crc32 and ArmBase for now)
 
         if (useLlvm)
         {

--- a/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.cs
+++ b/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.cs
@@ -139,7 +139,7 @@ public class AppleAppBuilderTask : Task
             throw new ArgumentException($"ProjectName='{ProjectName}' should not contain spaces");
         }
 
-        if (UseLlvm && !string.IsNullOrEmpty(LlvmPath))
+        if (UseLlvm && string.IsNullOrEmpty(LlvmPath))
         {
             // otherwise we might accidentally use some random llc/opt from PATH (installed with clang)
             throw new ArgumentException($"LlvmPath shoun't be empty when UseLlvm is set");

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -1,7 +1,7 @@
 MONO_CONFIG=Debug
 MONO_ARCH=arm64
 DOTNET := ../../../../.././dotnet.sh
-USE_LLVM=False
+USE_LLVM=True
 
 # usage example:
 # 'make all MONO_ARCH=x64 MONO_CONFIG=Release' to build the app for simulator

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -1,6 +1,7 @@
 MONO_CONFIG=Debug
 MONO_ARCH=arm64
 DOTNET := ../../../../.././dotnet.sh
+USE_LLVM=False
 
 # usage example:
 # 'make all MONO_ARCH=x64 MONO_CONFIG=Release' to build the app for simulator
@@ -11,7 +12,7 @@ program:
 
 bundle: clean program
 	$(DOTNET) msbuild /t:BuildAppBundle /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH) \
-	/p:UseLlvm=$(UseLlvm) /p:LlvmPath=$(LlvmPath)
+	/p:UseLlvm=$(USE_LLVM)
 
 deploy-sim:
 	$(DOTNET) msbuild /t:IosDeployToSimulator /p:Configuration=$(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH)

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -45,7 +45,7 @@
         DevTeamProvisioning="$(DevTeamProvisioning)"
         OutputDirectory="$(BundleDir)"
         UseLlvm="$(UseLlvm)"
-        LlvmPath="$(LlvmPath)"
+        LlvmPath="$(RuntimePackDir)\native\cross"
         Optimized="False"
         AppDir="$(BundleDir)">
         <Output TaskParameter="AppBundlePath" PropertyName="AppBundlePath" />


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/35306 is landed so we can now enable LLVM by default for the AppleAppBuilder and the HelloiOS sample 