### PR TITLE
Add zlib-dev to linux requirements

### DIFF
--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -86,9 +86,10 @@ Install the following packages for the toolchain:
 - libssl-dev
 - libkrb5-dev
 - libnuma-dev (optional, enables numa support)
+- zlib1g-dev
 
 A single line to install all packages above:
 
-    ~$ sudo apt-get install cmake llvm-9 clang-9 autoconf automake libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev
+    ~$ sudo apt-get install cmake llvm-9 clang-9 autoconf automake libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev zlib1g-dev
 
 You now have all the required components.


### PR DESCRIPTION
On Ubuntu, the build fails on missing zlib.