### PR TITLE
[runtime] Mono ALC embedding: use public types, correct hook signature

### DIFF
--- a/src/mono/mono/metadata/mono-private-unstable.h
+++ b/src/mono/mono/metadata/mono-private-unstable.h
@@ -19,10 +19,10 @@ typedef MonoGCHandle MonoAssemblyLoadContextGCHandle;
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssembly *
 mono_assembly_load_full_alc (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, const char *basedir, MonoImageOpenStatus *status);
 
-typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle *alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, gpointer user_data, MonoError *error);
+typedef MonoAssembly * (*MonoAssemblyPreLoadFuncV3) (MonoAssemblyLoadContextGCHandle alc_gchandle, MonoAssemblyName *aname, char **assemblies_path, void *user_data, MonoError *error);
 
 MONO_API MONO_RT_EXTERNAL_ONLY void
-mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, gpointer user_data, gboolean append);
+mono_install_assembly_preload_hook_v3 (MonoAssemblyPreLoadFuncV3 func, void *user_data, mono_bool append);
 
 MONO_API MONO_RT_EXTERNAL_ONLY MonoAssemblyLoadContextGCHandle
 mono_alc_get_default_gchandle (void);


### PR DESCRIPTION
We can't have GLib types in public headers. Oops.

There is potentially still an issue with `mono_alc_get_default_gchandle` not being exported, but that can wait for later.

cc: @garuma 