### PR TITLE
Finish the other part of the GCTotalPhysicalMemory config implementation

### DIFF
--- a/src/coreclr/src/gc/env/gcenv.os.h
+++ b/src/coreclr/src/gc/env/gcenv.os.h
@@ -433,10 +433,15 @@ public:
     // Remarks:
     //  If a process runs with a restricted memory limit, it returns the limit. If there's no limit
     //  specified, it returns amount of actual physical memory.
-    //
-    // PERF TODO: Requires more work to not treat the restricted case to be special.
-    // To be removed before 3.0 ships.
     static uint64_t GetPhysicalMemoryLimit(bool* is_restricted=NULL);
+
+    // Set the total physical memory that this process is allowed to use.
+    // Remarks:
+    //  A process can use a GC config (GCTotalPhysicalMemory) to specify the amount of physicla memory
+    //  it's allowed to use. And if no hardlimit (specified with the GCHeapHardLimit config) is specified,
+    //  this is treated as the restricted environment so the hardlimit will be calcuated accordingly, ie,
+    //  max (75% of the total physical memory, 20mb).
+    static bool SetRestrictedPhysicalMemoryLimit(uint64_t totalPhysicalMemory);
 
     // Get memory status
     // Parameters:

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -34925,9 +34925,19 @@ HRESULT GCHeap::Initialize()
     g_num_processors = GCToOSInterface::GetTotalProcessorCount();
     assert(g_num_processors != 0);
 
+    bool should_get_physical_mem = true;
     bool is_restricted;
     gc_heap::total_physical_mem = (size_t)GCConfig::GetGCTotalPhysicalMemory();
-    if (!(gc_heap::total_physical_mem))
+    if (gc_heap::total_physical_mem)
+    {
+        if (GCToOSInterface::SetRestrictedPhysicalMemoryLimit(gc_heap::total_physical_mem))
+        {
+            is_restricted = true;
+            should_get_physical_mem = false;
+        }
+    }
+
+    if (should_get_physical_mem)
     {
         gc_heap::total_physical_mem = GCToOSInterface::GetPhysicalMemoryLimit (&is_restricted);
     }

--- a/src/coreclr/src/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/src/gc/unix/gcenv.unix.cpp
@@ -1141,6 +1141,20 @@ uint64_t GetAvailablePageFile()
     return available;
 }
 
+// Set the total physical memory that this process is allowed to use.
+// Remarks:
+//  A process can use a GC config (GCTotalPhysicalMemory) to specify the amount of physicla memory
+//  it's allowed to use. And if no hardlimit (specified with the GCHeapHardLimit config) is specified,
+//  this is treated as the restricted environment so the hardlimit will be calcuated accordingly, ie,
+//  max (75% of the total physical memory, 20mb).
+bool GCToOSInterface::SetRestrictedPhysicalMemoryLimit(uint64_t totalPhysicalMemory)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    VolatileStore (&g_RestrictedPhysicalMemoryLimit, (size_t)totalPhysicalMemory);
+    return true;
+}
+
 // Get memory status
 // Parameters:
 //  memory_load - A number between 0 and 100 that specifies the approximate percentage of physical memory


### PR DESCRIPTION
The total physical memory specified by the GCTotalPhysicalMemory config
needs to be communicated over to the VM side for memory load calculation.
Otherwise inside GC we are using the correct physical memory specified,
but when we ask for the memory load it's still based on the total available
memory.