### PR TITLE
Mark eventsourceerror test as unloadability incompatible

### DIFF
--- a/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -4,6 +4,7 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This test was recently added and it has the same problem with
unloadability as the other tests marked as incompatible with
unloadability in https://github.com/dotnet/coreclr/pull/25954.