### PR TITLE
Adding a clarifying comment as to why HWIntrinsicInfo::lookupIval returns an inverted comparison op

### DIFF
--- a/src/coreclr/src/jit/hwintrinsic.h
+++ b/src/coreclr/src/jit/hwintrinsic.h
@@ -328,6 +328,11 @@ struct HWIntrinsicInfo
                     return static_cast<int>(FloatComparisonMode::OrderedGreaterThanSignaling);
                 }
 
+                // CompareGreaterThan is not directly supported in hardware without AVX support.
+                // We will return the inverted case here and lowering will itself swap the ops
+                // to ensure the emitted code remains correct. This simplifies the overall logic
+                // here and for other use cases.
+
                 assert(id != NI_AVX_CompareGreaterThan);
                 return static_cast<int>(FloatComparisonMode::OrderedLessThanSignaling);
             }
@@ -351,6 +356,11 @@ struct HWIntrinsicInfo
                 {
                     return static_cast<int>(FloatComparisonMode::OrderedGreaterThanOrEqualSignaling);
                 }
+
+                // CompareGreaterThanOrEqual is not directly supported in hardware without AVX support.
+                // We will return the inverted case here and lowering will itself swap the ops
+                // to ensure the emitted code remains correct. This simplifies the overall logic
+                // here and for other use cases.
 
                 assert(id != NI_AVX_CompareGreaterThanOrEqual);
                 return static_cast<int>(FloatComparisonMode::OrderedLessThanOrEqualSignaling);
@@ -385,6 +395,11 @@ struct HWIntrinsicInfo
                     return static_cast<int>(FloatComparisonMode::UnorderedNotGreaterThanSignaling);
                 }
 
+                // CompareNotGreaterThan is not directly supported in hardware without AVX support.
+                // We will return the inverted case here and lowering will itself swap the ops
+                // to ensure the emitted code remains correct. This simplifies the overall logic
+                // here and for other use cases.
+
                 assert(id != NI_AVX_CompareNotGreaterThan);
                 return static_cast<int>(FloatComparisonMode::UnorderedNotLessThanSignaling);
             }
@@ -408,6 +423,11 @@ struct HWIntrinsicInfo
                 {
                     return static_cast<int>(FloatComparisonMode::UnorderedNotGreaterThanOrEqualSignaling);
                 }
+
+                // CompareNotGreaterThanOrEqual is not directly supported in hardware without AVX support.
+                // We will return the inverted case here and lowering will itself swap the ops
+                // to ensure the emitted code remains correct. This simplifies the overall logic
+                // here and for other use cases.
 
                 assert(id != NI_AVX_CompareNotGreaterThanOrEqual);
                 return static_cast<int>(FloatComparisonMode::UnorderedNotLessThanOrEqualSignaling);


### PR DESCRIPTION
@echesakovMSFT, this adds a clarifying comment to `HWIntrinsicInfo::lookupIval` in an attempt to address the concern raised here: https://github.com/dotnet/runtime/pull/35421#discussion_r419775317