### PR TITLE
Remove workaround PreserveDependency in System.Data.Common

### DIFF
--- a/src/libraries/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/libraries/System.Data.Common/src/System.Data.Common.csproj
@@ -294,8 +294,6 @@
     <Compile Include="System\Data\SQLTypes\SQLBytes.cs" />
     <Compile Include="System\Data\ProviderBase\DataReaderContainer.cs" />
     <Compile Include="System\Data\ProviderBase\SchemaMapping.cs" />
-    <Compile Include="$(CommonPath)System\Runtime\CompilerServices\PreserveDependencyAttribute.cs"
-             Link="Common\System\Runtime\CompilerServices\PreserveDependencyAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.Data.Common/src/System/Data/DataColumn.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataColumn.cs
@@ -475,9 +475,7 @@ namespace System.Data
         [TypeConverter(typeof(ColumnTypeConverter))]
         public Type DataType
         {
-            [PreserveDependency(".ctor", "System.Data.ColumnTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             get { return _dataType; }
-            [PreserveDependency(".ctor", "System.Data.ColumnTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             set
             {
                 if (_dataType != value)
@@ -641,7 +639,6 @@ namespace System.Data
         [TypeConverter(typeof(DefaultValueTypeConverter))]
         public object DefaultValue
         {
-            [PreserveDependency(".ctor", "System.Data.DefaultValueTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             get
             {
                 Debug.Assert(_defaultValue != null, "It should not have been set to null.");
@@ -668,7 +665,6 @@ namespace System.Data
 
                 return _defaultValue;
             }
-            [PreserveDependency(".ctor", "System.Data.DefaultValueTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             set
             {
                 DataCommonEventSource.Log.Trace("<ds.DataColumn.set_DefaultValue|API> {0}", ObjectID);

--- a/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataTable.cs
@@ -1593,7 +1593,6 @@ namespace System.Data
         [TypeConverter(typeof(PrimaryKeyTypeConverter))]
         public DataColumn[] PrimaryKey
         {
-            [PreserveDependency(".ctor", "System.Data.PrimaryKeyTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             get
             {
                 UniqueConstraint primayKeyConstraint = _primaryKey;
@@ -1604,7 +1603,6 @@ namespace System.Data
                 }
                 return Array.Empty<DataColumn>();
             }
-            [PreserveDependency(".ctor", "System.Data.DefaultValueTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             set
             {
                 UniqueConstraint key = null;

--- a/src/libraries/System.Data.Common/src/System/Data/DataView.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataView.cs
@@ -476,9 +476,7 @@ namespace System.Data
         [RefreshProperties(RefreshProperties.All)]
         public DataTable Table
         {
-            [PreserveDependency(".ctor", "System.Data.DataTableTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             get { return _table; }
-            [PreserveDependency(".ctor", "System.Data.DataTableTypeConverter")] // TODO: Remove when https://github.com/mono/linker/issues/800 is fixed
             set
             {
                 DataCommonEventSource.Log.Trace("<ds.DataView.set_Table|API> {0}, {1}", ObjectID, (value != null) ? value.ObjectID : 0);


### PR DESCRIPTION
https://github.com/mono/linker/issues/800 has been fixed. So we can remove these attributes now.