### PR TITLE
Add error handling in build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -108,24 +108,45 @@ while [[ $# > 0 ]]; do
       exit 0
       ;;
      -subset|-s)
-      arguments="$arguments /p:Subset=$2"
-      shift 2
+      if [ -z ${2+x} ]; then 
+        arguments="$arguments /p:Subset=help"
+        shift 1
+      else 
+        arguments="$arguments /p:Subset=$2"
+        shift 2
+      fi
       ;;
      -arch)
+      if [ -z ${2+x} ]; then 
+        echo "No architecture supplied. See help (--help) for supported architectures." 1>&2
+        exit 1
+      fi
       arch=$2
       shift 2
       ;;
      -configuration|-c)
+     if [ -z ${2+x} ]; then 
+        echo "No configuration supplied. See help (--help) for supported configurations." 1>&2
+        exit 1
+      fi
       val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
       arguments="$arguments -configuration $val"
       shift 2
       ;;
      -framework|-f)
+      if [ -z ${2+x} ]; then 
+        echo "No framework supplied. See help (--help) for supported frameworks." 1>&2
+        exit 1
+      fi
       val="$(echo "$2" | awk '{print tolower($0)}')"
       arguments="$arguments /p:BuildTargetFramework=$val"
       shift 2
       ;;
      -os)
+      if [ -z ${2+x} ]; then 
+        echo "No target operating system supplied. See help (--help) for supported target operating systems." 1>&2
+        exit 1
+      fi
       os=$2
       arguments="$arguments /p:TargetOS=$2"
       shift 2
@@ -135,23 +156,35 @@ while [[ $# > 0 ]]; do
       shift 1
       ;;
      -testscope)
+      if [ -z ${2+x} ]; then 
+        echo "No test scope supplied. See help (--help) for supported test scope values." 1>&2
+        exit 1
+      fi
       arguments="$arguments /p:TestScope=$2"
       shift 2
       ;;
      -testnobuild)
-      arguments="$arguments /p:TestNoBuild=$2"
-      shift 2
+      arguments="$arguments /p:TestNoBuild=true"
+      shift 1
       ;;
      -coverage)
       arguments="$arguments /p:Coverage=true"
       shift 1
       ;;
      -runtimeconfiguration|-rc)
+      if [ -z ${2+x} ]; then 
+        echo "No runtime configuration supplied. See help (--help) for supported runtime configurations." 1>&2
+        exit 1
+      fi
       val="$(tr '[:lower:]' '[:upper:]' <<< ${2:0:1})${2:1}"
       arguments="$arguments /p:RuntimeConfiguration=$val"
       shift 2
       ;;
      -librariesconfiguration|-lc)
+      if [ -z ${2+x} ]; then 
+        echo "No libraries configuration supplied. See help (--help) for supported libraries configurations." 1>&2
+        exit 1
+      fi
       arguments="$arguments /p:LibrariesConfiguration=$2"
       shift 2
       ;;
@@ -165,6 +198,10 @@ while [[ $# > 0 ]]; do
       shift 1
       ;;
      -cmakeargs)
+      if [ -z ${2+x} ]; then 
+        echo "No cmake args supplied." 1>&2
+        exit 1
+      fi
       cmakeargs="${cmakeargs} ${opt} $2"
       shift 2
       ;;


### PR DESCRIPTION
Also pass help subset if it isn't set to invoke the help message and fix `TestNoBuild` argument.

Following the StackOverflow recommendation for how to check for an unset variable: https://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash.

Fixes https://github.com/dotnet/runtime/issues/35769

cc @hughbe