### PR TITLE
Struct Improvements

### DIFF
--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1960,15 +1960,22 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
             if (varTypeIsSIMD(targetType))
             {
-                assert(targetType == TYP_SIMD16);
                 if (targetReg != REG_NA)
                 {
-                    emit->emitIns_R_I(INS_movi, EA_16BYTE, targetReg, 0x00, INS_OPTS_16B);
+                    emit->emitIns_R_I(INS_movi, emitActualTypeSize(targetType), targetReg, 0x00, INS_OPTS_16B);
                     genProduceReg(tree);
                 }
                 else
                 {
-                    GetEmitter()->emitIns_S_S_R_R(INS_stp, EA_8BYTE, EA_8BYTE, REG_ZR, REG_ZR, varNum, 0);
+                    if (targetType == TYP_SIMD16)
+                    {
+                        GetEmitter()->emitIns_S_S_R_R(INS_stp, EA_8BYTE, EA_8BYTE, REG_ZR, REG_ZR, varNum, 0);
+                    }
+                    else
+                    {
+                        assert(targetType == TYP_SIMD8);
+                        GetEmitter()->emitIns_S_R(INS_str, EA_8BYTE, REG_ZR, varNum, 0);
+                    }
                     genUpdateLife(tree);
                 }
                 return;

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1953,17 +1953,24 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
         genConsumeRegs(data);
 
         regNumber dataReg = REG_NA;
-        if (data->isContainedIntOrIImmed())
+        if (data->isContained())
         {
             // This is only possible for a zero-init.
-            assert(data->IsIntegralConst(0));
+            assert(data->IsIntegralConst(0) || data->IsSIMDZero());
 
             if (varTypeIsSIMD(targetType))
             {
                 assert(targetType == TYP_SIMD16);
-                assert(targetReg != REG_NA);
-                emit->emitIns_R_I(INS_movi, EA_16BYTE, targetReg, 0x00, INS_OPTS_16B);
-                genProduceReg(tree);
+                if (targetReg != REG_NA)
+                {
+                    emit->emitIns_R_I(INS_movi, EA_16BYTE, targetReg, 0x00, INS_OPTS_16B);
+                    genProduceReg(tree);
+                }
+                else
+                {
+                    GetEmitter()->emitIns_S_S_R_R(INS_stp, EA_8BYTE, EA_8BYTE, REG_ZR, REG_ZR, varNum, 0);
+                    genUpdateLife(tree);
+                }
                 return;
             }
 
@@ -5019,7 +5026,20 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
     }
 
     GenTree* op1 = treeNode->AsOp()->gtOp1;
-    assert(!op1->isContained());
+
+    if (op1->isContained())
+    {
+        // This is only possible for a zero-init.
+        assert(op1->IsIntegralConst(0) || op1->IsSIMDZero());
+
+        // store lower 8 bytes
+        GetEmitter()->emitIns_S_R(ins_Store(TYP_DOUBLE), EA_8BYTE, REG_ZR, varNum, offs);
+
+        // Store upper 4 bytes
+        GetEmitter()->emitIns_S_R(ins_Store(TYP_FLOAT), EA_4BYTE, REG_ZR, varNum, offs + 8);
+
+        return;
+    }
     regNumber operandReg = genConsumeReg(op1);
 
     // Need an addtional integer register to extract upper 4 bytes from data.

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1447,7 +1447,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
 #ifdef FEATURE_SIMD
             // (In)Equality operation that produces bool result, when compared
             // against Vector zero, marks its Vector Zero operand as contained.
-            assert(tree->OperIsLeaf() || tree->IsIntegralConstVector(0));
+            assert(tree->OperIsLeaf() || tree->IsSIMDZero());
 #else
             assert(tree->OperIsLeaf());
 #endif

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -4676,17 +4676,6 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
             genStoreLclTypeSIMD12(tree);
             return;
         }
-
-        // TODO-CQ: It would be better to simply contain the zero, rather than
-        // generating zero into a register.
-        if (varTypeIsSIMD(targetType) && (targetReg != REG_NA) && op1->IsCnsIntOrI())
-        {
-            // This is only possible for a zero-init.
-            noway_assert(op1->IsIntegralConst(0));
-            genSIMDZero(targetType, varDsc->lvBaseType, targetReg);
-            genProduceReg(tree);
-            return;
-        }
 #endif // FEATURE_SIMD
 
         genConsumeRegs(op1);

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3498,10 +3498,12 @@ public:
 
         // We make local variable SIMD12 types 16 bytes instead of just 12. lvSize()
         // already does this calculation. However, we also need to prevent mapping types if the var is a
-        // dependently promoted struct field, which must remain its exact size within its parent struct.
+        // dependently promoted struct field, which must remain its exact size within its parent struct,
+        // unless it is the only field.
         // However, we don't know this until late, so we may have already pretended the field is bigger
         // before that.
-        if ((varDsc->lvSize() == 16) && !lvaIsFieldOfDependentlyPromotedStruct(varDsc))
+        if ((varDsc->lvSize() == 16) &&
+            (!lvaIsFieldOfDependentlyPromotedStruct(varDsc) || (lvaGetDesc(varDsc->lvParentLcl)->lvFieldCnt == 1)))
         {
             return true;
         }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3498,12 +3498,10 @@ public:
 
         // We make local variable SIMD12 types 16 bytes instead of just 12. lvSize()
         // already does this calculation. However, we also need to prevent mapping types if the var is a
-        // dependently promoted struct field, which must remain its exact size within its parent struct,
-        // unless it is the only field.
+        // dependently promoted struct field, which must remain its exact size within its parent struct.
         // However, we don't know this until late, so we may have already pretended the field is bigger
         // before that.
-        if ((varDsc->lvSize() == 16) &&
-            (!lvaIsFieldOfDependentlyPromotedStruct(varDsc) || (lvaGetDesc(varDsc->lvParentLcl)->lvFieldCnt == 1)))
+        if ((varDsc->lvSize() == 16) && !lvaIsFieldOfDependentlyPromotedStruct(varDsc))
         {
             return true;
         }

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -1646,6 +1646,7 @@ public:
     inline bool IsFPZero();
     inline bool IsIntegralConst(ssize_t constVal);
     inline bool IsIntegralConstVector(ssize_t constVal);
+    inline bool IsSIMDZero();
 
     inline bool IsBoxedValue();
 
@@ -6764,6 +6765,25 @@ inline bool GenTree::IsIntegralConstVector(ssize_t constVal)
         assert(varTypeIsIntegral(AsSIMD()->gtSIMDBaseType));
         assert(gtGetOp2IfPresent() == nullptr);
         return true;
+    }
+#endif
+
+    return false;
+}
+
+//-------------------------------------------------------------------
+// IsSIMDZero: returns true if this this is a SIMD vector
+// with all its elements equal to zero.
+//
+// Returns:
+//     True if this represents an integral const SIMD vector.
+//
+inline bool GenTree::IsSIMDZero()
+{
+#ifdef FEATURE_SIMD
+    if ((gtOper == GT_SIMD) && (AsSIMD()->gtSIMDIntrinsicID == SIMDIntrinsicInit))
+    {
+        return (gtGetOp1()->IsIntegralConst(0) || gtGetOp1()->IsFPZero());
     }
 #endif
 

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -730,13 +730,20 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc)
             return;
         }
     }
+
+    const LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
+
 #ifdef FEATURE_SIMD
     if (varTypeIsSIMD(storeLoc))
     {
-        if (op1->IsIntegralConst(0))
+        // If this is a store to memory, we can initialize a zero vector in memory from REG_ZR.
+        if ((op1->IsIntegralConst(0) || op1->IsSIMDZero()) && varDsc->lvDoNotEnregister)
         {
-            // For an InitBlk we want op1 to be contained
             MakeSrcContained(storeLoc, op1);
+            if (op1->IsSIMDZero())
+            {
+                MakeSrcContained(op1, op1->gtGetOp1());
+            }
         }
         return;
     }
@@ -745,8 +752,7 @@ void Lowering::ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc)
     // If the source is a containable immediate, make it contained, unless it is
     // an int-size or larger store of zero to memory, because we can generate smaller code
     // by zeroing a register and then storing it.
-    const LclVarDsc* varDsc = comp->lvaGetDesc(storeLoc);
-    var_types        type   = varDsc->GetRegisterType(storeLoc);
+    var_types type = varDsc->GetRegisterType(storeLoc);
     if (IsContainableImmed(storeLoc, op1) && (!op1->IsIntegralConst(0) || varTypeIsSmall(type)))
     {
         MakeSrcContained(storeLoc, op1);

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3113,7 +3113,20 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
 #endif // !TARGET_64BIT
     else if (op1->isContained())
     {
-        srcCount = 0;
+#ifdef TARGET_XARCH
+        if (varTypeIsSIMD(storeLoc))
+        {
+            // This is the zero-init case, and we need a register to hold the zero.
+            // (On Arm64 we can just store REG_ZR.)
+            assert(op1->IsSIMDZero());
+            singleUseRef = BuildUse(op1->gtGetOp1());
+            srcCount     = 1;
+        }
+        else
+#endif
+        {
+            srcCount = 0;
+        }
     }
     else
     {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -17431,7 +17431,8 @@ void Compiler::fgMorphLocalField(GenTree* tree, GenTree* parent)
 
             var_types treeType  = tree->TypeGet();
             var_types fieldType = fldVarDsc->TypeGet();
-            if (fldOffset != BAD_VAR_NUM && (genTypeSize(fieldType) == genTypeSize(treeType)))
+            if (fldOffset != BAD_VAR_NUM &&
+                ((genTypeSize(fieldType) == genTypeSize(treeType)) || (varDsc->lvFieldCnt == 1)))
             {
                 // There is an existing sub-field we can use.
                 tree->AsLclFld()->SetLclNum(fieldLclIndex);


### PR DESCRIPTION
- Allow expanding SIMD12 field to 16 bytes if it is the only field.
- Similarly, if we have a struct with a single field we can reference it as the full size of the struct.
- Eliminate old code for an integer zero RHS with a SIMD12 LHS, and unify the codegen for zero-init for SIMD12 (between block init and assignment of SIMD init of 0)