### PR TITLE
Migrating libraries props into both iOS and Android test runner workflow

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -164,7 +164,6 @@
              AssemblyFile="$(ArtifactsObjDir)mono\AppleAppBuilder\$(HostArch)\$(Configuration)\AppleAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'iOS'" Name="BundleTestAppleApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
-      <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\runtimes\ios-$(TargetArchitecture)</RuntimePackDir>
       <BundleDir>$(OutDir)\Bundle</BundleDir>
       <AppleTestRunner>$(RepoRoot)\src\mono\msbuild\AppleTestRunner\bin</AppleTestRunner>
     </PropertyGroup>
@@ -175,14 +174,14 @@
     <ItemGroup>
       <TestBinaries Include="$(OutDir)\*.*"/>
       <AppleTestRunnerBinaries Include="$(AppleTestRunner)\*.*" />
-      <BclBinaries Include="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.*" Exclude="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\System.Runtime.WindowsRuntime.dll" />
-      <BclBinaries Include="$(RuntimePackDir)\native\*.*" Exclude="$(RuntimePackDir)\native\libmono.dylib" /> <!-- we use static libmono.a -->
+      <BclBinaries Include="$(NETCoreAppRuntimePackLibPath)\*.*" Exclude="$(NETCoreAppRuntimePackLibPath)\System.Runtime.WindowsRuntime.dll" />
+      <BclBinaries Include="$(NETCoreAppRuntimePackNativePath)\*.*" Exclude="$(NETCoreAppRuntimePackNativePath)\libmono.dylib" /> <!-- we use static libmono.a -->
       
       <!-- remove PDBs to save some space until we integrate ILLink -->
-      <BclBinaries Remove="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.pdb" />
+      <BclBinaries Remove="$(NETCoreAppRuntimePackLibPath)\*.pdb" />
     </ItemGroup>
     <Error Condition="!Exists('$(AppleTestRunner)')" Text="AppleTestRunner=$(AppleTestRunner) doesn't exist" />
-    <Error Condition="!Exists('$(RuntimePackDir)')" Text="RuntimePackDir=$(RuntimePackDir) doesn't exist" />
+    <Error Condition="!Exists('$(NETCoreAppRuntimePackRIDPath)')" Text="NETCoreAppRuntimePackRIDPath=$(NETCoreAppRuntimePackRIDPath) doesn't exist" />
     <RemoveDir Directories="$(BundleDir)" />
     <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
@@ -194,15 +193,15 @@
     <AppleAppBuilderTask 
         Arch="$(TargetArchitecture)"
         ProjectName="$(AssemblyName)"
-        MonoRuntimeHeaders="$(RuntimePackDir)\native\include\mono-2.0"
-        CrossCompiler="$(RuntimePackDir)\native\cross\mono-aot-cross"
+        MonoRuntimeHeaders="$(NETCoreAppRuntimePackNativePath)\include\mono-2.0"
+        CrossCompiler="$(NETCoreAppRuntimePackNativePath)\cross\mono-aot-cross"
         MainLibraryFileName="AppleTestRunner.dll"
         UseConsoleUITemplate="True"
         GenerateXcodeProject="True"
         BuildAppBundle="True"
         Optimized="True"
         UseLlvm="$(MonoEnableLLVM)"
-        LlvmPath="$(RuntimePackDir)\native\cross"
+        LlvmPath="$(NETCoreAppRuntimePackNativePath)\cross"
         DevTeamProvisioning="$(DevTeamProvisioning)"
         OutputDirectory="$(BundleDir)"
         AppDir="$(BundleDir)">

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -102,7 +102,6 @@
              AssemblyFile="$(ArtifactsObjDir)mono\AndroidAppBuilder\$(HostArch)\$(Configuration)\AndroidAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'Android'" Name="BundleTestAndroidApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
-      <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\runtimes\android-$(TargetArchitecture)</RuntimePackDir>
       <BundleDir>$(OutDir)\Bundle</BundleDir>
       <AndroidTestRunner>$(RepoRoot)\src\mono\msbuild\AndroidTestRunner\bin</AndroidTestRunner>
       <AndroidAbi Condition="'$(TargetArchitecture)'=='arm64'">arm64-v8a</AndroidAbi>
@@ -117,17 +116,17 @@
     <ItemGroup>
       <TestBinaries Include="$(OutDir)\*.*"/>
       <AndroidTestRunnerBinaries Include="$(AndroidTestRunner)\*.*" />
-      <BclBinaries Include="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.*" 
-                   Exclude="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\System.Runtime.WindowsRuntime.dll" />
-      <BclBinaries Include="$(RuntimePackDir)\native\*.*" Exclude="$(RuntimePackDir)\native\libmono.dylib" />
+      <BclBinaries Include="$(NETCoreAppRuntimePackLibPath)\*.*"
+                   Exclude="$(NETCoreAppRuntimePackLibPath)\System.Runtime.WindowsRuntime.dll" />
+      <BclBinaries Include="$(NETCoreAppRuntimePackNativePath)\*.*" Exclude="$(NETCoreAppRuntimePackNativePath)\libmono.dylib" />
       
       <!-- remove PDBs and DBGs to save some space until we integrate ILLink -->
-      <BclBinaries Remove="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.pdb" />
-      <BclBinaries Remove="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.dbg" />
+      <BclBinaries Remove="$(NETCoreAppRuntimePackLibPath)\*.pdb" />
+      <BclBinaries Remove="$(NETCoreAppRuntimePackLibPath)\*.dbg" />
     </ItemGroup>
 
     <Error Condition="!Exists('$(AndroidTestRunner)')" Text="AndroidTestRunner=$(AndroidTestRunner) doesn't exist" />
-    <Error Condition="!Exists('$(RuntimePackDir)')" Text="RuntimePackDir=$(RuntimePackDir) doesn't exist" />
+    <Error Condition="!Exists('$(NETCoreAppRuntimePackRIDPath)')" Text="NETCoreAppRuntimePackRIDPath=$(NETCoreAppRuntimePackRIDPath) doesn't exist" />
     <RemoveDir Directories="$(BundleDir)" />
     <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(AndroidTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
@@ -146,7 +145,7 @@
     <AndroidAppBuilderTask 
         Abi="$(AndroidAbi)"
         ProjectName="$(AssemblyName)"
-        MonoRuntimeHeaders="$(RuntimePackDir)\native\include\mono-2.0"
+        MonoRuntimeHeaders="$(NETCoreAppRuntimePackNativePath)\include\mono-2.0"
         MainLibraryFileName="AndroidTestRunner.dll"
         OutputDir="$(BundleDir)"
         SourceDir="$(BundleDir)">

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -273,8 +273,9 @@
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
 
     <NETCoreAppRuntimePackPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'lib-runtime-packs'))</NETCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackLibPath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackPath)', 'runtimes', '$(PackageRID)', 'lib', '$(NETCoreAppFramework)'))</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackPath)', 'runtimes', '$(PackageRID)', 'native'))</NETCoreAppRuntimePackNativePath>
+    <NETCoreAppRuntimePackRIDPath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackPath)', 'runtimes', '$(PackageRID)'))</NETCoreAppRuntimePackRIDPath>
+    <NETCoreAppRuntimePackLibPath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackRIDPath)' 'lib', '$(NETCoreAppFramework)'))</NETCoreAppRuntimePackLibPath>
+    <NETCoreAppRuntimePackNativePath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackRIDPath)', 'native'))</NETCoreAppRuntimePackNativePath>
     <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -926,7 +926,6 @@
 
   <Import Project="Directory.Build.targets" />
 
-
   <Target Name="BuildAppleAppBuilder">
     <MSBuild Projects="$(MonoProjectRoot)msbuild\AppleAppBuilder\AppleAppBuilder.csproj"
              Properties="Configuration=$(Configuration);Platform=$(HostArch)"


### PR DESCRIPTION
This PR targets "Migrate existing props and targets into the libraries test build flow" in #35123.

The changes are primarily simplifying hard-coded paths to the `lib-runtime-packs` `native` and `lib` sub-directories by extending runtime pack path properties.