### PR TITLE
Optimize call indirect for R2R, Arm and Arm64 scenarios

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2664,12 +2664,13 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         // Generate a direct call to a non-virtual user defined or helper method
         assert(callType == CT_HELPER || callType == CT_USER_FUNC);
         assert(call->gtEntryPoint.accessType == IAT_PVALUE);
+        assert(call->gtControlExpr == nullptr);
 
         regNumber tmpReg = call->GetSingleTempReg();
         GetEmitter()->emitIns_R_R(ins_Load(TYP_I_IMPL), emitActualTypeSize(TYP_I_IMPL), tmpReg, REG_R2R_INDIRECT_PARAM);
 
-        // We have already generated code for gtControlExpr evaluating it into a register.
-        // We just need to emit "call reg" in this case.
+        // We have now generated code for gtControlExpr evaluating it into `tmpReg`.
+        // We just need to emit "call tmpReg" in this case.
         //
         assert(genIsValidIntReg(tmpReg));
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3282,11 +3282,19 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
 
         case IAT_PVALUE:
         {
-            // Non-virtual direct calls to addresses accessed by
-            // a single indirection.
-            GenTree* cellAddr = AddrGen(addr);
-            GenTree* indir    = Ind(cellAddr);
-            result            = indir;
+            bool isR2RRelativeIndir = false;
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+            isR2RRelativeIndir = call->IsR2RRelativeIndir();
+#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
+
+            if (!isR2RRelativeIndir)
+            {
+                // Non-virtual direct calls to addresses accessed by
+                // a single indirection.
+                GenTree* cellAddr = AddrGen(addr);
+                GenTree* indir    = Ind(cellAddr);
+                result            = indir;
+            }
             break;
         }
 

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -173,6 +173,12 @@ int LinearScan::BuildCall(GenTreeCall* call)
             ctrlExprCandidates = RBM_FASTTAILCALL_TARGET;
         }
     }
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+    else if (call->IsR2RRelativeIndir())
+    {
+        buildInternalIntRegisterDefForNode(call);
+    }
+#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
 #ifdef TARGET_ARM
     else
     {


### PR DESCRIPTION
We generate unnecessary load of indirect cell address and can use the address that we have already loaded in ARM64. With this change, we save 8 bytes / call-site that does call indirect. The way it will be optimized is during lowering, `controlExpr` won't be created for such cases. Instead we would use temp register for such calls and during codegen, load the indirect from x11 into that temp register before calling the address in that temp register.

Address to some extent: https://github.com/dotnet/runtime/issues/35108

```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -5828536 (-10.07% of base)
    diff is an improvement.
Top file improvements (bytes):
     -687316 : System.Private.CoreLib.dasm (-10.30% of base)
     -551304 : System.Private.Xml.dasm (-10.26% of base)
     -418840 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-7.36% of base)
     -415680 : Microsoft.CodeAnalysis.VisualBasic.dasm (-10.94% of base)
     -401832 : System.Linq.Expressions.dasm (-7.79% of base)
     -364704 : Microsoft.CodeAnalysis.CSharp.dasm (-10.42% of base)
     -209096 : System.Data.Common.dasm (-10.82% of base)
     -136088 : System.Private.DataContractSerialization.dasm (-10.54% of base)
     -113512 : Newtonsoft.Json.dasm (-10.62% of base)
     -109584 : Microsoft.CodeAnalysis.dasm (-8.99% of base)
     -105208 : System.Net.Http.dasm (-11.00% of base)
      -94208 : System.DirectoryServices.dasm (-13.50% of base)
      -83672 : Microsoft.VisualBasic.Core.dasm (-11.55% of base)
      -77344 : System.Management.dasm (-12.61% of base)
      -73224 : System.Linq.Parallel.dasm (-7.63% of base)
      -72856 : System.Drawing.Common.dasm (-13.98% of base)
      -72224 : System.Text.Json.dasm (-9.51% of base)
      -69048 : System.Security.Cryptography.Pkcs.dasm (-12.93% of base)
      -60840 : System.Configuration.ConfigurationManager.dasm (-10.96% of base)
      -59324 : Microsoft.CSharp.dasm (-10.35% of base)
190 total files with Code Size differences (190 improved, 0 regressed), 76 unchanged.
Top method improvements (bytes):
      -75184 (-19.99% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.CallInstruction:FastCreate(System.Reflection.MethodInfo,System.Reflection.ParameterInfo[]):System.Linq.Expressions.Interpreter.CallInstruction (241 methods)
       -7456 (-6.93% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -6152 (-20.63% of base) : System.Private.CoreLib.dasm - HtmlEntities:.cctor()
       -5680 (-15.23% of base) : System.Text.RegularExpressions.dasm - System.Text.RegularExpressions.RegexCompiler:GenerateOneCode():this
       -4536 (-17.26% of base) : System.Data.Common.dasm - System.Data.BinaryNode:EvalBinaryOp(int,System.Data.ExpressionNode,System.Data.ExpressionNode,System.Data.DataRow,int,System.Int32[]):System.Object:this
       -4104 (-13.29% of base) : System.Private.Xml.dasm - System.Xml.Schema.XsdBuilder:.cctor()
       -3800 (-19.60% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.ADStoreCtx:.cctor()
       -3680 (-12.77% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateMethods():this
       -3432 (-18.86% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.ADAMStoreCtx:.cctor()
       -3432 (-15.56% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDateTimeFunction():this
       -3432 (-11.44% of base) : System.Private.CoreLib.dasm - System.Globalization.CultureData:get_RegionNames():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
       -3424 (-13.74% of base) : System.Private.Xml.dasm - System.Xml.Serialization.XmlReflectionImporter:ImportAccessorMapping(System.Xml.Serialization.MemberMapping,System.Xml.Serialization.FieldModel,System.Xml.Serialization.XmlAttributes,System.String,System.Type,bool,bool,System.Xml.Serialization.RecursionLimiter):this
       -3224 (-13.76% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateTypeConverterClass():System.CodeDom.CodeTypeDeclaration:this
       -3168 (-16.95% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.SAMStoreCtx:.cctor()
       -3128 (-8.11% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.DesktopAssemblyIdentityComparer:.cctor()
       -3064 (-4.70% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -2800 (-16.95% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFDateTimeFunction():this
       -2784 (-14.20% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.MicrosoftWindowsTCPIPTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -2696 (-14.20% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.WpfTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
       -2688 (-15.59% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:.cctor() (168 methods)
Top method improvements (percentages):
        -192 (-27.91% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.PortableShim:Initialize()
         -40 (-27.78% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMemberFieldSymbol:GetFieldDeclaration(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode):Microsoft.CodeAnalysis.CSharp.Syntax.BaseFieldDeclarationSyntax
         -24 (-27.27% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.FileIO.FileSystem:NormalizePath(System.String):System.String
         -24 (-27.27% of base) : System.Diagnostics.TraceSource.dasm - System.Diagnostics.Trace:Refresh()
         -88 (-26.19% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:ValidateOrder():this
         -24 (-26.09% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilation:get_RootNamespace():Microsoft.CodeAnalysis.VisualBasic.Symbols.NamespaceSymbol:this
         -24 (-26.09% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ProjectData:EndApp()
         -24 (-26.09% of base) : System.Configuration.ConfigurationManager.dasm - System.Configuration.DateTimeConfigurationCollection:get_Item(int):System.DateTime:this
         -24 (-26.09% of base) : System.Data.Common.dasm - System.Data.DataTable:CreateInstance():System.Data.DataTable:this
         -24 (-26.09% of base) : System.Linq.Expressions.dasm - System.Dynamic.Utils.TypeUtils:IsUnsigned(System.Type):bool
         -32 (-25.81% of base) : System.Net.Mail.dasm - ConnectAndHandshakeAsyncResult:End(System.IAsyncResult)
         -16 (-25.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ExplicitInterfaceHelpers:FindExplicitlyImplementedProperty(Microsoft.CodeAnalysis.CSharp.Symbols.PropertySymbol,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,System.String,Microsoft.CodeAnalysis.CSharp.Syntax.ExplicitInterfaceSpecifierSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.CSharp.Symbols.PropertySymbol
         -16 (-25.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.ExplicitInterfaceHelpers:FindExplicitlyImplementedMethod(Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol,Microsoft.CodeAnalysis.CSharp.Symbols.TypeSymbol,System.String,Microsoft.CodeAnalysis.CSharp.Syntax.ExplicitInterfaceSpecifierSyntax,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.CSharp.Symbols.MethodSymbol
         -16 (-25.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode:get_Parent():Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode:this
         -24 (-25.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - EndInvokeMethod:get_BoundAttributesSource():Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:this
         -24 (-25.00% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Emit.PEModuleBuilder:GetInitArrayHelper():Microsoft.Cci.IMethodReference:this
         -16 (-25.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode:get_Parent():Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode:this
         -24 (-25.00% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Emit.PEModuleBuilder:GetInitArrayHelper():Microsoft.Cci.IMethodReference:this
         -16 (-25.00% of base) : Microsoft.CSharp.dasm - System.Runtime.InteropServices.Variant:get_AsVariant():System.Object:this
         -16 (-25.00% of base) : Microsoft.CSharp.dasm - Microsoft.CSharp.RuntimeBinder.ComInterop.UnsafeMethods:GetObjectForVariant(System.Runtime.InteropServices.Variant):System.Object
155334 total methods with Code Size differences (155334 improved, 0 regressed), 67835 unchanged.
Completed analysis in 253.06s
```