### PR TITLE
Add AttributeTargets.Interface to SkipLocalsInitAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/SkipLocalsInitAttribute.cs
@@ -21,6 +21,7 @@ namespace System.Runtime.CompilerServices
     [AttributeUsage(AttributeTargets.Module
         | AttributeTargets.Class
         | AttributeTargets.Struct
+        | AttributeTargets.Interface
         | AttributeTargets.Constructor
         | AttributeTargets.Method
         | AttributeTargets.Property

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9073,7 +9073,7 @@ namespace System.Runtime.CompilerServices
         public object WrappedException { get { throw null; } }
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, Inherited=false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct | System.AttributeTargets.Interface, Inherited=false)]
     public sealed partial class SkipLocalsInitAttribute : System.Attribute
     {
         public SkipLocalsInitAttribute() { }


### PR DESCRIPTION
See https://github.com/dotnet/coreclr/pull/20093#issuecomment-532311218

The test was added: http://sourceroslyn.io/#Microsoft.CodeAnalysis.CSharp.Emit.UnitTests/Attributes/AttributeTests_WellKnownAttributes.cs,80a639784e161f94

However it looks like the PR was never updated