### PR TITLE
Fix crashes when tracing enabled and Socket disposed during connect

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -690,7 +690,14 @@ namespace System.Net.Sockets
                     {
                         _acceptSocket = _currentSocket.UpdateAcceptSocket(_acceptSocket!, _currentSocket._rightEndPoint!.Create(remoteSocketAddress));
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Accepted(_acceptSocket, _acceptSocket.RemoteEndPoint, _acceptSocket.LocalEndPoint);
+                        if (NetEventSource.IsEnabled)
+                        {
+                            try
+                            {
+                                NetEventSource.Accepted(_acceptSocket, _acceptSocket.RemoteEndPoint, _acceptSocket.LocalEndPoint);
+                            }
+                            catch (ObjectDisposedException) { }
+                        }
                     }
                     else
                     {
@@ -704,7 +711,14 @@ namespace System.Net.Sockets
                     socketError = FinishOperationConnect();
                     if (socketError == SocketError.Success)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Connected(_currentSocket!, _currentSocket!.LocalEndPoint, _currentSocket.RemoteEndPoint);
+                        if (NetEventSource.IsEnabled)
+                        {
+                            try
+                            {
+                                NetEventSource.Connected(_currentSocket!, _currentSocket!.LocalEndPoint, _currentSocket.RemoteEndPoint);
+                            }
+                            catch (ObjectDisposedException) { }
+                        }
 
                         // Mark socket connected.
                         _currentSocket!.SetToConnected();


### PR DESCRIPTION
Given the right (wrong) sequence of events, if tracing is enabled and a Socket is disposed of during a connect operation, the tracing code might try to access properties on the Socket that throw ObjectDisposedException, and these exceptions may propagate and crash the process.

cc: @davidsh

```
Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
  Object name: 'System.Net.Sockets.Socket'.
     at System.Net.Sockets.Socket.ThrowObjectDisposedException() in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 5267
     at System.Net.Sockets.Socket.ThrowIfDisposed() in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 5262
     at System.Net.Sockets.Socket.get_LocalEndPoint() in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs:line 305
     at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationSyncSuccess(Int32 bytesTransferred, SocketFlags flags) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs:line 707
     at System.Net.Sockets.SocketAsyncEventArgs.FinishOperationAsyncSuccess(Int32 bytesTransferred, SocketFlags flags) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs:line 771
     at System.Net.Sockets.SocketAsyncEventArgs.CompletionCallback(Int32 bytesTransferred, SocketFlags flags, SocketError socketError) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs:line 374
     at System.Net.Sockets.SocketAsyncEventArgs.ConnectCompletionCallback(SocketError socketError) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs:line 81
     at System.Net.Sockets.SocketAsyncContext.ConnectOperation.InvokeCallback(Boolean allowPooling) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 628
     at System.Net.Sockets.SocketAsyncContext.OperationQueue`1.ProcessAsyncOperation(TOperation op) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 915
     at System.Net.Sockets.SocketAsyncContext.ProcessAsyncWriteOperation(WriteOperation op) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 1329
     at System.Net.Sockets.SocketAsyncContext.WriteOperation.System.Threading.IThreadPoolWorkItem.Execute() in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 349
     at System.Net.Sockets.SocketAsyncContext.AsyncOperation.Process() in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 290
     at System.Net.Sockets.SocketAsyncContext.HandleEvents(SocketEvents events) in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs:line 2041
     at System.Net.Sockets.SocketAsyncEngine.System.Threading.IThreadPoolWorkItem.Execute() in /home/stephentoub/repos/runtime/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs:line 422
     at System.Threading.ThreadPoolWorkQueue.Dispatch() in /home/stephentoub/repos/runtime/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs:line 659
     at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback() in /home/stephentoub/repos/runtime/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs:line 29
```