### PR TITLE
Move test results into TestResults directory

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -116,7 +116,7 @@
     <MicrosoftNETTestSdkVersion>16.7.0-preview-20200429-01</MicrosoftNETTestSdkVersion>
     <MicrosoftDotNetXHarnessTestsRunnersVersion>1.0.0-prerelease.20254.1</MicrosoftDotNetXHarnessTestsRunnersVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
-    <CoverletCollectorVersion>1.2.0</CoverletCollectorVersion>
+    <CoverletCollectorVersion>1.2.1</CoverletCollectorVersion>
     <TraceEventVersion>2.0.5</TraceEventVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <MoqVersion>4.12.0</MoqVersion>

--- a/eng/testing/.runsettings
+++ b/eng/testing/.runsettings
@@ -4,7 +4,7 @@
     <!-- Timeout in ms, 5 minutes -->
     <TestSessionTimeout>300000</TestSessionTimeout>
     <!-- Directory for test run reports. E.g. trx, coverage etc. -->
-    <ResultsDirectory>.\</ResultsDirectory>
+    <ResultsDirectory>.\TestResults\</ResultsDirectory>
     <!-- Working directory for test invocation. Results directory can be relative to this. Used by IDEs. -->
     <SolutionDirectory>.\</SolutionDirectory>
     <!-- Degree of parallelization, spawns n test hosts to run tests. -->
@@ -25,16 +25,8 @@
   </RunConfiguration>
   <LoggerRunSettings>
     <Loggers>
-      <Logger uri="logger://Microsoft/TestPlatform/TrxLogger/v1">
-        <Configuration>
-          <LogFileName>testResults.trx</LogFileName>
-        </Configuration>
-      </Logger>
-      <Logger uri="logger://Microsoft/TestPlatform/HtmlLogger/v1">
-        <Configuration>
-          <LogFileName>testResults.html</LogFileName>
-        </Configuration>
-      </Logger>
+      <Logger friendlyName="trx" />
+      <Logger friendlyName="html" />
       <Logger friendlyName="console">
         <Configuration>
           <Verbosity>Minimal</Verbosity>
@@ -55,11 +47,7 @@
           <IncludeTestAssembly>false</IncludeTestAssembly>
         </Configuration>
       </DataCollector>
-      <DataCollector friendlyName="blame" enabled="true">
-        <Configuration>
-          <CollectDump CollectAlways="false" DumpType="mini" />
-        </Configuration>
-      </DataCollector>
+      <DataCollector friendlyName="blame" enabled="true" />
     </DataCollectors>
   </DataCollectionRunSettings>
 </RunSettings>

--- a/eng/testing/coverage.targets
+++ b/eng/testing/coverage.targets
@@ -37,14 +37,14 @@
           Condition="'$(Coverage)' == 'true' and '$(SkipCoverageReport)' != 'true'"
           AfterTargets="VSTest">
     <ItemGroup Condition="'$(CoverageReportInputPath)' == ''">
-      <CoverageOutputFile Include="$(OutDir)*\coverage.opencover.xml" />
+      <CoverageOutputFile Include="$(OutDir)TestResults\*\coverage.opencover.xml" />
     </ItemGroup>
 
     <PropertyGroup>
       <CoverageReportInputPath Condition="'$(CoverageReportInputPath)' == ''">%(CoverageOutputFile.Identity)</CoverageReportInputPath>
       <CoverageReportTypes Condition="'$(CoverageReportTypes)' == ''">Html</CoverageReportTypes>
       <CoverageReportVerbosity Condition="'$(CoverageReportVerbosity)' == ''">Info</CoverageReportVerbosity>
-      <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$([MSBuild]::NormalizeDirectory('$(OutDir)', 'report'))</CoverageReportDir>
+      <CoverageReportDir Condition="'$(CoverageReportDir)' == ''">$([MSBuild]::NormalizeDirectory('$(OutDir)', 'TestResults', 'report'))</CoverageReportDir>
       <CoverageReportCommand>"$(DotNetTool)" tool run reportgenerator "-reports:$(CoverageReportInputPath)" "-targetdir:$(CoverageReportDir.TrimEnd('\/'))" "-reporttypes:$(CoverageReportTypes)" "-verbosity:$(CoverageReportVerbosity)"</CoverageReportCommand>
     </PropertyGroup>
 

--- a/eng/testing/runsettings.targets
+++ b/eng/testing/runsettings.targets
@@ -41,4 +41,15 @@
       <RunSettingsFilePath>$(RunSettingsOutputFilePath)</RunSettingsFilePath>
     </PropertyGroup>
   </Target>
+
+  <!--
+    Clean the test results directory to guarantee that a report is generated from the
+    newest coverage results file.
+    Tracking issue https://github.com/microsoft/vstest/issues/2378.
+  -->
+  <Target Name="ClearTestResults"
+          BeforeTargets="VSTest"
+          Condition="'$(Coverage)' == 'true'">
+    <RemoveDir Directories="$(OutDir)TestResults" />
+  </Target>
 </Project>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -5,7 +5,7 @@
     <!-- For tests we want to continue running if a test run failed. -->
     <TestContinueOnError>ErrorAndContinue</TestContinueOnError>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
-    <CoverageReportInputPath>$(ArtifactsBinDir)*.Tests\*\coverage.opencover.xml</CoverageReportInputPath>
+    <CoverageReportInputPath>$(ArtifactsBinDir)*.Tests\TestResults\*\coverage.opencover.xml</CoverageReportInputPath>
     <CoverageReportDir>$(ArtifactsDir)coverage</CoverageReportDir>
     <EnableCoverageSupport>true</EnableCoverageSupport>
   </PropertyGroup>


### PR DESCRIPTION
and avoid unique test results name as VSTest has issues with that.
Disabling capturing blame mode dumps at the moment until we have
cross-plat support for it.
Cleaning the results directory if the code coverage data collector is
used as there's currently not an easy way to distinguish between a new
and an old coverage results file. See tracking issue.

This also updates the coverlet.collectors version from 1.2.0 to 1.2.1 which includes a ton of bug fixes (including different coverage numbers).