### PR TITLE
Use already defined generateAssemblyReferenceSource rather defining a new target

### DIFF
--- a/docs/coding-guidelines/updating-ref-source.md
+++ b/docs/coding-guidelines/updating-ref-source.md
@@ -3,15 +3,15 @@ This document provides the steps you need to take to update the reference assemb
 ## For most assemblies within libraries
 
 1. Implement the API in the source assembly and [build it](../workflow/building/libraries/README.md#building-individual-libraries).
-2. Run the following command (from the src directory) `msbuild /t:GenerateReferenceSource` to update the reference assembly**.
+2. Run the following command (from the src directory) `msbuild /t:GenerateReferenceAssemblySource` to update the reference assembly**.
 3. Navigate to the ref directory and build the reference assembly.
 4. Add, build, and run tests.
 
-** **Note:** If you already added the new API to the reference source, re-generating it (after building the source assembly) will update it to be fully qualified  and placed in the correct order. This can be done by running the `GenerateReferenceSource` command from the ref directory.
+** **Note:** If you already added the new API to the reference source, re-generating it (after building the source assembly) will update it to be fully qualified  and placed in the correct order. This can be done by running the `GenerateReferenceAssemblySource` command from the ref directory.
 
 ## For System.Runtime
 
 These steps can also be applied to some unique assemblies which depend on changes in System.Private.Corelib. (partial facades like System.Memory, for example).
 
-1) Run `dotnet build -c Release /t:GenerateReferenceSource` from the System.Runtime/ref directory.
+1) Run `dotnet build -c Release /t:GenerateReferenceAssemblySource` from the System.Runtime/ref directory.
 2) Filter out all unrelated changes and extract the changes you care about (ignore certain attributes being removed). Generally, this step is not required for other reference assemblies.

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -18,9 +18,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>8547938aefa24475a04877285553f0b2663ae249</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20256.5">
+    <Dependency Name="Microsoft.DotNet.GenAPI" Version="5.0.0-beta.20258.8">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>8547938aefa24475a04877285553f0b2663ae249</Sha>
+      <Sha>8078d8f3f77b7e8b7f6e289cf82cfdfa9c7a9355</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.GenFacades" Version="5.0.0-beta.20256.5">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -60,7 +60,7 @@
     <MicrosoftDotNetApiCompatVersion>5.0.0-beta.20256.5</MicrosoftDotNetApiCompatVersion>
     <MicrosoftDotNetBuildTasksFeedVersion>5.0.0-beta.20256.5</MicrosoftDotNetBuildTasksFeedVersion>
     <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20256.5</MicrosoftDotNetCodeAnalysisVersion>
-    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20256.5</MicrosoftDotNetGenAPIVersion>
+    <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20258.8</MicrosoftDotNetGenAPIVersion>
     <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20256.5</MicrosoftDotNetGenFacadesVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20256.5</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20256.5</MicrosoftDotNetXUnitConsoleRunnerVersion>

--- a/eng/outerBuild.targets
+++ b/eng/outerBuild.targets
@@ -1,7 +1,7 @@
-<Project>
-  <Target Name="GenerateReferenceSource" DependsOnTargets="GetProjectWithBestTargetFrameworks">
+<Project>  
+  <Target Name="GenerateReferenceAssemblySource" DependsOnTargets="GetProjectWithBestTargetFrameworks">
     <MSBuild Projects="@(InnerBuildProjectsWithBestTargetFramework)"
-             Targets="GenerateReferenceSource"
+             Targets="GenerateReferenceAssemblySource"
              BuildInParallel="$(BuildInParallel)">
     </MSBuild>
   </Target>

--- a/eng/outerBuild.targets
+++ b/eng/outerBuild.targets
@@ -1,4 +1,4 @@
-<Project>  
+<Project>
   <Target Name="GenerateReferenceAssemblySource" DependsOnTargets="GetProjectWithBestTargetFrameworks">
     <MSBuild Projects="@(InnerBuildProjectsWithBestTargetFramework)"
              Targets="GenerateReferenceAssemblySource"

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -111,6 +111,15 @@
     <Error Condition="'@(_missingReferenceFromRuntime)' != ''"
            Text="Could not resolve ReferenceFromRuntime item(s) '%(_missingReferenceFromRuntime.OriginalReferenceFromRuntime)' from '$(RuntimeProjectFile)'." />
   </Target>
+
+  <Target Name="SetGenApiProperties"
+          BeforeTargets="GenerateReferenceAssemblySource"
+          Condition="'@(ReferenceFromRuntime)' != ''">
+    <PropertyGroup>
+      <GenAPILibPath>$(RuntimePath.Trim('\/'));$(CoreCLRArtifactsPath.Trim('\/'))</GenAPILibPath>
+      <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
+    </PropertyGroup>
+  </Target>
   
   <Target Name="RemoveAliasedReferenceFromRuntime"
           AfterTargets="CoreCompile"

--- a/eng/referenceFromRuntime.targets
+++ b/eng/referenceFromRuntime.targets
@@ -112,15 +112,6 @@
            Text="Could not resolve ReferenceFromRuntime item(s) '%(_missingReferenceFromRuntime.OriginalReferenceFromRuntime)' from '$(RuntimeProjectFile)'." />
   </Target>
 
-  <Target Name="SetGenApiProperties"
-          BeforeTargets="GenerateReferenceAssemblySource"
-          Condition="'@(ReferenceFromRuntime)' != ''">
-    <PropertyGroup>
-      <GenAPILibPath>$(RuntimePath.Trim('\/'));$(CoreCLRArtifactsPath.Trim('\/'))</GenAPILibPath>
-      <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
-    </PropertyGroup>
-  </Target>
-  
   <Target Name="RemoveAliasedReferenceFromRuntime"
           AfterTargets="CoreCompile"
           Condition="'@(_aliasedReferencePathFromRuntime)' != ''">

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -155,22 +155,15 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_RefSourceFileOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</_RefSourceFileOutputPath>     
     <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
     <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
     <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath> 
     <GenAPILibPath>$(RefPath.Trim('\/'))</GenAPILibPath>
-    <GenAPITargetPath>$(_RefSourceFileOutputPath)</GenAPITargetPath>
+    <GenAPITargetPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</GenAPITargetPath>
     <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --exclude-attributes-list "$(_ExcludeAttributesList)"</GenAPIAdditionalParameters>
     <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
     <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
     <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters> 
-    <ReferenceFromRuntimeCount>@(ReferenceFromRuntime->Count())</ReferenceFromRuntimeCount>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(ReferenceFromRuntimeCount)' != '0'">
-    <GenAPILibPath>$(RuntimePath.Trim('\/'));$(CoreCLRArtifactsPath.Trim('\/'))</GenAPILibPath>
-    <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -165,6 +165,12 @@
     <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
     <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
     <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters> 
+    <ReferenceFromRuntimeCount>@(ReferenceFromRuntime->Count())</ReferenceFromRuntimeCount>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(ReferenceFromRuntimeCount)' != '0'">
+    <GenAPILibPath>$(RuntimePath.Trim('\/'));$(CoreCLRArtifactsPath.Trim('\/'))</GenAPILibPath>
+    <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -154,17 +154,20 @@
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
-    <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
-    <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath> 
-    <GenAPILibPath>$(RefPath.Trim('\/'))</GenAPILibPath>
-    <GenAPITargetPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</GenAPITargetPath>
-    <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --exclude-attributes-list "$(_ExcludeAttributesList)"</GenAPIAdditionalParameters>
-    <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
-    <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
-    <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters> 
-  </PropertyGroup>
+  <Target Name="SetGenApiProperties"
+          BeforeTargets="GenerateReferenceAssemblySource">
+    <PropertyGroup>
+      <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
+      <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
+      <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath> 
+      <GenAPITargetPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</GenAPITargetPath>
+      <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --exclude-attributes-list "$(_ExcludeAttributesList)"</GenAPIAdditionalParameters>
+      <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
+      <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
+      <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters>  
+      <GenAPIAdditionalParameters Condition="'@(ReferenceFromRuntime)' != ''">$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
+    </PropertyGroup>
+  </Target>
 
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -154,28 +154,18 @@
     <PackageReference Include="Microsoft.DotNet.GenFacades" Version="$(MicrosoftDotNetGenFacadesVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 
-  <Target Name="GenerateReferenceSource">
-    <PropertyGroup>
-      <_RefSourceFileOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</_RefSourceFileOutputPath>
-      <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
-      <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
-      <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath>
-    </PropertyGroup>
-
-    <PropertyGroup>
-      <_GenAPICmd>$(_GenAPICommand)</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) "@(IntermediateAssembly)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --lib-path "$(RefPath.Trim('\/'))"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --out "$(_RefSourceFileOutputPath)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --exclude-attributes-list "$(_ExcludeAttributesList)"</_GenAPICmd>
-      <_GenAPICmd Condition="Exists('$(_ExcludeAPIList)')">$(_GenAPICmd) --exclude-api-list "$(_ExcludeAPIList)"</_GenAPICmd>
-      <_GenAPICmd>$(_GenAPICmd) --header-file "$(_LicenseHeaderTxtPath)"</_GenAPICmd>
-      <_GenAPICmd Condition="'$(LangVersion)' != ''">$(_GenAPICmd) --lang-version "$(LangVersion)"</_GenAPICmd>
-    </PropertyGroup>
-
-    <Exec Command="$(_GenAPICmd)" />
-    <Message Text="Generated reference assembly source code: $(_RefSourceFileOutputPath)" />
-  </Target>
+  <PropertyGroup>
+    <_RefSourceFileOutputPath>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', '$(AssemblyName).cs'))</_RefSourceFileOutputPath>     
+    <_ExcludeAPIList>$([MSBuild]::NormalizePath('$(MSBuildProjectDirectory)', '..', 'ref', 'ReferenceSourceExcludeApi.txt'))</_ExcludeAPIList>
+    <_ExcludeAttributesList>$(RepositoryEngineeringDir)DefaultGenApiDocIds.txt</_ExcludeAttributesList>
+    <_LicenseHeaderTxtPath>$(RepositoryEngineeringDir)LicenseHeader.txt</_LicenseHeaderTxtPath> 
+    <GenAPILibPath>$(RefPath.Trim('\/'))</GenAPILibPath>
+    <GenAPITargetPath>$(_RefSourceFileOutputPath)</GenAPITargetPath>
+    <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --exclude-attributes-list "$(_ExcludeAttributesList)"</GenAPIAdditionalParameters>
+    <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
+    <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
+    <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters> 
+  </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -169,6 +169,10 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="GenerateReferenceSource" DependsOnTargets="GenerateReferenceAssemblySource">
+    <Message Text="This is a deprecated target. It will be removed in next infra rollout changes." Importance="high" />
+  </Target>
+
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />
 
   <!-- Import Packaging targets -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -170,7 +170,7 @@
   </Target>
 
   <Target Name="GenerateReferenceSource" DependsOnTargets="GenerateReferenceAssemblySource">
-    <Message Text="This is a deprecated target. It will be removed in next infra rollout changes." Importance="high" />
+    <Message Text="This is a deprecated target. It will be replaced by GenerateReferenceAssemblySource in next infra rollout changes." Importance="high" />
   </Target>
 
   <Import Project="$(RepositoryEngineeringDir)outerBuild.targets" Condition="'$(IsCrossTargetingBuild)' == 'true'" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/948
Fixes https://github.com/dotnet/runtime/issues/34604