### PR TITLE
improve resiliency of process tests

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/Helpers.cs
@@ -45,6 +45,7 @@ namespace System.Diagnostics.Tests
             foreach (Process p in all)
             {
                 Console.WriteLine("{0,8} {1}", p.Id, p.ProcessName);
+                p.Dispose();
             }
         }
     }

--- a/src/libraries/System.Diagnostics.Process/tests/Helpers.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/Helpers.cs
@@ -12,6 +12,8 @@ namespace System.Diagnostics.Tests
 {
     internal static class Helpers
     {
+        public const int PassingTestTimeoutMilliseconds = 60_000;
+
         public static async Task RetryWithBackoff(Action action, int delayInMilliseconds = 10, int times = 10)
         {
             // Guards against delay growing to an exceptionally large value. No special technical significance to
@@ -34,6 +36,15 @@ namespace System.Diagnostics.Tests
                     await Task.Delay(delayInMilliseconds);
                     delayInMilliseconds = Math.Min(maxDelayInMilliseconds, delayInMilliseconds * 2);
                 }
+            }
+        }
+
+        public static void DumpAllProcesses()
+        {
+            Process[] all = Process.GetProcesses();
+            foreach (Process p in all)
+            {
+                Console.WriteLine("{0,8} {1}", p.Id, p.ProcessName);
             }
         }
     }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -835,13 +835,13 @@ namespace System.Diagnostics.Tests
                     }
 
                     DateTime now = DateTime.UtcNow;
-                    if (start.Millisecond + Helpers.PassingTestTimeoutMilliseconds <= now.Millisecond)
+                    if (start.Ticks + (Helpers.PassingTestTimeoutMilliseconds * 10_000) <= now.Ticks)
                     {
                         Console.WriteLine("{0} Failed to kill process {1} started at {2}", now, nonChildProcess.Id, start);
                         Helpers.DumpAllProcesses();
-                    }
 
-                    Assert.True(start.Millisecond + Helpers.PassingTestTimeoutMilliseconds > now.Millisecond);
+                        Assert.True(false, "test timed out");
+                    }
                 }
 
                 // Call Process.Kill.

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -817,7 +817,7 @@ namespace System.Diagnostics.Tests
         {
             // In this test, we kill a process in a way the Process instance
             // is not aware the process has terminated when we invoke Process.Kill.
-
+            DateTime start = DateTime.UtcNow;
             using (Process nonChildProcess = CreateNonChildProcess())
             {
                 // Kill the process.
@@ -833,6 +833,15 @@ namespace System.Diagnostics.Tests
                         // process still exists, wait some time.
                         await Task.Delay(100);
                     }
+
+                    DateTime now = DateTime.UtcNow;
+                    if (start.Millisecond + Helpers.PassingTestTimeoutMilliseconds <= now.Millisecond)
+                    {
+                        Console.WriteLine("{0} Failed to kill process {1} started at {2}", now, nonChildProcess.Id, start);
+                        Helpers.DumpAllProcesses();
+                    }
+
+                    Assert.True(start.Millisecond + Helpers.PassingTestTimeoutMilliseconds > now.Millisecond);
                 }
 
                 // Call Process.Kill.

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2119,7 +2119,7 @@ namespace System.Diagnostics.Tests
             Process process = CreateProcess();
             process.Start();
 
-            process.WaitForExit();
+            Assert.True(process.WaitForExit(Helpers.PassingTestTimeoutMilliseconds));
 
             process.Kill(killTree);
         }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2119,7 +2119,7 @@ namespace System.Diagnostics.Tests
             Process process = CreateProcess();
             process.Start();
 
-            Assert.True(process.WaitForExit(Helpers.PassingTestTimeoutMilliseconds));
+            Assert.True(process.WaitForExit(Helpers.PassingTestTimeoutMilliseconds), $"Proccess {process.Id} did not finish in {Helpers.PassingTestTimeoutMilliseconds}.");
 
             process.Kill(killTree);
         }


### PR DESCRIPTION
I suspect Kill_ExitedChildProcess_DoesNotThrow is hanging in the WaitForExit so I modify it to use overload with timeout. I also add time limit and some more instrumentation to the Unix version. 

Now the test should fail instead of hanging and we should hopefully collect more information.

fixes #35506