### PR TITLE
SocketAsyncEngine.Unix: name socket event thread

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -309,6 +309,8 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading.ThreadPool" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Threading.Thread" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -309,5 +309,6 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Overlapped" />
     <Reference Include="System.Threading.ThreadPool" />
+    <Reference Include="System.Threading.Thread" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -277,9 +277,20 @@ namespace System.Net.Sockets
                     throw new InternalException(err);
                 }
 
-                Thread thread = new Thread(s => ((SocketAsyncEngine)s!).EventLoop());
-                thread.Name = ".NET Sockets";
-                thread.Start(this);
+                bool suppressFlow = !ExecutionContext.IsFlowSuppressed();
+                try
+                {
+                    if (suppressFlow) ExecutionContext.SuppressFlow();
+
+                    Thread thread = new Thread(s => ((SocketAsyncEngine)s!).EventLoop());
+                    thread.IsBackground = true;
+                    thread.Name = ".NET Sockets";
+                    thread.Start(this);
+                }
+                finally
+                {
+                    if (suppressFlow) ExecutionContext.RestoreFlow();
+                }
             }
             catch
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -277,24 +277,9 @@ namespace System.Net.Sockets
                     throw new InternalException(err);
                 }
 
-                //
-                // Start the event loop on its own thread.
-                //
-                bool suppressFlow = !ExecutionContext.IsFlowSuppressed();
-                try
-                {
-                    if (suppressFlow) ExecutionContext.SuppressFlow();
-                    Task.Factory.StartNew(
-                        s => ((SocketAsyncEngine)s!).EventLoop(),
-                        this,
-                        CancellationToken.None,
-                        TaskCreationOptions.LongRunning,
-                        TaskScheduler.Default);
-                }
-                finally
-                {
-                    if (suppressFlow) ExecutionContext.RestoreFlow();
-                }
+                Thread thread = new Thread(s => ((SocketAsyncEngine)s!).EventLoop());
+                thread.Name = ".NET Sockets";
+                thread.Start(this);
             }
             catch
             {


### PR DESCRIPTION
This makes it more easy to identify the thread amongst
the other threads in the application.

cc @stephentoub @dotnet/ncl 