### PR TITLE
Stop spamming System.Net.Http.Tests output with HTTP/2 skipped tests

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -341,7 +341,7 @@ namespace System.Net.Http.Functional.Tests
             if (LoopbackServerFactory.Version >= HttpVersion20.Value)
             {
                 // HTTP/2 does not use connection limits.
-                throw new SkipTestException("Not supported on HTTP/2 and later");
+                return;
             }
 
             using (HttpClientHandler handler = CreateHttpClientHandler())

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -493,7 +493,8 @@ namespace System.Net.Http.Functional.Tests
         {
             if (LoopbackServerFactory.Version >= HttpVersion20.Value)
             {
-                throw new SkipTestException("Host header is not supported on HTTP/2 and later.");
+                // Host header is not supported on HTTP/2 and later.
+                return;
             }
 
             var options = new LoopbackServer.Options { Address = address, UseSsl= useSsl };
@@ -930,7 +931,8 @@ namespace System.Net.Http.Functional.Tests
         {
             if (LoopbackServerFactory.Version >= HttpVersion20.Value)
             {
-                throw new SkipTestException("Folding is not supported on HTTP/2 and later.");
+                // Folding is not supported on HTTP/2 and later.
+                return;
             }
 
             // Using examples from https://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Response_fields
@@ -1062,8 +1064,10 @@ namespace System.Net.Http.Functional.Tests
         {
             if (LoopbackServerFactory.Version >= HttpVersion20.Value)
             {
-                throw new SkipTestException("Chunking is not supported on HTTP/2 and later.");
+                // Chunking is not supported on HTTP/2 and later.
+                return;
             }
+
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 using (HttpClient client = CreateHttpClient())
@@ -1292,7 +1296,8 @@ namespace System.Net.Http.Functional.Tests
 #endif
             if (LoopbackServerFactory.Version >= HttpVersion20.Value && chunked == true)
             {
-                throw new SkipTestException("Chunking is not supported on HTTP/2 and later.");
+                // Chunking is not supported on HTTP/2 and later.
+                return;
             }
 
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
@@ -2166,7 +2171,8 @@ namespace System.Net.Http.Functional.Tests
 
             if (LoopbackServerFactory.Version >= HttpVersion20.Value)
             {
-                throw new SkipTestException("Upgrade is not supported on HTTP/2 and later");
+                // Upgrade is not supported on HTTP/2 and later
+                return;
             }
 
             var clientFinished = new TaskCompletionSource<bool>();

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -21,6 +21,7 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandler_HttpClientMiniStress_NoVersion(ITestOutputHelper output) : base(output) { }
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         [InlineData(1000000)]
         public void CreateAndDestroyManyClients(int numClients)
         {
@@ -49,6 +50,7 @@ namespace System.Net.Http.Functional.Tests
         public SocketsHttpHandler_HttpClientMiniStress_Http11(ITestOutputHelper output) : base(output) { }
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         [MemberData(nameof(PostStressOptions))]
         public async Task ManyClients_ManyPosts_Async(int numRequests, int dop, int numBytes)
         {
@@ -102,6 +104,7 @@ namespace System.Net.Http.Functional.Tests
                 });
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         [MemberData(nameof(GetStressOptions))]
         public void SingleClient_ManyGets_Sync(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -116,6 +119,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         [MemberData(nameof(GetStressOptions))]
         public async Task SingleClient_ManyGets_Async(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -127,6 +131,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         [MemberData(nameof(GetStressOptions))]
         public void ManyClients_ManyGets(int numRequests, int dop, HttpCompletionOption completionOption)
         {
@@ -141,6 +146,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         [InlineData(5000)]
         public async Task MakeAndFaultManyRequests(int numRequests)
         {
@@ -217,6 +223,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [ConditionalFact(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
+        [OuterLoop]
         public async Task UnreadResponseMessage_Collectible()
         {
             await LoopbackServerFactory.CreateServerAsync(async (server, url) =>


### PR DESCRIPTION
There are a bunch of tests that don't make sense on HTTP/2, but end up executing because of how our tests are structured.  As a result, the test itself checks whether HTTP/2 is applicable and bails if it isn't.  Currently some of these are bailing by throwing a SkipTestException, which results in a message being output on the console.  Such messages are meant for tests that can be run in some circumstances, e.g. a stress test that needs an environment variable set.  They aren't needed when a test is never going to run.

I also marked the stress tests as outerloop so they don't spam the console when just running innerloop.

Before:
```
    Discovering: System.Net.Http.Functional.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Http.Functional.Tests (found 653 of 991 test cases)
    Starting:    System.Net.Http.Functional.Tests (parallel test collections = on, max threads = 12)
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClient_SelectedSites_Test.RetrieveSite_Succeeds [SKIP]
        Condition(s) not met: "IsSelectedSitesTestEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClient_SelectedSites_Test.RetrieveSite_Debug_Helper [SKIP]
        Condition(s) not met: "IsSelectedSitesTestEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_NoVersion.MakeAndFaultManyRequests [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_NoVersion.CreateAndDestroyManyClients [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_NoVersion.ManyClients_ManyGets [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_NoVersion.SingleClient_ManyGets_Sync [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_NoVersion.UnreadResponseMessage_Collectible [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_NoVersion.SingleClient_ManyGets_Async [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http2.UnreadResponseMessage_Collectible [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http2.ManyClients_ManyGets [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http2.SingleClient_ManyGets_Async [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http2.MakeAndFaultManyRequests [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http2.SingleClient_ManyGets_Sync [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http11.UnreadResponseMessage_Collectible [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http11.MakeAndFaultManyRequests [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http11.ManyClients_ManyPosts_Async [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http11.SingleClient_ManyGets_Async [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http11.SingleClient_ManyGets_Sync [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientMiniStress_Http11.ManyClients_ManyGets [SKIP]
        Condition(s) not met: "IsStressModeEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_ClientEKUServerAuth_Fails [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_NoEKUServerAuth_Ok [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_NoEKUClientAuth_Ok [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_ServerEKUClientAuth_Fails [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Credentials_DomainJoinedServerUsesKerberos_UseIpAddressAndHostHeader_Success [SKIP]
        Condition(s) not met: "IsDomainJoinedServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "\n ", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "\n ", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "\n\t", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Proxy_DomainJoinedProxyServerUsesKerberos_Success [SKIP]
        Condition(s) not met: "IsDomainJoinedServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "\n\t", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "\n    ", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\n", fold: "\n    ", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "\r\n ", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "\r\n ", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "\r\n\t", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "\r\n\t", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "\r\n    ", dribble: False) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_ManyDifferentResponseHeaders_ParsedCorrectly(newline: "\r\n", fold: "\r\n    ", dribble: True) [SKIP]
        Folding is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http2.MaxConnectionsPerServer_WaitingConnectionsAreCancelable [SKIP]
        Not supported on HTTP/2 and later
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Credentials_ServerUsesWindowsAuthentication_Success [SKIP]
        Condition(s) not met: "IsWindowsServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Credentials_DomainJoinedServerUsesKerberos_Success [SKIP]
        Condition(s) not met: "IsDomainJoinedServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.ReadAsStreamAsync_HandlerProducesWellBehavedResponseStream(chunked: True) [SKIP]
        Chunking is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(address: 127.0.0.1, useSsl: True) [SKIP]
        Host header is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(address: 127.0.0.1, useSsl: False) [SKIP]
        Host header is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(address: ::1, useSsl: True) [SKIP]
        Host header is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_SecureAndNonSecureIPBasedUri_CorrectlyFormatted(address: ::1, useSsl: False) [SKIP]
        Host header is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_NonTraditionalChunkSizes_Accepted [SKIP]
        Chunking is not supported on HTTP/2 and later.
      System.Net.Http.Functional.Tests.SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.SendAsync_101SwitchingProtocolsResponse_Success [SKIP]
        Upgrade is not supported on HTTP/2 and later
    Finished:    System.Net.Http.Functional.Tests
```

After:
```
    Discovering: System.Net.Http.Functional.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Http.Functional.Tests (found 636 of 991 test cases)
    Starting:    System.Net.Http.Functional.Tests (parallel test collections = on, max threads = 12)
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_ClientEKUServerAuth_Fails [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_NoEKUServerAuth_Ok [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_NoEKUClientAuth_Ok [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientEKUTest.HttpClient_ServerEKUClientAuth_Fails [SKIP]
        Condition(s) not met: "CanTestCertificates"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClient_SelectedSites_Test.RetrieveSite_Succeeds [SKIP]
        Condition(s) not met: "IsSelectedSitesTestEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClient_SelectedSites_Test.RetrieveSite_Debug_Helper [SKIP]
        Condition(s) not met: "IsSelectedSitesTestEnabled"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Credentials_DomainJoinedServerUsesKerberos_UseIpAddressAndHostHeader_Success [SKIP]
        Condition(s) not met: "IsDomainJoinedServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Proxy_DomainJoinedProxyServerUsesKerberos_Success [SKIP]
        Condition(s) not met: "IsDomainJoinedServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Credentials_ServerUsesWindowsAuthentication_Success [SKIP]
        Condition(s) not met: "IsWindowsServerAvailable"
      System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Authentication_Test.Credentials_DomainJoinedServerUsesKerberos_Success [SKIP]
        Condition(s) not met: "IsDomainJoinedServerAvailable"
    Finished:    System.Net.Http.Functional.Tests
```