### PR TITLE
Remove the Obsolete attribute from types that support COM events

### DIFF
--- a/src/coreclr/tests/src/Interop/COM/NETClients/Events/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Events/Program.cs
@@ -50,8 +50,6 @@ namespace NetClient
             }
         }
 
-#pragma warning disable 618 // Must test deprecated features
-
         // The ComAwareEventInfo is used by the compiler when PIAs
         // containing COM Events are embedded.
         static void Validate_COMEventViaComAwareEventInfo()
@@ -89,8 +87,6 @@ namespace NetClient
                 message = msg;
             }
         }
-
-#pragma warning restore 618 // Must test deprecated features
 
         static int Main(string[] doNotUse)
         {

--- a/src/coreclr/tests/src/Interop/COM/NETServer/EventTesting.cs
+++ b/src/coreclr/tests/src/Interop/COM/NETServer/EventTesting.cs
@@ -8,8 +8,6 @@ using System.Text;
 using System.Runtime.InteropServices;
 using Server.Contract;
 
-#pragma warning disable 618 // Must test deprecated features
-
 [ComVisible(true)]
 [Guid(Server.Contract.Guids.EventTesting)]
 [ComSourceInterfaces(typeof(Server.Contract.TestingEvents))]

--- a/src/coreclr/tests/src/Interop/COM/ServerContracts/Server.Events.cs
+++ b/src/coreclr/tests/src/Interop/COM/ServerContracts/Server.Events.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#pragma warning disable 618 // Must test deprecated features
-
 namespace Server.Contract
 {
     using System;
@@ -189,5 +187,3 @@ namespace Server.Contract
         }
     }
 }
-
-#pragma warning restore 618 // Must test deprecated features

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -172,7 +172,6 @@ namespace System.Runtime.InteropServices
         public string Value { get { throw null; } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    [System.ObsoleteAttribute("ComAwareEventInfo may be unavailable in future releases.")]
     public partial class ComAwareEventInfo : System.Reflection.EventInfo
     {
         public ComAwareEventInfo(System.Type type, string eventName) { }
@@ -219,7 +218,6 @@ namespace System.Runtime.InteropServices
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Interface, Inherited=false)]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    [System.ObsoleteAttribute("ComEventInterfaceAttribute may be unavailable in future releases.")]
     public sealed partial class ComEventInterfaceAttribute : System.Attribute
     {
         public ComEventInterfaceAttribute(System.Type SourceInterface, System.Type EventProvider) { }
@@ -227,7 +225,6 @@ namespace System.Runtime.InteropServices
         public System.Type SourceInterface { get { throw null; } }
     }
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    [System.ObsoleteAttribute("ComEventsHelper may be unavailable in future releases.")]
     public static partial class ComEventsHelper
     {
         public static void Combine(object rcw, System.Guid iid, int dispid, System.Delegate d) { }
@@ -271,7 +268,6 @@ namespace System.Runtime.InteropServices
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class, Inherited=true)]
     [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
-    [System.ObsoleteAttribute("ComSourceInterfacesAttribute may be unavailable in future releases.")]
     public sealed partial class ComSourceInterfacesAttribute : System.Attribute
     {
         public ComSourceInterfacesAttribute(string sourceInterfaces) { }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.Windows.cs
@@ -9,7 +9,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-#pragma warning disable 0618 // CompareEventInfo is marked as Obsolete.
     public partial class ComAwareEventInfoTests
     {
         [ComEventInterface(typeof(DispAttributeClass), typeof(int))]
@@ -126,5 +125,4 @@ namespace System.Runtime.InteropServices.Tests
             public void Event() { }
         }
     }
-#pragma warning restore 0618
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-#pragma warning disable 0618 // CompareEventInfo is marked as Obsolete.
     public partial class ComAwareEventInfoTests
     {
         [Fact]
@@ -109,5 +108,4 @@ namespace System.Runtime.InteropServices.Tests
             public void Raise(object sender) => Event.Invoke(1, null);
         }
     }
-#pragma warning restore 0618
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventInterfaceAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventInterfaceAttributeTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-#pragma warning disable 0618 // ComEventInterfaceAttribute is marked as Obsolete.
     public class ComEventInterfaceAttributeTests
     {
         [Theory]
@@ -19,5 +18,4 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(eventProvider, attribute.EventProvider);
         }
     }
-#pragma warning restore 0618
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventsHelperTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComEventsHelperTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-#pragma warning disable 0618 // ComEventsHelper is marked as Obsolete.
     public class ComEventsHelperTests
     {
         [Fact]
@@ -51,5 +50,4 @@ namespace System.Runtime.InteropServices.Tests
             AssertExtensions.Throws<ArgumentException>("obj", () => ComEventsHelper.Remove(1, Guid.Empty, 1, null));
         }
     }
-#pragma warning restore 0618
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComSourceInterfacesAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComSourceInterfacesAttributeTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Runtime.InteropServices.Tests
 {
-#pragma warning disable 0618 // ComSourceInterfacesAttribute is marked as Obsolete.
     public class ComSourceInterfacesAttributeTests
     {
         [Theory]
@@ -76,5 +75,4 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Throws<NullReferenceException>(() => new ComSourceInterfacesAttribute(typeof(int), typeof(string), typeof(bool), null));
         }
     }
-#pragma warning restore 0618
 }


### PR DESCRIPTION
Update tests to remove the suppression.

See https://github.com/dotnet/runtime/issues/35129#issuecomment-618819452

/cc @jkoritzinsky @elinor-fung 