### PR TITLE
[mono] Don't throw inheritance error on interfaces in IsDefined

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Attributes.cs
+++ b/src/libraries/System.Runtime/tests/System/Attributes.cs
@@ -81,6 +81,12 @@ namespace System.Tests
             Assert.False(Attribute.IsDefined(pi, typeof(ComVisibleAttribute), false));
             Assert.False(Attribute.IsDefined(pi, typeof(ComVisibleAttribute), true));
         }
+
+        [Fact]
+        public void IsDefined_Interface()
+        {
+            Assert.True(typeof(ExampleWithAttribute).IsDefined(typeof(INameable), false));
+        }
     }
 
     public static class AttributeGetCustomAttributes
@@ -205,6 +211,12 @@ namespace System.Tests
         {
             Assert.Equal("System.Tests.MyCustomAttribute System.Tests.MyCustomAttribute", string.Join(" ", typeof(MultipleAttributes).GetCustomAttributes(inherit: false)));
             Assert.Equal("System.Tests.MyCustomAttribute System.Tests.MyCustomAttribute", string.Join(" ", typeof(MultipleAttributes).GetCustomAttributes(inherit: true)));
+        }
+
+        [Fact]
+        public static void GetCustomAttributes_Interface()
+        {
+            Assert.True(typeof(ExampleWithAttribute).GetCustomAttributes(typeof(INameable), inherit: false)[0] is NameableAttribute);
         }
     }
 
@@ -798,4 +810,18 @@ namespace System.Tests
     class MultipleAttributes
     {
     }
+
+    public interface INameable
+    {
+        string Name { get; }
+    }
+
+    [AttributeUsage (AttributeTargets.All, AllowMultiple = true)]
+    public class NameableAttribute : Attribute, INameable
+    {
+        string INameable.Name => "Nameable";
+    }
+
+    [Nameable]
+    public class ExampleWithAttribute { }
 }

--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.Get.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.Get.cs
@@ -91,12 +91,6 @@ namespace System.Tests
         {
             Assert.Throws<AmbiguousMatchException>(() => typeof(ClassWithMixedCaseInterfaces).GetInterface("mixedinterface", ignoreCase: true));
         }
-
-        [Fact]
-        public void GetCustomAttributes_Interface()
-        {
-            Assert.True(typeof(ExampleWithAttribute).GetCustomAttributes(typeof(INameable), inherit: false)[0] is NameableAttribute);
-        }
     }
 
     public class ClassWithNoInterfaces { }
@@ -122,20 +116,6 @@ namespace System.Tests
         public interface Interface2 { }
         public interface Interface3 { }
     }
-
-    public interface INameable
-    {
-        string Name { get; }
-    }
-
-    [AttributeUsage (AttributeTargets.All, AllowMultiple=true)]
-    public class NameableAttribute : Attribute, INameable
-    {
-        string INameable.Name => "Nameable";
-    }
-
-    [Nameable]
-    public class ExampleWithAttribute { }
 }
 
 public interface Interface1 { }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Attribute.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Attribute.Mono.cs
@@ -12,7 +12,8 @@ namespace System
         {
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
-            if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute) && attributeType != typeof(CustomAttribute))
+            if (!attributeType.IsSubclassOf(typeof(Attribute)) && !attributeType.IsInterface
+                && attributeType != typeof(Attribute) && attributeType != typeof(CustomAttribute))
                 throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
             object[] attrs = CustomAttribute.GetCustomAttributes(element, attributeType, inherit);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/CustomAttribute.cs
@@ -551,7 +551,7 @@ namespace System.Reflection
         {
             if (attributeType == null)
                 throw new ArgumentNullException(nameof(attributeType));
-            if (!attributeType.IsSubclassOf(typeof(Attribute)) && attributeType != typeof(Attribute))
+            if (!attributeType.IsSubclassOf(typeof(Attribute)) && !attributeType.IsInterface && attributeType != typeof(Attribute))
                 throw new ArgumentException(SR.Argument_MustHaveAttributeBaseClass + " " + attributeType.FullName);
 
             AttributeUsageAttribute? usage = null;


### PR DESCRIPTION
Issue is very similar to the one fixed in https://github.com/dotnet/runtime/commit/3df21ae60ec7de12abc77f4cc329903abe9ea542. When adding the error messages, we were too strict on when to throw. This should hopefully avoid all that by being significantly more lax.

Test moved to be in a location better suited to both examples.

Fixes https://github.com/dotnet/runtime/issues/35514

cc: @rolfbjarne 