### PR TITLE
Server and client are synchronized via TaskCompletionSource

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1636,6 +1636,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task Http2_PendingSend_SendsReset(bool waitForData)
         {
             var cts = new CancellationTokenSource();
+            var rstReceived = new TaskCompletionSource<bool>();
 
             string content = new string('*', 300);
             var stream = new CustomContent.SlowTestStream(Encoding.UTF8.GetBytes(content), null, count: 60);
@@ -1649,8 +1650,8 @@ namespace System.Net.Http.Functional.Tests
 
                     await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await client.SendAsync(request, cts.Token));
 
-                    // Delay for a bit to ensure that the RST_STREAM for the previous request is sent before the next request starts.
-                    await Task.Delay(2000);
+                    // Wait until the RST_STREAM for the previous request is received before the next request starts.
+                    await rstReceived.Task.TimeoutAfter(TimeSpan.FromSeconds(60));
 
                     // Send another request to verify that connection is still functional.
                     request = new HttpRequestMessage(HttpMethod.Get, url);
@@ -1678,7 +1679,9 @@ namespace System.Net.Http.Functional.Tests
                     frameCount++;
                  } while (frame.Type != FrameType.RstStream);
 
-                 Assert.Equal(1, frame.StreamId);
+                Assert.Equal(1, frame.StreamId);
+
+                rstReceived.SetResult(true);
 
                 frame = null;
                 (streamId, requestData) = await connection.ReadAndParseRequestHeaderAsync();


### PR DESCRIPTION
Http2_PendingSend_SendsReset test fails because client sends the second request with EndOfStream flag sooner than the server reads the last RstStream frame of the first request. This is caused by too short delay before the second request is made on the client. This PR replaces Task.Delay with a synchronization via TaskCompletionSource.

Fixes #2131 