### PR TITLE
Handle more basic constraints chain statuses.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -166,7 +166,8 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
         *pStatus |= PAL_X509ChainNotValidForUsage;
     else if (CFEqual(keyString, CFSTR("AnchorTrusted")))
         *pStatus |= PAL_X509ChainUntrustedRoot;
-    else if (CFEqual(keyString, CFSTR("BasicConstraints")))
+    else if (CFEqual(keyString, CFSTR("BasicConstraints")) || CFEqual(keyString, CFSTR("BasicConstraintsCA")) ||
+             CFEqual(keyString, CFSTR("BasicConstraintsPathLen")))
         *pStatus |= PAL_X509ChainInvalidBasicConstraints;
     else if (CFEqual(keyString, CFSTR("UsageConstraints")))
         *pStatus |= PAL_X509ChainExplicitDistrust;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -202,11 +202,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void TestBasicConstraintsViolation()
+        public static void BasicConstraints_ExceedMaximumPathLength()
         {
-            byte[] serialNumber = new byte[9];
-            RandomNumberGenerator.Fill(serialNumber);
-            serialNumber[0] &= 0b01111111;
             using (RSA key = RSA.Create())
             {
                 CertificateRequest rootReq = new CertificateRequest(
@@ -219,60 +216,53 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     new X509BasicConstraintsExtension(
                         certificateAuthority: true,
                         hasPathLengthConstraint: true,
-                        pathLengthConstraint: 3,
-                        critical: true));
-
-                // Create two intermediates, one that can sign and one that cannot
-                // with the same subject and serial number. This will let us create
-                // a certificate with the CA:TRUE constraint, but build a chain with
-                // the CA:FALSE certificate.
-                CertificateRequest signingIntermediateReq = new CertificateRequest(
-                    "CN=Intermediate",
-                    key,
-                    HashAlgorithmName.SHA256,
-                    RSASignaturePadding.Pkcs1);
-
-                signingIntermediateReq.CertificateExtensions.Add(
-                    new X509BasicConstraintsExtension(
-                        certificateAuthority: true,
-                        hasPathLengthConstraint: true,
-                        pathLengthConstraint: 2,
-                        critical: true));
-
-                CertificateRequest noSigningIntermediateReq = new CertificateRequest(
-                    "CN=Intermediate",
-                    key,
-                    HashAlgorithmName.SHA256,
-                    RSASignaturePadding.Pkcs1);
-
-                noSigningIntermediateReq.CertificateExtensions.Add(
-                    new X509BasicConstraintsExtension(
-                        certificateAuthority: false,
-                        hasPathLengthConstraint: true,
                         pathLengthConstraint: 0,
                         critical: true));
 
+                CertificateRequest intermediateReq = new CertificateRequest(
+                    "CN=Intermediate",
+                    key,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                intermediateReq.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(
+                        certificateAuthority: true,
+                        hasPathLengthConstraint: true,
+                        pathLengthConstraint: 0,
+                        critical: true));
+                
                 CertificateRequest leafReq = new CertificateRequest(
                     "CN=Leaf",
                     key,
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
 
+                leafReq.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(
+                        certificateAuthority: false,
+                        hasPathLengthConstraint: true,
+                        pathLengthConstraint: 0,
+                        critical: true));
+
                 DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddDays(-1);
                 DateTimeOffset notAfter = notBefore.AddDays(30);
 
-                using (X509Certificate2 root = rootReq.CreateSelfSigned(notBefore, notAfter))
-                using (X509Certificate2 signingIntermediate = signingIntermediateReq.Create(root, notBefore, notAfter, serialNumber))
-                using (X509Certificate2 noSigningIntermediate = noSigningIntermediateReq.Create(root, notBefore, notAfter, serialNumber))
-                using (X509Certificate2 signingIntermediateWithKey = signingIntermediate.CopyWithPrivateKey(key))
-                using (X509Certificate2 leaf = leafReq.Create(signingIntermediateWithKey, notBefore, notAfter, serialNumber))
+                X509SignatureGenerator generator = X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1);
+
+                byte[] serial = new byte[8];
+                RandomNumberGenerator.Fill(serial);
+
+                using (X509Certificate2 root = rootReq.Create(rootReq.SubjectName, generator, notBefore, notAfter, serial))
+                using (X509Certificate2 intermediate = intermediateReq.Create(root.SubjectName, generator, notBefore, notAfter, serial))
+                using (X509Certificate2 leaf = leafReq.Create(intermediate.SubjectName, generator, notBefore, notAfter, serial))
+                using (X509Chain chain = new X509Chain())
                 {
-                    X509Chain chain = new X509Chain();
                     chain.ChainPolicy.ExtraStore.Add(root);
-                    chain.ChainPolicy.ExtraStore.Add(noSigningIntermediate);
+                    chain.ChainPolicy.ExtraStore.Add(intermediate);
                     chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                     Assert.False(chain.Build(leaf));
-                    
+
                     bool verifiedIntermediate = false;
 
                     foreach (X509ChainElement element in chain.ChainElements)
@@ -287,7 +277,88 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                         }
                     }
 
-                    Assert.True(verifiedIntermediate, "verify leaf certificate");
+                    Assert.True(verifiedIntermediate, "Verified intermediate certificate");
+                }
+            }
+        }
+
+        [Fact]
+        public static void BasicConstraints_ViolatesCaFalse()
+        {
+            using (RSA key = RSA.Create())
+            {
+                CertificateRequest rootReq = new CertificateRequest(
+                    "CN=Root",
+                    key,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                rootReq.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(
+                        certificateAuthority: true,
+                        hasPathLengthConstraint: true,
+                        pathLengthConstraint: 1,
+                        critical: true));
+
+                CertificateRequest intermediateReq = new CertificateRequest(
+                    "CN=Intermediate",
+                    key,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                intermediateReq.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(
+                        certificateAuthority: false,
+                        hasPathLengthConstraint: true,
+                        pathLengthConstraint: 0,
+                        critical: true));
+                
+                CertificateRequest leafReq = new CertificateRequest(
+                    "CN=Leaf",
+                    key,
+                    HashAlgorithmName.SHA256,
+                    RSASignaturePadding.Pkcs1);
+
+                leafReq.CertificateExtensions.Add(
+                    new X509BasicConstraintsExtension(
+                        certificateAuthority: false,
+                        hasPathLengthConstraint: true,
+                        pathLengthConstraint: 0,
+                        critical: true));
+
+                DateTimeOffset notBefore = DateTimeOffset.UtcNow.AddDays(-1);
+                DateTimeOffset notAfter = notBefore.AddDays(30);
+
+                X509SignatureGenerator generator = X509SignatureGenerator.CreateForRSA(key, RSASignaturePadding.Pkcs1);
+
+                byte[] serial = new byte[8];
+                RandomNumberGenerator.Fill(serial);
+
+                using (X509Certificate2 root = rootReq.Create(rootReq.SubjectName, generator, notBefore, notAfter, serial))
+                using (X509Certificate2 intermediate = intermediateReq.Create(root.SubjectName, generator, notBefore, notAfter, serial))
+                using (X509Certificate2 leaf = leafReq.Create(intermediate.SubjectName, generator, notBefore, notAfter, serial))
+                using (X509Chain chain = new X509Chain())
+                {
+                    chain.ChainPolicy.ExtraStore.Add(root);
+                    chain.ChainPolicy.ExtraStore.Add(intermediate);
+                    chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                    Assert.False(chain.Build(leaf));
+
+                    bool verifiedIntermediate = false;
+
+                    foreach (X509ChainElement element in chain.ChainElements)
+                    {
+                        if (element.Certificate.Subject == "CN=Intermediate")
+                        {
+                            const X509ChainStatusFlags expectedFlag = X509ChainStatusFlags.InvalidBasicConstraints;
+                            X509ChainStatusFlags intermediateStatus = element.AllStatusFlags();
+                            Assert.True((intermediateStatus & expectedFlag) == expectedFlag, $"Has {expectedFlag} flag");
+                            verifiedIntermediate = true;
+                            break;
+                        }
+                    }
+
+                    Assert.True(verifiedIntermediate, "Verified intermediate certificate");
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -208,7 +208,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 new X509BasicConstraintsExtension(
                     certificateAuthority: true,
                     hasPathLengthConstraint: true,
-                    pathLengthConstraint: 1,
+                    pathLengthConstraint: 0,
                     critical: true)
             };
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -238,9 +238,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                 chain.ChainPolicy.VerificationTime = endEntityCert.NotBefore.AddSeconds(1);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                chain.ChainPolicy.CustomTrustStore.Add(intermediateCert1);
-                chain.ChainPolicy.CustomTrustStore.Add(intermediateCert2);
                 chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert1);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert2);
 
                 Assert.False(chain.Build(endEntityCert));
                 Assert.Equal(X509ChainStatusFlags.InvalidBasicConstraints, chain.AllStatusFlags());
@@ -273,8 +273,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
                 chain.ChainPolicy.VerificationTime = endEntityCert.NotBefore.AddSeconds(1);
                 chain.ChainPolicy.TrustMode = X509ChainTrustMode.CustomRootTrust;
-                chain.ChainPolicy.CustomTrustStore.Add(intermediateCert);
                 chain.ChainPolicy.CustomTrustStore.Add(rootCert);
+                chain.ChainPolicy.ExtraStore.Add(intermediateCert);
 
                 Assert.False(chain.Build(endEntityCert));
                 Assert.Equal(X509ChainStatusFlags.InvalidBasicConstraints, chain.AllStatusFlags());


### PR DESCRIPTION
macOS can return additional chain status strings for a certificate that
was issued by a certificate that violated its basic constraints.

If a leaf certificate is issued from a certificate with CA:FALSE,
the strings BasicConstraintsCA and BasicConstraintsPathLen are
reported. We map these the same for BasicConstraints.

Relates to #35238.