### PR TITLE
RyuJIT: Don't convert GT/LE to EQ/NE for "ARR_LEN cmp 0"

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -12899,13 +12899,15 @@ DONE_MORPHING_CHILDREN:
                 }
                 else if (tree->IsUnsigned() && op2->IsIntegralConst(0))
                 {
-                    if ((oper == GT_GT) || (oper == GT_LE))
+                    if (!op1->OperIs(GT_ARR_LENGTH) && ((oper == GT_GT) || (oper == GT_LE)))
                     {
                         // IL doesn't have a cne instruction so compilers use cgt.un instead. The JIT
                         // recognizes certain patterns that involve GT_NE (e.g (x & 4) != 0) and fails
                         // if GT_GT is used instead. Transform (x GT_GT.unsigned 0) into (x GT_NE 0)
                         // and (x GT_LE.unsigned 0) into (x GT_EQ 0). The later case is rare, it sometimes
                         // occurs as a result of branch inversion.
+                        // NOTE: keep it as it is for Array.Length op1 since GT_NE/GT_EQ operators are
+                        // not bounds check elimination friendly yet.
                         oper = (oper == GT_LE) ? GT_EQ : GT_NE;
                         tree->SetOper(oper, GenTree::PRESERVE_VN);
                         tree->gtFlags &= ~GTF_UNSIGNED;


### PR DESCRIPTION
RyuJIT converts `(uint)x > 0` to `x != 0` (same for `<=`) but I suggest we keep it as it is for things like `(uint)array.Length > 0` since `!=` and `==` operators are not bound checks elimination friendly, e.g.:
```csharp
public static void Foo1(int[] array)
{
    if ((uint)array.Length > 0)
        array[0] = 42;
}

public static void Foo2(int[] array)
{
    if (0 < (uint)array.Length) // same condition, different order
        array[0] = 42;
}
```
### Before my changes
```asm
; Method Egor:Foo1(System.Int32[])
       4883EC28             sub      rsp, 40
       8B4108               mov      eax, dword ptr [rcx+8]
       85C0                 test     eax, eax
       740C                 je       SHORT G_M52406_IG04
       83F800               cmp      eax, 0
       760C                 jbe      SHORT G_M52406_IG05
       C741102A000000       mov      dword ptr [rcx+16], 42
G_M52406_IG04:
       4883C428             add      rsp, 40
       C3                   ret      
G_M52406_IG05:
       E81FC5485F           call     CORINFO_HELP_RNGCHKFAIL
       CC                   int3     
; Total bytes of code: 34


; Method Egor:Foo2(System.Int32[])
       8B4108               mov      eax, dword ptr [rcx+8]
       85C0                 test     eax, eax
       7407                 je       SHORT G_M52789_IG04
       C741102A000000       mov      dword ptr [rcx+16], 42
G_M52789_IG04:
       C3                   ret      
; Total bytes of code: 15
```
^ As you can see, bound checks are removed only for "unnatural" (IMO) condition in `Foo3`
That's why we have this "unnatural" conditions in [String.IsNullOrEmpty](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Private.CoreLib/src/System/String.cs#L497) and other places.

### After my changes
```asm
; Method Egor:Foo1(System.Int32[])
       8B4108               mov      eax, dword ptr [rcx+8]
       85C0                 test     eax, eax
       7407                 je       SHORT G_M52406_IG04
       C741102A000000       mov      dword ptr [rcx+16], 42
G_M52406_IG04:
       C3                   ret      
; Total bytes of code: 15


; Method Egor:Foo2(System.Int32[])
       8B4108               mov      eax, dword ptr [rcx+8]
       85C0                 test     eax, eax
       7407                 je       SHORT G_M52789_IG04
       C741102A000000       mov      dword ptr [rcx+16], 42
G_M52789_IG04:
       C3                   ret      
; Total bytes of code: 15
```