### PR TITLE
Fix the stackoverflow test output checks

### DIFF
--- a/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflow.cs
+++ b/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflow.cs
@@ -111,21 +111,24 @@ namespace TestStackOverflow
             }
         }
 
+        static void SecondaryThreadStart(bool smallframe)
+        {
+            if (smallframe)
+            {
+                InfiniteRecursionA();
+            }
+            else
+            {
+                InfiniteRecursionA2();
+            }
+        }
+
         static void SecondaryThreadsTest(bool smallframe)
         {
             Thread[] threads = new Thread[32];
             for (int i = 0; i < threads.Length; i++)
             {
-                threads[i] = new Thread(() => {
-                    if (smallframe)
-                    {
-                        InfiniteRecursionA();
-                    }
-                    else
-                    {
-                        InfiniteRecursionA2();
-                    }
-                });
+                threads[i] = new Thread(() => SecondaryThreadStart(smallframe));
                 threads[i].Start();
             }
 

--- a/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflow.cs
+++ b/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflow.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
+using System.Runtime.CompilerServices;
 
 namespace TestStackOverflow
 {
@@ -67,51 +68,47 @@ namespace TestStackOverflow
     }
     class Program
     {
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void InfiniteRecursionA()
         {
             InfiniteRecursionB();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void InfiniteRecursionB()
         {
             InfiniteRecursionC();
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void InfiniteRecursionC()
         {
             InfiniteRecursionA();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void InfiniteRecursionA2()
         {
             LargeStruct65536 s;
             InfiniteRecursionB2();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void InfiniteRecursionB2()
         {
             LargeStruct65536 s;
             InfiniteRecursionC2();
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         static void InfiniteRecursionC2()
         {
             LargeStruct65536 s;
             InfiniteRecursionA2();
         }
 
-        static void MainThreadTest(bool smallframe)
-        {
-            if (smallframe)
-            {
-                InfiniteRecursionA();
-            }
-            else
-            {
-                InfiniteRecursionA2();
-            }
-        }
-
-        static void SecondaryThreadStart(bool smallframe)
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void Test(bool smallframe)
         {
             if (smallframe)
             {
@@ -128,7 +125,7 @@ namespace TestStackOverflow
             Thread[] threads = new Thread[32];
             for (int i = 0; i < threads.Length; i++)
             {
-                threads[i] = new Thread(() => SecondaryThreadStart(smallframe));
+                threads[i] = new Thread(() => Test(smallframe));
                 threads[i].Start();
             }
 
@@ -147,7 +144,7 @@ namespace TestStackOverflow
             }
             else if (args[1] == "main")
             {
-                MainThreadTest(smallframe);
+                Test(smallframe);
             }
         }
     }

--- a/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -77,6 +77,12 @@ namespace TestStackOverflow
                     return false;
                 }
 
+                if (!lines.Exists(elem => elem.EndsWith("TestStackOverflow.Program.Test(Boolean)")))
+                {
+                    Console.WriteLine("Missing \"Test\" method frame");
+                    return false;
+                }
+
                 if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.InfiniteRecursionA()")))
                 {
                     Console.WriteLine("Missing \"InfiniteRecursionA\" method frame");
@@ -112,9 +118,9 @@ namespace TestStackOverflow
                     return false;
                 }
 
-                if (!lines.Exists(elem => elem.EndsWith("TestStackOverflow.Program.MainThreadTest(Boolean)")))
+                if (!lines.Exists(elem => elem.EndsWith("TestStackOverflow.Program.Test(Boolean)")))
                 {
-                    Console.WriteLine("Missing \"MainThreadTest\" method frame");
+                    Console.WriteLine("Missing \"Test\" method frame");
                     return false;
                 }
 
@@ -147,9 +153,9 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow", "smallframe secondary", out lines))
             {
-                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.SecondaryThreadStart(Boolean)")))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.Test(Boolean)")))
                 {
-                    Console.WriteLine("Missing \"TestStackOverflow.Program.SecondaryThreadStart\" method frame");
+                    Console.WriteLine("Missing \"TestStackOverflow.Program.Test\" method frame");
                     return false;
                 }
 
@@ -182,9 +188,9 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow", "largeframe secondary", out lines))
             {
-                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.SecondaryThreadStart(Boolean)")))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.Test(Boolean)")))
                 {
-                    Console.WriteLine("Missing \"TestStackOverflow.Program.SecondaryThreadStart\" method frame");
+                    Console.WriteLine("Missing \"TestStackOverflow.Program.Test\" method frame");
                     return false;
                 }
 

--- a/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
+++ b/src/coreclr/tests/src/baseservices/exceptions/stackoverflow/stackoverflowtester.cs
@@ -147,9 +147,9 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow", "smallframe secondary", out lines))
             {
-                if (!lines[lines.Count - 1].EndsWith("at System.Threading.ThreadHelper.ThreadStart()"))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.SecondaryThreadStart(Boolean)")))
                 {
-                    Console.WriteLine("Missing \"System.Threading.ThreadHelper.ThreadStart\" method frame at the last line");
+                    Console.WriteLine("Missing \"TestStackOverflow.Program.SecondaryThreadStart\" method frame");
                     return false;
                 }
 
@@ -182,9 +182,9 @@ namespace TestStackOverflow
             List<string> lines;
             if (TestStackOverflow("stackoverflow", "largeframe secondary", out lines))
             {
-                if (!lines[lines.Count - 1].EndsWith("at System.Threading.ThreadHelper.ThreadStart()"))
+                if (!lines.Exists(elem => elem.EndsWith("at TestStackOverflow.Program.SecondaryThreadStart(Boolean)")))
                 {
-                    Console.WriteLine("Missing \"System.Threading.ThreadHelper.ThreadStart\" method frame at the last line");
+                    Console.WriteLine("Missing \"TestStackOverflow.Program.SecondaryThreadStart\" method frame");
                     return false;
                 }
 


### PR DESCRIPTION
The System.Threading.ThreadHelper.ThreadStart can tail call the
System.Threading.ExecutionContext.RunInternal (and some other methods in
the runtime as well) and thus it would not be visible on the stack
trace. So the fix is to not to look at the System.Threading.ThreadHelper.ThreadStart
in the stack trace and use a method in the test itself instead. Since
the test is compiled with optimizations disabled, JIT should not do any
"interesting" things.

Close #35878