### PR TITLE
Optimize BitOperations uses in CoreLib

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -104,7 +104,7 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountHexDigits(ulong value)
         {
-            // The number of hex digits is Log16(value) + 1, or Log2(value) / 4 + 1
+            // The number of hex digits is log16(value) + 1, or log2(value) / 4 + 1
             return (BitOperations.Log2(value) >> 2) + 1;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/FormattingHelpers.CountDigits.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/FormattingHelpers.CountDigits.cs
@@ -104,7 +104,8 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int CountHexDigits(ulong value)
         {
-            return (64 - BitOperations.LeadingZeroCount(value | 1) + 3) >> 2;
+            // The number of hex digits is Log16(value) + 1, or Log2(value) / 4 + 1
+            return (BitOperations.Log2(value) >> 2) + 1;
         }
 
         // Counts the number of trailing '0' digits in a decimal number.

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs
@@ -14,7 +14,13 @@ namespace System.Buffers
         internal static int SelectBucketIndex(int bufferSize)
         {
             Debug.Assert(bufferSize >= 0);
-            return BitOperations.Log2Unsafe((uint)bufferSize - 1 | 0xF) - 3;
+
+            // Buffers are bucketed so that a request between 2^(n-1) + 1 and 2^n is given a buffer of 2^n
+            // Bucket index is log2(bufferSize - 1) with the exception that buffers between 1 and 16 bytes
+            // are combined, and the index is slid down by 3 to compensate.
+            // Zero is a valid bufferSize, and it is assigned the highest bucket index so that zero-length
+            // buffers are not retained by the pool. The pool will return the Array.Empty singleton for these.
+            return BitOperations.Log2((uint)bufferSize - 1 | 15) - 3;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Utilities.cs
@@ -14,8 +14,7 @@ namespace System.Buffers
         internal static int SelectBucketIndex(int bufferSize)
         {
             Debug.Assert(bufferSize >= 0);
-            uint bits = ((uint)bufferSize - 1) >> 4;
-            return 32 - BitOperations.LeadingZeroCount(bits);
+            return BitOperations.Log2Unsafe((uint)bufferSize - 1 | 0xF) - 3;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
@@ -126,18 +127,35 @@ namespace System.Numerics
         /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
         /// </summary>
         /// <param name="value">The value.</param>
+        // The 0->0 contract is fulfilled by setting the LSB to 1.
+        // Log(1) is 0, and setting the LSB for values > 1 does not change the Log2 result.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static int Log2(uint value)
+            => Log2Unsafe(value | 1);
+
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static int Log2(ulong value)
+            => Log2Unsafe(value | 1);
+
+        /// <summary>
+        /// Returns the integer (floor) log of the specified value, base 2.
+        /// The result is undefined for input value 0.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int Log2Unsafe(uint value)
         {
-            // Enforce conventional contract 0->0 (Log(0) is undefined)
-            if (value == 0)
-            {
-                return 0;
-            }
+            Debug.Assert(value != 0);
 
             // value    lzcnt   actual  expected
-            // ..0000   32      0        0 (by convention, guard clause)
+            // ..0000   32      31^32   undefined
             // ..0001   31      31-31    0
             // ..0010   30      31-30    1
             // 0010..    2      31-2    29
@@ -157,6 +175,7 @@ namespace System.Numerics
             // However BSR is much slower than LZCNT on AMD processors, so we leave it as a fallback only.
             if (X86Base.IsSupported)
             {
+                // BSR contract is 0->undefined
                 return (int)X86Base.BitScanReverse(value);
             }
 
@@ -166,18 +185,13 @@ namespace System.Numerics
 
         /// <summary>
         /// Returns the integer (floor) log of the specified value, base 2.
-        /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
+        /// The result is undefined for input value 0.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [CLSCompliant(false)]
-        public static int Log2(ulong value)
+        internal static int Log2Unsafe(ulong value)
         {
-            // Enforce conventional contract 0->0 (Log(0) is undefined)
-            if (value == 0)
-            {
-                return 0;
-            }
+            Debug.Assert(value != 0);
 
             if (Lzcnt.X64.IsSupported)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -124,38 +124,18 @@ namespace System.Numerics
 
         /// <summary>
         /// Returns the integer (floor) log of the specified value, base 2.
-        /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
         /// </summary>
         /// <param name="value">The value.</param>
-        // The 0->0 contract is fulfilled by setting the LSB to 1.
-        // Log(1) is 0, and setting the LSB for values > 1 does not change the Log2 result.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
         public static int Log2(uint value)
-            => Log2Unsafe(value | 1);
-
-        /// <summary>
-        /// Returns the integer (floor) log of the specified value, base 2.
-        /// Note that by convention, input value 0 returns 0 since Log(0) is undefined.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [CLSCompliant(false)]
-        public static int Log2(ulong value)
-            => Log2Unsafe(value | 1);
-
-        /// <summary>
-        /// Returns the integer (floor) log of the specified value, base 2.
-        /// The result is undefined for input value 0.
-        /// </summary>
-        /// <param name="value">The value.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int Log2Unsafe(uint value)
         {
-            Debug.Assert(value != 0);
+            // The 0->0 contract is fulfilled by setting the LSB to 1.
+            // Log(1) is 0, and setting the LSB for values > 1 does not change the log2 result.
+            value |= 1;
 
             // value    lzcnt   actual  expected
-            // ..0000   32      31^32   undefined
             // ..0001   31      31-31    0
             // ..0010   30      31-30    1
             // 0010..    2      31-2    29
@@ -171,11 +151,10 @@ namespace System.Numerics
                 return 31 ^ ArmBase.LeadingZeroCount(value);
             }
 
-            // BSR returns the answer we're looking for directly.
-            // However BSR is much slower than LZCNT on AMD processors, so we leave it as a fallback only.
+            // BSR returns the log2 result directly. However BSR is slower than LZCNT
+            // on AMD processors, so we leave it as a fallback only.
             if (X86Base.IsSupported)
             {
-                // BSR contract is 0->undefined
                 return (int)X86Base.BitScanReverse(value);
             }
 
@@ -185,13 +164,14 @@ namespace System.Numerics
 
         /// <summary>
         /// Returns the integer (floor) log of the specified value, base 2.
-        /// The result is undefined for input value 0.
+        /// Note that by convention, input value 0 returns 0 since log(0) is undefined.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int Log2Unsafe(ulong value)
+        [CLSCompliant(false)]
+        public static int Log2(ulong value)
         {
-            Debug.Assert(value != 0);
+            value |= 1;
 
             if (Lzcnt.X64.IsSupported)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1758,9 +1758,7 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundByte(ulong match)
-        {
-            return 7 - (BitOperations.LeadingZeroCount(match) >> 3);
-        }
+            => BitOperations.Log2Unsafe(match) >> 3;
 
         private const ulong XorPowerOfTwoToHighByte = (0x07ul |
                                                        0x06ul << 8 |

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1742,31 +1742,11 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundByte(ulong match)
-        {
-            if (Bmi1.X64.IsSupported)
-            {
-                return (int)(Bmi1.X64.TrailingZeroCount(match) >> 3);
-            }
-            else
-            {
-                // Flag least significant power of two bit
-                ulong powerOfTwoFlag = match ^ (match - 1);
-                // Shift all powers of two into the high byte and extract
-                return (int)((powerOfTwoFlag * XorPowerOfTwoToHighByte) >> 57);
-            }
-        }
+            => BitOperations.TrailingZeroCount(match) >> 3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundByte(ulong match)
             => BitOperations.Log2Unsafe(match) >> 3;
-
-        private const ulong XorPowerOfTwoToHighByte = (0x07ul |
-                                                       0x06ul << 8 |
-                                                       0x05ul << 16 |
-                                                       0x04ul << 24 |
-                                                       0x03ul << 32 |
-                                                       0x02ul << 40 |
-                                                       0x01ul << 48) + 1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ushort LoadUShort(ref byte start)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1746,7 +1746,7 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundByte(ulong match)
-            => BitOperations.Log2Unsafe(match) >> 3;
+            => BitOperations.Log2(match) >> 3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ushort LoadUShort(ref byte start)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -984,27 +984,7 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateFirstFoundChar(ulong match)
-        {
-            // TODO: Arm variants
-            if (Bmi1.X64.IsSupported)
-            {
-                return (int)(Bmi1.X64.TrailingZeroCount(match) >> 4);
-            }
-            else
-            {
-                unchecked
-                {
-                    // Flag least significant power of two bit
-                    ulong powerOfTwoFlag = match ^ (match - 1);
-                    // Shift all powers of two into the high byte and extract
-                    return (int)((powerOfTwoFlag * XorPowerOfTwoToHighChar) >> 49);
-                }
-            }
-        }
-
-        private const ulong XorPowerOfTwoToHighChar = (0x03ul |
-                                                       0x02ul << 16 |
-                                                       0x01ul << 32) + 1;
+            => BitOperations.TrailingZeroCount(match) >> 4;
 
         // Vector sub-search adapted from https://github.com/aspnet/KestrelHttpServer/pull/1138
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -1029,9 +1029,7 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundChar(ulong match)
-        {
-            return 3 - (BitOperations.LeadingZeroCount(match) >> 4);
-        }
+            => BitOperations.Log2Unsafe(match) >> 4;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector<ushort> LoadVector(ref char start, nint offset)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -1009,7 +1009,7 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int LocateLastFoundChar(ulong match)
-            => BitOperations.Log2Unsafe(match) >> 4;
+            => BitOperations.Log2(match) >> 4;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static Vector<ushort> LoadVector(ref char start, nint offset)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -410,7 +410,7 @@ namespace System.Text
 
             if ((bufferLength & 8) != 0)
             {
-                if (Bmi1.X64.IsSupported)
+                if (UIntPtr.Size == sizeof(ulong))
                 {
                     // If we can use 64-bit tzcnt to count the number of leading ASCII bytes, prefer it.
 
@@ -418,10 +418,10 @@ namespace System.Text
                     if (!AllBytesInUInt64AreAscii(candidateUInt64))
                     {
                         // Clear everything but the high bit of each byte, then tzcnt.
-                        // Remember the / 8 at the end to convert bit count to byte count.
+                        // Remember to divide by 8 at the end to convert bit count to byte count.
 
                         candidateUInt64 &= UInt64HighBitsOnlyMask;
-                        pBuffer += (nuint)(Bmi1.X64.TrailingZeroCount(candidateUInt64) / 8);
+                        pBuffer += (nuint)(BitOperations.TrailingZeroCount(candidateUInt64) >> 3);
                         goto Finish;
                     }
                 }
@@ -932,7 +932,7 @@ namespace System.Text
 
             if ((bufferLength & 4) != 0)
             {
-                if (Bmi1.X64.IsSupported)
+                if (UIntPtr.Size == sizeof(ulong))
                 {
                     // If we can use 64-bit tzcnt to count the number of leading ASCII chars, prefer it.
 
@@ -940,12 +940,12 @@ namespace System.Text
                     if (!AllCharsInUInt64AreAscii(candidateUInt64))
                     {
                         // Clear the low 7 bits (the ASCII bits) of each char, then tzcnt.
-                        // Remember the / 8 at the end to convert bit count to byte count,
+                        // Remember to divide by 8 at the end to convert bit count to byte count,
                         // then the & ~1 at the end to treat a match in the high byte of
                         // any char the same as a match in the low byte of that same char.
 
                         candidateUInt64 &= 0xFF80FF80_FF80FF80ul;
-                        pBuffer = (char*)((byte*)pBuffer + ((nuint)(Bmi1.X64.TrailingZeroCount(candidateUInt64) / 8) & ~(nuint)1));
+                        pBuffer = (char*)((byte*)pBuffer + ((nuint)(BitOperations.TrailingZeroCount(candidateUInt64) >> 3) & ~(nuint)1));
                         goto Finish;
                     }
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -144,7 +144,7 @@ namespace System.Text.Unicode
 
                         do
                         {
-                            if (Sse2.IsSupported && Bmi1.IsSupported)
+                            if (Sse2.IsSupported)
                             {
                                 // pInputBuffer is 32-bit aligned but not necessary 128-bit aligned, so we're
                                 // going to perform an unaligned load. We don't necessarily care about aligning
@@ -180,7 +180,6 @@ namespace System.Text.Unicode
 
                         Debug.Assert(BitConverter.IsLittleEndian);
                         Debug.Assert(Sse2.IsSupported);
-                        Debug.Assert(Bmi1.IsSupported);
 
                         // The 'mask' value will have a 0 bit for each ASCII byte we saw and a 1 bit
                         // for each non-ASCII byte we saw. We can count the number of ASCII bytes,
@@ -189,7 +188,7 @@ namespace System.Text.Unicode
 
                         Debug.Assert(mask != 0);
 
-                        pInputBuffer += Bmi1.TrailingZeroCount(mask);
+                        pInputBuffer += BitOperations.TrailingZeroCount(mask);
                         if (pInputBuffer > pFinalPosWhereCanReadDWordFromInputBuffer)
                         {
                             goto ProcessRemainingBytesSlow;


### PR DESCRIPTION
Following up on https://github.com/dotnet/runtime/pull/35598, this updates uses of `Lzcnt.LeadingZeroCount` and `Bmi1.TrailingZeroCount` to use the equivalent `BitOperations` methods, which are now optimized for all xarch and for ARM64.

I also found that most uses of `LeadingZeroCount` were actually calculating log2.  This presents opportunities to both simplify the code and to make it run faster on processors without LZCNT support as well as in R2R CoreLib.

When using LZCNT to calculate Log2, the result must be switched to the position of the highest non-zero bit.  Since the `LeadingZeroCount` BSR and software fallbacks calculate log2 first then switch it to LZCNT, any place LZCNT is used where log2 is intended means that the fallback result is double-swapped.  The changes here eliminate that.

~~In switching existing logic over to `BitOperations.Log2`, I found that most uses were protected against `0` inputs, making the zero-check branch in `Log2` unnecessary.  I have added an internal `Log2Unsafe` that skips that protection when the inputs are known to be non-zero.~~  I also made the public `Log2` branch-free, by simply setting the low bit of the input.  Log2(1) is 0, and log2 of any odd number would round down anyway.

The new `Log2` shows a decent performance gain over the previous improvement in https://github.com/dotnet/runtime/pull/34550

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.778 (1909/November2018Update/19H2)
Intel Core i7-6700K CPU 4.00GHz (Skylake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.100
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.22309, CoreFX 5.0.20.22309), X64 RyuJIT
  Job-TSFLZN : .NET Core 5.0 (CoreCLR 42.42.42.42424, CoreFX 42.42.42.42424), X64 RyuJIT
  Job-BBSNWR : .NET Core 5.0 (CoreCLR 42.42.42.42424, CoreFX 42.42.42.42424), X64 RyuJIT

PowerPlanMode=00000000-0000-0000-0000-000000000000  Arguments=/p:DebugType=portable  IterationTime=250.0000 ms  
MaxIterationCount=20  MinIterationCount=15  WarmupCount=1  

```
|                  Method |        Job |                   Toolchain |     Mean |   Error |  StdDev |   Median |      Min |      Max | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |---------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|------:|------:|------:|----------:|
|               Log2_uint | Job-TSFLZN | \corerun-bitops\corerun.exe | 599.7 ns | 2.10 ns | 1.87 ns | 599.7 ns | 596.6 ns | 603.6 ns |  0.82 |     - |     - |     - |         - |
|               Log2_uint | Job-BBSNWR | \corerun-master\corerun.exe | 735.4 ns | 1.58 ns | 1.32 ns | 735.5 ns | 733.2 ns | 738.2 ns |  1.00 |     - |     - |     - |         - |
|                         |            |                             |          |         |         |          |          |          |       |       |       |       |           |
|              Log2_ulong | Job-TSFLZN | \corerun-bitops\corerun.exe | 599.8 ns | 2.28 ns | 2.02 ns | 599.5 ns | 597.3 ns | 604.6 ns |  0.81 |     - |     - |     - |         - |
|              Log2_ulong | Job-BBSNWR | \corerun-master\corerun.exe | 737.8 ns | 3.53 ns | 2.95 ns | 738.3 ns | 730.7 ns | 742.5 ns |  1.00 |     - |     - |     - |         - |

With LZCNT disabled, the improvement is even greater since BSR returns log2 directly.  On Intel machines, the fallback is actually faster than the LZCNT version (not true for AMD unfortunately).

|                  Method |        Job |                   Toolchain |     Mean |   Error |  StdDev |   Median |      Min |      Max | Ratio | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |----------- |---------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|------:|------:|------:|------:|----------:|
|               Log2_uint | Job-FVXROL | \corerun-bitops\corerun.exe | 555.7 ns | 0.71 ns | 0.59 ns | 555.6 ns | 554.8 ns | 556.6 ns |  0.62 |     - |     - |     - |         - |
|               Log2_uint | Job-JLEBRF | \corerun-master\corerun.exe | 893.4 ns | 2.28 ns | 2.13 ns | 893.3 ns | 889.1 ns | 897.6 ns |  1.00 |     - |     - |     - |         - |
|                         |            |                             |          |         |         |          |          |          |       |       |       |       |           |
|              Log2_ulong | Job-FVXROL | \corerun-bitops\corerun.exe | 555.2 ns | 1.19 ns | 1.05 ns | 555.3 ns | 552.7 ns | 557.0 ns |  0.62 |     - |     - |     - |         - |
|              Log2_ulong | Job-JLEBRF | \corerun-master\corerun.exe | 892.6 ns | 4.36 ns | 4.07 ns | 892.5 ns | 884.8 ns | 899.5 ns |  1.00 |     - |     - |     - |         - |
