### PR TITLE
Improve deserialization perf for case-insensitive and missing-property cases

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -16,8 +16,8 @@ namespace System.Text.Json
     /// </remarks>
     public readonly struct JsonEncodedText : IEquatable<JsonEncodedText>
     {
-        private readonly byte[] _utf8Value;
-        private readonly string _value;
+        internal readonly byte[] _utf8Value;
+        internal readonly string _value;
 
         /// <summary>
         /// Returns the UTF-8 encoded representation of the pre-encoded JSON text.
@@ -29,6 +29,15 @@ namespace System.Text.Json
             Debug.Assert(utf8Value != null);
 
             _value = JsonReaderHelper.GetTextFromUtf8(utf8Value);
+            _utf8Value = utf8Value;
+        }
+
+        private JsonEncodedText(string stringValue, byte[] utf8Value)
+        {
+            Debug.Assert(stringValue != null);
+            Debug.Assert(utf8Value != null);
+
+            _value = stringValue;
             _utf8Value = utf8Value;
         }
 
@@ -122,6 +131,37 @@ namespace System.Text.Json
             else
             {
                 return new JsonEncodedText(utf8Value.ToArray());
+            }
+        }
+
+        /// <summary>
+        /// Internal version that keeps the existing string and byte[] references if there is no escaping required.
+        /// </summary>
+        internal static JsonEncodedText Encode(string stringValue, byte[] utf8Value, JavaScriptEncoder? encoder = null)
+        {
+            Debug.Assert(stringValue.Equals(JsonHelpers.Utf8GetString(utf8Value)));
+
+            if (utf8Value.Length == 0)
+            {
+                return new JsonEncodedText(stringValue, utf8Value);
+            }
+
+            JsonWriterHelper.ValidateValue(utf8Value);
+            return EncodeHelper(stringValue, utf8Value, encoder);
+        }
+
+        private static JsonEncodedText EncodeHelper(string stringValue, byte[] utf8Value, JavaScriptEncoder? encoder)
+        {
+            int idx = JsonWriterHelper.NeedsEscaping(utf8Value, encoder);
+
+            if (idx != -1)
+            {
+                return new JsonEncodedText(GetEscapedString(utf8Value, idx, encoder));
+            }
+            else
+            {
+                // Encoding is not necessary; use the same stringValue and utf8Value references.
+                return new JsonEncodedText(stringValue, utf8Value);
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -16,8 +16,8 @@ namespace System.Text.Json
     /// </remarks>
     public readonly struct JsonEncodedText : IEquatable<JsonEncodedText>
     {
-        internal readonly byte[] _utf8Value;
-        internal readonly string _value;
+        private readonly byte[] _utf8Value;
+        private readonly string _value;
 
         /// <summary>
         /// Returns the UTF-8 encoded representation of the pre-encoded JSON text.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -14,11 +14,11 @@ namespace System.Text.Json.Serialization.Converters
     {
         protected override bool ReadAndCacheConstructorArgument(ref ReadStack state, ref Utf8JsonReader reader, JsonParameterInfo jsonParameterInfo)
         {
-            bool success = jsonParameterInfo.ReadJson(ref state, ref reader, out object? arg0);
+            bool success = jsonParameterInfo.ReadJson(ref state, ref reader, out object? arg);
 
             if (success)
             {
-                ((object[])state.Current.CtorArgumentState!.Arguments)[jsonParameterInfo.Position] = arg0!;
+                ((object[])state.Current.CtorArgumentState!.Arguments)[jsonParameterInfo.Position] = arg!;
             }
 
             return success;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -454,41 +454,19 @@ namespace System.Text.Json.Serialization.Converters
 
             ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
 
-            if (!state.Current.JsonClassInfo.TryGetParameter(unescapedPropertyName, ref state.Current, out jsonParameterInfo))
-            {
-                return false;
-            }
+            jsonParameterInfo = state.Current.JsonClassInfo.GetParameter(
+                unescapedPropertyName,
+                ref state.Current,
+                out byte[] utf8PropertyName);
 
-            Debug.Assert(jsonParameterInfo != null);
-
-            // Increment ConstructorParameterIndex so GetProperty() starts with the next parameter the next time this function is called.
+            // Increment ConstructorParameterIndex so GetParameter() checks the next parameter first when called again.
             state.Current.CtorArgumentState!.ParameterIndex++;
 
-            // Support JsonException.Path.
-            Debug.Assert(
-                jsonParameterInfo.JsonPropertyName == null ||
-                options.PropertyNameCaseInsensitive ||
-                unescapedPropertyName.SequenceEqual(jsonParameterInfo.JsonPropertyName));
-
-            if (jsonParameterInfo.JsonPropertyName == null)
-            {
-                byte[] propertyNameArray = unescapedPropertyName.ToArray();
-                if (options.PropertyNameCaseInsensitive)
-                {
-                    // Each payload can have a different name here; remember the value on the temporary stack.
-                    state.Current.JsonPropertyName = propertyNameArray;
-                }
-                else
-                {
-                    //Prevent future allocs by caching globally on the JsonPropertyInfo which is specific to a Type+PropertyName
-                    // so it will match the incoming payload except when case insensitivity is enabled(which is handled above).
-                    jsonParameterInfo.JsonPropertyName = propertyNameArray;
-                }
-            }
+            // For case insensitive and missing property support of JsonPath, remember the value on the temporary stack.
+            state.Current.JsonPropertyName = utf8PropertyName;
 
             state.Current.CtorArgumentState.JsonParameterInfo = jsonParameterInfo;
-
-            return true;
+            return jsonParameterInfo != null;
         }
 
         internal override bool ConstructorIsParameterized => true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
@@ -22,22 +22,13 @@ namespace System.Text.Json
         // The default value of the parameter. This is `DefaultValue` of the `ParameterInfo`, if specified, or the CLR `default` for the `ParameterType`.
         public object? DefaultValue { get; protected set; }
 
-        // The name from a Json value. This is cached for performance on first deserialize.
-        public byte[]? JsonPropertyName { get; set; }
-
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonClassInfo that is cached on JsonSerializerOptions.
         protected JsonSerializerOptions Options { get; set; } = null!; // initialized in Init method
 
         public ParameterInfo ParameterInfo { get; private set; } = null!;
 
         // The name of the parameter as UTF-8 bytes.
-        public byte[] ParameterName { get; private set; } = null!;
-
-        // The name of the parameter.
-        public string NameAsString { get; private set; } = null!;
-
-        // Key for fast property name lookup.
-        public ulong ParameterNameKey { get; private set; }
+        public byte[] NameAsUtf8Bytes { get; private set; } = null!;
 
         // The zero-based position of the parameter in the formal parameter list.
         public int Position { get; private set; }
@@ -77,12 +68,7 @@ namespace System.Text.Json
 
         private void DetermineParameterName(JsonPropertyInfo matchingProperty)
         {
-            NameAsString = matchingProperty.NameAsString!;
-
-            // `NameAsString` is valid UTF16, so just call the simple UTF16->UTF8 encoder.
-            ParameterName = Encoding.UTF8.GetBytes(NameAsString);
-
-            ParameterNameKey = JsonClassInfo.GetKey(ParameterName);
+            NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!;
         }
 
         // Create a parameter that is ignored at run-time. It uses the same type (typeof(sbyte)) to help

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -83,10 +83,10 @@ namespace System.Text.Json
             Debug.Assert(NameAsString != null);
 
             // At this point propertyName is valid UTF16, so just call the simple UTF16->UTF8 encoder.
-            NameAsUtf8 = Encoding.UTF8.GetBytes(NameAsString);
+            NameAsUtf8Bytes = Encoding.UTF8.GetBytes(NameAsString);
 
             // Cache the escaped property name.
-            EscapedName = JsonEncodedText.Encode(NameAsString, NameAsUtf8, Options.Encoder);
+            EscapedName = JsonEncodedText.Encode(NameAsString, NameAsUtf8Bytes, Options.Encoder);
         }
 
         private void DetermineSerializationCapabilities(JsonIgnoreCondition? ignoreCondition)
@@ -189,9 +189,9 @@ namespace System.Text.Json
 
         // There are 3 copies of the property name:
         // 1) NameAsString. The unescaped property name.
-        // 2) NameAsUtf8. The Utf8 version of NameAsString. Used during during deserialization for property lookup.
-        // 3) EscapedName. The escaped verson of NameAsString and NameAsUtf8 written during serialization. Internally shares
-        // the same instances of NameAsString and NameAsUtf8 if there is no escaping.
+        // 2) NameAsUtf8Bytes. The Utf8 version of NameAsString. Used during during deserialization for property lookup.
+        // 3) EscapedName. The escaped verson of NameAsString and NameAsUtf8Bytes written during serialization. Internally shares
+        // the same instances of NameAsString and NameAsUtf8Bytes if there is no escaping.
 
         /// <summary>
         /// The unescaped name of the property.
@@ -204,7 +204,7 @@ namespace System.Text.Json
         /// <summary>
         /// Utf8 version of NameAsString.
         /// </summary>
-        public byte[]? NameAsUtf8 { get; private set; }
+        public byte[]? NameAsUtf8Bytes { get; private set; }
 
         /// <summary>
         /// The escaped name passed to the writer.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -83,13 +83,10 @@ namespace System.Text.Json
             Debug.Assert(NameAsString != null);
 
             // At this point propertyName is valid UTF16, so just call the simple UTF16->UTF8 encoder.
-            Name = Encoding.UTF8.GetBytes(NameAsString);
+            NameAsUtf8 = Encoding.UTF8.GetBytes(NameAsString);
 
             // Cache the escaped property name.
-            EscapedName = JsonEncodedText.Encode(Name, Options.Encoder);
-
-            ulong key = JsonClassInfo.GetKey(Name);
-            PropertyNameKey = key;
+            EscapedName = JsonEncodedText.Encode(NameAsString, NameAsUtf8, Options.Encoder);
         }
 
         private void DetermineSerializationCapabilities(JsonIgnoreCondition? ignoreCondition)
@@ -145,10 +142,6 @@ namespace System.Text.Json
             }
         }
 
-        // The escaped name passed to the writer.
-        // Use a field here (not a property) to avoid value semantics.
-        public JsonEncodedText? EscapedName;
-
         public static TAttribute? GetAttribute<TAttribute>(PropertyInfo propertyInfo) where TAttribute : Attribute
         {
             return (TAttribute?)propertyInfo.GetCustomAttribute(typeof(TAttribute), inherit: false);
@@ -194,15 +187,32 @@ namespace System.Text.Json
 
         public bool IsPropertyPolicy { get; protected set; }
 
-        // The name from a Json value. This is cached for performance on first deserialize.
-        public byte[]? JsonPropertyName { get; set; }
+        // There are 3 copies of the property name:
+        // 1) NameAsString. The unescaped property name.
+        // 2) NameAsUtf8. The Utf8 version of NameAsString. Used during during deserialization for property lookup.
+        // 3) EscapedName. The escaped verson of NameAsString and NameAsUtf8 written during serialization. Internally shares
+        // the same instances of NameAsString and NameAsUtf8 if there is no escaping.
 
-        // The name of the property with any casing policy or the name specified from JsonPropertyNameAttribute.
-        public byte[]? Name { get; private set; }
+        /// <summary>
+        /// The unescaped name of the property.
+        /// Is either the actual CLR property name,
+        /// the value specified in JsonPropertyNameAttribute,
+        /// or the value returned from PropertyNamingPolicy(clrPropertyName).
+        /// </summary>
         public string? NameAsString { get; private set; }
 
-        // Key for fast property name lookup.
-        public ulong PropertyNameKey { get; set; }
+        /// <summary>
+        /// Utf8 version of NameAsString.
+        /// </summary>
+        public byte[]? NameAsUtf8 { get; private set; }
+
+        /// <summary>
+        /// The escaped name passed to the writer.
+        /// </summary>
+        /// <remarks>
+        /// JsonEncodedText is a value type so a field is used (not a property) to avoid unnecessary copies.
+        /// </remarks>
+        public JsonEncodedText? EscapedName;
 
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonClassInfo that is cached on JsonSerializerOptions.
         protected JsonSerializerOptions Options { get; set; } = null!; // initialized in Init method

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -27,12 +27,20 @@ namespace System.Text.Json
         {
             Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object);
 
+            useExtensionProperty = false;
+
             ReadOnlySpan<byte> unescapedPropertyName = GetPropertyName(ref state, ref reader, options);
 
-            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(unescapedPropertyName, ref state.Current);
+            JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(
+                unescapedPropertyName,
+                ref state.Current,
+                out byte[] utf8PropertyName);
 
-            // Increment PropertyIndex so GetProperty() starts with the next property the next time this function is called.
+            // Increment PropertyIndex so GetProperty() checks the next property first when called again.
             state.Current.PropertyIndex++;
+
+            // For case insensitive and missing property support of JsonPath, remember the value on the temporary stack.
+            state.Current.JsonPropertyName = utf8PropertyName;
 
             // Determine if we should use the extension property.
             if (jsonPropertyInfo == JsonPropertyInfo.s_missingProperty)
@@ -50,41 +58,9 @@ namespace System.Text.Json
                     jsonPropertyInfo = dataExtProperty;
                     useExtensionProperty = true;
                 }
-                else
-                {
-                    useExtensionProperty = false;
-                }
-
-                state.Current.JsonPropertyInfo = jsonPropertyInfo;
-                return jsonPropertyInfo;
-            }
-
-            // Support JsonException.Path.
-            Debug.Assert(
-                jsonPropertyInfo.JsonPropertyName == null ||
-                options.PropertyNameCaseInsensitive ||
-                unescapedPropertyName.SequenceEqual(jsonPropertyInfo.JsonPropertyName));
-
-            state.Current.JsonPropertyInfo = jsonPropertyInfo;
-
-            if (jsonPropertyInfo.JsonPropertyName == null)
-            {
-                byte[] propertyNameArray = unescapedPropertyName.ToArray();
-                if (options.PropertyNameCaseInsensitive)
-                {
-                    // Each payload can have a different name here; remember the value on the temporary stack.
-                    state.Current.JsonPropertyName = propertyNameArray;
-                }
-                else
-                {
-                    // Prevent future allocs by caching globally on the JsonPropertyInfo which is specific to a Type+PropertyName
-                    // so it will match the incoming payload except when case insensitivity is enabled (which is handled above).
-                    state.Current.JsonPropertyInfo.JsonPropertyName = propertyNameArray;
-                }
             }
 
             state.Current.JsonPropertyInfo = jsonPropertyInfo;
-            useExtensionProperty = false;
             return jsonPropertyInfo;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ParameterRef.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ParameterRef.cs
@@ -12,7 +12,6 @@ namespace System.Text.Json
             Info = info;
         }
 
-        // The first 6 bytes are the first part of the name and last 2 bytes are the name's length.
         public readonly ulong Key;
 
         public readonly JsonParameterInfo Info;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ParameterRef.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ParameterRef.cs
@@ -6,14 +6,18 @@ namespace System.Text.Json
 {
     internal readonly struct ParameterRef
     {
-        public ParameterRef(ulong key, JsonParameterInfo info)
+        public ParameterRef(ulong key, JsonParameterInfo info, byte[] nameFromJson)
         {
             Key = key;
             Info = info;
+            NameFromJson = nameFromJson;
         }
 
         public readonly ulong Key;
 
         public readonly JsonParameterInfo Info;
+
+        // NameFromJson may be different than Info.NameAsUtf8Bytes when case insensitive is enabled.
+        public readonly byte[] NameFromJson;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PropertyRef.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PropertyRef.cs
@@ -6,17 +6,17 @@ namespace System.Text.Json
 {
     internal readonly struct PropertyRef
     {
-        public PropertyRef(ulong key, JsonPropertyInfo info, byte[] name)
+        public PropertyRef(ulong key, JsonPropertyInfo info, byte[] nameFromJson)
         {
             Key = key;
             Info = info;
-            Name = name;
+            NameFromJson = nameFromJson;
         }
 
         public readonly ulong Key;
         public readonly JsonPropertyInfo Info;
 
-        // Name may be different than Info.NameAsUtf8 when case insensitive is enabled.
-        public readonly byte[] Name;
+        // NameFromJson may be different than Info.NameAsUtf8Bytes when case insensitive is enabled.
+        public readonly byte[] NameFromJson;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PropertyRef.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/PropertyRef.cs
@@ -6,15 +6,17 @@ namespace System.Text.Json
 {
     internal readonly struct PropertyRef
     {
-        public PropertyRef(ulong key, JsonPropertyInfo info)
+        public PropertyRef(ulong key, JsonPropertyInfo info, byte[] name)
         {
             Key = key;
             Info = info;
+            Name = name;
         }
 
-        // The first 6 bytes are the first part of the name and last 2 bytes are the name's length.
         public readonly ulong Key;
-
         public readonly JsonPropertyInfo Info;
+
+        // Name may be different than Info.NameAsUtf8 when case insensitive is enabled.
+        public readonly byte[] Name;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -298,8 +298,9 @@ namespace System.Text.Json
                 if (utf8PropertyName == null)
                 {
                     // Attempt to get the JSON property name from the JsonPropertyInfo or JsonParameterInfo.
-                    utf8PropertyName = frame.JsonPropertyInfo?.JsonPropertyName ??
+                    utf8PropertyName = frame.JsonPropertyInfo?.NameAsUtf8 ??
                         frame.CtorArgumentState?.JsonParameterInfo?.JsonPropertyName;
+
                     if (utf8PropertyName == null)
                     {
                         // Attempt to get the JSON property name set manually for dictionary

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -298,8 +298,8 @@ namespace System.Text.Json
                 if (utf8PropertyName == null)
                 {
                     // Attempt to get the JSON property name from the JsonPropertyInfo or JsonParameterInfo.
-                    utf8PropertyName = frame.JsonPropertyInfo?.NameAsUtf8 ??
-                        frame.CtorArgumentState?.JsonParameterInfo?.JsonPropertyName;
+                    utf8PropertyName = frame.JsonPropertyInfo?.NameAsUtf8Bytes ??
+                        frame.CtorArgumentState?.JsonParameterInfo?.NameAsUtf8Bytes;
 
                     if (utf8PropertyName == null)
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReferenceHandling.cs
@@ -53,8 +53,8 @@ namespace System.Text.Json.Serialization
         /// </remarks>
         public static ReferenceHandling Preserve { get; } = new ReferenceHandling(PreserveReferencesHandling.All);
 
-        private readonly PreserveReferencesHandling _preserveHandlingOnSerialize;
-        private readonly PreserveReferencesHandling _preserveHandlingOnDeserialize;
+        private readonly bool _shouldReadPreservedReferences;
+        private readonly bool _shouldWritePreservedReferences;
 
         /// <summary>
         /// Creates a new instance of <see cref="ReferenceHandling"/> using the specified <paramref name="handling"/>
@@ -65,18 +65,18 @@ namespace System.Text.Json.Serialization
         // For future, someone may want to define their own custom Handler with different behaviors of PreserveReferenceHandling on Serialize vs Deserialize.
         private ReferenceHandling(PreserveReferencesHandling preserveHandlingOnSerialize, PreserveReferencesHandling preserveHandlingOnDeserialize)
         {
-            _preserveHandlingOnSerialize = preserveHandlingOnSerialize;
-            _preserveHandlingOnDeserialize = preserveHandlingOnDeserialize;
+            _shouldReadPreservedReferences = preserveHandlingOnDeserialize == PreserveReferencesHandling.All;
+            _shouldWritePreservedReferences = preserveHandlingOnSerialize == PreserveReferencesHandling.All;
         }
 
         internal bool ShouldReadPreservedReferences()
         {
-            return _preserveHandlingOnDeserialize == PreserveReferencesHandling.All;
+            return _shouldReadPreservedReferences;
         }
 
         internal bool ShouldWritePreservedReferences()
         {
-            return _preserveHandlingOnSerialize == PreserveReferencesHandling.All;
+            return _shouldWritePreservedReferences;
         }
     }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -100,6 +100,18 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void ExtensionPropertyInvalidJsonFail()
+        {
+            const string BadJson = @"{""Good"":""OK"",""Bad"":!}";
+
+            JsonException jsonException = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithExtensionPropertyAsObject>(BadJson));
+            Assert.Contains("Path: $.Bad | LineNumber: 0 | BytePositionInLine: 19.", jsonException.ToString());
+            Assert.NotNull(jsonException.InnerException);
+            Assert.IsAssignableFrom<JsonException>(jsonException.InnerException);
+            Assert.Contains("!", jsonException.InnerException.ToString());
+        }
+
+        [Fact]
         public static void ExtensionPropertyAlreadyInstantiated()
         {
             Assert.NotNull(new ClassWithExtensionPropertyAlreadyInstantiated().MyOverflow);

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyNameTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyNameTests.cs
@@ -232,6 +232,89 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
+        public static void EmptyPropertyNameInExtensionData()
+        {
+            {
+                string json = @"{"""":42}";
+                EmptyClassWithExtensionProperty obj = JsonSerializer.Deserialize<EmptyClassWithExtensionProperty>(json);
+                Assert.Equal(1, obj.MyOverflow.Count);
+                Assert.Equal(42, obj.MyOverflow[""].GetInt32());
+            }
+
+            {
+                // Verify that last-in wins.
+                string json = @"{"""":42, """":43}";
+                EmptyClassWithExtensionProperty obj = JsonSerializer.Deserialize<EmptyClassWithExtensionProperty>(json);
+                Assert.Equal(1, obj.MyOverflow.Count);
+                Assert.Equal(43, obj.MyOverflow[""].GetInt32());
+            }
+        }
+
+        [Fact]
+        public static void EmptyPropertyName_WinsOver_ExtensionDataEmptyPropertyName()
+        {
+            string json = @"{"""":1}";
+
+            ClassWithEmptyPropertyNameAndExtensionProperty obj;
+
+            // Create a new options instances to re-set any caches.
+            JsonSerializerOptions options = new JsonSerializerOptions();
+
+            // Verify the real property wins over the extension data property.
+            obj = JsonSerializer.Deserialize<ClassWithEmptyPropertyNameAndExtensionProperty>(json, options);
+            Assert.Equal(1, obj.MyInt1);
+            Assert.Null(obj.MyOverflow);
+        }
+
+        [Fact]
+        public static void EmptyPropertyNameAndExtensionData_ExtDataFirst()
+        {
+            // Verify any caching treats real property (with empty name) differently than a missing property.
+
+            ClassWithEmptyPropertyNameAndExtensionProperty obj;
+
+            // Create a new options instances to re-set any caches.
+            JsonSerializerOptions options = new JsonSerializerOptions();
+
+            // First populate cache with a missing property name.
+            string json = @"{""DoesNotExist"":42}";
+            obj = JsonSerializer.Deserialize<ClassWithEmptyPropertyNameAndExtensionProperty>(json, options);
+            Assert.Equal(0, obj.MyInt1);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(42, obj.MyOverflow["DoesNotExist"].GetInt32());
+
+            // Then use an empty property.
+            json = @"{"""":43}";
+            obj = JsonSerializer.Deserialize<ClassWithEmptyPropertyNameAndExtensionProperty>(json, options);
+            Assert.Equal(43, obj.MyInt1);
+            Assert.Null(obj.MyOverflow);
+        }
+
+        [Fact]
+        public static void EmptyPropertyAndExtensionData_PropertyFirst()
+        {
+            // Verify any caching treats real property (with empty name) differently than a missing property.
+
+            ClassWithEmptyPropertyNameAndExtensionProperty obj;
+
+            // Create a new options instances to re-set any caches.
+            JsonSerializerOptions options = new JsonSerializerOptions();
+
+            // First use an empty property.
+            string json = @"{"""":43}";
+            obj = JsonSerializer.Deserialize<ClassWithEmptyPropertyNameAndExtensionProperty>(json, options);
+            Assert.Equal(43, obj.MyInt1);
+            Assert.Null(obj.MyOverflow);
+
+            // Then populate cache with a missing property name.
+            json = @"{""DoesNotExist"":42}";
+            obj = JsonSerializer.Deserialize<ClassWithEmptyPropertyNameAndExtensionProperty>(json, options);
+            Assert.Equal(0, obj.MyInt1);
+            Assert.Equal(1, obj.MyOverflow.Count);
+            Assert.Equal(42, obj.MyOverflow["DoesNotExist"].GetInt32());
+        }
+
+        [Fact]
         public static void UnicodePropertyNames()
         {
             ClassWithUnicodeProperty obj = JsonSerializer.Deserialize<ClassWithUnicodeProperty>("{\"A\u0467\":1}");
@@ -512,6 +595,15 @@ namespace System.Text.Json.Serialization.Tests
 
     public class EmptyClassWithExtensionProperty
     {
+        [JsonExtensionData]
+        public IDictionary<string, JsonElement> MyOverflow { get; set; }
+    }
+
+    public class ClassWithEmptyPropertyNameAndExtensionProperty
+    {
+        [JsonPropertyName("")]
+        public int MyInt1 { get; set; }
+
         [JsonExtensionData]
         public IDictionary<string, JsonElement> MyOverflow { get; set; }
     }


### PR DESCRIPTION
~1.75x faster deserialization of a simple POCO when:
  - `JsonSerializerOptions.PropertyNameCaseInsensitive` is true AND 
  - Property names in JSON do not match property name (specified by either the CLR property name, the value specified by `[JsonPropertyName]`, or the property naming policy) AND
  - There is at least one property name > 7 bytes in length

In addition, similar perf results for property-misses cases (property names in JSON do not match any property).

Also there are less cache memory allocations for property names. This also has a startup CPU improvement - a simple POCO resulted in a .5ms startup improvements on first deserialization (~23.5ms to ~23.0ms). Private bytes savings were also verified using Process Explorer (very long property names were used).

Fixes https://github.com/dotnet/runtime/issues/30789 and the increased startup perf and reduced memory consumption helps with 5.0 serialization goals per https://github.com/dotnet/designs/pull/113.

In addition, there are less stack-based allocations for case-insensitive and missing-property scenarios (shown below in the benchmarks).

This may help with ASP.NET deserialization scenarios since they enable case-insensitive by default (cc @pranavkm). However, since ASP.NET also uses a camel-casing property naming policy, the benefit will not occur if the incoming JSON exactly matches what was produced by the camel-casing policy, as would be the case if all serialization occurs with System.Text.Json.

No measurable perf regressions on existing deserialization benchmarks (within +- 3%). Todo: add a case-insensitive and missing-property benchmark.

The main CPU benefit comes from avoiding the dictionary-based lookup for case-insensitive and missing-property scenarios and instead use the array-backed cache. The previous code would also unnecessarily grow and max out that array (64 elements) in certain cases before using the dictionary.

During testing, it was found that "missing properties" in JSON that are added to extension data did not properly support JsonPath semantics (used when a `JsonException` is thrown to report the invalid property). That was fixed and a test added.

Below are benchmarks for a simple 4-property POCO test class that has property names > 7 bytes.

```
3.1 performance
|                            Method |       Mean |   Error |  StdDev |     Median |        Min |        Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------- |-----------:|--------:|--------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
| CaseSensitive_Matching            |   844.2 ns | 4.25 ns | 3.55 ns |   844.2 ns |   838.6 ns |   850.6 ns | 0.0342 |     - |     - |     224 B |
| CaseInsensitive_Matching          |   833.3 ns | 3.84 ns | 3.40 ns |   832.6 ns |   829.4 ns |   841.1 ns | 0.0504 |     - |     - |     328 B |
| CaseSensitive_NotMatching(Missing)| 1,007.7 ns | 9.40 ns | 8.79 ns | 1,005.1 ns |   997.3 ns | 1,023.3 ns | 0.0722 |     - |     - |     464 B |
| CaseInsensitive_NotMatching       | 1,405.6 ns | 8.35 ns | 7.40 ns | 1,405.1 ns | 1,397.1 ns | 1,423.6 ns | 0.0626 |     - |     - |     408 B |

5.0 performance (BEFORE)
|                            Method |       Mean |    Error |   StdDev |     Median |        Min |        Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|-------:|------:|------:|----------:|
| CaseSensitive_Matching            |   826.0 ns |  6.41 ns |  5.99 ns |   827.1 ns |   815.7 ns |   836.1 ns | 0.0981 |     - |     - |     632 B |
| CaseInsensitive_Matching          |   844.7 ns |  2.95 ns |  2.46 ns |   845.1 ns |   841.2 ns |   848.5 ns | 0.1158 |     - |     - |     736 B |
| CaseSensitive_NotMatching(Missing)|   899.7 ns |  3.77 ns |  3.14 ns |   899.4 ns |   895.5 ns |   906.6 ns | 0.0182 |     - |     - |     120 B |
| CaseInsensitive_NotMatching       | 1,419.6 ns | 24.86 ns | 20.76 ns | 1,424.9 ns | 1,374.7 ns | 1,446.9 ns | 0.1263 |     - |     - |     816 B |

5.0 performance (AFTER)
|                            Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
| CaseSensitive_Matching            | 799.2 ns | 4.59 ns | 4.29 ns | 801.0 ns | 790.5 ns | 803.9 ns | 0.0985 |     - |     - |     632 B |
| CaseInsensitive_Matching          | 789.2 ns | 6.62 ns | 5.53 ns | 790.3 ns | 776.0 ns | 794.4 ns | 0.1004 |     - |     - |     632 B |
| CaseSensitive_NotMatching(Missing)| 479.9 ns | 0.75 ns | 0.59 ns | 479.8 ns | 479.1 ns | 481.0 ns | 0.0059 |     - |     - |      40 B |
| CaseInsensitive_NotMatching       | 783.5 ns | 3.26 ns | 2.89 ns | 783.5 ns | 779.0 ns | 789.2 ns | 0.1004 |     - |     - |     632 B |
```