### PR TITLE
WIP: Revert "Add runtimeFlavor parameter to build-test-job.yml"

### DIFF
--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -19,7 +19,6 @@ parameters:
   stagedBuild: false
   variables: {}
   pool: ''
-  runtimeFlavor: 'coreclr'
   runtimeFlavorDisplayName: 'CoreCLR'
 
 ### Build managed test components (native components are getting built as part

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -21,7 +21,6 @@ parameters:
   runInUnloadableContext: false
   variables: {}
   pool: ''
-  runtimeFlavor: 'coreclr'
   runtimeFlavorDisplayName: 'CoreCLR'
 
 ### Test run job

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -11,9 +11,9 @@ parameters:
 jobs:
 - template: ${{ coalesce(parameters.helixQueuesTemplate, parameters.jobTemplate) }}
   parameters:
-    ${{ if eq(parameters.jobParameters.runtimeFlavor, 'coreclr') }}:
+    ${{ if eq(parameters.runtimeFlavor, 'coreclr') }}:
       runtimeFlavorDisplayName: 'CoreCLR'
-    ${{ if eq(parameters.jobParameters.runtimeFlavor, 'mono') }}:
+    ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
       runtimeFlavorDisplayName: 'Mono'
     variables:
       # Disable component governance in our CI builds. These builds are not shipping nor

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -672,6 +672,7 @@ jobs:
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       liveRuntimeBuildConfig: release
+      runtimeFlavorDisplayName: 'Mono'
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
@@ -693,6 +694,7 @@ jobs:
       testGroup: innerloop
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       liveRuntimeBuildConfig: release
+      runtimeFlavorDisplayName: 'Mono'
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),


### PR DESCRIPTION
Reverts dotnet/runtime#35377

Sigh. For some reason, this seemingly unrelated change has broken the rolling build again. I'm not yet convinced we need to back the change out as I suspect the fix is going to be elsewhere and my change probably just uncovered it by properly propagating the runtime names but I'm triggering testing for the rollback nonetheless just to be sure.

Thanks

Tomas