### PR TITLE
Improve DSA digest handling on macOS

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -269,7 +269,7 @@ namespace System.Security.Cryptography
                     // MacOS only supports FIPS-186-2, which only defines SHA1
                     // as a supported algorithm.
                     if (rgbHash.Length != Sha1DigestSizeBytes)
-                        throw new CryptographicException(SR.Cryptography_HashSizeInvalid);
+                        throw new CryptographicException(SR.Format(SR.Cryptography_InvalidHashSize, "SHA1", Sha1DigestSizeBytes));
 
                     SecKeyPair keys = GetKeys();
 

--- a/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSASecurityTransforms.cs
@@ -261,8 +261,15 @@ namespace System.Security.Cryptography
 
                 public override byte[] CreateSignature(byte[] rgbHash)
                 {
+                    const int Sha1DigestSizeBytes = 20;
+
                     if (rgbHash == null)
                         throw new ArgumentNullException(nameof(rgbHash));
+
+                    // MacOS only supports FIPS-186-2, which only defines SHA1
+                    // as a supported algorithm.
+                    if (rgbHash.Length != Sha1DigestSizeBytes)
+                        throw new CryptographicException(SR.Cryptography_HashSizeInvalid);
 
                     SecKeyPair keys = GetKeys();
 
@@ -277,7 +284,7 @@ namespace System.Security.Cryptography
                     // are always 160 bits / 20 bytes (the size of SHA-1, and the only legal length for Q).
                     byte[] ieeeFormatSignature = AsymmetricAlgorithmHelpers.ConvertDerToIeee1363(
                         derFormatSignature.AsSpan(0, derFormatSignature.Length),
-                        fieldSizeBits: 160);
+                        fieldSizeBits: Sha1DigestSizeBytes * 8);
 
                     return ieeeFormatSignature;
                 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -374,6 +374,25 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
 
+        [ConditionalTheory(nameof(DoesNotSupportFips186_3))]
+        [InlineData(128)]
+        [InlineData(256)]
+        [InlineData(384)]
+        [InlineData(512)]
+        public void SignHash_DigestAlgorithmUnsupported(int hashSizeBits)
+        {
+            byte[] hash = new byte[hashSizeBits / 8];
+            RandomNumberGenerator.Fill(hash);
+
+            using (DSA dsa = DSAFactory.Create())
+            {
+                DSATestData.GetDSA1024_186_2(out DSAParameters parameters, out _, out _);
+                dsa.ImportParameters(parameters);
+                CryptographicException ce = Assert.Throws<CryptographicException>(() => dsa.CreateSignature(hash));
+                Assert.Contains("hash's size is not supported", ce.Message);
+            }
+        }
+
         private void SignAndVerify(byte[] data, string hashAlgorithmName, DSAParameters dsaParameters, int expectedSignatureLength)
         {
             using (DSA dsa = DSAFactory.Create())
@@ -394,5 +413,6 @@ namespace System.Security.Cryptography.Dsa.Tests
             }
         }
         public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
+        public static bool DoesNotSupportFips186_3 => !SupportsFips186_3;
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -389,7 +389,7 @@ namespace System.Security.Cryptography.Dsa.Tests
                 DSATestData.GetDSA1024_186_2(out DSAParameters parameters, out _, out _);
                 dsa.ImportParameters(parameters);
                 CryptographicException ce = Assert.Throws<CryptographicException>(() => dsa.CreateSignature(hash));
-                Assert.Contains("hash's size is not supported", ce.Message);
+                Assert.Equal("SHA1 algorithm hash size is 20 bytes.", ce.Message);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -162,6 +162,9 @@
   <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
     <value>The hash algorithm name cannot be null or empty.</value>
   </data>
+  <data name="Cryptography_HashSizeInvalid" xml:space="preserve">
+    <value>The specified hash's size is not supported on this platform.</value>
+  </data>
   <data name="Cryptography_InvalidOID" xml:space="preserve">
     <value>Object identifier (OID) is unknown.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -162,8 +162,8 @@
   <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
     <value>The hash algorithm name cannot be null or empty.</value>
   </data>
-  <data name="Cryptography_HashSizeInvalid" xml:space="preserve">
-    <value>The specified hash's size is not supported on this platform.</value>
+  <data name="Cryptography_InvalidHashSize" xml:space="preserve">
+    <value>{0} algorithm hash size is {1} bytes.</value>
   </data>
   <data name="Cryptography_InvalidOID" xml:space="preserve">
     <value>Object identifier (OID) is unknown.</value>

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Unix.cs
@@ -49,7 +49,16 @@ namespace System.Security.Cryptography
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5351", Justification = "This is the implementation of DSACryptoServiceProvider")]
-        public override byte[] CreateSignature(byte[] rgbHash) => _impl.CreateSignature(rgbHash);
+        public override byte[] CreateSignature(byte[] rgbHash)
+        {
+            if (rgbHash == null)
+                throw new ArgumentNullException(nameof(rgbHash));
+
+            if (rgbHash.Length != SHA1_HASHSIZE)
+                throw new CryptographicException(SR.Format(SR.Cryptography_InvalidHashSize, "SHA1", SHA1_HASHSIZE));
+
+            return _impl.CreateSignature(rgbHash);
+        }
 
         public override bool TryCreateSignature(ReadOnlySpan<byte> hash, Span<byte> destination, out int bytesWritten) =>
             _impl.TryCreateSignature(hash, destination, out bytesWritten);
@@ -212,8 +221,6 @@ namespace System.Security.Cryptography
                 throw new ArgumentNullException(nameof(rgbHash));
             if (PublicOnly)
                 throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
-            if (rgbHash.Length != SHA1_HASHSIZE)
-                throw new CryptographicException(SR.Format(SR.Cryptography_InvalidHashSize, "SHA1", SHA1_HASHSIZE));
 
             // Only SHA1 allowed; the default value is SHA1
             if (str != null && !string.Equals(str, "SHA1", StringComparison.OrdinalIgnoreCase))

--- a/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             return new DSACryptoServiceProvider(keySize);
         }
 
-        public bool SupportsFips186_3 => PlatformDetection.IsLinux;
+        public bool SupportsFips186_3 => false;
         public bool SupportsKeyGeneration => !PlatformDetection.IsOSX;
     }
 

--- a/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Dsa.Tests
             return new DSACryptoServiceProvider(keySize);
         }
 
-        public bool SupportsFips186_3 => false;
+        public bool SupportsFips186_3 => PlatformDetection.IsLinux;
         public bool SupportsKeyGeneration => !PlatformDetection.IsOSX;
     }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -345,6 +345,9 @@
   <data name="Cryptography_X509Store_WouldModifyAdminTrust" xml:space="preserve">
     <value>Removing the requested certificate would modify admin trust settings, and has been denied.</value>
   </data>
+  <data name="Cryptography_HashSizeInvalid" xml:space="preserve">
+    <value>The specified hash's size is not supported on this platform.</value>
+  </data>
   <data name="Cryptography_InvalidKeySize" xml:space="preserve">
     <value>Specified key is not a valid size for this algorithm.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -74,7 +74,7 @@
   </data>
   <data name="Arg_InvalidType" xml:space="preserve">
     <value>Invalid type.</value>
-  </data>  
+  </data>
   <data name="Arg_OutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
@@ -345,8 +345,8 @@
   <data name="Cryptography_X509Store_WouldModifyAdminTrust" xml:space="preserve">
     <value>Removing the requested certificate would modify admin trust settings, and has been denied.</value>
   </data>
-  <data name="Cryptography_HashSizeInvalid" xml:space="preserve">
-    <value>The specified hash's size is not supported on this platform.</value>
+  <data name="Cryptography_InvalidHashSize" xml:space="preserve">
+    <value>{0} algorithm hash size is {1} bytes.</value>
   </data>
   <data name="Cryptography_InvalidKeySize" xml:space="preserve">
     <value>Specified key is not a valid size for this algorithm.</value>


### PR DESCRIPTION
Fixes #28634

If you use `DSA.CreateSignature` on macOS with a digest that is bigger than 160 bits, you get a fairly obscure error that is hard to diagnose. Something like this:

```
Interop+AppleCrypto+AppleCFErrorCryptographicException: The operation couldn’t be completed. (Internal CSSM error error -2147415807 - Internal error #80010901
at SignTransform_block_invoke /AppleInternal/BuildRoot/Library/Caches/com.apple.xbs/Sources/Security/Security-59306.101.1/OSX/libsecurity_transform/lib/SecSignVerifyTransform.c:324)
```

This is because Apple only supports FIPS-186-2, or SHA1 digests. Using a SHA2 family digest will result in this error.

I am marking this as a draft pending feedback on this is also a breaking change with digests less than 160 bits. It seems that right now, `CreateSignature` works on any number of bytes <= 20. I'm not entirely sure what the underlying platform is actually doing with a 19-byte hash, but it doesn't throw an error.

However, it seems the intention of the code was that it is always 20 bytes. Furthermore, `SignData`, which takes raw data and hashes it for you, does not accept MD5.