### PR TITLE
Delete DataContractSerializer's ILLinkTrim.xml file

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/ILLinkTrim.xml
+++ b/src/libraries/System.Private.DataContractSerialization/src/ILLinkTrim.xml
@@ -1,8 +1,0 @@
-<linker>
-  <assembly fullname="System.Private.DataContractSerialization">
-    <type fullname="System.Runtime.Serialization.DataContractSerializer">
-      <!-- called through reflection by tests -->
-      <method name="set_Option" />
-    </type>
-  </assembly>
-</linker>


### PR DESCRIPTION
The whole assembly isn't being trimmed:
```
    <!-- Too much private reflection. Do not bother with trimming -->
    <ILLinkTrimAssembly>false</ILLinkTrimAssembly>
```
(On top of that, the set_Option that's being kept here is only set via reflection by test code that's not actually built today; it's guarded behind a compilation constant that's not set.)

cc: @eerhardt, @StephenMolloy, @HongGit