### PR TITLE
Create CI Lane for Mono in Interpreter Mode running the runtime tests

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -474,6 +474,6 @@ jobs:
       displayName: Publish Logs
       inputs:
         targetPath: $(Build.SourcesDirectory)/artifacts/log
-        artifactName: '${{ parameters.runtimeFlavor }}_$(LogNamePrefix)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
+        artifactName: '${{ parameters.runtimeFlavor }}_${{ parameters.runtimeMode }}_$(LogNamePrefix)_$(osGroup)$(osSubgroup)_$(archType)_$(buildConfig)_${{ parameters.testGroup }}'
       continueOnError: true
       condition: always()

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -76,12 +76,12 @@ jobs:
 
     # Compute job name from template parameters
     ${{ if eq(parameters.testGroup, 'innerloop') }}:
-      name: 'run_test_p0_${{ parameters.runtimeFlavor }}_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }}  Pri0 Test Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+      name: 'run_test_p0_${{ parameters.runtimeFlavor }}${{ parameters.runtimeMode }}_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} ${{ parameters.runtimeMode}} Pri0 Runtime Tests Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     ${{ if ne(parameters.testGroup, 'innerloop') }}:
       name: 'run_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Pri1 Test Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} Pri1 Runtime Tests Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     variables:
     - name: testhostArg

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -24,6 +24,7 @@ parameters:
   runtimeFlavor: 'coreclr'
   runtimeFlavorDisplayName: 'CoreCLR'
   runtimeMode: ''
+  runtimeModeDisplayName: ''
   # If true, tests were built in two phases
   # We will depend on both the TargetGeneric tests which are for AnyOS AnyCPU
   # as well as the TargetSpecific test.  Both sets of tests will be run

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -23,6 +23,7 @@ parameters:
   pool: ''
   runtimeFlavor: 'coreclr'
   runtimeFlavorDisplayName: 'CoreCLR'
+  runtimeMode: ''
   # If true, tests were built in two phases
   # We will depend on both the TargetGeneric tests which are for AnyOS AnyCPU
   # as well as the TargetSpecific test.  Both sets of tests will be run

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -77,11 +77,11 @@ jobs:
     # Compute job name from template parameters
     ${{ if eq(parameters.testGroup, 'innerloop') }}:
       name: 'run_test_p0_${{ parameters.runtimeFlavor }}${{ parameters.runtimeMode }}_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} ${{ parameters.runtimeMode}} Pri0 Runtime Tests Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} ${{ parameters.runtimeModeDisplayName}} Pri0 Runtime Tests Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     ${{ if ne(parameters.testGroup, 'innerloop') }}:
       name: 'run_test_p1_${{ parameters.displayNameArgs }}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}'
-      displayName: '${{ parameters.runtimeFlavorDisplayName }} Pri1 Runtime Tests Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
+      displayName: '${{ parameters.runtimeFlavorDisplayName }} ${{ parameters.runtimeModeDisplayName }} Pri1 Runtime Tests Run ${{ parameters.displayNameArgs }} ${{ parameters.osGroup }}${{ parameters.osSubgroup }} ${{ parameters.archType }} ${{ parameters.buildConfig }}'
 
     variables:
     - name: testhostArg
@@ -115,6 +115,10 @@ jobs:
       - ${{ if eq(parameters.compositeBuildMode, true) }}:
         - name: crossgenArg
           value: 'composite'
+
+    - ${{ if eq(parameters.runtimeMode, 'interpreter') }}:
+      - name: RuntimeModeDisplayName
+        value: 'Interpreter' 
 
     # Set job timeouts
     #

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -23,6 +23,7 @@ parameters:
   gcSimulatorTests: ''
   coreClrRepoRoot: ''
   runtimeFlavorDisplayName: 'CoreCLR'
+  runtimeMode: ''
 
 steps:
 - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
@@ -57,6 +58,7 @@ steps:
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       runtimeFlavorDisplayName: ${{ parameters.runtimeFlavorDisplayName }}
+      _RuntimeMode: #{{ parameters.runtimeMode }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -58,7 +58,7 @@ steps:
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       runtimeFlavorDisplayName: ${{ parameters.runtimeFlavorDisplayName }}
-      _RuntimeMode: #{{ parameters.runtimeMode }}
+      _RuntimeMode: ${{ parameters.runtimeMode }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed
@@ -100,6 +100,7 @@ steps:
       _TimeoutPerTestCollectionInMinutes: ${{ parameters.timeoutPerTestCollectionInMinutes }}
       _TimeoutPerTestInMinutes: ${{ parameters.timeoutPerTestInMinutes }}
       runtimeFlavorDisplayName: ${{ parameters.runtimeFlavorDisplayName }}
+      _RuntimeMode: ${{ parameters.runtimeMode }}
       ${{ if eq(parameters.publishTestResults, 'true') }}:
         SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       # TODO: remove NUGET_PACKAGES once https://github.com/dotnet/arcade/issues/1578 is fixed

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -733,6 +733,7 @@ jobs:
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       liveRuntimeBuildConfig: release
       runtimeMode: 'interpreter'
+      runtimeModeDisplayName: "Interpreter"
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -717,6 +717,28 @@ jobs:
           eq(variables['isFullMatrix'], true))
 
 #
+# Mono CoreCLR runtime Test executions using live libraries
+# Only when Mono is changed
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: release
+    runtimeFlavor: mono
+    platforms:
+    - OSX_x64
+    helixQueueGroup: pr
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: innerloop
+      liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+      liveRuntimeBuildConfig: release
+      runtimeMode: 'interpreter'
+      condition: >-
+        or(
+          eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
+          eq(variables['isFullMatrix'], true))
+
+#
 # Libraries Release Test Execution against a release mono runtime.
 # Only when libraries or mono changed
 #

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -887,5 +887,3 @@ jobs:
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
           eq(variables['isFullMatrix'], true))
-
-

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -733,7 +733,7 @@ jobs:
       liveLibrariesBuildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
       liveRuntimeBuildConfig: release
       runtimeMode: 'interpreter'
-      runtimeModeDisplayName: "Interpreter"
+      runtimeModeDisplayName: 'Interpreter'
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -887,3 +887,5 @@ jobs:
           eq(dependencies.checkout.outputs['SetPathVars_coreclr.containsChange'], true),
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
           eq(variables['isFullMatrix'], true))
+
+

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -233,7 +233,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetWindows) == 'true' and $(RuntimeMode == 'interpreter' ">
-    <HelixPreCommand Include=set MONO_ENV_OPTIONS='--interpreter'/>
+    <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter' "/>
   </ItemGroup>
 
 

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -181,6 +181,7 @@
     <TestRunNamePrefix Condition=" '$(RunCrossGen2)' == 'true' ">R2R-CG2 </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(TargetOS) $(TargetArchitecture) $(Configuration) @ </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(TargetOS) $(TargetArchitecture) $(Configuration) $(Scenario) @ </TestRunNamePrefix>
+    <TestRunNamePrefix Condition=" Condition=" '$(RuntimeMode)' == 'interpreter' ">$(TestRunNamePrefix) Interpreter </TestRunNamePrefix>  
     <TimeoutPerTestInMilliseconds Condition=" '$(TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
     <_XUnitParallelMode>collections</_XUnitParallelMode>

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -207,7 +207,7 @@
     <HelixPreCommand Include="set __CollectDumps=1" />
     <HelixPreCommand Include="set __CrashDumpFolder=%HELIX_DUMP_FOLDER%" />
     <HelixPreCommand Include="type %__TestEnv%" />
-    <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter' " Condition=" '$(RuntimeMode)' == 'interpreter' " />
+    <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter'" Condition=" '$(RuntimeMode)' == 'interpreter' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -232,7 +232,7 @@
     <HelixPreCommand Include="export MONO_ENV_OPTIONS='--interpreter"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetWindows) == 'true' and $(RuntimeMode == 'interpreter' ">
+  <ItemGroup Condition=" '$(TargetWindows)' == 'true' and $(RuntimeMode == 'interpreter' ">
     <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter' "/>
   </ItemGroup>
 

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -207,6 +207,7 @@
     <HelixPreCommand Include="set __CollectDumps=1" />
     <HelixPreCommand Include="set __CrashDumpFolder=%HELIX_DUMP_FOLDER%" />
     <HelixPreCommand Include="type %__TestEnv%" />
+    <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter' " Condition=" '$(RuntimeMode)' == 'interpreter' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
@@ -226,16 +227,8 @@
     <HelixPreCommand Include="cat $__TestEnv" />
     <HelixPreCommand Include="sudo bash -c 'echo $HELIX_DUMP_FOLDER/core.%u.%p > /proc/sys/kernel/core_pattern'" Condition=" '$(TargetOS)' != 'OSX' " />
     <HelixPreCommand Include="ulimit -c unlimited" Condition=" '$(TargetOS)' == 'OSX' " />
+    <HelixPreCommand Include="export MONO_ENV_OPTIONS='--interpreter" Condition=" '$(RuntimeMode)' == 'interpreter' " />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' and $(RuntimeMode) == 'interpreter' " >
-    <HelixPreCommand Include="export MONO_ENV_OPTIONS='--interpreter"/>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetWindows)' == 'true' and '$(RuntimeMode)' == 'interpreter' ">
-    <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter' "/>
-  </ItemGroup>
-
 
   <PropertyGroup>
     <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -32,7 +32,7 @@
         GcSimulatorTests=$(_GcSimulatorTests);
         RunInUnloadableContext=$(_RunInUnloadableContext);
         TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
-        TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes)
+        TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes);
         RuntimeMode=$(_RuntimeMode)
       </_PropertiesToPass>
     </PropertyGroup>

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -232,7 +232,7 @@
     <HelixPreCommand Include="export MONO_ENV_OPTIONS='--interpreter"/>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetWindows)' == 'true' and $(RuntimeMode == 'interpreter' ">
+  <ItemGroup Condition=" '$(TargetWindows)' == 'true' and '$(RuntimeMode)' == 'interpreter' ">
     <HelixPreCommand Include="set MONO_ENV_OPTIONS='--interpreter' "/>
   </ItemGroup>
 

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -33,6 +33,7 @@
         RunInUnloadableContext=$(_RunInUnloadableContext);
         TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
         TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes)
+        RuntimeMode=$(_RuntimeMode)
       </_PropertiesToPass>
     </PropertyGroup>
 
@@ -223,10 +224,18 @@
     <HelixPreCommand Include="export __CrashDumpFolder=$HELIX_DUMP_FOLDER" Condition=" '$(TargetOS)' != 'OSX' " />
     <HelixPreCommand Include="export __CrashDumpFolder=/cores" Condition=" '$(TargetOS)' == 'OSX' " /> <!-- Helix doesn't specify the dump folder for OSX 10.14, so we need to manually specify it. Tracked by dotnet/core-eng#7872 -->
     <HelixPreCommand Include="cat $__TestEnv" />
-
     <HelixPreCommand Include="sudo bash -c 'echo $HELIX_DUMP_FOLDER/core.%u.%p > /proc/sys/kernel/core_pattern'" Condition=" '$(TargetOS)' != 'OSX' " />
     <HelixPreCommand Include="ulimit -c unlimited" Condition=" '$(TargetOS)' == 'OSX' " />
   </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetsWindows)' != 'true' and $(RuntimeMode) == 'interpreter' " >
+    <HelixPreCommand Include="export MONO_ENV_OPTIONS='--interpreter"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetWindows) == 'true' and $(RuntimeMode == 'interpreter' ">
+    <HelixPreCommand Include=set MONO_ENV_OPTIONS='--interpreter'/>
+  </ItemGroup>
+
 
   <PropertyGroup>
     <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>

--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -181,7 +181,7 @@
     <TestRunNamePrefix Condition=" '$(RunCrossGen2)' == 'true' ">R2R-CG2 </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' == 'normal' ">$(TestRunNamePrefix)$(TargetOS) $(TargetArchitecture) $(Configuration) @ </TestRunNamePrefix>
     <TestRunNamePrefix Condition=" '$(Scenario)' != 'normal' ">$(TestRunNamePrefix)$(TargetOS) $(TargetArchitecture) $(Configuration) $(Scenario) @ </TestRunNamePrefix>
-    <TestRunNamePrefix Condition=" Condition=" '$(RuntimeMode)' == 'interpreter' ">$(TestRunNamePrefix) Interpreter </TestRunNamePrefix>  
+    <TestRunNamePrefix Condition=" '$(RuntimeMode)' == 'interpreter' ">$(TestRunNamePrefix) Interpreter </TestRunNamePrefix>  
     <TimeoutPerTestInMilliseconds Condition=" '$(TimeoutPerTestInMinutes)' != '' ">$([System.TimeSpan]::FromMinutes($(TimeoutPerTestInMinutes)).TotalMilliseconds)</TimeoutPerTestInMilliseconds>
     <WaitForWorkItemCompletion>true</WaitForWorkItemCompletion>
     <_XUnitParallelMode>collections</_XUnitParallelMode>


### PR DESCRIPTION
Create CI Lane for Mono in Interpreter mode running the runtime tests. To do this we need to ensure that the environment variable MONO_ENV_OPTIONS contains "--interpreter" when running the tests.