### PR TITLE
Fix R2R GC hole on ARM64

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -492,7 +492,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public override int GetRetBuffArgOffset(bool hasThis) => OffsetOfX8Register;
 
-            public override bool IsRetBuffPassedAsFirstArg => true;
+            public override bool IsRetBuffPassedAsFirstArg => false;
         }
     }
 }

--- a/src/coreclr/src/tools/r2rtest/CpaotRunner.cs
+++ b/src/coreclr/src/tools/r2rtest/CpaotRunner.cs
@@ -73,8 +73,8 @@ namespace R2RTest
             // Output
             yield return $"-o:{outputFileName}";
 
-            // Todo: Allow control of some of these
-            yield return "--targetarch=x64";
+            // Todo: Allow cross-architecture compilation
+            //yield return "--targetarch=x64";
 
             if (_options.Map)
             {


### PR DESCRIPTION
`TransitionBlock.IsRetBuffPassedAsFirstArg` must return `false` for ARM64.