### PR TITLE
[Wasm] Additional signatures for SkiaSharp interop

### DIFF
--- a/src/mono/mono/mini/wasm_m2n_invoke.g.h
+++ b/src/mono/mono/mini/wasm_m2n_invoke.g.h
@@ -1018,6 +1018,371 @@ wasm_invoke_vil (void *target_func, InterpMethodArguments *margs)
 }
 
 static void
+wasm_invoke_fifff (void *target_func, InterpMethodArguments *margs)
+{
+	typedef float (*T)(int arg_0, float arg_1, float arg_2, float arg_3);
+	T func = (T)target_func;
+	float res = func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)]);
+	*(float*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_fii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef float (*T)(int arg_0, int arg_1);
+	T func = (T)target_func;
+	float res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1]);
+	*(float*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_fiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef float (*T)(int arg_0, int arg_1, int arg_2);
+	T func = (T)target_func;
+	float res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2]);
+	*(float*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_fiiiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef float (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
+	float res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5]);
+	*(float*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iffffiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(float arg_0, float arg_1, float arg_2, float arg_3, int arg_4, int arg_5, int arg_6, int arg_7);
+	T func = (T)target_func;
+	int res = func (*(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)], (int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iffi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(float arg_0, float arg_1, int arg_2);
+	T func = (T)target_func;
+	int res = func (*(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [0]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iffif (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(float arg_0, float arg_1, int arg_2, float arg_3);
+	T func = (T)target_func;
+	int res = func (*(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (2)]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iffifi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(float arg_0, float arg_1, int arg_2, float arg_3, int arg_4);
+	T func = (T)target_func;
+	int res = func (*(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (2)], (int)(gssize)margs->iargs [1]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_ifi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(float arg_0, int arg_1);
+	T func = (T)target_func;
+	int res = func (*(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [0]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_ifiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(float arg_0, int arg_1, int arg_2, int arg_3);
+	T func = (T)target_func;
+	int res = func (*(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iififiiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, float arg_1, int arg_2, float arg_3, int arg_4, int arg_5, int arg_6, int arg_7, int arg_8);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5], (int)(gssize)margs->iargs [6]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iififiiiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, float arg_1, int arg_2, float arg_3, int arg_4, int arg_5, int arg_6, int arg_7, int arg_8, int arg_9);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5], (int)(gssize)margs->iargs [6], (int)(gssize)margs->iargs [7]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iifiiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, float arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iifiiiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, float arg_1, int arg_2, int arg_3, int arg_4, int arg_5, int arg_6, int arg_7);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5], (int)(gssize)margs->iargs [6]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiifffii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, float arg_2, float arg_3, float arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiffifffii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, float arg_2, float arg_3, int arg_4, float arg_5, float arg_6, float arg_7, int arg_8, int arg_9);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)], *(float*)&margs->fargs [FIDX (4)], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiffiffii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, float arg_2, float arg_3, int arg_4, float arg_5, float arg_6, int arg_7, int arg_8);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiffii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, float arg_2, float arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiffiiiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, float arg_2, float arg_3, int arg_4, int arg_5, int arg_6, int arg_7, int arg_8);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5], (int)(gssize)margs->iargs [6]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiiif (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, float arg_4);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], *(float*)&margs->fargs [FIDX (0)]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiiifii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, float arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiiiiffi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, float arg_5, float arg_6, int arg_7);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [5]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_iiiiiiiffi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef int (*T)(int arg_0, int arg_1, int arg_2, int arg_3, int arg_4, int arg_5, float arg_6, float arg_7, int arg_8);
+	T func = (T)target_func;
+	int res = func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [6]);
+	*(int*)margs->retval = res;
+
+}
+
+static void
+wasm_invoke_vifff (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)]);
+
+}
+
+static void
+wasm_invoke_viffffi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, float arg_4, int arg_5);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)], (int)(gssize)margs->iargs [1]);
+
+}
+
+static void
+wasm_invoke_vifffi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, int arg_4);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], (int)(gssize)margs->iargs [1]);
+
+}
+
+static void
+wasm_invoke_vifffiiff (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, float arg_3, int arg_4, int arg_5, float arg_6, float arg_7);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (3)], *(float*)&margs->fargs [FIDX (4)]);
+
+}
+
+static void
+wasm_invoke_viffi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, float arg_1, float arg_2, int arg_3);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [1]);
+
+}
+
+static void
+wasm_invoke_vifi (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, float arg_1, int arg_2);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [1]);
+
+}
+
+static void
+wasm_invoke_viiff (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, float arg_2, float arg_3);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)]);
+
+}
+
+static void
+wasm_invoke_viiffff (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, float arg_2, float arg_3, float arg_4, float arg_5);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], *(float*)&margs->fargs [FIDX (2)], *(float*)&margs->fargs [FIDX (3)]);
+
+}
+
+static void
+wasm_invoke_viiffii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, float arg_2, float arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3]);
+
+}
+
+static void
+wasm_invoke_viiif (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, float arg_3);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (0)]);
+
+}
+
+static void
+wasm_invoke_viiiffii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, float arg_3, float arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4]);
+
+}
+
+static void
+wasm_invoke_viiiffiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, float arg_3, float arg_4, int arg_5, int arg_6, int arg_7);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (0)], *(float*)&margs->fargs [FIDX (1)], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5]);
+
+}
+
+static void
+wasm_invoke_viiifii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, float arg_3, int arg_4, int arg_5);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4]);
+
+}
+
+static void
+wasm_invoke_viiifiii (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, float arg_3, int arg_4, int arg_5, int arg_6);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], *(float*)&margs->fargs [FIDX (0)], (int)(gssize)margs->iargs [3], (int)(gssize)margs->iargs [4], (int)(gssize)margs->iargs [5]);
+
+}
+
+static void
+wasm_invoke_viiiif (void *target_func, InterpMethodArguments *margs)
+{
+	typedef void (*T)(int arg_0, int arg_1, int arg_2, int arg_3, float arg_4);
+	T func = (T)target_func;
+	func ((int)(gssize)margs->iargs [0], (int)(gssize)margs->iargs [1], (int)(gssize)margs->iargs [2], (int)(gssize)margs->iargs [3], *(float*)&margs->fargs [FIDX (0)]);
+
+}
+
+static void
 icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodArguments *margs)
 {
 	if (cookie[0] == 'V') {
@@ -1095,26 +1460,95 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 								return;
 							}
 						}
+						else if (cookie[5] == 'F') {
+							if (cookie[6] == '\0') {
+								// found: VIIIIF depth 8
+								wasm_invoke_viiiif (target_func, margs);
+								return;
+							}
+						}
 						else if (cookie[5] == '\0') {
-							// found: VIIII depth 7
+							// found: VIIII depth 8
 							wasm_invoke_viiii (target_func, margs);
 							return;
 						}
 					}
+					else if (cookie[4] == 'F') {
+						if (cookie[5] == 'F') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == 'I') {
+										if (cookie[9] == '\0') {
+											// found: VIIIFFIII depth 11
+											wasm_invoke_viiiffiii (target_func, margs);
+											return;
+										}
+									}
+									else if (cookie[8] == '\0') {
+										// found: VIIIFFII depth 11
+										wasm_invoke_viiiffii (target_func, margs);
+										return;
+									}
+								}
+							}
+						}
+						else if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == '\0') {
+										// found: VIIIFIII depth 11
+										wasm_invoke_viiifiii (target_func, margs);
+										return;
+									}
+								}
+								else if (cookie[7] == '\0') {
+									// found: VIIIFII depth 11
+									wasm_invoke_viiifii (target_func, margs);
+									return;
+								}
+							}
+						}
+						else if (cookie[5] == '\0') {
+							// found: VIIIF depth 9
+							wasm_invoke_viiif (target_func, margs);
+							return;
+						}
+					}
 					else if (cookie[4] == '\0') {
-						// found: VIII depth 6
+						// found: VIII depth 7
 						wasm_invoke_viii (target_func, margs);
 						return;
 					}
 				}
 				else if (cookie[3] == 'F') {
 					if (cookie[4] == 'F') {
-						if (cookie[5] == 'I') {
-							if (cookie[6] == '\0') {
-								// found: VIIFFI depth 8
+						if (cookie[5] == 'F') {
+							if (cookie[6] == 'F') {
+								if (cookie[7] == '\0') {
+									// found: VIIFFFF depth 9
+									wasm_invoke_viiffff (target_func, margs);
+									return;
+								}
+							}
+						}
+						else if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == '\0') {
+									// found: VIIFFII depth 10
+									wasm_invoke_viiffii (target_func, margs);
+									return;
+								}
+							}
+							else if (cookie[6] == '\0') {
+								// found: VIIFFI depth 10
 								wasm_invoke_viiffi (target_func, margs);
 								return;
 							}
+						}
+						else if (cookie[5] == '\0') {
+							// found: VIIFF depth 9
+							wasm_invoke_viiff (target_func, margs);
+							return;
 						}
 					}
 				}
@@ -1127,43 +1561,87 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 			else if (cookie[2] == 'F') {
 				if (cookie[3] == 'F') {
 					if (cookie[4] == 'F') {
-						if (cookie[5] == 'F') {
+						if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == 'F') {
+									if (cookie[8] == 'F') {
+										if (cookie[9] == '\0') {
+											// found: VIFFFIIFF depth 11
+											wasm_invoke_vifffiiff (target_func, margs);
+											return;
+										}
+									}
+								}
+							}
+							else if (cookie[6] == '\0') {
+								// found: VIFFFI depth 9
+								wasm_invoke_vifffi (target_func, margs);
+								return;
+							}
+						}
+						else if (cookie[5] == 'F') {
 							if (cookie[6] == 'F') {
 								if (cookie[7] == 'F') {
 									if (cookie[8] == '\0') {
-										// found: VIFFFFFF depth 10
+										// found: VIFFFFFF depth 11
 										wasm_invoke_viffffff (target_func, margs);
 										return;
 									}
 								}
 								else if (cookie[7] == 'I') {
 									if (cookie[8] == '\0') {
-										// found: VIFFFFFI depth 11
+										// found: VIFFFFFI depth 12
 										wasm_invoke_vifffffi (target_func, margs);
 										return;
 									}
 								}
 								else if (cookie[7] == '\0') {
-									// found: VIFFFFF depth 11
+									// found: VIFFFFF depth 12
 									wasm_invoke_vifffff (target_func, margs);
 									return;
 								}
 							}
+							else if (cookie[6] == 'I') {
+								if (cookie[7] == '\0') {
+									// found: VIFFFFI depth 11
+									wasm_invoke_viffffi (target_func, margs);
+									return;
+								}
+							}
 							else if (cookie[6] == '\0') {
-								// found: VIFFFF depth 9
+								// found: VIFFFF depth 11
 								wasm_invoke_viffff (target_func, margs);
 								return;
 							}
 						}
+						else if (cookie[5] == '\0') {
+							// found: VIFFF depth 9
+							wasm_invoke_vifff (target_func, margs);
+							return;
+						}
+					}
+					else if (cookie[4] == 'I') {
+						if (cookie[5] == '\0') {
+							// found: VIFFI depth 8
+							wasm_invoke_viffi (target_func, margs);
+							return;
+						}
 					}
 					else if (cookie[4] == '\0') {
-						// found: VIFF depth 7
+						// found: VIFF depth 8
 						wasm_invoke_viff (target_func, margs);
 						return;
 					}
 				}
+				else if (cookie[3] == 'I') {
+					if (cookie[4] == '\0') {
+						// found: VIFI depth 7
+						wasm_invoke_vifi (target_func, margs);
+						return;
+					}
+				}
 				else if (cookie[3] == '\0') {
-					// found: VIF depth 6
+					// found: VIF depth 7
 					wasm_invoke_vif (target_func, margs);
 					return;
 				}
@@ -1247,6 +1725,59 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 								else if (cookie[7] == '\0') {
 									// found: IIIFFFF depth 10
 									wasm_invoke_iiiffff (target_func, margs);
+									return;
+								}
+							}
+							else if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == '\0') {
+										// found: IIIFFFII depth 11
+										wasm_invoke_iiifffii (target_func, margs);
+										return;
+									}
+								}
+							}
+						}
+						else if (cookie[5] == 'I') {
+							if (cookie[6] == 'F') {
+								if (cookie[7] == 'F') {
+									if (cookie[8] == 'F') {
+										if (cookie[9] == 'I') {
+											if (cookie[10] == 'I') {
+												if (cookie[11] == '\0') {
+													// found: IIIFFIFFFII depth 14
+													wasm_invoke_iiiffifffii (target_func, margs);
+													return;
+												}
+											}
+										}
+									}
+									else if (cookie[8] == 'I') {
+										if (cookie[9] == 'I') {
+											if (cookie[10] == '\0') {
+												// found: IIIFFIFFII depth 14
+												wasm_invoke_iiiffiffii (target_func, margs);
+												return;
+											}
+										}
+									}
+								}
+							}
+							else if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == 'I') {
+										if (cookie[9] == 'I') {
+											if (cookie[10] == '\0') {
+												// found: IIIFFIIIII depth 14
+												wasm_invoke_iiiffiiiii (target_func, margs);
+												return;
+											}
+										}
+									}
+								}
+								else if (cookie[7] == '\0') {
+									// found: IIIFFII depth 12
+									wasm_invoke_iiiffii (target_func, margs);
 									return;
 								}
 							}
@@ -1334,8 +1865,15 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 								}
 								else if (cookie[7] == 'F') {
 									if (cookie[8] == 'F') {
-										if (cookie[9] == '\0') {
-											// found: IIIIIIIFF depth 13
+										if (cookie[9] == 'I') {
+											if (cookie[10] == '\0') {
+												// found: IIIIIIIFFI depth 14
+												wasm_invoke_iiiiiiiffi (target_func, margs);
+												return;
+											}
+										}
+										else if (cookie[9] == '\0') {
+											// found: IIIIIIIFF depth 14
 											wasm_invoke_iiiiiiiff (target_func, margs);
 											return;
 										}
@@ -1353,10 +1891,19 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 								}
 							}
 							else if (cookie[6] == 'F') {
-								if (cookie[7] == 'I') {
+								if (cookie[7] == 'F') {
 									if (cookie[8] == 'I') {
 										if (cookie[9] == '\0') {
-											// found: IIIIIIFII depth 13
+											// found: IIIIIIFFI depth 13
+											wasm_invoke_iiiiiiffi (target_func, margs);
+											return;
+										}
+									}
+								}
+								else if (cookie[7] == 'I') {
+									if (cookie[8] == 'I') {
+										if (cookie[9] == '\0') {
+											// found: IIIIIIFII depth 14
 											wasm_invoke_iiiiiifii (target_func, margs);
 											return;
 										}
@@ -1388,6 +1935,20 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 										}
 									}
 								}
+							}
+							else if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == '\0') {
+										// found: IIIIIFII depth 13
+										wasm_invoke_iiiiifii (target_func, margs);
+										return;
+									}
+								}
+							}
+							else if (cookie[6] == '\0') {
+								// found: IIIIIF depth 12
+								wasm_invoke_iiiiif (target_func, margs);
+								return;
 							}
 						}
 						else if (cookie[5] == '\0') {
@@ -1437,87 +1998,51 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 				}
 			}
 			else if (cookie[2] == 'F') {
-				if (cookie[3] == 'F') {
+				if (cookie[3] == 'I') {
 					if (cookie[4] == 'F') {
-						if (cookie[5] == 'F') {
-							if (cookie[6] == 'F') {
-								if (cookie[7] == 'F') {
-									if (cookie[8] == 'F') {
-										if (cookie[9] == 'F') {
-											if (cookie[10] == '\0') {
-												// found: IIFFFFFFFF depth 13
-												wasm_invoke_iiffffffff (target_func, margs);
+						if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == 'I') {
+										if (cookie[9] == 'I') {
+											if (cookie[10] == 'I') {
+												if (cookie[11] == '\0') {
+													// found: IIFIFIIIIII depth 14
+													wasm_invoke_iififiiiiii (target_func, margs);
+													return;
+												}
+											}
+											else if (cookie[10] == '\0') {
+												// found: IIFIFIIIII depth 14
+												wasm_invoke_iififiiiii (target_func, margs);
 												return;
 											}
 										}
 									}
-									else if (cookie[8] == '\0') {
-										// found: IIFFFFFF depth 12
-										wasm_invoke_iiffffff (target_func, margs);
-										return;
-									}
 								}
 							}
-							else if (cookie[6] == 'I') {
-								if (cookie[7] == 'I') {
-									if (cookie[8] == '\0') {
-										// found: IIFFFFII depth 12
-										wasm_invoke_iiffffii (target_func, margs);
-										return;
-									}
-								}
-								else if (cookie[7] == '\0') {
-									// found: IIFFFFI depth 12
-									wasm_invoke_iiffffi (target_func, margs);
-									return;
-								}
-							}
-						}
-						else if (cookie[5] == 'I') {
-							if (cookie[6] == '\0') {
-								// found: IIFFFI depth 10
-								wasm_invoke_iifffi (target_func, margs);
-								return;
-							}
-						}
-						else if (cookie[5] == '\0') {
-							// found: IIFFF depth 10
-							wasm_invoke_iifff (target_func, margs);
-							return;
 						}
 					}
 					else if (cookie[4] == 'I') {
 						if (cookie[5] == 'I') {
 							if (cookie[6] == 'I') {
-								if (cookie[7] == '\0') {
-									// found: IIFFIII depth 11
-									wasm_invoke_iiffiii (target_func, margs);
-									return;
+								if (cookie[7] == 'I') {
+									if (cookie[8] == 'I') {
+										if (cookie[9] == '\0') {
+											// found: IIFIIIIII depth 13
+											wasm_invoke_iifiiiiii (target_func, margs);
+											return;
+										}
+									}
+									else if (cookie[8] == '\0') {
+										// found: IIFIIIII depth 13
+										wasm_invoke_iifiiiii (target_func, margs);
+										return;
+									}
 								}
 							}
 							else if (cookie[6] == '\0') {
-								// found: IIFFII depth 11
-								wasm_invoke_iiffii (target_func, margs);
-								return;
-							}
-						}
-						else if (cookie[5] == '\0') {
-							// found: IIFFI depth 10
-							wasm_invoke_iiffi (target_func, margs);
-							return;
-						}
-					}
-					else if (cookie[4] == '\0') {
-						// found: IIFF depth 9
-						wasm_invoke_iiff (target_func, margs);
-						return;
-					}
-				}
-				else if (cookie[3] == 'I') {
-					if (cookie[4] == 'I') {
-						if (cookie[5] == 'I') {
-							if (cookie[6] == '\0') {
-								// found: IIFIII depth 10
+								// found: IIFIII depth 11
 								wasm_invoke_iifiii (target_func, margs);
 								return;
 							}
@@ -1531,6 +2056,82 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 					else if (cookie[4] == '\0') {
 						// found: IIFI depth 9
 						wasm_invoke_iifi (target_func, margs);
+						return;
+					}
+				}
+				else if (cookie[3] == 'F') {
+					if (cookie[4] == 'F') {
+						if (cookie[5] == 'F') {
+							if (cookie[6] == 'F') {
+								if (cookie[7] == 'F') {
+									if (cookie[8] == 'F') {
+										if (cookie[9] == 'F') {
+											if (cookie[10] == '\0') {
+												// found: IIFFFFFFFF depth 14
+												wasm_invoke_iiffffffff (target_func, margs);
+												return;
+											}
+										}
+									}
+									else if (cookie[8] == '\0') {
+										// found: IIFFFFFF depth 13
+										wasm_invoke_iiffffff (target_func, margs);
+										return;
+									}
+								}
+							}
+							else if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == '\0') {
+										// found: IIFFFFII depth 13
+										wasm_invoke_iiffffii (target_func, margs);
+										return;
+									}
+								}
+								else if (cookie[7] == '\0') {
+									// found: IIFFFFI depth 13
+									wasm_invoke_iiffffi (target_func, margs);
+									return;
+								}
+							}
+						}
+						else if (cookie[5] == 'I') {
+							if (cookie[6] == '\0') {
+								// found: IIFFFI depth 11
+								wasm_invoke_iifffi (target_func, margs);
+								return;
+							}
+						}
+						else if (cookie[5] == '\0') {
+							// found: IIFFF depth 11
+							wasm_invoke_iifff (target_func, margs);
+							return;
+						}
+					}
+					else if (cookie[4] == 'I') {
+						if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == '\0') {
+									// found: IIFFIII depth 12
+									wasm_invoke_iiffiii (target_func, margs);
+									return;
+								}
+							}
+							else if (cookie[6] == '\0') {
+								// found: IIFFII depth 12
+								wasm_invoke_iiffii (target_func, margs);
+								return;
+							}
+						}
+						else if (cookie[5] == '\0') {
+							// found: IIFFI depth 11
+							wasm_invoke_iiffi (target_func, margs);
+							return;
+						}
+					}
+					else if (cookie[4] == '\0') {
+						// found: IIFF depth 10
+						wasm_invoke_iiff (target_func, margs);
 						return;
 					}
 				}
@@ -1600,11 +2201,24 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 			if (cookie[2] == 'F') {
 				if (cookie[3] == 'F') {
 					if (cookie[4] == 'F') {
-						if (cookie[5] == 'F') {
+						if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == 'I') {
+									if (cookie[8] == 'I') {
+										if (cookie[9] == '\0') {
+											// found: IFFFFIIII depth 12
+											wasm_invoke_iffffiiii (target_func, margs);
+											return;
+										}
+									}
+								}
+							}
+						}
+						else if (cookie[5] == 'F') {
 							if (cookie[6] == 'F') {
 								if (cookie[7] == 'I') {
 									if (cookie[8] == '\0') {
-										// found: IFFFFFFI depth 11
+										// found: IFFFFFFI depth 12
 										wasm_invoke_iffffffi (target_func, margs);
 										return;
 									}
@@ -1614,17 +2228,52 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 					}
 				}
 				else if (cookie[3] == 'I') {
-					if (cookie[4] == 'I') {
+					if (cookie[4] == 'F') {
+						if (cookie[5] == 'I') {
+							if (cookie[6] == '\0') {
+								// found: IFFIFI depth 10
+								wasm_invoke_iffifi (target_func, margs);
+								return;
+							}
+						}
+						else if (cookie[5] == '\0') {
+							// found: IFFIF depth 10
+							wasm_invoke_iffif (target_func, margs);
+							return;
+						}
+					}
+					else if (cookie[4] == 'I') {
 						if (cookie[5] == '\0') {
-							// found: IFFII depth 9
+							// found: IFFII depth 10
 							wasm_invoke_iffii (target_func, margs);
 							return;
 						}
 					}
+					else if (cookie[4] == '\0') {
+						// found: IFFI depth 10
+						wasm_invoke_iffi (target_func, margs);
+						return;
+					}
+				}
+			}
+			else if (cookie[2] == 'I') {
+				if (cookie[3] == 'I') {
+					if (cookie[4] == 'I') {
+						if (cookie[5] == '\0') {
+							// found: IFIII depth 9
+							wasm_invoke_ifiii (target_func, margs);
+							return;
+						}
+					}
+				}
+				else if (cookie[3] == '\0') {
+					// found: IFI depth 8
+					wasm_invoke_ifi (target_func, margs);
+					return;
 				}
 			}
 			else if (cookie[2] == '\0') {
-				// found: IF depth 6
+				// found: IF depth 7
 				wasm_invoke_if (target_func, margs);
 				return;
 			}
@@ -1662,58 +2311,141 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 			return;
 		}
 	}
+	else if (cookie[0] == 'F') {
+		if (cookie[1] == 'I') {
+			if (cookie[2] == 'I') {
+				if (cookie[3] == 'I') {
+					if (cookie[4] == 'I') {
+						if (cookie[5] == 'I') {
+							if (cookie[6] == 'I') {
+								if (cookie[7] == '\0') {
+									// found: FIIIIII depth 10
+									wasm_invoke_fiiiiii (target_func, margs);
+									return;
+								}
+							}
+						}
+					}
+					else if (cookie[4] == '\0') {
+						// found: FIII depth 8
+						wasm_invoke_fiii (target_func, margs);
+						return;
+					}
+				}
+				else if (cookie[3] == '\0') {
+					// found: FII depth 7
+					wasm_invoke_fii (target_func, margs);
+					return;
+				}
+			}
+			else if (cookie[2] == 'F') {
+				if (cookie[3] == 'F') {
+					if (cookie[4] == 'F') {
+						if (cookie[5] == '\0') {
+							// found: FIFFF depth 9
+							wasm_invoke_fifff (target_func, margs);
+							return;
+						}
+					}
+					else if (cookie[4] == '\0') {
+						// found: FIFF depth 9
+						wasm_invoke_fiff (target_func, margs);
+						return;
+					}
+				}
+				else if (cookie[3] == '\0') {
+					// found: FIF depth 8
+					wasm_invoke_fif (target_func, margs);
+					return;
+				}
+			}
+			else if (cookie[2] == '\0') {
+				// found: FI depth 7
+				wasm_invoke_fi (target_func, margs);
+				return;
+			}
+		}
+		else if (cookie[1] == 'F') {
+			if (cookie[2] == 'F') {
+				if (cookie[3] == 'F') {
+					if (cookie[4] == '\0') {
+						// found: FFFF depth 8
+						wasm_invoke_ffff (target_func, margs);
+						return;
+					}
+				}
+				else if (cookie[3] == '\0') {
+					// found: FFF depth 8
+					wasm_invoke_fff (target_func, margs);
+					return;
+				}
+			}
+			else if (cookie[2] == 'I') {
+				if (cookie[3] == '\0') {
+					// found: FFI depth 8
+					wasm_invoke_ffi (target_func, margs);
+					return;
+				}
+			}
+			else if (cookie[2] == '\0') {
+				// found: FF depth 8
+				wasm_invoke_ff (target_func, margs);
+				return;
+			}
+		}
+	}
 	else if (cookie[0] == 'L') {
 		if (cookie[1] == 'I') {
 			if (cookie[2] == 'L') {
 				if (cookie[3] == 'I') {
 					if (cookie[4] == 'I') {
 						if (cookie[5] == '\0') {
-							// found: LILII depth 8
+							// found: LILII depth 9
 							wasm_invoke_lilii (target_func, margs);
 							return;
 						}
 					}
 					else if (cookie[4] == '\0') {
-						// found: LILI depth 8
+						// found: LILI depth 9
 						wasm_invoke_lili (target_func, margs);
 						return;
 					}
 				}
 				else if (cookie[3] == 'L') {
 					if (cookie[4] == '\0') {
-						// found: LILL depth 8
+						// found: LILL depth 9
 						wasm_invoke_lill (target_func, margs);
 						return;
 					}
 				}
 				else if (cookie[3] == '\0') {
-					// found: LIL depth 8
+					// found: LIL depth 9
 					wasm_invoke_lil (target_func, margs);
 					return;
 				}
 			}
 			else if (cookie[2] == 'I') {
 				if (cookie[3] == '\0') {
-					// found: LII depth 7
+					// found: LII depth 8
 					wasm_invoke_lii (target_func, margs);
 					return;
 				}
 			}
 			else if (cookie[2] == '\0') {
-				// found: LI depth 7
+				// found: LI depth 8
 				wasm_invoke_li (target_func, margs);
 				return;
 			}
 		}
 		else if (cookie[1] == 'L') {
 			if (cookie[2] == '\0') {
-				// found: LL depth 6
+				// found: LL depth 7
 				wasm_invoke_ll (target_func, margs);
 				return;
 			}
 		}
 		else if (cookie[1] == '\0') {
-			// found: L depth 6
+			// found: L depth 7
 			wasm_invoke_l (target_func, margs);
 			return;
 		}
@@ -1723,26 +2455,26 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 			if (cookie[2] == 'D') {
 				if (cookie[3] == 'D') {
 					if (cookie[4] == '\0') {
-						// found: DDDD depth 8
+						// found: DDDD depth 9
 						wasm_invoke_dddd (target_func, margs);
 						return;
 					}
 				}
 				else if (cookie[3] == '\0') {
-					// found: DDD depth 8
+					// found: DDD depth 9
 					wasm_invoke_ddd (target_func, margs);
 					return;
 				}
 			}
 			else if (cookie[2] == 'I') {
 				if (cookie[3] == '\0') {
-					// found: DDI depth 8
+					// found: DDI depth 9
 					wasm_invoke_ddi (target_func, margs);
 					return;
 				}
 			}
 			else if (cookie[2] == '\0') {
-				// found: DD depth 8
+				// found: DD depth 9
 				wasm_invoke_dd (target_func, margs);
 				return;
 			}
@@ -1751,71 +2483,20 @@ icall_trampoline_dispatch (const char *cookie, void *target_func, InterpMethodAr
 			if (cookie[2] == 'D') {
 				if (cookie[3] == 'D') {
 					if (cookie[4] == '\0') {
-						// found: DIDD depth 9
+						// found: DIDD depth 10
 						wasm_invoke_didd (target_func, margs);
 						return;
 					}
 				}
 				else if (cookie[3] == '\0') {
-					// found: DID depth 9
+					// found: DID depth 10
 					wasm_invoke_did (target_func, margs);
 					return;
 				}
 			}
 			else if (cookie[2] == '\0') {
-				// found: DI depth 8
+				// found: DI depth 9
 				wasm_invoke_di (target_func, margs);
-				return;
-			}
-		}
-	}
-	else if (cookie[0] == 'F') {
-		if (cookie[1] == 'F') {
-			if (cookie[2] == 'F') {
-				if (cookie[3] == 'F') {
-					if (cookie[4] == '\0') {
-						// found: FFFF depth 9
-						wasm_invoke_ffff (target_func, margs);
-						return;
-					}
-				}
-				else if (cookie[3] == '\0') {
-					// found: FFF depth 9
-					wasm_invoke_fff (target_func, margs);
-					return;
-				}
-			}
-			else if (cookie[2] == 'I') {
-				if (cookie[3] == '\0') {
-					// found: FFI depth 9
-					wasm_invoke_ffi (target_func, margs);
-					return;
-				}
-			}
-			else if (cookie[2] == '\0') {
-				// found: FF depth 9
-				wasm_invoke_ff (target_func, margs);
-				return;
-			}
-		}
-		else if (cookie[1] == 'I') {
-			if (cookie[2] == 'F') {
-				if (cookie[3] == 'F') {
-					if (cookie[4] == '\0') {
-						// found: FIFF depth 10
-						wasm_invoke_fiff (target_func, margs);
-						return;
-					}
-				}
-				else if (cookie[3] == '\0') {
-					// found: FIF depth 10
-					wasm_invoke_fif (target_func, margs);
-					return;
-				}
-			}
-			else if (cookie[2] == '\0') {
-				// found: FI depth 9
-				wasm_invoke_fi (target_func, margs);
 				return;
 			}
 		}


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19671,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This change adds the set of signatures required for SkiaSharp to work untouched using the signatures already provided for the existing platform.

This change should not be required, as it is very specific to a library set. The m2n generator should allow for an external set of cookies, provided by the additional libraries linked by the packager. See https://github.com/mono/mono/issues/19670 for a more detailed issue on a possible solution.

/cc @mattleibow

---

Here's the list of enabled methods by this change:

```
VIIFFII :
System.Void SkiaSharp.SkiaApi::sk_canvas_draw_arc(System.IntPtr,SkiaSharp.SKRect*,System.Single,System.Single,System.Boolean,System.IntPtr)
VIFFFI :
System.Void SkiaSharp.SkiaApi::sk_canvas_draw_circle(System.IntPtr,System.Single,System.Single,System.Single,System.IntPtr)
VIFFFFI :
System.Void SkiaSharp.SkiaApi::sk_canvas_draw_line(System.IntPtr,System.Single,System.Single,System.Single,System.Single,System.IntPtr)
VIFFI :
System.Void SkiaSharp.SkiaApi::sk_canvas_draw_point(System.IntPtr,System.Single,System.Single,System.IntPtr)
VIFI :
System.Void SkiaSharp.SkiaApi::sk_codec_get_scaled_dimensions(System.IntPtr,System.Single,SkiaSharp.SKSizeI*)
IIIIIFII :
System.IntPtr SkiaSharp.SkiaApi::sk_font_break_text(System.IntPtr,System.Void*,System.IntPtr,SkiaSharp.SKTextEncoding,System.Single,System.Single*,System.IntPtr)
FII :
System.Single SkiaSharp.SkiaApi::sk_font_get_metrics(System.IntPtr,SkiaSharp.SKFontMetrics*)
VIIIIF :
System.Void SkiaSharp.SkiaApi::sk_font_get_xpos(System.IntPtr,System.UInt16*,System.Int32,System.Single*,System.Single)
FIIIIII :
System.Single SkiaSharp.SkiaApi::sk_font_measure_text(System.IntPtr,System.Void*,System.IntPtr,SkiaSharp.SKTextEncoding,SkiaSharp.SKRect*,System.IntPtr)
VIIIFFII :
System.Void SkiaSharp.SkiaApi::sk_text_utils_get_path(System.Void*,System.IntPtr,SkiaSharp.SKTextEncoding,System.Single,System.Single,System.IntPtr,System.IntPtr)
IFFFFIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_arithmetic(System.Single,System.Single,System.Single,System.Single,System.Boolean,System.IntPtr,System.IntPtr,System.IntPtr)
IIIFFII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_distant_lit_diffuse(SkiaSharp.SKPoint3*,System.UInt32,System.Single,System.Single,System.IntPtr,System.IntPtr)
IIIFFFII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_distant_lit_specular(SkiaSharp.SKPoint3*,System.UInt32,System.Single,System.Single,System.Single,System.IntPtr,System.IntPtr)
IFFFFIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_drop_shadow(System.Single,System.Single,System.Single,System.Single,System.UInt32,SkiaSharp.SKDropShadowImageFilterShadowMode,System.IntPtr,System.IntPtr)
IIIFFIIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_matrix_convolution(SkiaSharp.SKSizeI*,System.Single*,System.Single,System.Single,SkiaSharp.SKPointI*,SkiaSharp.SKMatrixConvolutionTileMode,System.Boolean,System.IntPtr,System.IntPtr)
IIIFFII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_point_lit_diffuse(SkiaSharp.SKPoint3*,System.UInt32,System.Single,System.Single,System.IntPtr,System.IntPtr)
IIIFFFII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_point_lit_specular(SkiaSharp.SKPoint3*,System.UInt32,System.Single,System.Single,System.Single,System.IntPtr,System.IntPtr)
IIIFFIFFII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_spot_lit_diffuse(SkiaSharp.SKPoint3*,SkiaSharp.SKPoint3*,System.Single,System.Single,System.UInt32,System.Single,System.Single,System.IntPtr,System.IntPtr)
IIIFFIFFFII :
System.IntPtr SkiaSharp.SkiaApi::sk_imagefilter_new_spot_lit_specular(SkiaSharp.SKPoint3*,SkiaSharp.SKPoint3*,System.Single,System.Single,System.UInt32,System.Single,System.Single,System.Single,System.IntPtr,System.IntPtr)
FIFFF :
System.Single SkiaSharp.SkiaApi::sk_3dview_dot_with_normal(System.IntPtr,System.Single,System.Single,System.Single)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_3dview_translate(System.IntPtr,System.Single,System.Single,System.Single)
VIFFI :
System.Void SkiaSharp.SkiaApi::sk_matrix_map_vector(SkiaSharp.SKMatrix*,System.Single,System.Single,SkiaSharp.SKPoint*)
VIFFI :
System.Void SkiaSharp.SkiaApi::sk_matrix_map_xy(SkiaSharp.SKMatrix*,System.Single,System.Single,SkiaSharp.SKPoint*)
FIII :
System.Single SkiaSharp.SkiaApi::sk_matrix44_get(System.IntPtr,System.Int32,System.Int32)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_post_scale(System.IntPtr,System.Single,System.Single,System.Single)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_post_translate(System.IntPtr,System.Single,System.Single,System.Single)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_pre_scale(System.IntPtr,System.Single,System.Single,System.Single)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_pre_translate(System.IntPtr,System.Single,System.Single,System.Single)
VIIIF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_set(System.IntPtr,System.Int32,System.Int32,System.Single)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_set_scale(System.IntPtr,System.Single,System.Single,System.Single)
VIFFF :
System.Void SkiaSharp.SkiaApi::sk_matrix44_set_translate(System.IntPtr,System.Single,System.Single,System.Single)
IIIIIF :
System.Boolean SkiaSharp.SkiaApi::sk_paint_get_fill_path(System.IntPtr,System.IntPtr,System.IntPtr,SkiaSharp.SKRect*,System.Single)
VIIFF :
System.Void SkiaSharp.SkiaApi::sk_path_add_arc(System.IntPtr,SkiaSharp.SKRect*,System.Single,System.Single)
VIFFFI :
System.Void SkiaSharp.SkiaApi::sk_path_add_circle(System.IntPtr,System.Single,System.Single,System.Single,SkiaSharp.SKPathDirection)
VIFFFIIFF :
System.Void SkiaSharp.SkiaApi::sk_path_arc_to(System.IntPtr,System.Single,System.Single,System.Single,SkiaSharp.SKPathArcSize,SkiaSharp.SKPathDirection,System.Single,System.Single)
VIFFFIIFF :
System.Void SkiaSharp.SkiaApi::sk_path_rarc_to(System.IntPtr,System.Single,System.Single,System.Single,SkiaSharp.SKPathArcSize,SkiaSharp.SKPathDirection,System.Single,System.Single)
IFI :
System.IntPtr SkiaSharp.SkiaApi::sk_path_effect_create_2d_line(System.Single,SkiaSharp.SKMatrix*)
IFFI :
System.IntPtr SkiaSharp.SkiaApi::sk_path_effect_create_discrete(System.Single,System.Single,System.UInt32)
IFFI :
System.IntPtr SkiaSharp.SkiaApi::sk_path_effect_create_trim(System.Single,System.Single,SkiaSharp.SKTrimPathEffectMode)
VIIFFFF :
System.Void SkiaSharp.SkiaApi::sk_rrect_set_nine_patch(System.IntPtr,SkiaSharp.SKRect*,System.Single,System.Single,System.Single,System.Single)
VIIFF :
System.Void SkiaSharp.SkiaApi::sk_rrect_set_rect_xy(System.IntPtr,SkiaSharp.SKRect*,System.Single,System.Single)
IFIII :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_lerp(System.Single,System.IntPtr,System.IntPtr,SkiaSharp.SKMatrix*)
IFFIFI :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_perlin_noise_fractal_noise(System.Single,System.Single,System.Int32,System.Single,SkiaSharp.SKSizeI*)
IFFIF :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_perlin_noise_improved_noise(System.Single,System.Single,System.Int32,System.Single)
IFFIFI :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_perlin_noise_turbulence(System.Single,System.Single,System.Int32,System.Single,SkiaSharp.SKSizeI*)
IIFIIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_radial_gradient(SkiaSharp.SKPoint*,System.Single,System.UInt32*,System.Single*,System.Int32,SkiaSharp.SKShaderTileMode,SkiaSharp.SKMatrix*)
IIFIIIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_radial_gradient_color4f(SkiaSharp.SKPoint*,System.Single,SkiaSharp.SKColorF*,System.IntPtr,System.Single*,System.Int32,SkiaSharp.SKShaderTileMode,SkiaSharp.SKMatrix*)
IIIIIIFFI :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_sweep_gradient(SkiaSharp.SKPoint*,System.UInt32*,System.Single*,System.Int32,SkiaSharp.SKShaderTileMode,System.Single,System.Single,SkiaSharp.SKMatrix*)
IIIIIIIFFI :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_sweep_gradient_color4f(SkiaSharp.SKPoint*,SkiaSharp.SKColorF*,System.IntPtr,System.Single*,System.Int32,SkiaSharp.SKShaderTileMode,System.Single,System.Single,SkiaSharp.SKMatrix*)
IIFIFIIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_two_point_conical_gradient(SkiaSharp.SKPoint*,System.Single,SkiaSharp.SKPoint*,System.Single,System.UInt32*,System.Single*,System.Int32,SkiaSharp.SKShaderTileMode,SkiaSharp.SKMatrix*)
IIFIFIIIIII :
System.IntPtr SkiaSharp.SkiaApi::sk_shader_new_two_point_conical_gradient_color4f(SkiaSharp.SKPoint*,System.Single,SkiaSharp.SKPoint*,System.Single,SkiaSharp.SKColorF*,System.IntPtr,System.Single*,System.Int32,SkiaSharp.SKShaderTileMode,SkiaSharp.SKMatrix*)
VIIIFFII :
System.Void SkiaSharp.SkiaApi::sk_textblob_builder_alloc_run(System.IntPtr,System.IntPtr,System.Int32,System.Single,System.Single,SkiaSharp.SKRect*,SkiaSharp.SKRunBufferInternal*)
VIIIFII :
System.Void SkiaSharp.SkiaApi::sk_textblob_builder_alloc_run_pos_h(System.IntPtr,System.IntPtr,System.Int32,System.Single,SkiaSharp.SKRect*,SkiaSharp.SKRunBufferInternal*)
VIIIFFIII :
System.Void SkiaSharp.SkiaApi::sk_textblob_builder_alloc_run_text(System.IntPtr,System.IntPtr,System.Int32,System.Single,System.Single,System.Int32,SkiaSharp.SKRect*,SkiaSharp.SKRunBufferInternal*)
VIIIFIII :
System.Void SkiaSharp.SkiaApi::sk_textblob_builder_alloc_run_text_pos_h(System.IntPtr,System.IntPtr,System.Int32,System.Single,System.Int32,SkiaSharp.SKRect*,SkiaSharp.SKRunBufferInternal*)
```