### PR TITLE
Further tuning of the CORE_ROOT folder content

### DIFF
--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -29,11 +29,11 @@
       <RunTimeDependencyCopyLocalFile Include="@(AllResolvedRuntimeDependencies)"  Exclude="@(RunTimeDependencyExcludeFiles)"/>
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
-      
+    </ItemGroup>
+
+    <ItemGroup>
       <RunTimeArtifactsExcludeFiles Include="PDB/createdump.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/dbgshim.pdb" />
-      <RunTimeArtifactsExcludeFiles Include="PDB/ilasm.pdb" />
-      <RunTimeArtifactsExcludeFiles Include="PDB/ildasm.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/linuxonjit.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/mcs.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/mscordaccore.pdb" />
@@ -44,13 +44,34 @@
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-collector.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-counter.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-simple.pdb" />
-      
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(MinimalCoreRoot)' == 'true'">
+      <RunTimeArtifactsExcludeFiles Include="PDB/ilasm.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/ildasm.pdb" />
+    </ItemGroup>
+
+    <ItemGroup>
       <RunTimeArtifactsIncludeFolders Include="/" />
+
+      <!-- Used by the Crossgen comparison job -->
       <RunTimeArtifactsIncludeFolders Include="IL/" />
+
+      <!-- Used for Crossgen2 R2R tests -->
       <RunTimeArtifactsIncludeFolders Include="crossgen2/" />
+
+      <!-- Used for capturing symbolic stack traces using Watson -->
       <RunTimeArtifactsIncludeFolders Include="PDB/" />
+
+      <!-- Used by the coreroot_determinism test -->
       <RunTimeArtifactsIncludeFolders Include="R2RTest/" />
 
+      <!-- Used for ARM / ARM64 cross-compilation -->
+      <RunTimeArtifactsIncludeFolders Include="x86/" />
+      <RunTimeArtifactsIncludeFolders Include="x64/" />
+    </ItemGroup>
+
+    <ItemGroup>
       <!-- Add binary dependencies to copy-local items -->
       <RunTimeDependencyCopyLocal
           Include="$(CoreCLRArtifactsPath)%(RunTimeArtifactsIncludeFolders.Identity)*"

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -36,6 +36,9 @@
       <RunTimeArtifactsExcludeFiles Include="PDB/ildasm.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/linuxonjit.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/mcs.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mscordaccore.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mscordbi.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mscorrc.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/protononjit.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-collector.pdb" />

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -65,10 +65,6 @@
 
       <!-- Used by the coreroot_determinism test -->
       <RunTimeArtifactsIncludeFolders Include="R2RTest/" />
-
-      <!-- Used for ARM / ARM64 cross-compilation -->
-      <RunTimeArtifactsIncludeFolders Include="x86/" />
-      <RunTimeArtifactsIncludeFolders Include="x64/" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -30,19 +30,14 @@
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
       
-      <RunTimeArtifactsExcludeFiles Include="protononjit.dll" />
-      <RunTimeArtifactsExcludeFiles Include="linuxonjit.dll" />
-      
       <RunTimeArtifactsIncludeFolders Include="/" />
       <RunTimeArtifactsIncludeFolders Include="IL/" />
       <RunTimeArtifactsIncludeFolders Include="crossgen2/" />
-      <RunTimeArtifactsIncludeFolders Include="PDB/" />
       <RunTimeArtifactsIncludeFolders Include="R2RTest/" />
 
       <!-- Add binary dependencies to copy-local items -->
       <RunTimeDependencyCopyLocal
           Include="$(CoreCLRArtifactsPath)%(RunTimeArtifactsIncludeFolders.Identity)*"
-          Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)%(Identity)')"
           TargetDir="%(RunTimeArtifactsIncludeFolders.Identity)" />
     </ItemGroup>
 

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -30,14 +30,31 @@
       <RunTimeDependencyCopyLocal Include="@(RunTimeDependencyCopyLocalFile -> '%(File)')"  />
       <RunTimeDependencyCopyLocal Include="$(TargetingPackPath)/*" />
       
+      <RunTimeArtifactsExcludeFiles Include="PDB/createdump.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/dbgshim.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/ilasm.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/ildasm.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/linuxonjit.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mcs.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mscordaccore.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mscordbi.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/mscorrc.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/protononjit.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/superpmi.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-collector.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-counter.pdb" />
+      <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-simple.pdb" />
+      
       <RunTimeArtifactsIncludeFolders Include="/" />
       <RunTimeArtifactsIncludeFolders Include="IL/" />
       <RunTimeArtifactsIncludeFolders Include="crossgen2/" />
+      <RunTimeArtifactsIncludeFolders Include="PDB/" />
       <RunTimeArtifactsIncludeFolders Include="R2RTest/" />
 
       <!-- Add binary dependencies to copy-local items -->
       <RunTimeDependencyCopyLocal
           Include="$(CoreCLRArtifactsPath)%(RunTimeArtifactsIncludeFolders.Identity)*"
+          Exclude="@(RunTimeArtifactsExcludeFiles -> '$(CoreCLRArtifactsPath)%(Identity)')"
           TargetDir="%(RunTimeArtifactsIncludeFolders.Identity)" />
     </ItemGroup>
 

--- a/src/coreclr/tests/src/Common/Directory.Build.targets
+++ b/src/coreclr/tests/src/Common/Directory.Build.targets
@@ -36,9 +36,6 @@
       <RunTimeArtifactsExcludeFiles Include="PDB/ildasm.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/linuxonjit.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/mcs.pdb" />
-      <RunTimeArtifactsExcludeFiles Include="PDB/mscordaccore.pdb" />
-      <RunTimeArtifactsExcludeFiles Include="PDB/mscordbi.pdb" />
-      <RunTimeArtifactsExcludeFiles Include="PDB/mscorrc.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/protononjit.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi.pdb" />
       <RunTimeArtifactsExcludeFiles Include="PDB/superpmi-shim-collector.pdb" />


### PR DESCRIPTION
Based on Sergey's feedback I'm putting back the alternate JITs
(linuxonjit, protononjit) as they are actively used by the JIT team
in specialized scenarios. I have also removed the PDB subfolder -
while we can have an orthogonal discussion what PDB's we may want
to make available to test runs in Helix, the current subfolder has
no value and was only present due to the pre-existing trivial script
logic blindly copying over the entire binary artifact subtree.

Thanks

Tomas