### PR TITLE
Delete FX_PRODUCT_VERSION host key/value pair

### DIFF
--- a/src/coreclr/src/vm/eventreporter.cpp
+++ b/src/coreclr/src/vm/eventreporter.cpp
@@ -17,12 +17,11 @@
 #include "eventreporter.h"
 #include "typestring.h"
 #include "debugdebugger.h"
+#include "clrversion.h"
 
 #include <configuration.h>
 
 #include "../dlls/mscorrc/resource.h"
-
-#include "getproductversionnumber.h"
 
 //---------------------------------------------------------------------------------------
 //
@@ -90,35 +89,12 @@ EventReporter::EventReporter(EventReporterType type)
         m_Description.Append(ssMessage);
     }
 
-    BOOL fHasVersion = FALSE;
-    DWORD dwMajorVersion = 0;
-    DWORD dwMinorVersion = 0;
-    DWORD dwBuild = 0;
-    DWORD dwRevision = 0;
-    EventReporter::GetCoreCLRInstanceProductVersion(&dwMajorVersion, &dwMinorVersion, &dwBuild, &dwRevision);
-    m_Description.AppendPrintf(W("%lu.%lu.%lu.%lu\n"),dwMajorVersion, dwMinorVersion, dwBuild, dwRevision);
-    fHasVersion = TRUE;
+    m_Description.Append(VER_FILEVERSION_STR_L);
+    m_Description.Append(W("\n"));
 
-    if (!fHasVersion)
-    {
-        ssMessage.Clear();
-        if(!ssMessage.LoadResource(CCompRC::Optional, IDS_ER_UNKNOWN))
-            m_Description.Append(W("unknown\n"));
-        else
-        {
-            m_Description.Append(ssMessage);
-            m_Description.Append(W("\n"));
-        }
-    }
-
-    // Log the .NET Version if we can get it
-    LPCWSTR fxProductVersion = Configuration::GetKnobStringValue(W("FX_PRODUCT_VERSION"));
-    if (fxProductVersion != nullptr)
-    {
-        m_Description.Append(W(".NET Version: "));
-        m_Description.Append(fxProductVersion);
-        m_Description.Append(W("\n"));
-    }
+    m_Description.Append(W(".NET Version: "));
+    m_Description.Append(CLR_PRODUCT_VERSION_L);
+    m_Description.Append(W("\n"));
 
     ssMessage.Clear();
 
@@ -721,43 +697,5 @@ void DoReportForUnhandledNativeException(PEXCEPTION_POINTERS pExceptionInfo)
         EX_END_CATCH(SwallowAllExceptions);
 
         reporter.Report();
-    }
-}
-
-// This function will return the product version of CoreCLR
-// instance we are executing in.
-void EventReporter::GetCoreCLRInstanceProductVersion(DWORD * pdwMajor, DWORD * pdwMinor, DWORD * pdwBuild, DWORD * pdwRevision)
-{
-    STATIC_CONTRACT_THROWS;
-
-    // Get the instance of the runtime
-    HMODULE hModRuntime = GetCLRModule();
-    _ASSERTE(hModRuntime != NULL);
-
-    // Get the path to the runtime
-    PathString runtimePath;
-    DWORD ret = WszGetModuleFileName(hModRuntime, runtimePath);
-    if (ret != 0)
-    {
-        // Got the path - get the file version from the path
-        SString path;
-        path.Clear();
-        path.Append(runtimePath);
-        DWORD dwVersionMS = 0;
-        DWORD dwVersionLS = 0;
-        GetProductVersionNumber(path, &dwVersionMS, &dwVersionLS);
-
-        // Get the Major.Minor.Build.Revision details from the returned values
-        *pdwMajor = HIWORD(dwVersionMS);
-        *pdwMinor = LOWORD(dwVersionMS);
-        *pdwBuild = HIWORD(dwVersionLS);
-        *pdwRevision = LOWORD(dwVersionLS);
-        LOG((LF_CORDB, LL_INFO100, "GetCoreCLRInstanceVersion: Got CoreCLR version: %lu.%lu.%lu.%lu\n",
-            *pdwMajor, *pdwMinor, *pdwBuild, *pdwRevision));
-    }
-    else
-    {
-        // Failed to get the path
-        LOG((LF_CORDB, LL_INFO100, "GetCoreCLRInstanceVersion: Unable to get CoreCLR version.\n"));
     }
 }

--- a/src/coreclr/src/vm/eventreporter.h
+++ b/src/coreclr/src/vm/eventreporter.h
@@ -49,8 +49,6 @@ private:
     // Flag to indicate if the buffer is full
     BOOL fBufferFull;
 
-    static void GetCoreCLRInstanceProductVersion(DWORD * pdwMajor, DWORD * pdwMinor, DWORD * pdwBuild, DWORD * pdwRevision);
-
 public:
     // Construct
     EventReporter(EventReporterType type);

--- a/src/installer/corehost/cli/hostpolicy/coreclr.cpp
+++ b/src/installer/corehost/cli/hostpolicy/coreclr.cpp
@@ -199,7 +199,6 @@ namespace
         _X("APP_CONTEXT_DEPS_FILES"),
         _X("FX_DEPS_FILE"),
         _X("PROBING_DIRECTORIES"),
-        _X("FX_PRODUCT_VERSION"),
         _X("STARTUP_HOOKS"),
         _X("APP_PATHS"),
         _X("APP_NI_PATHS"),

--- a/src/installer/corehost/cli/hostpolicy/coreclr.h
+++ b/src/installer/corehost/cli/hostpolicy/coreclr.h
@@ -62,7 +62,6 @@ enum class common_property
     AppContextDepsFiles,
     FxDepsFile,
     ProbingDirectories,
-    FxProductVersion,
     StartUpHooks,
     AppPaths,
     AppNIPaths,

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -590,7 +590,6 @@ void deps_resolver_t::init_known_entry_path(const deps_entry_t& entry, const pal
     if (m_coreclr_path.empty() && ends_with(path, DIR_SEPARATOR + pal::string_t(LIBCORECLR_NAME), false))
     {
         m_coreclr_path = path;
-        m_coreclr_library_version = entry.library_version;
         return;
     }
 }

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.h
@@ -168,11 +168,6 @@ public:
         return m_fx_definitions;
     }
 
-    const pal::string_t& get_coreclr_library_version() const
-    {
-        return m_coreclr_library_version;
-    }
-
     bool is_framework_dependent() const
     {
         return m_is_framework_dependent;
@@ -254,9 +249,6 @@ private:
 
     // Special entry for coreclr path
     pal::string_t m_coreclr_path;
-
-    // Special entry for coreclr library version
-    pal::string_t m_coreclr_library_version;
 
     // The filepaths for the app custom deps
     std::vector<pal::string_t> m_additional_deps_files;

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -149,16 +149,6 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
         ++fx_curr;
     }
 
-    pal::string_t clr_library_version;
-    if (resolver.is_framework_dependent())
-    {
-        clr_library_version = get_root_framework(fx_definitions).get_found_version();
-    }
-    else
-    {
-        clr_library_version = resolver.get_coreclr_library_version();
-    }
-
     // Build properties for CoreCLR instantiation
     pal::string_t app_base = resolver.get_app_dir();
     coreclr_properties.add(common_property::TrustedPlatformAssemblies, probe_paths.tpa.c_str());
@@ -168,7 +158,6 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     coreclr_properties.add(common_property::AppContextDepsFiles, app_context_deps_str.c_str());
     coreclr_properties.add(common_property::FxDepsFile, fx_deps_str.c_str());
     coreclr_properties.add(common_property::ProbingDirectories, resolver.get_lookup_probe_directories().c_str());
-    coreclr_properties.add(common_property::FxProductVersion, clr_library_version.c_str());
     coreclr_properties.add(common_property::RuntimeIdentifier, get_current_runtime_id(true /*use_fallback*/).c_str());
 
     bool set_app_paths = false;

--- a/src/installer/test/Assets/TestProjects/PortableApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/PortableApp/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace PortableApp
 {
@@ -12,15 +13,10 @@ namespace PortableApp
         {
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
-            Console.WriteLine($"Framework Version:{GetFrameworkVersionFromAppDomain()}");
+            Console.WriteLine(RuntimeInformation.FrameworkDescription);
 
             // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
             var t = typeof(Newtonsoft.Json.JsonReader);
-        }
-
-        private static string GetFrameworkVersionFromAppDomain()
-        {
-            return System.AppDomain.CurrentDomain.GetData("FX_PRODUCT_VERSION") as string;
         }
     }
 }

--- a/src/installer/test/Assets/TestProjects/SharedFxLookupPortableApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/SharedFxLookupPortableApp/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace SharedFxLookupPortableApp
 {
@@ -12,15 +13,10 @@ namespace SharedFxLookupPortableApp
         {
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
-            Console.WriteLine($"Framework Version:{GetFrameworkVersionFromAppDomain()}");
+            Console.WriteLine(RuntimeInformation.FrameworkDescription);
 
             // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
             var t = typeof(Newtonsoft.Json.JsonReader);
-        }
-
-        private static string GetFrameworkVersionFromAppDomain()
-        {
-            return System.AppDomain.CurrentDomain.GetData("FX_PRODUCT_VERSION") as string;
         }
     }
 }

--- a/src/installer/test/Assets/TestProjects/StandaloneApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/StandaloneApp/Program.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace StandaloneApp
 {
@@ -12,15 +13,10 @@ namespace StandaloneApp
         {
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
-            Console.WriteLine($"Framework Version:{GetFrameworkVersionFromAppDomain()}");
+            Console.WriteLine(RuntimeInformation.FrameworkDescription);
 
             // A small operation involving NewtonSoft.Json to ensure the assembly is loaded properly
             var t = typeof(Newtonsoft.Json.JsonReader);
-        }
-
-        private static string GetFrameworkVersionFromAppDomain()
-        {
-            return System.AppDomain.CurrentDomain.GetData("FX_PRODUCT_VERSION") as string;
         }
     }
 }

--- a/src/installer/test/Assets/TestProjects/TestWindowsOsShimsApp/Program.cs
+++ b/src/installer/test/Assets/TestProjects/TestWindowsOsShimsApp/Program.cs
@@ -13,9 +13,9 @@ namespace TestWindowsOsShimsApp
         {
             Console.WriteLine("Hello World!");
             Console.WriteLine(string.Join(Environment.NewLine, args));
-            Console.WriteLine($"Framework Version:{GetFrameworkVersionFromAppDomain()}");
+            Console.WriteLine(RuntimeInformation.FrameworkDescription);
 
-        #if WINDOWS
+#if WINDOWS
             Version osVersion = RtlGetVersion();
             if (osVersion == null)
             {
@@ -33,12 +33,7 @@ namespace TestWindowsOsShimsApp
                     Console.WriteLine($"Reported OS version is lower than the true OS version - shims in use.");
                 }
             }
-        #endif
-        }
-
-        private static string GetFrameworkVersionFromAppDomain()
-        {
-            return System.AppDomain.CurrentDomain.GetData("FX_PRODUCT_VERSION") as string;
+#endif
         }
 
 #if WINDOWS

--- a/src/installer/test/HostActivation.Tests/PortableAppActivation.cs
+++ b/src/installer/test/HostActivation.Tests/PortableAppActivation.cs
@@ -263,7 +263,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
 
 
             // Verify running from within the working directory
@@ -276,7 +276,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
         [Theory]
@@ -315,7 +315,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
 
                 // Verify running from within the working directory
                 Command.Create(appExe)
@@ -329,7 +329,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World")
-                    .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                    .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
             }
         }
 

--- a/src/installer/test/HostActivation.Tests/RuntimeProperties.cs
+++ b/src/installer/test/HostActivation.Tests/RuntimeProperties.cs
@@ -18,27 +18,6 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
         }
 
         [Fact]
-        public void CommonProperty_AppCanGetData()
-        {
-            var fixture = sharedState.RuntimePropertiesFixture
-                .Copy();
-
-            string name = "FX_PRODUCT_VERSION";
-            string value = fixture.RepoDirProvider.MicrosoftNETCoreAppVersion;
-
-            var dotnet = fixture.BuiltDotnet;
-            var appDll = fixture.TestProject.AppDll;
-            dotnet.Exec(appDll, name)
-                .EnvironmentVariable("COREHOST_TRACE", "1")
-                .CaptureStdErr()
-                .CaptureStdOut()
-                .Execute()
-                .Should().Pass()
-                .And.HaveStdErrContaining($"Property {name} = {value}")
-                .And.HaveStdOutContaining($"AppContext.GetData({name}) = {value}");
-        }
-
-        [Fact]
         public void AppConfigProperty_AppCanGetData()
         {
             var fixture = sharedState.RuntimePropertiesFixture
@@ -102,7 +81,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
             var fixture = sharedState.RuntimePropertiesFixture
                 .Copy();
 
-            string name = "FX_PRODUCT_VERSION";
+            string name = "RUNTIME_IDENTIFIER";
             RuntimeConfig.FromFile(fixture.TestProject.RuntimeConfigJson)
                 .WithProperty(name, sharedState.AppTestPropertyValue)
                 .Save();

--- a/src/installer/test/HostActivation.Tests/StandaloneAppActivation.cs
+++ b/src/installer/test/HostActivation.Tests/StandaloneAppActivation.cs
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation
                 .Execute()
                 .Should().Pass()
                 .And.HaveStdOutContaining("Hello World")
-                .And.HaveStdOutContaining($"Framework Version:{sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion}");
+                .And.HaveStdOutContaining(sharedTestState.RepoDirectories.MicrosoftNETCoreAppVersion);
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -142,10 +142,7 @@ namespace System
         {
             get
             {
-                // FX_PRODUCT_VERSION is expected to be set by the host
-                // Use AssemblyInformationalVersionAttribute as fallback if the exact product version is not specified by the host
-                string? versionString = AppContext.GetData("FX_PRODUCT_VERSION") as string ??
-                    typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+                string? versionString = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
                 ReadOnlySpan<char> versionSpan = versionString.AsSpan();
 

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -18,21 +18,15 @@ namespace System.Runtime.InteropServices
             {
                 if (s_frameworkDescription == null)
                 {
-                    string? versionString = AppContext.GetData("FX_PRODUCT_VERSION") as string;
+                    string? versionString = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
 
-                    if (versionString == null)
+                    // Strip the git hash if there is one
+                    if (versionString != null)
                     {
-                        // Use AssemblyInformationalVersionAttribute as fallback if the exact product version is not specified by the host
-                        versionString = typeof(object).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
-
-                        // Strip the git hash if there is one
-                        if (versionString != null)
+                        int plusIndex = versionString.IndexOf('+');
+                        if (plusIndex != -1)
                         {
-                            int plusIndex = versionString.IndexOf('+');
-                            if (plusIndex != -1)
-                            {
-                                versionString = versionString.Substring(0, plusIndex);
-                            }
+                            versionString = versionString.Substring(0, plusIndex);
                         }
                     }
 


### PR DESCRIPTION
It is no longer necessary now that the whole runtime is being built together in dotnet/runtime repo.