### PR TITLE
Vectorize interface casts

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -206,6 +206,7 @@ namespace System.Runtime.CompilerServices
         [DebuggerHidden]
         [StackTraceHidden]
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static object? IsInstanceOfInterface(void* toTypeHnd, object? obj)
         {
             if (obj != null)
@@ -455,6 +456,7 @@ namespace System.Runtime.CompilerServices
         [DebuggerHidden]
         [StackTraceHidden]
         [DebuggerStepThrough]
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
         private static object? ChkCastInterface(void* toTypeHnd, object? obj)
         {
             if (obj != null)


### PR DESCRIPTION
For the unrolled loop there are currently 8 conditional jumps for 4 checks
```asm
G_M54280_IG04:
    cmp      qword ptr [r9+8*r10], rcx
    je       SHORT G_M54280_IG06
    dec      r8
    test     r8, r8
    je       SHORT G_M54280_IG05
    cmp      qword ptr [r9+8*r10+8], rcx
    je       SHORT G_M54280_IG06
    dec      r8
    test     r8, r8
    je       SHORT G_M54280_IG05
    cmp      qword ptr [r9+8*r10+16], rcx
    je       SHORT G_M54280_IG06
    dec      r8
    test     r8, r8
    je       SHORT G_M54280_IG05
    cmp      qword ptr [r9+8*r10+24], rcx
    je       SHORT G_M54280_IG06
    dec      r8
    test     r8, r8
    je       SHORT G_M54280_IG05
    add      r10, 4
    jmp      SHORT G_M54280_IG04
```
The vectorized path changes it to 2 per 4 checks
```asm
G_M8434_IG04:
    mov      rsi, r9
    vmovupd  xmm1, xmmword ptr [rsi+r10]
    mov      rsi, r9
    lea      rdi, [r10+16]
    vmovupd  xmm2, xmmword ptr [rsi+rdi]
    vpcmpeqq xmm1, xmm1, xmm0
    vpcmpeqq xmm2, xmm2, xmm0
    vpor     xmm1, xmm1, xmm2
    vpmovmskb esi, xmm1
    test     esi, esi
    jne      SHORT G_M8434_IG09
    add      r10, 32
    cmp      r10, r11
    jb       SHORT G_M8434_IG04
```
And non-vectorized path to 5 per 4 checks
```asm
G_M8434_IG04:
    cmp      qword ptr [rdi+8*rbx], rcx
    je       SHORT G_M8434_IG09
    cmp      qword ptr [rdi+8*rbx+8], rcx
    je       SHORT G_M8434_IG09
    cmp      qword ptr [rdi+8*rbx+16], rcx
    je       SHORT G_M8434_IG09
    cmp      qword ptr [rdi+8*rbx+24], rcx
    je       SHORT G_M8434_IG09
    add      rbx, 4
    cmp      rbx, rax
    ja       SHORT G_M8434_IG04
```

/cc @VSadov @jkotas 