### PR TITLE
Fix ZeroInit of finally vars

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -7569,6 +7569,25 @@ void CodeGen::genFnProlog()
 
         bool isInReg    = varDsc->lvIsInReg();
         bool isInMemory = !isInReg || varDsc->lvLiveInOutOfHndlr;
+
+        // Note that 'lvIsInReg()' will only be accurate for variables that are actually live-in to
+        // the first block. This will include all possibly-uninitialized locals, whose liveness
+        // will naturally propagate up to the entry block. However, we also set 'lvMustInit' for
+        // locals that are live-in to a finally block, and those may not be live-in to the first
+        // block. For those, we don't want to initialize the register, as it will not actually be
+        // occupying it on entry.
+        if (isInReg)
+        {
+            if (compiler->lvaEnregEHVars && varDsc->lvLiveInOutOfHndlr)
+            {
+                isInReg = VarSetOps::IsMember(compiler, compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex);
+            }
+            else
+            {
+                assert(VarSetOps::IsMember(compiler, compiler->fgFirstBB->bbLiveIn, varDsc->lvVarIndex));
+            }
+        }
+
         if (isInReg)
         {
             regMaskTP regMask = genRegMask(varDsc->GetRegNum());


### PR DESCRIPTION
Finally vars need zero-init'ing if we are enregistering them, but they will not necessarily be live-in to the first block, so we have to take care not to zero-init its last associated register in that case.