### PR TITLE
Remove unused library definition

### DIFF
--- a/src/coreclr/src/unwinder/CMakeLists.txt
+++ b/src/coreclr/src/unwinder/CMakeLists.txt
@@ -29,8 +29,3 @@ add_dependencies(unwinder_dac eventing_headers)
 set_target_properties(unwinder_dac PROPERTIES DAC_COMPONENT TRUE)
 target_compile_definitions(unwinder_dac PRIVATE FEATURE_NO_HOST)
 
-add_library_clr(unwinder_dac_amd64 ${UNWINDER_SOURCES})
-add_dependencies(unwinder_dac_amd64 eventing_headers)
-set_target_properties(unwinder_dac_amd64 PROPERTIES DAC_COMPONENT TRUE)
-target_compile_definitions(unwinder_dac_amd64 PRIVATE FEATURE_NO_HOST)
-


### PR DESCRIPTION
I also suspect the 
```cmake
convert_to_absolute_path(UNWINDER_SOURCES ${UNWINDER_SOURCES})
```

Is also unnecessary.  It seemed those were needed when we were including thise files in the dbi/dac/... files.

I left it because that could actually be a widesweeping cleanup.