### PR TITLE
Enable more formerly-failing-on-mono tests.

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1445,12 +1445,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Performance/CodeQuality/BilinearInterpol/BilinearInterpol/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16895/b16895/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34386</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b27883/b27883/**">
-            <Issue>https://github.com/dotnet/runtime/issues/34387</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31283/b31283/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
@@ -1471,9 +1465,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_545500/**">
             <Issue>https://github.com/dotnet/runtime/issues/34084</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_578217/**">
-            <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271/**">
             <Issue>needs triage</Issue>


### PR DESCRIPTION
See:
 - https://github.com/dotnet/runtime/issues/34387,
 - https://github.com/dotnet/runtime/issues/34384, and
 - https://github.com/dotnet/runtime/issues/34386.