### PR TITLE
Fix FieldRVA handling of Field tokens

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedFieldRvaNode.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedFieldRvaNode.cs
@@ -60,11 +60,20 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             MetadataReader metadataReader = _module.MetadataReader;
             BlobReader metadataBlob = new BlobReader(_module.PEReader.GetMetadata().Pointer, _module.PEReader.GetMetadata().Length);
             metadataBlob.Offset = metadataReader.GetTableMetadataOffset(TableIndex.FieldRva);
-
+            bool compressedFieldRef = 6 == metadataReader.GetTableRowSize(TableIndex.FieldRva);
+            
             for (int i = 1; i <= metadataReader.GetTableRowCount(TableIndex.FieldRva); i++)
             {
                 int currentFieldRva = metadataBlob.ReadInt32();
-                short currentFieldRid = metadataBlob.ReadInt16();
+                int currentFieldRid;
+                if (compressedFieldRef)
+                {
+                    currentFieldRid = metadataBlob.ReadInt16();
+                }
+                else
+                {
+                    currentFieldRid = metadataBlob.ReadInt32();
+                }
                 if (currentFieldRva != _rva)
                     continue;
 


### PR DESCRIPTION
FieldRefs in the metadata tables are variable sized. We assumed the common 2 byte encoding, but if there are at least 0x10000 fields in the assembly 4 bytes are used in all tables with FieldRefs, including the FieldRva table we walk and patch.

Use row size to make sure we adjust based on the encoding, and preserve it when rewriting the metadata.

This was discovered compiling an assembly with 80,000 fields across various classes.