### PR TITLE
[mono] Add basic OpenSSL support for Android

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -133,6 +133,14 @@
     <Copy SourceFiles="@(AndroidTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
 
+    <!-- TEMP: consume OpenSSL binaries from external sources via env. variables -->
+    <Copy Condition="'$(AndroidOpenSslCryptoLib)' != ''"
+          SourceFiles="$(AndroidOpenSslCryptoLib)"
+          DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
+    <Copy Condition="'$(AndroidOpenSslLib)' != ''"
+          SourceFiles="$(AndroidOpenSslLib)"
+          DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
+
     <WriteLinesToFile File="$(BundleDir)\xunit-excludes.txt" Lines="$(_withoutCategories.Replace(';', '%0dcategory='))" />
 
     <AndroidAppBuilderTask 

--- a/src/libraries/Native/Unix/CMakeLists.txt
+++ b/src/libraries/Native/Unix/CMakeLists.txt
@@ -215,7 +215,9 @@ elseif(CLR_CMAKE_TARGET_TVOS)
 elseif(CLR_CMAKE_TARGET_ANDROID AND NOT CROSS_ROOTFS)
     add_subdirectory(System.Globalization.Native)
     #add_subdirectory(System.Net.Security.Native) # TODO: reenable
-    #add_subdirectory(System.Security.Cryptography.Native) # TODO: reenable
+    if (NOT "$ENV{AndroidOpenSslHeaders}" STREQUAL "")
+        add_subdirectory(System.Security.Cryptography.Native)
+    endif()
 else()
     add_subdirectory(System.Globalization.Native)
     add_subdirectory(System.Net.Security.Native)

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/CMakeLists.txt
@@ -12,7 +12,16 @@ if(CMAKE_STATIC_LIB_LINK)
    set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
 endif(CMAKE_STATIC_LIB_LINK)
 
-find_package(OpenSSL)
+if(CLR_CMAKE_TARGET_ANDROID AND NOT CROSS_ROOTFS)
+    # TEMP: consume OpenSSL dependencies from external sources via env. variables
+    set(OPENSSL_FOUND 1)
+    set(OPENSSL_INCLUDE_DIR $ENV{AndroidOpenSslHeaders})
+    set(OPENSSL_CRYPTO_LIBRARY $ENV{AndroidOpenSslCryptoLib})
+    set(OPENSSL_SSL_LIBRARY $ENV{AndroidOpenSslLib})
+else()
+    find_package(OpenSSL)
+endif()
+
 if(NOT OPENSSL_FOUND)
     message(FATAL_ERROR "!!! Cannot find libssl and System.Security.Cryptography.Native cannot build without it. Try installing libssl-dev (or the appropriate package for your platform) !!!. See the requirements document for your specific operating system: https://github.com/dotnet/runtime/tree/master/docs/workflow/requirements.")
 endif(NOT OPENSSL_FOUND)

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -477,8 +477,8 @@
              Link="Common\System\Security\Cryptography\RSAOpenSsl.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\DesImplementation.Unix.cs" />
-    <Compile Condition="'$(TargetsAndroid)' != 'true'" Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
-    <Compile Condition="'$(TargetsAndroid)' == 'true'" Include="Internal\Cryptography\HashProviderDispenser.Android.cs" />
+    <Compile Condition="'$(TargetsAndroid)' != 'true' or '$(AndroidOpenSslHeaders)' != ''" Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
+    <Compile Condition="'$(TargetsAndroid)' == 'true' and '$(AndroidOpenSslHeaders)' == ''" Include="Internal\Cryptography\HashProviderDispenser.Android.cs" />
     <Compile Include="Internal\Cryptography\OpenSslCipher.cs" />
     <Compile Include="Internal\Cryptography\RandomNumberGeneratorImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\RC2Implementation.Unix.cs" />

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -34,6 +34,15 @@
     <RemoveDir Directories="$(BundleDir)" />
     <Copy SourceFiles="@(AppBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(BclBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
+
+    <!-- TEMP: consume OpenSSL binaries from external sources via env. variables -->
+    <Copy Condition="'$(AndroidOpenSslCryptoLib)' != ''"
+          SourceFiles="$(AndroidOpenSslCryptoLib)"
+          DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
+    <Copy Condition="'$(AndroidOpenSslLib)' != ''"
+          SourceFiles="$(AndroidOpenSslLib)"
+          DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
+
     <AndroidAppBuilderTask 
         Abi="$(AndroidAbi)"
         ProjectName="HelloAndroid"


### PR DESCRIPTION
Temp solution to enable `System.Security.Cryptography.Native` for Android while we figure out how to build/consume it properly.

#### Steps to enable:
1) Download and unzip `https://maven.google.com/com/android/ndk/thirdparty/openssl/1.1.1g-alpha-1/openssl-1.1.1g-alpha-1.aar`
2) Set these env variables:
```
export AndroidOpenSslHeaders="/Users/egorbo/prj/openssl-1.1.1g-alpha-1.aar/prefab/modules/ssl/include"
export AndroidOpenSslCryptoLib="/Users/egorbo/prj/openssl-1.1.1g-alpha-1.aar/prefab/modules/crypto/libs/android.x86_64/libcrypto.so"
export AndroidOpenSslLib="/Users/egorbo/prj/openssl-1.1.1g-alpha-1.aar/prefab/modules/ssl/libs/android.x86_64/libssl.so"
```
(make sure you use the right ABI in the paths, e.g. `android.x86_64` for `-arch x64` or `android.arm64-v8a` for `-arch arm64`)

3) build repo normally, e.g.
```
./build.sh -os Android -subset Mono+Libs
```

I am preparing a PR to update the docs and will include these temp hints.