### PR TITLE
S.S.C.Algorithms: Fix duplicate theories warning

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/BlockSizeValueTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/BlockSizeValueTests.cs
@@ -9,23 +9,44 @@ namespace System.Security.Cryptography.Hashing.Algorithms.Tests
 {
     public class BlockSizeValueTests
     {
-        public static IEnumerable<object[]> GetBlockSizeValue()
+        [Fact]
+        public static void BlockSizeValueTest_HMACMD5()
         {
-            return new[]
-            {
-                new object[] { new HMACMD5Test().GetBlockSizeValue(),    64  },
-                new object[] { new HMACSHA1Test().GetBlockSizeValue(),   64  },
-                new object[] { new HMACSHA256Test().GetBlockSizeValue(), 64  },
-                new object[] { new HMACSHA384Test().GetBlockSizeValue(), 128 },
-                new object[] { new HMACSHA512Test().GetBlockSizeValue(), 128 },
-            };
+            int hmacBlockSizeValue = new HMACMD5Test().GetBlockSizeValue();
+            const int ExpectedBlockSize = 64;
+            Assert.Equal(ExpectedBlockSize, hmacBlockSizeValue);
         }
 
-        [Theory]
-        [MemberData(nameof(GetBlockSizeValue))]
-        public static void BlockSizeValueTest(int hmacBlockSizeValue, int expectedBlockSizeValue)
+        [Fact]
+        public static void BlockSizeValueTest_HMACSHA1()
         {
-            Assert.Equal(expectedBlockSizeValue, hmacBlockSizeValue);
+            int hmacBlockSizeValue = new HMACSHA1Test().GetBlockSizeValue();
+            const int ExpectedBlockSize = 64;
+            Assert.Equal(ExpectedBlockSize, hmacBlockSizeValue);
+        }
+
+        [Fact]
+        public static void BlockSizeValueTest_HMACSHA256()
+        {
+            int hmacBlockSizeValue = new HMACSHA256Test().GetBlockSizeValue();
+            const int ExpectedBlockSize = 64;
+            Assert.Equal(ExpectedBlockSize, hmacBlockSizeValue);
+        }
+
+        [Fact]
+        public static void BlockSizeValueTest_HMACSHA384()
+        {
+            int hmacBlockSizeValue = new HMACSHA384Test().GetBlockSizeValue();
+            const int ExpectedBlockSize = 128;
+            Assert.Equal(ExpectedBlockSize, hmacBlockSizeValue);
+        }
+
+        [Fact]
+        public static void BlockSizeValueTest_HMACSHA512()
+        {
+            int hmacBlockSizeValue = new HMACSHA512Test().GetBlockSizeValue();
+            const int ExpectedBlockSize = 128;
+            Assert.Equal(ExpectedBlockSize, hmacBlockSizeValue);
         }
     }
 


### PR DESCRIPTION
xunit warning:

> Skipping test case with duplicate ID '658dd5afec16f3397ac5ef6b298eb8b71ae5a86f' ('System.Security.Cryptography.Hashing.Algorithms.Tests.BlockSizeValueTests.BlockSizeValueTest(hmacBlockSizeValue: 64, expectedBlockSizeValue: 64)' and 'System.Security.Cryptography.Hashing.Algorithms.Tests.BlockSizeValueTests.BlockSizeValueTest(hmacBlockSizeValue: 64, expectedBlockSizeValue: 64)')

Since different HMAC algorithms have the same block size, the test cases was being folded down in to `[64, 64], [128, 128]`.

Simplest change is to just break them in to individual facts. I don't anticipate new algorithms would be added frequently here.

This seems like a genuinely useful warning from xunit, so I don't expect we'd want to get in the habit of ignoring these.