### PR TITLE
Fix Interop.Sys.Write signature

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Write.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Write.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -21,6 +22,6 @@ internal static partial class Interop
         internal static extern unsafe int Write(SafeHandle fd, byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
-        internal static extern unsafe int Write(int fd, byte* buffer, int bufferSize);
+        internal static extern unsafe int Write(IntPtr fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -354,7 +354,7 @@ namespace System.Net.Sockets
             // Write to the pipe, which will wake up the event loop and cause it to exit.
             //
             byte b = 1;
-            int bytesWritten = Interop.Sys.Write(_shutdownWritePipe, &b, 1);
+            int bytesWritten = Interop.Sys.Write((IntPtr)_shutdownWritePipe, &b, 1);
             if (bytesWritten != 1)
             {
                 throw new InternalException(bytesWritten);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebugProvider.Unix.cs
@@ -87,7 +87,7 @@ namespace System.Diagnostics
                     int totalBytesWritten = 0;
                     while (bufCount > 0)
                     {
-                        int bytesWritten = Interop.Sys.Write(2 /* stderr */, buf + totalBytesWritten, bufCount);
+                        int bytesWritten = Interop.Sys.Write((IntPtr)2 /* stderr */, buf + totalBytesWritten, bufCount);
                         if (bytesWritten < 0)
                         {
                             // On error, simply stop writing the debug output.  This could commonly happen if stderr


### PR DESCRIPTION
SystemNative_Write expects fd passed as intptr, while the original sigature was using int. This crashed on mono interpreter because we didn't zero extend the int argument to an intptr, passing in an invalid descriptor.