### PR TITLE
Fix OSX debug / checked build symbols

### DIFF
--- a/eng/native/functions.cmake
+++ b/eng/native/functions.cmake
@@ -268,13 +268,20 @@ function(strip_symbols targetName outputFilename)
         message(FATAL_ERROR "strip not found")
       endif()
 
+      string(TOLOWER "${CMAKE_BUILD_TYPE}" LOWERCASE_CMAKE_BUILD_TYPE)
+      if (LOWERCASE_CMAKE_BUILD_TYPE STREQUAL release)
+        set(strip_command ${STRIP} -S ${strip_source_file})
+      else ()
+        set(strip_command)
+      endif ()
+
       add_custom_command(
         TARGET ${targetName}
         POST_BUILD
         VERBATIM
         COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
-        COMMAND ${STRIP} -S ${strip_source_file}
-        COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+        COMMAND ${strip_command}
+        COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
         )
     else (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
       set(strip_destination_file ${strip_source_file}.dbg)
@@ -286,7 +293,7 @@ function(strip_symbols targetName outputFilename)
         COMMAND ${CMAKE_OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
         COMMAND ${CMAKE_OBJCOPY} --strip-debug ${strip_source_file}
         COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
-        COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+        COMMENT "Stripping symbols from ${strip_source_file} into file ${strip_destination_file}"
         )
     endif (CLR_CMAKE_TARGET_OSX OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS)
 


### PR DESCRIPTION
The strip command we invoke was stripping even the information that
is necessary for the debugger to find the separate .dwarf files,
so these symbol files had to be loaded manually into lldb. With
this fix, lldb loads them automatically.

I've also added missing double quotes in the COMMENT command as without these,  the printed message contained only the source filename and nothing else.