### PR TITLE
Remove unused locals in System.Private.DataContractSerialization

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ReflectionXmlFormatReader.cs
@@ -55,7 +55,7 @@ namespace System.Runtime.Serialization
             context.IncrementItemCount(memberCount);
             int memberIndex = -1;
             int firstRequiredMember;
-            bool[] requiredMembers = GetRequiredMembers(classContract, out firstRequiredMember);
+            _ = GetRequiredMembers(classContract, out firstRequiredMember);
             bool hasRequiredMembers = (firstRequiredMember < memberCount);
             int requiredIndex = hasRequiredMembers ? firstRequiredMember : -1;
             DataMember[] members = new DataMember[memberCount];

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaExporter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaExporter.cs
@@ -450,7 +450,7 @@ namespace System.Runtime.Serialization
             XmlElement isValueTypeElement = null;
             if (dataContract.BaseContract != null)
             {
-                XmlSchemaComplexContentExtension extension = CreateTypeContent(type, dataContract.BaseContract.StableName, schema);
+                _ = CreateTypeContent(type, dataContract.BaseContract.StableName, schema);
             }
             else
             {

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -119,7 +119,7 @@ namespace System.Runtime.Serialization
                         ReadClass(classContract);
                     }
 
-                    bool isFactoryType = InvokeFactoryMethod(classContract, objectId);
+                    _ = InvokeFactoryMethod(classContract, objectId);
                     if (Globals.TypeOfIDeserializationCallback.IsAssignableFrom(classContract.UnderlyingType))
                     {
                         _ilg.Call(_objectLocal, XmlFormatGeneratorStatics.OnDeserializationMethod, null);

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBufferReader.cs
@@ -491,7 +491,7 @@ namespace System.Xml
         public Guid ReadGuid()
         {
             int offset;
-            byte[] buffer = GetBuffer(ValueHandleLength.Guid, out offset);
+            _ = GetBuffer(ValueHandleLength.Guid, out offset);
             Guid guid = GetGuid(offset);
             Advance(ValueHandleLength.Guid);
             return guid;
@@ -500,7 +500,7 @@ namespace System.Xml
         public string ReadUTF8String(int length)
         {
             int offset;
-            byte[] buffer = GetBuffer(length, out offset);
+            _ = GetBuffer(length, out offset);
             char[] chars = GetCharBuffer(length);
             int charCount = GetChars(offset, length, chars);
             string value = new string(chars, 0, charCount);
@@ -844,7 +844,6 @@ namespace System.Xml
 
         public bool IsWhitespaceUnicode(int offset, int length)
         {
-            byte[] buffer = _buffer;
             for (int i = 0; i < length; i += sizeof(char))
             {
                 char ch = (char)GetInt16(offset + i);


### PR DESCRIPTION
Relates to issue #30457

Summary: 
<details>
<summary>5 unused local variables replaced with discard because of side effect; 1 removed assignment</summary>
<pre>
System\Runtime\Serialization\ReflectionXmlFormatReader.cs(58,20): warning S1481: Remove the unused local variable 'requiredMembers'.
 System\Runtime\Serialization\SchemaExporter.cs(453,50): warning S1481: Remove the unused local variable 'extension'.
 System\Runtime\Serialization\XmlFormatReaderGenerator.cs(122,26): warning S1481: Remove the unused local variable 'isFactoryType'.
 System\Xml\XmlBufferReader.cs(494,20): warning S1481: Remove the unused local variable 'buffer'.
 System\Xml\XmlBufferReader.cs(503,20): warning S1481: Remove the unused local variable 'buffer'.
 System\Xml\XmlBufferReader.cs(847,20): warning S1481: Remove the unused local variable 'buffer'.
</details>