### PR TITLE
Disable NonDisposedSocket_SafeHandlesCollected test

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -751,6 +751,7 @@ namespace System.Net.Sockets.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/35846", TestPlatforms.Linux)]
         public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)
         {
             List<WeakReference> handles = await CreateHandlesAsync(clientAsync);


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/35846

Disable in effort to get green CI and PR builds.

cc: @wfurt @stephentoub @alnikola