### PR TITLE
Support nocheck prefix

### DIFF
--- a/src/coreclr/src/inc/opcode.def
+++ b/src/coreclr/src/inc/opcode.def
@@ -317,7 +317,7 @@ OPDEF(CEE_INITOBJ,                    "initobj",          PopI,               Pu
 OPDEF(CEE_CONSTRAINED,                "constrained.",     Pop0,               Push0,       InlineType,         IPrefix,     2,  0xFE,    0x16,    META)
 OPDEF(CEE_CPBLK,                      "cpblk",            PopI+PopI+PopI,     Push0,       InlineNone,         IPrimitive,  2,  0xFE,    0x17,    NEXT)
 OPDEF(CEE_INITBLK,                    "initblk",          PopI+PopI+PopI,     Push0,       InlineNone,         IPrimitive,  2,  0xFE,    0x18,    NEXT)
-OPDEF(CEE_UNUSED69,                   "unused",           Pop0,               Push0,       InlineNone,         IPrimitive,  2,  0xFE,    0x19,    NEXT)
+OPDEF(CEE_NOCHECK,                    "no.",              Pop0,               Push0,       ShortInlineI,       IPrefix,     2,  0xFE,    0x19,    META)
 OPDEF(CEE_RETHROW,                    "rethrow",          Pop0,               Push0,       InlineNone,         IObjModel,   2,  0xFE,    0x1A,    THROW)
 OPDEF(CEE_UNUSED51,                   "unused",           Pop0,               Push0,       InlineNone,         IPrimitive,  2,  0xFE,    0x1B,    NEXT)
 OPDEF(CEE_SIZEOF,                     "sizeof",           Pop0,               PushI,       InlineType,         IPrimitive,  2,  0xFE,    0x1C,    NEXT)

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -4702,6 +4702,7 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
             case CEE_CONSTRAINED:
             case CEE_READONLY:
             case CEE_VOLATILE:
+            case CEE_NOCHECK:
             case CEE_TAILCALL:
             {
                 if (codeAddr >= codeEndp)
@@ -5607,6 +5608,7 @@ unsigned Compiler::fgMakeBasicBlocks(const BYTE* codeAddr, IL_OFFSET codeSize, F
             case CEE_CONSTRAINED:
             case CEE_VOLATILE:
             case CEE_UNALIGNED:
+            case CEE_NOCHECK:
                 // fgFindJumpTargets should have ruled out this possibility
                 //   (i.e. a prefix opcodes as last intruction in a block)
                 noway_assert(codeAddr < codeEndp);


### PR DESCRIPTION
Resolves #10112

> I would think that, at the very least, we should ignore the opcode (other than the "correctness/verifiability" checks) rather than throwing InvalidProgramException.

It is spec compliant, as it is just a hint, but right now it has no actual functionality (it is verified and immediately ignored). It needs test but I don't know how to write JIT tests yet

It does not allow multiple `no`. prefixes, such as
`no. typecheck no. rangecheck ldelema` - only `no. typecheck | rangecheck ldelema`