### PR TITLE
Fix Path.GetPathRoot wrong check in Unix

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -127,7 +127,6 @@ namespace System.IO
 
         public static ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
         {
-            if (PathInternal.IsEffectivelyEmpty(path)) return ReadOnlySpan<char>.Empty;
             return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString.AsSpan() : ReadOnlySpan<char>.Empty;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -127,7 +127,7 @@ namespace System.IO
 
         public static ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
         {
-            if (PathInternal.IsEffectivelyEmpty(path)) return null;
+            if (PathInternal.IsEffectivelyEmpty(path)) return ReadOnlySpan<char>.Empty;
             return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString.AsSpan() : ReadOnlySpan<char>.Empty;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs
@@ -122,13 +122,13 @@ namespace System.IO
         public static string? GetPathRoot(string? path)
         {
             if (PathInternal.IsEffectivelyEmpty(path)) return null;
-
             return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString : string.Empty;
         }
 
         public static ReadOnlySpan<char> GetPathRoot(ReadOnlySpan<char> path)
         {
-            return PathInternal.IsEffectivelyEmpty(path) && IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString.AsSpan() : ReadOnlySpan<char>.Empty;
+            if (PathInternal.IsEffectivelyEmpty(path)) return null;
+            return IsPathRooted(path) ? PathInternal.DirectorySeparatorCharAsString.AsSpan() : ReadOnlySpan<char>.Empty;
         }
 
         /// <summary>Gets whether the system is case-sensitive.</summary>

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -52,6 +52,7 @@ namespace System.IO.Tests
             Assert.Equal(curDir, Path.GetDirectoryName(Path.Combine(curDir, "baz")));
 
             Assert.Null(Path.GetDirectoryName(Path.GetPathRoot(curDir)));
+            Assert.True(Path.GetDirectoryName(Path.GetPathRoot(curDir.AsSpan())).IsEmpty);
         }
 
         [Fact]
@@ -108,10 +109,16 @@ namespace System.IO.Tests
         public void GetPathRoot_Basic()
         {
             string cwd = Directory.GetCurrentDirectory();
-            Assert.Equal(cwd.Substring(0, cwd.IndexOf(Path.DirectorySeparatorChar) + 1), Path.GetPathRoot(cwd));
+            string substring = cwd.Substring(0, cwd.IndexOf(Path.DirectorySeparatorChar) + 1);
+
+            Assert.Equal(substring, Path.GetPathRoot(cwd));
+            PathAssert.Equal(substring.AsSpan(), Path.GetPathRoot(cwd.AsSpan()));
+
             Assert.True(Path.IsPathRooted(cwd));
 
             Assert.Equal(string.Empty, Path.GetPathRoot(@"file.exe"));
+            Assert.True(Path.GetPathRoot(@"file.exe".AsSpan()).IsEmpty);
+
             Assert.False(Path.IsPathRooted("file.exe"));
         }
 
@@ -417,6 +424,7 @@ namespace System.IO.Tests
                     Assert.EndsWith(bad, Path.GetFullPath(bad));
                 }
                 Assert.Equal(string.Empty, Path.GetPathRoot(bad));
+                Assert.True(Path.GetPathRoot(bad.AsSpan()).IsEmpty);
                 Assert.False(Path.IsPathRooted(bad));
             });
         }
@@ -431,7 +439,7 @@ namespace System.IO.Tests
                 Assert.Equal(string.Empty, new string(Path.GetExtension(bad.AsSpan())));
                 Assert.Equal(bad, new string(Path.GetFileName(bad.AsSpan())));
                 Assert.Equal(bad, new string(Path.GetFileNameWithoutExtension(bad.AsSpan())));
-                Assert.Equal(string.Empty, new string(Path.GetPathRoot(bad.AsSpan())));
+                Assert.True(Path.GetPathRoot(bad.AsSpan()).IsEmpty);
                 Assert.False(Path.IsPathRooted(bad.AsSpan()));
             });
         }

--- a/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/IO/PathTests_Unix.cs
@@ -21,6 +21,17 @@ namespace System.IO.Tests
             Assert.Empty(Path.GetPathRoot(value));
         }
 
+        [Fact]
+        public static void GetPathRoot_VerifySameOutput_SpanVsString()
+        {
+            string original = "/home/../folder/../..";
+            string expected = "/";
+            string actualString = Path.GetPathRoot(original);
+            ReadOnlySpan<char> actualSpan = Path.GetPathRoot(original.AsSpan());
+            Assert.Equal(expected, actualString);
+            Assert.Equal(expected, actualSpan.ToString());
+        }
+
         [Theory,
             InlineData("B:", "B:"),
             InlineData("A:.", "A:.")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/35260

The first element in the condition of the conditional operator was wrong: We should return null if the passed path is effectively empty. I made sure the structure looked just like in the other method overload, to avoid confusion.

I added one unit test to verify the particular case in which I found the bug. In my [PR for redundant segments](https://github.com/dotnet/runtime/pull/2187) I will be adding many more since GetPathRoot is used by the new API.