### PR TITLE
Add backup server to HttpClient UnicodeHostName test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1624,12 +1624,32 @@ namespace System.Net.Http.Functional.Tests
         {
             using (HttpClient client = CreateHttpClient())
             {
-                // international version of the Starbucks website
-                // punycode: xn--oy2b35ckwhba574atvuzkc.com
-                string server = "http://\uc2a4\ud0c0\ubc85\uc2a4\ucf54\ub9ac\uc544.com";
-                using (HttpResponseMessage response = await client.GetAsync(server))
+                try
                 {
-                    response.EnsureSuccessStatusCode();
+                    // international version of the Starbucks website
+                    // punycode: xn--oy2b35ckwhba574atvuzkc.com
+                    string server = "http://\uc2a4\ud0c0\ubc85\uc2a4\ucf54\ub9ac\uc544.com";
+                    using (HttpResponseMessage response = await client.GetAsync(server))
+                    {
+                        response.EnsureSuccessStatusCode();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    try
+                    {
+                        // a simple WebApp running on Azure
+                        // punycode: xn--nicode-2ya.azurewebsites.net
+                        string backupServer = "http://ünicode.azurewebsites.net/time";
+                        using (HttpResponseMessage response = await client.GetAsync(backupServer))
+                        {
+                            response.EnsureSuccessStatusCode();
+                        }
+                    }
+                    catch (Exception secondEx)
+                    {
+                        throw new AggregateException(ex, secondEx);
+                    }
                 }
             }
         }

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1640,7 +1640,7 @@ namespace System.Net.Http.Functional.Tests
                     {
                         // a simple WebApp running on Azure
                         // punycode: xn--nicode-2ya.azurewebsites.net
-                        string backupServer = "http://ünicode.azurewebsites.net/time";
+                        string backupServer = "http://\u00FCnicode.azurewebsites.net/time";
                         using (HttpResponseMessage response = await client.GetAsync(backupServer))
                         {
                             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
This outerloop test (`GetAsync_UnicodeHostName_SuccessStatusCodeInResponse`) is failing more frequently recently (12 times this week) with either `Name or service not known` or timing out after 100s.

Adding a backup server to mitigate the failure noise. As that endpoint is logging requests I will also be able to tell if the Starbucks website starts failing a lot more in the future.