### PR TITLE
Optimize BitOperations.PopCount() with arm64 intrinsics

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -251,7 +251,7 @@ namespace System.Numerics
                 // Vector64.CreateScalar(uint) generates suboptimal code by storing and
                 // loading the result to memory.
                 // See https://github.com/dotnet/runtime/issues/35976 for details.
-                // Hence use Vector4.Create(ulong) to create Vector64<ulong> and operate on that.
+                // Hence use Vector64.Create(ulong) to create Vector64<ulong> and operate on that.
                 Vector64<ulong> input = Vector64.Create((ulong)value);
                 Vector64<byte> aggregated = AdvSimd.Arm64.AddAcross(AdvSimd.PopCount(input.AsByte()));
                 return AdvSimd.Extract(aggregated, 0);

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -244,12 +244,9 @@ namespace System.Numerics
                 return (int)Popcnt.PopCount(value);
             }
 
-            if (AdvSimd.IsSupported && AdvSimd.Arm64.IsSupported)
+            if (AdvSimd.IsSupported)
             {
-                // PopCount works on vector so convert input value to vector first.
-                Vector64<uint> input = Vector64.CreateScalar(value);
-                Vector64<byte> aggregated = AdvSimd.Arm64.AddAcross(AdvSimd.PopCount(input.AsByte()));
-                return (int)AdvSimd.Extract(aggregated, 0);
+                return PopCount((ulong)value);
             }
 
             return SoftwareFallback(value);
@@ -283,12 +280,12 @@ namespace System.Numerics
                 return (int)Popcnt.X64.PopCount(value);
             }
 
-            if (AdvSimd.IsSupported && AdvSimd.Arm64.IsSupported)
+            if (AdvSimd.IsSupported)
             {
                 // PopCount works on vector so convert input value to vector first.
-                Vector128<ulong> input = Vector128.CreateScalar(value);
+                Vector64<ulong> input = Vector64.Create(value);
                 Vector64<byte> aggregated = AdvSimd.Arm64.AddAcross(AdvSimd.PopCount(input.AsByte()));
-                return (int)AdvSimd.Extract(aggregated, 0);
+                return AdvSimd.Extract(aggregated, 0);
             }
 
 #if TARGET_32BIT

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -7,11 +7,11 @@ namespace System.Runtime.Intrinsics
     internal static class Vector64
     {
         public static Vector64<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
+        public static Vector64<byte> AsByte<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector64<T>
         where T : struct
     {
-        public static Vector64<byte> AsByte<T>(this Vector64<T> vector) => throw new PlatformNotSupportedException();
     }
 
     internal static class Vector128
@@ -143,9 +143,8 @@ namespace System.Runtime.Intrinsics.Arm
 
     internal abstract class AdvSimd : ArmBase
     {
-        public abstract class Arm64
+        public new abstract class Arm64 : ArmBase.Arm64
         {
-            public const bool IsSupported = false;
             public static Vector64<byte> AddAcross(Vector64<byte> value) => throw new PlatformNotSupportedException();
         }
         public static byte Extract(Vector64<byte> vector, byte index) => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -4,6 +4,16 @@
 
 namespace System.Runtime.Intrinsics
 {
+    internal static class Vector64
+    {
+        public static Vector64<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
+    }
+    internal readonly struct Vector64<T>
+        where T : struct
+    {
+        public static Vector64<byte> AsByte<T>(this Vector64<T> vector) => throw new PlatformNotSupportedException();
+    }
+
     internal static class Vector128
     {
         public static Vector128<short> Create(short value) => throw new PlatformNotSupportedException();
@@ -129,5 +139,16 @@ namespace System.Runtime.Intrinsics.Arm
         public const bool IsSupported = false;
         public static int LeadingZeroCount(uint value) => throw new PlatformNotSupportedException();
         public static uint ReverseElementBits(uint value) => throw new PlatformNotSupportedException();
+    }
+
+    internal abstract class AdvSimd : ArmBase
+    {
+        public abstract class Arm64
+        {
+            public static Vector64<byte> AddAcross(Vector64<byte> value) => throw new PlatformNotSupportedException();
+        }
+        public const bool IsSupported = false;
+        public static byte Extract(Vector64<byte> vector, byte index) => throw new PlatformNotSupportedException();
+        public static Vector64<byte> PopCount(Vector64<byte> value) => throw new PlatformNotSupportedException();
     }
 }

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -145,9 +145,9 @@ namespace System.Runtime.Intrinsics.Arm
     {
         public abstract class Arm64
         {
+            public const bool IsSupported = false;
             public static Vector64<byte> AddAcross(Vector64<byte> value) => throw new PlatformNotSupportedException();
         }
-        public const bool IsSupported = false;
         public static byte Extract(Vector64<byte> vector, byte index) => throw new PlatformNotSupportedException();
         public static Vector64<byte> PopCount(Vector64<byte> value) => throw new PlatformNotSupportedException();
     }


### PR DESCRIPTION
Optimize `BitOperations.PopCount()` using arm64 hardware intrinsic.

```asm
G_M3674_IG02:
        0F000410          movi    v16.2s, #0x00
        4E041C10          ins     v16.s[0], w0
        FD000FB0          str     d16, [fp,#24]
        FD400FB0          ldr     d16, [fp,#24]
        0E205A10          cnt     v16.8b, v16.8b
        0E31BA10          addv    b16, v16.8b
        0E013E00          umov    w0, v16.b[0]
```
Without optimization: 5.0038669 secs.
With optimization: 1.8343483 secs.

Contributes to #33308
Fixes: #33495