### PR TITLE
Fix buffer overflow in assert

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -17494,7 +17494,7 @@ void Compiler::impImportBlockPending(BasicBlock* block)
 #ifdef DEBUG
             char buffer[400];
             sprintf_s(buffer, sizeof(buffer),
-                      "Block at offset %4.4x to %4.4x in %s entered with different stack depths.\n"
+                      "Block at offset %4.4x to %4.4x in %0.200s entered with different stack depths.\n"
                       "Previous depth was %d, current depth is %d",
                       block->bbCodeOffs, block->bbCodeOffsEnd, info.compFullName, block->bbStkDepth,
                       verCurrentState.esStackDepth);


### PR DESCRIPTION
I ran into a buffer overflow in this noway assert while doing a superpmi run with the linux/x64 altjit. Unfortunately after updating sources I'm no longer seeing it, so I can't figure out what caused the assert to fire, but I figure we should at least fix the buffer overflow in the assert.