### PR TITLE
Fix ETWFireEvent macro to emit events correctly

### DIFF
--- a/src/coreclr/src/inc/eventtracebase.h
+++ b/src/coreclr/src/inc/eventtracebase.h
@@ -109,7 +109,7 @@ enum EtwThreadFlags
 #if defined(FEATURE_PERFTRACING)
 #define ETW_INLINE
 #define ETWOnStartup(StartEventName, EndEventName)
-#define ETWFireEvent(EventName)
+#define ETWFireEvent(EventName) FireEtw##EventName(GetClrInstanceId())
 
 #define ETW_TRACING_INITIALIZED(RegHandle) (TRUE)
 #define ETW_EVENT_ENABLED(Context, EventDescriptor) (EventPipeHelper::IsEnabled(Context, EventDescriptor.Level, EventDescriptor.Keyword) || \


### PR DESCRIPTION
This PR fixes `ETWFireEvent` on UNIX platforms.

The macro `ETWFireEvent` is currently null'd out for UNIX platforms, which was causing Startup/MainStart and Startup/MainEnd events from not being emitted. These two events, along with EEStartupStart are the only events that use this macro, and all three events take in ClrInstanceID as their sole parameter, so it is possible to fix the macro this way and get the events out. 

cc @ooooolivia 