### PR TITLE
JIT: fixes for EH Write Thru and OSR

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -3851,7 +3851,7 @@ void CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg, bool* pXtraRegClobbere
 #endif // !TARGET_64BIT
         {
             // If this arg is never on the stack, go to the next one.
-            if (!regArgTab[argNum].stackArg)
+            if (!regArgTab[argNum].stackArg && !regArgTab[argNum].writeThru)
             {
                 continue;
             }

--- a/src/coreclr/src/jit/patchpoint.cpp
+++ b/src/coreclr/src/jit/patchpoint.cpp
@@ -24,20 +24,17 @@
 //
 //   * no patchpoints in handler regions
 //   * no patchpoints for localloc methods
-//   * no patchpoints in try regions (workaround)
 //   * no patchpoints for synchronized methods (workaround)
 //
 class PatchpointTransformer
 {
-    unsigned  ppCounterLclNum;
     const int HIGH_PROBABILITY = 99;
+    unsigned  ppCounterLclNum;
     Compiler* compiler;
 
 public:
-    PatchpointTransformer(Compiler* compiler) : compiler(compiler)
+    PatchpointTransformer(Compiler* compiler) : ppCounterLclNum(BAD_VAR_NUM), compiler(compiler)
     {
-        ppCounterLclNum                            = compiler->lvaGrabTemp(true DEBUGARG("patchpoint counter"));
-        compiler->lvaTable[ppCounterLclNum].lvType = TYP_INT;
     }
 
     //------------------------------------------------------------------------
@@ -53,11 +50,8 @@ public:
             compiler->fgEnsureFirstBBisScratch();
         }
 
-        BasicBlock* block = compiler->fgFirstBB;
-        TransformEntry(block);
-
         int count = 0;
-        for (block = block->bbNext; block != nullptr; block = block->bbNext)
+        for (BasicBlock* block = compiler->fgFirstBB->bbNext; block != nullptr; block = block->bbNext)
         {
             if (block->bbFlags & BBF_PATCHPOINT)
             {
@@ -119,6 +113,16 @@ private:
     //
     void TransformBlock(BasicBlock* block)
     {
+        // If we haven't allocated the counter temp yet, set it up
+        if (ppCounterLclNum == BAD_VAR_NUM)
+        {
+            ppCounterLclNum                            = compiler->lvaGrabTemp(true DEBUGARG("patchpoint counter"));
+            compiler->lvaTable[ppCounterLclNum].lvType = TYP_INT;
+
+            // and initialize in the entry block
+            TransformEntry(compiler->fgFirstBB);
+        }
+
         // Capture the IL offset
         IL_OFFSET ilOffset = block->bbCodeOffs;
         assert(ilOffset != BAD_IL_OFFSET);


### PR DESCRIPTION
For EH Write Thru: make sure to initialize the stack home for any EH live
register parameters. Fixes some runtime errors.

For OSR: don't allocate the patchpoint counter local until we're going to
transform a patchpoint. Fixes a post-phase assert.