### PR TITLE
Add new attributes for ILLink analysis.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -193,7 +193,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Decimal.DecCalc.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\DefaultBinder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Delegate.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\DynamicDependencyAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\NullableAttributes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\CodeAnalysis\SuppressMessageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\ConditionalAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Diagnostics\Contracts\ContractException.cs" />
@@ -1560,8 +1564,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\InteropServices\WindowsRuntime\EventRegistrationToken.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
-      <Compile Include="$(MSBuildThisFileDirectory)\System\Runtime\InteropServices\WindowsRuntime\Attributes.cs" />
-      <Compile Include="$(MSBuildThisFileDirectory)\System\Runtime\InteropServices\WindowsRuntime\IActivationFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\System\Runtime\InteropServices\WindowsRuntime\Attributes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\System\Runtime\InteropServices\WindowsRuntime\IActivationFactory.cs" />
   </ItemGroup>
   <!-- CoreCLR uses PAL layer that emulates Windows API on Unix. This is bridge for that PAL layer. See issue dotnet/runtime/#31721. -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' or '$(FeatureCoreCLR)'=='true'">

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicDependencyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicDependencyAttribute.cs
@@ -1,0 +1,131 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// States a dependency that one member has on another.
+    /// </summary>
+    /// <remarks>
+    /// This can be used to inform tooling of a dependency that is otherwise not evident purely from
+    /// metadata and IL, for example a member relied on via reflection.
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Constructor | AttributeTargets.Field | AttributeTargets.Method,
+        AllowMultiple = true, Inherited = false)]
+    public sealed class DynamicDependencyAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified member signature.
+        /// </summary>
+        /// <param name="memberSignature">The signature of the member depended on.</param>
+        public DynamicDependencyAttribute(string memberSignature)
+        {
+            MemberSignature = memberSignature;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified member signature and <see cref="System.Type"/>.
+        /// </summary>
+        /// <param name="memberSignature">The signature of the member depended on.</param>
+        /// <param name="type">The <see cref="System.Type"/> containing <paramref name="memberSignature"/>.</param>
+        public DynamicDependencyAttribute(string memberSignature, Type type)
+        {
+            MemberSignature = memberSignature;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified member signature, type name, and assembly name.
+        /// </summary>
+        /// <param name="memberSignature">The signature of the member depended on.</param>
+        /// <param name="typeName">The full name of the type containing the specified member.</param>
+        /// <param name="assemblyName">The assembly name of the type containing the specified member.</param>
+        public DynamicDependencyAttribute(string memberSignature, string typeName, string assemblyName)
+        {
+            MemberSignature = memberSignature;
+            TypeName = typeName;
+            AssemblyName = assemblyName;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified member types and <see cref="System.Type"/>.
+        /// </summary>
+        /// <param name="memberTypes">The types of members depended on.</param>
+        /// <param name="type">The <see cref="System.Type"/> containing the specified members.</param>
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, Type type)
+        {
+            MemberTypes = memberTypes;
+            Type = type;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
+        /// with the specified member types, type name, and assembly name.
+        /// </summary>
+        /// <param name="memberTypes">The types of members depended on.</param>
+        /// <param name="typeName">The full name of the type containing the specified members.</param>
+        /// <param name="assemblyName">The assembly name of the type containing the specified members.</param>
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, string typeName, string assemblyName)
+        {
+            MemberTypes = memberTypes;
+            TypeName = typeName;
+            AssemblyName = assemblyName;
+        }
+
+        /// <summary>
+        /// Gets the signature of the member depended on.
+        /// </summary>
+        /// <remarks>
+        /// Either <see cref="MemberSignature"/> must be a valid string or <see cref="MemberTypes"/>
+        /// must not equal <see cref="DynamicallyAccessedMemberTypes.None"/>, but not both.
+        /// </remarks>
+        public string? MemberSignature { get; }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members depended on.
+        /// </summary>
+        /// <remarks>
+        /// Either <see cref="MemberSignature"/> must be a valid string or <see cref="MemberTypes"/>
+        /// must not equal <see cref="DynamicallyAccessedMemberTypes.None"/>, but not both.
+        /// </remarks>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+
+        /// <summary>
+        /// Gets the <see cref="System.Type"/> containing the specified member.
+        /// </summary>
+        /// <remarks>
+        /// If neither <see cref="Type"/> nor <see cref="TypeName"/> are specified,
+        /// the type of the consumer is assumed.
+        /// </remarks>
+        public Type? Type { get; }
+
+        /// <summary>
+        /// Gets the full name of the type containing the specified member.
+        /// </summary>
+        /// <remarks>
+        /// If neither <see cref="Type"/> nor <see cref="TypeName"/> are specified,
+        /// the type of the consumer is assumed.
+        /// </remarks>
+        public string? TypeName { get; }
+
+        /// <summary>
+        /// Gets the assembly name of the specified type.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AssemblyName"/> is only valid when <see cref="TypeName"/> is specified.
+        /// </remarks>
+        public string? AssemblyName { get; }
+
+        /// <summary>
+        /// Gets or sets the condition in which the dependency is applicable, e.g. "DEBUG".
+        /// </summary>
+        public string? Condition { get; set; }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicDependencyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicDependencyAttribute.cs
@@ -18,7 +18,7 @@ namespace System.Diagnostics.CodeAnalysis
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified member signature.
+        /// with the specified signature of a member on the same type as the consumer.
         /// </summary>
         /// <param name="memberSignature">The signature of the member depended on.</param>
         public DynamicDependencyAttribute(string memberSignature)
@@ -28,7 +28,7 @@ namespace System.Diagnostics.CodeAnalysis
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified member signature and <see cref="System.Type"/>.
+        /// with the specified signature of a member on a <see cref="System.Type"/>.
         /// </summary>
         /// <param name="memberSignature">The signature of the member depended on.</param>
         /// <param name="type">The <see cref="System.Type"/> containing <paramref name="memberSignature"/>.</param>
@@ -40,7 +40,7 @@ namespace System.Diagnostics.CodeAnalysis
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified member signature, type name, and assembly name.
+        /// with the specified signature of a member on a type in an assembly.
         /// </summary>
         /// <param name="memberSignature">The signature of the member depended on.</param>
         /// <param name="typeName">The full name of the type containing the specified member.</param>
@@ -54,7 +54,7 @@ namespace System.Diagnostics.CodeAnalysis
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified member types and <see cref="System.Type"/>.
+        /// with the specified types of members on a <see cref="System.Type"/>.
         /// </summary>
         /// <param name="memberTypes">The types of members depended on.</param>
         /// <param name="type">The <see cref="System.Type"/> containing the specified members.</param>
@@ -66,7 +66,7 @@ namespace System.Diagnostics.CodeAnalysis
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DynamicDependencyAttribute"/> class
-        /// with the specified member types, type name, and assembly name.
+        /// with the specified types of members on a type in an assembly.
         /// </summary>
         /// <param name="memberTypes">The types of members depended on.</param>
         /// <param name="typeName">The full name of the type containing the specified members.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -86,11 +86,6 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>
         /// Specifies all members.
         /// </summary>
-        All = DefaultConstructor | PublicConstructors | NonPublicConstructors |
-            PublicMethods | NonPublicMethods |
-            PublicFields | NonPublicFields |
-            PublicNestedTypes | NonPublicNestedTypes |
-            PublicProperties | NonPublicProperties |
-            PublicEvents | NonPublicEvents
+        All = ~None
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies the types of members that are dynamically accessed.
+    ///
+    /// This enumeration has a <see cref="FlagsAttribute"/> attribute that allows a
+    /// bitwise combination of its member values.
+    /// </summary>
+    [Flags]
+    public enum DynamicallyAccessedMemberTypes
+    {
+        /// <summary>
+        /// Specifies no members.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Specifies the default, parameterless public constructor.
+        /// </summary>
+        DefaultConstructor = 0x0001,
+
+        /// <summary>
+        /// Specifies all public constructors.
+        /// </summary>
+        PublicConstructors = 0x0002 | DefaultConstructor,
+
+        /// <summary>
+        /// Specifies all non-public constructors.
+        /// </summary>
+        NonPublicConstructors = 0x0004,
+
+        /// <summary>
+        /// Specifies all public methods.
+        /// </summary>
+        PublicMethods = 0x0008,
+
+        /// <summary>
+        /// Specifies all non-public methods.
+        /// </summary>
+        NonPublicMethods = 0x0010,
+
+        /// <summary>
+        /// Specifies all public fields.
+        /// </summary>
+        PublicFields = 0x0020,
+
+        /// <summary>
+        /// Specifies all non-public fields.
+        /// </summary>
+        NonPublicFields = 0x0040,
+
+        /// <summary>
+        /// Specifies all public nested types.
+        /// </summary>
+        PublicNestedTypes = 0x0080,
+
+        /// <summary>
+        /// Specifies all non-public nested types.
+        /// </summary>
+        NonPublicNestedTypes = 0x0100,
+
+        /// <summary>
+        /// Specifies all public properties.
+        /// </summary>
+        PublicProperties = 0x0200,
+
+        /// <summary>
+        /// Specifies all non-public properties.
+        /// </summary>
+        NonPublicProperties = 0x0400,
+
+        /// <summary>
+        /// Specifies all public events.
+        /// </summary>
+        PublicEvents = 0x0800,
+
+        /// <summary>
+        /// Specifies all non-public events.
+        /// </summary>
+        NonPublicEvents = 0x1000,
+
+        /// <summary>
+        /// Specifies all members.
+        /// </summary>
+        All = DefaultConstructor | PublicConstructors | NonPublicConstructors |
+            PublicMethods | NonPublicMethods |
+            PublicFields | NonPublicFields |
+            PublicNestedTypes | NonPublicNestedTypes |
+            PublicProperties | NonPublicProperties |
+            PublicEvents | NonPublicEvents
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
@@ -1,0 +1,41 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that certain members on a specified <see cref="Type"/> are accessed dynamically,
+    /// for example through <see cref="System.Reflection"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows tools to understand which members are being accessed during the execution
+    /// of a program.
+    ///
+    /// This attribute is valid on members whose type is <see cref="Type"/> or <see cref="string"/>.
+    ///
+    /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
+    /// that the string represents a fully qualified type name.
+    /// </remarks>
+    [AttributeUsage(
+        AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
+        AttributeTargets.Parameter |AttributeTargets.Property)]
+    public sealed class DynamicallyAccessedMembersAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DynamicallyAccessedMembersAttribute"/> class
+        /// with the specified member types.
+        /// </summary>
+        /// <param name="memberTypes">The types of members dynamically accessed.</param>
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            MemberTypes = memberTypes;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DynamicallyAccessedMemberTypes"/> which specifies the type
+        /// of members dynamically accessed.
+        /// </summary>
+        public DynamicallyAccessedMemberTypes MemberTypes { get; }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
@@ -19,7 +19,8 @@ namespace System.Diagnostics.CodeAnalysis
     /// </remarks>
     [AttributeUsage(
         AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
-        AttributeTargets.Parameter |AttributeTargets.Property)]
+        AttributeTargets.Parameter | AttributeTargets.Property,
+        Inherited = false)]
     public sealed class DynamicallyAccessedMembersAttribute : Attribute
     {
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>
+    /// Suppresses reporting of a specific rule violation, allowing multiple suppressions on a
+    /// single code artifact.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="UnconditionalSuppressMessageAttribute"/> is different than
+    /// <see cref="SuppressMessageAttribute"/> in that it doesn't have a
+    /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    public sealed class UnconditionalSuppressMessageAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>
+        /// class, specifying the category of the tool and the identifier for an analysis rule.
+        /// </summary>
+        /// <param name="category">The category for the attribute.</param>
+        /// <param name="checkId">The identifier of the analysis rule the attribute applies to.</param>
+        public UnconditionalSuppressMessageAttribute(string category, string checkId)
+        {
+            Category = category;
+            CheckId = checkId;
+        }
+
+        /// <summary>
+        /// Gets the category identifying the classification of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Category"/> property describes the tool or tool analysis category
+        /// for which a message suppression attribute applies.
+        /// </remarks>
+        public string Category { get; }
+
+        /// <summary>
+        /// Gets the identifier of the analysis tool rule to be suppressed.
+        /// </summary>
+        /// <remarks>
+        /// Concatenated together, the <see cref="Category"/> and <see cref="CheckId"/>
+        /// properties form a unique check identifier.
+        /// </remarks>
+        public string CheckId { get; }
+
+        /// <summary>
+        /// Gets or sets the scope of the code that is relevant for the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The Scope property is an optional argument that specifies the metadata scope for which
+        /// the attribute is relevant.
+        /// </remarks>
+        public string? Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets a fully qualified path that represents the target of the attribute.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="Target"/> property is an optional argument identifying the analysis target
+        /// of the attribute. An example value is "System.IO.Stream.ctor():System.Void".
+        /// Because it is fully qualified, it can be long, particularly for targets such as parameters.
+        /// The analysis tool user interface should be capable of automatically formatting the parameter.
+        /// </remarks>
+        public string? Target { get; set; }
+
+        /// <summary>
+        /// Gets or sets an optional argument expanding on exclusion criteria.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="MessageId "/> property is an optional argument that specifies additional
+        /// exclusion where the literal metadata target is not sufficiently precise. For example,
+        /// the <see cref="UnconditionalSuppressMessageAttribute"/> cannot be applied within a method,
+        /// and it may be desirable to suppress a violation against a statement in the method that will
+        /// give a rule violation, but not against all statements in the method.
+        /// </remarks>
+        public string? MessageId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the justification for suppressing the code analysis message.
+        /// </summary>
+        public string? Justification { get; set; }
+    }
+}

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5610,6 +5610,46 @@ namespace System.Diagnostics.CodeAnalysis
         public DoesNotReturnIfAttribute(bool parameterValue) { }
         public bool ParameterValue { get { throw null; } }
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Constructor | System.AttributeTargets.Field | System.AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public sealed class DynamicDependencyAttribute : System.Attribute
+    {
+        public DynamicDependencyAttribute(string memberSignature) { }
+        public DynamicDependencyAttribute(string memberSignature, Type type) { }
+        public DynamicDependencyAttribute(string memberSignature, string typeName, string assemblyName) { }
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, Type type) { }
+        public DynamicDependencyAttribute(DynamicallyAccessedMemberTypes memberTypes, string typeName, string assemblyName) { }
+        public DynamicallyAccessedMemberTypes MemberTypes { get { throw null; } }
+        public string? MemberSignature { get { throw null; } }
+        public Type? Type { get { throw null; } }
+        public string? TypeName { get { throw null; } }
+        public string? AssemblyName { get { throw null; } }
+        public string? Condition { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.GenericParameter | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue)]
+    public sealed class DynamicallyAccessedMembersAttribute : System.Attribute
+    {
+        public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) { }
+        public DynamicallyAccessedMemberTypes MemberTypes { get { throw null; } }
+    }
+    [System.FlagsAttribute]
+    public enum DynamicallyAccessedMemberTypes
+    {
+        None = 0,
+        DefaultConstructor = 1,
+        PublicConstructors = 3,
+        NonPublicConstructors = 4,
+        PublicMethods = 8,
+        NonPublicMethods = 16,
+        PublicFields = 32,
+        NonPublicFields = 64,
+        PublicNestedTypes = 128,
+        NonPublicNestedTypes = 256,
+        PublicProperties = 512,
+        NonPublicProperties = 1024,
+        PublicEvents = 2048,
+        NonPublicEvents = 4096,
+        All = 8191
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Struct, Inherited=false, AllowMultiple=false)]
     public sealed partial class ExcludeFromCodeCoverageAttribute : System.Attribute
     {
@@ -5663,6 +5703,17 @@ namespace System.Diagnostics.CodeAnalysis
     public sealed partial class SuppressMessageAttribute : System.Attribute
     {
         public SuppressMessageAttribute(string category, string checkId) { }
+        public string Category { get { throw null; } }
+        public string CheckId { get { throw null; } }
+        public string? Justification { get { throw null; } set { } }
+        public string? MessageId { get { throw null; } set { } }
+        public string? Scope { get { throw null; } set { } }
+        public string? Target { get { throw null; } set { } }
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.All, Inherited=false, AllowMultiple=true)]
+    public sealed class UnconditionalSuppressMessageAttribute : System.Attribute
+    {
+        public UnconditionalSuppressMessageAttribute(string category, string checkId) { }
         public string Category { get { throw null; } }
         public string CheckId { get { throw null; } }
         public string? Justification { get { throw null; } set { } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5625,7 +5625,7 @@ namespace System.Diagnostics.CodeAnalysis
         public string? AssemblyName { get { throw null; } }
         public string? Condition { get { throw null; } set { } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.GenericParameter | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.GenericParameter | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
     public sealed class DynamicallyAccessedMembersAttribute : System.Attribute
     {
         public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) { }
@@ -5634,6 +5634,7 @@ namespace System.Diagnostics.CodeAnalysis
     [System.FlagsAttribute]
     public enum DynamicallyAccessedMemberTypes
     {
+        All = -1,
         None = 0,
         DefaultConstructor = 1,
         PublicConstructors = 3,
@@ -5648,7 +5649,6 @@ namespace System.Diagnostics.CodeAnalysis
         NonPublicProperties = 1024,
         PublicEvents = 2048,
         NonPublicEvents = 4096,
-        All = 8191
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Property | System.AttributeTargets.Struct, Inherited=false, AllowMultiple=false)]
     public sealed partial class ExcludeFromCodeCoverageAttribute : System.Attribute

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="System\DBNullTests.cs" />
     <Compile Include="System\DecimalTests.cs" />
     <Compile Include="System\DelegateTests.cs" />
+    <Compile Include="System\Diagnostics\CodeAnalysis\DynamicDependencyAttributeTests.cs" />
     <Compile Include="System\DivideByZeroExceptionTests.cs" />
     <Compile Include="System\DoubleTests.cs" />
     <Compile Include="System\DuplicateWaitObjectExceptionTests.cs" />
@@ -167,6 +168,8 @@
     <Compile Include="System\ComponentModel\DefaultValueAttributeTests.cs" />
     <Compile Include="System\ComponentModel\EditorBrowsableAttributeTests.cs" />
     <Compile Include="System\Diagnostics\ConditionalAttributeTests.cs" />
+    <Compile Include="System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttributeTests.cs" />
+    <Compile Include="System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttributeTests.cs" />
     <Compile Include="System\IO\DirectoryNotFoundExceptionTests.cs" />
     <Compile Include="System\IO\DirectoryNotFoundException.InteropTests.cs" />
     <Compile Include="System\IO\EndOfStreamExceptionTests.cs" />

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/DynamicDependencyAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/DynamicDependencyAttributeTests.cs
@@ -1,0 +1,104 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Diagnostics.CodeAnalysis.Tests
+{
+    public class DynamicDependencyAttributeTestsTests
+    {
+        [Theory]
+        [InlineData("Foo()")]
+        [InlineData(null)]
+        [InlineData("")]
+        public void TestConstructorSignature(string memberSignature)
+        {
+            var dda = new DynamicDependencyAttribute(memberSignature);
+
+            Assert.Equal(memberSignature, dda.MemberSignature);
+            Assert.Equal(DynamicallyAccessedMemberTypes.None, dda.MemberTypes);
+            Assert.Null(dda.Type);
+            Assert.Null(dda.TypeName);
+            Assert.Null(dda.AssemblyName);
+            Assert.Null(dda.Condition);
+        }
+
+        [Theory]
+        [InlineData("Foo()", typeof(string))]
+        [InlineData(null, null)]
+        [InlineData("", typeof(void))]
+        public void TestConstructorSignatureType(string memberSignature, Type type)
+        {
+            var dda = new DynamicDependencyAttribute(memberSignature, type);
+
+            Assert.Equal(memberSignature, dda.MemberSignature);
+            Assert.Equal(DynamicallyAccessedMemberTypes.None, dda.MemberTypes);
+            Assert.Equal(type, dda.Type);
+            Assert.Null(dda.TypeName);
+            Assert.Null(dda.AssemblyName);
+            Assert.Null(dda.Condition);
+        }
+
+        [Theory]
+        [InlineData("Foo()", "System.String", "System.Runtime")]
+        [InlineData(null, null, null)]
+        [InlineData("", "", "")]
+        public void TestConstructorSignatureTypeNameAssemblyName(string memberSignature, string typeName, string assemblyName)
+        {
+            var dda = new DynamicDependencyAttribute(memberSignature, typeName, assemblyName);
+
+            Assert.Equal(memberSignature, dda.MemberSignature);
+            Assert.Equal(DynamicallyAccessedMemberTypes.None, dda.MemberTypes);
+            Assert.Null(dda.Type);
+            Assert.Equal(typeName, dda.TypeName);
+            Assert.Equal(assemblyName, dda.AssemblyName);
+            Assert.Null(dda.Condition);
+        }
+
+        [Theory]
+        [InlineData(DynamicallyAccessedMemberTypes.PublicMethods, typeof(string))]
+        [InlineData(DynamicallyAccessedMemberTypes.None, null)]
+        [InlineData(DynamicallyAccessedMemberTypes.All, typeof(void))]
+        public void TestConstructorMemberTypes(DynamicallyAccessedMemberTypes memberTypes, Type type)
+        {
+            var dda = new DynamicDependencyAttribute(memberTypes, type);
+
+            Assert.Null(dda.MemberSignature);
+            Assert.Equal(memberTypes, dda.MemberTypes);
+            Assert.Equal(type, dda.Type);
+            Assert.Null(dda.TypeName);
+            Assert.Null(dda.AssemblyName);
+            Assert.Null(dda.Condition);
+        }
+
+        [Theory]
+        [InlineData(DynamicallyAccessedMemberTypes.PublicMethods, "System.String", "System.Runtime")]
+        [InlineData(DynamicallyAccessedMemberTypes.None, null, null)]
+        [InlineData(DynamicallyAccessedMemberTypes.All, "", "")]
+        public void TestConstructorMemberTypesTypeNameAssemblyName(DynamicallyAccessedMemberTypes memberTypes, string typeName, string assemblyName)
+        {
+            var dda = new DynamicDependencyAttribute(memberTypes, typeName, assemblyName);
+
+            Assert.Null(dda.MemberSignature);
+            Assert.Equal(memberTypes, dda.MemberTypes);
+            Assert.Null(dda.Type);
+            Assert.Equal(typeName, dda.TypeName);
+            Assert.Equal(assemblyName, dda.AssemblyName);
+            Assert.Null(dda.Condition);
+        }
+
+        [Fact]
+        public void TestCondition()
+        {
+            var dda = new DynamicDependencyAttribute("Foo()");
+            Assert.Null(dda.Condition);
+
+            dda.Condition = "DEBUG";
+            Assert.Equal("DEBUG", dda.Condition);
+
+            dda.Condition = null;
+            Assert.Null(dda.Condition);
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttributeTests.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Diagnostics.CodeAnalysis.Tests
+{
+    public class DynamicallyAccessedMembersAttributeTests
+    {
+        [Theory]
+        [InlineData(DynamicallyAccessedMemberTypes.None)]
+        [InlineData(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicProperties)]
+        [InlineData(DynamicallyAccessedMemberTypes.All)]
+        public void TestConstructor(DynamicallyAccessedMemberTypes memberTypes)
+        {
+            var dama = new DynamicallyAccessedMembersAttribute(memberTypes);
+
+            Assert.Equal(memberTypes, dama.MemberTypes);
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttributeTests.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Diagnostics.CodeAnalysis.Tests
+{
+    public class UnconditionalSuppressMessageAttributeTests
+    {
+        [Theory]
+        [InlineData("Category", "CheckId", "Justification", "MessageId", "Scope", "Target")]
+        [InlineData("", "", "", "", "", "")]
+        [InlineData(null, null, null, null, null, null)]
+        [InlineData("", null, "Justification", null, "Scope", "")]
+        public void TestConstructor(string category, string id, string justification, string messageId, string scope, string target)
+        {
+            var usma = new UnconditionalSuppressMessageAttribute(category, id)
+            {
+                Justification = justification,
+                MessageId = messageId,
+                Scope = scope,
+                Target = target
+            };
+
+            Assert.Equal(category, usma.Category);
+            Assert.Equal(id, usma.CheckId);
+            Assert.Equal(justification, usma.Justification);
+            Assert.Equal(messageId, usma.MessageId);
+            Assert.Equal(scope, usma.Scope);
+            Assert.Equal(target, usma.Target);
+        }
+    }
+}


### PR DESCRIPTION
Add the following new attributes that will be used by the linker. See the original design proposal here: https://github.com/mono/linker/pull/988.

- DynamicallyAccessedMembersAttribute
- DynamicDependencyAttribute
- UnconditionalSuppressMessageAttribute

Fix #33861, #35339, #30902