### PR TITLE
Make corerun exit code more useful

### DIFF
--- a/src/coreclr/src/hosts/corerun/corerun.cpp
+++ b/src/coreclr/src/hosts/corerun/corerun.cpp
@@ -767,6 +767,7 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
     hr = InitializeHost(log, hostEnvironment, appPath, appNiPath, nativeDllSearchDirs, appLocalWinmetadata, &hostHandle, (unsigned int*)&domainId);
     if (FAILED(hr))
     {
+        exitCode = hr;
         return false;
     }
 


### PR DESCRIPTION
In case `corerun` failed to initialize the `CoreCLR`, we should use the failure HR as the process exit code.