### PR TITLE
[interp] Add x86 support

### DIFF
--- a/src/mono/mono/metadata/object-offsets.h
+++ b/src/mono/mono/metadata/object-offsets.h
@@ -299,6 +299,14 @@ DECL_OFFSET(CallContext, stack)
 #endif
 
 #if defined(TARGET_X86)
+DECL_OFFSET(CallContext, eax)
+DECL_OFFSET(CallContext, edx)
+DECL_OFFSET(CallContext, fret)
+DECL_OFFSET(CallContext, stack_size)
+DECL_OFFSET(CallContext, stack)
+#endif
+
+#if defined(TARGET_X86)
 DECL_OFFSET(GSharedVtCallInfo, stack_usage)
 DECL_OFFSET(GSharedVtCallInfo, vret_slot)
 DECL_OFFSET(GSharedVtCallInfo, vret_arg_slot)

--- a/src/mono/mono/mini/exceptions-x86.c
+++ b/src/mono/mono/mini/exceptions-x86.c
@@ -1242,3 +1242,15 @@ mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 
 	MONO_CONTEXT_SET_IP (ctx, func);
 }
+
+void
+mono_arch_undo_ip_adjustment (MonoContext *ctx)
+{
+	ctx->eip++;
+}
+
+void
+mono_arch_do_ip_adjustment (MonoContext *ctx)
+{
+	ctx->eip--;
+}

--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -181,7 +181,11 @@ typedef struct _StackFragment StackFragment;
 struct _StackFragment {
 	guint8 *pos, *end;
 	struct _StackFragment *next;
-	double data [1];
+#if SIZEOF_VOID_P == 4
+	/* Align data field to MINT_VT_ALIGNMENT */
+	gint32 pad;
+#endif
+	double data [MONO_ZERO_LEN_ARRAY];
 };
 
 typedef struct {

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2482,6 +2482,12 @@ interp_transform_call (TransformData *td, MonoMethod *method, MonoMethod *target
 			td->last_ins->data [0] = get_data_item_index (td, (void *)csignature);
 		} else if (calli) {
 			td->last_ins->data [0] = get_data_item_index (td, (void *)csignature);
+#ifdef TARGET_X86
+			/* Windows not tested/supported yet */
+			if (td->last_ins->opcode == MINT_CALLI_NAT)
+				g_assertf (csignature->call_convention == MONO_CALL_DEFAULT || csignature->call_convention == MONO_CALL_C, "Interpreter supports only cdecl pinvoke on x86");
+#endif
+
 			if (op != -1) {
 				td->last_ins->data[1] = op;
 				if (td->last_ins->opcode == MINT_CALLI_NAT_FAST)

--- a/src/mono/mono/mini/mini-x86.c
+++ b/src/mono/mono/mini/mini-x86.c
@@ -567,6 +567,112 @@ static gboolean storage_in_ireg (ArgStorage storage)
 	return (storage == ArgInIReg || storage == ArgValuetypeInReg);
 }
 
+static int
+arg_need_temp (ArgInfo *ainfo)
+{
+	/*
+	 * We always fetch the double value from the fpstack. In that case, we
+	 * need to have a separate tmp that is the double value casted to float
+	 */
+	if (ainfo->storage == ArgOnFloatFpStack)
+		return sizeof (float);
+	return 0;
+}
+
+static gpointer
+arg_get_storage (CallContext *ccontext, ArgInfo *ainfo)
+{
+	switch (ainfo->storage) {
+		case ArgOnStack:
+			return ccontext->stack + ainfo->offset;
+		case ArgOnDoubleFpStack:
+			return &ccontext->fret;
+		case ArgInIReg:
+			/* If pair, the storage is for EDX:EAX */
+			return &ccontext->eax;
+		default:
+			g_error ("Arg storage type not yet supported");
+        }
+}
+
+static void
+arg_get_val (CallContext *ccontext, ArgInfo *ainfo, gpointer dest)
+{
+	g_assert (ainfo->storage == ArgOnFloatFpStack);
+
+	*(float*) dest = (float)ccontext->fret;
+}
+
+void
+mono_arch_set_native_call_context_args (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
+{
+	CallInfo *cinfo = get_call_info (NULL, sig);
+	MonoEECallbacks *interp_cb = mini_get_interp_callbacks ();
+	gpointer storage;
+	ArgInfo *ainfo;
+
+	memset (ccontext, 0, sizeof (CallContext));
+
+	ccontext->stack_size = ALIGN_TO (cinfo->stack_usage, MONO_ARCH_FRAME_ALIGNMENT);
+	if (ccontext->stack_size)
+		ccontext->stack = (guint8*)g_calloc (1, ccontext->stack_size);
+
+	if (sig->ret->type != MONO_TYPE_VOID) {
+		ainfo = &cinfo->ret;
+		if (ainfo->storage == ArgOnStack) {
+			/* This is a value type return. The pointer to vt storage is pushed as first argument */
+			g_assert (ainfo->offset == 0);
+			g_assert (ainfo->nslots == 1);
+			storage = interp_cb->frame_arg_to_storage ((MonoInterpFrameHandle)frame, sig, -1);
+			*(host_mgreg_t*)ccontext->stack = (host_mgreg_t)storage;
+		}
+	}
+
+	g_assert (!sig->hasthis);
+
+	for (int i = 0; i < sig->param_count; i++) {
+		ainfo = &cinfo->args [i];
+
+		storage = arg_get_storage (ccontext, ainfo);
+
+		interp_cb->frame_arg_to_data ((MonoInterpFrameHandle)frame, sig, i, storage);
+	}
+
+	g_free (cinfo);
+}
+
+void
+mono_arch_get_native_call_context_ret (CallContext *ccontext, gpointer frame, MonoMethodSignature *sig)
+{
+	const MonoEECallbacks *interp_cb;
+	CallInfo *cinfo;
+	ArgInfo *ainfo;
+	gpointer storage;
+
+	/* No return value */
+	if (sig->ret->type == MONO_TYPE_VOID)
+		return;
+
+	interp_cb = mini_get_interp_callbacks ();
+	cinfo = get_call_info (NULL, sig);
+	ainfo = &cinfo->ret;
+
+	/* Check if return value was stored directly at address passed in reg */
+	if (cinfo->ret.storage != ArgOnStack) {
+		int temp_size = arg_need_temp (ainfo);
+
+		if (temp_size) {
+			storage = alloca (temp_size);
+			arg_get_val (ccontext, ainfo, storage);
+		} else {
+			storage = arg_get_storage (ccontext, ainfo);
+		}
+		interp_cb->data_to_frame_arg ((MonoInterpFrameHandle)frame, sig, -1, storage);
+	}
+
+	g_free (cinfo);
+}
+
 /*
  * mono_arch_get_argument_info:
  * @csig:  a method signature

--- a/src/mono/mono/mini/mini-x86.h
+++ b/src/mono/mono/mini/mini-x86.h
@@ -204,6 +204,10 @@ typedef struct {
 #define MONO_ARCH_HAVE_GET_TRAMPOLINES 1
 #define MONO_ARCH_HAVE_GENERAL_RGCTX_LAZY_FETCH_TRAMPOLINE 1
 
+#define MONO_ARCH_INTERPRETER_SUPPORTED 1
+#define MONO_ARCH_HAVE_INTERP_NATIVE_TO_MANAGED 1
+#define MONO_ARCH_HAVE_INTERP_PINVOKE_TRAMP 1
+
 #define MONO_ARCH_HAVE_CMOV_OPS 1
 
 #ifdef MONO_ARCH_SIMD_INTRINSICS
@@ -331,6 +335,17 @@ struct CallInfo {
 	ArgInfo sig_cookie;
 	ArgInfo args [1];
 };
+
+typedef struct {
+	/* EAX:EDX */
+	host_mgreg_t eax;
+	host_mgreg_t edx;
+	/* Floating point return value read from the top of x86 fpstack */
+	double fret;
+	/* Stack usage, used for passing params on stack */
+	guint32 stack_size;
+	guint8 *stack;
+} CallContext;
 
 guint32
 mono_x86_get_this_arg_offset (MonoMethodSignature *sig);

--- a/src/mono/mono/mini/tramp-x86.c
+++ b/src/mono/mono/mini/tramp-x86.c
@@ -719,3 +719,92 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 
 	return buf;
 }
+
+gpointer
+mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
+{
+#ifndef DISABLE_INTERPRETER
+	guint8 *start = NULL, *code;
+	guint8 *label_start_copy, *label_exit_copy;
+	MonoJumpInfo *ji = NULL;
+	GSList *unwind_ops = NULL;
+	int buf_len;
+	int ccontext_offset, target_offset;
+
+	buf_len = 512;
+	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
+
+	x86_push_reg (code, X86_EBP);
+	/* args are on the stack, above saved EBP and pushed return EIP */
+	target_offset = 2 * sizeof (target_mgreg_t);
+	ccontext_offset = target_offset + sizeof (target_mgreg_t);
+	x86_mov_reg_reg (code, X86_EBP, X86_ESP);
+
+	/* Save some used regs and align stack to 16 bytes */
+	x86_push_reg (code, X86_EDI);
+	x86_push_reg (code, X86_ESI);
+
+	/* load pointer to CallContext* into ESI */
+	x86_mov_reg_membase (code, X86_ESI, X86_EBP, ccontext_offset, sizeof (target_mgreg_t));
+
+	/* allocate the stack space necessary for the call */
+	x86_mov_reg_membase (code, X86_ECX, X86_ESI, MONO_STRUCT_OFFSET (CallContext, stack_size), sizeof (target_mgreg_t));
+	x86_alu_reg_reg (code, X86_SUB, X86_ESP, X86_ECX);
+
+	/* copy stack from the CallContext, ESI = source, EDI = dest, ECX bytes to copy */
+	x86_mov_reg_membase (code, X86_ESI, X86_ESI, MONO_STRUCT_OFFSET (CallContext, stack), sizeof (target_mgreg_t));
+	x86_mov_reg_reg (code, X86_EDI, X86_ESP);
+
+	label_start_copy = code;
+	x86_test_reg_reg (code, X86_ECX, X86_ECX);
+	label_exit_copy = code;
+	x86_branch8 (code, X86_CC_Z, 0, FALSE);
+	x86_mov_reg_membase (code, X86_EDX, X86_ESI, 0, sizeof (target_mgreg_t));
+	x86_mov_membase_reg (code, X86_EDI, 0, X86_EDX, sizeof (target_mgreg_t));
+	x86_alu_reg_imm (code, X86_ADD, X86_EDI, sizeof (target_mgreg_t));
+	x86_alu_reg_imm (code, X86_ADD, X86_ESI, sizeof (target_mgreg_t));
+	x86_alu_reg_imm (code, X86_SUB, X86_ECX, sizeof (target_mgreg_t));
+	x86_jump_code (code, label_start_copy);
+	x86_patch (label_exit_copy, code);
+
+	/* load target addr */
+	x86_mov_reg_membase (code, X86_EAX, X86_EBP, target_offset, sizeof (target_mgreg_t));
+
+	/* call into native function */
+	x86_call_reg (code, X86_EAX);
+
+	/* Save return values into CallContext* */
+	x86_mov_reg_membase (code, X86_ESI, X86_EBP, ccontext_offset, sizeof (target_mgreg_t));
+	x86_mov_membase_reg (code, X86_ESI, MONO_STRUCT_OFFSET (CallContext, eax), X86_EAX, sizeof (target_mgreg_t));
+	x86_mov_membase_reg (code, X86_ESI, MONO_STRUCT_OFFSET (CallContext, edx), X86_EDX, sizeof (target_mgreg_t));
+
+	/*
+	 * We always pop ST0, even if we don't have return value. We seem to get away with
+	 * this because fpstack is either empty or has one fp return value on top and the cpu
+	 * doesn't trap if we read top of empty stack.
+	 */
+	x86_fst_membase (code, X86_ESI, MONO_STRUCT_OFFSET (CallContext, fret), TRUE, TRUE);
+
+	/* restore ESI, EDI which were saved below rbp */
+	x86_mov_reg_membase (code, X86_EDI, X86_EBP, - sizeof (target_mgreg_t), sizeof (target_mgreg_t));
+	x86_mov_reg_membase (code, X86_ESI, X86_EBP, - 2 * sizeof (target_mgreg_t), sizeof (target_mgreg_t));
+	x86_mov_reg_reg (code, X86_ESP, X86_EBP);
+
+	x86_pop_reg (code, X86_EBP);
+
+	x86_ret (code);
+
+	g_assertf ((code - start) <= buf_len, "%d %d", (int)(code - start), buf_len);
+
+	mono_arch_flush_icache (start, code - start);
+	MONO_PROFILER_RAISE (jit_code_buffer, (start, code - start, MONO_PROFILER_CODE_BUFFER_HELPER, NULL));
+
+	if (info)
+		*info = mono_tramp_info_create ("interp_to_native_trampoline", start, code - start, ji, unwind_ops);
+
+	return start;
+#else
+	g_assert_not_reached ();
+	return NULL;
+#endif /* DISABLE_INTERPRETER */
+}

--- a/src/mono/mono/tests/Makefile.am
+++ b/src/mono/mono/tests/Makefile.am
@@ -2034,6 +2034,14 @@ INTERP_DISABLED_TESTS += \
 	pinvoke3.exe
 endif
 
+if X86
+INTERP_DISABLED_TESTS += \
+	bug-60862.exe \
+	cominterop.exe \
+	dim-diamondshape.exe \
+	pinvoke3.exe
+endif
+
 TESTS_CS=$(filter-out $(DISABLED_TESTS),$(TESTS_CS_SRC:.cs=.exe))
 TESTS_IL=$(filter-out $(DISABLED_TESTS),$(TESTS_IL_SRC:.il=.exe))
 TESTS_BENCH=$(filter-out $(DISABLED_TESTS),$(TESTS_BENCH_SRC:.cs=.exe))


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19730,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This mainly consists of a trampoline that is used when calling from interp into native code, as well as the call convention logic that initializes the CallContext structure (which is passed to the trampoline). On other platforms we also have a single trampoline used when entering interpreter code. That trampoline works in a similar way and its purpose is to avoid compilation of all possible interp entry signatures, which is problematic on full aot scenarios. Given the interp x86 support is currently provided for android, we can avoid using that trampoline for now and use the per signature jit compiled interp_in_wrappers instead.

The few disabled interp tests are the same as on amd64.

We only support pinvoke into cdecl functions.