### PR TITLE
Improve ContinueWith perf with NotOn* options

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2967,11 +2967,11 @@ namespace System.Threading.Tasks
         // Breaks out logic for recording a cancellation request
         // This overload should only be used for promise tasks where no cancellation token
         // was supplied when the task was created.
-        internal void RecordInternalCancellationRequest(CancellationToken tokenToRecord)
+        internal void RecordInternalCancellationRequest(CancellationToken tokenToRecord, object? cancellationException)
         {
-            RecordInternalCancellationRequest();
-
             Debug.Assert((Options & (TaskCreationOptions)InternalTaskOptions.PromiseTask) != 0, "Task.RecordInternalCancellationRequest(CancellationToken) only valid for promise-style task");
+
+            RecordInternalCancellationRequest();
             Debug.Assert(m_contingentProperties!.m_cancellationToken == default);
 
             // Store the supplied cancellation token as this task's token.
@@ -2980,14 +2980,6 @@ namespace System.Threading.Tasks
             {
                 m_contingentProperties.m_cancellationToken = tokenToRecord;
             }
-        }
-
-        // Breaks out logic for recording a cancellation request
-        // This overload should only be used for promise tasks where no cancellation token
-        // was supplied when the task was created.
-        internal void RecordInternalCancellationRequest(CancellationToken tokenToRecord, object? cancellationException)
-        {
-            RecordInternalCancellationRequest(tokenToRecord);
 
             // Store the supplied cancellation exception
             if (cancellationException != null)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -3259,7 +3259,7 @@ namespace System.Threading.Tasks
                         // The continuation was unregistered and null'd out, so just skip it.
                         continue;
                     }
-                    else if (currentContinuation is StandardTaskContinuation stc)
+                    else if (currentContinuation is ContinueWithTaskContinuation stc)
                     {
                         if ((stc.m_options & TaskContinuationOptions.ExecuteSynchronously) == 0)
                         {
@@ -4197,7 +4197,7 @@ namespace System.Threading.Tasks
             Debug.Assert(!continuationTask.IsCompleted, "Did not expect continuationTask to be completed");
 
             // Create a TaskContinuation
-            TaskContinuation continuation = new StandardTaskContinuation(continuationTask, options, scheduler);
+            TaskContinuation continuation = new ContinueWithTaskContinuation(continuationTask, options, scheduler);
 
             // If cancellationToken is cancellable, then assign it.
             if (cancellationToken.CanBeCanceled)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -335,7 +335,7 @@ namespace System.Threading.Tasks
             }
             // Otherwise, the final state of this task does not match the desired
             // continuation activation criteria; cancel it to denote this.
-            else continuationTask.InternalCancel(false);
+            else continuationTask.InternalCancel();
         }
 
         internal override Delegate[]? GetDelegateContinuationsForDebugger()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -257,7 +257,7 @@ namespace System.Threading.Tasks
     }
 
     /// <summary>Provides the standard implementation of a task continuation.</summary>
-    internal class StandardTaskContinuation : TaskContinuation
+    internal sealed class ContinueWithTaskContinuation : TaskContinuation
     {
         /// <summary>The unstarted continuation task.</summary>
         internal readonly Task m_task;
@@ -270,7 +270,7 @@ namespace System.Threading.Tasks
         /// <param name="task">The task to be activated.</param>
         /// <param name="options">The continuation options.</param>
         /// <param name="scheduler">The scheduler to use for the continuation.</param>
-        internal StandardTaskContinuation(Task task, TaskContinuationOptions options, TaskScheduler scheduler)
+        internal ContinueWithTaskContinuation(Task task, TaskContinuationOptions options, TaskScheduler scheduler)
         {
             Debug.Assert(task != null, "TaskContinuation ctor: task is null");
             Debug.Assert(scheduler != null, "TaskContinuation ctor: scheduler is null");

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskContinuation.cs
@@ -333,9 +333,12 @@ namespace System.Threading.Tasks
                     }
                 }
             }
-            // Otherwise, the final state of this task does not match the desired
-            // continuation activation criteria; cancel it to denote this.
-            else continuationTask.InternalCancel();
+            else
+            {
+                // Otherwise, the final state of this task does not match the desired
+                // continuation activation criteria; cancel it to denote this.
+                continuationTask.InternalCancel();
+            }
         }
 
         internal override Delegate[]? GetDelegateContinuationsForDebugger()


### PR DESCRIPTION
This came about while looking at allocations and CPU costs in some HttpClient code.  When ContinueWith is used with TaskContinuationOptions.NotOn* options, when the antecedent task completes we compare the state of that antecedent task against the NotOn* options: if the options permit it, the continuation is queued/invoked, and if they don't, the continuation is canceled.  That cancellation then ends up being common in cases where a ContinueWith is used, for example, to log exceptions that result from a faulted task, e.g.
```C#
private static void Log(Task task) =>
    task.ContinueWith(t => Log(t.Exception),
        CancellationToken.None,
        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
        TaskScheduler.Default);
```
We can handle that cancellation much more efficiently than we are today.  Today that's resulting in us expanding the ContingentProperties inside of the task, in order to store that cancellation was requested internally, but that's not actually necessary.  It's also resulting in us doing several atomic transitions via interlockeds, but that's only necessary if the task could have transitioned in any way, which is only possible if a cancelable token is provided.

This PR removes that overhead.  It also shrinks the size of the object created by ContinueWith by a field, seals and renames it, and removes some dead code from related code paths.

|  Method |           Toolchain |     Mean |   Error |  StdDev | Ratio |  Gen 0 |  Gen 1 | Allocated |
|-------- |-------------------- |---------:|--------:|--------:|------:|-------:|-------:|----------:|
|  Cancel | \master | 140.8 ns | 0.49 ns | 0.46 ns |  1.00 | 0.0300 | 0.0010 |     192 B |
|  Cancel |     \pr | 106.4 ns | 0.95 ns | 0.79 ns |  0.76 | 0.0160 | 0.0010 |     104 B |
|         |         |          |         |         |       |        |        |           |
| Execute | \master | 157.2 ns | 0.45 ns | 0.38 ns |  1.00 | 0.0170 | 0.0010 |     112 B |
| Execute |     \pr | 156.0 ns | 0.60 ns | 0.53 ns |  0.99 | 0.0160 | 0.0010 |     104 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Runtime.CompilerServices;
using System.Threading;
using System.Threading.Tasks;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    const int Iters = 1_000_000;

    private AsyncTaskMethodBuilder[] tasks = new AsyncTaskMethodBuilder[Iters];

    [IterationSetup]
    public void Setup()
    {
        Array.Clear(tasks, 0, tasks.Length);
        for (int i = 0; i < tasks.Length; i++)
            _ = tasks[i].Task;
    }

    [Benchmark(OperationsPerInvoke = Iters)]
    public void Cancel()
    {
        for (int i = 0; i < tasks.Length; i++)
        {
            tasks[i].Task.ContinueWith(_ => { }, CancellationToken.None, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
            tasks[i].SetResult();
        }
    }

    [Benchmark(OperationsPerInvoke = Iters)]
    public void Execute()
    {
        for (int i = 0; i < tasks.Length; i++)
        {
            tasks[i].Task.ContinueWith(_ => { }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
            tasks[i].SetResult();
        }
    }
}
```

cc: @kouvel, @tarekgh 