### PR TITLE
Fix the initial segment size computation

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -9742,7 +9742,7 @@ size_t gc_heap::get_segment_size_hard_limit (uint32_t* num_heaps, bool should_ad
         }
     }
 
-    size_t seg_size = aligned_hard_limit / *num_heaps;
+    size_t seg_size = aligned_hard_limit / *num_heaps / 3;
     size_t aligned_seg_size = (use_large_pages_p ? align_on_segment_hard_limit (seg_size) : round_up_power2 (seg_size));
 
     assert (g_theGCHeap->IsValidSegmentSize (aligned_seg_size));


### PR DESCRIPTION
I think I have found a bug when I am trying to enable large page on the `low_memory_container` perf test case.

The test case limited the physical memory to 600 MB, the logic in `GCHeap::Initialize()` let the heap_hard_limit to 75% of the total physical memory or at 20MB. So it turns into 450 MB in our case.

Later on, the `get_segment_size_hard_limit()` computes the segment size using the hard limit value. Ignoring alignment, it is roughly dividing the memory by the number of heaps. In my case, the test cases configured to have 6 heaps, so we have around 75 MB for the `segsize`.

Later on, the `segsize` is also used as the large object heap size, and also the pinned object heap size, so overall, we are requesting for 6 heaps x (segsize + largesegsize + pinsegsize) = 6 x 3 x 75 = 1350MB, that fails because we only have 600 MB.

It looks like `get_segment_size_hard_limit()` should further divide by 3 to account for the heap size is used 3 times later, am I correct?