### PR TITLE
Fix buffer overrun in JIT for Vector256<T> types on ARM64

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -1738,6 +1738,10 @@ public:
 #else
         unsigned int regSize = 1;
 #endif
+
+        if (numRegs > MAX_ARG_REG_COUNT)
+            NO_WAY("Multireg argument exceeds the maximum length");
+
         for (unsigned int regIndex = 1; regIndex < numRegs; regIndex++)
         {
             argReg = (regNumber)(argReg + regSize);

--- a/src/coreclr/src/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -96,7 +96,6 @@ namespace ILCompiler
                 {
                     8 => ValueTypeShapeCharacteristics.Vector64Aggregate,
                     16 => ValueTypeShapeCharacteristics.Vector128Aggregate,
-                    32 => ValueTypeShapeCharacteristics.Vector256Aggregate,
                     _ => ValueTypeShapeCharacteristics.None
                 };
             }
@@ -107,9 +106,7 @@ namespace ILCompiler
         {
             return type.IsIntrinsic &&
                 type.Namespace == "System.Runtime.Intrinsics" &&
-                (type.Name == "Vector64`1" ||
-                type.Name == "Vector128`1" ||
-                type.Name == "Vector256`1") &&
+                ((type.Name == "Vector64`1") || (type.Name == "Vector128`1")) &&
                 type.Instantiation[0].IsPrimitive;
         }
     }

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2206,7 +2206,7 @@ namespace Internal.JitInterface
             var type = (DefType)HandleToObject(hClass);
 
             // For 8-byte vectors return CORINFO_TYPE_DOUBLE, which is mapped by JIT to SIMD8.
-            // Otherwise, return CORINFO_TYPE_VALUECLASS, which is mapped by JIT to SIMD16.
+            // For 16-byte vectors return CORINFO_TYPE_VALUECLASS, which is mapped by JIT to SIMD16.
             // See MethodTable::GetHFAType and Compiler::GetHfaType.
             return (type.ValueTypeShapeCharacteristics & ValueTypeShapeCharacteristics.AggregateMask) switch
             {
@@ -2214,7 +2214,6 @@ namespace Internal.JitInterface
                 ValueTypeShapeCharacteristics.Float64Aggregate => CorInfoType.CORINFO_TYPE_DOUBLE,
                 ValueTypeShapeCharacteristics.Vector64Aggregate => CorInfoType.CORINFO_TYPE_DOUBLE,
                 ValueTypeShapeCharacteristics.Vector128Aggregate => CorInfoType.CORINFO_TYPE_VALUECLASS,
-                ValueTypeShapeCharacteristics.Vector256Aggregate => CorInfoType.CORINFO_TYPE_VALUECLASS,
                 _ => CorInfoType.CORINFO_TYPE_UNDEF
             };
         }

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/DefType.FieldLayout.cs
@@ -321,7 +321,6 @@ namespace Internal.TypeSystem
                 ValueTypeShapeCharacteristics.Float64Aggregate => 8,
                 ValueTypeShapeCharacteristics.Vector64Aggregate => 8,
                 ValueTypeShapeCharacteristics.Vector128Aggregate => 16,
-                ValueTypeShapeCharacteristics.Vector256Aggregate => 16,
                 _ => throw new InvalidOperationException()
             };
         }

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/FieldLayoutAlgorithm.cs
@@ -133,11 +133,6 @@ namespace Internal.TypeSystem
         Vector128Aggregate = 0x08,
 
         /// <summary>
-        /// The type is an aggregate of 256-bit short-vector values.
-        /// </summary>
-        Vector256Aggregate = 0x10,
-
-        /// <summary>
         /// The mask for homogeneous aggregates of floating-point values.
         /// </summary>
         FloatingPointAggregateMask = Float32Aggregate | Float64Aggregate,
@@ -145,7 +140,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// The mask for homogeneous aggregates of short-vector values.
         /// </summary>
-        ShortVectorAggregateMask = Vector64Aggregate | Vector128Aggregate | Vector256Aggregate,
+        ShortVectorAggregateMask = Vector64Aggregate | Vector128Aggregate,
 
         /// <summary>
         /// The mask for homogeneous aggregates.

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MetadataFieldLayoutAlgorithm.cs
@@ -906,7 +906,6 @@ namespace Internal.TypeSystem
                         ValueTypeShapeCharacteristics.Float64Aggregate => 8,
                         ValueTypeShapeCharacteristics.Vector64Aggregate => 8,
                         ValueTypeShapeCharacteristics.Vector128Aggregate => 16,
-                        ValueTypeShapeCharacteristics.Vector256Aggregate => 32,
                         _ => throw new ArgumentOutOfRangeException()
                     };
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -88,7 +88,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     ValueTypeShapeCharacteristics.Vector64Aggregate => CorElementType.ELEMENT_TYPE_R8,
                     // See MethodTable::GetHFAType
                     ValueTypeShapeCharacteristics.Vector128Aggregate => CorElementType.ELEMENT_TYPE_VALUETYPE,
-                    ValueTypeShapeCharacteristics.Vector256Aggregate => CorElementType.ELEMENT_TYPE_VALUETYPE,
                     _ => CorElementType.Invalid
                 };
                 dataBuilder.EmitUInt((uint)elementType);

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1195,10 +1195,6 @@ int MethodTable::GetVectorSize()
         {
             vectorSize = 16;
         }
-        else if (strcmp(className, "Vector256`1") == 0)
-        {
-            vectorSize = 32;
-        }
         else if (strcmp(className, "Vector64`1") == 0)
         {
             vectorSize = 8;


### PR DESCRIPTION
The release build of JIT may crash due to buffer overrun caused by inconsistent handling of `Vector256<T>` types.  The [PacketTracer](https://github.com/dotnet/runtime/tree/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/tests/src/JIT/Performance/CodeQuality/HWIntrinsic/X86/PacketTracer) test has a 96-byte struct with three `Vector256<float>` fields.  The [`MethodTable::GetVectorSize`](https://github.com/dotnet/runtime/blob/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/src/vm/class.cpp#L1177) function returns 32 (bytes) for `Vector256<T>` types and I added equivalent code for Crossgen2 in #35576.  Since 96 / 32 < 4, [`EEClass::CheckForHFA`](https://github.com/dotnet/runtime/blob/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/src/vm/class.cpp#L1300) considers this struct as a HVA that has to be passed in `V` registers.  Later we divide the struct size 96 by the actual `V` register size 16 and try to assign 6 registers to this struct in the following loop:

https://github.com/dotnet/runtime/blob/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/src/jit/compiler.h#L1741-L1745 https://github.com/dotnet/runtime/blob/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/src/jit/compiler.h#L1478-L1482 https://github.com/dotnet/runtime/blob/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/src/jit/compiler.h#L1401-L1405

Here `MAX_ARG_REG_COUNT` is 4 per ABI and `numRegs` is 6, which causes the loop to override `numRegs` with a huge value (`regNumberSmall` is byte-sized) and trash all the following memory until it reaches the end of the OS allocation segment.  (The debug build of JIT would hit the assert at line 1480 above, but actually it hits the size assert even earlier.)

At present we hit this issue for Crossgen2 only, because for the old Crossgen, compilation of `Vector256<T>` and other SIMD hardware intrinsic types is enabled only for System.Private.CoreLib assembly:

https://github.com/dotnet/runtime/blob/96268f3ef58674d66908ff90da0f32fc04c1f68f/src/coreclr/src/vm/methodtablebuilder.cpp#L9525-L9539

If that `#ifdef` is removed, the old Crossgen hits this issue as well.  Finally, normal JIT does not hit the issue on this test due to the test code being under `if (Avx2.IsSupported)`.

~~The proposed fix is to use 16 bytes 'vector size' for `Vector256<T>` types and add a `NO_WAY` check to protect against a dangerous buffer overrun.~~
Since in other places JIT does not recognize `Vector256<T>` types as intrinsic for ARM64, the fix is to not recognize it as intrinsic in `MethodTable::GetVectorSize` or Crossgen2's type system either. That allows to remove the `ValueTypeShapeCharacteristics.Vector256Aggregate` flag.  Also add a `NO_WAY` check to protect against a dangerous buffer overrun in `fgArgTabEntry::SetMultiRegNums`.