### PR TITLE
enable package Testing for Runtime.CompilerServices.Unsafe

### DIFF
--- a/src/libraries/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
+++ b/src/libraries/pkg/test/frameworkSettings/netcoreapp5.0/settings.targets
@@ -8,9 +8,4 @@
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WPF" />
     <KnownFrameworkReference Remove="Microsoft.WindowsDesktop.App.WindowsForms" />
   </ItemGroup>
-
-  <!-- This should be removed after the sdk contains the 5.0.0.0 assembly version of this assembly. -->
-  <ItemGroup>
-    <IgnoredReference Include="System.Runtime.CompilerServices.Unsafe" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31697

```
dotnet msbuild src\libraries\pkg\test\testPackages.proj /t:Build /p:TestPackages=System.Runtime.CompilerServices.Unsafe
```

Console Output
```
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp1.0
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp3.0 RID=win7-x86
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=win7-x86
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=win7-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=centos.7-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=linuxmint.17-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=debian.8-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=rhel.7.2-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=ubuntu.14.04-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=ubuntu.16.04-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=osx.10.12-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=fedora.24-x64
    Testing System.Runtime.CompilerServices.Unsafe TFM=netcoreapp5.0 RID=opensuse.42
```