### PR TITLE
Lazy load System.Private.Uri.dll

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -114,6 +114,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt32Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt64Converter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UriConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Value\UriConverterFactory.cs" />
     <Compile Include="System\Text\Json\Serialization\DefaultReferenceResolver.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonCamelCaseNamingPolicy.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UriConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UriConverterFactory.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Avoid loading System.Private.Uri.dll until necessary.
+    /// </summary>
+    internal sealed class UriConverterFactory : JsonConverterFactory
+    {
+        public override bool CanConvert(Type type)
+        {
+            return type.ToString() == "System.Uri";
+        }
+
+        public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
+        {
+            return new UriConverter();
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UriConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UriConverterFactory.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Text.Json.Serialization.Converters
 {
     /// <summary>
@@ -11,12 +13,19 @@ namespace System.Text.Json.Serialization.Converters
     {
         public override bool CanConvert(Type type)
         {
-            return type.ToString() == "System.Uri";
+            return (type.ToString() == "System.Uri" && IsSystemUriType(type));
         }
 
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
             return new UriConverter();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static bool IsSystemUriType(Type type)
+        {
+            // Verify the Type is what we expect.
+            return (type == typeof(Uri));
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -26,6 +26,7 @@ namespace System.Text.Json
             new NullableConverterFactory(),
             new EnumConverterFactory(),
             new KeyValuePairConverterFactory(),
+            new UriConverterFactory(),
             // IEnumerable should always be second to last since they can convert any IEnumerable.
             new IEnumerableConverterFactory(),
             // Object should always be last since it converts any type.
@@ -37,7 +38,7 @@ namespace System.Text.Json
 
         private static Dictionary<Type, JsonConverter> GetDefaultSimpleConverters()
         {
-            const int NumberOfSimpleConverters = 23;
+            const int NumberOfSimpleConverters = 22;
             var converters = new Dictionary<Type, JsonConverter>(NumberOfSimpleConverters);
 
             // Use a dictionary for simple converters.
@@ -64,7 +65,6 @@ namespace System.Text.Json
             Add(new UInt16Converter());
             Add(new UInt32Converter());
             Add(new UInt64Converter());
-            Add(new UriConverter());
 
             Debug.Assert(NumberOfSimpleConverters == converters.Count);
 


### PR DESCRIPTION
The `System.Private.Uri.dll` assembly was always being loaded even though a `System.Uri` object may never be serialized\deserialized. This delay-loads the assembly until there is a reference to System.Uri.

Saves ~1ms on startup (~22.5ms to ~21.5ms).

Fixes https://github.com/dotnet/runtime/issues/35029
