### PR TITLE
Improve Guid equality checks on 64-bit platforms

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -789,19 +789,15 @@ namespace System
             else g = (Guid)o;
 
             // Now compare each of the elements
-            return g._a == _a &&
-                Unsafe.Add(ref g._a, 1) == Unsafe.Add(ref _a, 1) &&
-                Unsafe.Add(ref g._a, 2) == Unsafe.Add(ref _a, 2) &&
-                Unsafe.Add(ref g._a, 3) == Unsafe.Add(ref _a, 3);
+            return Unsafe.As<int, long>(ref g._a) == Unsafe.As<int, long>(ref _a) &&
+                Unsafe.As<byte, long>(ref g._d) == Unsafe.As<byte, long>(ref _d);
         }
 
         public bool Equals(Guid g)
         {
             // Now compare each of the elements
-            return g._a == _a &&
-                Unsafe.Add(ref g._a, 1) == Unsafe.Add(ref _a, 1) &&
-                Unsafe.Add(ref g._a, 2) == Unsafe.Add(ref _a, 2) &&
-                Unsafe.Add(ref g._a, 3) == Unsafe.Add(ref _a, 3);
+            return Unsafe.As<int, long>(ref g._a) == Unsafe.As<int, long>(ref _a) &&
+                Unsafe.As<byte, long>(ref g._d) == Unsafe.As<byte, long>(ref _d);
         }
 
         private int GetResult(uint me, uint them) => me < them ? -1 : 1;
@@ -937,17 +933,13 @@ namespace System
         }
 
         public static bool operator ==(Guid a, Guid b) =>
-            a._a == b._a &&
-                Unsafe.Add(ref a._a, 1) == Unsafe.Add(ref b._a, 1) &&
-                Unsafe.Add(ref a._a, 2) == Unsafe.Add(ref b._a, 2) &&
-                Unsafe.Add(ref a._a, 3) == Unsafe.Add(ref b._a, 3);
+            Unsafe.As<int, long>(ref a._a) == Unsafe.As<int, long>(ref b._a) &&
+                Unsafe.As<byte, long>(ref a._d) == Unsafe.As<byte, long>(ref b._d);
 
         public static bool operator !=(Guid a, Guid b) =>
             // Now compare each of the elements
-            a._a != b._a ||
-                Unsafe.Add(ref a._a, 1) != Unsafe.Add(ref b._a, 1) ||
-                Unsafe.Add(ref a._a, 2) != Unsafe.Add(ref b._a, 2) ||
-                Unsafe.Add(ref a._a, 3) != Unsafe.Add(ref b._a, 3);
+            Unsafe.As<int, long>(ref a._a) != Unsafe.As<int, long>(ref b._a) ||
+                Unsafe.As<byte, long>(ref a._d) != Unsafe.As<byte, long>(ref b._d);
 
         public string ToString(string? format)
         {


### PR DESCRIPTION
Current code does four 32-bit comparisons. Instead,
do two 64-bit comparisons. On x86, the JIT-generated
code is slightly different, but equally fast.

This will be even better on arm64 which passes everything
in 64-bit registers, after #35622 is addressed in the JIT.

Perf results:

x64:

|            Method | Tool |       Mean |     Error |    StdDev |     Median |        Min |        Max | Ratio | RatioSD |
|------------------ |------|-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|
|        EqualsSame | base |   2.322 ns | 0.0210 ns | 0.0187 ns |   2.324 ns |   2.294 ns |   2.351 ns |  1.00 |    0.00 |
|        EqualsSame | diff |   1.547 ns | 0.0092 ns | 0.0071 ns |   1.547 ns |   1.535 ns |   1.559 ns |  0.67 |    0.01 |
|    EqualsOperator | base |   2.890 ns | 0.3896 ns | 0.4169 ns |   3.030 ns |   1.722 ns |   3.074 ns |  1.00 |    0.00 |
|    EqualsOperator | diff |   1.346 ns | 0.0160 ns | 0.0150 ns |   1.346 ns |   1.331 ns |   1.380 ns |  0.49 |    0.12 |
| NotEqualsOperator | base |   1.738 ns | 0.0306 ns | 0.0255 ns |   1.730 ns |   1.712 ns |   1.805 ns |  1.00 |    0.00 |
| NotEqualsOperator | diff |   1.401 ns | 0.0425 ns | 0.0355 ns |   1.389 ns |   1.360 ns |   1.476 ns |  0.81 |    0.02 |

x86:

|            Method | Tool |       Mean |     Error |    StdDev |     Median |        Min |        Max | Ratio | RatioSD |
|------------------ |------|-----------:|----------:|----------:|-----------:|-----------:|-----------:|------:|--------:|
|        EqualsSame | base |   3.164 ns | 0.0234 ns | 0.0208 ns |   3.159 ns |   3.136 ns |   3.203 ns |  1.00 |    0.00 |
|        EqualsSame | diff |   3.079 ns | 0.0327 ns | 0.0306 ns |   3.074 ns |   3.041 ns |   3.146 ns |  0.97 |    0.01 |
|    EqualsOperator | base |   2.736 ns | 0.0252 ns | 0.0236 ns |   2.726 ns |   2.710 ns |   2.783 ns |  1.00 |    0.00 |
|    EqualsOperator | diff |   2.613 ns | 0.0262 ns | 0.0245 ns |   2.600 ns |   2.589 ns |   2.662 ns |  0.95 |    0.01 |
| NotEqualsOperator | base |   2.708 ns | 0.0096 ns | 0.0080 ns |   2.705 ns |   2.699 ns |   2.723 ns |  1.00 |    0.00 |
| NotEqualsOperator | diff |   2.573 ns | 0.0666 ns | 0.0591 ns |   2.552 ns |   2.526 ns |   2.709 ns |  0.95 |    0.02 |