### PR TITLE
fix build.ps1 script execution error on cmd due to whitespace

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,5 +4,5 @@ setlocal
 set _args=%*
 if "%~1"=="-?" set _args=-help
 
-powershell -ExecutionPolicy ByPass -NoProfile -Command "%~dp0eng\build.ps1" %_args%
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\build.ps1'" %_args%
 exit /b %ERRORLEVEL%


### PR DESCRIPTION
`build.cmd` unable to execute on command prompt due to white space issue in the file path.

Powershell doesn’t natively support a parameter for a script to run.  The default command-line argument is “-command,” which defines the command as though you had typed it at the prompt.
Now although, `"%~dp0eng\build.ps1"`is quoted in a double quote but it is treated as a string and will not be executed. I found a bug with the code in a [file](https://github.com/dotnet/runtime/blob/master/build.cmd) due to the mentioned issue.

The call operator (`&`) allows you to execute a command, script, or function, I made PR for the bug fix.

[Fix #35458](https://github.com/dotnet/runtime/issues/35458)
