### PR TITLE
Prefix protected fields with underscore for the internal XmlRawWriter

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.cs
@@ -17,8 +17,8 @@ namespace System.Xml
 {
     internal class HtmlEncodedRawTextWriter : XmlEncodedRawTextWriter
     {
-        protected ByteStack elementScope;
-        protected ElementProperties currentElementProperties;
+        protected ByteStack _elementScope;
+        protected ElementProperties _currentElementProperties;
         private AttributeProperties _currentAttributeProperties;
 
         private bool _endsWithAmpersand;
@@ -27,8 +27,8 @@ namespace System.Xml
         private string _mediaType;
         private bool _doNotEscapeUriAttributes;
 
-        protected static TernaryTreeReadOnly elementPropertySearch;
-        protected static TernaryTreeReadOnly attributePropertySearch;
+        protected static TernaryTreeReadOnly _elementPropertySearch;
+        protected static TernaryTreeReadOnly _attributePropertySearch;
 
         private const int StackIncrement = 10;
 
@@ -57,7 +57,7 @@ namespace System.Xml
         {
             Debug.Assert(name != null && name.Length > 0);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             RawText("<!DOCTYPE ");
 
@@ -76,27 +76,27 @@ namespace System.Xml
                     RawText("\" \"");
                     RawText(sysid);
                 }
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'"';
             }
             else if (sysid != null)
             {
                 RawText(" SYSTEM \"");
                 RawText(sysid);
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'"';
             }
             else
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
             }
 
             if (subset != null)
             {
-                bufChars[bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'[';
                 RawText(subset);
-                bufChars[bufPos++] = (char)']';
+                _bufChars[_bufPos++] = (char)']';
             }
 
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // For the HTML element, it should call this method with ns and prefix as String.Empty
@@ -104,24 +104,24 @@ namespace System.Xml
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
-            elementScope.Push((byte)currentElementProperties);
+            _elementScope.Push((byte)_currentElementProperties);
 
             if (ns.Length == 0)
             {
                 Debug.Assert(prefix.Length == 0);
 
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-                currentElementProperties = (ElementProperties)elementPropertySearch.FindCaseInsensitiveString(localName);
-                base.bufChars[bufPos++] = (char)'<';
+                _currentElementProperties = (ElementProperties)_elementPropertySearch.FindCaseInsensitiveString(localName);
+                base._bufChars[_bufPos++] = (char)'<';
                 base.RawText(localName);
-                base.attrEndPos = bufPos;
+                base._attrEndPos = _bufPos;
             }
             else
             {
                 // Since the HAS_NS has no impact to the ElementTextBlock behavior,
                 // we don't need to push it into the stack.
-                currentElementProperties = ElementProperties.HAS_NS;
+                _currentElementProperties = ElementProperties.HAS_NS;
                 base.WriteStartElement(prefix, localName, ns);
             }
         }
@@ -129,12 +129,12 @@ namespace System.Xml
         // Output >. For HTML needs to output META info
         internal override void StartElementContent()
         {
-            base.bufChars[base.bufPos++] = (char)'>';
+            base._bufChars[base._bufPos++] = (char)'>';
 
             // Detect whether content is output
-            contentPos = bufPos;
+            _contentPos = _bufPos;
 
-            if ((currentElementProperties & ElementProperties.HEAD) != 0)
+            if ((_currentElementProperties & ElementProperties.HEAD) != 0)
             {
                 WriteMetaElement();
             }
@@ -150,14 +150,14 @@ namespace System.Xml
             {
                 Debug.Assert(prefix.Length == 0);
 
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-                if ((currentElementProperties & ElementProperties.EMPTY) == 0)
+                if ((_currentElementProperties & ElementProperties.EMPTY) == 0)
                 {
-                    bufChars[base.bufPos++] = (char)'<';
-                    bufChars[base.bufPos++] = (char)'/';
+                    _bufChars[base._bufPos++] = (char)'<';
+                    _bufChars[base._bufPos++] = (char)'/';
                     base.RawText(localName);
-                    bufChars[base.bufPos++] = (char)'>';
+                    _bufChars[base._bufPos++] = (char)'>';
                 }
             }
             else
@@ -166,7 +166,7 @@ namespace System.Xml
                 base.WriteEndElement(prefix, localName, ns);
             }
 
-            currentElementProperties = (ElementProperties)elementScope.Pop();
+            _currentElementProperties = (ElementProperties)_elementScope.Pop();
         }
 
         internal override void WriteFullEndElement(string prefix, string localName, string ns)
@@ -175,14 +175,14 @@ namespace System.Xml
             {
                 Debug.Assert(prefix.Length == 0);
 
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-                if ((currentElementProperties & ElementProperties.EMPTY) == 0)
+                if ((_currentElementProperties & ElementProperties.EMPTY) == 0)
                 {
-                    bufChars[base.bufPos++] = (char)'<';
-                    bufChars[base.bufPos++] = (char)'/';
+                    _bufChars[base._bufPos++] = (char)'<';
+                    _bufChars[base._bufPos++] = (char)'/';
                     base.RawText(localName);
-                    bufChars[base.bufPos++] = (char)'>';
+                    _bufChars[base._bufPos++] = (char)'>';
                 }
             }
             else
@@ -191,7 +191,7 @@ namespace System.Xml
                 base.WriteFullEndElement(prefix, localName, ns);
             }
 
-            currentElementProperties = (ElementProperties)elementScope.Pop();
+            _currentElementProperties = (ElementProperties)_elementScope.Pop();
         }
 
         // 1. How the outputBooleanAttribute(fBOOL) and outputHtmlUriText(fURI) being set?
@@ -299,22 +299,22 @@ namespace System.Xml
             {
                 Debug.Assert(prefix.Length == 0);
 
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-                if (base.attrEndPos == bufPos)
+                if (base._attrEndPos == _bufPos)
                 {
-                    base.bufChars[bufPos++] = (char)' ';
+                    base._bufChars[_bufPos++] = (char)' ';
                 }
                 base.RawText(localName);
 
-                if ((currentElementProperties & (ElementProperties.BOOL_PARENT | ElementProperties.URI_PARENT | ElementProperties.NAME_PARENT)) != 0)
+                if ((_currentElementProperties & (ElementProperties.BOOL_PARENT | ElementProperties.URI_PARENT | ElementProperties.NAME_PARENT)) != 0)
                 {
-                    _currentAttributeProperties = (AttributeProperties)attributePropertySearch.FindCaseInsensitiveString(localName) &
-                                                 (AttributeProperties)currentElementProperties;
+                    _currentAttributeProperties = (AttributeProperties)_attributePropertySearch.FindCaseInsensitiveString(localName) &
+                                                 (AttributeProperties)_currentElementProperties;
 
                     if ((_currentAttributeProperties & AttributeProperties.BOOLEAN) != 0)
                     {
-                        base.inAttributeValue = true;
+                        base._inAttributeValue = true;
                         return;
                     }
                 }
@@ -323,8 +323,8 @@ namespace System.Xml
                     _currentAttributeProperties = AttributeProperties.DEFAULT;
                 }
 
-                base.bufChars[bufPos++] = (char)'=';
-                base.bufChars[bufPos++] = (char)'"';
+                base._bufChars[_bufPos++] = (char)'=';
+                base._bufChars[_bufPos++] = (char)'"';
             }
             else
             {
@@ -332,7 +332,7 @@ namespace System.Xml
                 _currentAttributeProperties = AttributeProperties.DEFAULT;
             }
 
-            base.inAttributeValue = true;
+            base._inAttributeValue = true;
         }
 
         // Output the amp; at end of EndAttribute
@@ -340,7 +340,7 @@ namespace System.Xml
         {
             if ((_currentAttributeProperties & AttributeProperties.BOOLEAN) != 0)
             {
-                base.attrEndPos = bufPos;
+                base._attrEndPos = _bufPos;
             }
             else
             {
@@ -350,12 +350,12 @@ namespace System.Xml
                     _endsWithAmpersand = false;
                 }
 
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-                base.bufChars[bufPos++] = (char)'"';
+                base._bufChars[_bufPos++] = (char)'"';
             }
-            base.inAttributeValue = false;
-            base.attrEndPos = bufPos;
+            base._inAttributeValue = false;
+            base._attrEndPos = _bufPos;
         }
 
         // HTML PI's use ">" to terminate rather than "?>".
@@ -363,18 +363,18 @@ namespace System.Xml
         {
             Debug.Assert(target != null && target.Length != 0 && text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[base.bufPos++] = (char)'<';
-            bufChars[base.bufPos++] = (char)'?';
+            _bufChars[base._bufPos++] = (char)'<';
+            _bufChars[base._bufPos++] = (char)'?';
             base.RawText(target);
-            bufChars[base.bufPos++] = (char)' ';
+            _bufChars[base._bufPos++] = (char)' ';
 
             base.WriteCommentOrPi(text, '?');
 
-            base.bufChars[base.bufPos++] = (char)'>';
+            base._bufChars[base._bufPos++] = (char)'>';
 
-            if (base.bufPos > base.bufLen)
+            if (base._bufPos > base._bufLen)
             {
                 FlushBuffer();
             }
@@ -385,12 +385,12 @@ namespace System.Xml
         {
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
 
             fixed (char* pSrc = text)
             {
                 char* pSrcEnd = pSrc + text.Length;
-                if (base.inAttributeValue)
+                if (base._inAttributeValue)
                 {
                     WriteHtmlAttributeTextBlock(pSrc, pSrcEnd);
                 }
@@ -422,11 +422,11 @@ namespace System.Xml
             Debug.Assert(index >= 0);
             Debug.Assert(count >= 0 && index + count <= buffer.Length);
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
 
             fixed (char* pSrcBegin = &buffer[index])
             {
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrcBegin, pSrcBegin + count);
                 }
@@ -447,16 +447,16 @@ namespace System.Xml
             Debug.Assert((int)ElementProperties.BOOL_PARENT == (int)AttributeProperties.BOOLEAN);
             Debug.Assert((int)ElementProperties.NAME_PARENT == (int)AttributeProperties.NAME);
 
-            if (elementPropertySearch == null)
+            if (_elementPropertySearch == null)
             {
-                //elementPropertySearch should be init last for the mutli thread safe situation.
-                attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
-                elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
+                //_elementPropertySearch should be init last for the mutli thread safe situation.
+                _attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
+                _elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
             }
 
-            elementScope = new ByteStack(StackIncrement);
+            _elementScope = new ByteStack(StackIncrement);
             _uriEscapingBuffer = new byte[5];
-            currentElementProperties = ElementProperties.DEFAULT;
+            _currentElementProperties = ElementProperties.DEFAULT;
 
             _mediaType = settings.MediaType;
             _doNotEscapeUriAttributes = settings.DoNotEscapeUriAttributes;
@@ -474,7 +474,7 @@ namespace System.Xml
             base.RawText(" content=\"");
             base.RawText(_mediaType);
             base.RawText("; charset=");
-            base.RawText(base.encoding.WebName);
+            base.RawText(base._encoding.WebName);
             base.RawText("\">");
         }
 
@@ -489,7 +489,7 @@ namespace System.Xml
         // only the top of the stack is the real E1 element properties.
         protected unsafe void WriteHtmlElementTextBlock(char* pSrc, char* pSrcEnd)
         {
-            if ((currentElementProperties & ElementProperties.NO_ENTITIES) != 0)
+            if ((_currentElementProperties & ElementProperties.NO_ENTITIES) != 0)
             {
                 base.RawText(pSrc, pSrcEnd);
             }
@@ -518,7 +518,7 @@ namespace System.Xml
                     WriteHtmlAttributeText(pSrc, pSrcEnd);
                 }
             }
-            else if ((currentElementProperties & ElementProperties.HAS_NS) != 0)
+            else if ((_currentElementProperties & ElementProperties.HAS_NS) != 0)
             {
                 base.WriteAttributeTextBlock(pSrc, pSrcEnd);
             }
@@ -559,20 +559,20 @@ namespace System.Xml
                 _endsWithAmpersand = false;
             }
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 char ch = (char)0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
                     {
                         *pDst++ = (char)ch;
                         pSrc++;
@@ -588,7 +588,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -632,7 +632,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -647,20 +647,20 @@ namespace System.Xml
                 _endsWithAmpersand = false;
             }
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 char ch = (char)0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch < 0x80))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch < 0x80))
                     {
                         *pDst++ = (char)ch;
                         pSrc++;
@@ -676,7 +676,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -735,17 +735,17 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
         // For handling &{ in Html text field. If & is not followed by {, it still needs to be escaped.
         private void OutputRestAmps()
         {
-            base.bufChars[bufPos++] = (char)'a';
-            base.bufChars[bufPos++] = (char)'m';
-            base.bufChars[bufPos++] = (char)'p';
-            base.bufChars[bufPos++] = (char)';';
+            base._bufChars[_bufPos++] = (char)'a';
+            base._bufChars[_bufPos++] = (char)'m';
+            base._bufChars[_bufPos++] = (char)'p';
+            base._bufChars[_bufPos++] = (char)';';
         }
     }
 
@@ -825,69 +825,69 @@ namespace System.Xml
             base.WriteDocType(name, pubid, sysid, subset);
 
             // Allow indentation after DocTypeDecl
-            _endBlockPos = base.bufPos;
+            _endBlockPos = base._bufPos;
         }
 
         public override void WriteStartElement(string prefix, string localName, string ns)
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            base.elementScope.Push((byte)base.currentElementProperties);
+            base._elementScope.Push((byte)base._currentElementProperties);
 
             if (ns.Length == 0)
             {
                 Debug.Assert(prefix.Length == 0);
 
-                base.currentElementProperties = (ElementProperties)elementPropertySearch.FindCaseInsensitiveString(localName);
+                base._currentElementProperties = (ElementProperties)_elementPropertySearch.FindCaseInsensitiveString(localName);
 
-                if (_endBlockPos == base.bufPos && (base.currentElementProperties & ElementProperties.BLOCK_WS) != 0)
+                if (_endBlockPos == base._bufPos && (base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
                 {
                     WriteIndent();
                 }
                 _indentLevel++;
 
-                base.bufChars[bufPos++] = (char)'<';
+                base._bufChars[_bufPos++] = (char)'<';
             }
             else
             {
-                base.currentElementProperties = ElementProperties.HAS_NS | ElementProperties.BLOCK_WS;
+                base._currentElementProperties = ElementProperties.HAS_NS | ElementProperties.BLOCK_WS;
 
-                if (_endBlockPos == base.bufPos)
+                if (_endBlockPos == base._bufPos)
                 {
                     WriteIndent();
                 }
                 _indentLevel++;
 
-                base.bufChars[base.bufPos++] = (char)'<';
+                base._bufChars[base._bufPos++] = (char)'<';
                 if (prefix.Length != 0)
                 {
                     base.RawText(prefix);
-                    base.bufChars[base.bufPos++] = (char)':';
+                    base._bufChars[base._bufPos++] = (char)':';
                 }
             }
             base.RawText(localName);
-            base.attrEndPos = bufPos;
+            base._attrEndPos = _bufPos;
         }
 
         internal override void StartElementContent()
         {
-            base.bufChars[base.bufPos++] = (char)'>';
+            base._bufChars[base._bufPos++] = (char)'>';
 
             // Detect whether content is output
-            base.contentPos = base.bufPos;
+            base._contentPos = base._bufPos;
 
-            if ((currentElementProperties & ElementProperties.HEAD) != 0)
+            if ((_currentElementProperties & ElementProperties.HEAD) != 0)
             {
                 WriteIndent();
                 WriteMetaElement();
-                _endBlockPos = base.bufPos;
+                _endBlockPos = base._bufPos;
             }
-            else if ((base.currentElementProperties & ElementProperties.BLOCK_WS) != 0)
+            else if ((base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
             {
                 // store the element block position
-                _endBlockPos = base.bufPos;
+                _endBlockPos = base._bufPos;
             }
         }
 
@@ -899,12 +899,12 @@ namespace System.Xml
             _indentLevel--;
 
             // If this element has block whitespace properties,
-            isBlockWs = (base.currentElementProperties & ElementProperties.BLOCK_WS) != 0;
+            isBlockWs = (base._currentElementProperties & ElementProperties.BLOCK_WS) != 0;
             if (isBlockWs)
             {
                 // And if the last node to be output had block whitespace properties,
                 // And if content was output within this element,
-                if (_endBlockPos == base.bufPos && base.contentPos != base.bufPos)
+                if (_endBlockPos == base._bufPos && base._contentPos != base._bufPos)
                 {
                     // Then indent
                     WriteIndent();
@@ -914,12 +914,12 @@ namespace System.Xml
             base.WriteEndElement(prefix, localName, ns);
 
             // Reset contentPos in case of empty elements
-            base.contentPos = 0;
+            base._contentPos = 0;
 
             // Mark end of element in buffer for element's with block whitespace properties
             if (isBlockWs)
             {
-                _endBlockPos = base.bufPos;
+                _endBlockPos = base._bufPos;
             }
         }
 
@@ -927,7 +927,7 @@ namespace System.Xml
         {
             if (_newLineOnAttributes)
             {
-                RawText(base.newLineChars);
+                RawText(base._newLineChars);
                 _indentLevel++;
                 WriteIndent();
                 _indentLevel--;
@@ -938,7 +938,7 @@ namespace System.Xml
         protected override void FlushBuffer()
         {
             // Make sure the buffer will reset the block position
-            _endBlockPos = (_endBlockPos == base.bufPos) ? 1 : 0;
+            _endBlockPos = (_endBlockPos == base._bufPos) ? 1 : 0;
             base.FlushBuffer();
         }
 
@@ -966,7 +966,7 @@ namespace System.Xml
             // <inline><?PI?>   -- suppress ws betw <inline> and PI
             // <inline><!-- --> -- suppress ws betw <inline> and comment
 
-            RawText(base.newLineChars);
+            RawText(base._newLineChars);
             for (int i = _indentLevel; i > 0; i--)
             {
                 RawText(_indentChars);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.ttinclude
@@ -19,8 +19,8 @@ namespace System.Xml
 {
     internal class <#= ClassName #> : <#= BaseClassName #>
     {
-        protected ByteStack elementScope;
-        protected ElementProperties currentElementProperties;
+        protected ByteStack _elementScope;
+        protected ElementProperties _currentElementProperties;
         private AttributeProperties _currentAttributeProperties;
 
         private bool _endsWithAmpersand;
@@ -29,8 +29,8 @@ namespace System.Xml
         private string _mediaType;
         private bool _doNotEscapeUriAttributes;
 
-        protected static TernaryTreeReadOnly elementPropertySearch;
-        protected static TernaryTreeReadOnly attributePropertySearch;
+        protected static TernaryTreeReadOnly _elementPropertySearch;
+        protected static TernaryTreeReadOnly _attributePropertySearch;
 
         private const int StackIncrement = 10;
 <# if (WriterType == RawTextWriterType.Encoded) { #>
@@ -108,7 +108,7 @@ namespace System.Xml
         {
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
-            elementScope.Push((byte)currentElementProperties);
+            _elementScope.Push((byte)_currentElementProperties);
 
             if (ns.Length == 0)
             {
@@ -116,7 +116,7 @@ namespace System.Xml
 
 #><#= SetTextContentMark(4, false) #>
 
-                currentElementProperties = (ElementProperties)elementPropertySearch.FindCaseInsensitiveString(localName);
+                _currentElementProperties = (ElementProperties)_elementPropertySearch.FindCaseInsensitiveString(localName);
                 base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
                 base.RawText(localName);
                 base.attrEndPos = bufPos;
@@ -125,7 +125,7 @@ namespace System.Xml
             {
                 // Since the HAS_NS has no impact to the ElementTextBlock behavior,
                 // we don't need to push it into the stack.
-                currentElementProperties = ElementProperties.HAS_NS;
+                _currentElementProperties = ElementProperties.HAS_NS;
                 base.WriteStartElement(prefix, localName, ns);
             }
         }
@@ -138,7 +138,7 @@ namespace System.Xml
             // Detect whether content is output
             contentPos = bufPos;
 
-            if ((currentElementProperties & ElementProperties.HEAD) != 0)
+            if ((_currentElementProperties & ElementProperties.HEAD) != 0)
             {
                 WriteMetaElement();
             }
@@ -156,7 +156,7 @@ namespace System.Xml
 
 #><#= SetTextContentMark(4, false) #>
 
-                if ((currentElementProperties & ElementProperties.EMPTY) == 0)
+                if ((_currentElementProperties & ElementProperties.EMPTY) == 0)
                 {
                     <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'<';
                     <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'/';
@@ -170,7 +170,7 @@ namespace System.Xml
                 base.WriteEndElement(prefix, localName, ns);
             }
 
-            currentElementProperties = (ElementProperties)elementScope.Pop();
+            _currentElementProperties = (ElementProperties)_elementScope.Pop();
         }
 
         internal override void WriteFullEndElement(string prefix, string localName, string ns)
@@ -181,7 +181,7 @@ namespace System.Xml
 
 #><#= SetTextContentMark(4, false) #>
 
-                if ((currentElementProperties & ElementProperties.EMPTY) == 0)
+                if ((_currentElementProperties & ElementProperties.EMPTY) == 0)
                 {
                     <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'<';
                     <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'/';
@@ -195,7 +195,7 @@ namespace System.Xml
                 base.WriteFullEndElement(prefix, localName, ns);
             }
 
-            currentElementProperties = (ElementProperties)elementScope.Pop();
+            _currentElementProperties = (ElementProperties)_elementScope.Pop();
         }
 
         // 1. How the outputBooleanAttribute(fBOOL) and outputHtmlUriText(fURI) being set?
@@ -311,10 +311,10 @@ namespace System.Xml
                 }
                 base.RawText(localName);
 
-                if ((currentElementProperties & (ElementProperties.BOOL_PARENT | ElementProperties.URI_PARENT | ElementProperties.NAME_PARENT)) != 0)
+                if ((_currentElementProperties & (ElementProperties.BOOL_PARENT | ElementProperties.URI_PARENT | ElementProperties.NAME_PARENT)) != 0)
                 {
-                    _currentAttributeProperties = (AttributeProperties)attributePropertySearch.FindCaseInsensitiveString(localName) &
-                                                 (AttributeProperties)currentElementProperties;
+                    _currentAttributeProperties = (AttributeProperties)_attributePropertySearch.FindCaseInsensitiveString(localName) &
+                                                 (AttributeProperties)_currentElementProperties;
 
                     if ((_currentAttributeProperties & AttributeProperties.BOOLEAN) != 0)
                     {
@@ -451,16 +451,16 @@ namespace System.Xml
             Debug.Assert((int)ElementProperties.BOOL_PARENT == (int)AttributeProperties.BOOLEAN);
             Debug.Assert((int)ElementProperties.NAME_PARENT == (int)AttributeProperties.NAME);
 
-            if (elementPropertySearch == null)
+            if (_elementPropertySearch == null)
             {
-                //elementPropertySearch should be init last for the mutli thread safe situation.
-                attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
-                elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
+                //_elementPropertySearch should be init last for the mutli thread safe situation.
+                _attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
+                _elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
             }
 
-            elementScope = new ByteStack(StackIncrement);
+            _elementScope = new ByteStack(StackIncrement);
             _uriEscapingBuffer = new byte[5];
-            currentElementProperties = ElementProperties.DEFAULT;
+            _currentElementProperties = ElementProperties.DEFAULT;
 
             _mediaType = settings.MediaType;
             _doNotEscapeUriAttributes = settings.DoNotEscapeUriAttributes;
@@ -493,7 +493,7 @@ namespace System.Xml
         // only the top of the stack is the real E1 element properties.
         protected unsafe void WriteHtmlElementTextBlock(char* pSrc, char* pSrcEnd)
         {
-            if ((currentElementProperties & ElementProperties.NO_ENTITIES) != 0)
+            if ((_currentElementProperties & ElementProperties.NO_ENTITIES) != 0)
             {
                 base.RawText(pSrc, pSrcEnd);
             }
@@ -522,7 +522,7 @@ namespace System.Xml
                     WriteHtmlAttributeText(pSrc, pSrcEnd);
                 }
             }
-            else if ((currentElementProperties & ElementProperties.HAS_NS) != 0)
+            else if ((_currentElementProperties & ElementProperties.HAS_NS) != 0)
             {
                 base.WriteAttributeTextBlock(pSrc, pSrcEnd);
             }
@@ -844,15 +844,15 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            base.elementScope.Push((byte)base.currentElementProperties);
+            base._elementScope.Push((byte)base._currentElementProperties);
 
             if (ns.Length == 0)
             {
                 Debug.Assert(prefix.Length == 0);
 
-                base.currentElementProperties = (ElementProperties)elementPropertySearch.FindCaseInsensitiveString(localName);
+                base._currentElementProperties = (ElementProperties)_elementPropertySearch.FindCaseInsensitiveString(localName);
 
-                if (_endBlockPos == base.bufPos && (base.currentElementProperties & ElementProperties.BLOCK_WS) != 0)
+                if (_endBlockPos == base.bufPos && (base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
                 {
                     WriteIndent();
                 }
@@ -862,7 +862,7 @@ namespace System.Xml
             }
             else
             {
-                base.currentElementProperties = ElementProperties.HAS_NS | ElementProperties.BLOCK_WS;
+                base._currentElementProperties = ElementProperties.HAS_NS | ElementProperties.BLOCK_WS;
 
                 if (_endBlockPos == base.bufPos)
                 {
@@ -888,13 +888,13 @@ namespace System.Xml
             // Detect whether content is output
             base.contentPos = base.bufPos;
 
-            if ((currentElementProperties & ElementProperties.HEAD) != 0)
+            if ((_currentElementProperties & ElementProperties.HEAD) != 0)
             {
                 WriteIndent();
                 WriteMetaElement();
                 _endBlockPos = base.bufPos;
             }
-            else if ((base.currentElementProperties & ElementProperties.BLOCK_WS) != 0)
+            else if ((base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
             {
                 // store the element block position
                 _endBlockPos = base.bufPos;
@@ -909,7 +909,7 @@ namespace System.Xml
             _indentLevel--;
 
             // If this element has block whitespace properties,
-            isBlockWs = (base.currentElementProperties & ElementProperties.BLOCK_WS) != 0;
+            isBlockWs = (base._currentElementProperties & ElementProperties.BLOCK_WS) != 0;
             if (isBlockWs)
             {
                 // And if the last node to be output had block whitespace properties,

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/QueryOutputWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/QueryOutputWriter.cs
@@ -91,11 +91,11 @@ namespace System.Xml
         {
             get
             {
-                return this.resolver;
+                return this._resolver;
             }
             set
             {
-                this.resolver = value;
+                this._resolver = value;
                 _wrapped.NamespaceResolver = value;
             }
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriterEncoded.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriterEncoded.ttinclude
@@ -5,7 +5,7 @@
     WriterType = RawTextWriterType.Encoded;
     ClassName = "XmlEncodedRawTextWriter";
     ClassNameIndent = "XmlEncodedRawTextWriterIndent";
-    BufferName = "bufChars";
+    BufferName = "_bufChars";
     BufferType = "char";
     EncodeCharBody = @"/* Surrogate character */
 if (XmlCharType.IsSurrogate(ch))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextEncodedRawTextWriter.cs
@@ -67,12 +67,12 @@ namespace System.Xml
         // Ignore attributes
         public override void WriteStartAttribute(string prefix, string localName, string ns)
         {
-            base.inAttributeValue = true;
+            base._inAttributeValue = true;
         }
 
         public override void WriteEndAttribute()
         {
-            base.inAttributeValue = false;
+            base._inAttributeValue = false;
         }
 
         // Ignore namespace declarations
@@ -118,7 +118,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteWhitespace(string ws)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(ws);
             }
@@ -127,7 +127,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteString(string textBlock)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(textBlock);
             }
@@ -136,7 +136,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteChars(char[] buffer, int index, int count)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(buffer, index, count);
             }
@@ -145,7 +145,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteRaw(char[] buffer, int index, int count)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(buffer, index, count);
             }
@@ -154,7 +154,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteRaw(string data)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(data);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextUtf8RawTextWriter.cs
@@ -62,12 +62,12 @@ namespace System.Xml
         // Ignore attributes
         public override void WriteStartAttribute(string prefix, string localName, string ns)
         {
-            base.inAttributeValue = true;
+            base._inAttributeValue = true;
         }
 
         public override void WriteEndAttribute()
         {
-            base.inAttributeValue = false;
+            base._inAttributeValue = false;
         }
 
         // Ignore namespace declarations
@@ -113,7 +113,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteWhitespace(string ws)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(ws);
             }
@@ -122,7 +122,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteString(string textBlock)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(textBlock);
             }
@@ -131,7 +131,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteChars(char[] buffer, int index, int count)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(buffer, index, count);
             }
@@ -140,7 +140,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteRaw(char[] buffer, int index, int count)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(buffer, index, count);
             }
@@ -149,7 +149,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteRaw(string data)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(data);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAutoDetectWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAutoDetectWriter.cs
@@ -277,11 +277,11 @@ namespace System.Xml
         {
             get
             {
-                return this.resolver;
+                return this._resolver;
             }
             set
             {
-                this.resolver = value;
+                this._resolver = value;
 
                 if (_wrapped == null)
                     _eventCache.NamespaceResolver = value;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -31,60 +31,60 @@ namespace System.Xml
         private readonly bool _useAsync;
 
         // main buffer
-        protected byte[] bufBytes;
+        protected byte[] _bufBytes;
 
         // output stream
-        protected Stream stream;
+        protected Stream _stream;
 
         // encoding of the stream or text writer
-        protected Encoding encoding;
+        protected Encoding _encoding;
 
         // char type tables
-        protected XmlCharType xmlCharType = XmlCharType.Instance;
+        protected XmlCharType _xmlCharType = XmlCharType.Instance;
 
         // buffer positions
-        protected int bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
-                                      // close an empty element or in CDATA section detection of double ]; bufChars[0] will always be 0
-        protected int textPos = 1;    // text end position; don't indent first element, pi, or comment
-        protected int contentPos;     // element content end position
-        protected int cdataPos;       // cdata end position
-        protected int attrEndPos;     // end of the last attribute
-        protected int bufLen = BUFSIZE;
+        protected int _bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
+                                       // close an empty element or in CDATA section detection of double ]; bufChars[0] will always be 0
+        protected int _textPos = 1;    // text end position; don't indent first element, pi, or comment
+        protected int _contentPos;     // element content end position
+        protected int _cdataPos;       // cdata end position
+        protected int _attrEndPos;     // end of the last attribute
+        protected int _bufLen = BUFSIZE;
 
         // flags
-        protected bool writeToNull;
-        protected bool hadDoubleBracket;
-        protected bool inAttributeValue;
+        protected bool _writeToNull;
+        protected bool _hadDoubleBracket;
+        protected bool _inAttributeValue;
 
-        protected int bufBytesUsed;
-        protected char[] bufChars;
+        protected int _bufBytesUsed;
+        protected char[] _bufChars;
 
         // encoder for encoding chars in specified encoding when writing to stream
-        protected Encoder encoder;
+        protected Encoder _encoder;
 
         // output text writer
-        protected TextWriter writer;
+        protected TextWriter _writer;
 
         // escaping of characters invalid in the output encoding
-        protected bool trackTextContent;
-        protected bool inTextContent;
+        protected bool _trackTextContent;
+        protected bool _inTextContent;
         private int _lastMarkPos;
         private int[] _textContentMarks;   // even indices contain text content start positions
                                            // odd indices contain markup start positions
         private readonly CharEntityEncoderFallback _charEntityFallback;
 
         // writer settings
-        protected NewLineHandling newLineHandling;
-        protected bool closeOutput;
-        protected bool omitXmlDeclaration;
-        protected string newLineChars;
-        protected bool checkCharacters;
+        protected NewLineHandling _newLineHandling;
+        protected bool _closeOutput;
+        protected bool _omitXmlDeclaration;
+        protected string _newLineChars;
+        protected bool _checkCharacters;
 
-        protected XmlStandalone standalone;
-        protected XmlOutputMethod outputMethod;
+        protected XmlStandalone _standalone;
+        protected XmlOutputMethod _outputMethod;
 
-        protected bool autoXmlDeclaration;
-        protected bool mergeCDataSections;
+        protected bool _autoXmlDeclaration;
+        protected bool _mergeCDataSections;
 
         //
         // Constants
@@ -103,19 +103,19 @@ namespace System.Xml
             _useAsync = settings.Async;
 
             // copy settings
-            newLineHandling = settings.NewLineHandling;
-            omitXmlDeclaration = settings.OmitXmlDeclaration;
-            newLineChars = settings.NewLineChars;
-            checkCharacters = settings.CheckCharacters;
-            closeOutput = settings.CloseOutput;
+            _newLineHandling = settings.NewLineHandling;
+            _omitXmlDeclaration = settings.OmitXmlDeclaration;
+            _newLineChars = settings.NewLineChars;
+            _checkCharacters = settings.CheckCharacters;
+            _closeOutput = settings.CloseOutput;
 
-            standalone = settings.Standalone;
-            outputMethod = settings.OutputMethod;
-            mergeCDataSections = settings.MergeCDataSections;
+            _standalone = settings.Standalone;
+            _outputMethod = settings.OutputMethod;
+            _mergeCDataSections = settings.MergeCDataSections;
 
-            if (checkCharacters && newLineHandling == NewLineHandling.Replace)
+            if (_checkCharacters && _newLineHandling == NewLineHandling.Replace)
             {
-                ValidateContentChars(newLineChars, "NewLineChars", false);
+                ValidateContentChars(_newLineChars, "NewLineChars", false);
             }
         }
 
@@ -124,20 +124,20 @@ namespace System.Xml
         {
             Debug.Assert(writer != null && settings != null);
 
-            this.writer = writer;
-            this.encoding = writer.Encoding;
+            this._writer = writer;
+            this._encoding = writer.Encoding;
             // the buffer is allocated will OVERFLOW in order to reduce checks when writing out constant size markup
             if (settings.Async)
             {
-                bufLen = ASYNCBUFSIZE;
+                _bufLen = ASYNCBUFSIZE;
             }
-            this.bufChars = new char[bufLen + OVERFLOW];
+            this._bufChars = new char[_bufLen + OVERFLOW];
 
             // Write the xml declaration
             if (settings.AutoXmlDeclaration)
             {
-                WriteXmlDeclaration(standalone);
-                autoXmlDeclaration = true;
+                WriteXmlDeclaration(_standalone);
+                _autoXmlDeclaration = true;
             }
         }
 
@@ -146,22 +146,22 @@ namespace System.Xml
         {
             Debug.Assert(stream != null && settings != null);
 
-            this.stream = stream;
-            this.encoding = settings.Encoding;
+            this._stream = stream;
+            this._encoding = settings.Encoding;
 
             // the buffer is allocated will OVERFLOW in order to reduce checks when writing out constant size markup
             if (settings.Async)
             {
-                bufLen = ASYNCBUFSIZE;
+                _bufLen = ASYNCBUFSIZE;
             }
 
-            bufChars = new char[bufLen + OVERFLOW];
-            bufBytes = new byte[bufChars.Length];
-            bufBytesUsed = 0;
+            _bufChars = new char[_bufLen + OVERFLOW];
+            _bufBytes = new byte[_bufChars.Length];
+            _bufBytesUsed = 0;
 
             // Init escaping of characters not fitting into the target encoding
-            trackTextContent = true;
-            inTextContent = false;
+            _trackTextContent = true;
+            _inTextContent = false;
             _lastMarkPos = 0;
             _textContentMarks = new int[INIT_MARKS_COUNT];
             _textContentMarks[0] = 1;
@@ -169,29 +169,29 @@ namespace System.Xml
             _charEntityFallback = new CharEntityEncoderFallback();
 
             // grab bom before possibly changing encoding settings
-            ReadOnlySpan<byte> bom = encoding.Preamble;
+            ReadOnlySpan<byte> bom = _encoding.Preamble;
 
             // the encoding instance this creates can differ from the one passed in
-            this.encoding = Encoding.GetEncoding(
+            this._encoding = Encoding.GetEncoding(
                 settings.Encoding.CodePage,
                 _charEntityFallback,
                 settings.Encoding.DecoderFallback);
 
-            encoder = encoding.GetEncoder();
+            _encoder = _encoding.GetEncoder();
 
             if (!stream.CanSeek || stream.Position == 0)
             {
                 if (bom.Length != 0)
                 {
-                    this.stream.Write(bom);
+                    this._stream.Write(bom);
                 }
             }
 
             // Write the xml declaration
             if (settings.AutoXmlDeclaration)
             {
-                WriteXmlDeclaration(standalone);
-                autoXmlDeclaration = true;
+                WriteXmlDeclaration(_standalone);
+                _autoXmlDeclaration = true;
             }
         }
 
@@ -205,17 +205,17 @@ namespace System.Xml
             {
                 XmlWriterSettings settings = new XmlWriterSettings();
 
-                settings.Encoding = encoding;
-                settings.OmitXmlDeclaration = omitXmlDeclaration;
-                settings.NewLineHandling = newLineHandling;
-                settings.NewLineChars = newLineChars;
-                settings.CloseOutput = closeOutput;
+                settings.Encoding = _encoding;
+                settings.OmitXmlDeclaration = _omitXmlDeclaration;
+                settings.NewLineHandling = _newLineHandling;
+                settings.NewLineChars = _newLineChars;
+                settings.CloseOutput = _closeOutput;
                 settings.ConformanceLevel = ConformanceLevel.Auto;
-                settings.CheckCharacters = checkCharacters;
+                settings.CheckCharacters = _checkCharacters;
 
-                settings.AutoXmlDeclaration = autoXmlDeclaration;
-                settings.Standalone = standalone;
-                settings.OutputMethod = outputMethod;
+                settings.AutoXmlDeclaration = _autoXmlDeclaration;
+                settings.Standalone = _standalone;
+                settings.OutputMethod = _outputMethod;
 
                 settings.ReadOnly = true;
                 return settings;
@@ -226,9 +226,9 @@ namespace System.Xml
         internal override void WriteXmlDeclaration(XmlStandalone standalone)
         {
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
                 RawText("<?xml version=\"");
 
@@ -236,10 +236,10 @@ namespace System.Xml
                 RawText("1.0");
 
                 // Encoding
-                if (encoding != null)
+                if (_encoding != null)
                 {
                     RawText("\" encoding=\"");
-                    RawText(encoding.WebName);
+                    RawText(_encoding.WebName);
                 }
 
                 // Standalone
@@ -256,7 +256,7 @@ namespace System.Xml
         internal override void WriteXmlDeclaration(string xmldecl)
         {
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
                 WriteProcessingInstruction("xml", xmldecl);
             }
@@ -267,7 +267,7 @@ namespace System.Xml
         {
             Debug.Assert(name != null && name.Length > 0);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             RawText("<!DOCTYPE ");
             RawText(name);
@@ -280,27 +280,27 @@ namespace System.Xml
                 {
                     RawText(sysid);
                 }
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'"';
             }
             else if (sysid != null)
             {
                 RawText(" SYSTEM \"");
                 RawText(sysid);
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'"';
             }
             else
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
             }
 
             if (subset != null)
             {
-                bufChars[bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'[';
                 RawText(subset);
-                bufChars[bufPos++] = (char)']';
+                _bufChars[_bufPos++] = (char)']';
             }
 
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
@@ -309,29 +309,29 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'<';
             if (prefix != null && prefix.Length != 0)
             {
                 RawText(prefix);
-                bufChars[bufPos++] = (char)':';
+                _bufChars[_bufPos++] = (char)':';
             }
 
             RawText(localName);
 
-            attrEndPos = bufPos;
+            _attrEndPos = _bufPos;
         }
 
         // Serialize the end of an element start tag in preparation for content serialization: ">"
         internal override void StartElementContent()
         {
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'>';
 
             // StartElementContent is always called; therefore, in order to allow shortcut syntax, we save the
             // position of the '>' character.  If WriteEndElement is called and no other characters have been
             // output, then the '>' character can be overwritten with the shortcut syntax " />".
-            contentPos = bufPos;
+            _contentPos = _bufPos;
         }
 
         // Serialize an element end tag: "</prefix:localName>", if content was output.  Otherwise, serialize
@@ -341,29 +341,29 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (contentPos != bufPos)
+            if (_contentPos != _bufPos)
             {
                 // Content has been output, so can't use shortcut syntax
-                bufChars[bufPos++] = (char)'<';
-                bufChars[bufPos++] = (char)'/';
+                _bufChars[_bufPos++] = (char)'<';
+                _bufChars[_bufPos++] = (char)'/';
 
                 if (prefix != null && prefix.Length != 0)
                 {
                     RawText(prefix);
-                    bufChars[bufPos++] = (char)':';
+                    _bufChars[_bufPos++] = (char)':';
                 }
                 RawText(localName);
-                bufChars[bufPos++] = (char)'>';
+                _bufChars[_bufPos++] = (char)'>';
             }
             else
             {
                 // Use shortcut syntax; overwrite the already output '>' character
-                bufPos--;
-                bufChars[bufPos++] = (char)' ';
-                bufChars[bufPos++] = (char)'/';
-                bufChars[bufPos++] = (char)'>';
+                _bufPos--;
+                _bufChars[_bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)'/';
+                _bufChars[_bufPos++] = (char)'>';
             }
         }
 
@@ -373,18 +373,18 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
-            bufChars[bufPos++] = (char)'/';
+            _bufChars[_bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'/';
 
             if (prefix != null && prefix.Length != 0)
             {
                 RawText(prefix);
-                bufChars[bufPos++] = (char)':';
+                _bufChars[_bufPos++] = (char)':';
             }
             RawText(localName);
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize an attribute tag using double quotes around the attribute value: 'prefix:localName="'
@@ -393,33 +393,33 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (attrEndPos == bufPos)
+            if (_attrEndPos == _bufPos)
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
             }
 
             if (prefix != null && prefix.Length > 0)
             {
                 RawText(prefix);
-                bufChars[bufPos++] = (char)':';
+                _bufChars[_bufPos++] = (char)':';
             }
             RawText(localName);
-            bufChars[bufPos++] = (char)'=';
-            bufChars[bufPos++] = (char)'"';
+            _bufChars[_bufPos++] = (char)'=';
+            _bufChars[_bufPos++] = (char)'"';
 
-            inAttributeValue = true;
+            _inAttributeValue = true;
         }
 
         // Serialize the end of an attribute value using double quotes: '"'
         public override void WriteEndAttribute()
         {
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'"';
-            inAttributeValue = false;
-            attrEndPos = bufPos;
+            _bufChars[_bufPos++] = (char)'"';
+            _inAttributeValue = false;
+            _attrEndPos = _bufPos;
         }
 
         internal override void WriteNamespaceDeclaration(string prefix, string namespaceName)
@@ -443,7 +443,7 @@ namespace System.Xml
         {
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             if (prefix.Length == 0)
             {
@@ -453,22 +453,22 @@ namespace System.Xml
             {
                 RawText(" xmlns:");
                 RawText(prefix);
-                bufChars[bufPos++] = (char)'=';
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'=';
+                _bufChars[_bufPos++] = (char)'"';
             }
 
-            inAttributeValue = true;
+            _inAttributeValue = true;
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
         }
 
         internal override void WriteEndNamespaceDeclaration()
         {
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
-            inAttributeValue = false;
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
+            _inAttributeValue = false;
 
-            bufChars[bufPos++] = (char)'"';
-            attrEndPos = bufPos;
+            _bufChars[_bufPos++] = (char)'"';
+            _attrEndPos = _bufPos;
         }
 
         // Serialize a CData section.  If the "]]>" pattern is found within
@@ -477,36 +477,36 @@ namespace System.Xml
         {
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (mergeCDataSections && bufPos == cdataPos)
+            if (_mergeCDataSections && _bufPos == _cdataPos)
             {
                 // Merge adjacent cdata sections - overwrite the "]]>" characters
-                Debug.Assert(bufPos >= 4);
-                bufPos -= 3;
+                Debug.Assert(_bufPos >= 4);
+                _bufPos -= 3;
             }
             else
             {
                 // Start a new cdata section
-                bufChars[bufPos++] = (char)'<';
-                bufChars[bufPos++] = (char)'!';
-                bufChars[bufPos++] = (char)'[';
-                bufChars[bufPos++] = (char)'C';
-                bufChars[bufPos++] = (char)'D';
-                bufChars[bufPos++] = (char)'A';
-                bufChars[bufPos++] = (char)'T';
-                bufChars[bufPos++] = (char)'A';
-                bufChars[bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'<';
+                _bufChars[_bufPos++] = (char)'!';
+                _bufChars[_bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'C';
+                _bufChars[_bufPos++] = (char)'D';
+                _bufChars[_bufPos++] = (char)'A';
+                _bufChars[_bufPos++] = (char)'T';
+                _bufChars[_bufPos++] = (char)'A';
+                _bufChars[_bufPos++] = (char)'[';
             }
 
             WriteCDataSection(text);
 
-            bufChars[bufPos++] = (char)']';
-            bufChars[bufPos++] = (char)']';
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)']';
+            _bufChars[_bufPos++] = (char)']';
+            _bufChars[_bufPos++] = (char)'>';
 
-            textPos = bufPos;
-            cdataPos = bufPos;
+            _textPos = _bufPos;
+            _cdataPos = _bufPos;
         }
 
         // Serialize a comment.
@@ -514,18 +514,18 @@ namespace System.Xml
         {
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
-            bufChars[bufPos++] = (char)'!';
-            bufChars[bufPos++] = (char)'-';
-            bufChars[bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'!';
+            _bufChars[_bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'-';
 
             WriteCommentOrPi(text, '-');
 
-            bufChars[bufPos++] = (char)'-';
-            bufChars[bufPos++] = (char)'-';
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize a processing instruction.
@@ -534,20 +534,20 @@ namespace System.Xml
             Debug.Assert(name != null && name.Length > 0);
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
-            bufChars[bufPos++] = (char)'?';
+            _bufChars[_bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'?';
             RawText(name);
 
             if (text.Length > 0)
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
                 WriteCommentOrPi(text, '?');
             }
 
-            bufChars[bufPos++] = (char)'?';
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'?';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize an entity reference.
@@ -555,18 +555,18 @@ namespace System.Xml
         {
             Debug.Assert(name != null && name.Length > 0);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'&';
+            _bufChars[_bufPos++] = (char)'&';
             RawText(name);
-            bufChars[bufPos++] = (char)';';
+            _bufChars[_bufPos++] = (char)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 FlushBuffer();
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a character entity reference.
@@ -574,26 +574,26 @@ namespace System.Xml
         {
             string strVal = ((int)ch).ToString("X", NumberFormatInfo.InvariantInfo);
 
-            if (checkCharacters && !xmlCharType.IsCharData(ch))
+            if (_checkCharacters && !_xmlCharType.IsCharData(ch))
             {
                 // we just have a single char, not a surrogate, therefore we have to pass in '\0' for the second char
                 throw XmlConvert.CreateInvalidCharException(ch, '\0');
             }
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'&';
-            bufChars[bufPos++] = (char)'#';
-            bufChars[bufPos++] = (char)'x';
+            _bufChars[_bufPos++] = (char)'&';
+            _bufChars[_bufPos++] = (char)'#';
+            _bufChars[_bufPos++] = (char)'x';
             RawText(strVal);
-            bufChars[bufPos++] = (char)';';
+            _bufChars[_bufPos++] = (char)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 FlushBuffer();
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a whitespace node.
@@ -602,12 +602,12 @@ namespace System.Xml
         {
             Debug.Assert(ws != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             fixed (char* pSrc = ws)
             {
                 char* pSrcEnd = pSrc + ws.Length;
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrc, pSrcEnd);
                 }
@@ -624,12 +624,12 @@ namespace System.Xml
         {
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
 
             fixed (char* pSrc = text)
             {
                 char* pSrcEnd = pSrc + text.Length;
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrc, pSrcEnd);
                 }
@@ -643,15 +643,15 @@ namespace System.Xml
         // Serialize surrogate character entity.
         public override void WriteSurrogateCharEntity(char lowChar, char highChar)
         {
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
             int surrogateChar = XmlCharType.CombineSurrogateChar(lowChar, highChar);
 
-            bufChars[bufPos++] = (char)'&';
-            bufChars[bufPos++] = (char)'#';
-            bufChars[bufPos++] = (char)'x';
+            _bufChars[_bufPos++] = (char)'&';
+            _bufChars[_bufPos++] = (char)'#';
+            _bufChars[_bufPos++] = (char)'x';
             RawText(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo));
-            bufChars[bufPos++] = (char)';';
-            textPos = bufPos;
+            _bufChars[_bufPos++] = (char)';';
+            _textPos = _bufPos;
         }
 
         // Serialize either attribute or element text using XML rules.
@@ -663,11 +663,11 @@ namespace System.Xml
             Debug.Assert(index >= 0);
             Debug.Assert(count >= 0 && index + count <= buffer.Length);
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
 
             fixed (char* pSrcBegin = &buffer[index])
             {
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrcBegin, pSrcBegin + count);
                 }
@@ -687,14 +687,14 @@ namespace System.Xml
             Debug.Assert(index >= 0);
             Debug.Assert(count >= 0 && index + count <= buffer.Length);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             fixed (char* pSrcBegin = &buffer[index])
             {
                 WriteRawWithCharChecking(pSrcBegin, pSrcBegin + count);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize raw data.
@@ -703,14 +703,14 @@ namespace System.Xml
         {
             Debug.Assert(data != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             fixed (char* pSrcBegin = data)
             {
                 WriteRawWithCharChecking(pSrcBegin, pSrcBegin + data.Length);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Flush all bytes in the buffer to output and close the output stream or writer.
@@ -724,47 +724,47 @@ namespace System.Xml
             finally
             {
                 // Future calls to Close or Flush shouldn't write to Stream or Writer
-                writeToNull = true;
+                _writeToNull = true;
 
-                if (stream != null)
+                if (_stream != null)
                 {
                     try
                     {
-                        stream.Flush();
+                        _stream.Flush();
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                stream.Dispose();
+                                _stream.Dispose();
                             }
                         }
                         finally
                         {
-                            stream = null;
+                            _stream = null;
                         }
                     }
                 }
-                else if (writer != null)
+                else if (_writer != null)
                 {
                     try
                     {
-                        writer.Flush();
+                        _writer.Flush();
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                writer.Dispose();
+                                _writer.Dispose();
                             }
                         }
                         finally
                         {
-                            writer = null;
+                            _writer = null;
                         }
                     }
                 }
@@ -776,13 +776,13 @@ namespace System.Xml
         {
             FlushBuffer();
             FlushEncoder();
-            if (stream != null)
+            if (_stream != null)
             {
-                stream.Flush();
+                _stream.Flush();
             }
-            else if (writer != null)
+            else if (_writer != null)
             {
-                writer.Flush();
+                _writer.Flush();
             }
         }
 
@@ -795,13 +795,13 @@ namespace System.Xml
             try
             {
                 // Output all characters (except for previous characters stored at beginning of buffer)
-                if (!writeToNull)
+                if (!_writeToNull)
                 {
-                    Debug.Assert(stream != null || writer != null);
+                    Debug.Assert(_stream != null || _writer != null);
 
-                    if (stream != null)
+                    if (_stream != null)
                     {
-                        if (trackTextContent)
+                        if (_trackTextContent)
                         {
                             _charEntityFallback.Reset(_textContentMarks, _lastMarkPos);
                             // reset text content tracking
@@ -819,14 +819,14 @@ namespace System.Xml
                             }
                             Debug.Assert(_textContentMarks[0] == 1);
                         }
-                        EncodeChars(1, bufPos, true);
+                        EncodeChars(1, _bufPos, true);
                     }
                     else
                     {
-                        if (bufPos - 1 > 0)
+                        if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            writer.Write(bufChars, 1, bufPos - 1);
+                            _writer.Write(_bufChars, 1, _bufPos - 1);
                         }
                     }
                 }
@@ -834,20 +834,20 @@ namespace System.Xml
             catch
             {
                 // Future calls to flush (i.e. when Close() is called) don't attempt to write to stream
-                writeToNull = true;
+                _writeToNull = true;
                 throw;
             }
             finally
             {
                 // Move last buffer character to the beginning of the buffer (so that previous character can always be determined)
-                bufChars[0] = bufChars[bufPos - 1];
+                _bufChars[0] = _bufChars[_bufPos - 1];
 
                 // Reset buffer position
-                textPos = (textPos == bufPos) ? 1 : 0;
-                attrEndPos = (attrEndPos == bufPos) ? 1 : 0;
-                contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
-                cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
-                bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
+                _textPos = (_textPos == _bufPos) ? 1 : 0;
+                _attrEndPos = (_attrEndPos == _bufPos) ? 1 : 0;
+                _contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
+                _cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
+                _bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
                                    // close an empty element or in CDATA section detection of double ]; bufChars[0] will always be 0
             }
         }
@@ -864,35 +864,35 @@ namespace System.Xml
                 {
                     _charEntityFallback.StartOffset = startOffset;
                 }
-                encoder.Convert(bufChars, startOffset, endOffset - startOffset, bufBytes, bufBytesUsed, bufBytes.Length - bufBytesUsed, false, out chEnc, out bEnc, out completed);
+                _encoder.Convert(_bufChars, startOffset, endOffset - startOffset, _bufBytes, _bufBytesUsed, _bufBytes.Length - _bufBytesUsed, false, out chEnc, out bEnc, out completed);
                 startOffset += chEnc;
-                bufBytesUsed += bEnc;
-                if (bufBytesUsed >= (bufBytes.Length - 16))
+                _bufBytesUsed += bEnc;
+                if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    stream.Write(bufBytes, 0, bufBytesUsed);
-                    bufBytesUsed = 0;
+                    _stream.Write(_bufBytes, 0, _bufBytesUsed);
+                    _bufBytesUsed = 0;
                 }
             }
-            if (writeAllToStream && bufBytesUsed > 0)
+            if (writeAllToStream && _bufBytesUsed > 0)
             {
-                stream.Write(bufBytes, 0, bufBytesUsed);
-                bufBytesUsed = 0;
+                _stream.Write(_bufBytes, 0, _bufBytesUsed);
+                _bufBytesUsed = 0;
             }
         }
 
         private void FlushEncoder()
         {
-            Debug.Assert(bufPos == 1);
-            if (stream != null)
+            Debug.Assert(_bufPos == 1);
+            if (_stream != null)
             {
                 int chEnc;
                 int bEnc;
                 bool completed;
                 // decode no chars, just flush
-                encoder.Convert(bufChars, 1, 0, bufBytes, 0, bufBytes.Length, true, out chEnc, out bEnc, out completed);
+                _encoder.Convert(_bufChars, 1, 0, _bufBytes, 0, _bufBytes.Length, true, out chEnc, out bEnc, out completed);
                 if (bEnc != 0)
                 {
-                    stream.Write(bufBytes, 0, bEnc);
+                    _stream.Write(_bufBytes, 0, bEnc);
                 }
             }
         }
@@ -901,20 +901,20 @@ namespace System.Xml
         // are entitized.
         protected unsafe void WriteAttributeTextBlock(char* pSrc, char* pSrcEnd)
         {
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -931,7 +931,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -957,7 +957,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0x9:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (char)ch;
                                 pDst++;
@@ -969,7 +969,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (char)ch;
                                 pDst++;
@@ -981,7 +981,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (char)ch;
                                 pDst++;
@@ -1016,7 +1016,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1024,20 +1024,20 @@ namespace System.Xml
         // are entitized.
         protected unsafe void WriteElementTextBlock(char* pSrc, char* pSrcEnd)
         {
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -1054,7 +1054,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1079,7 +1079,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1090,7 +1090,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            switch (newLineHandling)
+                            switch (_newLineHandling)
                             {
                                 case NewLineHandling.Replace:
                                     // Replace "\r\n", or "\r" with NewLineChars
@@ -1136,9 +1136,9 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
-                textPos = bufPos;
-                contentPos = 0;
+                _bufPos = (int)(pDst - pDstBegin);
+                _textPos = _bufPos;
+                _contentPos = 0;
             }
         }
 
@@ -1154,18 +1154,18 @@ namespace System.Xml
 
         protected unsafe void RawText(char* pSrcBegin, char* pSrcEnd)
         {
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
                 char* pSrc = pSrcBegin;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
                     while (pDst < pDstEnd && ((ch = *pSrc) < XmlCharType.SurHighStart))
@@ -1185,7 +1185,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1212,27 +1212,27 @@ namespace System.Xml
                     }
                 }
 
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
         protected unsafe void WriteRawWithCharChecking(char* pSrcBegin, char* pSrcEnd)
         {
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
                 char* pSrc = pSrcBegin;
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsTextChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsTextChar((char)(ch = *pSrc)))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -1250,7 +1250,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1267,7 +1267,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1284,7 +1284,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1318,7 +1318,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1326,7 +1326,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     FlushBuffer();
                 }
@@ -1335,24 +1335,24 @@ namespace System.Xml
             // write text
             fixed (char* pSrcBegin = text)
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
                 char* pSrc = pSrcBegin;
 
                 char* pSrcEnd = pSrcBegin + text.Length;
 
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
+                    while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -1370,7 +1370,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1410,7 +1410,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1427,7 +1427,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1467,7 +1467,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1475,7 +1475,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     FlushBuffer();
                 }
@@ -1486,24 +1486,24 @@ namespace System.Xml
 
             fixed (char* pSrcBegin = text)
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
                 char* pSrc = pSrcBegin;
 
                 char* pSrcEnd = pSrcBegin + text.Length;
 
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -1521,7 +1521,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1531,7 +1531,7 @@ namespace System.Xml
                     switch (ch)
                     {
                         case '>':
-                            if (hadDoubleBracket && pDst[-1] == (char)']')
+                            if (_hadDoubleBracket && pDst[-1] == (char)']')
                             {   // pDst[-1] will always correct - there is a padding character at bufChars[0]
                                 // The characters "]]>" were found within the CData text
                                 pDst = RawEndCData(pDst);
@@ -1543,17 +1543,17 @@ namespace System.Xml
                         case ']':
                             if (pDst[-1] == (char)']')
                             {   // pDst[-1] will always correct - there is a padding character at bufChars[0]
-                                hadDoubleBracket = true;
+                                _hadDoubleBracket = true;
                             }
                             else
                             {
-                                hadDoubleBracket = false;
+                                _hadDoubleBracket = false;
                             }
                             *pDst = (char)']';
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1570,7 +1570,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1612,7 +1612,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1645,10 +1645,10 @@ namespace System.Xml
 
         private unsafe char* InvalidXmlChar(int ch, char* pDst, bool entitize)
         {
-            Debug.Assert(!xmlCharType.IsWhiteSpace((char)ch));
-            Debug.Assert(!xmlCharType.IsAttributeValueChar((char)ch));
+            Debug.Assert(!_xmlCharType.IsWhiteSpace((char)ch));
+            Debug.Assert(!_xmlCharType.IsAttributeValueChar((char)ch));
 
-            if (checkCharacters)
+            if (_checkCharacters)
             {
                 // This method will never be called on surrogates, so it is ok to pass in '\0' to the CreateInvalidCharException
                 throw XmlConvert.CreateInvalidCharException((char)ch, '\0');
@@ -1695,14 +1695,14 @@ namespace System.Xml
 
         protected void ChangeTextContentMark(bool value)
         {
-            Debug.Assert(inTextContent != value);
-            Debug.Assert(inTextContent || ((_lastMarkPos & 1) == 0));
-            inTextContent = value;
+            Debug.Assert(_inTextContent != value);
+            Debug.Assert(_inTextContent || ((_lastMarkPos & 1) == 0));
+            _inTextContent = value;
             if (_lastMarkPos + 1 == _textContentMarks.Length)
             {
                 GrowTextContentMarks();
             }
-            _textContentMarks[++_lastMarkPos] = bufPos;
+            _textContentMarks[++_lastMarkPos] = _bufPos;
         }
 
         private void GrowTextContentMarks()
@@ -1715,12 +1715,12 @@ namespace System.Xml
         // Write NewLineChars to the specified buffer position and return an updated position.
         protected unsafe char* WriteNewLine(char* pDst)
         {
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
                 // Let RawText do the real work
-                RawText(newLineChars);
-                return pDstBegin + bufPos;
+                RawText(_newLineChars);
+                return pDstBegin + _bufPos;
             }
         }
 
@@ -1858,7 +1858,7 @@ namespace System.Xml
         {
             if (allowOnlyWhitespace)
             {
-                if (!xmlCharType.IsOnlyWhitespace(chars))
+                if (!_xmlCharType.IsOnlyWhitespace(chars))
                 {
                     throw new ArgumentException(SR.Format(SR.Xml_IndentCharsNotWhitespace, propertyName));
                 }
@@ -1868,7 +1868,7 @@ namespace System.Xml
                 string error = null;
                 for (int i = 0; i < chars.Length; i++)
                 {
-                    if (!xmlCharType.IsTextChar(chars[i]))
+                    if (!_xmlCharType.IsTextChar(chars[i]))
                     {
                         switch (chars[i])
                         {
@@ -1918,14 +1918,14 @@ namespace System.Xml
         //
         // Fields
         //
-        protected int indentLevel;
-        protected bool newLineOnAttributes;
-        protected string indentChars;
+        protected int _indentLevel;
+        protected bool _newLineOnAttributes;
+        protected string _indentChars;
 
-        protected bool mixedContent;
+        protected bool _mixedContent;
         private BitStack _mixedContentStack;
 
-        protected ConformanceLevel conformanceLevel = ConformanceLevel.Auto;
+        protected ConformanceLevel _conformanceLevel = ConformanceLevel.Auto;
 
         //
         // Constructors
@@ -1951,8 +1951,8 @@ namespace System.Xml
 
                 settings.ReadOnly = false;
                 settings.Indent = true;
-                settings.IndentChars = indentChars;
-                settings.NewLineOnAttributes = newLineOnAttributes;
+                settings.IndentChars = _indentChars;
+                settings.NewLineOnAttributes = _newLineOnAttributes;
                 settings.ReadOnly = true;
 
                 return settings;
@@ -1962,7 +1962,7 @@ namespace System.Xml
         public override void WriteDocType(string name, string pubid, string sysid, string subset)
         {
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
@@ -1974,12 +1974,12 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
-            indentLevel++;
-            _mixedContentStack.PushBit(mixedContent);
+            _indentLevel++;
+            _mixedContentStack.PushBit(_mixedContent);
 
             base.WriteStartElement(prefix, localName, ns);
         }
@@ -1987,16 +1987,16 @@ namespace System.Xml
         internal override void StartElementContent()
         {
             // If this is the root element and we're writing a document
-            //   do not inherit the mixedContent flag into the root element.
+            //   do not inherit the _mixedContent flag into the root element.
             //   This is to allow for whitespace nodes on root level
             //   without disabling indentation for the whole document.
-            if (indentLevel == 1 && conformanceLevel == ConformanceLevel.Document)
+            if (_indentLevel == 1 && _conformanceLevel == ConformanceLevel.Document)
             {
-                mixedContent = false;
+                _mixedContent = false;
             }
             else
             {
-                mixedContent = _mixedContentStack.PeekBit();
+                _mixedContent = _mixedContentStack.PeekBit();
             }
             base.StartElementContent();
         }
@@ -2004,22 +2004,22 @@ namespace System.Xml
         internal override void OnRootElement(ConformanceLevel currentConformanceLevel)
         {
             // Just remember the current conformance level
-            conformanceLevel = currentConformanceLevel;
+            _conformanceLevel = currentConformanceLevel;
         }
 
         internal override void WriteEndElement(string prefix, string localName, string ns)
         {
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     WriteIndent();
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             base.WriteEndElement(prefix, localName, ns);
         }
@@ -2027,16 +2027,16 @@ namespace System.Xml
         internal override void WriteFullEndElement(string prefix, string localName, string ns)
         {
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     WriteIndent();
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             base.WriteFullEndElement(prefix, localName, ns);
         }
@@ -2045,7 +2045,7 @@ namespace System.Xml
         public override void WriteStartAttribute(string prefix, string localName, string ns)
         {
             // Add indentation
-            if (newLineOnAttributes)
+            if (_newLineOnAttributes)
             {
                 WriteIndent();
             }
@@ -2055,13 +2055,13 @@ namespace System.Xml
 
         public override void WriteCData(string text)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteCData(text);
         }
 
         public override void WriteComment(string text)
         {
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
@@ -2071,7 +2071,7 @@ namespace System.Xml
 
         public override void WriteProcessingInstruction(string target, string text)
         {
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
@@ -2081,55 +2081,55 @@ namespace System.Xml
 
         public override void WriteEntityRef(string name)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteEntityRef(name);
         }
 
         public override void WriteCharEntity(char ch)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteCharEntity(ch);
         }
 
         public override void WriteSurrogateCharEntity(char lowChar, char highChar)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteSurrogateCharEntity(lowChar, highChar);
         }
 
         public override void WriteWhitespace(string ws)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteWhitespace(ws);
         }
 
         public override void WriteString(string text)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteString(text);
         }
 
         public override void WriteChars(char[] buffer, int index, int count)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteChars(buffer, index, count);
         }
 
         public override void WriteRaw(char[] buffer, int index, int count)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteRaw(buffer, index, count);
         }
 
         public override void WriteRaw(string data)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteRaw(data);
         }
 
         public override void WriteBase64(byte[] buffer, int index, int count)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteBase64(buffer, index, count);
         }
 
@@ -2138,25 +2138,25 @@ namespace System.Xml
         //
         private void Init(XmlWriterSettings settings)
         {
-            indentLevel = 0;
-            indentChars = settings.IndentChars;
-            newLineOnAttributes = settings.NewLineOnAttributes;
+            _indentLevel = 0;
+            _indentChars = settings.IndentChars;
+            _newLineOnAttributes = settings.NewLineOnAttributes;
             _mixedContentStack = new BitStack();
 
             // check indent characters that they are valid XML characters
-            if (base.checkCharacters)
+            if (base._checkCharacters)
             {
-                if (newLineOnAttributes)
+                if (_newLineOnAttributes)
                 {
-                    base.ValidateContentChars(indentChars, "IndentChars", true);
-                    base.ValidateContentChars(newLineChars, "NewLineChars", true);
+                    base.ValidateContentChars(_indentChars, "IndentChars", true);
+                    base.ValidateContentChars(_newLineChars, "NewLineChars", true);
                 }
                 else
                 {
-                    base.ValidateContentChars(indentChars, "IndentChars", false);
-                    if (base.newLineHandling != NewLineHandling.Replace)
+                    base.ValidateContentChars(_indentChars, "IndentChars", false);
+                    if (base._newLineHandling != NewLineHandling.Replace)
                     {
-                        base.ValidateContentChars(newLineChars, "NewLineChars", false);
+                        base.ValidateContentChars(_newLineChars, "NewLineChars", false);
                     }
                 }
             }
@@ -2165,10 +2165,10 @@ namespace System.Xml
         // Add indentation to output.  Write newline and then repeat IndentChars for each indent level.
         private void WriteIndent()
         {
-            RawText(base.newLineChars);
-            for (int i = indentLevel; i > 0; i--)
+            RawText(base._newLineChars);
+            for (int i = _indentLevel; i > 0; i--)
             {
-                RawText(indentChars);
+                RawText(_indentChars);
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -35,19 +35,19 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
-                if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+                if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
                 await RawTextAsync("<?xml version=\"").ConfigureAwait(false);
 
                 // Version
                 await RawTextAsync("1.0").ConfigureAwait(false);
 
                 // Encoding
-                if (encoding != null)
+                if (_encoding != null)
                 {
                     await RawTextAsync("\" encoding=\"").ConfigureAwait(false);
-                    await RawTextAsync(encoding.WebName).ConfigureAwait(false);
+                    await RawTextAsync(_encoding.WebName).ConfigureAwait(false);
                 }
 
                 // Standalone
@@ -65,7 +65,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
                 return WriteProcessingInstructionAsync("xml", xmldecl);
             }
@@ -82,47 +82,47 @@ namespace System.Xml
             finally
             {
                 // Future calls to Close or Flush shouldn't write to Stream or Writer
-                writeToNull = true;
+                _writeToNull = true;
 
-                if (stream != null)
+                if (_stream != null)
                 {
                     try
                     {
-                        await stream.FlushAsync().ConfigureAwait(false);
+                        await _stream.FlushAsync().ConfigureAwait(false);
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                await stream.DisposeAsync().ConfigureAwait(false);
+                                await _stream.DisposeAsync().ConfigureAwait(false);
                             }
                         }
                         finally
                         {
-                            stream = null;
+                            _stream = null;
                         }
                     }
                 }
-                else if (writer != null)
+                else if (_writer != null)
                 {
                     try
                     {
-                        await writer.FlushAsync().ConfigureAwait(false);
+                        await _writer.FlushAsync().ConfigureAwait(false);
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                await writer.DisposeAsync().ConfigureAwait(false);
+                                await _writer.DisposeAsync().ConfigureAwait(false);
                             }
                         }
                         finally
                         {
-                            writer = null;
+                            _writer = null;
                         }
                     }
                 }
@@ -135,7 +135,7 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             await RawTextAsync("<!DOCTYPE ").ConfigureAwait(false);
             await RawTextAsync(name).ConfigureAwait(false);
@@ -148,27 +148,27 @@ namespace System.Xml
                 {
                     await RawTextAsync(sysid).ConfigureAwait(false);
                 }
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'"';
             }
             else if (sysid != null)
             {
                 await RawTextAsync(" SYSTEM \"").ConfigureAwait(false);
                 await RawTextAsync(sysid).ConfigureAwait(false);
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'"';
             }
             else
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
             }
 
             if (subset != null)
             {
-                bufChars[bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'[';
                 await RawTextAsync(subset).ConfigureAwait(false);
-                bufChars[bufPos++] = (char)']';
+                _bufChars[_bufPos++] = (char)']';
             }
 
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
@@ -178,10 +178,10 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             Task task;
-            bufChars[bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'<';
             if (prefix != null && prefix.Length != 0)
             {
                 task = RawTextAsync(prefix, ":", localName);
@@ -195,7 +195,7 @@ namespace System.Xml
 
         private void WriteStartElementAsync_SetAttEndPos()
         {
-            attrEndPos = bufPos;
+            _attrEndPos = _bufPos;
         }
 
         // Serialize an element end tag: "</prefix:localName>", if content was output.  Otherwise, serialize
@@ -206,13 +206,13 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (contentPos != bufPos)
+            if (_contentPos != _bufPos)
             {
                 // Content has been output, so can't use shortcut syntax
-                bufChars[bufPos++] = (char)'<';
-                bufChars[bufPos++] = (char)'/';
+                _bufChars[_bufPos++] = (char)'<';
+                _bufChars[_bufPos++] = (char)'/';
 
                 if (prefix != null && prefix.Length != 0)
                 {
@@ -226,10 +226,10 @@ namespace System.Xml
             else
             {
                 // Use shortcut syntax; overwrite the already output '>' character
-                bufPos--;
-                bufChars[bufPos++] = (char)' ';
-                bufChars[bufPos++] = (char)'/';
-                bufChars[bufPos++] = (char)'>';
+                _bufPos--;
+                _bufChars[_bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)'/';
+                _bufChars[_bufPos++] = (char)'>';
             }
             return Task.CompletedTask;
         }
@@ -241,10 +241,10 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
-            bufChars[bufPos++] = (char)'/';
+            _bufChars[_bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'/';
 
             if (prefix != null && prefix.Length != 0)
             {
@@ -263,11 +263,11 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length > 0);
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (attrEndPos == bufPos)
+            if (_attrEndPos == _bufPos)
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
             }
             Task task;
             if (prefix != null && prefix.Length > 0)
@@ -283,9 +283,9 @@ namespace System.Xml
 
         private void WriteStartAttribute_SetInAttribute()
         {
-            bufChars[bufPos++] = (char)'=';
-            bufChars[bufPos++] = (char)'"';
-            inAttributeValue = true;
+            _bufChars[_bufPos++] = (char)'=';
+            _bufChars[_bufPos++] = (char)'"';
+            _inAttributeValue = true;
         }
 
         // Serialize the end of an attribute value using double quotes: '"'
@@ -293,11 +293,11 @@ namespace System.Xml
         {
             CheckAsyncCall();
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'"';
-            inAttributeValue = false;
-            attrEndPos = bufPos;
+            _bufChars[_bufPos++] = (char)'"';
+            _inAttributeValue = false;
+            _attrEndPos = _bufPos;
 
             return Task.CompletedTask;
         }
@@ -317,7 +317,7 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(prefix != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             if (prefix.Length == 0)
             {
@@ -327,25 +327,25 @@ namespace System.Xml
             {
                 await RawTextAsync(" xmlns:").ConfigureAwait(false);
                 await RawTextAsync(prefix).ConfigureAwait(false);
-                bufChars[bufPos++] = (char)'=';
-                bufChars[bufPos++] = (char)'"';
+                _bufChars[_bufPos++] = (char)'=';
+                _bufChars[_bufPos++] = (char)'"';
             }
 
-            inAttributeValue = true;
+            _inAttributeValue = true;
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
         }
 
         internal override Task WriteEndNamespaceDeclarationAsync()
         {
             CheckAsyncCall();
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            inAttributeValue = false;
+            _inAttributeValue = false;
 
-            bufChars[bufPos++] = (char)'"';
-            attrEndPos = bufPos;
+            _bufChars[_bufPos++] = (char)'"';
+            _attrEndPos = _bufPos;
 
             return Task.CompletedTask;
         }
@@ -357,36 +357,36 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (mergeCDataSections && bufPos == cdataPos)
+            if (_mergeCDataSections && _bufPos == _cdataPos)
             {
                 // Merge adjacent cdata sections - overwrite the "]]>" characters
-                Debug.Assert(bufPos >= 4);
-                bufPos -= 3;
+                Debug.Assert(_bufPos >= 4);
+                _bufPos -= 3;
             }
             else
             {
                 // Start a new cdata section
-                bufChars[bufPos++] = (char)'<';
-                bufChars[bufPos++] = (char)'!';
-                bufChars[bufPos++] = (char)'[';
-                bufChars[bufPos++] = (char)'C';
-                bufChars[bufPos++] = (char)'D';
-                bufChars[bufPos++] = (char)'A';
-                bufChars[bufPos++] = (char)'T';
-                bufChars[bufPos++] = (char)'A';
-                bufChars[bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'<';
+                _bufChars[_bufPos++] = (char)'!';
+                _bufChars[_bufPos++] = (char)'[';
+                _bufChars[_bufPos++] = (char)'C';
+                _bufChars[_bufPos++] = (char)'D';
+                _bufChars[_bufPos++] = (char)'A';
+                _bufChars[_bufPos++] = (char)'T';
+                _bufChars[_bufPos++] = (char)'A';
+                _bufChars[_bufPos++] = (char)'[';
             }
 
             await WriteCDataSectionAsync(text).ConfigureAwait(false);
 
-            bufChars[bufPos++] = (char)']';
-            bufChars[bufPos++] = (char)']';
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)']';
+            _bufChars[_bufPos++] = (char)']';
+            _bufChars[_bufPos++] = (char)'>';
 
-            textPos = bufPos;
-            cdataPos = bufPos;
+            _textPos = _bufPos;
+            _cdataPos = _bufPos;
         }
 
         // Serialize a comment.
@@ -395,18 +395,18 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
-            bufChars[bufPos++] = (char)'!';
-            bufChars[bufPos++] = (char)'-';
-            bufChars[bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'!';
+            _bufChars[_bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'-';
 
             await WriteCommentOrPiAsync(text, '-').ConfigureAwait(false);
 
-            bufChars[bufPos++] = (char)'-';
-            bufChars[bufPos++] = (char)'-';
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'-';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize a processing instruction.
@@ -416,20 +416,20 @@ namespace System.Xml
             Debug.Assert(name != null && name.Length > 0);
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'<';
-            bufChars[bufPos++] = (char)'?';
+            _bufChars[_bufPos++] = (char)'<';
+            _bufChars[_bufPos++] = (char)'?';
             await RawTextAsync(name).ConfigureAwait(false);
 
             if (text.Length > 0)
             {
-                bufChars[bufPos++] = (char)' ';
+                _bufChars[_bufPos++] = (char)' ';
                 await WriteCommentOrPiAsync(text, '?').ConfigureAwait(false);
             }
 
-            bufChars[bufPos++] = (char)'?';
-            bufChars[bufPos++] = (char)'>';
+            _bufChars[_bufPos++] = (char)'?';
+            _bufChars[_bufPos++] = (char)'>';
         }
 
         // Serialize an entity reference.
@@ -438,18 +438,18 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(name != null && name.Length > 0);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'&';
+            _bufChars[_bufPos++] = (char)'&';
             await RawTextAsync(name).ConfigureAwait(false);
-            bufChars[bufPos++] = (char)';';
+            _bufChars[_bufPos++] = (char)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 await FlushBufferAsync().ConfigureAwait(false);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a character entity reference.
@@ -458,26 +458,26 @@ namespace System.Xml
             CheckAsyncCall();
             string strVal = ((int)ch).ToString("X", NumberFormatInfo.InvariantInfo);
 
-            if (checkCharacters && !xmlCharType.IsCharData(ch))
+            if (_checkCharacters && !_xmlCharType.IsCharData(ch))
             {
                 // we just have a single char, not a surrogate, therefore we have to pass in '\0' for the second char
                 throw XmlConvert.CreateInvalidCharException(ch, '\0');
             }
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            bufChars[bufPos++] = (char)'&';
-            bufChars[bufPos++] = (char)'#';
-            bufChars[bufPos++] = (char)'x';
+            _bufChars[_bufPos++] = (char)'&';
+            _bufChars[_bufPos++] = (char)'#';
+            _bufChars[_bufPos++] = (char)'x';
             await RawTextAsync(strVal).ConfigureAwait(false);
-            bufChars[bufPos++] = (char)';';
+            _bufChars[_bufPos++] = (char)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 await FlushBufferAsync().ConfigureAwait(false);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a whitespace node.
@@ -487,9 +487,9 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(ws != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
-            if (inAttributeValue)
+            if (_inAttributeValue)
             {
                 return WriteAttributeTextBlockAsync(ws);
             }
@@ -506,9 +506,9 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(text != null);
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
 
-            if (inAttributeValue)
+            if (_inAttributeValue)
             {
                 return WriteAttributeTextBlockAsync(text);
             }
@@ -523,16 +523,16 @@ namespace System.Xml
         {
             CheckAsyncCall();
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             int surrogateChar = XmlCharType.CombineSurrogateChar(lowChar, highChar);
 
-            bufChars[bufPos++] = (char)'&';
-            bufChars[bufPos++] = (char)'#';
-            bufChars[bufPos++] = (char)'x';
+            _bufChars[_bufPos++] = (char)'&';
+            _bufChars[_bufPos++] = (char)'#';
+            _bufChars[_bufPos++] = (char)'x';
             await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(false);
-            bufChars[bufPos++] = (char)';';
-            textPos = bufPos;
+            _bufChars[_bufPos++] = (char)';';
+            _textPos = _bufPos;
         }
 
         // Serialize either attribute or element text using XML rules.
@@ -545,9 +545,9 @@ namespace System.Xml
             Debug.Assert(index >= 0);
             Debug.Assert(count >= 0 && index + count <= buffer.Length);
 
-            if (trackTextContent && inTextContent != true) { ChangeTextContentMark(true); }
+            if (_trackTextContent && _inTextContent != true) { ChangeTextContentMark(true); }
 
-            if (inAttributeValue)
+            if (_inAttributeValue)
             {
                 return WriteAttributeTextBlockAsync(buffer, index, count);
             }
@@ -567,11 +567,11 @@ namespace System.Xml
             Debug.Assert(index >= 0);
             Debug.Assert(count >= 0 && index + count <= buffer.Length);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(false);
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize raw data.
@@ -581,11 +581,11 @@ namespace System.Xml
             CheckAsyncCall();
             Debug.Assert(data != null);
 
-            if (trackTextContent && inTextContent != false) { ChangeTextContentMark(false); }
+            if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
 
             await WriteRawWithCharCheckingAsync(data).ConfigureAwait(false);
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Flush all characters in the buffer to output and call Flush() on the output object.
@@ -595,13 +595,13 @@ namespace System.Xml
             await FlushBufferAsync().ConfigureAwait(false);
             await FlushEncoderAsync().ConfigureAwait(false);
 
-            if (stream != null)
+            if (_stream != null)
             {
-                await stream.FlushAsync().ConfigureAwait(false);
+                await _stream.FlushAsync().ConfigureAwait(false);
             }
-            else if (writer != null)
+            else if (_writer != null)
             {
-                await writer.FlushAsync().ConfigureAwait(false);
+                await _writer.FlushAsync().ConfigureAwait(false);
             }
         }
 
@@ -614,13 +614,13 @@ namespace System.Xml
             try
             {
                 // Output all characters (except for previous characters stored at beginning of buffer)
-                if (!writeToNull)
+                if (!_writeToNull)
                 {
-                    Debug.Assert(stream != null || writer != null);
+                    Debug.Assert(_stream != null || _writer != null);
 
-                    if (stream != null)
+                    if (_stream != null)
                     {
-                        if (trackTextContent)
+                        if (_trackTextContent)
                         {
                             _charEntityFallback.Reset(_textContentMarks, _lastMarkPos);
                             // reset text content tracking
@@ -638,14 +638,14 @@ namespace System.Xml
                             }
                             Debug.Assert(_textContentMarks[0] == 1);
                         }
-                        await EncodeCharsAsync(1, bufPos, true).ConfigureAwait(false);
+                        await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(false);
                     }
                     else
                     {
-                        if (bufPos - 1 > 0)
+                        if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await writer.WriteAsync(bufChars.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
+                            await _writer.WriteAsync(_bufChars.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
                         }
                     }
                 }
@@ -653,21 +653,21 @@ namespace System.Xml
             catch
             {
                 // Future calls to flush (i.e. when Close() is called) don't attempt to write to stream
-                writeToNull = true;
+                _writeToNull = true;
                 throw;
             }
             finally
             {
                 // Move last buffer character to the beginning of the buffer (so that previous character can always be determined)
-                bufChars[0] = bufChars[bufPos - 1];
+                _bufChars[0] = _bufChars[_bufPos - 1];
 
 
                 // Reset buffer position
-                textPos = (textPos == bufPos) ? 1 : 0;
-                attrEndPos = (attrEndPos == bufPos) ? 1 : 0;
-                contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
-                cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
-                bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
+                _textPos = (_textPos == _bufPos) ? 1 : 0;
+                _attrEndPos = (_attrEndPos == _bufPos) ? 1 : 0;
+                _contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
+                _cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
+                _bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
                                    // close an empty element or in CDATA section detection of double ]; _BUFFER[0] will always be 0
             }
         }
@@ -683,35 +683,35 @@ namespace System.Xml
                 {
                     _charEntityFallback.StartOffset = startOffset;
                 }
-                encoder.Convert(bufChars, startOffset, endOffset - startOffset, bufBytes, bufBytesUsed, bufBytes.Length - bufBytesUsed, false, out chEnc, out bEnc, out completed);
+                _encoder.Convert(_bufChars, startOffset, endOffset - startOffset, _bufBytes, _bufBytesUsed, _bufBytes.Length - _bufBytesUsed, false, out chEnc, out bEnc, out completed);
                 startOffset += chEnc;
-                bufBytesUsed += bEnc;
-                if (bufBytesUsed >= (bufBytes.Length - 16))
+                _bufBytesUsed += bEnc;
+                if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
-                    bufBytesUsed = 0;
+                    await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                    _bufBytesUsed = 0;
                 }
             }
-            if (writeAllToStream && bufBytesUsed > 0)
+            if (writeAllToStream && _bufBytesUsed > 0)
             {
-                await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
-                bufBytesUsed = 0;
+                await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                _bufBytesUsed = 0;
             }
         }
 
         private Task FlushEncoderAsync()
         {
-            Debug.Assert(bufPos == 1);
-            if (stream != null)
+            Debug.Assert(_bufPos == 1);
+            if (_stream != null)
             {
                 int chEnc;
                 int bEnc;
                 bool completed;
                 // decode no chars, just flush
-                encoder.Convert(bufChars, 1, 0, bufBytes, 0, bufBytes.Length, true, out chEnc, out bEnc, out completed);
+                _encoder.Convert(_bufChars, 1, 0, _bufBytes, 0, _bufBytes.Length, true, out chEnc, out bEnc, out completed);
                 if (bEnc != 0)
                 {
-                    return stream.WriteAsync(bufBytes, 0, bEnc);
+                    return _stream.WriteAsync(_bufBytes, 0, bEnc);
                 }
             }
 
@@ -724,20 +724,20 @@ namespace System.Xml
         {
             char* pRaw = pSrc;
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -754,7 +754,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -778,7 +778,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0x9:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (char)ch;
                                 pDst++;
@@ -790,7 +790,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (char)ch;
                                 pDst++;
@@ -802,7 +802,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (char)ch;
                                 pDst++;
@@ -837,7 +837,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
 
             return -1;
@@ -928,20 +928,20 @@ namespace System.Xml
             needWriteNewLine = false;
             char* pRaw = pSrc;
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -958,7 +958,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -981,9 +981,9 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
-                                bufPos = (int)(pDst - pDstBegin);
+                                _bufPos = (int)(pDst - pDstBegin);
                                 needWriteNewLine = true;
                                 return (int)(pSrc - pRaw);
                             }
@@ -994,7 +994,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            switch (newLineHandling)
+                            switch (_newLineHandling)
                             {
                                 case NewLineHandling.Replace:
                                     // Replace "\r\n", or "\r" with NewLineChars
@@ -1003,7 +1003,7 @@ namespace System.Xml
                                         pSrc++;
                                     }
 
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
 
@@ -1041,9 +1041,9 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
-                textPos = bufPos;
-                contentPos = 0;
+                _bufPos = (int)(pDst - pDstBegin);
+                _textPos = _bufPos;
+                _contentPos = 0;
             }
 
             return -1;
@@ -1054,7 +1054,7 @@ namespace System.Xml
             needWriteNewLine = false;
             if (count == 0)
             {
-                contentPos = 0;
+                _contentPos = 0;
                 return -1;
             }
             fixed (char* pSrc = &chars[index])
@@ -1070,7 +1070,7 @@ namespace System.Xml
             needWriteNewLine = false;
             if (count == 0)
             {
-                contentPos = 0;
+                _contentPos = 0;
                 return -1;
             }
             fixed (char* pSrc = text)
@@ -1095,7 +1095,7 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1135,7 +1135,7 @@ namespace System.Xml
 
             if (newLine)
             {
-                await RawTextAsync(newLineChars).ConfigureAwait(false);
+                await RawTextAsync(_newLineChars).ConfigureAwait(false);
                 curIndex++;
                 leftCount--;
             }
@@ -1152,7 +1152,7 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1167,18 +1167,18 @@ namespace System.Xml
         {
             char* pRaw = pSrcBegin;
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
                 char* pSrc = pSrcBegin;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
                     while (pDst < pDstEnd && ((ch = *pSrc) < XmlCharType.SurHighStart))
@@ -1198,7 +1198,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -1223,7 +1223,7 @@ namespace System.Xml
                     }
                 }
 
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
 
             return -1;
@@ -1342,21 +1342,21 @@ namespace System.Xml
             needWriteNewLine = false;
             char* pRaw = pSrcBegin;
 
-            fixed (char* pDstBegin = bufChars)
+            fixed (char* pDstBegin = _bufChars)
             {
                 char* pSrc = pSrcBegin;
-                char* pDst = pDstBegin + bufPos;
+                char* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && xmlCharType.IsTextChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsTextChar((char)(ch = *pSrc)))
                     {
                         *pDst = (char)ch;
                         pDst++;
@@ -1374,7 +1374,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -1389,7 +1389,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1397,7 +1397,7 @@ namespace System.Xml
                                     pSrc++;
                                 }
 
-                                bufPos = (int)(pDst - pDstBegin);
+                                _bufPos = (int)(pDst - pDstBegin);
                                 needWriteNewLine = true;
                                 return (int)(pSrc - pRaw);
                             }
@@ -1408,9 +1408,9 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
-                                bufPos = (int)(pDst - pDstBegin);
+                                _bufPos = (int)(pDst - pDstBegin);
                                 needWriteNewLine = true;
                                 return (int)(pSrc - pRaw);
                             }
@@ -1444,7 +1444,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
 
             return -1;
@@ -1493,7 +1493,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1517,7 +1517,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1539,7 +1539,7 @@ namespace System.Xml
             {
                 char* pSrcBegin = pSrcText + index;
 
-                fixed (char* pDstBegin = bufChars)
+                fixed (char* pDstBegin = _bufChars)
                 {
                     char* pSrc = pSrcBegin;
 
@@ -1547,18 +1547,18 @@ namespace System.Xml
 
                     char* pSrcEnd = pSrcBegin + count;
 
-                    char* pDst = pDstBegin + bufPos;
+                    char* pDst = pDstBegin + _bufPos;
 
                     int ch = 0;
                     while (true)
                     {
                         char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                        if (pDstEnd > pDstBegin + bufLen)
+                        if (pDstEnd > pDstBegin + _bufLen)
                         {
-                            pDstEnd = pDstBegin + bufLen;
+                            pDstEnd = pDstBegin + _bufLen;
                         }
 
-                        while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
+                        while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
                         {
                             *pDst = (char)ch;
                             pDst++;
@@ -1576,7 +1576,7 @@ namespace System.Xml
                         // end of buffer
                         if (pDst >= pDstEnd)
                         {
-                            bufPos = (int)(pDst - pDstBegin);
+                            _bufPos = (int)(pDst - pDstBegin);
                             return (int)(pSrc - pRaw);
                         }
 
@@ -1614,7 +1614,7 @@ namespace System.Xml
                                 pDst++;
                                 break;
                             case (char)0xD:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
                                     // Normalize "\r\n", or "\r" to NewLineChars
                                     if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1622,7 +1622,7 @@ namespace System.Xml
                                         pSrc++;
                                     }
 
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1633,9 +1633,9 @@ namespace System.Xml
                                 }
                                 break;
                             case (char)0xA:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1675,7 +1675,7 @@ namespace System.Xml
                         }
                         pSrc++;
                     }
-                    bufPos = (int)(pDst - pDstBegin);
+                    _bufPos = (int)(pDst - pDstBegin);
                 }
 
                 return -1;
@@ -1686,7 +1686,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     await FlushBufferAsync().ConfigureAwait(false);
                 }
@@ -1704,7 +1704,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1729,7 +1729,7 @@ namespace System.Xml
             {
                 char* pSrcBegin = pSrcText + index;
 
-                fixed (char* pDstBegin = bufChars)
+                fixed (char* pDstBegin = _bufChars)
                 {
                     char* pSrc = pSrcBegin;
 
@@ -1737,18 +1737,18 @@ namespace System.Xml
 
                     char* pRaw = pSrc;
 
-                    char* pDst = pDstBegin + bufPos;
+                    char* pDst = pDstBegin + _bufPos;
 
                     int ch = 0;
                     while (true)
                     {
                         char* pDstEnd = pDst + (pSrcEnd - pSrc);
-                        if (pDstEnd > pDstBegin + bufLen)
+                        if (pDstEnd > pDstBegin + _bufLen)
                         {
-                            pDstEnd = pDstBegin + bufLen;
+                            pDstEnd = pDstBegin + _bufLen;
                         }
 
-                        while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
+                        while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
                         {
                             *pDst = (char)ch;
                             pDst++;
@@ -1766,7 +1766,7 @@ namespace System.Xml
                         // end of buffer
                         if (pDst >= pDstEnd)
                         {
-                            bufPos = (int)(pDst - pDstBegin);
+                            _bufPos = (int)(pDst - pDstBegin);
                             return (int)(pSrc - pRaw);
                         }
 
@@ -1774,7 +1774,7 @@ namespace System.Xml
                         switch (ch)
                         {
                             case '>':
-                                if (hadDoubleBracket && pDst[-1] == (char)']')
+                                if (_hadDoubleBracket && pDst[-1] == (char)']')
                                 {   // pDst[-1] will always correct - there is a padding character at _BUFFER[0]
                                     // The characters "]]>" were found within the CData text
                                     pDst = RawEndCData(pDst);
@@ -1786,17 +1786,17 @@ namespace System.Xml
                             case ']':
                                 if (pDst[-1] == (char)']')
                                 {   // pDst[-1] will always correct - there is a padding character at _BUFFER[0]
-                                    hadDoubleBracket = true;
+                                    _hadDoubleBracket = true;
                                 }
                                 else
                                 {
-                                    hadDoubleBracket = false;
+                                    _hadDoubleBracket = false;
                                 }
                                 *pDst = (char)']';
                                 pDst++;
                                 break;
                             case (char)0xD:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
                                     // Normalize "\r\n", or "\r" to NewLineChars
                                     if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1804,7 +1804,7 @@ namespace System.Xml
                                         pSrc++;
                                     }
 
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1815,9 +1815,9 @@ namespace System.Xml
                                 }
                                 break;
                             case (char)0xA:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1859,7 +1859,7 @@ namespace System.Xml
                         }
                         pSrc++;
                     }
-                    bufPos = (int)(pDst - pDstBegin);
+                    _bufPos = (int)(pDst - pDstBegin);
                 }
 
                 return -1;
@@ -1870,7 +1870,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     await FlushBufferAsync().ConfigureAwait(false);
                 }
@@ -1888,7 +1888,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1907,7 +1907,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -1920,12 +1920,12 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
-            indentLevel++;
-            _mixedContentStack.PushBit(mixedContent);
+            _indentLevel++;
+            _mixedContentStack.PushBit(_mixedContent);
 
             await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
@@ -1934,16 +1934,16 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     await WriteIndentAsync().ConfigureAwait(false);
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
@@ -1952,16 +1952,16 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     await WriteIndentAsync().ConfigureAwait(false);
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
@@ -1971,7 +1971,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            if (newLineOnAttributes)
+            if (_newLineOnAttributes)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -1982,14 +1982,14 @@ namespace System.Xml
         public override Task WriteCDataAsync(string text)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteCDataAsync(text);
         }
 
         public override async Task WriteCommentAsync(string text)
         {
             CheckAsyncCall();
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -2000,7 +2000,7 @@ namespace System.Xml
         public override async Task WriteProcessingInstructionAsync(string target, string text)
         {
             CheckAsyncCall();
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -2011,63 +2011,63 @@ namespace System.Xml
         public override Task WriteEntityRefAsync(string name)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteEntityRefAsync(name);
         }
 
         public override Task WriteCharEntityAsync(char ch)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteCharEntityAsync(ch);
         }
 
         public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteSurrogateCharEntityAsync(lowChar, highChar);
         }
 
         public override Task WriteWhitespaceAsync(string ws)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteWhitespaceAsync(ws);
         }
 
         public override Task WriteStringAsync(string text)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteStringAsync(text);
         }
 
         public override Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteCharsAsync(buffer, index, count);
         }
 
         public override Task WriteRawAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteRawAsync(buffer, index, count);
         }
 
         public override Task WriteRawAsync(string data)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteRawAsync(data);
         }
 
         public override Task WriteBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteBase64Async(buffer, index, count);
         }
 
@@ -2075,10 +2075,10 @@ namespace System.Xml
         private async Task WriteIndentAsync()
         {
             CheckAsyncCall();
-            await RawTextAsync(base.newLineChars).ConfigureAwait(false);
-            for (int i = indentLevel; i > 0; i--)
+            await RawTextAsync(base._newLineChars).ConfigureAwait(false);
+            for (int i = _indentLevel; i > 0; i--)
             {
-                await RawTextAsync(indentChars).ConfigureAwait(false);
+                await RawTextAsync(_indentChars).ConfigureAwait(false);
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEventCache.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEventCache.cs
@@ -431,7 +431,7 @@ namespace System.Xml
         /// </summary>
         public override void WriteValue(object value)
         {
-            WriteString(XmlUntypedConverter.Untyped.ToString(value, this.resolver));
+            WriteString(XmlUntypedConverter.Untyped.ToString(value, this._resolver));
         }
 
         public override void WriteValue(string value)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
@@ -252,7 +252,7 @@ namespace System.Xml
                 // Encoding
                 if (_encoding != null)
                 {
-                    RawText("\" _encoding=\"");
+                    RawText("\" encoding=\"");
                     RawText(_encoding.WebName);
                 }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
@@ -28,44 +28,44 @@ namespace System.Xml
         private readonly bool _useAsync;
 
         // main buffer
-        protected byte[] bufBytes;
+        protected byte[] _bufBytes;
 
         // output stream
-        protected Stream stream;
+        protected Stream _stream;
 
         // encoding of the stream or text writer
-        protected Encoding encoding;
+        protected Encoding _encoding;
 
         // char type tables
-        protected XmlCharType xmlCharType = XmlCharType.Instance;
+        protected XmlCharType _xmlCharType = XmlCharType.Instance;
 
         // buffer positions
-        protected int bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
-                                      // close an empty element or in CDATA section detection of double ]; <#= BufferName #>[0] will always be 0
-        protected int textPos = 1;    // text end position; don't indent first element, pi, or comment
-        protected int contentPos;     // element content end position
-        protected int cdataPos;       // cdata end position
-        protected int attrEndPos;     // end of the last attribute
-        protected int bufLen = BUFSIZE;
+        protected int _bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
+                                       // close an empty element or in CDATA section detection of double ]; <#= BufferName #>[0] will always be 0
+        protected int _textPos = 1;    // text end position; don't indent first element, pi, or comment
+        protected int _contentPos;     // element content end position
+        protected int _cdataPos;       // cdata end position
+        protected int _attrEndPos;     // end of the last attribute
+        protected int _bufLen = BUFSIZE;
 
         // flags
-        protected bool writeToNull;
-        protected bool hadDoubleBracket;
-        protected bool inAttributeValue;
+        protected bool _writeToNull;
+        protected bool _hadDoubleBracket;
+        protected bool _inAttributeValue;
 
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-        protected int bufBytesUsed;
-        protected char[] bufChars;
+        protected int _bufBytesUsed;
+        protected char[] _bufChars;
 
         // encoder for encoding chars in specified encoding when writing to stream
-        protected Encoder encoder;
+        protected Encoder _encoder;
 
         // output text writer
-        protected TextWriter writer;
+        protected TextWriter _writer;
 
         // escaping of characters invalid in the output encoding
-        protected bool trackTextContent;
-        protected bool inTextContent;
+        protected bool _trackTextContent;
+        protected bool _inTextContent;
         private int _lastMarkPos;
         private int[] _textContentMarks;   // even indices contain text content start positions
                                            // odd indices contain markup start positions
@@ -73,17 +73,17 @@ namespace System.Xml
 <# } #>
 
         // writer settings
-        protected NewLineHandling newLineHandling;
-        protected bool closeOutput;
-        protected bool omitXmlDeclaration;
-        protected string newLineChars;
-        protected bool checkCharacters;
+        protected NewLineHandling _newLineHandling;
+        protected bool _closeOutput;
+        protected bool _omitXmlDeclaration;
+        protected string _newLineChars;
+        protected bool _checkCharacters;
 
-        protected XmlStandalone standalone;
-        protected XmlOutputMethod outputMethod;
+        protected XmlStandalone _standalone;
+        protected XmlOutputMethod _outputMethod;
 
-        protected bool autoXmlDeclaration;
-        protected bool mergeCDataSections;
+        protected bool _autoXmlDeclaration;
+        protected bool _mergeCDataSections;
 
         //
         // Constants
@@ -102,19 +102,19 @@ namespace System.Xml
             _useAsync = settings.Async;
 
             // copy settings
-            newLineHandling = settings.NewLineHandling;
-            omitXmlDeclaration = settings.OmitXmlDeclaration;
-            newLineChars = settings.NewLineChars;
-            checkCharacters = settings.CheckCharacters;
-            closeOutput = settings.CloseOutput;
+            _newLineHandling = settings.NewLineHandling;
+            _omitXmlDeclaration = settings.OmitXmlDeclaration;
+            _newLineChars = settings.NewLineChars;
+            _checkCharacters = settings.CheckCharacters;
+            _closeOutput = settings.CloseOutput;
 
-            standalone = settings.Standalone;
-            outputMethod = settings.OutputMethod;
-            mergeCDataSections = settings.MergeCDataSections;
+            _standalone = settings.Standalone;
+            _outputMethod = settings.OutputMethod;
+            _mergeCDataSections = settings.MergeCDataSections;
 
-            if (checkCharacters && newLineHandling == NewLineHandling.Replace)
+            if (_checkCharacters && _newLineHandling == NewLineHandling.Replace)
             {
-                ValidateContentChars(newLineChars, "NewLineChars", false);
+                ValidateContentChars(_newLineChars, "NewLineChars", false);
             }
         }
 <# if (WriterType == RawTextWriterType.Encoded) { #>
@@ -124,20 +124,20 @@ namespace System.Xml
         {
             Debug.Assert(writer != null && settings != null);
 
-            this.writer = writer;
-            this.encoding = writer.Encoding;
+            this._writer = writer;
+            this._encoding = writer.Encoding;
             // the buffer is allocated will OVERFLOW in order to reduce checks when writing out constant size markup
             if (settings.Async)
             {
-                bufLen = ASYNCBUFSIZE;
+                _bufLen = ASYNCBUFSIZE;
             }
-            this.bufChars = new <#= BufferType #>[bufLen + OVERFLOW];
+            this._bufChars = new <#= BufferType #>[_bufLen + OVERFLOW];
 
             // Write the xml declaration
             if (settings.AutoXmlDeclaration)
             {
-                WriteXmlDeclaration(standalone);
-                autoXmlDeclaration = true;
+                WriteXmlDeclaration(_standalone);
+                _autoXmlDeclaration = true;
             }
         }
 <# } #>
@@ -147,35 +147,35 @@ namespace System.Xml
         {
             Debug.Assert(stream != null && settings != null);
 
-            this.stream = stream;
-            this.encoding = settings.Encoding;
+            this._stream = stream;
+            this._encoding = settings.Encoding;
 
             // the buffer is allocated will OVERFLOW in order to reduce checks when writing out constant size markup
             if (settings.Async)
             {
-                bufLen = ASYNCBUFSIZE;
+                _bufLen = ASYNCBUFSIZE;
             }
 
-            <#= BufferName #> = new <#= BufferType #>[bufLen + OVERFLOW];
+            <#= BufferName #> = new <#= BufferType #>[_bufLen + OVERFLOW];
 <# if (WriterType == RawTextWriterType.Utf8) { #>
             // Output UTF-8 byte order mark if Encoding object wants it
             if (!stream.CanSeek || stream.Position == 0)
             {
-                ReadOnlySpan<byte> bom = encoding.Preamble;
+                ReadOnlySpan<byte> bom = _encoding.Preamble;
                 if (bom.Length != 0)
                 {
-                    bom.CopyTo(new Span<byte>(bufBytes).Slice(1));
-                    bufPos += bom.Length;
-                    textPos += bom.Length;
+                    bom.CopyTo(new Span<byte>(_bufBytes).Slice(1));
+                    _bufPos += bom.Length;
+                    _textPos += bom.Length;
                 }
             }
 <# } else { #>
-            bufBytes = new byte[bufChars.Length];
-            bufBytesUsed = 0;
+            _bufBytes = new byte[_bufChars.Length];
+            _bufBytesUsed = 0;
 
             // Init escaping of characters not fitting into the target encoding
-            trackTextContent = true;
-            inTextContent = false;
+            _trackTextContent = true;
+            _inTextContent = false;
             _lastMarkPos = 0;
             _textContentMarks = new int[INIT_MARKS_COUNT];
             _textContentMarks[0] = 1;
@@ -183,21 +183,21 @@ namespace System.Xml
             _charEntityFallback = new CharEntityEncoderFallback();
 
             // grab bom before possibly changing encoding settings
-            ReadOnlySpan<byte> bom = encoding.Preamble;
+            ReadOnlySpan<byte> bom = _encoding.Preamble;
 
             // the encoding instance this creates can differ from the one passed in
-            this.encoding = Encoding.GetEncoding(
+            this._encoding = Encoding.GetEncoding(
                 settings.Encoding.CodePage,
                 _charEntityFallback,
                 settings.Encoding.DecoderFallback);
 
-            encoder = encoding.GetEncoder();
+            _encoder = _encoding.GetEncoder();
 
-            if (!stream.CanSeek || stream.Position == 0)
+            if (!_stream.CanSeek || _stream.Position == 0)
             {
                 if (bom.Length != 0)
                 {
-                    this.stream.Write(bom);
+                    this._stream.Write(bom);
                 }
             }
 <# } #>
@@ -205,8 +205,8 @@ namespace System.Xml
             // Write the xml declaration
             if (settings.AutoXmlDeclaration)
             {
-                WriteXmlDeclaration(standalone);
-                autoXmlDeclaration = true;
+                WriteXmlDeclaration(_standalone);
+                _autoXmlDeclaration = true;
             }
         }
 
@@ -220,17 +220,17 @@ namespace System.Xml
             {
                 XmlWriterSettings settings = new XmlWriterSettings();
 
-                settings.Encoding = encoding;
-                settings.OmitXmlDeclaration = omitXmlDeclaration;
-                settings.NewLineHandling = newLineHandling;
-                settings.NewLineChars = newLineChars;
-                settings.CloseOutput = closeOutput;
+                settings.Encoding = _encoding;
+                settings.OmitXmlDeclaration = _omitXmlDeclaration;
+                settings.NewLineHandling = _newLineHandling;
+                settings.NewLineChars = _newLineChars;
+                settings.CloseOutput = _closeOutput;
                 settings.ConformanceLevel = ConformanceLevel.Auto;
-                settings.CheckCharacters = checkCharacters;
+                settings.CheckCharacters = _checkCharacters;
 
-                settings.AutoXmlDeclaration = autoXmlDeclaration;
-                settings.Standalone = standalone;
-                settings.OutputMethod = outputMethod;
+                settings.AutoXmlDeclaration = _autoXmlDeclaration;
+                settings.Standalone = _standalone;
+                settings.OutputMethod = _outputMethod;
 
                 settings.ReadOnly = true;
                 return settings;
@@ -241,7 +241,7 @@ namespace System.Xml
         internal override void WriteXmlDeclaration(XmlStandalone standalone)
         {
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {<# /* Code block is to squash extra line. */
 #><#= SetTextContentMark(4, 1, false) #>
                 RawText("<?xml version=\"");
@@ -250,10 +250,10 @@ namespace System.Xml
                 RawText("1.0");
 
                 // Encoding
-                if (encoding != null)
+                if (_encoding != null)
                 {
-                    RawText("\" encoding=\"");
-                    RawText(encoding.WebName);
+                    RawText("\" _encoding=\"");
+                    RawText(_encoding.WebName);
                 }
 
                 // Standalone
@@ -270,7 +270,7 @@ namespace System.Xml
         internal override void WriteXmlDeclaration(string xmldecl)
         {
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
                 WriteProcessingInstruction("xml", xmldecl);
             }
@@ -294,27 +294,27 @@ namespace System.Xml
                 {
                     RawText(sysid);
                 }
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else if (sysid != null)
             {
                 RawText(" SYSTEM \"");
                 RawText(sysid);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
             }
 
             if (subset != null)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
                 RawText(subset);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
             }
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
@@ -325,27 +325,27 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
             if (prefix != null && prefix.Length != 0)
             {
                 RawText(prefix);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)':';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)':';
             }
 
             RawText(localName);
 
-            attrEndPos = bufPos;
+            _attrEndPos = _bufPos;
         }
 
         // Serialize the end of an element start tag in preparation for content serialization: ">"
         internal override void StartElementContent()
         {
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
 
             // StartElementContent is always called; therefore, in order to allow shortcut syntax, we save the
             // position of the '>' character.  If WriteEndElement is called and no other characters have been
             // output, then the '>' character can be overwritten with the shortcut syntax " />".
-            contentPos = bufPos;
+            _contentPos = _bufPos;
         }
 
         // Serialize an element end tag: "</prefix:localName>", if content was output.  Otherwise, serialize
@@ -357,27 +357,27 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            if (contentPos != bufPos)
+            if (_contentPos != _bufPos)
             {
                 // Content has been output, so can't use shortcut syntax
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'/';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'/';
 
                 if (prefix != null && prefix.Length != 0)
                 {
                     RawText(prefix);
-                    <#= BufferName #>[bufPos++] = (<#= BufferType #>)':';
+                    <#= BufferName #>[_bufPos++] = (<#= BufferType #>)':';
                 }
                 RawText(localName);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
             }
             else
             {
                 // Use shortcut syntax; overwrite the already output '>' character
-                bufPos--;
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'/';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+                _bufPos--;
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'/';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
             }
         }
 
@@ -389,16 +389,16 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'/';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'/';
 
             if (prefix != null && prefix.Length != 0)
             {
                 RawText(prefix);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)':';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)':';
             }
             RawText(localName);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize an attribute tag using double quotes around the attribute value: 'prefix:localName="'
@@ -409,21 +409,21 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            if (attrEndPos == bufPos)
+            if (_attrEndPos == _bufPos)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
             }
 
             if (prefix != null && prefix.Length > 0)
             {
                 RawText(prefix);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)':';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)':';
             }
             RawText(localName);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'=';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'=';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
 
-            inAttributeValue = true;
+            _inAttributeValue = true;
         }
 
         // Serialize the end of an attribute value using double quotes: '"'
@@ -431,9 +431,9 @@ namespace System.Xml
         {<#
 #><#= SetTextContentMark(3, 1, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
-            inAttributeValue = false;
-            attrEndPos = bufPos;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
+            _inAttributeValue = false;
+            _attrEndPos = _bufPos;
         }
 
         internal override void WriteNamespaceDeclaration(string prefix, string namespaceName)
@@ -467,21 +467,21 @@ namespace System.Xml
             {
                 RawText(" xmlns:");
                 RawText(prefix);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'=';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'=';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
 
-            inAttributeValue = true;<#
+            _inAttributeValue = true;<#
 #><#= SetTextContentMark(3, true) #>
         }
 
         internal override void WriteEndNamespaceDeclaration()
         {<#
 #><#= SetTextContentMark(3, 1, false) #>
-            inAttributeValue = false;
+            _inAttributeValue = false;
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
-            attrEndPos = bufPos;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
+            _attrEndPos = _bufPos;
         }
 
         // Serialize a CData section.  If the "]]>" pattern is found within
@@ -492,34 +492,34 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            if (mergeCDataSections && bufPos == cdataPos)
+            if (_mergeCDataSections && _bufPos == _cdataPos)
             {
                 // Merge adjacent cdata sections - overwrite the "]]>" characters
-                Debug.Assert(bufPos >= 4);
-                bufPos -= 3;
+                Debug.Assert(_bufPos >= 4);
+                _bufPos -= 3;
             }
             else
             {
                 // Start a new cdata section
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'!';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'C';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'D';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'A';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'T';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'A';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'!';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'C';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'D';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'A';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'T';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'A';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
             }
 
             WriteCDataSection(text);
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
 
-            textPos = bufPos;
-            cdataPos = bufPos;
+            _textPos = _bufPos;
+            _cdataPos = _bufPos;
         }
 
         // Serialize a comment.
@@ -529,16 +529,16 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'!';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'!';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
 
             WriteCommentOrPi(text, '-');
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize a processing instruction.
@@ -549,18 +549,18 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'?';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'?';
             RawText(name);
 
             if (text.Length > 0)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
                 WriteCommentOrPi(text, '?');
             }
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'?';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'?';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize an entity reference.
@@ -570,16 +570,16 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'&';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
             RawText(name);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 FlushBuffer();
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a character entity reference.
@@ -587,7 +587,7 @@ namespace System.Xml
         {
             string strVal = ((int)ch).ToString("X", NumberFormatInfo.InvariantInfo);
 
-            if (checkCharacters && !xmlCharType.IsCharData(ch))
+            if (_checkCharacters && !_xmlCharType.IsCharData(ch))
             {
                 // we just have a single char, not a surrogate, therefore we have to pass in '\0' for the second char
                 throw XmlConvert.CreateInvalidCharException(ch, '\0');
@@ -595,18 +595,18 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'&';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'#';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'x';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'#';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'x';
             RawText(strVal);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 FlushBuffer();
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a whitespace node.
@@ -620,7 +620,7 @@ namespace System.Xml
             fixed (char* pSrc = ws)
             {
                 char* pSrcEnd = pSrc + ws.Length;
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrc, pSrcEnd);
                 }
@@ -642,7 +642,7 @@ namespace System.Xml
             fixed (char* pSrc = text)
             {
                 char* pSrcEnd = pSrc + text.Length;
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrc, pSrcEnd);
                 }
@@ -659,12 +659,12 @@ namespace System.Xml
 #><#= SetTextContentMark(3, 1, false) #>
             int surrogateChar = XmlCharType.CombineSurrogateChar(lowChar, highChar);
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'&';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'#';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'x';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'#';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'x';
             RawText(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo));
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
-            textPos = bufPos;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
+            _textPos = _bufPos;
         }
 
         // Serialize either attribute or element text using XML rules.
@@ -680,7 +680,7 @@ namespace System.Xml
 
             fixed (char* pSrcBegin = &buffer[index])
             {
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrcBegin, pSrcBegin + count);
                 }
@@ -707,7 +707,7 @@ namespace System.Xml
                 WriteRawWithCharChecking(pSrcBegin, pSrcBegin + count);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize raw data.
@@ -723,7 +723,7 @@ namespace System.Xml
                 WriteRawWithCharChecking(pSrcBegin, pSrcBegin + data.Length);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Flush all bytes in the buffer to output and close the output stream or writer.
@@ -737,48 +737,48 @@ namespace System.Xml
             finally
             {
                 // Future calls to Close or Flush shouldn't write to Stream or Writer
-                writeToNull = true;
+                _writeToNull = true;
 
-                if (stream != null)
+                if (_stream != null)
                 {
                     try
                     {
-                        stream.Flush();
+                        _stream.Flush();
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                stream.Dispose();
+                                _stream.Dispose();
                             }
                         }
                         finally
                         {
-                            stream = null;
+                            _stream = null;
                         }
                     }
                 }
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-                else if (writer != null)
+                else if (_writer != null)
                 {
                     try
                     {
-                        writer.Flush();
+                        _writer.Flush();
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                writer.Dispose();
+                                _writer.Dispose();
                             }
                         }
                         finally
                         {
-                            writer = null;
+                            _writer = null;
                         }
                     }
                 }
@@ -792,18 +792,18 @@ namespace System.Xml
             FlushBuffer();
             FlushEncoder();
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-            if (stream != null)
+            if (_stream != null)
             {
-                stream.Flush();
+                _stream.Flush();
             }
 <# } else { #>
-            if (stream != null)
+            if (_stream != null)
             {
-                stream.Flush();
+                _stream.Flush();
             }
-            else if (writer != null)
+            else if (_writer != null)
             {
-                writer.Flush();
+                _writer.Flush();
             }
 <# } #>
         }
@@ -817,20 +817,20 @@ namespace System.Xml
             try
             {
                 // Output all characters (except for previous characters stored at beginning of buffer)
-                if (!writeToNull)
+                if (!_writeToNull)
                 {
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    if (bufPos - 1 > 0)
+                    if (_bufPos - 1 > 0)
                     {
-                        Debug.Assert(stream != null);
-                        stream.Write(<#= BufferName #>, 1, bufPos - 1);
+                        Debug.Assert(_stream != null);
+                        _stream.Write(<#= BufferName #>, 1, _bufPos - 1);
                     }
 <# } else { #>
-                    Debug.Assert(stream != null || writer != null);
+                    Debug.Assert(_stream != null || _writer != null);
 
-                    if (stream != null)
+                    if (_stream != null)
                     {
-                        if (trackTextContent)
+                        if (_trackTextContent)
                         {
                             _charEntityFallback.Reset(_textContentMarks, _lastMarkPos);
                             // reset text content tracking
@@ -848,14 +848,14 @@ namespace System.Xml
                             }
                             Debug.Assert(_textContentMarks[0] == 1);
                         }
-                        EncodeChars(1, bufPos, true);
+                        EncodeChars(1, _bufPos, true);
                     }
                     else
                     {
-                        if (bufPos - 1 > 0)
+                        if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            writer.Write(<#= BufferName #>, 1, bufPos - 1);
+                            _writer.Write(<#= BufferName #>, 1, _bufPos - 1);
                         }
                     }
 <# } #>
@@ -864,30 +864,30 @@ namespace System.Xml
             catch
             {
                 // Future calls to flush (i.e. when Close() is called) don't attempt to write to stream
-                writeToNull = true;
+                _writeToNull = true;
                 throw;
             }
             finally
             {
                 // Move last buffer character to the beginning of the buffer (so that previous character can always be determined)
-                <#= BufferName #>[0] = <#= BufferName #>[bufPos - 1];
+                <#= BufferName #>[0] = <#= BufferName #>[_bufPos - 1];
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                 if (IsSurrogateByte(<#= BufferName #>[0]))
                 {
                     // Last character was the first byte in a surrogate encoding, so move last three
                     // bytes of encoding to the beginning of the buffer.
-                    <#= BufferName #>[1] = <#= BufferName #>[bufPos];
-                    <#= BufferName #>[2] = <#= BufferName #>[bufPos + 1];
-                    <#= BufferName #>[3] = <#= BufferName #>[bufPos + 2];
+                    <#= BufferName #>[1] = <#= BufferName #>[_bufPos];
+                    <#= BufferName #>[2] = <#= BufferName #>[_bufPos + 1];
+                    <#= BufferName #>[3] = <#= BufferName #>[_bufPos + 2];
                 }
 <# } #>
 
                 // Reset buffer position
-                textPos = (textPos == bufPos) ? 1 : 0;
-                attrEndPos = (attrEndPos == bufPos) ? 1 : 0;
-                contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
-                cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
-                bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
+                _textPos = (_textPos == _bufPos) ? 1 : 0;
+                _attrEndPos = (_attrEndPos == _bufPos) ? 1 : 0;
+                _contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
+                _cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
+                _bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
                                    // close an empty element or in CDATA section detection of double ]; <#= BufferName #>[0] will always be 0
             }
         }
@@ -911,35 +911,35 @@ namespace System.Xml
                 {
                     _charEntityFallback.StartOffset = startOffset;
                 }
-                encoder.Convert(<#= BufferName #>, startOffset, endOffset - startOffset, bufBytes, bufBytesUsed, bufBytes.Length - bufBytesUsed, false, out chEnc, out bEnc, out completed);
+                _encoder.Convert(<#= BufferName #>, startOffset, endOffset - startOffset, _bufBytes, _bufBytesUsed, _bufBytes.Length - _bufBytesUsed, false, out chEnc, out bEnc, out completed);
                 startOffset += chEnc;
-                bufBytesUsed += bEnc;
-                if (bufBytesUsed >= (bufBytes.Length - 16))
+                _bufBytesUsed += bEnc;
+                if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    stream.Write(bufBytes, 0, bufBytesUsed);
-                    bufBytesUsed = 0;
+                    _stream.Write(_bufBytes, 0, _bufBytesUsed);
+                    _bufBytesUsed = 0;
                 }
             }
-            if (writeAllToStream && bufBytesUsed > 0)
+            if (writeAllToStream && _bufBytesUsed > 0)
             {
-                stream.Write(bufBytes, 0, bufBytesUsed);
-                bufBytesUsed = 0;
+                _stream.Write(_bufBytes, 0, _bufBytesUsed);
+                _bufBytesUsed = 0;
             }
         }
 
         private void FlushEncoder()
         {
-            Debug.Assert(bufPos == 1);
-            if (stream != null)
+            Debug.Assert(_bufPos == 1);
+            if (_stream != null)
             {
                 int chEnc;
                 int bEnc;
                 bool completed;
                 // decode no chars, just flush
-                encoder.Convert(<#= BufferName #>, 1, 0, bufBytes, 0, bufBytes.Length, true, out chEnc, out bEnc, out completed);
+                _encoder.Convert(<#= BufferName #>, 1, 0, _bufBytes, 0, _bufBytes.Length, true, out chEnc, out bEnc, out completed);
                 if (bEnc != 0)
                 {
-                    stream.Write(bufBytes, 0, bEnc);
+                    _stream.Write(_bufBytes, 0, bEnc);
                 }
             }
         }
@@ -951,21 +951,21 @@ namespace System.Xml
         {
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 for (;;)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -983,7 +983,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1009,7 +1009,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0x9:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (<#= BufferType #>)ch;
                                 pDst++;
@@ -1021,7 +1021,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (<#= BufferType #>)ch;
                                 pDst++;
@@ -1033,7 +1033,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (<#= BufferType #>)ch;
                                 pDst++;
@@ -1050,7 +1050,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1060,21 +1060,21 @@ namespace System.Xml
         {
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 for (;;)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -1092,7 +1092,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1117,7 +1117,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1128,7 +1128,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            switch (newLineHandling)
+                            switch (_newLineHandling)
                             {
                                 case NewLineHandling.Replace:
                                     // Replace "\r\n", or "\r" with NewLineChars
@@ -1156,9 +1156,9 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
-                textPos = bufPos;
-                contentPos = 0;
+                _bufPos = (int)(pDst - pDstBegin);
+                _textPos = _bufPos;
+                _contentPos = 0;
             }
         }
 
@@ -1176,16 +1176,16 @@ namespace System.Xml
         {
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
                 char* pSrc = pSrcBegin;
 
                 int ch = 0;
                 for (;;)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
@@ -1209,7 +1209,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1218,7 +1218,7 @@ namespace System.Xml
 <#= EncodeChar(5, false) #>
                 }
 
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1227,21 +1227,21 @@ namespace System.Xml
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
                 char* pSrc = pSrcBegin;
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 for (;;)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsTextChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsTextChar((char)(ch = *pSrc)))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -1260,7 +1260,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1277,7 +1277,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1294,7 +1294,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1310,7 +1310,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1318,7 +1318,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     FlushBuffer();
                 }
@@ -1333,21 +1333,21 @@ namespace System.Xml
 
                 char* pSrcEnd = pSrcBegin + text.Length;
 
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 for (;;)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
+                    while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -1366,7 +1366,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1406,7 +1406,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1423,7 +1423,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1445,7 +1445,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1453,7 +1453,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     FlushBuffer();
                 }
@@ -1470,21 +1470,21 @@ namespace System.Xml
 
                 char* pSrcEnd = pSrcBegin + text.Length;
 
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 for (;;)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']' && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']' && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -1503,7 +1503,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -1513,7 +1513,7 @@ namespace System.Xml
                     switch (ch)
                     {
                         case '>':
-                            if (hadDoubleBracket && pDst[-1] == (<#= BufferType #>)']')
+                            if (_hadDoubleBracket && pDst[-1] == (<#= BufferType #>)']')
                             {   // pDst[-1] will always correct - there is a padding character at <#= BufferName #>[0]
                                 // The characters "]]>" were found within the CData text
                                 pDst = RawEndCData(pDst);
@@ -1525,17 +1525,17 @@ namespace System.Xml
                         case ']':
                             if (pDst[-1] == (<#= BufferType #>)']')
                             {   // pDst[-1] will always correct - there is a padding character at <#= BufferName #>[0]
-                                hadDoubleBracket = true;
+                                _hadDoubleBracket = true;
                             }
                             else
                             {
-                                hadDoubleBracket = false;
+                                _hadDoubleBracket = false;
                             }
                             *pDst = (<#= BufferType #>)']';
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1552,7 +1552,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 pDst = WriteNewLine(pDst);
                             }
@@ -1576,7 +1576,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -1630,10 +1630,10 @@ namespace System.Xml
 
         private unsafe <#= BufferType #>* InvalidXmlChar(int ch, <#= BufferType #>* pDst, bool entitize)
         {
-            Debug.Assert(!xmlCharType.IsWhiteSpace((char)ch));
-            Debug.Assert(!xmlCharType.IsAttributeValueChar((char)ch));
+            Debug.Assert(!_xmlCharType.IsWhiteSpace((char)ch));
+            Debug.Assert(!_xmlCharType.IsAttributeValueChar((char)ch));
 
-            if (checkCharacters)
+            if (_checkCharacters)
             {
                 // This method will never be called on surrogates, so it is ok to pass in '\0' to the CreateInvalidCharException
                 throw XmlConvert.CreateInvalidCharException((char)ch, '\0');
@@ -1724,14 +1724,14 @@ namespace System.Xml
 <# if (WriterType == RawTextWriterType.Encoded) { #>
         protected void ChangeTextContentMark(bool value)
         {
-            Debug.Assert(inTextContent != value);
-            Debug.Assert(inTextContent || ((_lastMarkPos & 1) == 0));
-            inTextContent = value;
+            Debug.Assert(_inTextContent != value);
+            Debug.Assert(_inTextContent || ((_lastMarkPos & 1) == 0));
+            _inTextContent = value;
             if (_lastMarkPos + 1 == _textContentMarks.Length)
             {
                 GrowTextContentMarks();
             }
-            _textContentMarks[++_lastMarkPos] = bufPos;
+            _textContentMarks[++_lastMarkPos] = _bufPos;
         }
 
         private void GrowTextContentMarks()
@@ -1747,10 +1747,10 @@ namespace System.Xml
         {
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
                 // Let RawText do the real work
-                RawText(newLineChars);
-                return pDstBegin + bufPos;
+                RawText(_newLineChars);
+                return pDstBegin + _bufPos;
             }
         }
 
@@ -1888,7 +1888,7 @@ namespace System.Xml
         {
             if (allowOnlyWhitespace)
             {
-                if (!xmlCharType.IsOnlyWhitespace(chars))
+                if (!_xmlCharType.IsOnlyWhitespace(chars))
                 {
                     throw new ArgumentException(SR.Format(SR.Xml_IndentCharsNotWhitespace, propertyName));
                 }
@@ -1898,7 +1898,7 @@ namespace System.Xml
                 string error = null;
                 for (int i = 0; i < chars.Length; i++)
                 {
-                    if (!xmlCharType.IsTextChar(chars[i]))
+                    if (!_xmlCharType.IsTextChar(chars[i]))
                     {
                         switch (chars[i])
                         {
@@ -1948,14 +1948,14 @@ namespace System.Xml
         //
         // Fields
         //
-        protected int indentLevel;
-        protected bool newLineOnAttributes;
-        protected string indentChars;
+        protected int _indentLevel;
+        protected bool _newLineOnAttributes;
+        protected string _indentChars;
 
-        protected bool mixedContent;
+        protected bool _mixedContent;
         private BitStack _mixedContentStack;
 
-        protected ConformanceLevel conformanceLevel = ConformanceLevel.Auto;
+        protected ConformanceLevel _conformanceLevel = ConformanceLevel.Auto;
 
         //
         // Constructors
@@ -1984,8 +1984,8 @@ namespace System.Xml
 
                 settings.ReadOnly = false;
                 settings.Indent = true;
-                settings.IndentChars = indentChars;
-                settings.NewLineOnAttributes = newLineOnAttributes;
+                settings.IndentChars = _indentChars;
+                settings.NewLineOnAttributes = _newLineOnAttributes;
                 settings.ReadOnly = true;
 
                 return settings;
@@ -1995,7 +1995,7 @@ namespace System.Xml
         public override void WriteDocType(string name, string pubid, string sysid, string subset)
         {
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
@@ -2007,12 +2007,12 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
-            indentLevel++;
-            _mixedContentStack.PushBit(mixedContent);
+            _indentLevel++;
+            _mixedContentStack.PushBit(_mixedContent);
 
             base.WriteStartElement(prefix, localName, ns);
         }
@@ -2020,16 +2020,16 @@ namespace System.Xml
         internal override void StartElementContent()
         {
             // If this is the root element and we're writing a document
-            //   do not inherit the mixedContent flag into the root element.
+            //   do not inherit the _mixedContent flag into the root element.
             //   This is to allow for whitespace nodes on root level
             //   without disabling indentation for the whole document.
-            if (indentLevel == 1 && conformanceLevel == ConformanceLevel.Document)
+            if (_indentLevel == 1 && _conformanceLevel == ConformanceLevel.Document)
             {
-                mixedContent = false;
+                _mixedContent = false;
             }
             else
             {
-                mixedContent = _mixedContentStack.PeekBit();
+                _mixedContent = _mixedContentStack.PeekBit();
             }
             base.StartElementContent();
         }
@@ -2037,22 +2037,22 @@ namespace System.Xml
         internal override void OnRootElement(ConformanceLevel currentConformanceLevel)
         {
             // Just remember the current conformance level
-            conformanceLevel = currentConformanceLevel;
+            _conformanceLevel = currentConformanceLevel;
         }
 
         internal override void WriteEndElement(string prefix, string localName, string ns)
         {
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     WriteIndent();
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             base.WriteEndElement(prefix, localName, ns);
         }
@@ -2060,16 +2060,16 @@ namespace System.Xml
         internal override void WriteFullEndElement(string prefix, string localName, string ns)
         {
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     WriteIndent();
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             base.WriteFullEndElement(prefix, localName, ns);
         }
@@ -2078,7 +2078,7 @@ namespace System.Xml
         public override void WriteStartAttribute(string prefix, string localName, string ns)
         {
             // Add indentation
-            if (newLineOnAttributes)
+            if (_newLineOnAttributes)
             {
                 WriteIndent();
             }
@@ -2088,13 +2088,13 @@ namespace System.Xml
 
         public override void WriteCData(string text)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteCData(text);
         }
 
         public override void WriteComment(string text)
         {
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
@@ -2104,7 +2104,7 @@ namespace System.Xml
 
         public override void WriteProcessingInstruction(string target, string text)
         {
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 WriteIndent();
             }
@@ -2114,55 +2114,55 @@ namespace System.Xml
 
         public override void WriteEntityRef(string name)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteEntityRef(name);
         }
 
         public override void WriteCharEntity(char ch)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteCharEntity(ch);
         }
 
         public override void WriteSurrogateCharEntity(char lowChar, char highChar)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteSurrogateCharEntity(lowChar, highChar);
         }
 
         public override void WriteWhitespace(string ws)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteWhitespace(ws);
         }
 
         public override void WriteString(string text)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteString(text);
         }
 
         public override void WriteChars(char[] buffer, int index, int count)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteChars(buffer, index, count);
         }
 
         public override void WriteRaw(char[] buffer, int index, int count)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteRaw(buffer, index, count);
         }
 
         public override void WriteRaw(string data)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteRaw(data);
         }
 
         public override void WriteBase64(byte[] buffer, int index, int count)
         {
-            mixedContent = true;
+            _mixedContent = true;
             base.WriteBase64(buffer, index, count);
         }
 
@@ -2171,25 +2171,25 @@ namespace System.Xml
         //
         private void Init(XmlWriterSettings settings)
         {
-            indentLevel = 0;
-            indentChars = settings.IndentChars;
-            newLineOnAttributes = settings.NewLineOnAttributes;
+            _indentLevel = 0;
+            _indentChars = settings.IndentChars;
+            _newLineOnAttributes = settings.NewLineOnAttributes;
             _mixedContentStack = new BitStack();
 
             // check indent characters that they are valid XML characters
-            if (base.checkCharacters)
+            if (base._checkCharacters)
             {
-                if (newLineOnAttributes)
+                if (_newLineOnAttributes)
                 {
-                    base.ValidateContentChars(indentChars, "IndentChars", true);
-                    base.ValidateContentChars(newLineChars, "NewLineChars", true);
+                    base.ValidateContentChars(_indentChars, "IndentChars", true);
+                    base.ValidateContentChars(_newLineChars, "NewLineChars", true);
                 }
                 else
                 {
-                    base.ValidateContentChars(indentChars, "IndentChars", false);
-                    if (base.newLineHandling != NewLineHandling.Replace)
+                    base.ValidateContentChars(_indentChars, "IndentChars", false);
+                    if (base._newLineHandling != NewLineHandling.Replace)
                     {
-                        base.ValidateContentChars(newLineChars, "NewLineChars", false);
+                        base.ValidateContentChars(_newLineChars, "NewLineChars", false);
                     }
                 }
             }
@@ -2198,10 +2198,10 @@ namespace System.Xml
         // Add indentation to output.  Write newline and then repeat IndentChars for each indent level.
         private void WriteIndent()
         {
-            RawText(base.newLineChars);
-            for (int i = indentLevel; i > 0; i--)
+            RawText(base._newLineChars);
+            for (int i = _indentLevel; i > 0; i--)
             {
-                RawText(indentChars);
+                RawText(_indentChars);
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -37,7 +37,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {<# /* Code block is to squash extra line. */
 #><#= SetTextContentMark(4, 1, false) #>
                 await RawTextAsync("<?xml version=\"").ConfigureAwait(false);
@@ -46,14 +46,14 @@ namespace System.Xml
                 await RawTextAsync("1.0").ConfigureAwait(false);
 
                 // Encoding
-                if (encoding != null)
+                if (_encoding != null)
                 {
                     await RawTextAsync("\" encoding=\"").ConfigureAwait(false);
-                    await RawTextAsync(encoding.WebName).ConfigureAwait(false);
+                    await RawTextAsync(_encoding.WebName).ConfigureAwait(false);
                 }
 
                 // Standalone
-                if (standalone != XmlStandalone.Omit)
+                if (_standalone != XmlStandalone.Omit)
                 {
                     await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
                     await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);
@@ -67,7 +67,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Output xml declaration only if user allows it and it was not already output
-            if (!omitXmlDeclaration && !autoXmlDeclaration)
+            if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
                 return WriteProcessingInstructionAsync("xml", xmldecl);
             }
@@ -84,48 +84,48 @@ namespace System.Xml
             finally
             {
                 // Future calls to Close or Flush shouldn't write to Stream or Writer
-                writeToNull = true;
+                _writeToNull = true;
 
-                if (stream != null)
+                if (_stream != null)
                 {
                     try
                     {
-                        await stream.FlushAsync().ConfigureAwait(false);
+                        await _stream.FlushAsync().ConfigureAwait(false);
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                await stream.DisposeAsync().ConfigureAwait(false);
+                                await _stream.DisposeAsync().ConfigureAwait(false);
                             }
                         }
                         finally
                         {
-                            stream = null;
+                            _stream = null;
                         }
                     }
                 }
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-                else if (writer != null)
+                else if (_writer != null)
                 {
                     try
                     {
-                        await writer.FlushAsync().ConfigureAwait(false);
+                        await _writer.FlushAsync().ConfigureAwait(false);
                     }
                     finally
                     {
                         try
                         {
-                            if (closeOutput)
+                            if (_closeOutput)
                             {
-                                await writer.DisposeAsync().ConfigureAwait(false);
+                                await _writer.DisposeAsync().ConfigureAwait(false);
                             }
                         }
                         finally
                         {
-                            writer = null;
+                            _writer = null;
                         }
                     }
                 }
@@ -152,27 +152,27 @@ namespace System.Xml
                 {
                     await RawTextAsync(sysid).ConfigureAwait(false);
                 }
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else if (sysid != null)
             {
                 await RawTextAsync(" SYSTEM \"").ConfigureAwait(false);
                 await RawTextAsync(sysid).ConfigureAwait(false);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
             }
 
             if (subset != null)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
                 await RawTextAsync(subset).ConfigureAwait(false);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
             }
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize the beginning of an element start tag: "<prefix:localName"
@@ -185,7 +185,7 @@ namespace System.Xml
 #><#= SetTextContentMark(3, false) #>
 
             Task task;
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
             if (prefix != null && prefix.Length != 0)
             {
                 task = RawTextAsync(prefix, ":", localName);
@@ -199,7 +199,7 @@ namespace System.Xml
 
         private void WriteStartElementAsync_SetAttEndPos()
         {
-            attrEndPos = bufPos;
+            _attrEndPos = _bufPos;
         }
 
         // Serialize an element end tag: "</prefix:localName>", if content was output.  Otherwise, serialize
@@ -212,11 +212,11 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            if (contentPos != bufPos)
+            if (_contentPos != _bufPos)
             {
                 // Content has been output, so can't use shortcut syntax
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'/';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'/';
 
                 if (prefix != null && prefix.Length != 0)
                 {
@@ -230,10 +230,10 @@ namespace System.Xml
             else
             {
                 // Use shortcut syntax; overwrite the already output '>' character
-                bufPos--;
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'/';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+                _bufPos--;
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'/';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
             }
             return Task.CompletedTask;
         }
@@ -247,8 +247,8 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'/';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'/';
 
             if (prefix != null && prefix.Length != 0)
             {
@@ -269,9 +269,9 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            if (attrEndPos == bufPos)
+            if (_attrEndPos == _bufPos)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
             }
             Task task;
             if (prefix != null && prefix.Length > 0)
@@ -287,9 +287,9 @@ namespace System.Xml
 
         private void WriteStartAttribute_SetInAttribute()
         {
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'=';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
-            inAttributeValue = true;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'=';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
+            _inAttributeValue = true;
         }
 
         // Serialize the end of an attribute value using double quotes: '"'
@@ -299,9 +299,9 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
-            inAttributeValue = false;
-            attrEndPos = bufPos;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
+            _inAttributeValue = false;
+            _attrEndPos = _bufPos;
 
             return Task.CompletedTask;
         }
@@ -331,11 +331,11 @@ namespace System.Xml
             {
                 await RawTextAsync(" xmlns:").ConfigureAwait(false);
                 await RawTextAsync(prefix).ConfigureAwait(false);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'=';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'=';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
 
-            inAttributeValue = true;<#
+            _inAttributeValue = true;<#
 #><#= SetTextContentMark(3, true) #>
         }
 
@@ -345,10 +345,10 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            inAttributeValue = false;
+            _inAttributeValue = false;
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
-            attrEndPos = bufPos;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
+            _attrEndPos = _bufPos;
 
             return Task.CompletedTask;
         }
@@ -362,34 +362,34 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            if (mergeCDataSections && bufPos == cdataPos)
+            if (_mergeCDataSections && _bufPos == _cdataPos)
             {
                 // Merge adjacent cdata sections - overwrite the "]]>" characters
-                Debug.Assert(bufPos >= 4);
-                bufPos -= 3;
+                Debug.Assert(_bufPos >= 4);
+                _bufPos -= 3;
             }
             else
             {
                 // Start a new cdata section
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'!';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'C';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'D';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'A';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'T';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'A';
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'!';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'C';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'D';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'A';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'T';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'A';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
             }
 
             await WriteCDataSectionAsync(text).ConfigureAwait(false);
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
 
-            textPos = bufPos;
-            cdataPos = bufPos;
+            _textPos = _bufPos;
+            _cdataPos = _bufPos;
         }
 
         // Serialize a comment.
@@ -400,16 +400,16 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'!';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'!';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
 
             await WriteCommentOrPiAsync(text, '-').ConfigureAwait(false);
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'-';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'-';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize a processing instruction.
@@ -421,18 +421,18 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'?';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'?';
             await RawTextAsync(name).ConfigureAwait(false);
 
             if (text.Length > 0)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
                 await WriteCommentOrPiAsync(text, '?').ConfigureAwait(false);
             }
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'?';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'?';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // Serialize an entity reference.
@@ -443,16 +443,16 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'&';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
             await RawTextAsync(name).ConfigureAwait(false);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 await FlushBufferAsync().ConfigureAwait(false);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a character entity reference.
@@ -461,7 +461,7 @@ namespace System.Xml
             CheckAsyncCall();
             string strVal = ((int)ch).ToString("X", NumberFormatInfo.InvariantInfo);
 
-            if (checkCharacters && !xmlCharType.IsCharData(ch))
+            if (_checkCharacters && !_xmlCharType.IsCharData(ch))
             {
                 // we just have a single char, not a surrogate, therefore we have to pass in '\0' for the second char
                 throw XmlConvert.CreateInvalidCharException(ch, '\0');
@@ -469,18 +469,18 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'&';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'#';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'x';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'#';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'x';
             await RawTextAsync(strVal).ConfigureAwait(false);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
 
-            if (bufPos > bufLen)
+            if (_bufPos > _bufLen)
             {
                 await FlushBufferAsync().ConfigureAwait(false);
             }
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize a whitespace node.
@@ -491,7 +491,7 @@ namespace System.Xml
             Debug.Assert(ws != null);<#
 #><#= SetTextContentMark(3, false) #>
 
-            if (inAttributeValue)
+            if (_inAttributeValue)
             {
                 return WriteAttributeTextBlockAsync(ws);
             }
@@ -509,7 +509,7 @@ namespace System.Xml
             Debug.Assert(text != null);<#
 #><#= SetTextContentMark(3, true) #>
 
-            if (inAttributeValue)
+            if (_inAttributeValue)
             {
                 return WriteAttributeTextBlockAsync(text);
             }
@@ -527,12 +527,12 @@ namespace System.Xml
 
             int surrogateChar = XmlCharType.CombineSurrogateChar(lowChar, highChar);
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'&';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'#';
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'x';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'&';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'#';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'x';
             await RawTextAsync(surrogateChar.ToString("X", NumberFormatInfo.InvariantInfo)).ConfigureAwait(false);
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
-            textPos = bufPos;
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
+            _textPos = _bufPos;
         }
 
         // Serialize either attribute or element text using XML rules.
@@ -547,7 +547,7 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, true) #>
 
-            if (inAttributeValue)
+            if (_inAttributeValue)
             {
                 return WriteAttributeTextBlockAsync(buffer, index, count);
             }
@@ -571,7 +571,7 @@ namespace System.Xml
 
             await WriteRawWithCharCheckingAsync(buffer, index, count).ConfigureAwait(false);
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Serialize raw data.
@@ -585,7 +585,7 @@ namespace System.Xml
 
             await WriteRawWithCharCheckingAsync(data).ConfigureAwait(false);
 
-            textPos = bufPos;
+            _textPos = _bufPos;
         }
 
         // Flush all characters in the buffer to output and call Flush() on the output object.
@@ -597,14 +597,14 @@ namespace System.Xml
             await FlushEncoderAsync().ConfigureAwait(false);
 <# } #>
 
-            if (stream != null)
+            if (_stream != null)
             {
-                await stream.FlushAsync().ConfigureAwait(false);
+                await _stream.FlushAsync().ConfigureAwait(false);
             }
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-            else if (writer != null)
+            else if (_writer != null)
             {
-                await writer.FlushAsync().ConfigureAwait(false);
+                await _writer.FlushAsync().ConfigureAwait(false);
             }
 <# } #>
         }
@@ -618,20 +618,20 @@ namespace System.Xml
             try
             {
                 // Output all characters (except for previous characters stored at beginning of buffer)
-                if (!writeToNull)
+                if (!_writeToNull)
                 {
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    if (bufPos - 1 > 0)
+                    if (_bufPos - 1 > 0)
                     {
-                        Debug.Assert(stream != null);
-                        await stream.WriteAsync(bufBytes.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
+                        Debug.Assert(_stream != null);
+                        await _stream.WriteAsync(_bufBytes.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
                     }
 <# } else { #>
-                    Debug.Assert(stream != null || writer != null);
+                    Debug.Assert(_stream != null || _writer != null);
 
-                    if (stream != null)
+                    if (_stream != null)
                     {
-                        if (trackTextContent)
+                        if (_trackTextContent)
                         {
                             _charEntityFallback.Reset(_textContentMarks, _lastMarkPos);
                             // reset text content tracking
@@ -649,14 +649,14 @@ namespace System.Xml
                             }
                             Debug.Assert(_textContentMarks[0] == 1);
                         }
-                        await EncodeCharsAsync(1, bufPos, true).ConfigureAwait(false);
+                        await EncodeCharsAsync(1, _bufPos, true).ConfigureAwait(false);
                     }
                     else
                     {
-                        if (bufPos - 1 > 0)
+                        if (_bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await writer.WriteAsync(<#= BufferName #>.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
+                            await _writer.WriteAsync(<#= BufferName #>.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
                         }
                     }
 <# } #>
@@ -665,31 +665,31 @@ namespace System.Xml
             catch
             {
                 // Future calls to flush (i.e. when Close() is called) don't attempt to write to stream
-                writeToNull = true;
+                _writeToNull = true;
                 throw;
             }
             finally
             {
                 // Move last buffer character to the beginning of the buffer (so that previous character can always be determined)
-                <#= BufferName #>[0] = <#= BufferName #>[bufPos - 1];
+                <#= BufferName #>[0] = <#= BufferName #>[_bufPos - 1];
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                if (IsSurrogateByte(bufBytes[0]))
+                if (IsSurrogateByte(_bufBytes[0]))
                 {
                     // Last character was the first byte in a surrogate encoding, so move last three
                     // bytes of encoding to the beginning of the buffer.
-                    bufBytes[1] = bufBytes[bufPos];
-                    bufBytes[2] = bufBytes[bufPos + 1];
-                    bufBytes[3] = bufBytes[bufPos + 2];
+                    _bufBytes[1] = _bufBytes[_bufPos];
+                    _bufBytes[2] = _bufBytes[_bufPos + 1];
+                    _bufBytes[3] = _bufBytes[_bufPos + 2];
                 }
 <# } #>
 
                 // Reset buffer position
-                textPos = (textPos == bufPos) ? 1 : 0;
-                attrEndPos = (attrEndPos == bufPos) ? 1 : 0;
-                contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
-                cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
-                bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
+                _textPos = (_textPos == _bufPos) ? 1 : 0;
+                _attrEndPos = (_attrEndPos == _bufPos) ? 1 : 0;
+                _contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
+                _cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
+                _bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
                                    // close an empty element or in CDATA section detection of double ]; _BUFFER[0] will always be 0
             }
         }
@@ -706,35 +706,35 @@ namespace System.Xml
                 {
                     _charEntityFallback.StartOffset = startOffset;
                 }
-                encoder.Convert(<#= BufferName #>, startOffset, endOffset - startOffset, bufBytes, bufBytesUsed, bufBytes.Length - bufBytesUsed, false, out chEnc, out bEnc, out completed);
+                _encoder.Convert(<#= BufferName #>, startOffset, endOffset - startOffset, _bufBytes, _bufBytesUsed, _bufBytes.Length - _bufBytesUsed, false, out chEnc, out bEnc, out completed);
                 startOffset += chEnc;
-                bufBytesUsed += bEnc;
-                if (bufBytesUsed >= (bufBytes.Length - 16))
+                _bufBytesUsed += bEnc;
+                if (_bufBytesUsed >= (_bufBytes.Length - 16))
                 {
-                    await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
-                    bufBytesUsed = 0;
+                    await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                    _bufBytesUsed = 0;
                 }
             }
-            if (writeAllToStream && bufBytesUsed > 0)
+            if (writeAllToStream && _bufBytesUsed > 0)
             {
-                await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
-                bufBytesUsed = 0;
+                await _stream.WriteAsync(_bufBytes.AsMemory(0, _bufBytesUsed)).ConfigureAwait(false);
+                _bufBytesUsed = 0;
             }
         }
 
         private Task FlushEncoderAsync()
         {
-            Debug.Assert(bufPos == 1);
-            if (stream != null)
+            Debug.Assert(_bufPos == 1);
+            if (_stream != null)
             {
                 int chEnc;
                 int bEnc;
                 bool completed;
                 // decode no chars, just flush
-                encoder.Convert(<#= BufferName #>, 1, 0, bufBytes, 0, bufBytes.Length, true, out chEnc, out bEnc, out completed);
+                _encoder.Convert(<#= BufferName #>, 1, 0, _bufBytes, 0, _bufBytes.Length, true, out chEnc, out bEnc, out completed);
                 if (bEnc != 0)
                 {
-                    return stream.WriteAsync(bufBytes, 0, bEnc);
+                    return _stream.WriteAsync(_bufBytes, 0, bEnc);
                 }
             }
 
@@ -750,21 +750,21 @@ namespace System.Xml
 
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -782,7 +782,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -806,7 +806,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0x9:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (<#= BufferType #>)ch;
                                 pDst++;
@@ -818,7 +818,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (<#= BufferType #>)ch;
                                 pDst++;
@@ -830,7 +830,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.None)
+                            if (_newLineHandling == NewLineHandling.None)
                             {
                                 *pDst = (<#= BufferType #>)ch;
                                 pDst++;
@@ -847,7 +847,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
 
             return -1;
@@ -940,21 +940,21 @@ namespace System.Xml
 
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -972,7 +972,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -995,9 +995,9 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
-                                bufPos = (int)(pDst - pDstBegin);
+                                _bufPos = (int)(pDst - pDstBegin);
                                 needWriteNewLine = true;
                                 return (int)(pSrc - pRaw);
                             }
@@ -1008,7 +1008,7 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xD:
-                            switch (newLineHandling)
+                            switch (_newLineHandling)
                             {
                                 case NewLineHandling.Replace:
                                     // Replace "\r\n", or "\r" with NewLineChars
@@ -1017,7 +1017,7 @@ namespace System.Xml
                                         pSrc++;
                                     }
 
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
 
@@ -1037,9 +1037,9 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
-                textPos = bufPos;
-                contentPos = 0;
+                _bufPos = (int)(pDst - pDstBegin);
+                _textPos = _bufPos;
+                _contentPos = 0;
             }
 
             return -1;
@@ -1050,7 +1050,7 @@ namespace System.Xml
             needWriteNewLine = false;
             if (count == 0)
             {
-                contentPos = 0;
+                _contentPos = 0;
                 return -1;
             }
             fixed (char* pSrc = &chars[index])
@@ -1066,7 +1066,7 @@ namespace System.Xml
             needWriteNewLine = false;
             if (count == 0)
             {
-                contentPos = 0;
+                _contentPos = 0;
                 return -1;
             }
             fixed (char* pSrc = text)
@@ -1091,7 +1091,7 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1131,7 +1131,7 @@ namespace System.Xml
 
             if (newLine)
             {
-                await RawTextAsync(newLineChars).ConfigureAwait(false);
+                await RawTextAsync(_newLineChars).ConfigureAwait(false);
                 curIndex++;
                 leftCount--;
             }
@@ -1148,7 +1148,7 @@ namespace System.Xml
                 if (needWriteNewLine)
                 {
                     //hit WriteNewLine
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1165,16 +1165,16 @@ namespace System.Xml
 
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
                 char* pSrc = pSrcBegin;
 
                 int ch = 0;
                 while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
@@ -1198,14 +1198,14 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
 <#= EncodeChar(5, false) #>
                 }
 
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
 
             return -1;
@@ -1327,21 +1327,21 @@ namespace System.Xml
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
                 char* pSrc = pSrcBegin;
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
                 while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch <= 0x7F))
+                    while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsTextChar((char)(ch = *pSrc)))
+                    while (pDst < pDstEnd && _xmlCharType.IsTextChar((char)(ch = *pSrc)))
 <# } #>
                     {
                         *pDst = (<#= BufferType #>)ch;
@@ -1360,7 +1360,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         return (int)(pSrc - pRaw);
                     }
 
@@ -1375,7 +1375,7 @@ namespace System.Xml
                             pDst++;
                             break;
                         case (char)0xD:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
                                 // Normalize "\r\n", or "\r" to NewLineChars
                                 if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1383,7 +1383,7 @@ namespace System.Xml
                                     pSrc++;
                                 }
 
-                                bufPos = (int)(pDst - pDstBegin);
+                                _bufPos = (int)(pDst - pDstBegin);
                                 needWriteNewLine = true;
                                 return (int)(pSrc - pRaw);
                             }
@@ -1394,9 +1394,9 @@ namespace System.Xml
                             }
                             break;
                         case (char)0xA:
-                            if (newLineHandling == NewLineHandling.Replace)
+                            if (_newLineHandling == NewLineHandling.Replace)
                             {
-                                bufPos = (int)(pDst - pDstBegin);
+                                _bufPos = (int)(pDst - pDstBegin);
                                 needWriteNewLine = true;
                                 return (int)(pSrc - pRaw);
                             }
@@ -1412,7 +1412,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
 
             return -1;
@@ -1461,7 +1461,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1485,7 +1485,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1515,21 +1515,21 @@ namespace System.Xml
 
                     char* pSrcEnd = pSrcBegin + count;
 
-                    <#= BufferType #>* pDst = pDstBegin + bufPos;
+                    <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                     int ch = 0;
                     while (true)
                     {
                         <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                        if (pDstEnd > pDstBegin + bufLen)
+                        if (pDstEnd > pDstBegin + _bufLen)
                         {
-                            pDstEnd = pDstBegin + bufLen;
+                            pDstEnd = pDstBegin + _bufLen;
                         }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                        while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar && ch <= 0x7F))
+                        while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar && ch <= 0x7F))
 <# } else { #>
-                        while (pDst < pDstEnd && (xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
+                        while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
 <# } #>
                         {
                             *pDst = (<#= BufferType #>)ch;
@@ -1548,7 +1548,7 @@ namespace System.Xml
                         // end of buffer
                         if (pDst >= pDstEnd)
                         {
-                            bufPos = (int)(pDst - pDstBegin);
+                            _bufPos = (int)(pDst - pDstBegin);
                             return (int)(pSrc - pRaw);
                         }
 
@@ -1586,7 +1586,7 @@ namespace System.Xml
                                 pDst++;
                                 break;
                             case (char)0xD:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
                                     // Normalize "\r\n", or "\r" to NewLineChars
                                     if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1594,7 +1594,7 @@ namespace System.Xml
                                         pSrc++;
                                     }
 
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1605,9 +1605,9 @@ namespace System.Xml
                                 }
                                 break;
                             case (char)0xA:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1629,7 +1629,7 @@ namespace System.Xml
                         }
                         pSrc++;
                     }
-                    bufPos = (int)(pDst - pDstBegin);
+                    _bufPos = (int)(pDst - pDstBegin);
                 }
 
                 return -1;
@@ -1640,7 +1640,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     await FlushBufferAsync().ConfigureAwait(false);
                 }
@@ -1658,7 +1658,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1691,21 +1691,21 @@ namespace System.Xml
 
                     char* pRaw = pSrc;
 
-                    <#= BufferType #>* pDst = pDstBegin + bufPos;
+                    <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                     int ch = 0;
                     while (true)
                     {
                         <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                        if (pDstEnd > pDstBegin + bufLen)
+                        if (pDstEnd > pDstBegin + _bufLen)
                         {
-                            pDstEnd = pDstBegin + bufLen;
+                            pDstEnd = pDstBegin + _bufLen;
                         }
 
 <# if (WriterType == RawTextWriterType.Utf8) { #>
-                        while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']' && ch <= 0x7F))
+                        while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']' && ch <= 0x7F))
 <# } else { #>
-                        while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
+                        while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
 <# } #>
                         {
                             *pDst = (<#= BufferType #>)ch;
@@ -1724,7 +1724,7 @@ namespace System.Xml
                         // end of buffer
                         if (pDst >= pDstEnd)
                         {
-                            bufPos = (int)(pDst - pDstBegin);
+                            _bufPos = (int)(pDst - pDstBegin);
                             return (int)(pSrc - pRaw);
                         }
 
@@ -1732,7 +1732,7 @@ namespace System.Xml
                         switch (ch)
                         {
                             case '>':
-                                if (hadDoubleBracket && pDst[-1] == (<#= BufferType #>)']')
+                                if (_hadDoubleBracket && pDst[-1] == (<#= BufferType #>)']')
                                 {   // pDst[-1] will always correct - there is a padding character at _BUFFER[0]
                                     // The characters "]]>" were found within the CData text
                                     pDst = RawEndCData(pDst);
@@ -1744,17 +1744,17 @@ namespace System.Xml
                             case ']':
                                 if (pDst[-1] == (<#= BufferType #>)']')
                                 {   // pDst[-1] will always correct - there is a padding character at _BUFFER[0]
-                                    hadDoubleBracket = true;
+                                    _hadDoubleBracket = true;
                                 }
                                 else
                                 {
-                                    hadDoubleBracket = false;
+                                    _hadDoubleBracket = false;
                                 }
                                 *pDst = (<#= BufferType #>)']';
                                 pDst++;
                                 break;
                             case (char)0xD:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
                                     // Normalize "\r\n", or "\r" to NewLineChars
                                     if (pSrc + 1 < pSrcEnd && pSrc[1] == '\n')
@@ -1762,7 +1762,7 @@ namespace System.Xml
                                         pSrc++;
                                     }
 
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1773,9 +1773,9 @@ namespace System.Xml
                                 }
                                 break;
                             case (char)0xA:
-                                if (newLineHandling == NewLineHandling.Replace)
+                                if (_newLineHandling == NewLineHandling.Replace)
                                 {
-                                    bufPos = (int)(pDst - pDstBegin);
+                                    _bufPos = (int)(pDst - pDstBegin);
                                     needWriteNewLine = true;
                                     return (int)(pSrc - pRaw);
                                 }
@@ -1799,7 +1799,7 @@ namespace System.Xml
                         }
                         pSrc++;
                     }
-                    bufPos = (int)(pDst - pDstBegin);
+                    _bufPos = (int)(pDst - pDstBegin);
                 }
 
                 return -1;
@@ -1810,7 +1810,7 @@ namespace System.Xml
         {
             if (text.Length == 0)
             {
-                if (bufPos >= bufLen)
+                if (_bufPos >= _bufLen)
                 {
                     await FlushBufferAsync().ConfigureAwait(false);
                 }
@@ -1828,7 +1828,7 @@ namespace System.Xml
                 leftCount -= writeLen;
                 if (needWriteNewLine)
                 {
-                    await RawTextAsync(newLineChars).ConfigureAwait(false);
+                    await RawTextAsync(_newLineChars).ConfigureAwait(false);
                     curIndex++;
                     leftCount--;
                 }
@@ -1847,7 +1847,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -1860,12 +1860,12 @@ namespace System.Xml
             Debug.Assert(localName != null && localName.Length != 0 && prefix != null && ns != null);
 
             // Add indentation
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
-            indentLevel++;
-            _mixedContentStack.PushBit(mixedContent);
+            _indentLevel++;
+            _mixedContentStack.PushBit(_mixedContent);
 
             await base.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
@@ -1874,16 +1874,16 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     await WriteIndentAsync().ConfigureAwait(false);
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             await base.WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
@@ -1892,16 +1892,16 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            indentLevel--;
-            if (!mixedContent && base.contentPos != base.bufPos)
+            _indentLevel--;
+            if (!_mixedContent && base._contentPos != base._bufPos)
             {
                 // There was content, so try to indent
-                if (base.textPos != base.bufPos)
+                if (base._textPos != base._bufPos)
                 {
                     await WriteIndentAsync().ConfigureAwait(false);
                 }
             }
-            mixedContent = _mixedContentStack.PopBit();
+            _mixedContent = _mixedContentStack.PopBit();
 
             await base.WriteFullEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
@@ -1911,7 +1911,7 @@ namespace System.Xml
         {
             CheckAsyncCall();
             // Add indentation
-            if (newLineOnAttributes)
+            if (_newLineOnAttributes)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -1922,14 +1922,14 @@ namespace System.Xml
         public override Task WriteCDataAsync(string text)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteCDataAsync(text);
         }
 
         public override async Task WriteCommentAsync(string text)
         {
             CheckAsyncCall();
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -1940,7 +1940,7 @@ namespace System.Xml
         public override async Task WriteProcessingInstructionAsync(string target, string text)
         {
             CheckAsyncCall();
-            if (!mixedContent && base.textPos != base.bufPos)
+            if (!_mixedContent && base._textPos != base._bufPos)
             {
                 await WriteIndentAsync().ConfigureAwait(false);
             }
@@ -1951,63 +1951,63 @@ namespace System.Xml
         public override Task WriteEntityRefAsync(string name)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteEntityRefAsync(name);
         }
 
         public override Task WriteCharEntityAsync(char ch)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteCharEntityAsync(ch);
         }
 
         public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteSurrogateCharEntityAsync(lowChar, highChar);
         }
 
         public override Task WriteWhitespaceAsync(string ws)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteWhitespaceAsync(ws);
         }
 
         public override Task WriteStringAsync(string text)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteStringAsync(text);
         }
 
         public override Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteCharsAsync(buffer, index, count);
         }
 
         public override Task WriteRawAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteRawAsync(buffer, index, count);
         }
 
         public override Task WriteRawAsync(string data)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteRawAsync(data);
         }
 
         public override Task WriteBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            mixedContent = true;
+            _mixedContent = true;
             return base.WriteBase64Async(buffer, index, count);
         }
 
@@ -2015,10 +2015,10 @@ namespace System.Xml
         private async Task WriteIndentAsync()
         {
             CheckAsyncCall();
-            await RawTextAsync(base.newLineChars).ConfigureAwait(false);
-            for (int i = indentLevel; i > 0; i--)
+            await RawTextAsync(base._newLineChars).ConfigureAwait(false);
+            for (int i = _indentLevel; i > 0; i--)
             {
-                await RawTextAsync(indentChars).ConfigureAwait(false);
+                await RawTextAsync(_indentChars).ConfigureAwait(false);
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriter.cs
@@ -44,10 +44,10 @@ namespace System.Xml
         // Fields
         //
         // base64 converter
-        protected XmlRawWriterBase64Encoder? base64Encoder;
+        protected XmlRawWriterBase64Encoder? _base64Encoder;
 
         // namespace resolver
-        protected IXmlNamespaceResolver? resolver;
+        protected IXmlNamespaceResolver? _resolver;
 
         //
         // XmlWriter implementation
@@ -88,13 +88,13 @@ namespace System.Xml
         // By default, convert base64 value to string and call WriteString.
         public override void WriteBase64(byte[] buffer, int index, int count)
         {
-            if (base64Encoder == null)
+            if (_base64Encoder == null)
             {
-                base64Encoder = new XmlRawWriterBase64Encoder(this);
+                _base64Encoder = new XmlRawWriterBase64Encoder(this);
             }
 
             // Encode will call WriteRaw to write out the encoded characters
-            base64Encoder.Encode(buffer, index, count);
+            _base64Encoder.Encode(buffer, index, count);
         }
 
         // Raw writers do not have to keep track of namespaces.
@@ -193,7 +193,7 @@ namespace System.Xml
                 throw new ArgumentNullException(nameof(value));
             }
 
-            WriteString(XmlUntypedConverter.Untyped.ToString(value, resolver));
+            WriteString(XmlUntypedConverter.Untyped.ToString(value, _resolver));
         }
 
         // Override in order to handle Xml simple typed values and to pass resolver for QName values
@@ -234,11 +234,11 @@ namespace System.Xml
         {
             get
             {
-                return resolver;
+                return _resolver;
             }
             set
             {
-                resolver = value;
+                _resolver = value;
             }
         }
 
@@ -315,8 +315,8 @@ namespace System.Xml
         internal virtual void WriteEndBase64()
         {
             // The Flush will call WriteRaw to write out the rest of the encoded characters
-            Debug.Assert(base64Encoder != null);
-            base64Encoder.Flush();
+            Debug.Assert(_base64Encoder != null);
+            _base64Encoder.Flush();
         }
 
         internal virtual void Close(WriteState currentState)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
@@ -81,12 +81,12 @@ namespace System.Xml
         // By default, convert base64 value to string and call WriteString.
         public override Task WriteBase64Async(byte[] buffer, int index, int count)
         {
-            if (base64Encoder == null)
+            if (_base64Encoder == null)
             {
-                base64Encoder = new XmlRawWriterBase64Encoder(this);
+                _base64Encoder = new XmlRawWriterBase64Encoder(this);
             }
             // Encode will call WriteRaw to write out the encoded characters
-            return base64Encoder.EncodeAsync(buffer, index, count);
+            return _base64Encoder.EncodeAsync(buffer, index, count);
         }
 
         // Raw writers do not have to verify NmToken values.
@@ -226,8 +226,8 @@ namespace System.Xml
         internal virtual Task WriteEndBase64Async()
         {
             // The Flush will call WriteRaw to write out the rest of the encoded characters
-            Debug.Assert(base64Encoder != null);
-            return base64Encoder.FlushAsync();
+            Debug.Assert(_base64Encoder != null);
+            return _base64Encoder.FlushAsync();
         }
 
         internal virtual ValueTask DisposeAsyncCore(WriteState currentState)


### PR DESCRIPTION
Add underscore prefix to protected fields for the internal `XmlRawWriter` and its descendant classes 

Issue #35320

Please review
Thank you in advance
