### PR TITLE
fix handling of COMPlus_ZapDisable

### DIFF
--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -1768,10 +1768,8 @@ void SystemDomain::Init()
     // to allow stub caches to use the memory pool. Do not
     // initialze it here!
 
-#ifdef FEATURE_PREJIT
     if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_ZapDisable) != 0)
         g_fAllowNativeImages = false;
-#endif
 
     m_pSystemFile = NULL;
     m_pSystemAssembly = NULL;


### PR DESCRIPTION
In the past, it was possible to use assemblies on different platforms then build for with
```
COMPlus_ZapDisable=1
COMPlus_ReadyToRun=0
```
when set, one could use for example Linux SDK on OSX or FreeBSD. 
That no longer works and that make new platform bringup more difficult. 

It seems like we no longer use FEATURE_PREJIT but the logic still works correctly. 
With this change I could use assemblies from Linux SDK on platforms other than Linux. 