### PR TITLE
[mono] Fix 32bit Android build

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -99,7 +99,7 @@
  <!-- Generate a self-contained app bundle for Android with tests.
        This target is executed once build is done for a test lib (after CopyFilesToOutputDirectory target) -->
   <UsingTask TaskName="AndroidAppBuilderTask" 
-             AssemblyFile="$(ArtifactsObjDir)mono\AndroidAppBuilder\$(TargetArchitecture)\$(Configuration)\AndroidAppBuilder.dll" />
+             AssemblyFile="$(ArtifactsObjDir)mono\AndroidAppBuilder\$(HostArch)\$(Configuration)\AndroidAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'Android'" Name="BundleTestAndroidApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
       <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\runtimes\android-$(TargetArchitecture)</RuntimePackDir>
@@ -153,7 +153,7 @@
   <!-- Generate a self-contained app bundle for iOS with tests.
        This target is executed once build is done for a test lib (after CopyFilesToOutputDirectory target) -->
   <UsingTask TaskName="AppleAppBuilderTask" 
-             AssemblyFile="$(ArtifactsObjDir)mono\AppleAppBuilder\$(TargetArchitecture)\$(Configuration)\AppleAppBuilder.dll" />
+             AssemblyFile="$(ArtifactsObjDir)mono\AppleAppBuilder\$(HostArch)\$(Configuration)\AppleAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'iOS'" Name="BundleTestAppleApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
       <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\runtimes\ios-$(TargetArchitecture)</RuntimePackDir>

--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -929,7 +929,7 @@
 
   <Target Name="BuildAppleAppBuilder">
     <MSBuild Projects="$(MonoProjectRoot)msbuild\AppleAppBuilder\AppleAppBuilder.csproj"
-             Properties="Configuration=$(Configuration)"
+             Properties="Configuration=$(Configuration);Platform=$(HostArch)"
              Targets="Restore;Build" />
     <MSBuild Projects="$(MonoProjectRoot)msbuild\AppleTestRunner\AppleTestRunner.csproj"
              Properties="Configuration=$(Configuration)"
@@ -938,7 +938,7 @@
 
   <Target Name="BuildAndroidAppBuilder">
     <MSBuild Projects="$(MonoProjectRoot)msbuild\AndroidAppBuilder\AndroidAppBuilder.csproj"
-             Properties="Configuration=$(Configuration)"
+             Properties="Configuration=$(Configuration);Platform=$(HostArch)"
              Targets="Restore;Build" />
     <MSBuild Projects="$(MonoProjectRoot)msbuild\AndroidTestRunner\AndroidTestRunner.csproj"
              Properties="Configuration=$(Configuration)"

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -83,17 +83,8 @@ mono_native_thread_join_handle (HANDLE thread_handle, gboolean close_handle);
 #include <zircon/syscalls.h>
 #endif
 
-#if !defined(ENABLE_NETCORE) && defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
-// tkill was deprecated and removed in the recent versions of Android NDK
-#define USE_TKILL_ON_ANDROID 1
-#endif
-
 #ifdef HOST_ANDROID
 #include <errno.h>
-
-#ifdef USE_TKILL_ON_ANDROID
-extern int tkill (pid_t tid, int signal);
-#endif
 #endif
 
 #include "icall-decl.h"

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -83,7 +83,8 @@ mono_native_thread_join_handle (HANDLE thread_handle, gboolean close_handle);
 #include <zircon/syscalls.h>
 #endif
 
-#if defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
+#if !defined(ENABLE_NETCORE) && defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
+// tkill was deprecated and removed in the recent versions of Android NDK
 #define USE_TKILL_ON_ANDROID 1
 #endif
 

--- a/src/mono/mono/utils/mono-threads-posix.c
+++ b/src/mono/mono/utils/mono-threads-posix.c
@@ -35,9 +35,6 @@
 #if !defined(ENABLE_NETCORE) && defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
 // tkill was deprecated and removed in the recent versions of Android NDK
 #define USE_TKILL_ON_ANDROID 1
-#endif
-
-#ifdef USE_TKILL_ON_ANDROID
 extern int tkill (pid_t tid, int signal);
 #endif
 

--- a/src/mono/mono/utils/mono-threads-posix.c
+++ b/src/mono/mono/utils/mono-threads-posix.c
@@ -32,7 +32,8 @@
 
 #include <errno.h>
 
-#if defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
+#if !defined(ENABLE_NETCORE) && defined(HOST_ANDROID) && !defined(TARGET_ARM64) && !defined(TARGET_AMD64)
+// tkill was deprecated and removed in the recent versions of Android NDK
 #define USE_TKILL_ON_ANDROID 1
 #endif
 

--- a/src/mono/msbuild/AndroidAppBuilder/Templates/runtime-android.c
+++ b/src/mono/msbuild/AndroidAppBuilder/Templates/runtime-android.c
@@ -12,6 +12,7 @@
 #include <mono/jit/mono-private-unstable.h>
 
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -182,6 +183,12 @@ strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
     strncpy (buff, copy_buff, nbuff);
     if (isCopy)
         (*env)->ReleaseStringUTFChars (env, str, copy_buff);
+}
+
+int
+tkill(pid_t tid, int sig)
+{
+    return syscall(__NR_tkill, tid, sig);
 }
 
 int

--- a/src/mono/msbuild/AndroidAppBuilder/Templates/runtime-android.c
+++ b/src/mono/msbuild/AndroidAppBuilder/Templates/runtime-android.c
@@ -186,12 +186,6 @@ strncpy_str (JNIEnv *env, char *buff, jstring str, int nbuff)
 }
 
 int
-tkill(pid_t tid, int sig)
-{
-    return syscall(__NR_tkill, tid, sig);
-}
-
-int
 Java_net_dot_MonoRunner_initRuntime (JNIEnv* env, jobject thiz, jstring j_files_dir, jstring j_cache_dir, jstring j_docs_dir)
 {
     char file_dir[2048];

--- a/src/mono/msbuild/AndroidAppBuilder/Templates/runtime-android.c
+++ b/src/mono/msbuild/AndroidAppBuilder/Templates/runtime-android.c
@@ -12,7 +12,6 @@
 #include <mono/jit/mono-private-unstable.h>
 
 #include <sys/stat.h>
-#include <sys/syscall.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
1) Use `HostArch` for AppBuilder tasks 
2) Remove `tkill` for Android 32bit since it's not available in recent Android NDKs anymore.