### PR TITLE
Fix some incorrect warnings in LiveBuilds.targets

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -79,8 +79,8 @@
   </PropertyGroup>
 
   <Target Name="ResolveRuntimeFilesFromLocalBuild">
-    <Error Condition="!Exists('$(CoreCLRArtifactsPath)') and '$(RuntimeFlavor)' == 'CoreCLR'" Text="The CoreCLR artifacts path does not exist '$(CoreCLRArtifactsPath)'. The CoreCLR subset category must be built before building this project." />
-    <Error Condition="!Exists('$(MonoArtifactsPath)') and '$(RuntimeFlavor)' == 'Mono'" Text="The Mono artifacts path does not exist '$(MonoArtifactsPath)'. The Mono subset category must be built before building this project." />
+    <Error Condition="!Exists('$(CoreCLRArtifactsPath)') and '$(RuntimeFlavor)' == 'CoreCLR'" Text="The CoreCLR artifacts path does not exist '$(CoreCLRArtifactsPath)'. The 'clr' subset must be built before building this project." />
+    <Error Condition="!Exists('$(MonoArtifactsPath)') and '$(RuntimeFlavor)' == 'Mono'" Text="The Mono artifacts path does not exist '$(MonoArtifactsPath)'. The 'mono' subset must be built before building this project." />
 
     <PropertyGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
       <CoreCLRArtifactsPath>$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)'))</CoreCLRArtifactsPath>
@@ -139,12 +139,12 @@
         Include="$(MonoArtifactsPath)\include\**\*.*" />
     </ItemGroup>
 
-    <Error Condition="'@(RuntimeFiles)' == ''" Text="The $(RuntimeFlavor) subset category must be built before building this project." />
+    <Error Condition="'@(RuntimeFiles)' == ''" Text="The '$(RuntimeFlavor)' subset must be built before building this project." />
   </Target>
 
   <Target Name="EnsureLocalArtifactsExist">
-    <Error Condition="!Exists('$(LibrariesSharedFrameworkRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkRefArtifactsPath)" />
-    <Error Condition="'$(IncludeOOBLibraries)' == 'true' and !Exists('$(LibrariesAllRefArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllRefArtifactsPath)" />
+    <Error Condition="!Exists('$(LibrariesSharedFrameworkRefArtifactsPath)')" Text="The 'libs' subset must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkRefArtifactsPath)" />
+    <Error Condition="'$(IncludeOOBLibraries)' == 'true' and !Exists('$(LibrariesAllRefArtifactsPath)')" Text="The 'libs' subset must be built before building this project. Missing artifacts: $(LibrariesAllRefArtifactsPath)" />
   </Target>
 
   <!--
@@ -153,9 +153,9 @@
   -->
   <Target Name="EnsureLocalOSGroupConfigurationArchitectureSpecificArtifactsExist"
           Condition="'$(LibrariesTargetOSConfigurationArchitecture)' != '*'">
-    <Error Condition="!Exists('$(LibrariesSharedFrameworkBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkBinArtifactsPath)" />
-    <Error Condition="'$(IncludeOOBLibraries)' == 'true' and !Exists('$(LibrariesAllBinArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesAllBinArtifactsPath)" />
-    <Error Condition="!Exists('$(LibrariesNativeArtifactsPath)')" Text="The libraries subset category must be built before building this project. Missing artifacts: $(LibrariesNativeArtifactsPath)" />
+    <Error Condition="!Exists('$(LibrariesSharedFrameworkBinArtifactsPath)')" Text="The 'libs' subset must be built before building this project. Missing artifacts: $(LibrariesSharedFrameworkBinArtifactsPath)" />
+    <Error Condition="'$(IncludeOOBLibraries)' == 'true' and !Exists('$(LibrariesAllBinArtifactsPath)')" Text="The 'libs' subset must be built before building this project. Missing artifacts: $(LibrariesAllBinArtifactsPath)" />
+    <Error Condition="!Exists('$(LibrariesNativeArtifactsPath)')" Text="The 'libs' subset must be built before building this project. Missing artifacts: $(LibrariesNativeArtifactsPath)" />
   </Target>
 
   <Target Name="ResolveLibrariesFromLocalBuild"
@@ -184,8 +184,8 @@
         IsNative="true" />
     </ItemGroup>
 
-    <Error Condition="'@(LibrariesRefAssemblies)' == ''" Text="The libraries subset category must be built before building this project." />
-    <Error Condition="'@(LibrariesRuntimeFiles)' == ''" Text="The libraries subset category must be built before building this project." />
+    <Error Condition="'@(LibrariesRefAssemblies)' == ''" Text="The 'libs' subset must be built before building this project." />
+    <Error Condition="'@(LibrariesRuntimeFiles)' == ''" Text="The 'libs' subset must be built before building this project." />
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
So as far as I can tell, we've removed subset categories. We've also renamed `libraries` to `libs`:

E.g. running `dotnet build` in `src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray` when I've only run `./build -subset clr` has the following error
```
hugh@Hughs-MacBook-Air BoolArray % dotnet build
Microsoft (R) Build Engine version 16.6.0-preview-20173-01+2d82e1a86 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
/Users/hugh/Documents/GitHub/runtime/eng/liveBuilds.targets(146,5): error : The libraries subset category must be built before building this project. Missing artifacts: /Users/hugh/Documents/GitHub/runtime/artifacts/bin/ref/microsoft.netcore.app/Release/ [/Users/hugh/Documents/GitHub/runtime/src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj]

Build FAILED.

/Users/hugh/Documents/GitHub/runtime/eng/liveBuilds.targets(146,5): error : The libraries subset category must be built before building this project. Missing artifacts: /Users/hugh/Documents/GitHub/runtime/artifacts/bin/ref/microsoft.netcore.app/Release/ [/Users/hugh/Documents/GitHub/runtime/src/coreclr/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.csproj]
    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:01.73
```

This should refer to `libs` and `subset` instead of `subset category`