### PR TITLE
Remove GeneratedAssemblyInfoFile workaround

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,22 +20,10 @@
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <GeneratedAssemblyInfoFile>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(MSBuildProjectName).AssemblyInfo$(DefaultLanguageSourceExtension)'))</GeneratedAssemblyInfoFile>
-  </PropertyGroup>
-
   <!-- Language configuration -->
   <PropertyGroup>
     <!-- default to allowing all language features -->
     <LangVersion>preview</LangVersion>
     <LangVersion Condition="'$(Language)' == 'VB'">latest</LangVersion>
   </PropertyGroup>
-
-  <!--
-    All source inputs to the compiler should be generated before BeforeCompile target. Sdk is not
-    honoring this for GenerateAssemblyInfo target. https://github.com/dotnet/sdk/issues/10614 
-  -->
-  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
-  </ItemGroup>
 </Project>

--- a/src/libraries/intellisense.targets
+++ b/src/libraries/intellisense.targets
@@ -64,10 +64,6 @@
 
   <Import Project="$(MSBuildThisDirectory)targetframework.props" />
   
-  <PropertyGroup>
-    <GeneratedAssemblyInfoFile>$(IntermediateOutputPath)$(MSBuildProjectName).AssemblyInfo$(DefaultLanguageSourceExtension)</GeneratedAssemblyInfoFile>
-  </PropertyGroup>
-  
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '' and '$(TargetFrameworkVersion)' != ''">
     <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == '' and '$([System.String]::IsNullOrWhitespace($(TargetFrameworkProfile)))' != 'true'">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion),Profile=$(TargetFrameworkProfile)</TargetFrameworkMoniker>
     <TargetFrameworkMoniker Condition="'$(TargetFrameworkMoniker)' == ''">$(TargetFrameworkIdentifier),Version=$(TargetFrameworkVersion)</TargetFrameworkMoniker>


### PR DESCRIPTION
The underlying issue is fixed in the SDK.