### PR TITLE
Fix a potential memory leak due to EventPipe buffer allocation

### DIFF
--- a/src/coreclr/src/vm/eventpipebuffer.cpp
+++ b/src/coreclr/src/vm/eventpipebuffer.cpp
@@ -31,7 +31,13 @@ EventPipeBuffer::EventPipeBuffer(unsigned int bufferSize, EventPipeThread* pWrit
     // to servicing releases. We may come back in the future to reassess this and potentially improve
     // the throughput via more performant solution afterwards.
     m_pBuffer = (BYTE*)ClrVirtualAlloc(NULL, bufferSize, MEM_COMMIT, PAGE_READWRITE);
+
+    // memset may be unnecessary here because VirtualAlloc with MEM_COMMIT zero-initializes the pages and mmap also zero-initializes
+    // if MAP_UNINITIALIZED isn't passed (which ClrVirtualAlloc doesn't). If this memset ends up being a perf cost in future investigations
+    // we may remove this. But for risk mitigation we're leaving it as-is.
+    // (See https://github.com/dotnet/runtime/pull/35924#discussion_r421282564 for discussion on this)
     memset(m_pBuffer, 0, bufferSize);
+    
     m_pLimit = m_pBuffer + bufferSize;
     m_pCurrent = GetNextAlignedAddress(m_pBuffer);
 

--- a/src/coreclr/src/vm/eventpipebuffer.cpp
+++ b/src/coreclr/src/vm/eventpipebuffer.cpp
@@ -23,7 +23,7 @@ EventPipeBuffer::EventPipeBuffer(unsigned int bufferSize, EventPipeThread* pWrit
     m_state = EventPipeBufferState::WRITABLE;
     m_pWriterThread = pWriterThread;
     m_eventSequenceNumber = eventSequenceNumber;
-    m_pBuffer = new BYTE[bufferSize];
+    m_pBuffer = (BYTE*)ClrVirtualAlloc(NULL, bufferSize, MEM_COMMIT, PAGE_READWRITE);
     memset(m_pBuffer, 0, bufferSize);
     m_pLimit = m_pBuffer + bufferSize;
     m_pCurrent = GetNextAlignedAddress(m_pBuffer);
@@ -47,7 +47,7 @@ EventPipeBuffer::~EventPipeBuffer()
     }
     CONTRACTL_END;
 
-    delete[] m_pBuffer;
+    ClrVirtualFree(m_pBuffer, 0, MEM_RELEASE);
 }
 
 bool EventPipeBuffer::WriteEvent(Thread *pThread, EventPipeSession &session, EventPipeEvent &event, EventPipeEventPayload &payload, LPCGUID pActivityId, LPCGUID pRelatedActivityId, StackContents *pStack)

--- a/src/coreclr/src/vm/eventpipebuffer.cpp
+++ b/src/coreclr/src/vm/eventpipebuffer.cpp
@@ -23,6 +23,13 @@ EventPipeBuffer::EventPipeBuffer(unsigned int bufferSize, EventPipeThread* pWrit
     m_state = EventPipeBufferState::WRITABLE;
     m_pWriterThread = pWriterThread;
     m_eventSequenceNumber = eventSequenceNumber;
+    // Use ClrVirtualAlloc instead of malloc to allocate buffer to avoid potential internal fragmentation in the native CRT heap.
+    // (See https://github.com/dotnet/runtime/pull/35924 and https://github.com/microsoft/ApplicationInsights-dotnet/issues/1678 for more details)
+    //
+    // This fix does cause a little bit of performance regression (1-2%) in throughput,
+    // but within acceptable boundaries, while minimizing the risk of the fix to be backported
+    // to servicing releases. We may come back in the future to reassess this and potentially improve
+    // the throughput via more performant solution afterwards.
     m_pBuffer = (BYTE*)ClrVirtualAlloc(NULL, bufferSize, MEM_COMMIT, PAGE_READWRITE);
     memset(m_pBuffer, 0, bufferSize);
     m_pLimit = m_pBuffer + bufferSize;

--- a/src/coreclr/src/vm/eventpipebuffermanager.cpp
+++ b/src/coreclr/src/vm/eventpipebuffermanager.cpp
@@ -168,6 +168,9 @@ EventPipeBuffer* EventPipeBufferManager::AllocateBufferForThread(EventPipeThread
         const unsigned int maxBufferSize = 1024 * 1024;
         bufferSize = Min(bufferSize, maxBufferSize);
 
+        // Make the buffer size fit into with pagesize-aligned block.
+        bufferSize = bufferSize + (g_SystemInfo.dwAllocationGranularity - (bufferSize % g_SystemInfo.dwAllocationGranularity));
+
         // EX_TRY is used here as opposed to new (nothrow) because
         // the constructor also allocates a private buffer, which
         // could throw, and cannot be easily checked

--- a/src/coreclr/src/vm/eventpipebuffermanager.cpp
+++ b/src/coreclr/src/vm/eventpipebuffermanager.cpp
@@ -168,8 +168,8 @@ EventPipeBuffer* EventPipeBufferManager::AllocateBufferForThread(EventPipeThread
         const unsigned int maxBufferSize = 1024 * 1024;
         bufferSize = Min(bufferSize, maxBufferSize);
 
-        // Make the buffer size fit into with pagesize-aligned block.
-        bufferSize = bufferSize + (g_SystemInfo.dwAllocationGranularity - (bufferSize % g_SystemInfo.dwAllocationGranularity));
+        // Make the buffer size fit into with pagesize-aligned block, since ClrVirtualAlloc expects page-aligned sizes to be passed as arguments (see ctor of EventPipeBuffer)
+        bufferSize = (bufferSize + g_SystemInfo.dwAllocationGranularity - 1) & ~static_cast<unsigned int>(g_SystemInfo.dwAllocationGranularity - 1);
 
         // EX_TRY is used here as opposed to new (nothrow) because
         // the constructor also allocates a private buffer, which


### PR DESCRIPTION
This fixes a potential memory leak due to EventPipe buffer allocation causing internal fragmentation within glibc's arenas. It was originally reported in https://github.com/microsoft/ApplicationInsights-dotnet/issues/1678. glibc maintains a pool of memory called arenas per-thread that it uses to allocate blocks of memory requested by `malloc`. EventPipe may allocate from many threads, and when it does that, it end up causing glibc to commit more memory than what the runtime thinks it committed. 

The fix is quite simple - change `malloc` to `ClrVirtualAlloc` which uses `mmap`. I verified the fix does not introduce a significant performant with benchmarks.

The fix was tested against the repro provided by the customer who reported the issue, and was verified that it fixes the issue (more details here: https://github.com/microsoft/ApplicationInsights-dotnet/issues/1678#issuecomment-610727099).

