### PR TITLE
Mark LoadAssemblyAndGetFunctionPointer as NativeCallable

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -47,6 +47,7 @@ namespace Internal.Runtime.InteropServices
         /// <param name="delegateTypeNative">Assembly qualified delegate type name</param>
         /// <param name="reserved">Extensibility parameter (currently unused)</param>
         /// <param name="functionHandle">Pointer where to store the function pointer result</param>
+        [NativeCallable]
         public static int LoadAssemblyAndGetFunctionPointer(IntPtr assemblyPathNative,
                                                             IntPtr typeNameNative,
                                                             IntPtr methodNameNative,


### PR DESCRIPTION
Missed in https://github.com/dotnet/runtime/issues/34270