### PR TITLE
Disable LZCNT in crossgen

### DIFF
--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2177,13 +2177,15 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
                 }
             }
 #if defined(TARGET_X86) || defined(TARGET_AMD64)
-            else if ((strcmp(isaName, "Avx") == 0) || (strcmp(isaName, "Fma") == 0) || (strcmp(isaName, "Avx2") == 0) || (strcmp(isaName, "Bmi1") == 0) || (strcmp(isaName, "Bmi2") == 0))
+            else if ((strcmp(isaName, "Avx") == 0) || (strcmp(isaName, "Fma") == 0) || (strcmp(isaName, "Avx2") == 0)
+                     || (strcmp(isaName, "Bmi1") == 0) || (strcmp(isaName, "Bmi2") == 0) || (strcmp(isaName, "Lzcnt") == 0))
             {
                 if ((enclosingClassName == nullptr) || fIsPlatformSubArchitecture)
                 {
-                    // If it is the get_IsSupported method for an ISA which requires the VEX
-                    // encoding we want to expand unconditionally. This will force those code
+                    // If it is the get_IsSupported method for an ISA which is intentionally not enabled
+                    // for crossgen, we want to expand unconditionally. This will force those code
                     // paths to be treated as dead code and dropped from the compilation.
+                    // See Zapper::InitializeCompilerFlags
                     //
                     // For all of the other intrinsics in an ISA which requires the VEX encoding
                     // we need to treat them as regular method calls. This is done because RyuJIT

--- a/src/coreclr/src/zap/zapper.cpp
+++ b/src/coreclr/src/zap/zapper.cpp
@@ -1213,11 +1213,11 @@ void Zapper::InitializeCompilerFlags(CORCOMPILE_VERSION_INFO * pVersionInfo)
         m_pOpt->m_compilerFlags.Set(InstructionSet_SSE41);
         m_pOpt->m_compilerFlags.Set(InstructionSet_SSE42);
         m_pOpt->m_compilerFlags.Set(InstructionSet_POPCNT);
-        // Leaving out CORJIT_FLAGS::CORJIT_FLAG_USE_AVX, CORJIT_FLAGS::CORJIT_FLAG_USE_FMA
-        // CORJIT_FLAGS::CORJIT_FLAG_USE_AVX2, CORJIT_FLAGS::CORJIT_FLAG_USE_BMI1,
-        // CORJIT_FLAGS::CORJIT_FLAG_USE_BMI2 on purpose - these require VEX encodings
+        // Leaving out InstructionSet_AVX, InstructionSet_FMA, InstructionSet_AVX2,
+        // InstructionSet_BMI1, InstructionSet_BMI2 on purpose - these require VEX encodings
         // and the JIT doesn't support generating code for methods with mixed encodings.
-        m_pOpt->m_compilerFlags.Set(InstructionSet_LZCNT);
+        // Also leaving out InstructionSet_LZCNT because BSR from InstructionSet_X86Base
+        // is used as a fallback in CoreLib and doesn't require an IsSupported check.
 #endif // defined(TARGET_X86) || defined(TARGET_AMD64)
     }
 #endif // defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_ARM64)


### PR DESCRIPTION
As a followup to https://github.com/dotnet/runtime/pull/34550#issuecomment-613047645, this is removing LZCNT from the list of x86 ISAs whitelisted for crossgen on CoreLib.

Now that `BitOperations.TrailingZeroCount` has a fallback to `BSR`, the cost of querying `Lzcnt.IsSupported` before using `LZCNT` is higher than simply using the fallback.  This is a situation very specific to `LZCNT` because it's most often a one-and-done instruction and the fallback is only very marginally slower.

R2RDump diff summary for `System.Private.CoreLib.dll` before and after this change:

```
Left file:  C:\corerun-before\System.Private.CoreLib.dll (10525696 B)
Right file: C:\corerun-afters\System.Private.CoreLib.dll (10523136 B)

 LEFT_SIZE RIGHT_SIZE       DIFF  R2R methods (19033 ELEMENTS)
--------------------------------------------------------------
       206        161        -45  Void System.Array+SorterObjectArray.IntrospectiveSort(Int32, Int32)
       206        161        -45  Void System.Array+SorterGenericArray.IntrospectiveSort(Int32, Int32)
      1521       1499        -22  Int32 System.Decimal+DecCalc.ScaleResult(System.Decimal+DecCalc+Buf24*, UInt32, Int32)
      1817       1781        -36  Void System.Decimal+DecCalc.VarDecDiv(ref System.Decimal+DecCalc, ref System.Decimal+DecCalc)
       783        765        -18  Void System.Decimal+DecCalc.VarDecModFull(ref System.Decimal+DecCalc, ref System.Decimal+DecCalc, Int32)
       587        561        -26  Void System.Number.Dragon4Double(Double, Int32, Boolean, ref System.Number+NumberBuffer)
       554        530        -24  Void System.Number.Dragon4Single(Single, Int32, Boolean, ref System.Number+NumberBuffer)
      3011       2975        -36  UInt32 System.Number.Dragon4(UInt64, Int32, UInt32, Boolean, Int32, Boolean, System.Span`1<Byte>, ref Int32)
       224        205        -19  String System.Number.Int32ToHexStr(Int32, Char, Int32)
       238        226        -12  Boolean System.Number.TryInt32ToHexStr(Int32, Char, Int32, System.Span`1<Char>, ref Int32)
       298        279        -19  String System.Number.Int64ToHexStr(Int64, Char, Int32)
       331        308        -23  Boolean System.Number.TryInt64ToHexStr(Int64, Char, Int32, System.Span`1<Char>, ref Int32)
       566        528        -38  UInt64 System.Number.AssembleFloatingPointBits(ref System.Number+FloatingPointInfo, UInt64, Int32, Boolean)
       757        738        -19  UInt64 System.Number.NumberToFloatingPointBitsSlow(ref System.Number+NumberBuffer, ref System.Number+FloatingPointInfo, UInt32, UInt32, UInt32)
        53         23        -30  UInt32 System.Number+BigInteger.CountSignificantBits(UInt32)
        57         25        -32  UInt32 System.Number+BigInteger.CountSignificantBits(UInt64)
        80         46        -34  UInt32 System.Number+BigInteger.CountSignificantBits(ref System.Number+BigInteger)
      1258       1228        -30  Void System.Number+BigInteger.DivRem(ref System.Number+BigInteger, ref System.Number+BigInteger, ref System.Number+BigInteger, ref System.Number+BigInteger)
       144        125        -19  System.Number+DiyFp System.Number+DiyFp.Normalize()
        60         28        -32  Int32 System.SpanHelpers.LocateLastFoundByte(UInt64)
        60         28        -32  Int32 System.SpanHelpers.LocateLastFoundChar(UInt64)
        56         17        -39  Int32 System.Numerics.BitOperations.LeadingZeroCount(UInt32)
        60         19        -41  Int32 System.Numerics.BitOperations.LeadingZeroCount(UInt64)
        53         11        -42  Int32 System.Numerics.BitOperations.Log2(UInt32)
        57         13        -44  Int32 System.Numerics.BitOperations.Log2(UInt64)
       108         90        -18  Int32 System.Buffers.Utilities.SelectBucketIndex(Int32)
        64         32        -32  Int32 System.Buffers.Text.FormattingHelpers.CountHexDigits(UInt64)
       240        181        -59  Boolean System.Buffers.Text.Utf8Formatter.TryFormatUInt64X(UInt64, Byte, Boolean, System.Span`1<Byte>, ref Int32)
   2623915    2623049       -866  <TOTAL>
```

<details>
    <summary>R2RDump disasm for `System.SpanHelpers.LocateLastFoundByte(UInt64)`</summary>

```
BEFORE
=============================================================

Int32 System.SpanHelpers.LocateLastFoundByte(UInt64)
Id: 4876
StartAddress: 0x004BE290
Size: 60 bytes
UnwindRVA: 0x0086F9BC
Version:            1
Flags:              0x03 EHANDLER UHANDLER
SizeOfProlog:       0x0005
CountOfUnwindCodes: 2
FrameRegister:      RAX
FrameOffset:        0x0
PersonalityRVA:     0x2973D
UnwindCode[0]: CodeOffset 0x0005 FrameOffset 0x3205 NextOffset 0x-1 Op 32
UnwindCode[1]: CodeOffset 0x0001 FrameOffset 0x6001 NextOffset 0x-1 Op RSI(6)

Debug Info
    Bounds:
    Native Offset: 0x0, Prolog, Source Types: StackEmpty
    Native Offset: 0x8, IL Offset: 0x0000, Source Types: StackEmpty
    Native Offset: 0x2E, NoMapping, Source Types: StackEmpty
    Native Offset: 0x36, Epilog, Source Types: StackEmpty

    Variable Locations:
    Variable Number: 0
    Start Offset: 0x0
    End Offset: 0x8
    Loc Type: VLT_REG
    Register: RCX

    Variable Number: 0
    Start Offset: 0x8
    End Offset: 0x12
    Loc Type: VLT_REG
    Register: RSI

    Variable Number: 0
    Start Offset: 0x1B
    End Offset: 0x20
    Loc Type: VLT_REG
    Register: RSI

  4be290: 56                    push rsi
                                UWOP_PUSH_NONVOL RSI(6)
  4be291: 48 83 ec 20           sub rsp, 32
                                UWOP_ALLOC_SMALL 32
  4be295: 48 8b f1              mov rsi, rcx
  4be298: ff 15 0a 28 b5 ff     call qword ptr [0x10aa8]      // Boolean System.Runtime.Intrinsics.X86.Lzcnt+X64.get_IsSupported() (METHOD_ENTRY_DEF_TOKEN)
  4be29e: 84 c0                 test al, al
  4be2a0: 74 09                 je 0x4BE2AB
  4be2a2: 33 c0                 xor eax, eax
  4be2a4: f3 48 0f bd c6        lzcnt rax, rsi
  4be2a9: eb 13                 jmp 0x4BE2BE
  4be2ab: 48 85 f6              test rsi, rsi
  4be2ae: 74 09                 je 0x4BE2B9
  4be2b0: 48 0f bd c6           bsr rax, rsi
  4be2b4: 83 f0 3f              xor eax, 63
  4be2b7: eb 05                 jmp 0x4BE2BE
  4be2b9: b8 40 00 00 00        mov eax, 64
  4be2be: c1 f8 03              sar eax, 3
  4be2c1: f7 d8                 neg eax
  4be2c3: 83 c0 07              add eax, 7
  4be2c6: 48 83 c4 20           add rsp, 32
  4be2ca: 5e                    pop rsi
  4be2cb: c3                    ret

=============================================================

AFTER
=============================================================

Int32 System.SpanHelpers.LocateLastFoundByte(UInt64)
Id: 4876
StartAddress: 0x004BE0B0
Size: 28 bytes
UnwindRVA: 0x00868D54
Version:            1
Flags:              0x03 EHANDLER UHANDLER
SizeOfProlog:       0x0000
CountOfUnwindCodes: 0
FrameRegister:      RAX
FrameOffset:        0x0
PersonalityRVA:     0x2973D

Debug Info
    Bounds:
    Native Offset: 0x0, Prolog, Source Types: StackEmpty
    Native Offset: 0x0, IL Offset: 0x0000, Source Types: StackEmpty
    Native Offset: 0x13, NoMapping, Source Types: StackEmpty
    Native Offset: 0x1B, Epilog, Source Types: StackEmpty

    Variable Locations:
    Variable Number: 0
    Start Offset: 0x0
    End Offset: 0x1
    Loc Type: VLT_REG
    Register: RCX

    Variable Number: 0
    Start Offset: 0x0
    End Offset: 0x5
    Loc Type: VLT_REG
    Register: RCX

  4be0b0: 48 85 c9              test rcx, rcx
  4be0b3: 74 09                 je 0x4BE0BE
  4be0b5: 48 0f bd c1           bsr rax, rcx
  4be0b9: 83 f0 3f              xor eax, 63
  4be0bc: eb 05                 jmp 0x4BE0C3
  4be0be: b8 40 00 00 00        mov eax, 64
  4be0c3: c1 f8 03              sar eax, 3
  4be0c6: f7 d8                 neg eax
  4be0c8: 83 c0 07              add eax, 7
  4be0cb: c3                    ret

=============================================================
```
</details>

Note: `Lzcnt.LeadingZeroCount` is called only from `BitOperations.LeadingZeroCount` in CoreLib.  All changes shown are from the inlined version of `BitOperations.LeadingZeroCount`.

cc @tannergooding @davidwrighton 