### PR TITLE
Disable tests which require precise GC on mono

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -111,7 +111,7 @@ namespace System.IO.Tests
             }).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void NoDispose_CallsVirtualDisposeFalseArg_ThrowsDuringFlushWriteBuffer_FinalizerWontThrow()
         {
             RemoteExecutor.Invoke(() =>
@@ -185,7 +185,7 @@ namespace System.IO.Tests
             Assert.False(disposeInvoked, "Expected finalizer to have been suppressed");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public void Finalizer_CallsVirtualDispose_FalseArg()
         {
             bool disposeInvoked = false;

--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -217,7 +217,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void RunThreadLocalTest7_WeakReference()
         {
             var threadLocalWeakReferenceTest = new ThreadLocalWeakReferenceTest();


### PR DESCRIPTION
While these didn't seem to fail with jit, they do fail with interpreter.