### PR TITLE
Fixing break on OOB System.IO.Ports package where native dependency was no longer produced

### DIFF
--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -7244,7 +7244,7 @@
   },
   "ModulesToPackages": {
     "sni.dll": "runtime.native.System.Data.SqlClient.sni",
-    "System.IO.Ports.Native": "runtime.native.System.IO.Ports"
+    "libSystem.IO.Ports.Native": "runtime.native.System.IO.Ports"
   },
   "MetaPackages": {
     "NETStandard.Library": [


### PR DESCRIPTION
When we merged the PR that added a lib prefix to our native libraries we didn't take into account that System.IO.Ports today is OOB and has a native shim that also ships oob. That change broke the package since now the package isn't being emitted with a package dependency to package runtime.native.SYstem.IO.Ports. This change fixes that.