### PR TITLE
[wasm][debugger] Fix `evaluateOnCallFrame` for valuetype locals

### DIFF
--- a/src/mono/mono/mini/mini-wasm-debugger.c
+++ b/src/mono/mono/mini/mini-wasm-debugger.c
@@ -859,7 +859,7 @@ static gboolean describe_value(MonoType * type, gpointer addr, gboolean expandVa
 
 				method = mono_get_delegate_invoke_internal (klass);
 				if (!method) {
-					DEBUG_PRINTF (1, "Could not get a method for the delegate for %s\n", class_name);
+					DEBUG_PRINTF (2, "Could not get a method for the delegate for %s\n", class_name);
 					break;
 				}
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19638,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>.. including generic, and async methods. This fixes `hover` for valuetype locals.