### PR TITLE
Delete JIT_PATH host key/value pair

### DIFF
--- a/src/coreclr/src/dlls/mscoree/unixinterface.cpp
+++ b/src/coreclr/src/dlls/mscoree/unixinterface.cpp
@@ -130,11 +130,6 @@ static void ConvertConfigPropertiesToUnicode(
     *propertyValuesWRef = propertyValuesW;
 }
 
-#if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
-// Reference to the global holding the path to the JIT
-extern LPCWSTR g_CLRJITPath;
-#endif // !defined(FEATURE_MERGE_JIT_AND_ENGINE)
-
 #ifdef FEATURE_GDBJIT
 GetInfoForMethodDelegate getInfoForMethodDelegate = NULL;
 extern "C" int coreclr_create_delegate(void*, unsigned int, const char*, const char*, const char*, void**);
@@ -197,11 +192,6 @@ int coreclr_initialize(
 
     // This will take ownership of propertyKeysWTemp and propertyValuesWTemp
     Configuration::InitializeConfigurationKnobs(propertyCount, propertyKeysW, propertyValuesW);
-
-#if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
-    // Fetch the path to JIT binary, if specified
-    g_CLRJITPath = Configuration::GetKnobStringValue(W("JIT_PATH"));
-#endif // !defined(FEATURE_MERGE_JIT_AND_ENGINE)
 
     STARTUP_FLAGS startupFlags;
     InitializeStartupFlags(&startupFlags);

--- a/src/installer/corehost/cli/hostmisc/pal.h
+++ b/src/installer/corehost/cli/hostmisc/pal.h
@@ -79,8 +79,6 @@
 #define FALLBACK_HOST_RID _X("linux")
 #endif
 
-#define LIBCLRJIT_NAME MAKE_LIBNAME("clrjit")
-
 #define LIBCORECLR_FILENAME (LIB_PREFIX _X("coreclr"))
 #define LIBCORECLR_NAME MAKE_LIBNAME("coreclr")
 

--- a/src/installer/corehost/cli/hostpolicy/coreclr.cpp
+++ b/src/installer/corehost/cli/hostpolicy/coreclr.cpp
@@ -200,7 +200,6 @@ namespace
         _X("FX_DEPS_FILE"),
         _X("PROBING_DIRECTORIES"),
         _X("FX_PRODUCT_VERSION"),
-        _X("JIT_PATH"),
         _X("STARTUP_HOOKS"),
         _X("APP_PATHS"),
         _X("APP_NI_PATHS"),

--- a/src/installer/corehost/cli/hostpolicy/coreclr.h
+++ b/src/installer/corehost/cli/hostpolicy/coreclr.h
@@ -63,7 +63,6 @@ enum class common_property
     FxDepsFile,
     ProbingDirectories,
     FxProductVersion,
-    JitPath,
     StartUpHooks,
     AppPaths,
     AppNIPaths,

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -593,11 +593,6 @@ void deps_resolver_t::init_known_entry_path(const deps_entry_t& entry, const pal
         m_coreclr_library_version = entry.library_version;
         return;
     }
-    if (m_clrjit_path.empty() && ends_with(path, DIR_SEPARATOR + pal::string_t(LIBCLRJIT_NAME), false))
-    {
-        m_clrjit_path = path;
-        return;
-    }
 }
 
 void deps_resolver_t::resolve_additional_deps(const arguments_t& args, const deps_json_t::rid_fallback_graph_t& rid_fallback_graph)
@@ -826,7 +821,6 @@ bool deps_resolver_t::resolve_probe_dirs(
         add_unique_path(asset_type, m_app_dir, &items, output, &non_serviced, core_servicing);
 
         (void) library_exists_in_dir(m_app_dir, LIBCORECLR_NAME, &m_coreclr_path);
-        (void) library_exists_in_dir(m_app_dir, LIBCLRJIT_NAME, &m_clrjit_path);
     }
 
     // Handle any additional deps.json that were specified.
@@ -892,7 +886,6 @@ bool deps_resolver_t::resolve_probe_paths(probe_paths_t* probe_paths, std::unord
 
     // If we found coreclr and the jit during native path probe, set the paths now.
     probe_paths->coreclr = m_coreclr_path;
-    probe_paths->clrjit = m_clrjit_path;
 
     return true;
 }

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.h
@@ -23,7 +23,6 @@ struct probe_paths_t
     pal::string_t native;
     pal::string_t resources;
     pal::string_t coreclr;
-    pal::string_t clrjit;
 };
 
 struct deps_resolved_asset_t

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.h
@@ -259,9 +259,6 @@ private:
     // Special entry for coreclr library version
     pal::string_t m_coreclr_library_version;
 
-    // Special entry for JIT path
-    pal::string_t m_clrjit_path;
-
     // The filepaths for the app custom deps
     std::vector<pal::string_t> m_additional_deps_files;
 

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -86,21 +86,6 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
 
     probe_paths.tpa.append(corelib_path);
 
-    pal::string_t clrjit_path = probe_paths.clrjit;
-    if (clrjit_path.empty())
-    {
-        trace::warning(_X("Could not resolve CLRJit path"));
-    }
-    else if (pal::realpath(&clrjit_path))
-    {
-        trace::verbose(_X("The resolved JIT path is '%s'"), clrjit_path.c_str());
-    }
-    else
-    {
-        clrjit_path.clear();
-        trace::warning(_X("Could not resolve symlink to CLRJit path '%s'"), probe_paths.clrjit.c_str());
-    }
-
     const fx_definition_vector_t &fx_definitions = resolver.get_fx_definitions();
 
     pal::string_t fx_deps_str;
@@ -146,9 +131,6 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     coreclr_properties.add(common_property::ProbingDirectories, resolver.get_lookup_probe_directories().c_str());
     coreclr_properties.add(common_property::FxProductVersion, clr_library_version.c_str());
     coreclr_properties.add(common_property::RuntimeIdentifier, get_current_runtime_id(true /*use_fallback*/).c_str());
-
-    if (!clrjit_path.empty())
-        coreclr_properties.add(common_property::JitPath, clrjit_path.c_str());
 
     bool set_app_paths = false;
 

--- a/src/installer/test/HostActivation.Tests/SharedFxLookup.cs
+++ b/src/installer/test/HostActivation.Tests/SharedFxLookup.cs
@@ -189,13 +189,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             coreClrProperty.Parent.Add(newCoreClrProperty);
             coreClrProperty.Remove();
 
-            // Change the clrjit.dll asset to specify only "clrjit.dll" as the relative path (no directories).
-            string clrJitLibraryName = RuntimeInformationExtensions.GetSharedLibraryFileNameForCurrentPlatform("clrjit");
-            JProperty clrJitProperty = netCoreAppNativeAssets.First(p => p.Name.Contains(clrJitLibraryName));
-            JProperty newClrJitProperty = new JProperty(clrJitProperty.Name.Substring(clrJitProperty.Name.LastIndexOf('/') + 1), clrJitProperty.Value);
-            clrJitProperty.Parent.Add(newClrJitProperty);
-            clrJitProperty.Remove();
-
             File.WriteAllText(sharedFxDepsJsonPath, root.ToString());
 
             dotnet.Exec(appDll)
@@ -205,8 +198,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .CaptureStdErr()
                 .Execute()
                 .Should().Pass()
-                .And.HaveStdErrContaining($"CoreCLR path = '{Path.Combine(sharedFxPath, coreClrLibraryName)}'")
-                .And.HaveStdErrContaining($"The resolved JIT path is '{Path.Combine(sharedFxPath, clrJitLibraryName)}'");
+                .And.HaveStdErrContaining($"CoreCLR path = '{Path.Combine(sharedFxPath, coreClrLibraryName)}'");
         }
     }
 }


### PR DESCRIPTION
This was originally introduced to deal with the JIT being in a separate NuGet package. No longer the case for a years.