### PR TITLE
Fix a couple of Windows createdump issues

### DIFF
--- a/src/coreclr/src/debug/createdump/createdumpwindows.cpp
+++ b/src/coreclr/src/debug/createdump/createdumpwindows.cpp
@@ -41,9 +41,9 @@ CreateDump(const char* dumpPath, int pid, MINIDUMP_TYPE minidumpType)
         else
         {
             int err = GetLastError();
-            if (err != ERROR_PARTIAL_COPY)
+            if (err != HRESULT_FROM_WIN32(ERROR_PARTIAL_COPY))
             {
-                fprintf(stderr, "Write dump FAILED %d\n", err);
+                fprintf(stderr, "Write dump FAILED 0x%08x\n", err);
                 break;
             }
         }

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -644,6 +644,11 @@ void EEStartupHelper()
         IfFailGo(EEConfig::Setup());
 
 #ifndef CROSSGEN_COMPILE
+
+#ifdef HOST_WINDOWS
+        InitializeCrashDump();
+#endif // HOST_WINDOWS
+
         // Initialize Numa and CPU group information
         // Need to do this as early as possible. Used by creating object handle
         // table inside Ref_Initialization() before GC is initialized.

--- a/src/coreclr/src/vm/exceptionhandling.cpp
+++ b/src/coreclr/src/vm/exceptionhandling.cpp
@@ -241,9 +241,6 @@ void InitializeExceptionHandling()
     // Register handler for termination requests (e.g. SIGTERM)
     PAL_SetTerminationRequestHandler(HandleTerminationRequest);
 #endif // TARGET_UNIX
-#ifdef HOST_WINDOWS
-    InitializeCrashDump();
-#endif // HOST_WINDOWS
 }
 
 struct UpdateObjectRefInResumeContextCallbackState


### PR DESCRIPTION
Fix createdump crash triggering on x86 runtime

The new crash triggering code in excep.cpp was in a #ifndef CROSSGEN_COMPILE
block that isn't defined on the x86 Windows build. Move the code out that
conditional block.

Fix ERROR_PARTIAL_COPY retry. MiniDumpWriteDump sets the last error to the HRESULT instead of win32 error code