### PR TITLE
Fix ManagedWebSocket.CloseAsync cancellation

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Test.Common;
 using System.Text;
 using System.Threading;
@@ -323,6 +324,48 @@ namespace System.Net.WebSockets.Client.Tests
                     Assert.Equal(WebSocketState.Aborted, cws.State);
                 }
             }
+        }
+
+        [ConditionalFact(nameof(WebSocketsSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        public async Task CloseAsync_CancelableEvenWhenPendingReceive_Throws()
+        {
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await LoopbackServer.CreateClientAndServerAsync(async uri =>
+            {
+                try
+                {
+                    using (var cws = new ClientWebSocket())
+                    using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
+                    {
+                        await cws.ConnectAsync(uri, cts.Token);
+
+                        Task receiveTask = cws.ReceiveAsync(new byte[1], CancellationToken.None);
+
+                        var cancelCloseCts = new CancellationTokenSource();
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                        {
+                            Task t = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, null, cancelCloseCts.Token);
+                            cancelCloseCts.Cancel();
+                            await t;
+                        });
+
+                        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => receiveTask);
+                    }
+                }
+                finally
+                {
+                    tcs.SetResult(true);
+                }
+            }, server => server.AcceptConnectionAsync(async connection =>
+            {
+                Dictionary<string, string> headers = await LoopbackHelper.WebSocketHandshakeAsync(connection);
+                Assert.NotNull(headers);
+
+                await tcs.Task;
+
+            }), new LoopbackServer.Options { WebSocketEndpoint = true });
         }
     }
 }


### PR DESCRIPTION
We allow at most one pending receive operation on a web socket, and CloseAsync needs to both send and receive, so if there's a pending receive already, it just reuses / waits for that existing one, which records if it sees a close frame.  However, if the close operation is initiated with a cancellation token that's different from the cancellation token the receive operation was initiated with, the close won't respect the supplied cancellation token because it's just waiting on the existing receive.  The fix is simply to register with this new cancellation token as well when there's an existing receive that we wait on.

Fixes https://github.com/dotnet/runtime/issues/35666