### PR TITLE
fix a regression in gc_heap::get_current_allocated

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -15020,11 +15020,12 @@ size_t gc_heap::get_total_allocated_since_last_gc()
 // Gets what's allocated on both SOH, LOH, etc that hasn't been collected.
 size_t gc_heap::get_current_allocated()
 {
-    size_t current_alloc = 0;
-    for (int i = max_generation; i < total_generation_count; i++)
+    dynamic_data* dd = dynamic_data_of (0);
+    size_t current_alloc = dd_desired_allocation (dd) - dd_new_allocation (dd);
+    for (int i = uoh_start_generation; i < total_generation_count; i++)
     {
         dynamic_data* dd = dynamic_data_of (i);
-        current_alloc = dd_desired_allocation (dd) - dd_new_allocation (dd);
+        current_alloc += dd_desired_allocation (dd) - dd_new_allocation (dd);
     }
     return current_alloc;
 }


### PR DESCRIPTION
introduced by 
Refactor handling of non-SOH generations [#1688](https://github.com/dotnet/runtime/pull/1688)

this is supposed to get the user allocations, originally it was getting gen0 and gen3. with the refactor it should get gen0 and all UOH allocations.

unfortunately I didn't notice this when I did the CR.
