### PR TITLE
Obsolete RuntimeHelpers.OffsetToStringData

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1447,31 +1447,44 @@ namespace Internal.TypeSystem.Interop
             if (ShouldBePinned)
             {
                 //
-                // Pin the string and push a pointer to the first character on the stack.
+                // Pin the char& and push a pointer to the first character on the stack.
                 //
-                TypeDesc stringType = Context.GetWellKnownType(WellKnownType.String);
+                TypeDesc charRefType = Context.GetWellKnownType(WellKnownType.Char).MakeByRefType();
 
-                ILLocalVariable vPinnedString = emitter.NewLocal(stringType, true);
-                ILCodeLabel lNullString = emitter.NewCodeLabel();
+                ILLocalVariable vPinnedCharRef = emitter.NewLocal(charRefType, true);
+
+                ILCodeLabel lNonNullString = emitter.NewCodeLabel();
+                ILCodeLabel lCommonExit = emitter.NewCodeLabel();
 
                 LoadManagedValue(codeStream);
-                codeStream.EmitStLoc(vPinnedString);
-                codeStream.EmitLdLoc(vPinnedString);
+                codeStream.Emit(ILOpcode.brtrue, lNonNullString);
 
-                codeStream.Emit(ILOpcode.conv_i);
-                codeStream.Emit(ILOpcode.dup);
+                //
+                // Null input case
+                // Don't pin anything - load a zero-value nuint (void*) onto the stack
+                //
+                codeStream.Emit(ILOpcode.ldc_i4_0);
+                codeStream.Emit(ILOpcode.conv_u);
+                codeStream.Emit(ILOpcode.br, lCommonExit);
 
-                // Marshalling a null string?
-                codeStream.Emit(ILOpcode.brfalse, lNullString);
-
+                //
+                // Non-null input case
+                // Extract the char& from the string, pin it, then convert it to a nuint (void*)
+                //
+                codeStream.EmitLabel(lNonNullString);
+                LoadManagedValue(codeStream);
                 codeStream.Emit(ILOpcode.call, emitter.NewToken(
-                    Context.SystemModule.
-                        GetKnownType("System.Runtime.CompilerServices", "RuntimeHelpers").
-                            GetKnownMethod("get_OffsetToStringData", null)));
+                    Context.GetWellKnownType(WellKnownType.String).
+                        GetKnownMethod("GetPinnableReference", null)));
+                codeStream.EmitStLoc(vPinnedCharRef);
+                codeStream.EmitLdLoc(vPinnedCharRef);
+                codeStream.Emit(ILOpcode.conv_u);
 
-                codeStream.Emit(ILOpcode.add);
-
-                codeStream.EmitLabel(lNullString);
+                //
+                // Common exit
+                // Top of stack contains a nuint (void*) pointing to start of char data, or nullptr
+                //
+                codeStream.EmitLabel(lCommonExit);
                 StoreNativeValue(codeStream);
             }
             else

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9093,6 +9093,7 @@ namespace System.Runtime.CompilerServices
     }
     public static partial class RuntimeHelpers
     {
+        [System.ObsoleteAttribute("OffsetToStringData is obsolete. Use string.GetPinnableReference() instead.")]
         public static int OffsetToStringData { get { throw null; } }
         public static IntPtr AllocateTypeAssociatedMemory(Type type, int size) { throw null; }
         public static void EnsureSufficientExecutionStack() { }

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpersTests.cs
@@ -71,22 +71,6 @@ namespace System.Runtime.CompilerServices.Tests
         }
 
         [Fact]
-        public static unsafe void OffsetToStringData()
-        {
-            // RuntimeHelpers.OffsetToStringData
-            char[] expectedValues = new char[] { 'a', 'b', 'c', 'd', 'e', 'f' };
-            string s = "abcdef";
-
-            fixed (char* values = s) // Compiler will use OffsetToStringData with fixed statements
-            {
-                for (int i = 0; i < expectedValues.Length; i++)
-                {
-                    Assert.Equal(expectedValues[i], values[i]);
-                }
-            }
-        }
-
-        [Fact]
         public static void InitializeArray()
         {
             // Void RuntimeHelpers.InitializeArray(Array, RuntimeFieldHandle)


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/31406.

`RuntimeHelpers.OffsetToStringData` is the last remaining public API which exposes the concept of `string`'s raw data as being inline directly after the object header. We want code to use `string.GetPinnableReference` instead. It's more future-proof and plays better with the experiments we're running on the `string` class.

/cc @jkoritzinsky, who assisted offline with the marshalling codegen. Thanks! :)
/cc @terrajobst to see if there are any concerns with the deprecation message. We obsoleted `string.Copy` in .NET Core 3.0 using a standard (no diagnostic id) obsolete attribute. I feel this is along the same lines so doesn't deserve its own diagnostic id.