### PR TITLE
Run runtime tests with mono on test change.

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -282,7 +282,6 @@ jobs:
     - iOS_x64
     - iOS_arm
     - iOS_arm64
-    - OSX_x64
     - Linux_x64
     - Linux_arm
     - Linux_arm64
@@ -297,9 +296,29 @@ jobs:
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
+          eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
+          eq(variables['isFullMatrix'], true))
+
+#
+# Build Mono release
+# Only when libraries, mono, or the runtime tests changed
+# Currently only these architectures are needed for the runtime tests.
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/mono/templates/build-job.yml
+    runtimeFlavor: mono
+    buildConfig: release
+    platforms:
+   - OSX_x64
+   jobParameters:
+      condition: >-
+        or(
+          eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
           eq(variables['isFullMatrix'], true))
+
+
 
 #
 # Build Mono LLVM debug

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -74,6 +74,8 @@ jobs:
     - subset: mono
       include:
       - src/libraries/System.Private.CoreLib/*
+      - src/coreclr/tests
+      - src/coreclr/build-test.sh
       exclude:
       - eng/Version.Details.xml
       - '*.md'

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -297,6 +297,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
+          eq(dependencies.checkout.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -890,3 +890,5 @@ jobs:
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
           eq(variables['isFullMatrix'], true))
+
+

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -890,5 +890,3 @@ jobs:
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
           eq(variables['isFullMatrix'], true))
-
-

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -74,8 +74,6 @@ jobs:
     - subset: mono
       include:
       - src/libraries/System.Private.CoreLib/*
-      - src/coreclr/tests/*
-      - src/coreclr/build-test.sh
       exclude:
       - eng/Version.Details.xml
       - '*.md'
@@ -103,6 +101,10 @@ jobs:
       - eng/pipelines/coreclr/*
       - eng/pipelines/mono/*
       - eng/pipelines/installer/*
+    - subset: runtimetests
+      include:
+      - /src/coreclr/tests/*
+      - /src/coreclr/build-test.sh
     - subset: installer
       include:
       - docs/manpages/*
@@ -695,6 +697,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
+          eq(dependencies.checkout.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
 #
@@ -716,6 +719,7 @@ jobs:
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
+          eq(dependencies.checkout.outputs['SetPathVars_runtimetests.containsChange'], true),
           eq(variables['isFullMatrix'], true))
 
 #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -309,8 +309,8 @@ jobs:
     runtimeFlavor: mono
     buildConfig: release
     platforms:
-   - OSX_x64
-   jobParameters:
+    - OSX_x64
+    jobParameters:
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -74,7 +74,7 @@ jobs:
     - subset: mono
       include:
       - src/libraries/System.Private.CoreLib/*
-      - src/coreclr/tests
+      - src/coreclr/tests/*
       - src/coreclr/build-test.sh
       exclude:
       - eng/Version.Details.xml


### PR DESCRIPTION
Update runtime.yml so that we run the runtime tests using mono if tests are changes, or the build-test.sh script is changes (in addition to running them on coreclr).