### PR TITLE
Crossgen2: Support HVA for ARM64

### DIFF
--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -624,7 +624,7 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
             // If the argType is a struct, then check if it is an HFA
             if (varTypeIsStruct(argType))
             {
-                // hfaType is set to float, double or SIMD type if it is an HFA, otherwise TYP_UNDEF.
+                // hfaType is set to float, double, or SIMD type if it is an HFA, otherwise TYP_UNDEF
                 hfaType  = GetHfaType(typeHnd);
                 isHfaArg = varTypeIsValidHfaType(hfaType);
             }
@@ -643,9 +643,9 @@ void Compiler::lvaInitUserArgs(InitVarDscInfo* varDscInfo)
 
         if (isHfaArg)
         {
-            // We have an HFA argument, so from here on out treat the type as a float, double or vector.
-            // The orginal struct type is available by using origArgType
-            // We also update the cSlots to be the number of float/double fields in the HFA
+            // We have an HFA argument, so from here on out treat the type as a float, double, or vector.
+            // The orginal struct type is available by using origArgType.
+            // We also update the cSlots to be the number of float/double/vector fields in the HFA.
             argType = hfaType;
             varDsc->SetHfaType(hfaType);
             cSlots = varDsc->lvHfaSlots();
@@ -2614,10 +2614,11 @@ void Compiler::lvaSetStruct(unsigned varNum, CORINFO_CLASS_HANDLE typeHnd, bool 
             }
 #endif // FEATURE_SIMD
 #ifdef FEATURE_HFA
-            // for structs that are small enough, we check and set lvIsHfa and lvHfaTypeIsFloat
+            // For structs that are small enough, we check and set HFA element type
             if (varDsc->lvExactSize <= MAX_PASS_MULTIREG_BYTES)
             {
-                var_types hfaType = GetHfaType(typeHnd); // set to float or double if it is an HFA, otherwise TYP_UNDEF
+                // hfaType is set to float, double or SIMD type if it is an HFA, otherwise TYP_UNDEF
+                var_types hfaType = GetHfaType(typeHnd);
                 if (varTypeIsValidHfaType(hfaType))
                 {
                     varDsc->SetHfaType(hfaType);

--- a/src/coreclr/src/jit/regalloc.cpp
+++ b/src/coreclr/src/jit/regalloc.cpp
@@ -175,6 +175,7 @@ regNumber Compiler::raUpdateRegStateForArg(RegState* regState, LclVarDsc* argDsc
         }
         else
         {
+            assert(!regState->rsIsFloat);
             unsigned cSlots = argDsc->lvSize() / TARGET_POINTER_SIZE;
             for (unsigned i = 1; i < cSlots; i++)
             {
@@ -183,7 +184,6 @@ regNumber Compiler::raUpdateRegStateForArg(RegState* regState, LclVarDsc* argDsc
                 {
                     break;
                 }
-                assert(regState->rsIsFloat == false);
                 regState->rsCalleeRegArgMaskLiveIn |= genRegMask(nextArgReg);
             }
         }

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -59,10 +59,10 @@ namespace Internal.JitInterface
 
         private ExceptionDispatchInfo _lastException;
 
-        [DllImport(JitLibrary, CallingConvention=CallingConvention.StdCall)] // stdcall in CoreCLR!
+        [DllImport(JitLibrary, CallingConvention = CallingConvention.StdCall)] // stdcall in CoreCLR!
         private extern static IntPtr jitStartup(IntPtr host);
 
-        [DllImport(JitLibrary, CallingConvention=CallingConvention.StdCall)]
+        [DllImport(JitLibrary, CallingConvention = CallingConvention.StdCall)]
         private extern static IntPtr getJit();
 
         [DllImport(JitSupportLibrary)]
@@ -79,7 +79,7 @@ namespace Internal.JitInterface
         }
 
         [DllImport(JitSupportLibrary)]
-        private extern static CorJitResult JitCompileMethod(out IntPtr exception, 
+        private extern static CorJitResult JitCompileMethod(out IntPtr exception,
             IntPtr jit, IntPtr thisHandle, IntPtr callbacks,
             ref CORINFO_METHOD_INFO info, uint flags, out IntPtr nativeEntry, out uint codeSize);
 
@@ -492,7 +492,7 @@ namespace Internal.JitInterface
 
                 if (method.IsArrayAddressMethod())
                     hasHiddenParameter = true;
-                
+
                 // We only populate sigInst for intrinsic methods because most of the time,
                 // JIT doesn't care what the instantiation is and this is expensive.
                 Instantiation owningTypeInst = method.OwningType.Instantiation;
@@ -1237,7 +1237,7 @@ namespace Internal.JitInterface
                 *namespaceName = null;
             return null;
         }
-        
+
         private CORINFO_CLASS_STRUCT_* getTypeInstantiationArgument(CORINFO_CLASS_STRUCT_* cls, uint index)
         {
             TypeDesc type = HandleToObject(cls);
@@ -1690,7 +1690,7 @@ namespace Internal.JitInterface
                 // This optimization may cause static fields in reference types to be accessed without cctor being triggered
                 // for NULL "this" object. It does not conform with what the spec says. However, we have been historically 
                 // doing it for perf reasons.
-                if (!typeToInit.IsValueType && ! typeToInit.IsInterface && !typeToInit.IsBeforeFieldInit)
+                if (!typeToInit.IsValueType && !typeToInit.IsInterface && !typeToInit.IsBeforeFieldInit)
                 {
                     if (typeToInit == typeFromContext(context) || typeToInit == MethodBeingCompiled.OwningType)
                     {
@@ -2014,7 +2014,7 @@ namespace Internal.JitInterface
         {
             var td = HandleToObject(cls) as ArrayType;
             Debug.Assert(td != null);
-            return (uint) td.Rank;
+            return (uint)td.Rank;
         }
 
         private void* getArrayInitializationData(CORINFO_FIELD_STRUCT_* field, uint size)
@@ -2204,7 +2204,19 @@ namespace Internal.JitInterface
         private CorInfoType getHFAType(CORINFO_CLASS_STRUCT_* hClass)
         {
             var type = (DefType)HandleToObject(hClass);
-            return type.IsHfa ? asCorInfoType(type.HfaElementType) : CorInfoType.CORINFO_TYPE_UNDEF;
+
+            // For 8-byte vectors return CORINFO_TYPE_DOUBLE, which is mapped by JIT to SIMD8.
+            // Otherwise, return CORINFO_TYPE_VALUECLASS, which is mapped by JIT to SIMD16.
+            // See MethodTable::GetHFAType and Compiler::GetHfaType.
+            return (type.ValueTypeShapeCharacteristics & ValueTypeShapeCharacteristics.AggregateMask) switch
+            {
+                ValueTypeShapeCharacteristics.Float32Aggregate => CorInfoType.CORINFO_TYPE_FLOAT,
+                ValueTypeShapeCharacteristics.Float64Aggregate => CorInfoType.CORINFO_TYPE_DOUBLE,
+                ValueTypeShapeCharacteristics.Vector64Aggregate => CorInfoType.CORINFO_TYPE_DOUBLE,
+                ValueTypeShapeCharacteristics.Vector128Aggregate => CorInfoType.CORINFO_TYPE_VALUECLASS,
+                ValueTypeShapeCharacteristics.Vector256Aggregate => CorInfoType.CORINFO_TYPE_VALUECLASS,
+                _ => CorInfoType.CORINFO_TYPE_UNDEF
+            };
         }
 
         private HRESULT GetErrorHRESULT(_EXCEPTION_POINTERS* pExceptionPointers)

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -281,22 +281,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        /// <summary>
-        /// Gets a value indicating whether the fields of the type satisfy the Homogeneous Float Aggregate classification.
-        /// </summary>
-        public bool IsHfa
-        {
-            get
-            {
-                if (!_fieldLayoutFlags.HasFlags(FieldLayoutFlags.ComputedValueTypeShapeCharacteristics))
-                {
-                    ComputeValueTypeShapeCharacteristics();
-                }
-                return (_valueTypeShapeCharacteristics & ValueTypeShapeCharacteristics.HomogenousFloatAggregate) != 0;
-            }
-        }
-
-        internal ValueTypeShapeCharacteristics ValueTypeShapeCharacteristics
+        public ValueTypeShapeCharacteristics ValueTypeShapeCharacteristics
         {
             get
             {
@@ -308,24 +293,38 @@ namespace Internal.TypeSystem
             }
         }
 
-        /// <summary>
-        /// Get the Homogeneous Float Aggregate element type if this is a HFA type (<see cref="IsHfa"/> is true).
-        /// </summary>
-        public DefType HfaElementType
-        {
-            get
-            {
-                // We are not caching this because this is rare and not worth wasting space in DefType.
-                return this.Context.GetLayoutAlgorithmForType(this).ComputeHomogeneousFloatAggregateElementType(this);
-            }
-        }
-
         private void ComputeValueTypeShapeCharacteristics()
         {
             _valueTypeShapeCharacteristics = this.Context.GetLayoutAlgorithmForType(this).ComputeValueTypeShapeCharacteristics(this);
             _fieldLayoutFlags.AddFlags(FieldLayoutFlags.ComputedValueTypeShapeCharacteristics);
         }
 
+        /// <summary>
+        /// Gets a value indicating whether the type is a homogeneous floating-point or short-vector aggregate.
+        /// </summary>
+        public bool IsHomogeneousAggregate
+        {
+            get
+            {
+                return (ValueTypeShapeCharacteristics & ValueTypeShapeCharacteristics.AggregateMask) != 0;
+            }
+        }
+
+        /// <summary>
+        /// If the type is a homogeneous floating-point or short-vector aggregate, returns its element size.
+        /// </summary>
+        public int GetHomogeneousAggregateElementSize()
+        {
+            return (ValueTypeShapeCharacteristics & ValueTypeShapeCharacteristics.AggregateMask) switch
+            {
+                ValueTypeShapeCharacteristics.Float32Aggregate => 4,
+                ValueTypeShapeCharacteristics.Float64Aggregate => 8,
+                ValueTypeShapeCharacteristics.Vector64Aggregate => 8,
+                ValueTypeShapeCharacteristics.Vector128Aggregate => 16,
+                ValueTypeShapeCharacteristics.Vector256Aggregate => 16,
+                _ => throw new InvalidOperationException()
+            };
+        }
 
         public void ComputeInstanceLayout(InstanceLayoutKind layoutKind)
         {

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -33,16 +33,10 @@ namespace Internal.TypeSystem
         public abstract bool ComputeContainsGCPointers(DefType type);
 
         /// <summary>
-        /// Compute the shape of a valuetype. The shape information is used to control code generation and allocation
-        /// (such as vectorization, passing the valuetype by value across method calls, or boxing alignment).
+        /// Compute the shape of a value type. The shape information is used to control code generation and allocation
+        /// (such as vectorization, passing the value type by value across method calls, or boxing alignment).
         /// </summary>
         public abstract ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type);
-
-        /// <summary>
-        /// If the type has <see cref="ValueTypeShapeCharacteristics.HomogenousFloatAggregate"/> characteristic, returns
-        /// the element type of the homogenous float aggregate. This will either be System.Double or System.Float.
-        /// </summary>
-        public abstract DefType ComputeHomogeneousFloatAggregateElementType(DefType type);
     }
 
     /// <summary>
@@ -119,8 +113,43 @@ namespace Internal.TypeSystem
         None = 0x00,
 
         /// <summary>
-        /// The structure is an aggregate of floating point values of the same type.
+        /// The type is an aggregate of 32-bit floating-point values.
         /// </summary>
-        HomogenousFloatAggregate = 0x01,
+        Float32Aggregate = 0x01,
+
+        /// <summary>
+        /// The type is an aggregate of 64-bit floating-point values.
+        /// </summary>
+        Float64Aggregate = 0x02,
+
+        /// <summary>
+        /// The type is an aggregate of 64-bit short-vector values.
+        /// </summary>
+        Vector64Aggregate = 0x04,
+
+        /// <summary>
+        /// The type is an aggregate of 128-bit short-vector values.
+        /// </summary>
+        Vector128Aggregate = 0x08,
+
+        /// <summary>
+        /// The type is an aggregate of 256-bit short-vector values.
+        /// </summary>
+        Vector256Aggregate = 0x10,
+
+        /// <summary>
+        /// The mask for homogeneous aggregates of floating-point values.
+        /// </summary>
+        FloatingPointAggregateMask = Float32Aggregate | Float64Aggregate,
+
+        /// <summary>
+        /// The mask for homogeneous aggregates of short-vector values.
+        /// </summary>
+        ShortVectorAggregateMask = Vector64Aggregate | Vector128Aggregate | Vector256Aggregate,
+
+        /// <summary>
+        /// The mask for homogeneous aggregates.
+        /// </summary>
+        AggregateMask = FloatingPointAggregateMask | ShortVectorAggregateMask,
     }
 }

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -830,132 +830,98 @@ namespace Internal.TypeSystem
             if (!type.IsValueType)
                 return ValueTypeShapeCharacteristics.None;
 
-            ValueTypeShapeCharacteristics result = ComputeHomogeneousFloatAggregateCharacteristic(type);
+            ValueTypeShapeCharacteristics result = ComputeHomogeneousAggregateCharacteristic(type);
 
             // TODO: System V AMD64 characteristics (https://github.com/dotnet/corert/issues/158)
 
             return result;
         }
 
-        private ValueTypeShapeCharacteristics ComputeHomogeneousFloatAggregateCharacteristic(DefType type)
+        private ValueTypeShapeCharacteristics ComputeHomogeneousAggregateCharacteristic(DefType type)
         {
             Debug.Assert(type.IsValueType);
 
-            MetadataType metadataType = (MetadataType)type;
-
-            if (type.Context.Target.Architecture != TargetArchitecture.ARM && type.Context.Target.Architecture != TargetArchitecture.ARM64)
+            TargetArchitecture targetArch = type.Context.Target.Architecture;
+            if ((targetArch != TargetArchitecture.ARM) && (targetArch != TargetArchitecture.ARM64))
                 return ValueTypeShapeCharacteristics.None;
 
-            // No HFAs with explicit layout. There may be cases where explicit layout may be still
-            // eligible for HFA, but it is hard to tell the real intent. Make it simple and just 
-            // unconditionally disable HFAs for explicit layout.
+            MetadataType metadataType = (MetadataType)type;
+
+            // No HAs with explicit layout. There may be cases where explicit layout may be still
+            // eligible for HA, but it is hard to tell the real intent. Make it simple and just 
+            // unconditionally disable HAs for explicit layout.
             if (metadataType.IsExplicitLayout)
                 return ValueTypeShapeCharacteristics.None;
 
             switch (metadataType.Category)
             {
+                // These are the primitive types that constitute a HFA type
                 case TypeFlags.Single:
+                    return ValueTypeShapeCharacteristics.Float32Aggregate;
                 case TypeFlags.Double:
-                    // These are the primitive types that constitute a HFA type.
-                    return ValueTypeShapeCharacteristics.HomogenousFloatAggregate;
+                    return ValueTypeShapeCharacteristics.Float64Aggregate;
 
                 case TypeFlags.ValueType:
-                    DefType expectedElementType = null;
+                    // Find the common element type if any
+                    ValueTypeShapeCharacteristics haResultType = ValueTypeShapeCharacteristics.None;
 
                     foreach (FieldDesc field in metadataType.GetFields())
                     {
                         if (field.IsStatic)
                             continue;
 
-                        // If a field isn't a DefType, then this type cannot be an HFA type
-                        // If a field isn't a HFA type, then this type cannot be an HFA type
-                        DefType fieldType = field.FieldType as DefType;
-                        if (fieldType == null || !fieldType.IsHfa)
+                        // If a field isn't a DefType, then this type cannot be a HA type
+                        if (!(field.FieldType is DefType fieldType))
                             return ValueTypeShapeCharacteristics.None;
 
-                        if (expectedElementType == null)
+                        // If a field isn't a HA type, then this type cannot be a HA type
+                        ValueTypeShapeCharacteristics haFieldType = fieldType.ValueTypeShapeCharacteristics & ValueTypeShapeCharacteristics.AggregateMask;
+                        if (haFieldType == ValueTypeShapeCharacteristics.None)
+                            return ValueTypeShapeCharacteristics.None;
+
+                        if (haResultType == ValueTypeShapeCharacteristics.None)
                         {
-                            // If we hadn't yet figured out what form of HFA this type might be, we've
-                            // now found one case.
-                            expectedElementType = fieldType.HfaElementType;
-                            Debug.Assert(expectedElementType != null);
+                            // If we hadn't yet figured out what form of HA this type might be, we've now found one case
+                            haResultType = haFieldType;
                         }
-                        else if (expectedElementType != fieldType.HfaElementType)
+                        else if (haResultType != haFieldType)
                         {
-                            // If we had already determined the possible HFA type of the current type, but
+                            // If we had already determined the possible HA type of the current type, but
                             // the field we've encountered is not of that type, then the current type cannot
-                            // be an HFA type.
+                            // be a HA type.
                             return ValueTypeShapeCharacteristics.None;
                         }
                     }
 
-                    // No fields means this is not HFA.
-                    if (expectedElementType == null)
-                        return ValueTypeShapeCharacteristics.None;
+                    int haElementSize = haResultType switch
+                    {
+                        ValueTypeShapeCharacteristics.Float32Aggregate => 4,
+                        ValueTypeShapeCharacteristics.Float64Aggregate => 8,
+                        ValueTypeShapeCharacteristics.Vector64Aggregate => 8,
+                        ValueTypeShapeCharacteristics.Vector128Aggregate => 16,
+                        ValueTypeShapeCharacteristics.Vector256Aggregate => 32,
+                        _ => 0
+                    };
 
-                    // Types which are indeterminate in field size are not considered to be HFA
-                    if (expectedElementType.InstanceFieldSize.IsIndeterminate)
-                        return ValueTypeShapeCharacteristics.None;
+                    Debug.Assert(haElementSize != 0);
 
-                    // Types which are indeterminate in field size are not considered to be HFA
+                    // Types which are indeterminate in field size are not considered to be HA
                     if (type.InstanceFieldSize.IsIndeterminate)
                         return ValueTypeShapeCharacteristics.None;
 
                     // Note that we check the total size, but do not perform any checks on number of fields:
-                    // - Type of fields can be HFA valuetype itself
-                    // - Managed C++ HFA valuetypes have just one <alignment member> of type float to signal that 
-                    //   the valuetype is HFA and explicitly specified size
-                    int maxSize = expectedElementType.InstanceFieldSize.AsInt * expectedElementType.Context.Target.MaximumHfaElementCount;
+                    // - Type of fields can be HA valuetype itself.
+                    // - Managed C++ HA valuetypes have just one <alignment member> of type float to signal that
+                    //   the valuetype is HA and explicitly specified size.
+                    int maxSize = haElementSize * type.Context.Target.MaxHomogeneousAggregateElementCount;
                     if (type.InstanceFieldSize.AsInt > maxSize)
                         return ValueTypeShapeCharacteristics.None;
 
-                    // All the tests passed. This is an HFA type.
-                    return ValueTypeShapeCharacteristics.HomogenousFloatAggregate;
+                    // All the tests passed. This is a HA type.
+                    return haResultType;
             }
 
             return ValueTypeShapeCharacteristics.None;
-        }
-
-        public override DefType ComputeHomogeneousFloatAggregateElementType(DefType type)
-        {
-            if (!type.IsHfa)
-                return null;
-
-            if (type.IsWellKnownType(WellKnownType.Double) || type.IsWellKnownType(WellKnownType.Single))
-                return type;
-
-            for (; ; )
-            {
-                Debug.Assert(type.IsValueType);
-
-                // All HFA fields have to be of the same HFA type, so we can just return the type of the first field
-                TypeDesc firstFieldType = null;
-                foreach (var field in type.GetFields())
-                {
-                    if (field.IsStatic)
-                        continue;
-
-                    firstFieldType = field.FieldType;
-                    break;
-                }
-                Debug.Assert(firstFieldType != null, "Why is IsHfa true on this type?");
-
-                switch (firstFieldType.Category)
-                {
-                    case TypeFlags.Single:
-                    case TypeFlags.Double:
-                        return (DefType)firstFieldType;
-
-                    case TypeFlags.ValueType:
-                        // Drill into the struct and find the type of its first field
-                        type = (DefType)firstFieldType;
-                        break;
-
-                    default:
-                        Debug.Fail("Why is IsHfa true on this type?");
-                        return null;
-                }
-            }
         }
 
         private struct SizeAndAlignment

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/TargetDetails.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/TargetDetails.cs
@@ -316,14 +316,15 @@ namespace Internal.TypeSystem
         }
 
         /// <summary>
-        /// Maximum number of elements in a HFA type.
+        /// Maximum number of elements in a homogeneous aggregate type.
         /// </summary>
-        public int MaximumHfaElementCount
+        public int MaxHomogeneousAggregateElementCount
         {
             get
             {
-                // There is a hard limit of 4 elements on an HFA type, see
+                // There is a hard limit of 4 elements on an HFA/HVA type, see
                 // https://devblogs.microsoft.com/cppblog/introducing-vector-calling-convention/
+                // and Procedure Call Standard for the Arm 64-bit Architecture.
                 Debug.Assert(Architecture == TargetArchitecture.ARM ||
                     Architecture == TargetArchitecture.ARM64 ||
                     Architecture == TargetArchitecture.X64 ||

--- a/src/coreclr/src/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedFieldLayoutAlgorithm.cs
@@ -58,13 +58,5 @@ namespace Internal.TypeSystem
 
             return canonicalType.ValueTypeShapeCharacteristics;
         }
-
-        public override DefType ComputeHomogeneousFloatAggregateElementType(DefType type)
-        {
-            RuntimeDeterminedType runtimeDeterminedType = (RuntimeDeterminedType)type;
-            DefType canonicalType = runtimeDeterminedType.CanonicalType;
-
-            return canonicalType.HfaElementType;
-        }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -120,20 +120,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             for (uint pos = 0; pos < nStackSlots; pos++)
             {
-                int ofs;
-
-                if (_target.Architecture == TargetArchitecture.X86)
-                {
-                    ofs = (int)(pos < _transitionBlock.NumArgumentRegisters ?
-                        _transitionBlock.OffsetOfArgumentRegisters + _transitionBlock.SizeOfArgumentRegisters - (pos + 1) * _target.PointerSize :
-                        _transitionBlock.OffsetOfArgs + (pos - _transitionBlock.NumArgumentRegisters) * _target.PointerSize);
-                }
-                else
-                {
-                    ofs = (int)(_transitionBlock.OffsetOfFirstGCRefMapSlot + pos * _target.PointerSize);
-                }
-
-                CORCOMPILE_GCREFMAP_TOKENS token = fakeStack[ofs];
+                int offset = _transitionBlock.OffsetFromGCRefMapPos(checked((int)pos));
+                CORCOMPILE_GCREFMAP_TOKENS token = fakeStack[offset];
 
                 if (token != CORCOMPILE_GCREFMAP_TOKENS.GCREFMAP_SKIP)
                 {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -77,7 +77,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         public abstract int OffsetOfArgumentRegisters { get; }
 
         /// <summary>
-        /// Only overridden on ARM64 to return offset of the X8 register.
+        /// The offset of the first slot in a GC ref map. Overridden on ARM64 to return the offset of the X8 register.
         /// </summary>
         public virtual int OffsetOfFirstGCRefMapSlot => OffsetOfArgumentRegisters;
 
@@ -105,11 +105,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         /// Recalculate pos in GC ref map to actual offset. This is the default implementation for all architectures
         /// except for X86 where it's overridden to supply a more complex algorithm.
         /// </summary>
-        /// <param name="pos"></param>
-        /// <returns></returns>
         public virtual int OffsetFromGCRefMapPos(int pos)
         {
-            return OffsetOfArgumentRegisters + pos * PointerSize;
+            return OffsetOfFirstGCRefMapSlot + pos * PointerSize;
         }
 
         /// <summary>
@@ -277,12 +275,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                                 {
                                     if (descriptor.eightByteClassifications0 == SystemVClassificationType.SystemVClassificationTypeSSE)
                                     {
+                                        // Structs occupying just one eightbyte are treated as int / double
                                         fpReturnSize = sizeof(double);
                                     }
                                 }
                                 else
                                 {
+                                    // Size of the struct is 16 bytes
                                     fpReturnSize = 16;
+                                    // The lowest two bits of the size encode the order of the int and SSE fields
                                     if (descriptor.eightByteClassifications0 == SystemVClassificationType.SystemVClassificationTypeSSE)
                                     {
                                         fpReturnSize += 1;
@@ -299,28 +300,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         }
                         else
                         {
-                            if (thRetType.IsHFA() && !isVarArgMethod)
+                            if (thRetType.IsHomogeneousAggregate() && !isVarArgMethod)
                             {
-                                CorElementType hfaType = thRetType.GetHFAType();
-
-                                switch (Architecture)
-                                {
-                                    case TargetArchitecture.ARM:
-                                        fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ?
-                                            (4 * (uint)sizeof(float)) :
-                                            (4 * (uint)sizeof(double));
-                                        break;
-
-                                    case TargetArchitecture.ARM64:
-                                        // DESKTOP BEHAVIOR fpReturnSize = (hfaType == CorElementType.ELEMENT_TYPE_R4) ? (4 * (uint)sizeof(float)) : (4 * (uint)sizeof(double));
-                                        // S and D registers overlap. Since we copy D registers in the UniversalTransitionThunk, we'll
-                                        // treat floats like doubles during copying.
-                                        fpReturnSize = 4 * (uint)sizeof(double);
-                                        break;
-
-                                    default:
-                                        throw new NotImplementedException();
-                                }
+                                int haElementSize = thRetType.GetHomogeneousAggregateElementSize();
+                                fpReturnSize = 4 * (uint)haElementSize;
                                 break;
                             }
 
@@ -481,8 +464,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             public static TransitionBlock Instance = new Arm64TransitionBlock();
 
-            private int OffsetOfX8Register => OffsetOfArgumentRegisters - PointerSize;
-
             public override TargetArchitecture Architecture => TargetArchitecture.ARM64;
             public override int PointerSize => 8;
             // X0 .. X7
@@ -492,6 +473,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Callee-saves, padding, m_x8RetBuffReg, argument registers
             public override int SizeOfTransitionBlock => SizeOfCalleeSavedRegisters + 2 * PointerSize + SizeOfArgumentRegisters;
             public override int OffsetOfArgumentRegisters => SizeOfCalleeSavedRegisters + 2 * PointerSize;
+            private int OffsetOfX8Register => OffsetOfArgumentRegisters - PointerSize;
             public override int OffsetOfFirstGCRefMapSlot => OffsetOfX8Register;
 
             // D0..D7
@@ -505,12 +487,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 Debug.Assert(th.IsValueType());
 
                 // Composites greater than 16 bytes are passed by reference
-                return (th.GetSize() > EnregisteredParamTypeMaxSize) && !th.IsHFA();
+                return (th.GetSize() > EnregisteredParamTypeMaxSize) && !th.IsHomogeneousAggregate();
             }
 
             public override int GetRetBuffArgOffset(bool hasThis) => OffsetOfX8Register;
 
             public override bool IsRetBuffPassedAsFirstArg => true;
         }
-    };
+    }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -139,11 +139,6 @@ namespace ILCompiler
             return false;
         }
 
-        public override DefType ComputeHomogeneousFloatAggregateElementType(DefType type)
-        {
-            return _fallbackAlgorithm.ComputeHomogeneousFloatAggregateElementType(type);
-        }
-
         public override ComputedInstanceFieldLayout ComputeInstanceLayout(DefType type, InstanceLayoutKind layoutKind)
         {
             DefType similarSpecifiedVector = GetSimilarVector(type);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -197,7 +197,15 @@ namespace ILCompiler
 
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
-            return _fallbackAlgorithm.ComputeValueTypeShapeCharacteristics(type);
+            if (type.Context.Target.Architecture == TargetArchitecture.ARM64)
+            {
+                return type.InstanceFieldSize.AsInt switch
+                {
+                    16 => ValueTypeShapeCharacteristics.Vector128Aggregate,
+                    _ => ValueTypeShapeCharacteristics.None
+                };
+            }
+            return ValueTypeShapeCharacteristics.None;
         }
 
         public static bool IsVectorOfTType(DefType type)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SystemObjectFieldLayoutAlgorithm.cs
@@ -54,11 +54,5 @@ namespace ILCompiler
         {
             return _fallbackAlgorithm.ComputeValueTypeShapeCharacteristics(type);
         }
-
-        public override DefType ComputeHomogeneousFloatAggregateElementType(DefType type)
-        {
-            return _fallbackAlgorithm.ComputeHomogeneousFloatAggregateElementType(type);
-        }
-
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
@@ -50,14 +50,17 @@ namespace ILCompiler.Reflection.ReadyToRun
         public abstract int OffsetOfArgumentRegisters { get; }
 
         /// <summary>
+        /// The offset of the first slot in a GC ref map. Overridden on ARM64 to return the offset of the X8 register.
+        /// </summary>
+        public virtual int OffsetOfFirstGCRefMapSlot => OffsetOfArgumentRegisters;
+
+        /// <summary>
         /// Recalculate pos in GC ref map to actual offset. This is the default implementation for all architectures
         /// except for X86 where it's overridden to supply a more complex algorithm.
         /// </summary>
-        /// <param name="pos"></param>
-        /// <returns></returns>
         public virtual int OffsetFromGCRefMapPos(int pos)
         {
-            return OffsetOfArgumentRegisters + pos * PointerSize;
+            return OffsetOfFirstGCRefMapSlot + pos * PointerSize;
         }
 
         /// <summary>
@@ -144,8 +147,8 @@ namespace ILCompiler.Reflection.ReadyToRun
             // Callee-saves, padding, m_x8RetBuffReg, argument registers
             public override int SizeOfTransitionBlock => SizeOfCalleeSavedRegisters + 2 * PointerSize + SizeOfArgumentRegisters;
             public override int OffsetOfArgumentRegisters => SizeOfCalleeSavedRegisters + 2 * PointerSize;
+            private int OffsetOfX8Register => OffsetOfArgumentRegisters - PointerSize;
+            public override int OffsetOfFirstGCRefMapSlot => OffsetOfX8Register;
         }
     }
-
 }
-

--- a/src/coreclr/src/vm/callingconvention.h
+++ b/src/coreclr/src/vm/callingconvention.h
@@ -638,7 +638,7 @@ public:
 
         int cSlots = (GetArgSize() + 7)/ 8;
 
-        // Composites greater than 16bytes are passed by reference
+        // Composites greater than 16 bytes are passed by reference
         if (GetArgType() == ELEMENT_TYPE_VALUETYPE && GetArgSize() > ENREGISTERED_PARAMTYPE_MAXSIZE)
         {
             cSlots = 1;
@@ -1346,8 +1346,8 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 
     case ELEMENT_TYPE_VALUETYPE:
     {
-        // Handle HFAs: packed structures of 2-4 floats or doubles that are passed in FP argument
-        // registers if possible.
+        // Handle HFAs: packed structures of 1-4 floats, doubles, or short vectors
+        // that are passed in FP argument registers if possible.
         if (thValueType.IsHFA())
         {
             CorElementType type = thValueType.GetHFAType();

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1256,11 +1256,6 @@ CorElementType MethodTable::GetHFAType()
         {
         case ELEMENT_TYPE_VALUETYPE:
             pMT = pFirstField->LookupApproxFieldTypeHandle().GetMethodTable();
-            vectorSize = pMT->GetVectorSize();
-            if (vectorSize != 0)
-            {
-                return (vectorSize == 8) ? ELEMENT_TYPE_R8 : ELEMENT_TYPE_VALUETYPE;
-            }
             break;
 
         case ELEMENT_TYPE_R4:


### PR DESCRIPTION
Support ARM64 HVAs in Crossgen2.

* Change `FieldLayoutAlgorithm.ComputeValueTypeShapeCharacteristics` method to compute the homogeneous aggregate element type and cache it in the existing field.  That allows to remove all `ComputeHomogeneousFloatAggregateElementType` methods.
* Change `MetadataFieldLayoutAlgorithm.ComputeHomogeneousAggregateCharacteristic` to compute HVAs in addition to HFAs.
* Change `CorInfoImpl.getHFAType` JIT callback to handle HVAs.  Note that returning `ELEMENT_TYPE_VALUETYPE` indicates the `TYP_SIMD16` type (see `Compiler::GetHfaType`).
* Change `TypeFixupSignature.EncodeTypeLayout` to handle HVAs.
* Support HVAs in the `ArgIterator` class.
* Fix `TransitionBlock.OffsetFromGCRefMapPos` for ARM64. R2RDump used to dump incorrect offsets.
* Use `TransitionBlock.OffsetFromGCRefMapPos` in `GCRefMapBuilder.GetCallRefMap` to simplify logic.
* Remove ARM64 .NET Native-specific code from TransitionBlock.cs and ArgIterator.cs files.

Minor:
* Remove a redundant `GetVectorSize` check in `MethodTable::GetHFAType`.
* Improve an assertion in `Compiler::raUpdateRegStateForArg`.
* Fix comments in JIT code.