### PR TITLE
Fix failures in unloadability tests

### DIFF
--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -87,9 +87,6 @@ void EEClass::Destruct(MethodTable * pOwningMT)
 
 #ifndef CROSSGEN_COMPILE
 
-    // Not expected to be called for array EEClass
-    _ASSERTE(!pOwningMT->IsArray());
-
 #ifdef _DEBUG
     _ASSERTE(!IsDestroyed());
     SetDestroyed();

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/API/ComWrappersTests.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
     <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
+    <!-- Native COM interfaces left alive at the test exit -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <DisableProjectBuild Condition="'$(TargetsWindows)' != 'true'">true</DisableProjectBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.Basic.csproj
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.Basic.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- TestAssemblyLoadContext.Load called from the finalizer -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.Basic.cs" />
     <Compile Include="BinderTracingTest.DefaultProbing.cs" />

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.csproj
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.csproj
@@ -1,4 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Test creates non-collectible AssemblyLoadContext -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="BinderTracingTest.EventHandlers.cs" />
     <Compile Include="BinderTracingTest.ResolutionFlow.cs" />


### PR DESCRIPTION
The assert in EEClass::Destroy is invalid after a change #1201 that has
removed ArrayTypeDesc. It was causing failures of a large portion of the
coreclr tests.

There were also three tests that were failing due to test
incompatibilities with unloadability, so I am marking them as such.