### PR TITLE
Insert missing break in hwintrinsicarm64.cpp

### DIFF
--- a/src/coreclr/src/jit/hwintrinsicarm64.cpp
+++ b/src/coreclr/src/jit/hwintrinsicarm64.cpp
@@ -374,6 +374,7 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
             assert(numArgs == 0);
 
             retNode = gtNewSimdHWIntrinsicNode(retType, intrinsic, baseType, simdSize);
+            break;
         }
         default:
         {


### PR DESCRIPTION
In my previous PR to introduce / vectorise `Vector{Size}<T>.AllBitsSet / Zero` 
 (https://github.com/dotnet/runtime/pull/33924), there was a missing `break;` in a switch statement in the importation logic, which resulted in the correct functions not being imported as `GT_HWINTRINSIC` nodes as the control fell through the `default` block, returning `nullptr` (meaning the method is not a valid HWINTRINSIC node and should be imported as regular function).

This was pointed out in https://github.com/dotnet/runtime/pull/35300#event-3291742581 by @echesakovMSFT, where `Vector128.CreateScalar` methods were found out to be using the software fallback.

JitDump of the importation part, prior to this change:
```
    [ 0]  10 (0x00a) call 0A00007D
In Compiler::impImportCall: opcode is call, kind=0, callRetType is struct, structSize is 8
Named Intrinsic System.Runtime.Intrinsics.Vector64`1.get_Zero: Notify VM instruction set (Vector64) must be supported.
Recognized
  Known type Vector64<int>
  Known type Vector64<int>
  Known type Vector64<int>


               [000039] I-C-G-------              ▌  CALL      simd8  System.Runtime.Intrinsics.Vector64`1[Int32][System.Int32].get_Zero (exactContextHnd=0x0000FFFF11276419)
```

JitDump of the importation part, after this change:
```
    [ 0]  10 (0x00a) call 0A00007D
In Compiler::impImportCall: opcode is call, kind=0, callRetType is struct, structSize is 8
Named Intrinsic System.Runtime.Intrinsics.Vector64`1.get_Zero: Notify VM instruction set (Vector64) must be supported.
Recognized
  Known type Vector64<int>
  Known type Vector64<int>

    [ 1]  15 (0x00f) stloc.0
lvaGrabTemp returning 4 (V04 tmp3) (a long lifetime temp) called for Inline stloc first use temp.
  Known type Vector64<int>


               [000041] -A----------              ▌  ASG       simd8  (copy)
               [000039] D------N----              ├──▌  LCL_VAR   simd8 <System.Runtime.Intrinsics.Vector64`1[Int32]> V04 tmp3
               [000038] ------------              └──▌  HWINTRINSIC simd8  int get_Zero
```

(I'm so sorry for missing this out, I think the build I was testing with before was somehow outdated)