### PR TITLE
[mono] Enable XHarness CLI for Android tests

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20230.6",
+      "version": "1.0.0-prerelease.20254.3",
       "commands": [
         "xharness"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,7 +9,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20230.1",
+      "version": "1.0.0-prerelease.20230.6",
       "commands": [
         "xharness"
       ]

--- a/eng/testing/AndroidRunnerTemplate.sh
+++ b/eng/testing/AndroidRunnerTemplate.sh
@@ -18,8 +18,6 @@ while true; do
     fi
 done
 
-
-## XHarness doesn't support macOS/Linux yet (in progress) so we'll use a hand-made adb script
- dotnet xharness android test -i="net.dot.MonoRunner" \
+dotnet xharness android test -i="net.dot.MonoRunner" \
     --package-name="net.dot.$TEST_NAME" \
     --app=$APK -o=$EXECUTION_DIR/Bundle/TestResults -v

--- a/eng/testing/AndroidRunnerTemplate.sh
+++ b/eng/testing/AndroidRunnerTemplate.sh
@@ -20,14 +20,6 @@ done
 
 
 ## XHarness doesn't support macOS/Linux yet (in progress) so we'll use a hand-made adb script
-# dotnet xharness android test -i="net.dot.MonoRunner" \
-# --package-name="net.dot.$TEST_NAME" \
-# --app=$APK -o=$EXECUTION_DIR/Bundle/TestResults -v
-
-ADB=$ANDROID_SDK_ROOT/platform-tools/adb
-echo "Installing net.dot.$TEST_NAME on an active device/emulator..."
-$ADB uninstall net.dot.$TEST_NAME > /dev/null 2>&1 || true
-$ADB install "$APK"
-echo "Running tests for $TEST_NAME (see live logs via logcat)..."
-$ADB shell am instrument -w net.dot.$TEST_NAME/net.dot.MonoRunner
-echo "Finished. See logcat for details, e.g. '$ADB logcat DOTNET:V -s'"
+ dotnet xharness android test -i="net.dot.MonoRunner" \
+    --package-name="net.dot.$TEST_NAME" \
+    --app=$APK -o=$EXECUTION_DIR/Bundle/TestResults -v

--- a/src/mono/msbuild/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/mono/msbuild/AndroidAppBuilder/ApkBuilder.cs
@@ -84,11 +84,17 @@ public class ApkBuilder
         // Copy AppDir to OutputDir/assets (ignore native files)
         Utils.DirectoryCopy(sourceDir, Path.Combine(OutputDir, "assets"), file =>
         {
-            var extension = Path.GetExtension(file);
+            string fileName = Path.GetFileName(file);
+            string extension = Path.GetExtension(file);
             // ignore native files, those go to lib/%abi%
             if (extension == ".so" || extension == ".a")
             {
                 // ignore ".pdb" and ".dbg" to make APK smaller
+                return false;
+            }
+            if (fileName.StartsWith("."))
+            {
+                // aapt complains on such files
                 return false;
             }
             return true;


### PR DESCRIPTION
Xharness now bundles adb for *.nix so I can remove my hand-made adb script to run the tests.