### PR TITLE
Optimize Vector4.Lerp

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -207,9 +207,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 Lerp(Vector2 value1, Vector2 value2, float amount)
         {
-            return new Vector2(
-                value1.X + (value2.X - value1.X) * amount,
-                value1.Y + (value2.Y - value1.Y) * amount);
+            return value1 + (value2 - value1) * amount;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -232,9 +232,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount)
         {
-            Vector3 firstInfluence = value1 * (1f - amount);
-            Vector3 secondInfluence = value2 * amount;
-            return firstInfluence + secondInfluence;
+            return value1 + (value2 - value1) * amount;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -232,7 +232,9 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 Lerp(Vector3 value1, Vector3 value2, float amount)
         {
-            return value1 + (value2 - value1) * amount;
+            Vector3 firstInfluence = value1 * (1f - amount);
+            Vector3 secondInfluence = value2 * amount;
+            return firstInfluence + secondInfluence;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -209,7 +209,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector4 Lerp(Vector4 value1, Vector4 value2, float amount)
         {
-            return (value2 - value1) * new Vector4(amount) + value1;
+            return value1 + (value2 - value1) * amount;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -209,11 +209,7 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector4 Lerp(Vector4 value1, Vector4 value2, float amount)
         {
-            return new Vector4(
-                value1.X + (value2.X - value1.X) * amount,
-                value1.Y + (value2.Y - value1.Y) * amount,
-                value1.Z + (value2.Z - value1.Z) * amount,
-                value1.W + (value2.W - value1.W) * amount);
+            return (value2 - value1) * new Vector4(amount) + value1;
         }
 
         /// <summary>


### PR DESCRIPTION
### Before:
```asm
G_M10056_IG01:
       sub      rsp, 56
       vzeroupper 
       vmovaps  qword ptr [rsp+20H], xmm6
       vmovaps  qword ptr [rsp+10H], xmm7
       vmovaps  qword ptr [rsp], xmm8
G_M10056_IG02:
       vmovss   xmm0, dword ptr [rdx]
       vmovss   xmm1, dword ptr [rdx+4]
       vmovss   xmm2, dword ptr [rdx+8]
       vmovss   xmm4, dword ptr [rdx+12]
       vmovss   xmm5, dword ptr [r8]
       vmovss   xmm6, dword ptr [r8+4]
       vmovss   xmm7, dword ptr [r8+8]
       vmovss   xmm8, dword ptr [r8+12]
       vsubss   xmm5, xmm5, xmm0
       vmulss   xmm5, xmm5, xmm3
       vaddss   xmm0, xmm5, xmm0
       vsubss   xmm5, xmm6, xmm1
       vmulss   xmm5, xmm5, xmm3
       vaddss   xmm1, xmm5, xmm1
       vsubss   xmm5, xmm7, xmm2
       vmulss   xmm5, xmm5, xmm3
       vaddss   xmm2, xmm5, xmm2
       vsubss   xmm5, xmm8, xmm4
       vmulss   xmm3, xmm5, xmm3
       vaddss   xmm3, xmm3, xmm4
       vxorps   xmm4, xmm4
       vmovss   xmm4, xmm4, xmm3
       vpslldq  xmm4, 4
       vmovss   xmm4, xmm4, xmm2
       vpslldq  xmm4, 4
       vmovss   xmm4, xmm4, xmm1
       vpslldq  xmm4, 4
       vmovss   xmm4, xmm4, xmm0
       vmovaps  xmm0, xmm4
       vmovupd  xmmword ptr [rcx], xmm0
       mov      rax, rcx
G_M10056_IG03:
       vmovaps  xmm6, qword ptr [rsp+20H]
       vmovaps  xmm7, qword ptr [rsp+10H]
       vmovaps  xmm8, qword ptr [rsp]
       add      rsp, 56
       ret      
; Total bytes of code: 182
```
### After:
```asm
       vzeroupper 
G_M18874_IG02:
       vmovupd  xmm0, xmmword ptr [r8]
       vmovupd  xmm1, xmmword ptr [rdx]
       vsubps   xmm0, xmm1
       vbroadcastss xmm3, xmm3
       vmulps   xmm0, xmm3
       vaddps   xmm0, xmm1, xmm0
       vmovupd  xmmword ptr [rcx], xmm0
       mov      rax, rcx
G_M18874_IG03:
       ret
```
