### PR TITLE
Add soft debugger support to s390x

### DIFF
--- a/src/mono/mono/arch/s390x/s390x-codegen.h
+++ b/src/mono/mono/arch/s390x/s390x-codegen.h
@@ -1384,6 +1384,7 @@ typedef struct {
 #define s390_lm(c, r1, r2, b, d)	S390_RS_1(c, 0x98, r1, r2, b, d)
 #define s390_lmg(c, r1, r2, b, d)	S390_RSY_1(c, 0xeb04, r1, r2, b, d)
 #define s390_lndbr(c, r1, r2)		S390_RRE(c, 0xb311, r1, r2)
+#define s390_lnebr(c, r1, r2)		S390_RRE(c, 0xb301, r1, r2)
 #define s390_lngr(c, r1, r2)		S390_RRE(c, 0xb901, r1, r2)
 #define s390_lnr(c, r1, r2)		S390_RR(c, 0x11, r1, r2)
 #define s390_lpdbr(c, r1, r2)		S390_RRE(c, 0xb310, r1, r2)

--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -87,40 +87,52 @@ get_pe_debug_info (MonoImage *image, guint8 *out_guid, gint32 *out_age, gint32 *
 				   int *ppdb_uncompressed_size, int *ppdb_compressed_size)
 {
 	MonoPEDirEntry *debug_dir_entry;
-	ImageDebugDirectory *debug_dir;
+	ImageDebugDirectory debug_dir;
 	int idx;
 	gboolean guid_found = FALSE;
+	guint8 *data;
 
 	*ppdb_data = NULL;
 
-	debug_dir_entry = &image->image_info->cli_header.datadir.pe_debug;
+	debug_dir_entry = (MonoPEDirEntry *) &image->image_info->cli_header.datadir.pe_debug;
 	if (!debug_dir_entry->size)
 		return FALSE;
 
 	int offset = mono_cli_rva_image_map (image, debug_dir_entry->rva);
 	for (idx = 0; idx < debug_dir_entry->size / sizeof (ImageDebugDirectory); ++idx) {
-		debug_dir = (ImageDebugDirectory*)(image->raw_data + offset) + idx;
-		if (debug_dir->type == DEBUG_DIR_ENTRY_CODEVIEW && debug_dir->major_version == 0x100 && debug_dir->minor_version == 0x504d) {
+		data = (guint8 *) ((ImageDebugDirectory *) (image->raw_data + offset) + idx);
+		debug_dir.characteristics = read32(data);
+		debug_dir.time_date_stamp = read32(data + 4);
+		debug_dir.major_version   = read16(data + 8);
+		debug_dir.minor_version   = read16(data + 10);
+		debug_dir.type            = read32(data + 12);
+		debug_dir.size_of_data    = read32(data + 16);
+		debug_dir.address         = read32(data + 20);
+		debug_dir.pointer         = read32(data + 24);
+		
+		if (debug_dir.type == DEBUG_DIR_ENTRY_CODEVIEW && debug_dir.major_version == 0x100 && debug_dir.minor_version == 0x504d) {
 			/* This is a 'CODEVIEW' debug directory */
-			CodeviewDebugDirectory *dir = (CodeviewDebugDirectory*)(image->raw_data + debug_dir->pointer);
+			CodeviewDebugDirectory dir;
+			data  = (guint8 *) (image->raw_data + debug_dir.pointer);
+			dir.signature = read32(data);
 
-			if (dir->signature == 0x53445352) {
-				memcpy (out_guid, dir->guid, 16);
-				*out_age = dir->age;
-				*out_timestamp = debug_dir->time_date_stamp;
+			if (dir.signature == 0x53445352) {
+				memcpy (out_guid, data + 4, 16);
+				*out_age = read32(data + 20);
+				*out_timestamp = debug_dir.time_date_stamp;
 				guid_found = TRUE;
 			}
 		}
-		if (debug_dir->type == DEBUG_DIR_ENTRY_PPDB && debug_dir->major_version >= 0x100 && debug_dir->minor_version == 0x100) {
+		if (debug_dir.type == DEBUG_DIR_ENTRY_PPDB && debug_dir.major_version >= 0x100 && debug_dir.minor_version == 0x100) {
 			/* Embedded PPDB blob */
 			/* See src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.EmbeddedPortablePdb.cs in corefx */
-			guint8 *data = (guint8*)(image->raw_data + debug_dir->pointer);
+			data = (guint8*)(image->raw_data + debug_dir.pointer);
 			guint32 magic = read32 (data);
 			g_assert (magic == EMBEDDED_PPDB_MAGIC);
 			guint32 size = read32 (data + 4);
 			*ppdb_data = data + 8;
 			*ppdb_uncompressed_size = size;
-			*ppdb_compressed_size = debug_dir->size_of_data - 8;
+			*ppdb_compressed_size = debug_dir.size_of_data - 8;
 		}
 	}
 	return guid_found;
@@ -156,7 +168,7 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 	MonoImageOpenStatus status;
 	guint8 pe_guid [16];
 	gint32 pe_age;
-	gint32 pe_timestamp;
+	gint32 pe_timestamp, pdb_timestamp;
 	guint8 *ppdb_data = NULL;
 	guint8 *to_free = NULL;
 	int ppdb_size = 0, ppdb_compressed_size = 0;
@@ -230,7 +242,8 @@ mono_ppdb_load_file (MonoImage *image, const guint8 *raw_contents, int size)
 	g_assert (pdb_stream);
 
 	/* The pdb id is a concentation of the pe guid and the timestamp */
-	if (memcmp (pe_guid, pdb_stream->guid, 16) != 0 || memcmp (&pe_timestamp, pdb_stream->guid + 16, 4) != 0) {
+	pdb_timestamp = read32(pdb_stream->guid + 16);
+	if (memcmp (pe_guid, pdb_stream->guid, 16) != 0 || pe_timestamp != pdb_timestamp) {
 		g_warning ("Symbol file %s doesn't match image %s", ppdb_image->name,
 				   image->name);
 		mono_image_close (ppdb_image);

--- a/src/mono/mono/mini/cpu-s390x.md
+++ b/src/mono/mono/mini/cpu-s390x.md
@@ -211,7 +211,7 @@ s390_move: len:48 src2:b src1:b
 s390_setf4ret: dest:f src1:f len:4
 sbb: dest:i src1:i src2:i len:6
 sbb_imm: dest:i src1:i len:14
-seq_point: len:54
+seq_point: len:64
 il_seq_point: len:0
 sext_i4: dest:i src1:i len:4
 zext_i4: dest:i src1:i len:4

--- a/src/mono/mono/mini/mini-s390x.h
+++ b/src/mono/mono/mini/mini-s390x.h
@@ -29,10 +29,15 @@ struct MonoLMF {
 	gdouble     fregs[16];
 };
 
+/**
+ * Platform-specific compile control information
+ */
 typedef struct MonoCompileArch {
-	int         bkchain_reg;
-	uint32_t    used_fp_regs;
-	int	    fpSize;
+	int         bkchain_reg;	/** Register being used as stack backchain */
+	uint32_t    used_fp_regs;	/** Floating point register use mask */
+	int	    fpSize;		/** Size of floating point save area */
+	MonoInst    *ss_tramp_var;	/** Single-step variable */
+	MonoInst    *bp_tramp_var;	/** Breakpoint variable */
 } MonoCompileArch;
 
 typedef struct
@@ -42,6 +47,12 @@ typedef struct
 	void *regs[8];
 	void *return_address;
 } MonoS390StackFrame;
+
+/* Structure used by the sequence points */
+struct SeqPointInfo {
+	gpointer ss_tramp_addr;
+	gpointer bp_addrs [MONO_ZERO_LEN_ARRAY];
+};
 
 #define MONO_ARCH_SIGSEGV_ON_ALTSTACK			1
 #define MONO_ARCH_EMULATE_LCONV_TO_R8_UN 		1
@@ -67,6 +78,8 @@ typedef struct
 #define MONO_ARCH_HAVE_OPTIMIZED_DIV			1
 #define MONO_ARCH_HAVE_OP_TAILCALL_MEMBASE		1
 #define MONO_ARCH_HAVE_OP_TAILCALL_REG			1
+#define MONO_ARCH_HAVE_SDB_TRAMPOLINES			1
+#define MONO_ARCH_HAVE_SETUP_RESUME_FROM_SIGNAL_HANDLER_CTX	1
 
 #define S390_STACK_ALIGNMENT		 8
 #define S390_FIRST_ARG_REG 		s390_r2

--- a/src/mono/mono/mini/unwind.c
+++ b/src/mono/mono/mini/unwind.c
@@ -310,6 +310,7 @@ mono_print_unwind_info (guint8 *unwind_info, int unwind_info_len)
 		switch (op) {
 		case DW_CFA_advance_loc:
 			pos += *p & 0x3f;
+			printf ("CFA: [%x] advance loc\n",pos);
 			p ++;
 			break;
 		case DW_CFA_offset:
@@ -419,14 +420,14 @@ mono_unwind_ops_encode_full (GSList *unwind_ops, guint32 *out_len, gboolean enab
 				*p ++ = DW_CFA_advance_loc4;
 				guint32 v = (guint32)(op->when - loc);
 				memcpy (p, &v, 4);
-				g_assert (read32 (p) == (guint32)(op->when - loc));
+				g_assert (read32 (p) == GUINT32_TO_LE((guint32)(op->when - loc)));
 				p += 4;
 				loc = op->when;
 			} else if (op->when - loc >= 256) {
 				*p ++ = DW_CFA_advance_loc2;
 				guint16 v = (guint16)(op->when - loc);
 				memcpy (p, &v, 2);
-				g_assert (read16 (p) == (guint32)(op->when - loc));
+				g_assert (read16 (p) == GUINT16_TO_LE((guint32)(op->when - loc)));
 				p += 2;
 				loc = op->when;
 			} else if (op->when - loc >= 32) {

--- a/src/mono/mono/utils/mono-hwcap-s390x.c
+++ b/src/mono/mono/utils/mono-hwcap-s390x.c
@@ -164,4 +164,5 @@ mono_hwcap_arch_init (void)
 	mono_hwcap_s390x_has_mie3 = facs.mie3;
 	mono_hwcap_s390x_has_gs   = facs.gs;
 	mono_hwcap_s390x_has_vef2 = facs.vef2;
+	mono_hwcap_s390x_has_eif  = facs.eif;
 }

--- a/src/mono/mono/utils/mono-hwcap-vars.h
+++ b/src/mono/mono/utils/mono-hwcap-vars.h
@@ -59,6 +59,7 @@ MONO_HWCAP_VAR(s390x_has_mie2)
 MONO_HWCAP_VAR(s390x_has_mie3)
 MONO_HWCAP_VAR(s390x_has_gs)
 MONO_HWCAP_VAR(s390x_has_vef2)
+MONO_HWCAP_VAR(s390x_has_eif)
 
 #elif defined (TARGET_SPARC) || defined (TARGET_SPARC64)
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19697,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>* Add soft debugger support to s390x
  - Implement the sdb trampoline
  - Big-endian fixes for ppdb debugger:
    - Fix utf16 strings
    - Fix decoding of ImageDebugDirectory structures
  - New implementation of OP_SEQ_POINT
  - Enable successful unwind by defining markpoints
  - Implement mono_arch_setup_resume_sighandler_ctx
  - Implement unwind ops in epilog

* Fix delegate-invoke processing
  - Handle up to 10 parameters
  - Use sigparam information to correctly "slide" parameters

* Fix floating point negative zero for s390x
  - Add a new instruction for use in OP_RxCONST -0
  - Check for -0 in constant

* Minor indentation fixes

* Fix atomic add implementation

* Check for additional hardware facilities



<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
