### PR TITLE
Reduce memory usage of crossgen2 debug data

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -22,8 +22,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         private FrameInfo[] _frameInfos;
         private byte[] _gcInfo;
         private ObjectData _ehInfo;
-        private OffsetMapping[] _debugLocInfos;
-        private NativeVarInfo[] _debugVarInfos;
+        private byte[] _debugLocInfos;
+        private byte[] _debugVarInfos;
         private DebugEHClauseInfo[] _debugEHClauseInfos;
         private List<ISymbolNode> _fixups;
         private MethodDesc[] _inlinedMethods;
@@ -268,20 +268,24 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _ehInfo = ehInfo;
         }
 
-        public OffsetMapping[] DebugLocInfos => _debugLocInfos;
-        public NativeVarInfo[] DebugVarInfos => _debugVarInfos;
+        public byte[] DebugLocInfos => _debugLocInfos;
+        public byte[] DebugVarInfos => _debugVarInfos;
         public DebugEHClauseInfo[] DebugEHClauseInfos => _debugEHClauseInfos;
 
         public void InitializeDebugLocInfos(OffsetMapping[] debugLocInfos)
         {
             Debug.Assert(_debugLocInfos == null);
-            _debugLocInfos = debugLocInfos;
+            // Process the debug info from JIT format to R2R format immediately as it is large
+            // and not used in the rest of the process except to emit.
+            _debugLocInfos = DebugInfoTableNode.CreateBoundsBlobForMethod(debugLocInfos);
         }
 
         public void InitializeDebugVarInfos(NativeVarInfo[] debugVarInfos)
         {
             Debug.Assert(_debugVarInfos == null);
-            _debugVarInfos = debugVarInfos;
+            // Process the debug info from JIT format to R2R format immediately as it is large
+            // and not used in the rest of the process except to emit.
+            _debugVarInfos = DebugInfoTableNode.CreateVarBlobForMethod(debugVarInfos);
         }
 
         public void InitializeDebugEHClauseInfos(DebugEHClauseInfo[] debugEHClauseInfos)


### PR DESCRIPTION
Reduce allocated object cost of debug info, by converting it into its final form as its extracted from the JIT and not as its emitted into the file. Also has a small benefit of increased parallelization as its now created in a parallel portion of the build instead of a sequential portion of the build. Overall size win of 0.5% observed.