### PR TITLE
Apply CA1835 - Prefer memory overloads for Stream.ReadAsync/WriteAsync

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/BufferedReadStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/BufferedReadStream.cs
@@ -97,7 +97,7 @@ namespace System.Net
 
         private async Task<int> ReadMoreAsync(int bytesAlreadyRead, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            int returnValue = await base.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+            int returnValue = await base.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
             return bytesAlreadyRead + returnValue;
         }
 

--- a/src/libraries/System.Private.Xml.Linq/tests/misc/LoadSaveAsyncTests.cs
+++ b/src/libraries/System.Private.Xml.Linq/tests/misc/LoadSaveAsyncTests.cs
@@ -415,6 +415,12 @@ namespace CoreXml.Test.XLinq
             Assert.True(_isAsync, "Stream is not in asynchronous mode when asynchronous Write is called");
             return Task.CompletedTask;
         }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        {
+            Assert.True(_isAsync, "Stream is not in asynchronous mode when asynchronous Write is called");
+            return default;
+        }
     }
 
     public class CheckSyncAsyncStream : Stream

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -645,7 +645,7 @@ namespace System.Xml
                         if (bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await writer.WriteAsync(bufChars, 1, bufPos - 1).ConfigureAwait(false);
+                            await writer.WriteAsync(bufChars.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
                         }
                     }
                 }
@@ -688,13 +688,13 @@ namespace System.Xml
                 bufBytesUsed += bEnc;
                 if (bufBytesUsed >= (bufBytes.Length - 16))
                 {
-                    await stream.WriteAsync(bufBytes, 0, bufBytesUsed).ConfigureAwait(false);
+                    await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
                     bufBytesUsed = 0;
                 }
             }
             if (writeAllToStream && bufBytesUsed > 0)
             {
-                await stream.WriteAsync(bufBytes, 0, bufBytesUsed).ConfigureAwait(false);
+                await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
                 bufBytesUsed = 0;
             }
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -624,7 +624,7 @@ namespace System.Xml
                     if (bufPos - 1 > 0)
                     {
                         Debug.Assert(stream != null);
-                        await stream.WriteAsync(bufBytes, 1, bufPos - 1).ConfigureAwait(false);
+                        await stream.WriteAsync(bufBytes.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
                     }
 <# } else { #>
                     Debug.Assert(stream != null || writer != null);
@@ -656,7 +656,7 @@ namespace System.Xml
                         if (bufPos - 1 > 0)
                         {
                             // Write text to TextWriter
-                            await writer.WriteAsync(<#= BufferName #>, 1, bufPos - 1).ConfigureAwait(false);
+                            await writer.WriteAsync(<#= BufferName #>.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
                         }
                     }
 <# } #>
@@ -711,13 +711,13 @@ namespace System.Xml
                 bufBytesUsed += bEnc;
                 if (bufBytesUsed >= (bufBytes.Length - 16))
                 {
-                    await stream.WriteAsync(bufBytes, 0, bufBytesUsed).ConfigureAwait(false);
+                    await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
                     bufBytesUsed = 0;
                 }
             }
             if (writeAllToStream && bufBytesUsed > 0)
             {
-                await stream.WriteAsync(bufBytes, 0, bufBytesUsed).ConfigureAwait(false);
+                await stream.WriteAsync(bufBytes.AsMemory(0, bufBytesUsed)).ConfigureAwait(false);
                 bufBytesUsed = 0;
             }
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -975,7 +975,7 @@ namespace System.Xml
             _ps.bytePos = 0;
             while (_ps.bytesUsed < 4 && _ps.bytes.Length - _ps.bytesUsed > 0)
             {
-                int read = await stream.ReadAsync(_ps.bytes, _ps.bytesUsed, _ps.bytes.Length - _ps.bytesUsed).ConfigureAwait(false);
+                int read = await stream.ReadAsync(_ps.bytes.AsMemory(_ps.bytesUsed)).ConfigureAwait(false);
                 if (read == 0)
                 {
                     _ps.isStreamEof = true;
@@ -1192,7 +1192,7 @@ namespace System.Xml
                     // read new bytes
                     if (_ps.bytePos == _ps.bytesUsed && _ps.bytes.Length - _ps.bytesUsed > 0)
                     {
-                        int read = await _ps.stream.ReadAsync(_ps.bytes, _ps.bytesUsed, _ps.bytes.Length - _ps.bytesUsed).ConfigureAwait(false);
+                        int read = await _ps.stream.ReadAsync(_ps.bytes.AsMemory(_ps.bytesUsed)).ConfigureAwait(false);
                         if (read == 0)
                         {
                             _ps.isStreamEof = true;
@@ -1214,7 +1214,7 @@ namespace System.Xml
             else if (_ps.textReader != null)
             {
                 // read chars
-                charsRead = await _ps.textReader.ReadAsync(_ps.chars, _ps.charsUsed, _ps.chars.Length - _ps.charsUsed - 1).ConfigureAwait(false);
+                charsRead = await _ps.textReader.ReadAsync(_ps.chars.AsMemory(_ps.charsUsed, _ps.chars.Length - _ps.charsUsed - 1)).ConfigureAwait(false);
                 _ps.charsUsed += charsRead;
             }
             else

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -552,7 +552,7 @@ namespace System.Xml
                     if (bufPos - 1 > 0)
                     {
                         Debug.Assert(stream != null);
-                        await stream.WriteAsync(bufBytes, 1, bufPos - 1).ConfigureAwait(false);
+                        await stream.WriteAsync(bufBytes.AsMemory(1, bufPos - 1)).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/libraries/System.Private.Xml/tests/XmlWriter/DisposeTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlWriter/DisposeTests.cs
@@ -255,6 +255,11 @@ namespace System.Xml.Tests
             {
                 return Task.CompletedTask;
             }
+
+            public override Task WriteAsync(ReadOnlyMemory<char> buffer, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
         }
 
         internal class AsyncOnlyStream : MemoryStream
@@ -278,6 +283,7 @@ namespace System.Xml.Tests
             {
                 return Task.CompletedTask;
             }
+
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
             {
                 return default;

--- a/src/libraries/System.Private.Xml/tests/XmlWriter/DisposeTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlWriter/DisposeTests.cs
@@ -278,6 +278,10 @@ namespace System.Xml.Tests
             {
                 return Task.CompletedTask;
             }
+            public override ValueTask WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+            {
+                return default;
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
+++ b/src/libraries/System.Runtime.WindowsRuntime/src/System/IO/StreamOperationsImplementation.cs
@@ -111,7 +111,7 @@ namespace System.IO
                     try
                     {
                         // Read asynchronously:
-                        bytesRead = await stream.ReadAsync(data!, offset + bytesCompleted, bytesRequested - bytesCompleted, cancelToken)
+                        bytesRead = await stream.ReadAsync(data!.AsMemory(offset + bytesCompleted, bytesRequested - bytesCompleted), cancelToken)
                                                 .ConfigureAwait(continueOnCapturedContext: false);
 
                         // We will continue here on a different thread when read async completed:
@@ -181,7 +181,7 @@ namespace System.IO
 
                     int bytesToWrite = (int)buffer.Length;
 
-                    await stream.WriteAsync(data, offset, bytesToWrite, cancelToken).ConfigureAwait(continueOnCapturedContext: false);
+                    await stream.WriteAsync(data.AsMemory(offset, bytesToWrite), cancelToken).ConfigureAwait(continueOnCapturedContext: false);
 
                     if (progressListener != null)
                         progressListener.Report((uint)bytesToWrite);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -675,9 +675,13 @@ namespace System.Text.Json
                     Debug.Assert(rented.Length >= JsonConstants.Utf8Bom.Length);
 
                     lastRead = await stream.ReadAsync(
+#if BUILDING_INBOX_LIBRARY
+                        rented.AsMemory(written, utf8BomLength - written),
+#else
                         rented,
                         written,
                         utf8BomLength - written,
+#endif
                         cancellationToken).ConfigureAwait(false);
 
                     written += lastRead;
@@ -702,9 +706,13 @@ namespace System.Text.Json
                     }
 
                     lastRead = await stream.ReadAsync(
+#if BUILDING_INBOX_LIBRARY
+                        rented.AsMemory(written),
+#else
                         rented,
                         written,
                         rented.Length - written,
+#endif
                         cancellationToken).ConfigureAwait(false);
 
                     written += lastRead;

--- a/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
+++ b/src/libraries/System.Windows.Extensions/src/System/Media/SoundPlayer.cs
@@ -489,7 +489,7 @@ namespace System.Media
 
                 _streamData = new byte[BlockSize];
 
-                int readBytes = await _stream.ReadAsync(_streamData, _currentPos, BlockSize, cancellationToken).ConfigureAwait(false);
+                int readBytes = await _stream.ReadAsync(_streamData.AsMemory(_currentPos, BlockSize), cancellationToken).ConfigureAwait(false);
                 int totalBytes = readBytes;
 
                 while (readBytes > 0)
@@ -501,7 +501,7 @@ namespace System.Media
                         Array.Copy(_streamData, newData, _streamData.Length);
                         _streamData = newData;
                     }
-                    readBytes = await _stream.ReadAsync(_streamData, _currentPos, BlockSize, cancellationToken).ConfigureAwait(false);
+                    readBytes = await _stream.ReadAsync(_streamData.AsMemory(_currentPos, BlockSize), cancellationToken).ConfigureAwait(false);
                     totalBytes += readBytes;
                 }
 


### PR DESCRIPTION
The CA1835 Roslyn analyzer/fixer has been merged to dotnet/roslyn-analyzers and now the rule needs to be applied in dotnet/runtime.

> Prefer Memory<T> overloads for Stream.Read/WriteAsync https://github.com/dotnet/runtime/issues/33790