### PR TITLE
Fix spurious error message in libnethost.lib scenarios

### DIFF
--- a/src/installer/corehost/cli/hostmisc/pal.windows.cpp
+++ b/src/installer/corehost/cli/hostmisc/pal.windows.cpp
@@ -652,10 +652,11 @@ bool pal::unicode_palstring(const char16_t* str, pal::string_t* out)
 // Return if path is valid and file exists, return true and adjust path as appropriate.
 bool pal::realpath(string_t* path, bool skip_error_logging)
 {
-    if (LongFile::IsNormalized(path->c_str()))
+    if (LongFile::IsNormalized(*path))
     {
         WIN32_FILE_ATTRIBUTE_DATA data;
-        if (GetFileAttributesExW(path->c_str(), GetFileExInfoStandard, &data) != 0)
+        if (path->empty() // An empty path doesn't exist
+            || GetFileAttributesExW(path->c_str(), GetFileExInfoStandard, &data) != 0)
         {
             return true;
         }


### PR DESCRIPTION
During a component scenario using the static `nethost`, the following error messages were being displayed since an empty string couldn't be converted to a "real path":

```
Error resolving full path []
Error resolving full path []
```

Changes:
- Empty paths don't exist, so no attribute will be found.
- Remove string copy.

/cc @vitek-karas @swaroop-sridhar @VSadov 