### PR TITLE
improve cmake version detection

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -53,7 +53,7 @@ check_prereqs()
 
     function version { echo "$@" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }'; }
 
-    local cmake_version="$(cmake --version | awk '/^cmake version [0-9]+\.[0-9]+\.[0-9]+$/ {print $3}')"
+    local cmake_version="$(cmake --version | awk '/^cmake.* version [0-9]+\.[0-9]+\.[0-9]+$/ {print $3}')"
 
     if [[ "$(version "$cmake_version")" -lt "$(version 3.14.2)" ]]; then
         echo "Please install CMake 3.14.2 or newer from http://www.cmake.org/download/ or https://apt.kitware.com and ensure it is on your path."; exit 1;


### PR DESCRIPTION
I was trying to build runtime on Centos7 and use available `cmake3-3.14.7-1.el7.x86_64` package. That should be sufficient to build but the build complained about old version.  

```
[root@cent runtime]# cmake --version
cmake3 version 3.14.7

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

this is because `version` is prefixed with `cmake3` instead of `cmake` 