### PR TITLE
Move FreeBSD builds to DncEng Pool provider builds

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -97,6 +97,16 @@ jobs:
           name: NetCoreInternal-Pool
           queue: BuildPool.Ubuntu.1604.Amd64
 
+        # Public FreeBSD Build Pool
+        ${{ if and(eq(parameters.osGroup, 'FreeBSD_x64'), eq(variables['System.TeamProject'], 'public')) }}:
+          name:  NetCorePublic-Pool
+          queue: BuildPool.Ubuntu.1604.Amd64.Open
+
+        # Official FreeBSD Build Pool
+        ${{ if and(eq(parameters.osGroup, 'FreeBSD_x64'), ne(variables['System.TeamProject'], 'public')) }}:
+          name: NetCoreInternal-Pool
+          queue: BuildPool.Ubuntu.1604.Amd64
+
         # Public OSX Build Pool
         ${{ if eq(parameters.osGroup, 'OSX') }}:
           vmImage: 'macOS-10.14'

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -88,22 +88,12 @@ jobs:
     ${{ if eq(parameters.jobParameters.pool, '') }}:
       pool:
         # Public Linux Build Pool
-        ${{ if and(eq(parameters.osGroup, 'Linux'), eq(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD_x64'), eq(variables['System.TeamProject'], 'public')) }}:
           name:  NetCorePublic-Pool
           queue: BuildPool.Ubuntu.1604.Amd64.Open
 
         # Official Build Linux Pool
-        ${{ if and(eq(parameters.osGroup, 'Linux'), ne(variables['System.TeamProject'], 'public')) }}:
-          name: NetCoreInternal-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64
-
-        # Public FreeBSD Build Pool
-        ${{ if and(eq(parameters.osGroup, 'FreeBSD_x64'), eq(variables['System.TeamProject'], 'public')) }}:
-          name:  NetCorePublic-Pool
-          queue: BuildPool.Ubuntu.1604.Amd64.Open
-
-        # Official FreeBSD Build Pool
-        ${{ if and(eq(parameters.osGroup, 'FreeBSD_x64'), ne(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD_x64'), ne(variables['System.TeamProject'], 'public')) }}:
           name: NetCoreInternal-Pool
           queue: BuildPool.Ubuntu.1604.Amd64
 

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -88,12 +88,12 @@ jobs:
     ${{ if eq(parameters.jobParameters.pool, '') }}:
       pool:
         # Public Linux Build Pool
-        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD_x64'), eq(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD'), eq(variables['System.TeamProject'], 'public')) }}:
           name:  NetCorePublic-Pool
           queue: BuildPool.Ubuntu.1604.Amd64.Open
 
         # Official Build Linux Pool
-        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD_x64'), ne(variables['System.TeamProject'], 'public')) }}:
+        ${{ if and(in(parameters.osGroup, 'Linux', 'FreeBSD'), ne(variables['System.TeamProject'], 'public')) }}:
           name: NetCoreInternal-Pool
           queue: BuildPool.Ubuntu.1604.Amd64
 


### PR DESCRIPTION
From chatting with @wfurt it seems FreeBSD's [very-large docker images are filling up the disk](https://dev.azure.com/dnceng/public/_build/results?buildId=618060&view=logs&jobId=dd0b2759-5918-5f16-563d-5e53487f9810&j=dd0b2759-5918-5f16-563d-5e53487f9810&t=4d22f787-eee9-50d3-a257-5cb17b9a6e23).