### PR TITLE
Add an atexit handler to bypass calls into ERR_ string routines.

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.h
@@ -6,6 +6,11 @@
 #include <stdint.h>
 #include "opensslshim.h"
 
+#ifdef NEED_OPENSSL_1_1
+extern int volatile g_str_read_count;
+extern int volatile g_err_unloaded;
+#endif
+
 /*
 Shims the ERR_clear_error method.
 */

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.h
@@ -7,7 +7,7 @@
 #include "opensslshim.h"
 
 #ifdef NEED_OPENSSL_1_1
-extern int volatile g_str_read_count;
+extern pthread_mutex_t g_err_mutex;
 extern int volatile g_err_unloaded;
 #endif
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_err.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include "opensslshim.h"
 
+#include <pthread.h>
+
 #ifdef NEED_OPENSSL_1_1
 extern pthread_mutex_t g_err_mutex;
 extern int volatile g_err_unloaded;


### PR DESCRIPTION
This works around Ubuntu's apparent lack of NO_ATEXIT support in their
build of OpenSSL.

Fixes #34231.