### PR TITLE
Add option for extra queries for SuperPmi

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -589,6 +589,7 @@ class SuperPMICollect:
             env_copy["SuperPMIShimPath"] = self.jit_path
             env_copy["COMPlus_AltJit"] = "*"
             env_copy["COMPlus_AltJitName"] = self.collection_shim_name
+            env_copy["COMPlus_EnableExtraSuperPmiQueries"] = "1"
 
             if self.coreclr_args.use_zapdisable:
                 env_copy["COMPlus_ZapDisable"] = "1"

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -5203,6 +5203,8 @@ int Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     forceFrameJIT = (void*)&me; // let us see the this pointer in fastchecked build
     // set this early so we can use it without relying on random memory values
     verbose = compIsForInlining() ? impInlineInfo->InlinerCompiler->verbose : false;
+
+    doExtraSuperPmiQueries = JitConfig.EnableExtraSuperPmiQueries();
 #endif
 
 #if defined(DEBUG) || defined(INLINE_DATA)

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -5203,8 +5203,6 @@ int Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     forceFrameJIT = (void*)&me; // let us see the this pointer in fastchecked build
     // set this early so we can use it without relying on random memory values
     verbose = compIsForInlining() ? impInlineInfo->InlinerCompiler->verbose : false;
-
-    doExtraSuperPmiQueries = JitConfig.EnableExtraSuperPmiQueries();
 #endif
 
 #if defined(DEBUG) || defined(INLINE_DATA)

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2095,6 +2095,8 @@ public:
     bool shouldUseVerboseSsa();
     bool treesBeforeAfterMorph; // If true, print trees before/after morphing (paired by an intra-compilation id:
     int  morphNum;              // This counts the the trees that have been morphed, allowing us to label each uniquely.
+    bool doExtraSuperPmiQueries;
+    void makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int level); // Make queries recursively 'level' deep.
 
     const char* VarNameToStr(VarName name)
     {

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -358,6 +358,10 @@ CONFIG_INTEGER(JitMeasureNowayAssert, W("JitMeasureNowayAssert"), 0) // Set to 1
 CONFIG_STRING(JitMeasureNowayAssertFile,
               W("JitMeasureNowayAssertFile")) // Set to file to write noway_assert usage to a file (if not
                                               // set: stdout). Only valid if MEASURE_NOWAY is defined.
+#if defined(DEBUG)
+CONFIG_INTEGER(EnableExtraSuperPmiQueries, W("EnableExtraSuperPmiQueries"), 0) // Make extra queries to somewhat
+                                                                               // future-proof SuperPmi method contexts.
+#endif                                                                         // DEBUG
 
 #if defined(DEBUG) || defined(INLINE_DATA)
 CONFIG_INTEGER(JitInlineDumpData, W("JitInlineDumpData"), 0)

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -2671,7 +2671,7 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
         varDsc->lvIsUnsafeBuffer = true;
     }
 #ifdef DEBUG
-    if (doExtraSuperPmiQueries)
+    if (JitConfig.EnableExtraSuperPmiQueries())
     {
         makeExtraStructQueries(typeHnd, 2);
     }
@@ -2688,7 +2688,7 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
 //
 void Compiler::makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int level)
 {
-    if (level == 0)
+    if (level <= 0)
     {
         return;
     }

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -2670,7 +2670,49 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
         compGSReorderStackLayout = true;
         varDsc->lvIsUnsafeBuffer = true;
     }
+#ifdef DEBUG
+    if (doExtraSuperPmiQueries)
+    {
+        makeExtraStructQueries(typeHnd, 2);
+    }
+#endif // DEBUG
 }
+
+#ifdef DEBUG
+//------------------------------------------------------------------------
+// makeExtraStructQueries: Query the information for the given struct handle.
+//
+// Arguments:
+//    structHandle -- The handle for the struct type we're querying.
+//    level        -- How many more levels to recurse.
+//
+void Compiler::makeExtraStructQueries(CORINFO_CLASS_HANDLE structHandle, int level)
+{
+    if (level == 0)
+    {
+        return;
+    }
+    assert(structHandle != NO_CLASS_HANDLE);
+    (void)typGetObjLayout(structHandle);
+    unsigned fieldCnt = info.compCompHnd->getClassNumInstanceFields(structHandle);
+    for (unsigned int i = 0; i < fieldCnt; i++)
+    {
+        CORINFO_FIELD_HANDLE fieldHandle      = info.compCompHnd->getFieldInClass(structHandle, i);
+        unsigned             fldOffset        = info.compCompHnd->getFieldOffset(fieldHandle);
+        CORINFO_CLASS_HANDLE fieldClassHandle = NO_CLASS_HANDLE;
+        CorInfoType          fieldCorType     = info.compCompHnd->getFieldType(fieldHandle, &fieldClassHandle);
+        var_types            fieldVarType     = JITtype2varType(fieldCorType);
+        if (fieldClassHandle != NO_CLASS_HANDLE)
+        {
+            if (varTypeIsStruct(fieldVarType))
+            {
+                fieldVarType = impNormStructType(fieldClassHandle);
+                makeExtraStructQueries(fieldClassHandle, level - 1);
+            }
+        }
+    }
+}
+#endif // DEBUG
 
 //------------------------------------------------------------------------
 // lvaSetStructUsedAsVarArg: update hfa information for vararg struct args


### PR DESCRIPTION
This adds an option to do extra queries for struct fields and types to make it easier to test and diff struct promotion enhancements, but we could consider adding other queries in future.