### PR TITLE
Add ASCII APIs and unit tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.Range.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.Range.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System
+{
+    public static partial class AssertExtensions
+    {
+        /// <summary>
+        /// Given a span <paramref name="span"/>, throws if the ranges <paramref name="expectedRange"/>
+        /// and <paramref name="actualRange"/> point to different slices within the span.
+        /// </summary>
+        public static void RangesEqual<T>(Span<T> span, Range expectedRange, Range actualRange)
+            => RangesEqual((ReadOnlySpan<T>)span, expectedRange, actualRange);
+
+        /// <summary>
+        /// Given a span <paramref name="span"/>, throws if the ranges <paramref name="expectedRange"/>
+        /// and <paramref name="actualRange"/> point to different slices within the span.
+        /// </summary>
+        public static void RangesEqual<T>(ReadOnlySpan<T> span, Range expectedRange, Range actualRange)
+        {
+            // Normalize (make absolute) the expected and actual ranges
+            // Normalization call below will throw if Ranges are out-of-bounds w.r.t. the input span
+
+            (int expectedOffset, int expectedLength) = expectedRange.GetOffsetAndLength(span.Length);
+            (int actualOffset, int actualLength) = actualRange.GetOffsetAndLength(span.Length);
+
+            Assert.Equal(expectedOffset..(expectedOffset + expectedLength), actualOffset..(actualOffset + actualLength));
+        }
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs
@@ -11,7 +11,7 @@ using System.Linq;
 
 namespace System
 {
-    public static class AssertExtensions
+    public static partial class AssertExtensions
     {
         private static bool IsNetFramework => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework");
 

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Unix.cs
@@ -27,6 +27,8 @@ namespace System.Buffers
 
             public override Span<T> Span => _buffer;
 
+            public override int Length => _buffer.Length;
+
             public override void Dispose()
             {
                 // no-op

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.Windows.cs
@@ -160,6 +160,8 @@ namespace System.Buffers
                 }
             }
 
+            public override int Length => _elementCount;
+
             public override void Dispose()
             {
                 _handle.Dispose();
@@ -191,10 +193,7 @@ namespace System.Buffers
                     // no-op; the handle will be disposed separately
                 }
 
-                public override Span<T> GetSpan()
-                {
-                    throw new NotImplementedException();
-                }
+                public override Span<T> GetSpan() => _impl.Span;
 
                 public override MemoryHandle Pin(int elementIndex)
                 {

--- a/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Buffers/BoundedMemory.cs
@@ -28,6 +28,11 @@ namespace System.Buffers
         public abstract Span<T> Span { get; }
 
         /// <summary>
+        /// Gets the length (in elements) of this <see cref="BoundedMemory{T}"/> instance.
+        /// </summary>
+        public abstract int Length { get; }
+
+        /// <summary>
         /// Disposes this <see cref="BoundedMemory{T}"/> instance.
         /// </summary>
         public abstract void Dispose();

--- a/src/libraries/Common/tests/TestUtilities/System/Xunit/AliasAttribute.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Xunit/AliasAttribute.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace Xunit
+{
+    /// <summary>
+    /// Provides an alias for a test method parameter. For use with <see cref="TupleMemberDataAttribute"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+    public sealed class AliasAttribute : Attribute
+    {
+        public AliasAttribute(string parameterName)
+        {
+            ParameterName = parameterName;
+        }
+
+        public string ParameterName { get; }
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/System/Xunit/TupleMemberDataAttribute.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/Xunit/TupleMemberDataAttribute.cs
@@ -1,0 +1,182 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit.Sdk;
+
+namespace Xunit
+{
+    /// <summary>
+    /// Used for data theory data sources that return enumerations of <see cref="ValueTuple"/>
+    /// or <see cref="Tuple"/> instead of enumerations of <see cref="object"/>.
+    /// </summary>
+    [DataDiscoverer("Xunit.Sdk.MemberDataDiscoverer", "xunit.core")]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+    public sealed class TupleMemberDataAttribute : MemberDataAttributeBase
+    {
+        public TupleMemberDataAttribute(string memberName, params object[] parameters)
+            : base(memberName, parameters)
+        {
+        }
+
+        protected override object[] ConvertDataItem(MethodInfo testMethod, object item)
+        {
+            if (item is null)
+            {
+                return null;
+            }
+
+            if (item is ITuple tuple)
+            {
+                Dictionary<string, object> tupleValues = GetTupleValuesDictionary(testMethod, tuple);
+                ParameterInfo[] testMethodParameters = testMethod.GetParameters();
+
+                object[] retVal = new object[testMethodParameters.Length];
+                for (int i = 0; i < testMethodParameters.Length; i++)
+                {
+                    string parameterName = testMethodParameters[i].GetCustomAttribute<AliasAttribute>()?.ParameterName
+                        ?? testMethodParameters[i].Name;
+
+                    if (!tupleValues.TryGetValue(parameterName, out retVal[i]))
+                    {
+                        throw new ArgumentException(FormattableString.Invariant($"Member {MemberName} on {MemberType ?? testMethod.DeclaringType} has no element corresponding to test method parameter '{parameterName}'."));
+                    }
+                }
+                return retVal;
+            }
+
+            throw new ArgumentException(FormattableString.Invariant($"Property {MemberName} on {MemberType ?? testMethod.DeclaringType} did not return a tuple."));
+        }
+
+        // from base implementation
+        private FieldInfo GetFieldInfo(Type type)
+        {
+            FieldInfo fieldInfo = null;
+            for (var reflectionType = type; reflectionType != null; reflectionType = reflectionType.GetTypeInfo().BaseType)
+            {
+                fieldInfo = reflectionType.GetRuntimeField(MemberName);
+                if (fieldInfo != null)
+                    break;
+            }
+
+            if (fieldInfo == null || !fieldInfo.IsStatic)
+                return null;
+
+            return fieldInfo;
+        }
+
+        // from base implementation
+        private MethodInfo GetMethodInfo(Type type)
+        {
+            MethodInfo methodInfo = null;
+            var parameterTypes = Parameters == null ? new Type[0] : Parameters.Select(p => p?.GetType()).ToArray();
+            for (var reflectionType = type; reflectionType != null; reflectionType = reflectionType.GetTypeInfo().BaseType)
+            {
+                methodInfo = reflectionType.GetRuntimeMethods()
+                                           .FirstOrDefault(m => m.Name == MemberName && ParameterTypesCompatible(m.GetParameters(), parameterTypes));
+                if (methodInfo != null)
+                    break;
+            }
+
+            if (methodInfo == null || !methodInfo.IsStatic)
+                return null;
+
+            return methodInfo;
+        }
+
+        // from base implementation
+        private PropertyInfo GetPropertyInfo(Type type)
+        {
+            PropertyInfo propInfo = null;
+            for (var reflectionType = type; reflectionType != null; reflectionType = reflectionType.GetTypeInfo().BaseType)
+            {
+                propInfo = reflectionType.GetRuntimeProperty(MemberName);
+                if (propInfo != null)
+                    break;
+            }
+
+            if (propInfo == null || propInfo.GetMethod == null || !propInfo.GetMethod.IsStatic)
+                return null;
+
+            return propInfo;
+        }
+
+        // from base implementation
+        private static bool ParameterTypesCompatible(ParameterInfo[] parameters, Type[] parameterTypes)
+        {
+            if (parameters?.Length != parameterTypes.Length)
+                return false;
+
+            for (int idx = 0; idx < parameters.Length; ++idx)
+                if (parameterTypes[idx] != null && !parameters[idx].ParameterType.GetTypeInfo().IsAssignableFrom(parameterTypes[idx].GetTypeInfo()))
+                    return false;
+
+            return true;
+        }
+
+        private Dictionary<string, object> GetTupleValuesDictionary(MethodInfo testMethod, ITuple item)
+        {
+            Type type = MemberType ?? testMethod.DeclaringType;
+            TupleElementNamesAttribute attr = null;
+
+            PropertyInfo propInfo = GetPropertyInfo(type);
+            if (propInfo != null)
+            {
+                attr = propInfo.GetCustomAttribute<TupleElementNamesAttribute>();
+                goto Return;
+            }
+
+            FieldInfo fieldInfo = GetFieldInfo(type);
+            if (fieldInfo != null)
+            {
+                attr = fieldInfo.GetCustomAttribute<TupleElementNamesAttribute>();
+                goto Return;
+            }
+
+            MethodInfo methodInfo = GetMethodInfo(type);
+            if (methodInfo != null)
+            {
+                attr = methodInfo.ReturnParameter.GetCustomAttribute<TupleElementNamesAttribute>();
+                goto Return;
+            }
+
+        Return:
+            return TupleToDictionary(item, attr);
+        }
+
+        private static Dictionary<string, object> TupleToDictionary(ITuple tuple, TupleElementNamesAttribute attr)
+        {
+            // For now we don't support nested tuples or tuples whose element names differ
+            // only in case. If we care about this scenario, we can add support for it in
+            // the future.
+
+            Dictionary<string, object> values = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < tuple.Length; i++)
+            {
+                values[i.ToString(CultureInfo.InvariantCulture)] = tuple[i];
+            }
+
+            IList<string> friendlyNameList = attr?.TransformNames;
+            if (friendlyNameList?.Count == tuple.Length)
+            {
+                for (int i = 0; i < tuple.Length; i++)
+                {
+                    string thisFriendlyName = friendlyNameList[i];
+                    if (!string.IsNullOrEmpty(thisFriendlyName))
+                    {
+                        values[thisFriendlyName] = tuple[i];
+                    }
+                }
+            }
+
+            return values;
+        }
+    }
+}

--- a/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
+++ b/src/libraries/Common/tests/TestUtilities/TestUtilities.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS1573</NoWarn>
@@ -20,6 +20,8 @@
     <Compile Include="System\IO\FileCleanupTestBase.cs" />
     <Compile Include="System\TestEnvironment.cs" />
     <Compile Include="System\ThreadCultureChange.cs" />
+    <Compile Include="System\Xunit\AliasAttribute.cs" />
+    <Compile Include="System\Xunit\TupleMemberDataAttribute.cs" />
     <!-- We don't compile per but and instead use runtime platform checks. -->
     <Compile Include="System\PlatformDetection.cs" />
     <Compile Include="System\PlatformDetection.Unix.cs" />
@@ -29,6 +31,10 @@
       variant from the Common folder and adding the missing members manually.
     -->
     <Compile Include="Interop\Interop.Libraries.cs" />
+  </ItemGroup>
+  <!-- .NET 5+ only -->
+  <ItemGroup Condition="'$(TargetsNetCoreApp)' == 'true'">
+    <Compile Include="System\AssertExtensions.Range.cs" />
   </ItemGroup>
   <!-- Windows imports -->
   <ItemGroup>

--- a/src/libraries/System.Memory/ref/System.Memory.cs
+++ b/src/libraries/System.Memory/ref/System.Memory.cs
@@ -303,7 +303,7 @@ namespace System.Buffers
         public override bool Equals(object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
         public static bool operator ==(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
-        public static implicit operator System.Buffers.StandardFormat (char symbol) { throw null; }
+        public static implicit operator System.Buffers.StandardFormat(char symbol) { throw null; }
         public static bool operator !=(System.Buffers.StandardFormat left, System.Buffers.StandardFormat right) { throw null; }
         public static System.Buffers.StandardFormat Parse(System.ReadOnlySpan<char> format) { throw null; }
         public static System.Buffers.StandardFormat Parse(string? format) { throw null; }
@@ -419,6 +419,59 @@ namespace System.Buffers.Binary
 }
 namespace System.Buffers.Text
 {
+    public static partial class Ascii
+    {
+        public static bool Equals(System.ReadOnlySpan<byte> left, string right) { throw null; }
+        public static bool Equals(System.ReadOnlySpan<byte> left, System.ReadOnlySpan<byte> right) { throw null; }
+        public static bool Equals(System.ReadOnlySpan<byte> left, System.ReadOnlySpan<char> right) { throw null; }
+        public static bool Equals(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) { throw null; }
+        public static bool EqualsIgnoreCase(System.ReadOnlySpan<byte> left, string right) { throw null; }
+        public static bool EqualsIgnoreCase(System.ReadOnlySpan<byte> left, System.ReadOnlySpan<byte> right) { throw null; }
+        public static bool EqualsIgnoreCase(System.ReadOnlySpan<byte> left, System.ReadOnlySpan<char> right) { throw null; }
+        public static bool EqualsIgnoreCase(System.ReadOnlySpan<char> left, System.ReadOnlySpan<char> right) { throw null; }
+        public static int GetHashCode(System.ReadOnlySpan<byte> value) { throw null; }
+        public static int GetHashCode(System.ReadOnlySpan<char> value) { throw null; }
+        public static int GetHashCodeIgnoreCase(System.ReadOnlySpan<byte> value) { throw null; }
+        public static int GetHashCodeIgnoreCase(System.ReadOnlySpan<char> value) { throw null; }
+        public static int GetIndexOfFirstNonAsciiByte(System.ReadOnlySpan<byte> buffer) { throw null; }
+        public static int GetIndexOfFirstNonAsciiChar(System.ReadOnlySpan<char> buffer) { throw null; }
+        public static int IndexOf(System.ReadOnlySpan<byte> text, string value) { throw null; }
+        public static int IndexOf(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<byte> value) { throw null; }
+        public static int IndexOf(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<char> value) { throw null; }
+        public static int IndexOfIgnoreCase(System.ReadOnlySpan<byte> text, string value) { throw null; }
+        public static int IndexOfIgnoreCase(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<byte> value) { throw null; }
+        public static int IndexOfIgnoreCase(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<char> value) { throw null; }
+        public static bool IsAscii(byte value) { throw null; }
+        public static bool IsAscii(char value) { throw null; }
+        public static bool IsAscii(System.ReadOnlySpan<byte> value) { throw null; }
+        public static bool IsAscii(System.ReadOnlySpan<char> value) { throw null; }
+        public static int LastIndexOf(System.ReadOnlySpan<byte> text, string value) { throw null; }
+        public static int LastIndexOf(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<byte> value) { throw null; }
+        public static int LastIndexOf(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<char> value) { throw null; }
+        public static int LastIndexOfIgnoreCase(System.ReadOnlySpan<byte> text, string value) { throw null; }
+        public static int LastIndexOfIgnoreCase(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<byte> value) { throw null; }
+        public static int LastIndexOfIgnoreCase(System.ReadOnlySpan<byte> text, System.ReadOnlySpan<char> value) { throw null; }
+        public static System.Buffers.OperationStatus NarrowFromUtf16(System.ReadOnlySpan<char> source, System.Span<byte> destination, out int charsConsumed, out int bytesWritten) { throw null; }
+        public static byte ToLower(byte value) { throw null; }
+        public static char ToLower(char value) { throw null; }
+        public static int ToLower(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public static int ToLower(System.ReadOnlySpan<char> source, System.Span<char> destination) { throw null; }
+        public static void ToLowerInPlace(System.Span<byte> value) { }
+        public static void ToLowerInPlace(System.Span<char> value) { }
+        public static byte ToUpper(byte value) { throw null; }
+        public static char ToUpper(char value) { throw null; }
+        public static int ToUpper(System.ReadOnlySpan<byte> source, System.Span<byte> destination) { throw null; }
+        public static int ToUpper(System.ReadOnlySpan<char> source, System.Span<char> destination) { throw null; }
+        public static void ToUpperInPlace(System.Span<byte> value) { }
+        public static void ToUpperInPlace(System.Span<char> value) { }
+        public static System.Range Trim(System.ReadOnlySpan<byte> value) { throw null; }
+        public static System.Range Trim(System.ReadOnlySpan<char> value) { throw null; }
+        public static System.Range TrimEnd(System.ReadOnlySpan<byte> value) { throw null; }
+        public static System.Range TrimEnd(System.ReadOnlySpan<char> value) { throw null; }
+        public static System.Range TrimStart(System.ReadOnlySpan<byte> value) { throw null; }
+        public static System.Range TrimStart(System.ReadOnlySpan<char> value) { throw null; }
+        public static System.Buffers.OperationStatus WidenToUtf16(System.ReadOnlySpan<byte> source, System.Span<char> destination, out int bytesConsumed, out int charsWritten) { throw null; }
+    }
     public static partial class Base64
     {
         public static System.Buffers.OperationStatus DecodeFromUtf8(System.ReadOnlySpan<byte> utf8, System.Span<byte> bytes, out int bytesConsumed, out int bytesWritten, bool isFinalBlock = true) { throw null; }

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.Casing.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.Casing.cs
@@ -1,0 +1,248 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Sdk;
+
+using static System.FormattableString;
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        private delegate void ChangeCaseInPlaceAction<T>(Span<T> span);
+        private delegate int ChangeCaseFunc<T>(ReadOnlySpan<T> source, Span<T> destination);
+
+        public static IEnumerable<(string input, string expectedUpper, string expectedLower)> ChangeCaseBytesTestData()
+        {
+            yield return ("", "", "");
+            yield return ("Hello", "HELLO", "hello");
+            yield return ("\rHello\n", "\rHELLO\n", "\rhello\n");
+            yield return ("\0xyz\0", "\0XYZ\0", "\0xyz\0");
+            yield return ("\0XYZ\0", "\0XYZ\0", "\0xyz\0");
+            yield return ("\u00C0bCDe", "\u00C0BCDE", "\u00C0bcde"); // U+00C0 is not ASCII so doesn't change case
+            yield return ("\u00E0bCDe", "\u00E0BCDE", "\u00E0bcde"); // U+00E0 is not ASCII so doesn't change case
+        }
+
+        public static IEnumerable<(string input, string expectedUpper, string expectedLower)> ChangeCaseCharsTestData()
+        {
+            yield return ("x\u0150X", "X\u0150X", "x\u0150x"); // U+0150 is not ASCII so doesn't change case
+            yield return ("xO\u030BX", "XO\u030BX", "xo\u030Bx"); // base char modified by U+030B is ASCII so will change case
+        }
+
+        [Fact]
+        public void ToLower_Byte_OverlappingBuffers_Throws()
+        {
+            byte[] buffer = new byte[10];
+
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToLower(buffer, buffer));
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToLower(buffer.AsSpan(1, 3), buffer.AsSpan(3, 5)));
+        }
+
+        [Fact]
+        public void ToLower_Char_OverlappingBuffers_Throws()
+        {
+            char[] buffer = new char[10];
+
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToLower(buffer, buffer));
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToLower(buffer.AsSpan(1, 3), buffer.AsSpan(3, 5)));
+        }
+
+        [Fact]
+        public void ToLower_SingleByte()
+        {
+            for (int i = 0; i <= byte.MaxValue; i++)
+            {
+                byte expected = (byte)i;
+                if (i >= 'A' && i <= 'Z')
+                {
+                    expected = (byte)(i - 'A' + 'a');
+                }
+
+                byte actual = Ascii.ToLower((byte)i);
+                if (actual != expected)
+                {
+                    throw new AssertActualExpectedException(
+                        expected: expected,
+                        actual: actual,
+                        userMessage: Invariant($"Unexpected result calling Ascii.ToLower((byte)0x{i:X2})."));
+                }
+            }
+        }
+
+        [Fact]
+        public void ToLower_SingleChar()
+        {
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                char expected = (char)i;
+                if (i >= 'A' && i <= 'Z')
+                {
+                    expected = (char)(i - 'A' + 'a');
+                }
+
+                char actual = Ascii.ToLower((char)i);
+                if (actual != expected)
+                {
+                    throw new AssertActualExpectedException(
+                        expected: expected,
+                        actual: actual,
+                        userMessage: Invariant($"Unexpected result calling Ascii.ToLower('\\u{i:X4}')."));
+                }
+            }
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(ChangeCaseBytesTestData))]
+        public void ToLower_MultiByte(string input, string expectedLower)
+        {
+            byte[] inputBytes = CharsToAsciiBytesChecked(input);
+            byte[] expectedLowerBytes = CharsToAsciiBytesChecked(expectedLower);
+
+            RunChangeCaseInPlaceTest(inputBytes, expectedLowerBytes, Ascii.ToLowerInPlace);
+            RunChangeCaseTest(inputBytes, expectedLowerBytes, Ascii.ToLower);
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(ChangeCaseBytesTestData))]
+        [TupleMemberData(nameof(ChangeCaseCharsTestData))]
+        public void ToLower_MultiChar(string input, string expectedLower)
+        {
+            char[] inputChars = input.ToCharArray();
+            char[] expectedLowerChars = expectedLower.ToCharArray();
+
+            RunChangeCaseInPlaceTest(inputChars, expectedLowerChars, Ascii.ToLowerInPlace);
+            RunChangeCaseTest(inputChars, expectedLowerChars, Ascii.ToLower);
+        }
+
+        [Fact]
+        public void ToUpper_Byte_OverlappingBuffers_Throws()
+        {
+            byte[] buffer = new byte[10];
+
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToUpper(buffer, buffer));
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToUpper(buffer.AsSpan(1, 3), buffer.AsSpan(3, 5)));
+        }
+
+        [Fact]
+        public void ToUpper_Char_OverlappingBuffers_Throws()
+        {
+            char[] buffer = new char[10];
+
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToUpper(buffer, buffer));
+            Assert.Throws<InvalidOperationException>(() => Ascii.ToUpper(buffer.AsSpan(1, 3), buffer.AsSpan(3, 5)));
+        }
+
+        [Fact]
+        public void ToUpper_SingleByte()
+        {
+            for (int i = 0; i <= byte.MaxValue; i++)
+            {
+                byte expected = (byte)i;
+                if (i >= 'a' && i <= 'z')
+                {
+                    expected = (byte)(i - 'a' + 'A');
+                }
+
+                byte actual = Ascii.ToUpper((byte)i);
+                if (actual != expected)
+                {
+                    throw new AssertActualExpectedException(
+                        expected: expected,
+                        actual: actual,
+                        userMessage: Invariant($"Unexpected result calling Ascii.ToUpper((byte)0x{i:X2})."));
+                }
+            }
+        }
+
+        [Fact]
+        public void ToUpper_SingleChar()
+        {
+            for (int i = 0; i <= char.MaxValue; i++)
+            {
+                char expected = (char)i;
+                if (i >= 'a' && i <= 'z')
+                {
+                    expected = (char)(i - 'a' + 'A');
+                }
+
+                char actual = Ascii.ToUpper((char)i);
+                if (actual != expected)
+                {
+                    throw new AssertActualExpectedException(
+                        expected: expected,
+                        actual: actual,
+                        userMessage: Invariant($"Unexpected result calling Ascii.ToUpper('\\u{i:X4}')."));
+                }
+            }
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(ChangeCaseBytesTestData))]
+        public void ToUpper_MultiByte(string input, string expectedUpper)
+        {
+            byte[] inputBytes = CharsToAsciiBytesChecked(input);
+            byte[] expectedUpperBytes = CharsToAsciiBytesChecked(expectedUpper);
+
+            RunChangeCaseInPlaceTest(inputBytes, expectedUpperBytes, Ascii.ToUpperInPlace);
+            RunChangeCaseTest(inputBytes, expectedUpperBytes, Ascii.ToUpper);
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(ChangeCaseBytesTestData))]
+        [TupleMemberData(nameof(ChangeCaseCharsTestData))]
+        public void ToUpper_MultiChar(string input, string expectedUpper)
+        {
+            char[] inputChars = input.ToCharArray();
+            char[] expectedUpperChars = expectedUpper.ToCharArray();
+
+            RunChangeCaseInPlaceTest(inputChars, expectedUpperChars, Ascii.ToUpperInPlace);
+            RunChangeCaseTest(inputChars, expectedUpperChars, Ascii.ToUpper);
+        }
+
+        private static void RunChangeCaseInPlaceTest<T>(T[] inputData, T[] expectedResult, ChangeCaseInPlaceAction<T> changeCaseInPlaceAction) where T : unmanaged
+        {
+            using (BoundedMemory<T> boundedMem = BoundedMemory.AllocateFromExistingData(inputData, PoisonPagePlacement.Before))
+            {
+                changeCaseInPlaceAction(boundedMem.Span);
+                Assert.Equal(expectedResult, boundedMem.Span.ToArray());
+            }
+            using (BoundedMemory<T> boundedMem = BoundedMemory.AllocateFromExistingData(inputData, PoisonPagePlacement.After))
+            {
+                changeCaseInPlaceAction(boundedMem.Span);
+                Assert.Equal(expectedResult, boundedMem.Span.ToArray());
+            }
+        }
+
+        private static void RunChangeCaseTest<T>(T[] inputData, T[] expectedResult, ChangeCaseFunc<T> changeCaseFunc) where T : unmanaged
+        {
+            // First, make sure the method throws an exception if the destination buffer is too small
+
+            if (expectedResult.Length > 0)
+            {
+                Assert.Throws<ArgumentException>(() => changeCaseFunc(inputData, new T[expectedResult.Length - 1]));
+            }
+
+            using BoundedMemory<T> sourceMem = BoundedMemory.AllocateFromExistingData(inputData);
+            sourceMem.MakeReadonly();
+
+            using BoundedMemory<T> destMem = BoundedMemory.Allocate<T>(expectedResult.Length + 1);
+            Span<T> destSpan = destMem.Span;
+
+            // Then try the operation with an exactly-sized span.
+
+            int actualResultElements = changeCaseFunc(sourceMem.Span, destSpan[1..]);
+            Assert.Equal(expectedResult, destSpan.Slice(1, actualResultElements).ToArray());
+
+            // Then try the operation with an overlong span.
+            // (Shouldn't overwrite the final element.)
+
+            destSpan[^1] = (T)((IConvertible)0xFF).ToType(typeof(T), null); // = 0xFF or U+00FF
+            actualResultElements = changeCaseFunc(sourceMem.Span, destSpan);
+            Assert.Equal(expectedResult, destSpan.Slice(0, actualResultElements).ToArray());
+            Assert.Equal(0xFF, Convert.ToByte(destSpan[^1])); // validate last element wasn't overwritten
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.Common.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.Common.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        private const int SizeOfVector128 = 128 / 8;
+
+        private static byte[] CharsToAsciiBytesChecked(ReadOnlySpan<char> chars)
+        {
+            byte[] retVal = new byte[chars.Length];
+            for (int i = 0; i < chars.Length; i++)
+            {
+                retVal[i] = checked((byte)chars[i]);
+            }
+            return retVal;
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.Equality.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.Equality.cs
@@ -1,0 +1,172 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        private delegate int ComputeHashCodeFunc<T>(ReadOnlySpan<T> span);
+
+        public static IEnumerable<(string left, string right, bool areEqualOrdinal, bool areEqualIgnoreCase)> EqualityAsciiCommonTestData()
+        {
+            yield return ("", "", true, true);
+            yield return ("\0", "\0", true, true);
+            yield return (" Hello ", " Hello ", true, true);
+            yield return (" Hello ", " hello ", false, true);
+            yield return (" xYz ", " XyZ ", false, true);
+            yield return ("\rhello\n", "\rHELLO\n", false, true);
+            yield return ("\nhello\r", "\rHELLO\n", false, false); // swapped control chars
+        }
+
+        public static IEnumerable<(string left, string right, bool areEqualOrdinal, bool areEqualIgnoreCase)> EqualityBytesBytesTestData()
+        {
+            // Exact byte comparisons for non-ASCII bytes
+            yield return ("xx\u00C0yy", "xx\u00C0yy", true, true);
+            yield return ("xX\u00C0yY", "Xx\u00C0Yy", false, true);
+            yield return ("xx\u00C0yy", "xx\u00E0yy", false, false); // U+00C0 and U+00E0 are non-ASCII so shouldn't case-convert
+        }
+
+        public static IEnumerable<(string left, string right, bool areEqualOrdinal, bool areEqualIgnoreCase)> EqualityBytesCharsTestData()
+        {
+            // Non-ASCII bytes should never compare as equal to non-ASCII chars
+            yield return ("xx\u00C0yy", "xx\u00C0yy", false, false);
+            yield return ("xX\u00C0yY", "Xx\u00C0Yy", false, false);
+            yield return ("xx\u00C0yy", "xx\u00E0yy", false, false);
+
+            // Don't normalize non-ASCII before comparisons
+            yield return ("\u00C0", "A\u0300", false, false); // U+00C0 => U+0041 + U+0300 (decomposed)
+        }
+
+        public static IEnumerable<(string left, string right, bool areEqualOrdinal, bool areEqualIgnoreCase)> EqualityCharsCharsTestData()
+        {
+            // Exact char comparisons for non-ASCII chars
+            yield return ("xx\u20A4yy", "xx\u20A4yy", true, true);
+
+            // Don't normalize non-ASII before comparisons
+            yield return ("\u00C0", "A\u0300", false, false); // U+00C0 => U+0041 + U+0300 (decomposed)
+            yield return ("\u00C0", "a\u0300", false, false);
+            yield return ("A\u0300", "a\u0300", false, true);
+        }
+
+        [Fact]
+        public void Equals_NullStringParamChecks()
+        {
+            Assert.Throws<ArgumentNullException>("right", () => Ascii.Equals(ReadOnlySpan<byte>.Empty, (string)null));
+            Assert.Throws<ArgumentNullException>("right", () => Ascii.EqualsIgnoreCase(ReadOnlySpan<byte>.Empty, (string)null));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(EqualityAsciiCommonTestData))]
+        [TupleMemberData(nameof(EqualityBytesBytesTestData))]
+        public void Equals_ByteByte(string left, string right, [Alias("areEqualOrdinal")] bool expectedAreEqual)
+        {
+            byte[] leftBytes = CharsToAsciiBytesChecked(left);
+            byte[] rightBytes = CharsToAsciiBytesChecked(right);
+
+            Assert.Equal(expectedAreEqual, Ascii.Equals(leftBytes, rightBytes));
+            Assert.Equal(expectedAreEqual, Ascii.Equals(rightBytes, leftBytes));
+            ValidateProbabilisticHashCode<byte>(leftBytes, rightBytes, Ascii.GetHashCode, expectedAreEqual);
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(EqualityAsciiCommonTestData))]
+        [TupleMemberData(nameof(EqualityBytesBytesTestData))]
+        public void Equals_ByteByte_IgnoreCase(string left, string right, [Alias("areEqualIgnoreCase")] bool expectedAreEqual)
+        {
+            byte[] leftBytes = CharsToAsciiBytesChecked(left);
+            byte[] rightBytes = CharsToAsciiBytesChecked(right);
+
+            Assert.Equal(expectedAreEqual, Ascii.EqualsIgnoreCase(leftBytes, rightBytes));
+            Assert.Equal(expectedAreEqual, Ascii.EqualsIgnoreCase(rightBytes, leftBytes));
+            ValidateProbabilisticHashCode<byte>(leftBytes, rightBytes, Ascii.GetHashCodeIgnoreCase, expectedAreEqual);
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(EqualityAsciiCommonTestData))]
+        [TupleMemberData(nameof(EqualityBytesCharsTestData))]
+        public void Equals_ByteChar(string left, string right, [Alias("areEqualOrdinal")] bool expectedAreEqual)
+        {
+            byte[] leftBytes = CharsToAsciiBytesChecked(left);
+
+            Assert.Equal(expectedAreEqual, Ascii.Equals(leftBytes, right.AsSpan()));
+            Assert.Equal(expectedAreEqual, Ascii.Equals(leftBytes, right /* as string */));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(EqualityAsciiCommonTestData))]
+        [TupleMemberData(nameof(EqualityBytesCharsTestData))]
+        public void Equals_ByteChar_IgnoreCase(string left, string right, [Alias("areEqualIgnoreCase")] bool expectedAreEqual)
+        {
+            byte[] leftBytes = CharsToAsciiBytesChecked(left);
+
+            Assert.Equal(expectedAreEqual, Ascii.EqualsIgnoreCase(leftBytes, right.AsSpan()));
+            Assert.Equal(expectedAreEqual, Ascii.EqualsIgnoreCase(leftBytes, right /* as string */));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(EqualityAsciiCommonTestData))]
+        [TupleMemberData(nameof(EqualityBytesBytesTestData))]
+        [TupleMemberData(nameof(EqualityCharsCharsTestData))]
+        public void Equals_CharChar(string left, string right, [Alias("areEqualOrdinal")] bool expectedAreEqual)
+        {
+            Assert.Equal(expectedAreEqual, Ascii.Equals(left.AsSpan(), right.AsSpan()));
+            Assert.Equal(expectedAreEqual, Ascii.Equals(right.AsSpan(), left.AsSpan()));
+            ValidateProbabilisticHashCode<char>(left, right, Ascii.GetHashCode, expectedAreEqual);
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(EqualityAsciiCommonTestData))]
+        [TupleMemberData(nameof(EqualityBytesBytesTestData))]
+        [TupleMemberData(nameof(EqualityCharsCharsTestData))]
+        public void Equals_CharChar_IgnoreCase(string left, string right, [Alias("areEqualIgnoreCase")] bool expectedAreEqual)
+        {
+            Assert.Equal(expectedAreEqual, Ascii.EqualsIgnoreCase(left.AsSpan(), right.AsSpan()));
+            Assert.Equal(expectedAreEqual, Ascii.EqualsIgnoreCase(right.AsSpan(), left.AsSpan()));
+            ValidateProbabilisticHashCode<char>(left, right, Ascii.GetHashCodeIgnoreCase, expectedAreEqual);
+        }
+
+        private static void ValidateProbabilisticHashCode<T>(ReadOnlySpan<T> left, ReadOnlySpan<T> right, ComputeHashCodeFunc<T> hashCodeFunc, bool expectedAreEqual)
+        {
+            int hashCodeLeft = hashCodeFunc(left);
+            int hashCodeRight = hashCodeFunc(right);
+
+            if (expectedAreEqual == (hashCodeLeft == hashCodeRight))
+            {
+                return; // "are hash codes equal?" matches "are buffers equal?" - all is well
+            }
+
+            if (expectedAreEqual)
+            {
+                throw new XunitException("Buffers are expected to compare as equal but produced different hash codes.");
+            }
+
+            // If we got to this point, we expected the buffers to compare as unequal, but they
+            // had the same hash code. We can't eagerly fail here because our hash code calculation
+            // routines are randomized, and we expect two unequal buffers to produce the same
+            // hash code every so often. To account for this, we'll run the test a few more
+            // times with buffers of slightly different length. If they all produce the same
+            // result, then there's probably a problem with the hash code computation.
+
+            for (int i = 1; i <= 8; i++)
+            {
+                T[] leftArray = new T[left.Length + i]; // pad with zeroes at the end
+                left.CopyTo(leftArray);
+
+                T[] rightArray = new T[right.Length + i]; // pad with zeroes at the end
+                right.CopyTo(rightArray);
+
+                if (hashCodeFunc(leftArray) != hashCodeFunc(rightArray))
+                {
+                    return; // buffers produced different hash codes - this is fine
+                }
+            }
+
+            throw new XunitException("Buffers are expected to compare as not equal but produced the same hash code after multiple rounds.");
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.IndexOf.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.IndexOf.cs
@@ -1,0 +1,136 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        public static IEnumerable<(string text, string value, int firstIndex, int lastIndex, int firstIndexIgnoreCase, int lastIndexIgnoreCase)> IndexOfAsciiCommonTestData()
+        {
+            yield return ("", "", 0, 0, 0, 0);
+            yield return ("\0", "", 0, 1, 0, 1);
+            yield return ("", "\0", -1, -1, -1, -1);
+            yield return (" Hello ", "l", 3, 4, 3, 4);
+            yield return (" Hello ", "h", -1, -1, 1, 1);
+            yield return ("xxyzXYZz", "xyz", 1, 1, 1, 4);
+        }
+
+        public static IEnumerable<(string text, string value, int firstIndex, int lastIndex, int firstIndexIgnoreCase, int lastIndexIgnoreCase)> IndexOfBytesBytesTestData()
+        {
+            // Exact byte comparisons for non-ASCII bytes
+            yield return ("xx\u00C0yy", "x\u00C0y", 1, 1, 1, 1);
+            yield return ("xX\u00C0yY", "x\u00C0Y", -1, -1, 1, 1);
+            yield return ("xx\u00C0yy", "x\u00E0y", -1, -1, -1, -1); // U+00C0 and U+00E0 are non-ASCII so shouldn't case-convert
+        }
+
+        public static IEnumerable<(string text, string value, int firstIndex, int lastIndex, int firstIndexIgnoreCase, int lastIndexIgnoreCase)> IndexOfBytesCharsTestData()
+        {
+            // Non-ASCII bytes should never compare as equal to non-ASCII chars
+            yield return ("xx\u00C0yy", "\u00C0", -1, -1, -1, -1);
+            yield return ("xX\u00C0yY", "\u00C0", -1, -1, -1, -1);
+            yield return ("xx\u00C0yy", "\u00E0", -1, -1, -1, -1);
+
+            // Don't normalize non-ASCII before comparisons
+            yield return ("\u00C0", "A\u0300", -1, -1, -1, -1); // U+00C0 => U+0041 + U+0300 (decomposed)
+            yield return ("\u00C0", "A", -1, -1, -1, -1);
+        }
+
+        [Fact]
+        public void IndexOf_NullStringParamChecks()
+        {
+            Assert.Throws<ArgumentNullException>("value", () => Ascii.IndexOf(ReadOnlySpan<byte>.Empty, (string)null));
+            Assert.Throws<ArgumentNullException>("value", () => Ascii.IndexOfIgnoreCase(ReadOnlySpan<byte>.Empty, (string)null));
+            Assert.Throws<ArgumentNullException>("value", () => Ascii.LastIndexOf(ReadOnlySpan<byte>.Empty, (string)null));
+            Assert.Throws<ArgumentNullException>("value", () => Ascii.LastIndexOfIgnoreCase(ReadOnlySpan<byte>.Empty, (string)null));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesBytesTestData))]
+        public void IndexOf_ByteByte(string text, string value, [Alias("firstIndex")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+            byte[] valueBytes = CharsToAsciiBytesChecked(value);
+
+            Assert.Equal(expectedResult, Ascii.IndexOf(textBytes, valueBytes));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesBytesTestData))]
+        public void IndexOf_ByteByte_IgnoreCase(string text, string value, [Alias("firstIndexIgnoreCase")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+            byte[] valueBytes = CharsToAsciiBytesChecked(value);
+
+            Assert.Equal(expectedResult, Ascii.IndexOfIgnoreCase(textBytes, valueBytes));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesCharsTestData))]
+        public void IndexOf_ByteChar(string text, string value, [Alias("firstIndex")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+
+            Assert.Equal(expectedResult, Ascii.IndexOf(textBytes, value.AsSpan()));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesCharsTestData))]
+        public void IndexOf_ByteChar_IgnoreCase(string text, string value, [Alias("firstIndexIgnoreCase")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+
+            Assert.Equal(expectedResult, Ascii.IndexOfIgnoreCase(textBytes, value.AsSpan()));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesBytesTestData))]
+        public void LastIndexOf_ByteByte(string text, string value, [Alias("lastIndex")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+            byte[] valueBytes = CharsToAsciiBytesChecked(value);
+
+            Assert.Equal(expectedResult, Ascii.LastIndexOf(textBytes, valueBytes));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesBytesTestData))]
+        public void LastIndexOf_ByteByte_IgnoreCase(string text, string value, [Alias("lastIndexIgnoreCase")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+            byte[] valueBytes = CharsToAsciiBytesChecked(value);
+
+            Assert.Equal(expectedResult, Ascii.LastIndexOfIgnoreCase(textBytes, valueBytes));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesCharsTestData))]
+        public void LastIndexOf_ByteChar(string text, string value, [Alias("lastIndex")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+
+            Assert.Equal(expectedResult, Ascii.LastIndexOf(textBytes, value.AsSpan()));
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(IndexOfAsciiCommonTestData))]
+        [TupleMemberData(nameof(IndexOfBytesCharsTestData))]
+        public void LastIndexOf_ByteChar_IgnoreCase(string text, string value, [Alias("lastIndexIgnoreCase")] int expectedResult)
+        {
+            byte[] textBytes = CharsToAsciiBytesChecked(text);
+
+            Assert.Equal(expectedResult, Ascii.LastIndexOfIgnoreCase(textBytes, value.AsSpan()));
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.IsAscii.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.IsAscii.cs
@@ -1,0 +1,215 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Numerics;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        [Theory]
+        [InlineData(0x0000, true)]
+        [InlineData(0x0001, true)]
+        [InlineData(0x0010, true)]
+        [InlineData(0x007F, true)]
+        [InlineData(0x0080, false)]
+        [InlineData(0x00FF, false)]
+        [InlineData(0x0800, false)]
+        [InlineData(0x7F00, false)]
+        [InlineData(0x8000, false)]
+        [InlineData(0xFFFF, false)]
+        public void IsAscii_SingleValue(uint value, bool expected)
+        {
+            // test char
+            Assert.Equal(expected, Ascii.IsAscii(checked((char)value)));
+
+            // test byte
+            if (value <= byte.MaxValue)
+            {
+                Assert.Equal(expected, Ascii.IsAscii((byte)value));
+            }
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiByte_EmptyInput_NullReference()
+        {
+            Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiByte(ReadOnlySpan<byte>.Empty));
+            Assert.True(Ascii.IsAscii(ReadOnlySpan<byte>.Empty));
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiByte_EmptyInput_NonNullReference()
+        {
+            using BoundedMemory<byte> mem = BoundedMemory.Allocate<byte>(0);
+            mem.MakeReadonly();
+
+            Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiByte(mem.Span));
+            Assert.True(Ascii.IsAscii(mem.Span));
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiByte_Vector128InnerLoop()
+        {
+            // The purpose of this test is to make sure we're identifying the correct
+            // vector (of the two that we're reading simultaneously) when performing
+            // the final ASCII drain at the end of the method once we've broken out
+            // of the inner loop.
+
+            using (BoundedMemory<byte> mem = BoundedMemory.Allocate<byte>(1024))
+            {
+                Span<byte> bytes = mem.Span;
+
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    bytes[i] &= 0x7F; // make sure each byte (of the pre-populated random data) is ASCII
+                }
+
+                Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiByte(bytes));
+                Assert.True(Ascii.IsAscii(bytes));
+
+                // Two vectors have offsets 0 .. 31. We'll go backward to avoid having to
+                // re-clear the vector every time.
+
+                for (int i = 2 * SizeOfVector128 - 1; i >= 0; i--)
+                {
+                    bytes[100 + i * 13] = 0x80; // 13 is relatively prime to 32, so it ensures all possible positions are hit
+                    Assert.Equal(100 + i * 13, Ascii.GetIndexOfFirstNonAsciiByte(bytes));
+                    Assert.False(Ascii.IsAscii(bytes));
+                }
+            }
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiByte_Boundaries()
+        {
+            // The purpose of this test is to make sure we're hitting all of the vectorized
+            // and draining logic correctly both in the SSE2 and in the non-SSE2 enlightened
+            // code paths. We shouldn't be reading beyond the boundaries we were given.
+
+            // The 5 * Vector test should make sure that we're exercising all possible
+            // code paths across both implementations.
+            using (BoundedMemory<byte> mem = BoundedMemory.Allocate<byte>(5 * Vector<byte>.Count))
+            {
+                Span<byte> bytes = mem.Span;
+
+                // First, try it with all-ASCII buffers.
+
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    bytes[i] &= 0x7F; // make sure each byte (of the pre-populated random data) is ASCII
+                }
+
+                for (int i = bytes.Length; i >= 0; i--)
+                {
+                    Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiByte(bytes.Slice(0, i)));
+                    Assert.True(Ascii.IsAscii(bytes));
+                }
+
+                // Then, try it with non-ASCII bytes.
+
+                for (int i = bytes.Length; i >= 1; i--)
+                {
+                    bytes[i - 1] = 0x80; // set non-ASCII
+                    Assert.Equal(i - 1, Ascii.GetIndexOfFirstNonAsciiByte(bytes.Slice(0, i)));
+                    Assert.False(Ascii.IsAscii(bytes));
+                }
+            }
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiChar_EmptyInput_NullReference()
+        {
+            Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiChar(ReadOnlySpan<char>.Empty));
+            Assert.True(Ascii.IsAscii(ReadOnlySpan<char>.Empty));
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiChar_EmptyInput_NonNullReference()
+        {
+            using BoundedMemory<char> mem = BoundedMemory.Allocate<char>(0);
+            mem.MakeReadonly();
+
+            Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiChar(mem.Span));
+            Assert.True(Ascii.IsAscii(mem.Span));
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiChar_Vector128InnerLoop()
+        {
+            // The purpose of this test is to make sure we're identifying the correct
+            // vector (of the two that we're reading simultaneously) when performing
+            // the final ASCII drain at the end of the method once we've broken out
+            // of the inner loop.
+            //
+            // Use U+0123 instead of U+0080 for this test because if our implementation
+            // uses pminuw / pmovmskb incorrectly, U+0123 will incorrectly show up as ASCII,
+            // causing our test to produce a false negative.
+
+            using (BoundedMemory<char> mem = BoundedMemory.Allocate<char>(1024))
+            {
+                Span<char> chars = mem.Span;
+
+                for (int i = 0; i < chars.Length; i++)
+                {
+                    chars[i] &= '\u007F'; // make sure each char (of the pre-populated random data) is ASCII
+                }
+
+                Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiChar(chars));
+                Assert.True(Ascii.IsAscii(chars));
+
+                // Two vectors have offsets 0 .. 31. We'll go backward to avoid having to
+                // re-clear the vector every time.
+
+                for (int i = 2 * SizeOfVector128 - 1; i >= 0; i--)
+                {
+                    chars[100 + i * 13] = '\u0123'; // 13 is relatively prime to 32, so it ensures all possible positions are hit
+                    Assert.Equal(100 + i * 13, Ascii.GetIndexOfFirstNonAsciiChar(chars));
+                    Assert.False(Ascii.IsAscii(chars));
+                }
+            }
+        }
+
+        [Fact]
+        public void GetIndexOfFirstNonAsciiChar_Boundaries()
+        {
+            // The purpose of this test is to make sure we're hitting all of the vectorized
+            // and draining logic correctly both in the SSE2 and in the non-SSE2 enlightened
+            // code paths. We shouldn't be reading beyond the boundaries we were given.
+            //
+            // The 5 * Vector test should make sure that we're exercising all possible
+            // code paths across both implementations. The sizeof(char) is because we're
+            // specifying element count, but underlying implementation reintepret casts to bytes.
+            //
+            // Use U+0123 instead of U+0080 for this test because if our implementation
+            // uses pminuw / pmovmskb incorrectly, U+0123 will incorrectly show up as ASCII,
+            // causing our test to produce a false negative.
+
+            using (BoundedMemory<char> mem = BoundedMemory.Allocate<char>(5 * Vector<byte>.Count / sizeof(char)))
+            {
+                Span<char> chars = mem.Span;
+
+                for (int i = 0; i < chars.Length; i++)
+                {
+                    chars[i] &= '\u007F'; // make sure each char (of the pre-populated random data) is ASCII
+                }
+
+                for (int i = chars.Length; i >= 0; i--)
+                {
+                    Assert.Equal(-1, Ascii.GetIndexOfFirstNonAsciiChar(chars.Slice(0, i)));
+                    Assert.True(Ascii.IsAscii(chars));
+                }
+
+                // Then, try it with non-ASCII bytes.
+
+                for (int i = chars.Length; i >= 1; i--)
+                {
+                    chars[i - 1] = '\u0123'; // set non-ASCII
+                    Assert.Equal(i - 1, Ascii.GetIndexOfFirstNonAsciiChar(chars.Slice(0, i)));
+                    Assert.False(Ascii.IsAscii(chars));
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.Transcode.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.Transcode.cs
@@ -1,0 +1,332 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        [Fact]
+        public void WidenAsciiToUtf16_EmptyInput_NullReferences()
+        {
+            OperationStatus status = Ascii.WidenToUtf16(ReadOnlySpan<byte>.Empty, Span<char>.Empty, out int bytesConsumed, out int charsWritten);
+            Assert.Equal(OperationStatus.Done, status);
+            Assert.Equal(0, bytesConsumed);
+            Assert.Equal(0, charsWritten);
+        }
+
+        [Fact]
+        public void WidenAsciiToUtf16_EmptyInput_NonNullReference()
+        {
+            using BoundedMemory<byte> sourceMem = BoundedMemory.Allocate<byte>(0);
+            sourceMem.MakeReadonly();
+
+            using BoundedMemory<char> destMem = BoundedMemory.Allocate<char>(0);
+
+            OperationStatus status = Ascii.WidenToUtf16(sourceMem.Span, destMem.Span, out int bytesConsumed, out int charsWritten);
+            Assert.Equal(OperationStatus.Done, status);
+            Assert.Equal(0, bytesConsumed);
+            Assert.Equal(0, charsWritten);
+        }
+
+        [Fact]
+        public void WidenAsciiToUtf16_AllAsciiInput()
+        {
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
+
+            // Fill source with 00 .. 7F, then trap future writes.
+
+            Span<byte> asciiSpan = asciiMem.Span;
+            for (int i = 0; i < asciiSpan.Length; i++)
+            {
+                asciiSpan[i] = (byte)i;
+            }
+            asciiMem.MakeReadonly();
+
+            // We'll write to the UTF-16 span.
+            // We test with a variety of span lengths to test alignment and fallthrough code paths.
+
+            Span<char> utf16Span = utf16Mem.Span;
+
+            for (int i = 0; i < asciiSpan.Length; i++)
+            {
+                utf16Span.Clear(); // remove any data from previous iteration
+
+                // First, validate that the workhorse saw the incoming data as all-ASCII.
+
+                OperationStatus status = Ascii.WidenToUtf16(asciiSpan.Slice(i), utf16Span.Slice(i), out int bytesConsumed, out int charsWritten);
+                Assert.Equal(OperationStatus.Done, status);
+                Assert.Equal(128 - i, bytesConsumed);
+                Assert.Equal(128 - i, charsWritten);
+
+                // Then, validate that the data was transcoded properly.
+
+                for (int j = i; j < 128; j++)
+                {
+                    Assert.Equal((ushort)asciiSpan[i], (ushort)utf16Span[i]);
+                }
+            }
+        }
+
+        [Fact]
+        public void WidenAsciiToUtf16_SomeNonAsciiInput()
+        {
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
+
+            // Fill source with 00 .. 7F, then trap future writes.
+
+            Span<byte> asciiSpan = asciiMem.Span;
+            for (int i = 0; i < asciiSpan.Length; i++)
+            {
+                asciiSpan[i] = (byte)i;
+            }
+
+            // We'll write to the UTF-16 span.
+
+            Span<char> utf16Span = utf16Mem.Span;
+
+            for (int i = asciiSpan.Length - 1; i >= 0; i--)
+            {
+                RandomNumberGenerator.Fill(MemoryMarshal.Cast<char, byte>(utf16Span)); // fill with garbage
+
+                // First, keep track of the garbage we wrote to the destination.
+                // We want to ensure it wasn't overwritten.
+
+                char[] expectedTrailingData = utf16Span.Slice(i).ToArray();
+
+                // Then, set the desired byte as non-ASCII, then check that the workhorse
+                // correctly saw the data as non-ASCII.
+
+                asciiSpan[i] |= (byte)0x80;
+                OperationStatus status = Ascii.WidenToUtf16(asciiSpan, utf16Span, out int bytesConsumed, out int charsWritten);
+                Assert.Equal((i == asciiSpan.Length) ? OperationStatus.Done : OperationStatus.InvalidData, status);
+                Assert.Equal(i, bytesConsumed);
+                Assert.Equal(i, charsWritten);
+
+                // Next, validate that the ASCII data was transcoded properly.
+
+                for (int j = 0; j < i; j++)
+                {
+                    Assert.Equal((ushort)asciiSpan[j], (ushort)utf16Span[j]);
+                }
+
+                // Finally, validate that the trailing data wasn't overwritten with non-ASCII data.
+
+                Assert.Equal(expectedTrailingData, utf16Span.Slice(i).ToArray());
+            }
+        }
+
+        [Fact]
+        public void WidenAsciiToUtf16_DestTooShort()
+        {
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(129);
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(129);
+
+            // Fill source with 00..80 (last byte is non-ASCII), then trap future writes.
+
+            Span<byte> asciiSpan = asciiMem.Span;
+            for (int i = 0; i < asciiSpan.Length; i++)
+            {
+                asciiSpan[i] = (byte)i;
+            }
+            asciiMem.MakeReadonly();
+
+            // We'll write to the UTF-16 span
+
+            Span<char> utf16Span = utf16Mem.Span;
+            utf16Span.Clear();
+
+            // If dest buffer runs out before we find non-ASCII data in the source,
+            // we report "dest too small".
+
+            OperationStatus status = Ascii.WidenToUtf16(asciiSpan, utf16Span.Slice(0, 128), out int bytesConsumed, out int charsWritten);
+            Assert.Equal(OperationStatus.DestinationTooSmall, status);
+            Assert.Equal(128, bytesConsumed);
+            Assert.Equal(128, charsWritten);
+
+            for (int i = 0; i < 128; i++)
+            {
+                Assert.Equal((ushort)asciiSpan[i], (ushort)utf16Span[i]);
+            }
+
+            // Otherwise we report that non-ASCII data was found.
+
+            utf16Span.Clear();
+            status = Ascii.WidenToUtf16(asciiSpan, utf16Span, out bytesConsumed, out charsWritten);
+            Assert.Equal(OperationStatus.InvalidData, status);
+            Assert.Equal(128, bytesConsumed);
+            Assert.Equal(128, charsWritten);
+
+            for (int i = 0; i < 128; i++)
+            {
+                Assert.Equal((ushort)asciiSpan[i], (ushort)utf16Span[i]);
+            }
+        }
+
+        [Fact]
+        public void NarrowUtf16ToAscii_EmptyInput_NullReferences()
+        {
+            OperationStatus status = Ascii.NarrowFromUtf16(ReadOnlySpan<char>.Empty, Span<byte>.Empty, out int charsConsumed, out int bytesWritten);
+            Assert.Equal(OperationStatus.Done, status);
+            Assert.Equal(0, charsConsumed);
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Fact]
+        public void NarrowUtf16ToAscii_EmptyInput_NonNullReference()
+        {
+            using BoundedMemory<char> sourceMem = BoundedMemory.Allocate<char>(0);
+            sourceMem.MakeReadonly();
+
+            using BoundedMemory<byte> destMem = BoundedMemory.Allocate<byte>(0);
+
+            OperationStatus status = Ascii.NarrowFromUtf16(sourceMem.Span, destMem.Span, out int charsConsumed, out int bytesWritten);
+            Assert.Equal(OperationStatus.Done, status);
+            Assert.Equal(0, charsConsumed);
+            Assert.Equal(0, bytesWritten);
+        }
+
+        [Fact]
+        public void NarrowUtf16ToAscii_AllAsciiInput()
+        {
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
+
+            // Fill source with 00 .. 7F.
+
+            Span<char> utf16Span = utf16Mem.Span;
+            for (int i = 0; i < utf16Span.Length; i++)
+            {
+                utf16Span[i] = (char)i;
+            }
+            utf16Mem.MakeReadonly();
+
+            // We'll write to the ASCII span.
+            // We test with a variety of span lengths to test alignment and fallthrough code paths.
+
+            Span<byte> asciiSpan = asciiMem.Span;
+
+            for (int i = 0; i < utf16Span.Length; i++)
+            {
+                asciiSpan.Clear(); // remove any data from previous iteration
+
+                // First, validate that the workhorse saw the incoming data as all-ASCII.
+
+                OperationStatus status = Ascii.NarrowFromUtf16(utf16Span.Slice(i), asciiSpan.Slice(i), out int charsConsumed, out int bytesWritten);
+                Assert.Equal(OperationStatus.Done, status);
+                Assert.Equal(128 - i, charsConsumed);
+                Assert.Equal(128 - i, bytesWritten);
+
+                // Then, validate that the data was transcoded properly.
+
+                for (int j = i; j < 128; j++)
+                {
+                    Assert.Equal((ushort)utf16Span[i], (ushort)asciiSpan[i]);
+                }
+            }
+        }
+
+        [Fact]
+        public void NarrowUtf16ToAscii_SomeNonAsciiInput()
+        {
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(128);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(128);
+
+            // Fill source with 00 .. 7F.
+
+            Span<char> utf16Span = utf16Mem.Span;
+            for (int i = 0; i < utf16Span.Length; i++)
+            {
+                utf16Span[i] = (char)i;
+            }
+
+            // We'll write to the ASCII span.
+
+            Span<byte> asciiSpan = asciiMem.Span;
+
+            for (int i = utf16Span.Length - 1; i >= 0; i--)
+            {
+                RandomNumberGenerator.Fill(asciiSpan); // fill with garbage
+
+                // First, keep track of the garbage we wrote to the destination.
+                // We want to ensure it wasn't overwritten.
+
+                byte[] expectedTrailingData = asciiSpan.Slice(i).ToArray();
+
+                // Then, set the desired byte as non-ASCII, then check that the workhorse
+                // correctly saw the data as non-ASCII.
+
+                utf16Span[i] = '\u0123'; // use U+0123 instead of U+0080 since it catches inappropriate pmovmskb usage
+                OperationStatus status = Ascii.NarrowFromUtf16(utf16Span, asciiSpan, out int charsConsumed, out int bytesWritten);
+                Assert.Equal((i == asciiSpan.Length) ? OperationStatus.Done : OperationStatus.InvalidData, status);
+                Assert.Equal(i, charsConsumed);
+                Assert.Equal(i, bytesWritten);
+
+                // Next, validate that the ASCII data was transcoded properly.
+
+                for (int j = 0; j < i; j++)
+                {
+                    Assert.Equal((ushort)utf16Span[j], (ushort)asciiSpan[j]);
+                }
+
+                // Finally, validate that the trailing data wasn't overwritten with non-ASCII data.
+
+                Assert.Equal(expectedTrailingData, asciiSpan.Slice(i).ToArray());
+            }
+        }
+
+        [Fact]
+        public void NarrowUtf16ToAscii_DestTooShort()
+        {
+            using BoundedMemory<char> utf16Mem = BoundedMemory.Allocate<char>(129);
+            using BoundedMemory<byte> asciiMem = BoundedMemory.Allocate<byte>(129);
+
+            // Fill source with U+0000..U+007F, plus U+0123 for the last char (to catch bad pmovmskb usage), then trap future writes
+
+            Span<char> utf16Span = utf16Mem.Span;
+            for (int i = 0; i < 128; i++)
+            {
+                utf16Span[i] = (char)i;
+            }
+            utf16Span[^1] = '\u0123';
+            utf16Mem.MakeReadonly();
+
+            // We'll write to the ASCII span
+
+            Span<byte> asciiSpan = asciiMem.Span;
+            asciiSpan.Clear();
+
+            // If dest buffer runs out before we find non-ASCII data in the source,
+            // we report "dest too small".
+
+            OperationStatus status = Ascii.NarrowFromUtf16(utf16Span, asciiSpan.Slice(0, 128), out int charsConsumed, out int bytesWritten);
+            Assert.Equal(OperationStatus.DestinationTooSmall, status);
+            Assert.Equal(128, charsConsumed);
+            Assert.Equal(128, bytesWritten);
+
+            for (int i = 0; i < 128; i++)
+            {
+                Assert.Equal((ushort)utf16Span[i], (ushort)asciiSpan[i]);
+            }
+
+            // Otherwise we report that non-ASCII data was found.
+
+            asciiSpan.Clear();
+            status = Ascii.NarrowFromUtf16(utf16Span, asciiSpan, out charsConsumed, out bytesWritten);
+            Assert.Equal(OperationStatus.InvalidData, status);
+            Assert.Equal(128, charsConsumed);
+            Assert.Equal(128, bytesWritten);
+
+            for (int i = 0; i < 128; i++)
+            {
+                Assert.Equal((ushort)utf16Span[i], (ushort)asciiSpan[i]);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/Ascii/AsciiTests.Trim.cs
+++ b/src/libraries/System.Memory/tests/Ascii/AsciiTests.Trim.cs
@@ -1,0 +1,94 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Buffers.Text.Tests
+{
+    public partial class AsciiUnitTests
+    {
+        public static IEnumerable<(string input, Range trimmedRange)> TrimBytesTestData()
+        {
+            yield return (input: string.Empty, trimmedRange: ..);
+            yield return (input: "hello", trimmedRange: ..);
+            yield return (input: " hello ", trimmedRange: 1..^1);
+            yield return (input: " \rhello \n", trimmedRange: 2..^2);
+            yield return (input: " \rhello\u00A0\n", trimmedRange: 2..^1); // U+00A0 is whitespace but isn't trimmed since it's not ASCII
+            yield return (input: "\0hello\0", trimmedRange: ..); // U+0000 shouldn't count as whitespace
+            yield return (input: "\t\n\v\f\r hello \r\f\v\n\t", trimmedRange: 6..^6);
+            yield return (input: "\t\n\v\f\r hello \r\f\0\v\n\t", trimmedRange: 6..^3); // U+0000 shouldn't count as whitespace
+        }
+
+        public static IEnumerable<(string input, Range trimmedRange)> TrimCharsTestData()
+        {
+            yield return (input: "\r\u2028hello\n\u2029\n", trimmedRange: 1..^1); // U+2028 and U+2029 are whitespace but aren't trimmed since not ASCII
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(TrimBytesTestData))]
+        public void TrimBytes_Tests(string input, [Alias("trimmedRange")] Range expectedTrimmedRange)
+        {
+            using BoundedMemory<byte> mem = BoundedMemory.AllocateFromExistingData(CharsToAsciiBytesChecked(input));
+            mem.MakeReadonly();
+
+            // First, call Trim()
+
+            Range actualTrimmedRange = Ascii.Trim(mem.Span);
+            AssertExtensions.RangesEqual(mem.Span, expectedTrimmedRange, actualTrimmedRange);
+
+            // Then call TrimStart()
+
+            actualTrimmedRange = Ascii.TrimStart(mem.Span);
+            AssertExtensions.RangesEqual(mem.Span, (expectedTrimmedRange.Start..), actualTrimmedRange);
+
+            // Then call TrimEnd()
+            // Special-case when the input contains all-whitespace data, since we want to
+            // return a zero-length slice at the *beginning* of the span, not the end of the span.
+
+            actualTrimmedRange = Ascii.TrimEnd(mem.Span);
+            if (expectedTrimmedRange.Start.GetOffset(mem.Length) == mem.Length)
+            {
+                AssertExtensions.RangesEqual(mem.Span, (0..0), actualTrimmedRange);
+            }
+            else
+            {
+                AssertExtensions.RangesEqual(mem.Span, (..expectedTrimmedRange.End), actualTrimmedRange);
+            }
+        }
+
+        [Theory]
+        [TupleMemberData(nameof(TrimBytesTestData))]
+        [TupleMemberData(nameof(TrimCharsTestData))]
+        public void TrimChars_Tests(string input, [Alias("trimmedRange")] Range expectedTrimmedRange)
+        {
+            using BoundedMemory<char> mem = BoundedMemory.AllocateFromExistingData<char>(input);
+            mem.MakeReadonly();
+
+            // First, call Trim()
+
+            Range actualTrimmedRange = Ascii.Trim(mem.Span);
+            AssertExtensions.RangesEqual(mem.Span, expectedTrimmedRange, actualTrimmedRange);
+
+            // Then call TrimStart()
+
+            actualTrimmedRange = Ascii.TrimStart(mem.Span);
+            AssertExtensions.RangesEqual(mem.Span, (expectedTrimmedRange.Start..), actualTrimmedRange);
+
+            // Then call TrimEnd()
+            // Special-case when the input contains all-whitespace data, since we want to
+            // return a zero-length slice at the *beginning* of the span, not the end of the span.
+
+            actualTrimmedRange = Ascii.TrimEnd(mem.Span);
+            if (expectedTrimmedRange.Start.GetOffset(mem.Length) == mem.Length)
+            {
+                AssertExtensions.RangesEqual(mem.Span, (0..0), actualTrimmedRange);
+            }
+            else
+            {
+                AssertExtensions.RangesEqual(mem.Span, (..expectedTrimmedRange.End), actualTrimmedRange);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -260,6 +260,15 @@
     <Compile Include="Base64\Base64TestHelper.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Ascii\AsciiTests.Casing.cs" />
+    <Compile Include="Ascii\AsciiTests.Common.cs" />
+    <Compile Include="Ascii\AsciiTests.Equality.cs" />
+    <Compile Include="Ascii\AsciiTests.IndexOf.cs" />
+    <Compile Include="Ascii\AsciiTests.IsAscii.cs" />
+    <Compile Include="Ascii\AsciiTests.Transcode.cs" />
+    <Compile Include="Ascii\AsciiTests.Trim.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Buffers\NativeMemoryManager.cs">
       <Link>Common\System\Buffers\NativeMemoryManager.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\MemoryManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\OperationStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\StandardFormat.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Ascii.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\FormattingHelpers.CountDigits.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Constants.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Buffers\Text\Utf8Formatter\FormattingHelpers.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Ascii.cs
@@ -1,0 +1,1244 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System.Buffers.Text
+{
+    /// <summary>
+    /// Provides APIs for performing text-like operations over <see cref="byte"/> or
+    /// <see cref="char"/> buffers which represent ASCII text.
+    /// </summary>
+    /// <remarks>
+    /// For the purposes of this class, "ASCII" means any <see cref="byte"/> or
+    /// <see cref="char"/> in the range 0 - 127, inclusive.
+    ///
+    /// Unless otherwise specified, APIs on this class treat non-ASCII data as opaque.
+    /// This means that <see cref="Equals(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+    /// may produce a different result than <see cref="string.Equals(string?, string?, StringComparison)"/>
+    /// with <see cref="StringComparison.OrdinalIgnoreCase"/>.
+    ///
+    /// All APIs on this class are culture-agnostic.
+    /// </remarks>
+    public static class Ascii
+    {
+        /*
+         * Some of these APIs are wrappers around other existing APIs; e.g.,
+         * Equals is a wrapper around MemoryExtensions.SequenceEqual. The reason
+         * for this is two-fold. First, it's discoverable to have both case-sensitive
+         * and case-insensitive methods side-by-side on this type. Second, it might
+         * not be intuitive to the caller as to what the correct behavior should be.
+         * For example, Ascii.Equals([ 30 40 50 DD ], [ 30 40 50 EE ]) will return
+         * a different answer than "Encoding.ASCII.GetString([ 30 40 50 DD ]) ==
+         * Encoding.ASCII.GetString([ 30 40 50 EE ])". The reason for this is that
+         * the Encoding classes can perform lossy substitution when they see non-
+         * ASCII data, while we generally treat the data as opaque. This generally
+         * results in this class having "correct" behavior over alternatives.
+         *
+         * For APIs which take both a source and a destination buffer, the behavior of
+         * the method is undefined if the source and destination buffers overlap,
+         * unless the API description specifies otherwise. The behavior of all APIs
+         * is undefined if another thread mutates the buffers while these APIs are
+         * operating on them.
+         */
+
+        /*
+         * Equals routines
+         *
+         * Compares two ASCII buffers for equality, optionally treating [A-Z] and [a-z] as equal.
+         * All non-ASCII bytes / chars are compared for pure binary equivalence.
+         */
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The comparison is performed in a case-sensitive fashion. Calling this method is equivalent
+        /// to comparing the raw binary contents of the two buffers for equality.
+        /// </remarks>
+        public static bool Equals(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+            => left.SequenceEqual(right);
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// The comparison is performed in a case-sensitive fashion. Calling this method is equivalent
+        /// to comparing the raw binary contents of the two buffers for equality.
+        /// </remarks>
+        public static bool Equals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+            => left.SequenceEqual(right);
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal
+        /// using a case-insensitive comparison.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        public static bool EqualsIgnoreCase(ReadOnlySpan<byte> left, ReadOnlySpan<byte> right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                byte leftValue = left[i];
+                byte rightValue = right[i];
+
+                // The elements must be an exact match, or they must be
+                // equivalent when converted to lowercase.
+
+                if ((leftValue != rightValue) && (ToLower(leftValue) != ToLower(rightValue)))
+                {
+                    return false;
+                }
+            }
+
+            return true; // no mismatches seen
+        }
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal
+        /// using a case-insensitive comparison.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        public static bool EqualsIgnoreCase(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                char leftValue = left[i];
+                char rightValue = right[i];
+
+                // The elements must be an exact match, or they must be
+                // equivalent when converted to lowercase.
+
+                if ((leftValue != rightValue) && (ToLower(leftValue) != ToLower(rightValue)))
+                {
+                    return false;
+                }
+            }
+
+            return true; // no mismatches seen
+        }
+
+        /*
+         * Compares an ASCII byte buffer and an ASCII char buffer for equality, optionally treating
+         * [A-Z] and [a-z] as equal. Returns false if the ASCII byte buffer contains any non-ASCII
+         * data or if the char buffer contains any element in the range [ 0080 .. FFFF ], as we
+         * wouldn't know what encoding to use to perform the transcode-then-compare operation.
+         */
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal.
+        /// One buffer is provided as 8-bit <see cref="byte"/>s. The other buffer is provided
+        /// as 16-bit <see cref="char"/>s.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        public static bool Equals(ReadOnlySpan<byte> left, ReadOnlySpan<char> right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                byte leftValue = left[i];
+                if (!IsAscii(leftValue) || leftValue != right[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal.
+        /// One buffer is provided as 8-bit <see cref="byte"/>s. The other buffer is provided
+        /// as 16-bit <see cref="char"/>s.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="right"/> is <see langword="null"/>.</exception>
+        public static bool Equals(ReadOnlySpan<byte> left, string right)
+        {
+            if (right is null)
+            {
+                throw new ArgumentNullException(nameof(right));
+            }
+
+            return Equals(left, right.AsSpan());
+        }
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal
+        /// using a case-insensitive comparison. One buffer is provided as 8-bit <see cref="byte"/>s.
+        /// The other buffer is provided as 16-bit <see cref="char"/>s.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        public static bool EqualsIgnoreCase(ReadOnlySpan<byte> left, ReadOnlySpan<char> right)
+        {
+            if (left.Length != right.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < left.Length; i++)
+            {
+                byte leftValue = left[i];
+                if (!IsAscii(leftValue) || ToLower(leftValue) != ToLower(right[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns a value stating whether the contents of two ASCII text buffers are equal
+        /// using a case-insensitive comparison. One buffer is provided as 8-bit <see cref="byte"/>s.
+        /// The other buffer is provided as 16-bit <see cref="char"/>s.
+        /// </summary>
+        /// <param name="left">The first ASCII text buffer to compare.</param>
+        /// <param name="right">The second ASCII text buffer to compare.</param>
+        /// <returns><see langword="true"/> if the buffers are equivalent; otherwise, <see langword="false"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="right"/> is <see langword="null"/>.</exception>
+        public static bool EqualsIgnoreCase(ReadOnlySpan<byte> left, string right)
+        {
+            if (right is null)
+            {
+                throw new ArgumentNullException(nameof(right));
+            }
+
+            return EqualsIgnoreCase(left, right.AsSpan());
+        }
+
+        /*
+         * IndexOf routines
+         *
+         * Searches for the first (last) occurrence of the target substring within the search space,
+         * optionally treating [A-Z] and [a-z] as equal. All non-ASCII bytes are compared for pure
+         * binary equivalence. Returns the index of where the first (last) match is found, else returns -1.
+         */
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the first occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// first appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int IndexOf(ReadOnlySpan<byte> text, ReadOnlySpan<byte> value)
+            => text.IndexOf(value);
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the first occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/> using a
+        /// case-insensitive comparison.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// first appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int IndexOfIgnoreCase(ReadOnlySpan<byte> text, ReadOnlySpan<byte> value)
+        {
+            // If 'value' is longer than 'text', 'lastIdx' will go negative.
+            // That's acceptable since it'll early exit the loop below.
+
+            int lastIdx = text.Length - value.Length;
+            for (int i = 0; i <= lastIdx; i++)
+            {
+                if (EqualsIgnoreCase(text.Slice(i, value.Length), value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the last occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// last appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int LastIndexOf(ReadOnlySpan<byte> text, ReadOnlySpan<byte> value)
+            => text.LastIndexOf(value);
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the last occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/> using a
+        /// case-insensitive comparison.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// last appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int LastIndexOfIgnoreCase(ReadOnlySpan<byte> text, ReadOnlySpan<byte> value)
+        {
+            // If 'value' is longer than 'text', 'lastIdx' will go negative.
+            // That's acceptable since it'll early exit the loop below.
+
+            int lastIdx = text.Length - value.Length;
+            for (int i = lastIdx; i >= 0; i--)
+            {
+                if (EqualsIgnoreCase(text.Slice(i, value.Length), value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /*
+         * Searches for the first (last) occurrence of the target substring within the search space,
+         * optionally treating [A-Z] and [a-z] as equal. Returns the index of where the first (last) match
+         * is found, else returns -1. If the target string contains any non-ASCII chars ([ 0080 .. FFFF ]),
+         * the search is assume to have failed, and the method returns -1.
+         */
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the first occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// first appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int IndexOf(ReadOnlySpan<byte> text, ReadOnlySpan<char> value)
+        {
+            // If 'value' is longer than 'text', 'lastIdx' will go negative.
+            // That's acceptable since it'll early exit the loop below.
+
+            int lastIdx = text.Length - value.Length;
+            for (int i = 0; i <= lastIdx; i++)
+            {
+                if (Equals(text.Slice(i, value.Length), value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the first occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// first appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+        public static int IndexOf(ReadOnlySpan<byte> text, string value)
+        {
+            if (value is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+            }
+
+            return IndexOf(text, value.AsSpan());
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the first occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/> using
+        /// a case-insensitive comparison.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// first appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int IndexOfIgnoreCase(ReadOnlySpan<byte> text, ReadOnlySpan<char> value)
+        {
+            // If 'value' is longer than 'text', 'lastIdx' will go negative.
+            // That's acceptable since it'll early exit the loop below.
+
+            int lastIdx = text.Length - value.Length;
+            for (int i = 0; i <= lastIdx; i++)
+            {
+                if (EqualsIgnoreCase(text.Slice(i, value.Length), value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the first occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/> using
+        /// a case-insensitive comparison.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// first appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+        public static int IndexOfIgnoreCase(ReadOnlySpan<byte> text, string value)
+        {
+            if (value is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+            }
+
+            return IndexOfIgnoreCase(text, value.AsSpan());
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the last occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// last appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int LastIndexOf(ReadOnlySpan<byte> text, ReadOnlySpan<char> value)
+        {
+            // If 'value' is longer than 'text', 'lastIdx' will go negative.
+            // That's acceptable since it'll early exit the loop below.
+
+            int lastIdx = text.Length - value.Length;
+            for (int i = lastIdx; i >= 0; i--)
+            {
+                if (Equals(text.Slice(i, value.Length), value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the last occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// last appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+        public static int LastIndexOf(ReadOnlySpan<byte> text, string value)
+        {
+            if (value is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+            }
+
+            return LastIndexOf(text, value.AsSpan());
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the last occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// last appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        public static int LastIndexOfIgnoreCase(ReadOnlySpan<byte> text, ReadOnlySpan<char> value)
+        {
+            // If 'value' is longer than 'text', 'lastIdx' will go negative.
+            // That's acceptable since it'll early exit the loop below.
+
+            int lastIdx = text.Length - value.Length;
+            for (int i = lastIdx; i >= 0; i--)
+            {
+                if (EqualsIgnoreCase(text.Slice(i, value.Length), value))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// Given two ASCII text buffers, searches for the last occurrence of where
+        /// <paramref name="value"/> appears within <paramref name="text"/>.
+        /// </summary>
+        /// <param name="text">The ASCII text buffer which will be searched.</param>
+        /// <param name="value">The ASCII text which will be sought within <paramref name="text"/>.</param>
+        /// <returns>The zero-based index in <paramref name="text"/> where <paramref name="value"/>
+        /// last appears; else -1 if <paramref name="value"/> is not found within <paramref name="text"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="value"/> is <see langword="null"/>.</exception>
+        public static int LastIndexOfIgnoreCase(ReadOnlySpan<byte> text, string value)
+        {
+            if (value is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
+            }
+
+            return LastIndexOfIgnoreCase(text, value.AsSpan());
+        }
+
+        /*
+         * GetIndexOfFirst* and IsAscii routines
+         *
+         * Given a buffer, returns the index of the first element in the buffer which
+         * is a non-ASCII byte, or -1 if the buffer is empty or all-ASCII. The bool-
+         * returning method is a convenience shortcut to perform the same check.
+         */
+
+        /// <summary>
+        /// Finds the first non-ASCII <see cref="byte"/> within the specified buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer whose contents should be examined.</param>
+        /// <returns>The zero-based index in <paramref name="buffer"/> where the first non-ASCII
+        /// <see cref="byte"/> appears; else -1 if <paramref name="buffer"/> is empty or
+        /// contains only ASCII <see cref="byte"/>s.</returns>
+        public static unsafe int GetIndexOfFirstNonAsciiByte(ReadOnlySpan<byte> buffer)
+        {
+            fixed (byte* pBuffer = &MemoryMarshal.GetReference(buffer))
+            {
+                int result = (int)ASCIIUtility.GetIndexOfFirstNonAsciiByte(pBuffer, (uint)buffer.Length);
+                if (result == buffer.Length)
+                {
+                    result = -1; // no non-ASCII data found
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Finds the first non-ASCII <see cref="char"/> within the specified buffer.
+        /// </summary>
+        /// <param name="buffer">The buffer whose contents should be examined.</param>
+        /// <returns>The zero-based index in <paramref name="buffer"/> where the first non-ASCII
+        /// <see cref="char"/> appears; else -1 if <paramref name="buffer"/> is empty or
+        /// contains only ASCII <see cref="char"/>s.</returns>
+        public static unsafe int GetIndexOfFirstNonAsciiChar(ReadOnlySpan<char> buffer)
+        {
+            fixed (char* pBuffer = &MemoryMarshal.GetReference(buffer))
+            {
+                int result = (int)ASCIIUtility.GetIndexOfFirstNonAsciiChar(pBuffer, (uint)buffer.Length);
+                if (result == buffer.Length)
+                {
+                    result = -1; // no non-ASCII data found
+                }
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a buffer contains only ASCII <see cref="byte"/>s.
+        /// </summary>
+        /// <param name="value">The buffer whose contents should be examined.</param>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is empty or
+        /// contains only ASCII <see cref="byte"/>s; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// This method is behaviorally equivalent to calling <see cref="GetIndexOfFirstNonAsciiByte"/>
+        /// and comparing the return value against -1.
+        /// </remarks>
+        public static bool IsAscii(ReadOnlySpan<byte> value) => GetIndexOfFirstNonAsciiByte(value) < 0;
+
+        /// <summary>
+        /// Determines whether a buffer contains only ASCII <see cref="char"/>s.
+        /// </summary>
+        /// <param name="value">The buffer whose contents should be examined.</param>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is empty or
+        /// contains only ASCII <see cref="char"/>s; otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// This method is behaviorally equivalent to calling <see cref="GetIndexOfFirstNonAsciiChar"/>
+        /// and comparing the return value against -1.
+        /// </remarks>
+        public static bool IsAscii(ReadOnlySpan<char> value) => GetIndexOfFirstNonAsciiChar(value) < 0;
+
+        /*
+         * Returns true iff the provided byte is an ASCII byte; i.e., in the range [ 00 .. 7F ];
+         * or if the provided char is in the range [ 0000 .. 007F ].
+         */
+
+        /// <summary>
+        /// Determines whether the specified <see cref="byte"/> is an ASCII <see cref="byte"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/> to examine.</param>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is an ASCII <see cref="byte"/>;
+        /// otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// An ASCII <see cref="byte"/> is defined as any <see cref="byte"/> in the range
+        /// 0x00 through 0x7F, inclusive.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAscii(byte value) => UnicodeUtility.IsAsciiCodePoint(value);
+
+        /// <summary>
+        /// Determines whether the specified <see cref="char"/> is an ASCII <see cref="char"/>.
+        /// </summary>
+        /// <param name="value">The <see cref="char"/> to examine.</param>
+        /// <returns><see langword="true"/> if <paramref name="value"/> is an ASCII <see cref="char"/>;
+        /// otherwise, <see langword="false"/>.</returns>
+        /// <remarks>
+        /// An ASCII <see cref="char"/> is defined as any <see cref="char"/> in the range
+        /// 0x0000 through 0x007F, inclusive.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAscii(char value) => UnicodeUtility.IsAsciiCodePoint(value);
+
+        /*
+         * ToLower / ToUpper routines
+         *
+         * Copies source to destination, converting [A-Z] -> [a-z] or vice versa during
+         * the copy. All values outside [A-Za-z] - including non-ASCII values - are unchanged
+         * during the copy.
+         */
+
+        /// <summary>
+        /// Copies the contents of <paramref name="source"/> to <paramref name="destination"/>,
+        /// converting any uppercase ASCII <see cref="byte"/>s to their lowercase equivalents
+        /// during the copy.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="destination">The destination buffer.</param>
+        /// <returns>
+        /// The number of <see cref="byte"/>s copied to <paramref name="destination"/>.
+        /// This will be equivalent to <paramref name="source"/>'s <see cref="Span{Byte}.Length"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is not large enough
+        /// to contain the copied data.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> and <paramref name="destination"/> overlap.</exception>
+        public static int ToLower(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < source.Length)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
+            if (source.Overlaps(destination))
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
+            }
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                destination[i] = ToLower(source[i]);
+            }
+
+            return source.Length;
+        }
+
+        /// <summary>
+        /// Copies the contents of <paramref name="source"/> to <paramref name="destination"/>,
+        /// converting any uppercase ASCII <see cref="char"/>s to their lowercase equivalents
+        /// during the copy.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="destination">The destination buffer.</param>
+        /// <returns>
+        /// The number of <see cref="char"/>s copied to <paramref name="destination"/>.
+        /// This will be equivalent to <paramref name="source"/>'s <see cref="Span{Char}.Length"/>.
+        /// </returns>
+        /// <remarks>
+        /// If <paramref name="source"/> contains non-ASCII data, use <see cref="MemoryExtensions.ToLowerInvariant"/> instead.
+        /// </remarks>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is not large enough
+        /// to contain the copied data.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> and <paramref name="destination"/> overlap.</exception>
+        public static int ToLower(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            if (destination.Length < source.Length)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
+            if (source.Overlaps(destination))
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
+            }
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                destination[i] = ToLower(source[i]);
+            }
+
+            return source.Length;
+        }
+
+        /// <summary>
+        /// Copies the contents of <paramref name="source"/> to <paramref name="destination"/>,
+        /// converting any lowercase ASCII <see cref="byte"/>s to their uppercase equivalents
+        /// during the copy.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="destination">The destination buffer.</param>
+        /// <returns>
+        /// The number of <see cref="byte"/>s copied to <paramref name="destination"/>.
+        /// This will be equivalent to <paramref name="source"/>'s <see cref="Span{Byte}.Length"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is not large enough
+        /// to contain the copied data.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> and <paramref name="destination"/> overlap.</exception>
+        public static int ToUpper(ReadOnlySpan<byte> source, Span<byte> destination)
+        {
+            if (destination.Length < source.Length)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
+            if (source.Overlaps(destination))
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
+            }
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                destination[i] = ToUpper(source[i]);
+            }
+
+            return source.Length;
+        }
+
+        /// <summary>
+        /// Copies the contents of <paramref name="source"/> to <paramref name="destination"/>,
+        /// converting any lowercase ASCII <see cref="char"/>s to their uppercase equivalents
+        /// during the copy.
+        /// </summary>
+        /// <param name="source">The source buffer.</param>
+        /// <param name="destination">The destination buffer.</param>
+        /// <returns>
+        /// The number of <see cref="char"/>s copied to <paramref name="destination"/>.
+        /// This will be equivalent to <paramref name="source"/>'s <see cref="Span{Char}.Length"/>.
+        /// </returns>
+        /// <remarks>
+        /// If <paramref name="source"/> contains non-ASCII data, use <see cref="MemoryExtensions.ToUpperInvariant"/> instead.
+        /// </remarks>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is not large enough
+        /// to contain the copied data.</exception>
+        /// <exception cref="InvalidOperationException"><paramref name="source"/> and <paramref name="destination"/> overlap.</exception>
+        public static int ToUpper(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            if (destination.Length < source.Length)
+            {
+                ThrowHelper.ThrowArgumentException_DestinationTooShort();
+            }
+
+            if (source.Overlaps(destination))
+            {
+                throw new InvalidOperationException(SR.InvalidOperation_SpanOverlappedOperation);
+            }
+
+            for (int i = 0; i < source.Length; i++)
+            {
+                destination[i] = ToUpper(source[i]);
+            }
+
+            return source.Length;
+        }
+
+        /*
+         * Performs case conversion ([A-Z] -> [a-z] or vice versa) in-place. All values
+         * outside [A-Za-z] - including non-ASCII values - are unchanged.
+         */
+
+        /// <summary>
+        /// Performs an in-place lowercase ASCII conversion of a buffer's contents.
+        /// </summary>
+        /// <param name="value">The buffer over which to operate.</param>
+        /// <remarks>
+        /// The contents of <paramref name="value"/> are modified in-place. Uppercase
+        /// ASCII <see cref="byte"/>s are converted to lowercase. Non-ASCII <see cref="byte"/>s
+        /// remain unchanged.
+        /// </remarks>
+        public static void ToLowerInPlace(Span<byte> value)
+        {
+            foreach (ref byte refElement in value)
+            {
+                refElement = ToLower(refElement);
+            }
+        }
+
+        /// <summary>
+        /// Performs an in-place lowercase ASCII conversion of a buffer's contents.
+        /// </summary>
+        /// <param name="value">The buffer over which to operate.</param>
+        /// <remarks>
+        /// The contents of <paramref name="value"/> are modified in-place. Uppercase
+        /// ASCII <see cref="char"/>s are converted to lowercase. Non-ASCII <see cref="char"/>s
+        /// remain unchanged.
+        /// </remarks>
+        public static void ToLowerInPlace(Span<char> value)
+        {
+            foreach (ref char refElement in value)
+            {
+                refElement = ToLower(refElement);
+            }
+        }
+
+        /// <summary>
+        /// Performs an in-place uppercase ASCII conversion of a buffer's contents.
+        /// </summary>
+        /// <param name="value">The buffer over which to operate.</param>
+        /// <remarks>
+        /// The contents of <paramref name="value"/> are modified in-place. Lowercase
+        /// ASCII <see cref="byte"/>s are converted to uppercase. Non-ASCII <see cref="byte"/>s
+        /// remain unchanged.
+        /// </remarks>
+        public static void ToUpperInPlace(Span<byte> value)
+        {
+            foreach (ref byte refElement in value)
+            {
+                refElement = ToUpper(refElement);
+            }
+        }
+
+        /// <summary>
+        /// Performs an in-place uppercase ASCII conversion of a buffer's contents.
+        /// </summary>
+        /// <param name="value">The buffer over which to operate.</param>
+        /// <remarks>
+        /// The contents of <paramref name="value"/> are modified in-place. Lowercase
+        /// ASCII <see cref="char"/>s are converted to uppercase. Non-ASCII <see cref="char"/>s
+        /// remain unchanged.
+        /// </remarks>
+        public static void ToUpperInPlace(Span<char> value)
+        {
+            foreach (ref char refElement in value)
+            {
+                refElement = ToUpper(refElement);
+            }
+        }
+
+        /*
+         * Performs case conversion on a single value, converting [A-Z] -> [a-z] or vice versa.
+         * All values outside [A-Za-z] - including non-ASCII values - are unchanged.
+         */
+
+        /// <summary>
+        /// Converts an ASCII <see cref="byte"/> to lowercase.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/> to convert.</param>
+        /// <returns>The lowercase form of <paramref name="value"/> if <paramref name="value"/>
+        /// is an uppercase ASCII <see cref="byte"/>; otherwise, returns <paramref name="value"/> unchanged
+        /// if <paramref name="value"/> is already lowercase or is not an ASCII <see cref="byte"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte ToLower(byte value)
+        {
+            if (UnicodeUtility.IsInRangeInclusive(value, 'A', 'Z'))
+            {
+                value = (byte)(value | 0x20u);
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Converts an ASCII <see cref="char"/> to lowercase.
+        /// </summary>
+        /// <param name="value">The <see cref="char"/> to convert.</param>
+        /// <returns>The lowercase form of <paramref name="value"/> if <paramref name="value"/>
+        /// is an uppercase ASCII <see cref="char"/>; otherwise, returns <paramref name="value"/> unchanged
+        /// if <paramref name="value"/> is already lowercase or is not an ASCII <see cref="char"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static char ToLower(char value)
+        {
+            if (UnicodeUtility.IsInRangeInclusive(value, 'A', 'Z'))
+            {
+                value = (char)(byte)(value | 0x20u);
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Converts an ASCII <see cref="byte"/> to uppercase.
+        /// </summary>
+        /// <param name="value">The <see cref="byte"/> to convert.</param>
+        /// <returns>The uppercase form of <paramref name="value"/> if <paramref name="value"/>
+        /// is an lowercase ASCII <see cref="byte"/>; otherwise, returns <paramref name="value"/> unchanged
+        /// if <paramref name="value"/> is already uppercase or is not an ASCII <see cref="byte"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static byte ToUpper(byte value)
+        {
+            if (UnicodeUtility.IsInRangeInclusive(value, 'a', 'z'))
+            {
+                value = (byte)(value & 0x5Fu); // = low 7 bits of ~0x20
+            }
+            return value;
+        }
+
+        /// <summary>
+        /// Converts an ASCII <see cref="char"/> to uppercase.
+        /// </summary>
+        /// <param name="value">The <see cref="char"/> to convert.</param>
+        /// <returns>The uppercase form of <paramref name="value"/> if <paramref name="value"/>
+        /// is an lowercase ASCII <see cref="char"/>; otherwise, returns <paramref name="value"/> unchanged
+        /// if <paramref name="value"/> is already uppercase or is not an ASCII <see cref="char"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static char ToUpper(char value)
+        {
+            if (UnicodeUtility.IsInRangeInclusive(value, 'a', 'z'))
+            {
+                value = (char)(value & 0x5Fu); // = low 7 bits of ~0x20
+            }
+            return value;
+        }
+
+        /*
+         * Hash code calculation routines
+         *
+         * Returns a hash code for the provided buffer suitable for use in a dictionary or
+         * other keyed collection. For the OrdinalIgnoreCase method, the values [A-Z] and [a-z]
+         * are treated as equivalent during hash code computation. All non-ASCII values
+         * are treated as opaque data. The hash code is randomized but is not guaranteed to
+         * implement any particular algorithm, nor is it guaranteed to be a member of the same
+         * PRF family as other GetHashCode routines in the framework.
+         */
+
+        /// <summary>
+        /// Computes a hash code over the contents of an ASCII buffer.
+        /// </summary>
+        /// <param name="value">The buffer over which to compute the hash code.</param>
+        /// <returns>A hash code for the contents of <paramref name="value"/>.</returns>
+        /// <remarks>
+        /// If two <see cref="byte"/> buffers <em>left</em> and <em>right</em> compare as equal under
+        /// <see cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>, then this method
+        /// will return identical hash codes for each buffer. The implementation of this
+        /// method is not guaranteed to match the implementation of any other GetHashCode
+        /// routine in the framework, including <see cref="GetHashCodeIgnoreCase(ReadOnlySpan{byte})"/>.
+        ///
+        /// This method is not intended to pair with <see cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
+        /// or other overloads that operate on heterogeneous parameter types.
+        ///
+        /// The output of this routine is hardened against hash code collision attacks.
+        /// </remarks>
+        public static int GetHashCode(ReadOnlySpan<byte> value)
+            => Marvin.ComputeHash32(value, Marvin.DefaultSeed);
+
+        /// <summary>
+        /// Computes a hash code over the contents of an ASCII buffer.
+        /// </summary>
+        /// <param name="value">The buffer over which to compute the hash code.</param>
+        /// <returns>A hash code for the contents of <paramref name="value"/>.</returns>
+        /// <remarks>
+        /// If two <see cref="char"/> buffers <em>left</em> and <em>right</em> compare as equal under
+        /// <see cref="Equals(ReadOnlySpan{char}, ReadOnlySpan{char})"/>, then this method
+        /// will return identical hash codes for each buffer. The implementation of this
+        /// method is not guaranteed to match the implementation of any other GetHashCode
+        /// routine in the framework, including <see cref="GetHashCodeIgnoreCase(ReadOnlySpan{char})"/>
+        /// or <see cref="string.GetHashCode"/>.
+        ///
+        /// This method is not intended to pair with <see cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
+        /// or other overloads that operate on heterogeneous parameter types.
+        ///
+        /// The output of this routine is hardened against hash code collision attacks.
+        /// </remarks>
+        public static int GetHashCode(ReadOnlySpan<char> value)
+            => string.GetHashCode(value);
+
+        /// <summary>
+        /// Computes a hash code over the contents of an ASCII buffer in a case-insensitive fashion.
+        /// </summary>
+        /// <param name="value">The buffer over which to compute the hash code.</param>
+        /// <returns>A hash code for the contents of <paramref name="value"/>.</returns>
+        /// <remarks>
+        /// If two <see cref="byte"/> buffers <em>left</em> and <em>right</em> compare as equal under
+        /// <see cref="EqualsIgnoreCase(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>, then this method
+        /// will return identical hash codes for each buffer. The implementation of this
+        /// method is not guaranteed to match the implementation of any other GetHashCode
+        /// routine in the framework, including <see cref="GetHashCode(ReadOnlySpan{byte})"/>.
+        ///
+        /// This method is not intended to pair with <see cref="EqualsIgnoreCase(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
+        /// or other overloads that operate on heterogeneous parameter types.
+        ///
+        /// The output of this routine is hardened against hash code collision attacks.
+        /// </remarks>
+        public static int GetHashCodeIgnoreCase(ReadOnlySpan<byte> value)
+        {
+            byte[] rentedArray = ArrayPool<byte>.Shared.Rent(value.Length);
+            int bytesWritten = ToLower(value, rentedArray);
+            int hashCode = GetHashCode(rentedArray.AsSpan(0, bytesWritten));
+            ArrayPool<byte>.Shared.Return(rentedArray);
+            return hashCode;
+        }
+
+        /// <summary>
+        /// Computes a hash code over the contents of an ASCII buffer in a case-insensitive fashion.
+        /// </summary>
+        /// <param name="value">The buffer over which to compute the hash code.</param>
+        /// <returns>A hash code for the contents of <paramref name="value"/>.</returns>
+        /// <remarks>
+        /// If two <see cref="char"/> buffers <em>left</em> and <em>right</em> compare as equal under
+        /// <see cref="EqualsIgnoreCase(ReadOnlySpan{char}, ReadOnlySpan{char})"/>, then this method
+        /// will return identical hash codes for each buffer. The implementation of this
+        /// method is not guaranteed to match the implementation of any other GetHashCode
+        /// routine in the framework, including <see cref="GetHashCode(ReadOnlySpan{char})"/>
+        /// or <see cref="string.GetHashCode(StringComparison)"/> with <see cref="StringComparison.OrdinalIgnoreCase"/>.
+        ///
+        /// This method is not intended to pair with <see cref="EqualsIgnoreCase(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
+        /// or other overloads that operate on heterogeneous parameter types.
+        ///
+        /// The output of this routine is hardened against hash code collision attacks.
+        /// </remarks>
+        public static int GetHashCodeIgnoreCase(ReadOnlySpan<char> value)
+        {
+            char[] rentedArray = ArrayPool<char>.Shared.Rent(value.Length);
+            int bytesWritten = ToLower(value, rentedArray);
+            int hashCode = GetHashCode(rentedArray.AsSpan(0, bytesWritten));
+            ArrayPool<char>.Shared.Return(rentedArray);
+            return hashCode;
+        }
+
+        /*
+         * Transcoding routines
+         *
+         * Widens an ASCII buffer to UTF-16 or narrows a UTF-16 buffer to ASCII.
+         * Returns OperationStatus.InvalidData if the source buffer contains a non-ASCII byte
+         * or a char in the range [ 0080 .. FFFF ].
+         */
+
+        /// <summary>
+        /// Copies data from an ASCII buffer <paramref name="source"/> to a UTF-16 buffer <paramref name="destination"/>,
+        /// widening ASCII <see cref="byte"/>s to UTF-16 <see cref="char"/>s during the copy.
+        /// </summary>
+        /// <param name="source">The ASCII source buffer.</param>
+        /// <param name="destination">The UTF-16 destination buffer.</param>
+        /// <param name="bytesConsumed">When this method returns, the number of <see cref="byte"/>s which were processed
+        /// from <paramref name="source"/>. This value will always match <paramref name="charsWritten"/>.</param>
+        /// <param name="charsWritten">When this method returns, the number of <see cref="char"/>s which were written
+        /// to <paramref name="destination"/>. This value will always match <paramref name="bytesConsumed"/>.</param>
+        /// <returns>An <see cref="OperationStatus"/> describing the state of the operation.</returns>
+        /// <remarks>
+        /// This method will not copy non-ASCII data from <paramref name="source"/> to <paramref name="destination"/>.
+        /// Instead, if non-ASCII data is encountered in <paramref name="source"/>, this method returns
+        /// <see cref="OperationStatus.InvalidData"/> and sets <paramref name="bytesConsumed"/> and <paramref name="charsWritten"/>
+        /// to how far the operation progressed before the non-ASCII source data was seen.
+        /// </remarks>
+        public static unsafe OperationStatus WidenToUtf16(ReadOnlySpan<byte> source, Span<char> destination, out int bytesConsumed, out int charsWritten)
+        {
+            fixed (byte* pSource = &MemoryMarshal.GetReference(source))
+            fixed (char* pDestination = &MemoryMarshal.GetReference(destination))
+            {
+                OperationStatus result = OperationStatus.Done;
+
+                int numElementsToConvert = source.Length;
+                if (numElementsToConvert > destination.Length)
+                {
+                    numElementsToConvert = destination.Length;
+                    result = OperationStatus.DestinationTooSmall;
+                }
+
+                int numElementsActuallyConverted = (int)ASCIIUtility.WidenAsciiToUtf16(pSource, pDestination, (uint)numElementsToConvert);
+                if (numElementsActuallyConverted < numElementsToConvert)
+                {
+                    result = OperationStatus.InvalidData;
+                }
+
+                bytesConsumed = numElementsActuallyConverted;
+                charsWritten = numElementsActuallyConverted;
+                return result;
+            }
+        }
+
+        /// <summary>
+        /// Copies data from a UTF-16 buffer <paramref name="source"/> to an ASCII buffer <paramref name="destination"/>,
+        /// narrowing UTF-16 <see cref="char"/>s to ASCII <see cref="byte"/>s during the copy.
+        /// </summary>
+        /// <param name="source">The ASCII source buffer.</param>
+        /// <param name="destination">The UTF-16 destination buffer.</param>
+        /// <param name="charsConsumed">When this method returns, the number of <see cref="char"/>s which were processed
+        /// from <paramref name="source"/>. This value will always match <paramref name="bytesWritten"/>.</param>
+        /// <param name="bytesWritten">When this method returns, the number of <see cref="byte"/>s which were written
+        /// to <paramref name="destination"/>. This value will always match <paramref name="charsConsumed"/>.</param>
+        /// <returns>An <see cref="OperationStatus"/> describing the state of the operation.</returns>
+        /// <remarks>
+        /// This method will not copy non-ASCII data from <paramref name="source"/> to <paramref name="destination"/>.
+        /// Instead, if non-ASCII data is encountered in <paramref name="source"/>, this method returns
+        /// <see cref="OperationStatus.InvalidData"/> and sets <paramref name="charsConsumed"/> and <paramref name="bytesWritten"/>
+        /// to how far the operation progressed before the non-ASCII source data was seen.
+        /// </remarks>
+        public static unsafe OperationStatus NarrowFromUtf16(ReadOnlySpan<char> source, Span<byte> destination, out int charsConsumed, out int bytesWritten)
+        {
+            fixed (char* pSource = &MemoryMarshal.GetReference(source))
+            fixed (byte* pDestination = &MemoryMarshal.GetReference(destination))
+            {
+                OperationStatus result = OperationStatus.Done;
+
+                int numElementsToConvert = source.Length;
+                if (numElementsToConvert > destination.Length)
+                {
+                    numElementsToConvert = destination.Length;
+                    result = OperationStatus.DestinationTooSmall;
+                }
+
+                int numElementsActuallyConverted = (int)ASCIIUtility.NarrowUtf16ToAscii(pSource, pDestination, (uint)numElementsToConvert);
+                if (numElementsActuallyConverted < numElementsToConvert)
+                {
+                    result = OperationStatus.InvalidData;
+                }
+
+                charsConsumed = numElementsActuallyConverted;
+                bytesWritten = numElementsActuallyConverted;
+                return result;
+            }
+        }
+
+        /*
+         * Trim routines
+         *
+         * Unlike string.Trim, these APIs only trim ASCII whitespace. So while
+         * "\u00A0Hello\u00A0".Trim() would return "Hello", these trim routines
+         * won't trim the [ 00A0 ] chars because they're not considered ASCII
+         * whitespace.
+         */
+
+        // returns true iff the specified char is a whitespace ASCII char
+        private static bool IsAsciiWhitespace(uint ch)
+        {
+            // Per https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt,
+            // the only whitespace ASCII chars are [ 0009..000D ] and [ 0020 ].
+
+            return (ch <= 0x20)
+                && (ch == 0x20 || UnicodeUtility.IsInRangeInclusive(ch, 0x09, 0x0D));
+        }
+
+        /// <summary>
+        /// Trims ASCII whitespace characters from both the beginning and the end of the input buffer.
+        /// </summary>
+        /// <param name="value">The input buffer from which to trim whitespace characters.</param>
+        /// <returns>
+        /// A <see cref="Range"/> which represents the data within <paramref name="value"/>
+        /// which remains after whitespace characters are trimmed.
+        /// </returns>
+        public static Range Trim(ReadOnlySpan<byte> value) => TrimCore(value, TrimType.Both);
+
+        /// <summary>
+        /// Trims ASCII whitespace characters from both the beginning and the end of the input buffer.
+        /// </summary>
+        /// <param name="value">The input buffer from which to trim whitespace characters.</param>
+        /// <returns>
+        /// A <see cref="Range"/> which represents the data within <paramref name="value"/>
+        /// which remains after whitespace characters are trimmed.
+        /// </returns>
+        public static Range Trim(ReadOnlySpan<char> value) => TrimCore(value, TrimType.Both);
+
+        /// <summary>
+        /// Trims ASCII whitespace characters from the beginning of the input buffer.
+        /// </summary>
+        /// <param name="value">The input buffer from which to trim whitespace characters.</param>
+        /// <returns>
+        /// A <see cref="Range"/> which represents the data within <paramref name="value"/>
+        /// which remains after whitespace characters are trimmed.
+        /// </returns>
+        public static Range TrimStart(ReadOnlySpan<byte> value) => TrimCore(value, TrimType.Head);
+
+        /// <summary>
+        /// Trims ASCII whitespace characters from the beginning of the input buffer.
+        /// </summary>
+        /// <param name="value">The input buffer from which to trim whitespace characters.</param>
+        /// <returns>
+        /// A <see cref="Range"/> which represents the data within <paramref name="value"/>
+        /// which remains after whitespace characters are trimmed.
+        /// </returns>
+        public static Range TrimStart(ReadOnlySpan<char> value) => TrimCore(value, TrimType.Head);
+
+        /// <summary>
+        /// Trims ASCII whitespace characters from the end of the input buffer.
+        /// </summary>
+        /// <param name="value">The input buffer from which to trim whitespace characters.</param>
+        /// <returns>
+        /// A <see cref="Range"/> which represents the data within <paramref name="value"/>
+        /// which remains after whitespace characters are trimmed.
+        /// </returns>
+        public static Range TrimEnd(ReadOnlySpan<byte> value) => TrimCore(value, TrimType.Tail);
+
+        /// <summary>
+        /// Trims ASCII whitespace characters from the end of the input buffer.
+        /// </summary>
+        /// <param name="value">The input buffer from which to trim whitespace characters.</param>
+        /// <returns>
+        /// A <see cref="Range"/> which represents the data within <paramref name="value"/>
+        /// which remains after whitespace characters are trimmed.
+        /// </returns>
+        public static Range TrimEnd(ReadOnlySpan<char> value) => TrimCore(value, TrimType.Tail);
+
+        private static Range TrimCore(ReadOnlySpan<byte> value, TrimType trimType)
+        {
+            int startIdx = 0;
+            if ((trimType & TrimType.Head) != 0)
+            {
+                for (; startIdx < value.Length; startIdx++)
+                {
+                    if (!IsAsciiWhitespace(value[startIdx]))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            int endIdx = value.Length - 1;
+            if ((trimType & TrimType.Tail) != 0)
+            {
+                for (; endIdx >= startIdx; endIdx--)
+                {
+                    if (!IsAsciiWhitespace(value[endIdx]))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return (startIdx..(endIdx + 1));
+        }
+
+        private static Range TrimCore(ReadOnlySpan<char> value, TrimType trimType)
+        {
+            int startIdx = 0;
+            if ((trimType & TrimType.Head) != 0)
+            {
+                for (; startIdx < value.Length; startIdx++)
+                {
+                    if (!IsAsciiWhitespace(value[startIdx]))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            int endIdx = value.Length - 1;
+            if ((trimType & TrimType.Tail) != 0)
+            {
+                for (; endIdx >= startIdx; endIdx--)
+                {
+                    if (!IsAsciiWhitespace(value[endIdx]))
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return (startIdx..(endIdx + 1));
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/28230 - create APIs that operate specifically on buffers of ASCII text (as bytes or chars). The `IsAscii`, `GetIndexOfFirstNonAsciiByte/Char`, and `Widen/Narrow` APIs are vectorized high-performance APIs since they call into the existing code paths. The other APIs aren't yet optimized for perf, but they are functional.

There's only one real source file in this PR, and it's around 90% devdoc and 10% implementation. The other files are ref asm updates or related to testing.

Some of the unit tests were copied from the existing [AsciiUtilityTests.cs](https://github.com/dotnet/runtime/blob/cce6883ec18e81de4f97070cbfb13b628078a351/src/libraries/System.Runtime/tests/System/Text/ASCIIUtilityTests.cs), with slight modifications to account for the different method signatures under test.

I was also experimenting with a mechanism to allow a single test data member to provide data for multiple tests, where the runtime would pick the data that was appropriate for the test method. For example, the test data member would provide an enumeration of `(string a, bool b, int c, double d)`, and that same enumeration could be used as input into both `TestMethodFoo(string a, int c)` and `TestMethodBar(string a, double d)`. The test executor would map only the required data without forcing the test method signatures to account for every possible permutation.