### PR TITLE
Enable DnsGetHostEntry_LocalHost_ReturnsFqdnAndLoopbackIPs

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -186,7 +186,6 @@ namespace System.Net.NameResolution.Tests
             await Assert.ThrowsAnyAsync<ArgumentOutOfRangeException>(() => Task.Factory.FromAsync(Dns.BeginGetHostEntry, Dns.EndGetHostEntry, hostNameOrAddress, null));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34317")]
         [Theory]
         [InlineData(0)]
         [InlineData(1)]


### PR DESCRIPTION
Test is enabled because the failures were caused by Helix infra issue (a misconfigured agent) which was fixed a couple of days ago.

Fixes #34317 