### PR TITLE
Disable preEnumerateTheories for running tests

### DIFF
--- a/eng/testing/xunit/xunit.runner.json
+++ b/eng/testing/xunit/xunit.runner.json
@@ -1,5 +1,6 @@
 {
     "diagnosticMessages": true,
     "longRunningTestSeconds": 120,
-    "shadowCopy": false
+    "shadowCopy": false,
+    "preEnumerateTheories": false
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/35807

With `dotnet test` turned on, xunit is now pre-enumerating all theory data.  This is causing two problems:
1. Most of our theories that use MemberData are causing useless warnings to be output to the console when running tests.  For a test suite like PLINQ's, this results in ~170KB of warning text spewed.
2. The pre-enumeration is adding non-trivial time overhead to test execution, e.g. on my machine System.Text.RegularExpressions.Tests are now taking > 15 seconds to execute whereas previously they took ~3 seconds.

The downside of this is the VS test explorer will group all data rows for a theory as a single item, but it's already doing that for many of our theories because they're not IXunitSerializable.  And someone who wants to debug just a single item can comment out the rest.