### PR TITLE
handle UnauthorizedAccessException from mmap on OSX

### DIFF
--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -91,7 +91,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    if (PlatformDetection.IsInContainer && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
+                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
                     {
                         throw new SkipTestException("Execute permission failing in container.");
                     }

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -93,7 +93,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 {
                     if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
                     {
-                        throw new SkipTestException("Execute permission failing in container.");
+                        throw new SkipTestException("Insufficient execute permission.");
                     }
 
                     throw;

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -91,8 +91,10 @@ namespace System.IO.MemoryMappedFiles.Tests
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
+                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) &&
+                       (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
                     {
+                        // Containers and OSX with SIP enabled do not have execute permissions by default.
                         throw new SkipTestException("Insufficient execute permission.");
                     }
 

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -91,8 +91,10 @@ namespace System.IO.MemoryMappedFiles.Tests
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
+                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) &&
+                        (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
                     {
+                        // Containers and OSX with SIP enabled do not have execute permissions by default.
                         throw new SkipTestException("Insufficient execute permission.");
                     }
 

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -91,7 +91,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 }
                 catch (UnauthorizedAccessException)
                 {
-                    if (PlatformDetection.IsInContainer && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
+                    if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
                     {
                         throw new SkipTestException("Execute permission failing in container.");
                     }

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -93,7 +93,7 @@ namespace System.IO.MemoryMappedFiles.Tests
                 {
                     if ((RuntimeInformation.IsOSPlatform(OSPlatform.OSX) || PlatformDetection.IsInContainer) && (viewAccess == MemoryMappedFileAccess.ReadExecute || viewAccess == MemoryMappedFileAccess.ReadWriteExecute))
                     {
-                        throw new SkipTestException("Execute permission failing in container.");
+                        throw new SkipTestException("Insufficient execute permission.");
                     }
 
                     throw;


### PR DESCRIPTION
I was trying to run tests on my Mac (Catalina 10.15.3)  and it failed with 
```
     System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations(mapAccess: ReadWriteExecute, viewAccess: ReadWriteExecute) [FAIL]
        System.UnauthorizedAccessException : Access to the path is denied.
        ---- System.IO.IOException : Operation not permitted
        Stack Trace:
          /Users/furt/github/wfurt-runtime2/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedView.Unix.cs(117,0): at System.IO.MemoryMappedFiles.MemoryMappedView.CreateView(SafeMemoryMappedFileHandle memMappedFileHandle, MemoryMappedFileAccess access, Int64 requestedOffset, Int64 requestedSize)
          /Users/furt/github/wfurt-runtime2/src/libraries/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs(417,0): at System.IO.MemoryMappedFiles.MemoryMappedFile.CreateViewStream(Int64 offset, Int64 size, MemoryMappedFileAccess access)
          /Users/furt/github/wfurt-runtime2/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs(87,0): at System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.<>c__DisplayClass1_0.<ValidAccessLevelCombinations>b__0()
          /Users/furt/github/wfurt-runtime2/src/libraries/Common/tests/TestUtilities/System/AssertExtensions.cs(242,0): at System.AssertExtensions.ThrowsIf[T](Boolean condition, Action action)
          /Users/furt/github/wfurt-runtime2/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs(81,0): at System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations(MemoryMappedFileAccess mapAccess, MemoryMappedFileAccess viewAccess)
          ----- Inner Stack Trace -----

      System.IO.MemoryMappedFiles.Tests.MemoryMappedViewStreamTests.ValidAccessLevelCombinations(mapAccess: ReadWriteExecute, viewAccess: ReadExecute) [FAIL]
```

I could make them pass by disabling system security protections. (SIP) 

I think it would be nice if the tests do not fail in default configuration.
(and we already have same issue with containers)  