### PR TITLE
Build warnings

### DIFF
--- a/src/coreclr/crossgen-corelib.sh
+++ b/src/coreclr/crossgen-corelib.sh
@@ -103,6 +103,7 @@ __LogsDir="$__RootBinDir/log/$__BuildType"
 
 # Set the remaining variables based upon the determined build configuration
 __BinDir="$__RootBinDir/bin/coreclr/$__TargetOS.$__BuildArch.$__BuildType"
+__IntermediatesDir="$__RootBinDir/obj/coreclr/$__TargetOS.$__BuildArch.$__BuildType"
 __CrossComponentBinDir="$__BinDir"
 
 __CrossArch="$__HostArch"

--- a/src/coreclr/src/jit/CMakeLists.txt
+++ b/src/coreclr/src/jit/CMakeLists.txt
@@ -322,7 +322,7 @@ else()
   elseif(CLR_CMAKE_HOST_SUNOS)
     # Add linker exports file option
     set(JIT_EXPORTS_LINKER_OPTION -Wl,-M,${JIT_EXPORTS_FILE})
-  endif(CLR_CMAKE_HOST_SUNOS)
+  endif()
 
   set(SHARED_LIB_SOURCES ${SOURCES})
 endif()


### PR DESCRIPTION
This gets rid of two minor warnings that show up when running ./build.sh:

```
  CMake Warning (dev) in src/jit/CMakeLists.txt:
    A logical block opening on the line
  
      /home/tmds/repos/runtime/src/coreclr/src/jit/CMakeLists.txt:315 (if)
  
    closes on the line
  
      /home/tmds/repos/runtime/src/coreclr/src/jit/CMakeLists.txt:326 (endif)
  
    with mis-matching arguments.
  This warning is for project developers.  Use -Wno-dev to suppress it.
```

```
  Commencing Crossgenning System.Private.CoreLib
  __DistroRid: linux-x64
  __RuntimeId: linux-x64
  Setting up directories for build
  mkdir: cannot create directory ‘’: No such file or directory
```