### PR TITLE
Delete an extra new line when there is a child.

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -11351,8 +11351,6 @@ void Compiler::gtDispTree(GenTree*     tree,
 
             if (tree->AsField()->gtFldObj && !topOnly)
             {
-                gtDispVN(tree);
-                printf("\n");
                 gtDispChild(tree->AsField()->gtFldObj, indentStack, IIArcBottom);
             }
 


### PR DESCRIPTION
I introduced an extra newline when a child is present, fix that.
`gtDispVN(tree)` is also part of `gtDispCommonEndLine`, so delete that as well.