### PR TITLE
Enable linux OOP unwinder on Windows for cross DAC

### DIFF
--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -75,6 +75,10 @@ if(CLR_CMAKE_HOST_UNIX)
 
     add_subdirectory(src/pal)
     add_subdirectory(src/hosts)
+else(CLR_CMAKE_HOST_UNIX)
+    if(CLR_CMAKE_TARGET_UNIX)
+        add_subdirectory(src/pal/src/libunwind)
+    endif(CLR_CMAKE_TARGET_UNIX)
 endif(CLR_CMAKE_HOST_UNIX)
 
 # Add this subdir. We install the headers for the jit.

--- a/src/coreclr/src/debug/daccess/dacfn.cpp
+++ b/src/coreclr/src/debug/daccess/dacfn.cpp
@@ -245,6 +245,16 @@ static BOOL DacReadAllAdapter(PVOID address, PVOID buffer, SIZE_T size)
     return TRUE;
 }
 
+#ifdef HOST_WINDOWS
+// For the cross OS dac, we don't have the full pal layer
+// Use these minimal prototypes instead of the full pal header
+typedef BOOL(*UnwindReadMemoryCallback)(PVOID address, PVOID buffer, SIZE_T size);
+
+extern
+BOOL
+PAL_VirtualUnwindOutOfProc(PT_CONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback);
+#endif
+
 HRESULT
 DacVirtualUnwind(ULONG32 threadId, PT_CONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers)
 {
@@ -273,9 +283,7 @@ DacVirtualUnwind(ULONG32 threadId, PT_CONTEXT context, PT_KNONVOLATILE_CONTEXT_P
 #endif
     {
         SIZE_T baseAddress = DacGlobalBase();
-#ifdef HOST_UNIX
         if (baseAddress == 0 || !PAL_VirtualUnwindOutOfProc(context, contextPointers, baseAddress, DacReadAllAdapter))
-#endif
         {
             hr = E_FAIL;
         }

--- a/src/coreclr/src/dlls/mscordac/CMakeLists.txt
+++ b/src/coreclr/src/dlls/mscordac/CMakeLists.txt
@@ -146,6 +146,12 @@ if(CLR_CMAKE_TARGET_WIN32)
     )
 endif(CLR_CMAKE_TARGET_WIN32)
 
+if(CLR_CMAKE_HOST_WIN32 AND CLR_CMAKE_TARGET_UNIX)
+    list(APPEND COREDAC_LIBRARIES
+        libunwind_xdac
+    )
+endif(CLR_CMAKE_HOST_WIN32 AND CLR_CMAKE_TARGET_UNIX)
+
 if(CLR_CMAKE_HOST_WIN32)
     # mscordac.def should be generated before mscordaccore.dll is built
     add_dependencies(mscordaccore mscordaccore_def)

--- a/src/coreclr/src/pal/src/exception/remote-unwind.cpp
+++ b/src/coreclr/src/pal/src/exception/remote-unwind.cpp
@@ -39,6 +39,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 --*/
 
+#ifdef HOST_UNIX
 #include "config.h"
 #include "pal/palinternal.h"
 #include "pal/dbgmsg.h"
@@ -64,25 +65,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 SET_DEFAULT_DEBUG_CHANNEL(EXCEPT);
 
-#if defined(HAVE_UNW_GET_ACCESSORS)
-
-#include <elf.h>
-#include <link.h>
-
-#if defined(HOST_X86) || defined(HOST_ARM)
-#define PRIx PRIx32
-#define PRIu PRIu32
-#define PRId PRId32
-#define PRIA "08"
-#define PRIxA PRIA PRIx
-#elif defined(HOST_AMD64) || defined(HOST_ARM64)
-#define PRIx PRIx64
-#define PRIu PRIu64
-#define PRId PRId64
-#define PRIA "016"
-#define PRIxA PRIA PRIx
-#endif
-
 #ifndef ElfW
 #define ElfW(foo) Elf_ ## foo
 #endif
@@ -91,6 +73,61 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT);
 #define Shdr   ElfW(Shdr)
 #define Nhdr   ElfW(Nhdr)
 #define Dyn    ElfW(Dyn)
+
+#else // HOST_UNIX
+
+#include <windows.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <libunwind.h>
+#include "debugmacros.h"
+#include "crosscomp.h"
+
+#define KNONVOLATILE_CONTEXT_POINTERS T_KNONVOLATILE_CONTEXT_POINTERS
+#define CONTEXT T_CONTEXT
+
+typedef BOOL(*UnwindReadMemoryCallback)(PVOID address, PVOID buffer, SIZE_T size);
+
+#define ASSERT(x, ...)
+#define TRACE(x, ...)
+
+#ifndef ElfW
+#ifdef TARGET_64BIT
+#define ElfW(foo) Elf64_ ## foo
+#else // TARGET_64BIT
+#define ElfW(foo) Elf32_ ## foo
+#endif // TARGET_64BIT
+#endif // ElfW
+
+#define Ehdr   ElfW(Ehdr)
+#define Phdr   ElfW(Phdr)
+#define Shdr   ElfW(Shdr)
+#define Nhdr   ElfW(Nhdr)
+#define Dyn    ElfW(Dyn)
+
+#define PALAPI
+
+#endif // HOST_UNIX
+
+#if defined(HAVE_UNW_GET_ACCESSORS)
+
+#include <elf.h>
+#include <link.h>
+
+#if defined(TARGET_X86) || defined(TARGET_ARM)
+#define PRIx PRIx32
+#define PRIu PRIu32
+#define PRId PRId32
+#define PRIA "08"
+#define PRIxA PRIA PRIx
+#elif defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#define PRIx PRIx64
+#define PRIu PRIu64
+#define PRId PRId64
+#define PRIA "016"
+#define PRIxA PRIA PRIx
+#endif
+
 
 extern "C" int
 _OOP_find_proc_info(
@@ -120,7 +157,7 @@ typedef struct _libunwindInfo
 
 static void UnwindContextToContext(unw_cursor_t *cursor, CONTEXT *winContext)
 {
-#if defined(HOST_AMD64)
+#if defined(TARGET_AMD64)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Rip);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Rsp);
     unw_get_reg(cursor, UNW_X86_64_RBP, (unw_word_t *) &winContext->Rbp);
@@ -129,14 +166,14 @@ static void UnwindContextToContext(unw_cursor_t *cursor, CONTEXT *winContext)
     unw_get_reg(cursor, UNW_X86_64_R13, (unw_word_t *) &winContext->R13);
     unw_get_reg(cursor, UNW_X86_64_R14, (unw_word_t *) &winContext->R14);
     unw_get_reg(cursor, UNW_X86_64_R15, (unw_word_t *) &winContext->R15);
-#elif defined(HOST_X86)
+#elif defined(TARGET_X86)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Eip);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Esp);
     unw_get_reg(cursor, UNW_X86_EBP, (unw_word_t *) &winContext->Ebp);
     unw_get_reg(cursor, UNW_X86_EBX, (unw_word_t *) &winContext->Ebx);
     unw_get_reg(cursor, UNW_X86_ESI, (unw_word_t *) &winContext->Esi);
     unw_get_reg(cursor, UNW_X86_EDI, (unw_word_t *) &winContext->Edi);
-#elif defined(HOST_ARM)
+#elif defined(TARGET_ARM)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Pc);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Sp);
     unw_get_reg(cursor, UNW_ARM_R4, (unw_word_t *) &winContext->R4);
@@ -149,7 +186,7 @@ static void UnwindContextToContext(unw_cursor_t *cursor, CONTEXT *winContext)
     unw_get_reg(cursor, UNW_ARM_R11, (unw_word_t *) &winContext->R11);
     unw_get_reg(cursor, UNW_ARM_R14, (unw_word_t *) &winContext->Lr);
     TRACE("sp %p pc %p lr %p\n", winContext->Sp, winContext->Pc, winContext->Lr);
-#elif defined(HOST_ARM64)
+#elif defined(TARGET_ARM64)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Pc);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Sp);
     unw_get_reg(cursor, UNW_AARCH64_X19, (unw_word_t *) &winContext->X19);
@@ -210,7 +247,7 @@ access_reg(unw_addr_space_t as, unw_regnum_t regnum, unw_word_t *valp, int write
 
     switch (regnum)
     {
-#if defined(HOST_AMD64)
+#if defined(TARGET_AMD64)
     case UNW_REG_IP:       *valp = (unw_word_t)winContext->Rip; break;
     case UNW_REG_SP:       *valp = (unw_word_t)winContext->Rsp; break;
     case UNW_X86_64_RBP:   *valp = (unw_word_t)winContext->Rbp; break;
@@ -219,14 +256,14 @@ access_reg(unw_addr_space_t as, unw_regnum_t regnum, unw_word_t *valp, int write
     case UNW_X86_64_R13:   *valp = (unw_word_t)winContext->R13; break;
     case UNW_X86_64_R14:   *valp = (unw_word_t)winContext->R14; break;
     case UNW_X86_64_R15:   *valp = (unw_word_t)winContext->R15; break;
-#elif defined(HOST_X86)
+#elif defined(TARGET_X86)
     case UNW_REG_IP:       *valp = (unw_word_t)winContext->Eip; break;
     case UNW_REG_SP:       *valp = (unw_word_t)winContext->Esp; break;
     case UNW_X86_EBX:      *valp = (unw_word_t)winContext->Ebx; break;
     case UNW_X86_ESI:      *valp = (unw_word_t)winContext->Esi; break;
     case UNW_X86_EDI:      *valp = (unw_word_t)winContext->Edi; break;
     case UNW_X86_EBP:      *valp = (unw_word_t)winContext->Ebp; break;
-#elif defined(HOST_ARM)
+#elif defined(TARGET_ARM)
     case UNW_ARM_R4:       *valp = (unw_word_t)winContext->R4; break;
     case UNW_ARM_R5:       *valp = (unw_word_t)winContext->R5; break;
     case UNW_ARM_R6:       *valp = (unw_word_t)winContext->R6; break;
@@ -238,7 +275,7 @@ access_reg(unw_addr_space_t as, unw_regnum_t regnum, unw_word_t *valp, int write
     case UNW_ARM_R13:      *valp = (unw_word_t)winContext->Sp; break;
     case UNW_ARM_R14:      *valp = (unw_word_t)winContext->Lr; break;
     case UNW_ARM_R15:      *valp = (unw_word_t)winContext->Pc; break;
-#elif defined(HOST_ARM64)
+#elif defined(TARGET_ARM64)
     case UNW_AARCH64_X19:  *valp = (unw_word_t)winContext->X19; break;
     case UNW_AARCH64_X20:  *valp = (unw_word_t)winContext->X20; break;
     case UNW_AARCH64_X21:  *valp = (unw_word_t)winContext->X21; break;
@@ -479,4 +516,4 @@ PAL_VirtualUnwindOutOfProc(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *cont
     return FALSE;
 }
 
-#endif // defined(HOST_AMD64) && defined(HAVE_UNW_GET_ACCESSORS)
+#endif // defined(HAVE_UNW_GET_ACCESSORS)

--- a/src/coreclr/src/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/src/pal/src/exception/seh-unwind.cpp
@@ -19,6 +19,7 @@ Abstract:
 
 --*/
 
+#ifdef HOST_UNIX
 #include "pal/context.h"
 #include "pal.h"
 #include <dlfcn.h>
@@ -35,6 +36,24 @@ Abstract:
 #ifdef __llvm__
 #pragma clang diagnostic pop
 #endif
+#else // HOST_UNIX
+
+#include <windows.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <libunwind.h>
+#include "debugmacros.h"
+#include "crosscomp.h"
+
+#define KNONVOLATILE_CONTEXT_POINTERS T_KNONVOLATILE_CONTEXT_POINTERS
+#define CONTEXT T_CONTEXT
+
+#define ASSERT(x, ...)
+#define TRACE(x, ...)
+
+#define PALAPI
+
+#endif // HOST_UNIX
 
 //----------------------------------------------------------------------
 // Virtual Unwinding
@@ -42,7 +61,7 @@ Abstract:
 
 #if UNWIND_CONTEXT_IS_UCONTEXT_T
 
-#if defined(HOST_AMD64)
+#if defined(TARGET_AMD64)
 #define ASSIGN_UNWIND_REGS \
     ASSIGN_REG(Rip)        \
     ASSIGN_REG(Rsp)        \
@@ -52,7 +71,7 @@ Abstract:
     ASSIGN_REG(R13)        \
     ASSIGN_REG(R14)        \
     ASSIGN_REG(R15)
-#elif defined(HOST_ARM64)
+#elif defined(TARGET_ARM64)
 #define ASSIGN_UNWIND_REGS \
     ASSIGN_REG(Pc)         \
     ASSIGN_REG(Sp)         \
@@ -68,7 +87,7 @@ Abstract:
     ASSIGN_REG(X26)        \
     ASSIGN_REG(X27)        \
     ASSIGN_REG(X28)
-#elif defined(HOST_X86)
+#elif defined(TARGET_X86)
 #define ASSIGN_UNWIND_REGS \
     ASSIGN_REG(Eip)        \
     ASSIGN_REG(Esp)        \
@@ -89,7 +108,7 @@ static void WinContextToUnwindContext(CONTEXT *winContext, unw_context_t *unwCon
 #else
 static void WinContextToUnwindContext(CONTEXT *winContext, unw_context_t *unwContext)
 {
-#if defined(HOST_ARM)
+#if defined(TARGET_ARM)
     // Assuming that unw_set_reg() on cursor will point the cursor to the
     // supposed stack frame is dangerous for libunwind-arm in Linux.
     // It is because libunwind's unw_cursor_t has other data structure
@@ -116,7 +135,7 @@ static void WinContextToUnwindContext(CONTEXT *winContext, unw_context_t *unwCon
 
 static void WinContextToUnwindCursor(CONTEXT *winContext, unw_cursor_t *cursor)
 {
-#if defined(HOST_AMD64)
+#if defined(TARGET_AMD64)
     unw_set_reg(cursor, UNW_REG_IP, winContext->Rip);
     unw_set_reg(cursor, UNW_REG_SP, winContext->Rsp);
     unw_set_reg(cursor, UNW_X86_64_RBP, winContext->Rbp);
@@ -125,7 +144,7 @@ static void WinContextToUnwindCursor(CONTEXT *winContext, unw_cursor_t *cursor)
     unw_set_reg(cursor, UNW_X86_64_R13, winContext->R13);
     unw_set_reg(cursor, UNW_X86_64_R14, winContext->R14);
     unw_set_reg(cursor, UNW_X86_64_R15, winContext->R15);
-#elif defined(HOST_X86)
+#elif defined(TARGET_X86)
     unw_set_reg(cursor, UNW_REG_IP, winContext->Eip);
     unw_set_reg(cursor, UNW_REG_SP, winContext->Esp);
     unw_set_reg(cursor, UNW_X86_EBP, winContext->Ebp);
@@ -138,7 +157,7 @@ static void WinContextToUnwindCursor(CONTEXT *winContext, unw_cursor_t *cursor)
 
 void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
 {
-#if defined(HOST_AMD64)
+#if defined(TARGET_AMD64)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Rip);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Rsp);
     unw_get_reg(cursor, UNW_X86_64_RBP, (unw_word_t *) &winContext->Rbp);
@@ -147,14 +166,14 @@ void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
     unw_get_reg(cursor, UNW_X86_64_R13, (unw_word_t *) &winContext->R13);
     unw_get_reg(cursor, UNW_X86_64_R14, (unw_word_t *) &winContext->R14);
     unw_get_reg(cursor, UNW_X86_64_R15, (unw_word_t *) &winContext->R15);
-#elif defined(HOST_X86)
+#elif defined(TARGET_X86)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Eip);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Esp);
     unw_get_reg(cursor, UNW_X86_EBP, (unw_word_t *) &winContext->Ebp);
     unw_get_reg(cursor, UNW_X86_EBX, (unw_word_t *) &winContext->Ebx);
     unw_get_reg(cursor, UNW_X86_ESI, (unw_word_t *) &winContext->Esi);
     unw_get_reg(cursor, UNW_X86_EDI, (unw_word_t *) &winContext->Edi);
-#elif defined(HOST_ARM)
+#elif defined(TARGET_ARM)
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Sp);
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Pc);
     unw_get_reg(cursor, UNW_ARM_R14, (unw_word_t *) &winContext->Lr);
@@ -166,7 +185,7 @@ void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
     unw_get_reg(cursor, UNW_ARM_R9, (unw_word_t *) &winContext->R9);
     unw_get_reg(cursor, UNW_ARM_R10, (unw_word_t *) &winContext->R10);
     unw_get_reg(cursor, UNW_ARM_R11, (unw_word_t *) &winContext->R11);
-#elif defined(HOST_ARM64)
+#elif defined(TARGET_ARM64)
     unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Pc);
     unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Sp);
     unw_get_reg(cursor, UNW_AARCH64_X29, (unw_word_t *) &winContext->Fp);
@@ -206,19 +225,19 @@ static void GetContextPointer(unw_cursor_t *cursor, unw_context_t *unwContext, i
 
 void GetContextPointers(unw_cursor_t *cursor, unw_context_t *unwContext, KNONVOLATILE_CONTEXT_POINTERS *contextPointers)
 {
-#if defined(HOST_AMD64)
+#if defined(TARGET_AMD64)
     GetContextPointer(cursor, unwContext, UNW_X86_64_RBP, &contextPointers->Rbp);
     GetContextPointer(cursor, unwContext, UNW_X86_64_RBX, &contextPointers->Rbx);
     GetContextPointer(cursor, unwContext, UNW_X86_64_R12, &contextPointers->R12);
     GetContextPointer(cursor, unwContext, UNW_X86_64_R13, &contextPointers->R13);
     GetContextPointer(cursor, unwContext, UNW_X86_64_R14, &contextPointers->R14);
     GetContextPointer(cursor, unwContext, UNW_X86_64_R15, &contextPointers->R15);
-#elif defined(HOST_X86)
+#elif defined(TARGET_X86)
     GetContextPointer(cursor, unwContext, UNW_X86_EBX, &contextPointers->Ebx);
     GetContextPointer(cursor, unwContext, UNW_X86_EBP, &contextPointers->Ebp);
     GetContextPointer(cursor, unwContext, UNW_X86_ESI, &contextPointers->Esi);
     GetContextPointer(cursor, unwContext, UNW_X86_EDI, &contextPointers->Edi);
-#elif defined(HOST_ARM)
+#elif defined(TARGET_ARM)
     GetContextPointer(cursor, unwContext, UNW_ARM_R4, &contextPointers->R4);
     GetContextPointer(cursor, unwContext, UNW_ARM_R5, &contextPointers->R5);
     GetContextPointer(cursor, unwContext, UNW_ARM_R6, &contextPointers->R6);
@@ -227,7 +246,7 @@ void GetContextPointers(unw_cursor_t *cursor, unw_context_t *unwContext, KNONVOL
     GetContextPointer(cursor, unwContext, UNW_ARM_R9, &contextPointers->R9);
     GetContextPointer(cursor, unwContext, UNW_ARM_R10, &contextPointers->R10);
     GetContextPointer(cursor, unwContext, UNW_ARM_R11, &contextPointers->R11);
-#elif defined(HOST_ARM64)
+#elif defined(TARGET_ARM64)
     GetContextPointer(cursor, unwContext, UNW_AARCH64_X19, &contextPointers->X19);
     GetContextPointer(cursor, unwContext, UNW_AARCH64_X20, &contextPointers->X20);
     GetContextPointer(cursor, unwContext, UNW_AARCH64_X21, &contextPointers->X21);
@@ -243,6 +262,8 @@ void GetContextPointers(unw_cursor_t *cursor, unw_context_t *unwContext, KNONVOL
 #error unsupported architecture
 #endif
 }
+
+#ifndef HOST_WINDOWS
 
 extern int g_common_signal_handler_context_locvar_offset;
 
@@ -313,16 +334,16 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
     if (unw_is_signal_frame(&cursor) > 0)
     {
         context->ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;
-#if defined(HOST_ARM) || defined(HOST_ARM64) || defined(HOST_X86)
+#if defined(TARGET_ARM) || defined(TARGET_ARM64) || defined(TARGET_X86)
         context->ContextFlags &= ~CONTEXT_UNWOUND_TO_CALL;
-#endif // HOST_ARM || HOST_ARM64
+#endif // TARGET_ARM || TARGET_ARM64
     }
     else
     {
         context->ContextFlags &= ~CONTEXT_EXCEPTION_ACTIVE;
-#if defined(HOST_ARM) || defined(HOST_ARM64) || defined(HOST_X86)
+#if defined(TARGET_ARM) || defined(TARGET_ARM64) || defined(TARGET_X86)
         context->ContextFlags |= CONTEXT_UNWOUND_TO_CALL;
-#endif // HOST_ARM || HOST_ARM64
+#endif // TARGET_ARM || TARGET_ARM64
     }
 
     // Update the passed in windows context to reflect the unwind
@@ -519,3 +540,5 @@ RaiseException(IN DWORD dwExceptionCode,
 
     LOGEXIT("RaiseException returns\n");
 }
+
+#endif // !HOST_WINDOWS

--- a/src/coreclr/src/pal/src/libunwind/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/libunwind/CMakeLists.txt
@@ -2,13 +2,13 @@ add_subdirectory(src)
 
 # define variables for the configure_file below
 
-if (CLR_CMAKE_HOST_ARCH_AMD64)
+if (CLR_CMAKE_TARGET_ARCH_AMD64)
     set(arch x86_64)
-elseif(CLR_CMAKE_HOST_ARCH_ARM64)
+elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
     set(arch aarch64)
-elseif(CLR_CMAKE_PLATFROM_ARCH_ARM)
+elseif(CLR_CMAKE_TARGET_ARCH_ARM)
     set(arch arm)
-elseif(CLR_CMAKE_HOST_ARCH_I386)
+elseif(CLR_CMAKE_TARGET_ARCH_I386)
     set(arch x86)
 endif()
 

--- a/src/coreclr/src/pal/src/libunwind/include/compiler.h
+++ b/src/coreclr/src/pal/src/libunwind/include/compiler.h
@@ -67,6 +67,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 # define unlikely(x)    (x)
 #endif
 
+#ifdef DACCESS_COMPILE
+# define PACKED
+# define THREAD
+#else
+# define PACKED         __attribute__((packed))
+# define THREAD         __thread
+#endif
+
 #define ARRAY_SIZE(a)   (sizeof (a) / sizeof ((a)[0]))
 
 #endif /* COMPILER_H */

--- a/src/coreclr/src/pal/src/libunwind/include/dwarf-eh.h
+++ b/src/coreclr/src/pal/src/libunwind/include/dwarf-eh.h
@@ -106,7 +106,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
 
 #define DW_EH_VERSION           1       /* The version we're implementing */
 
-struct __attribute__((packed)) dwarf_eh_frame_hdr
+struct PACKED dwarf_eh_frame_hdr
   {
     unsigned char version;
     unsigned char eh_frame_ptr_enc;

--- a/src/coreclr/src/pal/src/libunwind/include/libunwind-aarch64.h
+++ b/src/coreclr/src/pal/src/libunwind/include/libunwind-aarch64.h
@@ -56,6 +56,10 @@ typedef long double unw_tdep_fpreg_t;
 typedef struct
   {
     /* no aarch64-specific auxiliary proc-info */
+#ifdef DACCESS_COMPILE
+    // error C2016: C requires that a struct or union have at least one member
+    char dummy;
+#endif
   }
 unw_tdep_proc_info_t;
 
@@ -165,6 +169,10 @@ aarch64_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+#ifdef DACCESS_COMPILE
+    // error C2016: C requires that a struct or union have at least one member
+    char dummy;
+#endif
   }
 unw_tdep_save_loc_t;
 

--- a/src/coreclr/src/pal/src/libunwind/include/libunwind-arm.h
+++ b/src/coreclr/src/pal/src/libunwind/include/libunwind-arm.h
@@ -247,6 +247,10 @@ arm_regnum_t;
 typedef struct unw_tdep_save_loc
   {
     /* Additional target-dependent info on a save location.  */
+#ifdef DACCESS_COMPILE
+    // error C2016: C requires that a struct or union have at least one member
+    char dummy;
+#endif
   }
 unw_tdep_save_loc_t;
 
@@ -288,6 +292,10 @@ unw_tdep_context_t;
 typedef struct
   {
     /* no arm-specific auxiliary proc-info */
+#ifdef DACCESS_COMPILE
+    // error C2016: C requires that a struct or union have at least one member
+    char dummy;
+#endif
   }
 unw_tdep_proc_info_t;
 

--- a/src/coreclr/src/pal/src/libunwind/include/libunwind_i.h
+++ b/src/coreclr/src/pal/src/libunwind/include/libunwind_i.h
@@ -265,6 +265,11 @@ extern int unwi_dyn_validate_cache (unw_addr_space_t as, void *arg);
 extern unw_dyn_info_list_t _U_dyn_info_list;
 extern pthread_mutex_t _U_dyn_info_list_lock;
 
+#ifdef DACCESS_COMPILE
+// Use VC++ compatible variadic macros
+# define Debug(level,format, ...)
+# define Dprintf(format, ...)
+#else // DACCESS_COMPILE
 #if UNW_DEBUG
 #define unwi_debug_level                UNWI_ARCH_OBJ(debug_level)
 extern long unwi_debug_level;
@@ -286,6 +291,7 @@ do {                                                                    \
 # define Debug(level,format...)
 # define Dprintf(format...)
 #endif
+#endif // DACCESS_COMPILE
 
 static ALWAYS_INLINE int
 print_error (const char *string)

--- a/src/coreclr/src/pal/src/libunwind/include/tdep-aarch64/libunwind_i.h
+++ b/src/coreclr/src/pal/src/libunwind/include/tdep-aarch64/libunwind_i.h
@@ -170,6 +170,12 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 # define DWARF_FPREG_LOC(c,r)   DWARF_LOC((r), (DWARF_LOC_TYPE_REG      \
                                                 | DWARF_LOC_TYPE_FP))
 
+#ifdef DACCESS_COMPILE
+// Use VC++ compatible syntax for DWARF_IS_NULL_LOC
+#undef DWARF_IS_NULL_LOC
+#define DWARF_IS_NULL_LOC(l) (l.val == 0 && l.type == 0)
+#endif
+
 static inline int
 dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 {

--- a/src/coreclr/src/pal/src/libunwind/include/tdep-arm/libunwind_i.h
+++ b/src/coreclr/src/pal/src/libunwind/include/tdep-arm/libunwind_i.h
@@ -161,6 +161,12 @@ dwarf_put (struct dwarf_cursor *c, dwarf_loc_t loc, unw_word_t val)
 # define DWARF_FPREG_LOC(c,r)   DWARF_LOC((r), (DWARF_LOC_TYPE_REG      \
                                                 | DWARF_LOC_TYPE_FP))
 
+#ifdef DACCESS_COMPILE
+// Use VC++ compatible syntax for DWARF_IS_NULL_LOC
+#undef DWARF_IS_NULL_LOC
+#define DWARF_IS_NULL_LOC(l) (l.val == 0 && l.type == 0)
+#endif
+
 static inline int
 dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 {

--- a/src/coreclr/src/pal/src/libunwind/include/tdep-x86_64/libunwind_i.h
+++ b/src/coreclr/src/pal/src/libunwind/include/tdep-x86_64/libunwind_i.h
@@ -137,6 +137,12 @@ dwarf_get_uc(const struct dwarf_cursor *cursor)
 
 #endif /* !UNW_LOCAL_ONLY */
 
+#ifdef DACCESS_COMPILE
+// Use VC++ compatible syntax for DWARF_IS_NULL_LOC
+#undef DWARF_IS_NULL_LOC
+#define DWARF_IS_NULL_LOC(l) (l.val == 0 && l.type == 0)
+#endif
+
 static inline int
 dwarf_getfp (struct dwarf_cursor *c, dwarf_loc_t loc, unw_fpreg_t *val)
 {

--- a/src/coreclr/src/pal/src/libunwind/src/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/libunwind/src/CMakeLists.txt
@@ -17,43 +17,91 @@ add_definitions(-D_GNU_SOURCE)
 # Ensure that the remote and local unwind code can reside in the same binary without name clashing
 add_definitions("-Ddwarf_search_unwind_table_int=UNW_OBJ(dwarf_search_unwind_table_int)")
 
-# Disable warning due to incorrect format specifier in debugging printf via the Debug macro
-add_compile_options(-Wno-format -Wno-format-security)
+if(CLR_CMAKE_HOST_UNIX)
+    # Disable warning due to incorrect format specifier in debugging printf via the Debug macro
+    add_compile_options(-Wno-format -Wno-format-security)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-header-guard)
-else()
-  add_compile_options(-Wno-unused-value)
-  add_compile_options(-Wno-unused-result)
-endif()
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      add_compile_options(-Wno-header-guard)
+    else()
+      add_compile_options(-Wno-unused-value)
+      add_compile_options(-Wno-unused-result)
+    endif()
+    if(CLR_CMAKE_TARGET_ARCH_ARM)
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            # Disable warning due to labs function called on unsigned argument
+            add_compile_options(-Wno-absolute-value)
+            # Disable warning in asm: use of SP or PC in the list is deprecated
+            add_compile_options(-Wno-inline-asm)
+        endif()
+        # Disable warning for a bug in the libunwind source src/arm/Gtrace.c:529, but not in code that we exercise
+        add_compile_options(-Wno-implicit-function-declaration)
+        # Disable warning due to an unused function prel31_read
+        add_compile_options(-Wno-unused-function)
+    elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
+    endif()
+else(CLR_CMAKE_HOST_UNIX)
+    # Set compile options for windows cross DAC compile
+    add_definitions(-DDACCESS_COMPILE)
+    add_definitions(-DUNW_REMOTE_ONLY)
+    add_definitions(-DHAVE_UNW_GET_ACCESSORS)
+    add_definitions(-DHAVE_UNW_GET_SAVE_LOC)
+    add_definitions(-D__linux__)
+    add_definitions(-DHAVE_ELF_H)
+    add_definitions(-DHAVE_ENDIAN_H)
+    if (CLR_CMAKE_TARGET_ARCH_AMD64)
+        add_definitions(-D__x86_64__)
+        add_definitions(-D__amd64__)
+    elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
+        add_definitions(-D__aarch64__)
+    elseif(CLR_CMAKE_TARGET_ARCH_ARM)
+        add_definitions(-D__arm__)
+    endif()
 
-if(CLR_CMAKE_HOST_ARCH_ARM)
+    add_compile_options(/std:c++latest)
+    add_compile_options(/TC) # compile all files as C
+    add_compile_options(/permissive-)
+    add_compile_options(-wd4028) # formal parameter different from declaration
+    add_compile_options(-wd4029) # formal parameter list different from declaration
+    add_compile_options(-wd4068) # unknown pragma
+    add_compile_options(-wd4146) # minus operator applied to unsigned
+    add_compile_options(-wd4244) # possible loss of data
+    add_compile_options(-wd4267) # possible loss of data
+    add_compile_options(-wd4293) # shift count
+    add_compile_options(-wd4313) # fprintf argument type
+    add_compile_options(-wd4334) # 32-bit shift implicitly converted to 64 bits
+    add_compile_options(-wd4353) # nonstandard extension used: constant 0 as function expression
+    add_compile_options(-wd4473) # fprintf not enough argumets
+    add_compile_options(-wd4477) # fprintf argument type
+    add_compile_options(-wd4996) # may be unsafe
+
+    # files for cross os compilation
+    include_directories(cross-dac)
+    # other source files
+    include_directories(../include/tdep)
+    include_directories(../include)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR}/../include/tdep)
+    include_directories(${CMAKE_CURRENT_BINARY_DIR}/../include)
+    include_directories(${CLR_DIR}/src/inc)
+endif(CLR_CMAKE_HOST_UNIX)
+
+if(CLR_CMAKE_TARGET_ARCH_ARM)
     # Ensure that the remote and local unwind code can reside in the same binary without name clashing
     add_definitions("-Darm_search_unwind_table=UNW_OBJ(arm_search_unwind_table)")
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # Disable warning due to labs function called on unsigned argument
-        add_compile_options(-Wno-absolute-value)
-        # Disable warning in asm: use of SP or PC in the list is deprecated
-        add_compile_options(-Wno-inline-asm)
-    endif()
-    # Disable warning for a bug in the libunwind source src/arm/Gtrace.c:529, but not in code that we exercise
-    add_compile_options(-Wno-implicit-function-declaration)
-    # Disable warning due to an unused function prel31_read
-    add_compile_options(-Wno-unused-function)
     # We compile code with -std=c99 and the asm keyword is not recognized as it is a gnu extension
     add_definitions(-Dasm=__asm__)
     # The arm sources include ex_tables.h from include/tdep-arm without going through a redirection
     # in include/tdep like it works for similar files on other architectures. So we need to add
     # the include/tdep-arm to include directories
     include_directories(../include/tdep-arm)
-elseif(CLR_CMAKE_HOST_ARCH_ARM64)
+elseif(CLR_CMAKE_TARGET_ARCH_ARM64)
     if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         # Disable warning due to labs function called on unsigned argument
         add_compile_options(-Wno-absolute-value)
     endif()
     # We compile code with -std=c99 and the asm keyword is not recognized as it is a gnu extension
     add_definitions(-Dasm=__asm__)
-elseif(CLR_CMAKE_HOST_ARCH_I386)
+elseif(CLR_CMAKE_TARGET_ARCH_I386)
     # Disable warning for a bug in the libunwind source src/x86/Gos-linux.c, but not in code that we exercise
     add_compile_options(-Wno-incompatible-pointer-types)
 endif()
@@ -115,7 +163,7 @@ SET(libunwind_la_SOURCES_os_freebsd_local
 # Nothing
 )
 
-if(CLR_CMAKE_HOST_LINUX)
+if(CLR_CMAKE_TARGET_LINUX)
     SET(libunwind_la_SOURCES_os                 ${libunwind_la_SOURCES_os_linux})
     SET(libunwind_la_SOURCES_os_local           ${libunwind_la_SOURCES_os_linux_local})
     SET(libunwind_la_SOURCES_x86_os             x86/Gos-linux.c)
@@ -126,7 +174,7 @@ if(CLR_CMAKE_HOST_LINUX)
     SET(libunwind_la_SOURCES_arm_os             arm/Gos-linux.c)
     SET(libunwind_la_SOURCES_arm_os_local       arm/Los-linux.c)
     list(APPEND libunwind_coredump_la_SOURCES   coredump/_UCD_access_reg_linux.c)
-elseif(CLR_CMAKE_HOST_FREEBSD)
+elseif(CLR_CMAKE_TARGET_FREEBSD)
     SET(libunwind_la_SOURCES_os                 ${libunwind_la_SOURCES_os_freebsd})
     SET(libunwind_la_SOURCES_os_local           ${libunwind_la_SOURCES_os_freebsd_local})
     SET(libunwind_la_SOURCES_x86_os             x86/Gos-freebsd.c)
@@ -320,35 +368,54 @@ SET(libunwind_x86_64_la_SOURCES_x86_64
     x86_64/Gstash_frame.c x86_64/Gstep.c x86_64/Gtrace.c
 )
 
-if(CLR_CMAKE_HOST_ARCH_ARM64)
+if(CLR_CMAKE_TARGET_ARCH_ARM64)
     SET(libunwind_la_SOURCES                    ${libunwind_la_SOURCES_aarch64})
     SET(libunwind_remote_la_SOURCES             ${libunwind_aarch64_la_SOURCES_aarch64})
     SET(libunwind_elf_la_SOURCES                ${libunwind_elf64_la_SOURCES})
     list(APPEND libunwind_setjmp_la_SOURCES     aarch64/siglongjmp.S)
-elseif(CLR_CMAKE_HOST_ARCH_ARM)
+elseif(CLR_CMAKE_TARGET_ARCH_ARM)
     SET(libunwind_la_SOURCES                    ${libunwind_la_SOURCES_arm})
     SET(libunwind_remote_la_SOURCES             ${libunwind_arm_la_SOURCES_arm})
     SET(libunwind_elf_la_SOURCES                ${libunwind_elf32_la_SOURCES})
     list(APPEND libunwind_setjmp_la_SOURCES     arm/siglongjmp.S)
-elseif(CLR_CMAKE_HOST_ARCH_I386)
+elseif(CLR_CMAKE_TARGET_ARCH_I386)
     SET(libunwind_la_SOURCES                    ${libunwind_la_SOURCES_x86} ${libunwind_x86_la_SOURCES_os})
     SET(libunwind_remote_la_SOURCES             ${libunwind_x86_la_SOURCES_x86})
     SET(libunwind_elf_la_SOURCES                ${libunwind_elf32_la_SOURCES})
     list(APPEND libunwind_setjmp_la_SOURCES     x86/longjmp.S x86/siglongjmp.S)
-elseif(CLR_CMAKE_HOST_ARCH_AMD64)
+elseif(CLR_CMAKE_TARGET_ARCH_AMD64)
     SET(libunwind_la_SOURCES                    ${libunwind_la_SOURCES_x86_64})
     SET(libunwind_remote_la_SOURCES             ${libunwind_x86_64_la_SOURCES_x86_64})
     SET(libunwind_elf_la_SOURCES                ${libunwind_elf64_la_SOURCES})
     list(APPEND libunwind_setjmp_la_SOURCES     x86_64/longjmp.S x86_64/siglongjmp.SA)
 endif()
 
-add_library(libunwind
-  OBJECT
-  ${libunwind_la_SOURCES}
-  ${libunwind_remote_la_SOURCES}
-  ${libunwind_dwarf_local_la_SOURCES}
-  ${libunwind_dwarf_common_la_SOURCES}
-  ${libunwind_dwarf_generic_la_SOURCES}
-  ${libunwind_elf_la_SOURCES}
-)
+if(CLR_CMAKE_HOST_UNIX)
+    add_library(libunwind
+      OBJECT
+      ${libunwind_la_SOURCES}
+      ${libunwind_remote_la_SOURCES}
+      ${libunwind_dwarf_local_la_SOURCES}
+      ${libunwind_dwarf_common_la_SOURCES}
+      ${libunwind_dwarf_generic_la_SOURCES}
+      ${libunwind_elf_la_SOURCES}
+    )
+else(CLR_CMAKE_HOST_WIN4)
+    set_source_files_properties(../../exception/remote-unwind.cpp PROPERTIES COMPILE_FLAGS /TP)
+    set_source_files_properties(../../exception/seh-unwind.cpp PROPERTIES COMPILE_FLAGS /TP)
+    add_library(libunwind_xdac
+      OBJECT
+      ../../exception/remote-unwind.cpp
+      ../../exception/seh-unwind.cpp
+      cross-dac/cross-dac.c
+      # ${libunwind_la_SOURCES}  Local...
+      ${libunwind_remote_la_SOURCES}
+        # Commented out above for LOCAL + REMOTE runtime build
+        mi/Gget_accessors.c
+      # ${libunwind_dwarf_local_la_SOURCES}
+      ${libunwind_dwarf_common_la_SOURCES}
+      ${libunwind_dwarf_generic_la_SOURCES}
+      ${libunwind_elf_la_SOURCES}
+    )
+endif(CLR_CMAKE_HOST_UNIX)
 

--- a/src/coreclr/src/pal/src/libunwind/src/aarch64/Gtrace.c
+++ b/src/coreclr/src/pal/src/libunwind/src/aarch64/Gtrace.c
@@ -52,8 +52,8 @@ static pthread_once_t trace_cache_once = PTHREAD_ONCE_INIT;
 static sig_atomic_t trace_cache_once_happen;
 static pthread_key_t trace_cache_key;
 static struct mempool trace_cache_pool;
-static __thread  unw_trace_cache_t *tls_cache;
-static __thread  int tls_cache_destroyed;
+static THREAD unw_trace_cache_t *tls_cache;
+static THREAD int tls_cache_destroyed;
 
 /* Free memory for a thread's trace cache. */
 static void

--- a/src/coreclr/src/pal/src/libunwind/src/arm/Gtrace.c
+++ b/src/coreclr/src/pal/src/libunwind/src/arm/Gtrace.c
@@ -52,8 +52,8 @@ static pthread_once_t trace_cache_once = PTHREAD_ONCE_INIT;
 static sig_atomic_t trace_cache_once_happen;
 static pthread_key_t trace_cache_key;
 static struct mempool trace_cache_pool;
-static __thread  unw_trace_cache_t *tls_cache;
-static __thread  int tls_cache_destroyed;
+static THREAD unw_trace_cache_t *tls_cache;
+static THREAD int tls_cache_destroyed;
 
 /* Free memory for a thread's trace cache. */
 static void

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/cross-dac.c
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/cross-dac.c
@@ -1,0 +1,97 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This is minimal implementation of posix functions files required to cross compile
+// libunwind on a Windows host for DAC application.
+
+#include "cross-dac.h"
+#include <stdlib.h>
+
+int getpagesize(void)
+{
+    // 4096 is truth for most targets
+    // Unlikely to matter in dump debugging
+    return 4096;
+}
+
+void* mmap(void *addr, size_t length, int prot, int flags, int fd, size_t offset)
+{
+    // We shouldn't be doing anything other than anonymous mappings
+    if ((flags & MAP_ANON) == 0)
+        return MAP_FAILED;
+
+    return malloc(length);
+}
+
+int munmap(void *addr, size_t length)
+{
+    free(addr);
+    return 0;
+}
+
+int pthread_key_create(pthread_key_t *key, void (*destroy)(void*))
+{
+    // We are not implementing pthread_getspecific so this sholdn't matter much
+    return 0;
+}
+
+int pthread_setspecific(pthread_key_t key, const void *value)
+{
+    // We are not implementing pthread_getspecific so this sholdn't matter much
+    return 0;
+}
+
+int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+    // For dump debugging we don't need locking
+    // We expect to run in a single thread
+    return 0;
+}
+
+int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+    // For dump debugging we don't need locking
+    // We expect to run in a single thread
+    return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+    // For dump debugging we don't need locking
+    // We expect to run in a single thread
+    return 0;
+}
+
+int pthread_once(pthread_once_t *control, void (*init)(void))
+{
+    if (control == 0)
+        return -1;
+
+    // We expect to run in a single thread
+    // We don't need atomics here
+    if (*control != PTHREAD_ONCE_INIT)
+    {
+        (*init)();
+        *control = ~PTHREAD_ONCE_INIT;
+    }
+    return 0;
+}
+
+int sigfillset(sigset_t *set)
+{
+    // For dump debugging we don't need locking
+    return 0;
+}
+
+ssize_t      read(int fd, void *buf, size_t count)
+{
+    // For dump debugging we shouldn't need to open files
+    return -1;
+}
+
+int close(int fd)
+{
+    // For dump debugging we shouldn't need to open files
+    return -1;
+}

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/cross-dac.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/cross-dac.h
@@ -1,0 +1,86 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// This is minimal implementation of a header files required to cross compile
+// libunwind on a Windows host
+
+#ifndef CROSS_DAC_H_
+#define CROSS_DAC_H_
+
+#ifndef DACCESS_COMPILE
+#error This file should only be include when compiling for DAC
+// Contents of this file are here just to enable compliation of libunwind
+// on Windows.  Contents may not represent actual Posix headers
+// Many constants for instance are set to dummy values to make compilation possible...
+// Use at your own risk
+#endif
+
+#include <inttypes.h>
+#include <string.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#include "freebsd-elf_common.h"
+#include "freebsd-elf32.h"
+#include "freebsd-elf64.h"
+
+// Endian.h
+#define __LITTLE_ENDIAN        1234
+#define __BIG_ENDIAN           4321
+#define __BYTE_ORDER __LITTLE_ENDIAN
+
+#ifdef TARGET_AMD64
+typedef struct ucontext
+{
+    unsigned long DAC_IGNORE[16];
+}
+ucontext_t;
+#endif // TARGET_AMD64
+
+#ifdef TARGET_ARM64
+typedef struct ucontext
+{
+    unsigned long DAC_IGNORE[16];
+}
+ucontext_t;
+#endif // TARGET_ARM64
+
+typedef long pid_t;
+typedef long pthread_key_t;
+typedef long pthread_mutex_t;
+typedef long pthread_mutexattr_t;
+typedef long pthread_once_t;
+typedef ptrdiff_t ssize_t;
+typedef long siginfo_t;
+typedef long sigset_t;
+
+// Posix constants (with somewhat arbitrary values)
+
+#define MAP_FAILED (void *) -1
+#define MAP_ANON             1
+#define MAP_PRIVATE          2
+#define PROT_READ            4
+#define PROT_WRITE           8
+#define PTHREAD_DESTRUCTOR_ITERATIONS 0
+#define PTHREAD_MUTEX_INITIALIZER 0
+#define PTHREAD_ONCE_INIT 0
+
+// Posix function prototypes
+
+int          close(int);
+int          getpagesize(void);
+void*        mmap(void *, size_t, int, int, int, size_t);
+int          munmap(void *, size_t);
+int          open(const char *, int, ...);
+int          pthread_key_create(pthread_key_t *, void (*)(void*));
+int          pthread_mutex_init(pthread_mutex_t *, const pthread_mutexattr_t *);
+int          pthread_mutex_lock(pthread_mutex_t *);
+int          pthread_mutex_unlock(pthread_mutex_t *);
+int          pthread_once(pthread_once_t *, void (*)(void));
+int          pthread_setspecific(pthread_key_t, const void *);
+ssize_t      read(int fd, void *buf, size_t count);
+int          sigfillset(sigset_t *set);
+ssize_t      write(int, const void *, size_t);
+
+#endif // CROSS_DAC_ENDIAN_H_

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/elf.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/elf.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/endian.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/endian.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/freebsd-elf32.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/freebsd-elf32.h
@@ -1,0 +1,245 @@
+/*-
+ * Copyright (c) 1996-1998 John D. Polstra.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/sys/sys/elf32.h,v 1.8.14.2.2.1 2008/10/02 02:57:24 kensmith Exp $
+ */
+
+#ifndef _SYS_ELF32_H_
+#define _SYS_ELF32_H_ 1
+
+#include "freebsd-elf_common.h"
+
+/*
+ * ELF definitions common to all 32-bit architectures.
+ */
+
+typedef uint32_t	Elf32_Addr;
+typedef uint16_t	Elf32_Half;
+typedef uint32_t	Elf32_Off;
+typedef int32_t		Elf32_Sword;
+typedef uint32_t	Elf32_Word;
+typedef uint64_t	Elf32_Lword;
+
+typedef Elf32_Word	Elf32_Hashelt;
+
+/* Non-standard class-dependent datatype used for abstraction. */
+typedef Elf32_Word	Elf32_Size;
+typedef Elf32_Sword	Elf32_Ssize;
+
+/*
+ * ELF header.
+ */
+
+typedef struct {
+	unsigned char	e_ident[EI_NIDENT];	/* File identification. */
+	Elf32_Half	e_type;		/* File type. */
+	Elf32_Half	e_machine;	/* Machine architecture. */
+	Elf32_Word	e_version;	/* ELF format version. */
+	Elf32_Addr	e_entry;	/* Entry point. */
+	Elf32_Off	e_phoff;	/* Program header file offset. */
+	Elf32_Off	e_shoff;	/* Section header file offset. */
+	Elf32_Word	e_flags;	/* Architecture-specific flags. */
+	Elf32_Half	e_ehsize;	/* Size of ELF header in bytes. */
+	Elf32_Half	e_phentsize;	/* Size of program header entry. */
+	Elf32_Half	e_phnum;	/* Number of program header entries. */
+	Elf32_Half	e_shentsize;	/* Size of section header entry. */
+	Elf32_Half	e_shnum;	/* Number of section header entries. */
+	Elf32_Half	e_shstrndx;	/* Section name strings section. */
+} Elf32_Ehdr;
+
+/*
+ * Section header.
+ */
+
+typedef struct {
+	Elf32_Word	sh_name;	/* Section name (index into the
+					   section header string table). */
+	Elf32_Word	sh_type;	/* Section type. */
+	Elf32_Word	sh_flags;	/* Section flags. */
+	Elf32_Addr	sh_addr;	/* Address in memory image. */
+	Elf32_Off	sh_offset;	/* Offset in file. */
+	Elf32_Word	sh_size;	/* Size in bytes. */
+	Elf32_Word	sh_link;	/* Index of a related section. */
+	Elf32_Word	sh_info;	/* Depends on section type. */
+	Elf32_Word	sh_addralign;	/* Alignment in bytes. */
+	Elf32_Word	sh_entsize;	/* Size of each entry in section. */
+} Elf32_Shdr;
+
+/*
+ * Program header.
+ */
+
+typedef struct {
+	Elf32_Word	p_type;		/* Entry type. */
+	Elf32_Off	p_offset;	/* File offset of contents. */
+	Elf32_Addr	p_vaddr;	/* Virtual address in memory image. */
+	Elf32_Addr	p_paddr;	/* Physical address (not used). */
+	Elf32_Word	p_filesz;	/* Size of contents in file. */
+	Elf32_Word	p_memsz;	/* Size of contents in memory. */
+	Elf32_Word	p_flags;	/* Access permission flags. */
+	Elf32_Word	p_align;	/* Alignment in memory and file. */
+} Elf32_Phdr;
+
+/*
+ * Dynamic structure.  The ".dynamic" section contains an array of them.
+ */
+
+typedef struct {
+	Elf32_Sword	d_tag;		/* Entry type. */
+	union {
+		Elf32_Word	d_val;	/* Integer value. */
+		Elf32_Addr	d_ptr;	/* Address value. */
+	} d_un;
+} Elf32_Dyn;
+
+/*
+ * Relocation entries.
+ */
+
+/* Relocations that don't need an addend field. */
+typedef struct {
+	Elf32_Addr	r_offset;	/* Location to be relocated. */
+	Elf32_Word	r_info;		/* Relocation type and symbol index. */
+} Elf32_Rel;
+
+/* Relocations that need an addend field. */
+typedef struct {
+	Elf32_Addr	r_offset;	/* Location to be relocated. */
+	Elf32_Word	r_info;		/* Relocation type and symbol index. */
+	Elf32_Sword	r_addend;	/* Addend. */
+} Elf32_Rela;
+
+/* Macros for accessing the fields of r_info. */
+#define ELF32_R_SYM(info)	((info) >> 8)
+#define ELF32_R_TYPE(info)	((unsigned char)(info))
+
+/* Macro for constructing r_info from field values. */
+#define ELF32_R_INFO(sym, type)	(((sym) << 8) + (unsigned char)(type))
+
+/*
+ *	Note entry header
+ */
+typedef Elf_Note Elf32_Nhdr;
+
+/*
+ *	Move entry
+ */
+typedef struct {
+	Elf32_Lword	m_value;	/* symbol value */
+	Elf32_Word 	m_info;		/* size + index */
+	Elf32_Word	m_poffset;	/* symbol offset */
+	Elf32_Half	m_repeat;	/* repeat count */
+	Elf32_Half	m_stride;	/* stride info */
+} Elf32_Move;
+
+/*
+ *	The macros compose and decompose values for Move.r_info
+ *
+ *	sym = ELF32_M_SYM(M.m_info)
+ *	size = ELF32_M_SIZE(M.m_info)
+ *	M.m_info = ELF32_M_INFO(sym, size)
+ */
+#define	ELF32_M_SYM(info)	((info)>>8)
+#define	ELF32_M_SIZE(info)	((unsigned char)(info))
+#define	ELF32_M_INFO(sym, size)	(((sym)<<8)+(unsigned char)(size))
+
+/*
+ *	Hardware/Software capabilities entry
+ */
+typedef struct {
+	Elf32_Word	c_tag;		/* how to interpret value */
+	union {
+		Elf32_Word	c_val;
+		Elf32_Addr	c_ptr;
+	} c_un;
+} Elf32_Cap;
+
+/*
+ * Symbol table entries.
+ */
+
+typedef struct {
+	Elf32_Word	st_name;	/* String table index of name. */
+	Elf32_Addr	st_value;	/* Symbol value. */
+	Elf32_Word	st_size;	/* Size of associated object. */
+	unsigned char	st_info;	/* Type and binding information. */
+	unsigned char	st_other;	/* Reserved (not used). */
+	Elf32_Half	st_shndx;	/* Section index of symbol. */
+} Elf32_Sym;
+
+/* Macros for accessing the fields of st_info. */
+#define ELF32_ST_BIND(info)		((info) >> 4)
+#define ELF32_ST_TYPE(info)		((info) & 0xf)
+
+/* Macro for constructing st_info from field values. */
+#define ELF32_ST_INFO(bind, type)	(((bind) << 4) + ((type) & 0xf))
+
+/* Macro for accessing the fields of st_other. */
+#define ELF32_ST_VISIBILITY(oth)	((oth) & 0x3)
+
+/* Structures used by Sun & GNU symbol versioning. */
+typedef struct
+{
+	Elf32_Half	vd_version;
+	Elf32_Half	vd_flags;
+	Elf32_Half	vd_ndx;
+	Elf32_Half	vd_cnt;
+	Elf32_Word	vd_hash;
+	Elf32_Word	vd_aux;
+	Elf32_Word	vd_next;
+} Elf32_Verdef;
+
+typedef struct
+{
+	Elf32_Word	vda_name;
+	Elf32_Word	vda_next;
+} Elf32_Verdaux;
+
+typedef struct
+{
+	Elf32_Half	vn_version;
+	Elf32_Half	vn_cnt;
+	Elf32_Word	vn_file;
+	Elf32_Word	vn_aux;
+	Elf32_Word	vn_next;
+} Elf32_Verneed;
+
+typedef struct
+{
+	Elf32_Word	vna_hash;
+	Elf32_Half	vna_flags;
+	Elf32_Half	vna_other;
+	Elf32_Word	vna_name;
+	Elf32_Word	vna_next;
+} Elf32_Vernaux;
+
+typedef Elf32_Half Elf32_Versym;
+
+typedef struct {
+	Elf32_Half	si_boundto;	/* direct bindings - symbol bound to */
+	Elf32_Half	si_flags;	/* per symbol flags */
+} Elf32_Syminfo;
+
+#endif /* !_SYS_ELF32_H_ */

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/freebsd-elf64.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/freebsd-elf64.h
@@ -1,0 +1,252 @@
+/*-
+ * Copyright (c) 1996-1998 John D. Polstra.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/sys/sys/elf64.h,v 1.10.14.2.2.1 2008/10/02 02:57:24 kensmith Exp $
+ */
+
+#ifndef _SYS_ELF64_H_
+#define _SYS_ELF64_H_ 1
+
+#include "freebsd-elf_common.h"
+
+/*
+ * ELF definitions common to all 64-bit architectures.
+ */
+
+typedef uint64_t	Elf64_Addr;
+typedef uint16_t	Elf64_Half;
+typedef uint64_t	Elf64_Off;
+typedef int32_t		Elf64_Sword;
+typedef int64_t		Elf64_Sxword;
+typedef uint32_t	Elf64_Word;
+typedef uint64_t	Elf64_Lword;
+typedef uint64_t	Elf64_Xword;
+
+/*
+ * Types of dynamic symbol hash table bucket and chain elements.
+ *
+ * This is inconsistent among 64 bit architectures, so a machine dependent
+ * typedef is required.
+ */
+
+#ifdef __alpha__
+typedef Elf64_Off	Elf64_Hashelt;
+#else
+typedef Elf64_Word	Elf64_Hashelt;
+#endif
+
+/* Non-standard class-dependent datatype used for abstraction. */
+typedef Elf64_Xword	Elf64_Size;
+typedef Elf64_Sxword	Elf64_Ssize;
+
+/*
+ * ELF header.
+ */
+
+typedef struct {
+	unsigned char	e_ident[EI_NIDENT];	/* File identification. */
+	Elf64_Half	e_type;		/* File type. */
+	Elf64_Half	e_machine;	/* Machine architecture. */
+	Elf64_Word	e_version;	/* ELF format version. */
+	Elf64_Addr	e_entry;	/* Entry point. */
+	Elf64_Off	e_phoff;	/* Program header file offset. */
+	Elf64_Off	e_shoff;	/* Section header file offset. */
+	Elf64_Word	e_flags;	/* Architecture-specific flags. */
+	Elf64_Half	e_ehsize;	/* Size of ELF header in bytes. */
+	Elf64_Half	e_phentsize;	/* Size of program header entry. */
+	Elf64_Half	e_phnum;	/* Number of program header entries. */
+	Elf64_Half	e_shentsize;	/* Size of section header entry. */
+	Elf64_Half	e_shnum;	/* Number of section header entries. */
+	Elf64_Half	e_shstrndx;	/* Section name strings section. */
+} Elf64_Ehdr;
+
+/*
+ * Section header.
+ */
+
+typedef struct {
+	Elf64_Word	sh_name;	/* Section name (index into the
+					   section header string table). */
+	Elf64_Word	sh_type;	/* Section type. */
+	Elf64_Xword	sh_flags;	/* Section flags. */
+	Elf64_Addr	sh_addr;	/* Address in memory image. */
+	Elf64_Off	sh_offset;	/* Offset in file. */
+	Elf64_Xword	sh_size;	/* Size in bytes. */
+	Elf64_Word	sh_link;	/* Index of a related section. */
+	Elf64_Word	sh_info;	/* Depends on section type. */
+	Elf64_Xword	sh_addralign;	/* Alignment in bytes. */
+	Elf64_Xword	sh_entsize;	/* Size of each entry in section. */
+} Elf64_Shdr;
+
+/*
+ * Program header.
+ */
+
+typedef struct {
+	Elf64_Word	p_type;		/* Entry type. */
+	Elf64_Word	p_flags;	/* Access permission flags. */
+	Elf64_Off	p_offset;	/* File offset of contents. */
+	Elf64_Addr	p_vaddr;	/* Virtual address in memory image. */
+	Elf64_Addr	p_paddr;	/* Physical address (not used). */
+	Elf64_Xword	p_filesz;	/* Size of contents in file. */
+	Elf64_Xword	p_memsz;	/* Size of contents in memory. */
+	Elf64_Xword	p_align;	/* Alignment in memory and file. */
+} Elf64_Phdr;
+
+/*
+ * Dynamic structure.  The ".dynamic" section contains an array of them.
+ */
+
+typedef struct {
+	Elf64_Sxword	d_tag;		/* Entry type. */
+	union {
+		Elf64_Xword	d_val;	/* Integer value. */
+		Elf64_Addr	d_ptr;	/* Address value. */
+	} d_un;
+} Elf64_Dyn;
+
+/*
+ * Relocation entries.
+ */
+
+/* Relocations that don't need an addend field. */
+typedef struct {
+	Elf64_Addr	r_offset;	/* Location to be relocated. */
+	Elf64_Xword	r_info;		/* Relocation type and symbol index. */
+} Elf64_Rel;
+
+/* Relocations that need an addend field. */
+typedef struct {
+	Elf64_Addr	r_offset;	/* Location to be relocated. */
+	Elf64_Xword	r_info;		/* Relocation type and symbol index. */
+	Elf64_Sxword	r_addend;	/* Addend. */
+} Elf64_Rela;
+
+/* Macros for accessing the fields of r_info. */
+#define ELF64_R_SYM(info)	((info) >> 32)
+#define ELF64_R_TYPE(info)	((info) & 0xffffffffL)
+
+/* Macro for constructing r_info from field values. */
+#define ELF64_R_INFO(sym, type)	(((sym) << 32) + ((type) & 0xffffffffL))
+
+#define	ELF64_R_TYPE_DATA(info)	(((Elf64_Xword)(info)<<32)>>40)
+#define	ELF64_R_TYPE_ID(info)	(((Elf64_Xword)(info)<<56)>>56)
+#define	ELF64_R_TYPE_INFO(data, type)	\
+		(((Elf64_Xword)(data)<<8)+(Elf64_Xword)(type))
+
+/*
+ *	Note entry header
+ */
+typedef Elf_Note Elf64_Nhdr;
+
+/*
+ *	Move entry
+ */
+typedef struct {
+	Elf64_Lword	m_value;	/* symbol value */
+	Elf64_Xword 	m_info;		/* size + index */
+	Elf64_Xword	m_poffset;	/* symbol offset */
+	Elf64_Half	m_repeat;	/* repeat count */
+	Elf64_Half	m_stride;	/* stride info */
+} Elf64_Move;
+
+#define	ELF64_M_SYM(info)	((info)>>8)
+#define	ELF64_M_SIZE(info)	((unsigned char)(info))
+#define	ELF64_M_INFO(sym, size)	(((sym)<<8)+(unsigned char)(size))
+
+/*
+ *	Hardware/Software capabilities entry
+ */
+typedef struct {
+	Elf64_Xword	c_tag;		/* how to interpret value */
+	union {
+		Elf64_Xword	c_val;
+		Elf64_Addr	c_ptr;
+	} c_un;
+} Elf64_Cap;
+
+/*
+ * Symbol table entries.
+ */
+
+typedef struct {
+	Elf64_Word	st_name;	/* String table index of name. */
+	unsigned char	st_info;	/* Type and binding information. */
+	unsigned char	st_other;	/* Reserved (not used). */
+	Elf64_Half	st_shndx;	/* Section index of symbol. */
+	Elf64_Addr	st_value;	/* Symbol value. */
+	Elf64_Xword	st_size;	/* Size of associated object. */
+} Elf64_Sym;
+
+/* Macros for accessing the fields of st_info. */
+#define ELF64_ST_BIND(info)		((info) >> 4)
+#define ELF64_ST_TYPE(info)		((info) & 0xf)
+
+/* Macro for constructing st_info from field values. */
+#define ELF64_ST_INFO(bind, type)	(((bind) << 4) + ((type) & 0xf))
+
+/* Macro for accessing the fields of st_other. */
+#define ELF64_ST_VISIBILITY(oth)	((oth) & 0x3)
+
+/* Structures used by Sun & GNU-style symbol versioning. */
+typedef struct {
+	Elf64_Half	vd_version;
+	Elf64_Half	vd_flags;
+	Elf64_Half	vd_ndx;
+	Elf64_Half	vd_cnt;
+	Elf64_Word	vd_hash;
+	Elf64_Word	vd_aux;
+	Elf64_Word	vd_next;
+} Elf64_Verdef;
+
+typedef struct {
+	Elf64_Word	vda_name;
+	Elf64_Word	vda_next;
+} Elf64_Verdaux;
+
+typedef struct {
+	Elf64_Half	vn_version;
+	Elf64_Half	vn_cnt;
+	Elf64_Word	vn_file;
+	Elf64_Word	vn_aux;
+	Elf64_Word	vn_next;
+} Elf64_Verneed;
+
+typedef struct {
+	Elf64_Word	vna_hash;
+	Elf64_Half	vna_flags;
+	Elf64_Half	vna_other;
+	Elf64_Word	vna_name;
+	Elf64_Word	vna_next;
+} Elf64_Vernaux;
+
+typedef Elf64_Half Elf64_Versym;
+
+typedef struct {
+	Elf64_Half	si_boundto;	/* direct bindings - symbol bound to */
+	Elf64_Half	si_flags;	/* per symbol flags */
+} Elf64_Syminfo;
+
+#endif /* !_SYS_ELF64_H_ */

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/freebsd-elf_common.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/freebsd-elf_common.h
@@ -1,0 +1,865 @@
+/*-
+ * Copyright (c) 1998 John D. Polstra.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * $FreeBSD: src/sys/sys/elf_common.h,v 1.24 2008/08/02 01:20:10 imp Exp $
+ */
+
+#ifndef _SYS_ELF_COMMON_H_
+#define _SYS_ELF_COMMON_H_ 1
+
+/*
+ * ELF definitions that are independent of architecture or word size.
+ */
+
+/*
+ * Note header.  The ".note" section contains an array of notes.  Each
+ * begins with this header, aligned to a word boundary.  Immediately
+ * following the note header is n_namesz bytes of name, padded to the
+ * next word boundary.  Then comes n_descsz bytes of descriptor, again
+ * padded to a word boundary.  The values of n_namesz and n_descsz do
+ * not include the padding.
+ */
+
+typedef struct {
+	uint32_t	n_namesz;	/* Length of name. */
+	uint32_t	n_descsz;	/* Length of descriptor. */
+	uint32_t	n_type;		/* Type of this note. */
+} Elf_Note;
+
+/* Indexes into the e_ident array.  Keep synced with
+   http://www.sco.com/developers/gabi/latest/ch4.eheader.html */
+#define EI_MAG0		0	/* Magic number, byte 0. */
+#define EI_MAG1		1	/* Magic number, byte 1. */
+#define EI_MAG2		2	/* Magic number, byte 2. */
+#define EI_MAG3		3	/* Magic number, byte 3. */
+#define EI_CLASS	4	/* Class of machine. */
+#define EI_DATA		5	/* Data format. */
+#define EI_VERSION	6	/* ELF format version. */
+#define EI_OSABI	7	/* Operating system / ABI identification */
+#define EI_ABIVERSION	8	/* ABI version */
+#define OLD_EI_BRAND	8	/* Start of architecture identification. */
+#define EI_PAD		9	/* Start of padding (per SVR4 ABI). */
+#define EI_NIDENT	16	/* Size of e_ident array. */
+
+/* Values for the magic number bytes. */
+#define ELFMAG0		0x7f
+#define ELFMAG1		'E'
+#define ELFMAG2		'L'
+#define ELFMAG3		'F'
+#define ELFMAG		"\177ELF"	/* magic string */
+#define SELFMAG		4		/* magic string size */
+
+/* Values for e_ident[EI_VERSION] and e_version. */
+#define EV_NONE		0
+#define EV_CURRENT	1
+
+/* Values for e_ident[EI_CLASS]. */
+#define ELFCLASSNONE	0	/* Unknown class. */
+#define ELFCLASS32	1	/* 32-bit architecture. */
+#define ELFCLASS64	2	/* 64-bit architecture. */
+
+/* Values for e_ident[EI_DATA]. */
+#define ELFDATANONE	0	/* Unknown data format. */
+#define ELFDATA2LSB	1	/* 2's complement little-endian. */
+#define ELFDATA2MSB	2	/* 2's complement big-endian. */
+
+/* Values for e_ident[EI_OSABI]. */
+#define ELFOSABI_NONE		0	/* UNIX System V ABI */
+#define ELFOSABI_HPUX		1	/* HP-UX operating system */
+#define ELFOSABI_NETBSD		2	/* NetBSD */
+#define ELFOSABI_LINUX		3	/* GNU/Linux */
+#define ELFOSABI_HURD		4	/* GNU/Hurd */
+#define ELFOSABI_86OPEN		5	/* 86Open common IA32 ABI */
+#define ELFOSABI_SOLARIS	6	/* Solaris */
+#define ELFOSABI_AIX		7	/* AIX */
+#define ELFOSABI_IRIX		8	/* IRIX */
+#define ELFOSABI_FREEBSD	9	/* FreeBSD */
+#define ELFOSABI_TRU64		10	/* TRU64 UNIX */
+#define ELFOSABI_MODESTO	11	/* Novell Modesto */
+#define ELFOSABI_OPENBSD	12	/* OpenBSD */
+#define ELFOSABI_OPENVMS	13	/* Open VMS */
+#define ELFOSABI_NSK		14	/* HP Non-Stop Kernel */
+#define ELFOSABI_ARM		97	/* ARM */
+#define ELFOSABI_STANDALONE	255	/* Standalone (embedded) application */
+
+#define ELFOSABI_SYSV		ELFOSABI_NONE	/* symbol used in old spec */
+#define ELFOSABI_MONTEREY	ELFOSABI_AIX	/* Monterey */
+
+/* e_ident */
+#define IS_ELF(ehdr)	((ehdr).e_ident[EI_MAG0] == ELFMAG0 && \
+			 (ehdr).e_ident[EI_MAG1] == ELFMAG1 && \
+			 (ehdr).e_ident[EI_MAG2] == ELFMAG2 && \
+			 (ehdr).e_ident[EI_MAG3] == ELFMAG3)
+
+/* Values for e_type. */
+#define ET_NONE		0	/* Unknown type. */
+#define ET_REL		1	/* Relocatable. */
+#define ET_EXEC		2	/* Executable. */
+#define ET_DYN		3	/* Shared object. */
+#define ET_CORE		4	/* Core file. */
+#define ET_LOOS		0xfe00	/* First operating system specific. */
+#define ET_HIOS		0xfeff	/* Last operating system-specific. */
+#define ET_LOPROC	0xff00	/* First processor-specific. */
+#define ET_HIPROC	0xffff	/* Last processor-specific. */
+
+/* Values for e_machine. */
+#define EM_NONE		0	/* Unknown machine. */
+#define EM_M32		1	/* AT&T WE32100. */
+#define EM_SPARC	2	/* Sun SPARC. */
+#define EM_386		3	/* Intel i386. */
+#define EM_68K		4	/* Motorola 68000. */
+#define EM_88K		5	/* Motorola 88000. */
+#define EM_860		7	/* Intel i860. */
+#define EM_MIPS		8	/* MIPS R3000 Big-Endian only. */
+#define EM_S370		9	/* IBM System/370. */
+#define EM_MIPS_RS3_LE	10	/* MIPS R3000 Little-Endian. */
+#define EM_PARISC	15	/* HP PA-RISC. */
+#define EM_VPP500	17	/* Fujitsu VPP500. */
+#define EM_SPARC32PLUS	18	/* SPARC v8plus. */
+#define EM_960		19	/* Intel 80960. */
+#define EM_PPC		20	/* PowerPC 32-bit. */
+#define EM_PPC64	21	/* PowerPC 64-bit. */
+#define EM_S390		22	/* IBM System/390. */
+#define EM_V800		36	/* NEC V800. */
+#define EM_FR20		37	/* Fujitsu FR20. */
+#define EM_RH32		38	/* TRW RH-32. */
+#define EM_RCE		39	/* Motorola RCE. */
+#define EM_ARM		40	/* ARM. */
+#define EM_SH		42	/* Hitachi SH. */
+#define EM_SPARCV9	43	/* SPARC v9 64-bit. */
+#define EM_TRICORE	44	/* Siemens TriCore embedded processor. */
+#define EM_ARC		45	/* Argonaut RISC Core. */
+#define EM_H8_300	46	/* Hitachi H8/300. */
+#define EM_H8_300H	47	/* Hitachi H8/300H. */
+#define EM_H8S		48	/* Hitachi H8S. */
+#define EM_H8_500	49	/* Hitachi H8/500. */
+#define EM_IA_64	50	/* Intel IA-64 Processor. */
+#define EM_MIPS_X	51	/* Stanford MIPS-X. */
+#define EM_COLDFIRE	52	/* Motorola ColdFire. */
+#define EM_68HC12	53	/* Motorola M68HC12. */
+#define EM_MMA		54	/* Fujitsu MMA. */
+#define EM_PCP		55	/* Siemens PCP. */
+#define EM_NCPU		56	/* Sony nCPU. */
+#define EM_NDR1		57	/* Denso NDR1 microprocessor. */
+#define EM_STARCORE	58	/* Motorola Star*Core processor. */
+#define EM_ME16		59	/* Toyota ME16 processor. */
+#define EM_ST100	60	/* STMicroelectronics ST100 processor. */
+#define EM_TINYJ	61	/* Advanced Logic Corp. TinyJ processor. */
+#define EM_X86_64	62	/* Advanced Micro Devices x86-64 */
+#define	EM_AMD64	EM_X86_64	/* Advanced Micro Devices x86-64 (compat) */
+
+/* Non-standard or deprecated. */
+#define EM_486		6	/* Intel i486. */
+#define EM_MIPS_RS4_BE	10	/* MIPS R4000 Big-Endian */
+#define EM_ALPHA_STD	41	/* Digital Alpha (standard value). */
+#define EM_ALPHA	0x9026	/* Alpha (written in the absence of an ABI) */
+
+/* Special section indexes. */
+#define SHN_UNDEF	     0		/* Undefined, missing, irrelevant. */
+#define SHN_LORESERVE	0xff00		/* First of reserved range. */
+#define SHN_LOPROC	0xff00		/* First processor-specific. */
+#define SHN_HIPROC	0xff1f		/* Last processor-specific. */
+#define SHN_LOOS	0xff20		/* First operating system-specific. */
+#define SHN_HIOS	0xff3f		/* Last operating system-specific. */
+#define SHN_ABS		0xfff1		/* Absolute values. */
+#define SHN_COMMON	0xfff2		/* Common data. */
+#define SHN_XINDEX	0xffff		/* Escape -- index stored elsewhere. */
+#define SHN_HIRESERVE	0xffff		/* Last of reserved range. */
+
+/* sh_type */
+#define SHT_NULL		0	/* inactive */
+#define SHT_PROGBITS		1	/* program defined information */
+#define SHT_SYMTAB		2	/* symbol table section */
+#define SHT_STRTAB		3	/* string table section */
+#define SHT_RELA		4	/* relocation section with addends */
+#define SHT_HASH		5	/* symbol hash table section */
+#define SHT_DYNAMIC		6	/* dynamic section */ 
+#define SHT_NOTE		7	/* note section */
+#define SHT_NOBITS		8	/* no space section */
+#define SHT_REL			9	/* relocation section - no addends */
+#define SHT_SHLIB		10	/* reserved - purpose unknown */
+#define SHT_DYNSYM		11	/* dynamic symbol table section */ 
+#define SHT_INIT_ARRAY		14	/* Initialization function pointers. */
+#define SHT_FINI_ARRAY		15	/* Termination function pointers. */
+#define SHT_PREINIT_ARRAY	16	/* Pre-initialization function ptrs. */
+#define SHT_GROUP		17	/* Section group. */
+#define SHT_SYMTAB_SHNDX	18	/* Section indexes (see SHN_XINDEX). */
+#define SHT_LOOS		0x60000000	/* First of OS specific semantics */
+#define SHT_LOSUNW		0x6ffffff4
+#define SHT_SUNW_dof		0x6ffffff4
+#define SHT_SUNW_cap		0x6ffffff5
+#define SHT_SUNW_SIGNATURE	0x6ffffff6
+#define SHT_SUNW_ANNOTATE	0x6ffffff7
+#define SHT_SUNW_DEBUGSTR	0x6ffffff8
+#define SHT_SUNW_DEBUG		0x6ffffff9
+#define SHT_SUNW_move		0x6ffffffa
+#define SHT_SUNW_COMDAT		0x6ffffffb
+#define SHT_SUNW_syminfo	0x6ffffffc
+#define SHT_SUNW_verdef		0x6ffffffd
+#define SHT_GNU_verdef		0x6ffffffd	/* Symbol versions provided */
+#define SHT_SUNW_verneed	0x6ffffffe
+#define SHT_GNU_verneed		0x6ffffffe	/* Symbol versions required */
+#define SHT_SUNW_versym		0x6fffffff
+#define SHT_GNU_versym		0x6fffffff	/* Symbol version table */
+#define SHT_HISUNW		0x6fffffff
+#define SHT_HIOS		0x6fffffff	/* Last of OS specific semantics */
+#define SHT_LOPROC		0x70000000	/* reserved range for processor */
+#define SHT_AMD64_UNWIND	0x70000001	/* unwind information */
+#define SHT_HIPROC		0x7fffffff	/* specific section header types */
+#define SHT_LOUSER		0x80000000	/* reserved range for application */
+#define SHT_HIUSER		0xffffffff	/* specific indexes */
+
+/* Flags for sh_flags. */
+#define SHF_WRITE		0x1	/* Section contains writable data. */
+#define SHF_ALLOC		0x2	/* Section occupies memory. */
+#define SHF_EXECINSTR		0x4	/* Section contains instructions. */
+#define SHF_MERGE		0x10	/* Section may be merged. */
+#define SHF_STRINGS		0x20	/* Section contains strings. */
+#define SHF_INFO_LINK		0x40	/* sh_info holds section index. */
+#define SHF_LINK_ORDER		0x80	/* Special ordering requirements. */
+#define SHF_OS_NONCONFORMING	0x100	/* OS-specific processing required. */
+#define SHF_GROUP		0x200	/* Member of section group. */
+#define SHF_TLS			0x400	/* Section contains TLS data. */
+#define SHF_MASKOS	0x0ff00000	/* OS-specific semantics. */
+#define SHF_MASKPROC	0xf0000000	/* Processor-specific semantics. */
+
+/* Values for p_type. */
+#define PT_NULL		0	/* Unused entry. */
+#define PT_LOAD		1	/* Loadable segment. */
+#define PT_DYNAMIC	2	/* Dynamic linking information segment. */
+#define PT_INTERP	3	/* Pathname of interpreter. */
+#define PT_NOTE		4	/* Auxiliary information. */
+#define PT_SHLIB	5	/* Reserved (not used). */
+#define PT_PHDR		6	/* Location of program header itself. */
+#define	PT_TLS		7	/* Thread local storage segment */
+#define PT_LOOS		0x60000000	/* First OS-specific. */
+#define	PT_SUNW_UNWIND	0x6464e550	/* amd64 UNWIND program header */
+#define	PT_GNU_EH_FRAME	0x6474e550
+#define PT_GNU_STACK 0x6474e551
+#define	PT_LOSUNW	0x6ffffffa
+#define	PT_SUNWBSS	0x6ffffffa	/* Sun Specific segment */
+#define	PT_SUNWSTACK	0x6ffffffb	/* describes the stack segment */
+#define	PT_SUNWDTRACE	0x6ffffffc	/* private */
+#define	PT_SUNWCAP	0x6ffffffd	/* hard/soft capabilities segment */
+#define	PT_HISUNW	0x6fffffff
+#define PT_HIOS		0x6fffffff	/* Last OS-specific. */
+#define PT_LOPROC	0x70000000	/* First processor-specific type. */
+#define PT_HIPROC	0x7fffffff	/* Last processor-specific type. */
+
+/* Values for p_flags. */
+#define PF_X		0x1		/* Executable. */
+#define PF_W		0x2		/* Writable. */
+#define PF_R		0x4		/* Readable. */
+#define PF_MASKOS	0x0ff00000	/* Operating system-specific. */
+#define PF_MASKPROC	0xf0000000	/* Processor-specific. */
+
+/* Extended program header index. */
+#define	PN_XNUM		0xffff
+
+/* Values for d_tag. */
+#define DT_NULL		0	/* Terminating entry. */
+#define DT_NEEDED	1	/* String table offset of a needed shared
+				   library. */
+#define DT_PLTRELSZ	2	/* Total size in bytes of PLT relocations. */
+#define DT_PLTGOT	3	/* Processor-dependent address. */
+#define DT_HASH		4	/* Address of symbol hash table. */
+#define DT_STRTAB	5	/* Address of string table. */
+#define DT_SYMTAB	6	/* Address of symbol table. */
+#define DT_RELA		7	/* Address of ElfNN_Rela relocations. */
+#define DT_RELASZ	8	/* Total size of ElfNN_Rela relocations. */
+#define DT_RELAENT	9	/* Size of each ElfNN_Rela relocation entry. */
+#define DT_STRSZ	10	/* Size of string table. */
+#define DT_SYMENT	11	/* Size of each symbol table entry. */
+#define DT_INIT		12	/* Address of initialization function. */
+#define DT_FINI		13	/* Address of finalization function. */
+#define DT_SONAME	14	/* String table offset of shared object
+				   name. */
+#define DT_RPATH	15	/* String table offset of library path. [sup] */
+#define DT_SYMBOLIC	16	/* Indicates "symbolic" linking. [sup] */
+#define DT_REL		17	/* Address of ElfNN_Rel relocations. */
+#define DT_RELSZ	18	/* Total size of ElfNN_Rel relocations. */
+#define DT_RELENT	19	/* Size of each ElfNN_Rel relocation. */
+#define DT_PLTREL	20	/* Type of relocation used for PLT. */
+#define DT_DEBUG	21	/* Reserved (not used). */
+#define DT_TEXTREL	22	/* Indicates there may be relocations in
+				   non-writable segments. [sup] */
+#define DT_JMPREL	23	/* Address of PLT relocations. */
+#define	DT_BIND_NOW	24	/* [sup] */
+#define	DT_INIT_ARRAY	25	/* Address of the array of pointers to
+				   initialization functions */
+#define	DT_FINI_ARRAY	26	/* Address of the array of pointers to
+				   termination functions */
+#define	DT_INIT_ARRAYSZ	27	/* Size in bytes of the array of
+				   initialization functions. */
+#define	DT_FINI_ARRAYSZ	28	/* Size in bytes of the array of
+				   terminationfunctions. */
+#define	DT_RUNPATH	29	/* String table offset of a null-terminated
+				   library search path string. */
+#define	DT_FLAGS	30	/* Object specific flag values. */
+#define	DT_ENCODING	32	/* Values greater than or equal to DT_ENCODING
+				   and less than DT_LOOS follow the rules for
+				   the interpretation of the d_un union
+				   as follows: even == 'd_ptr', even == 'd_val'
+				   or none */
+#define	DT_PREINIT_ARRAY 32	/* Address of the array of pointers to
+				   pre-initialization functions. */
+#define	DT_PREINIT_ARRAYSZ 33	/* Size in bytes of the array of
+				   pre-initialization functions. */
+#define	DT_MAXPOSTAGS	34	/* number of positive tags */
+#define	DT_LOOS		0x6000000d	/* First OS-specific */
+#define	DT_SUNW_AUXILIARY	0x6000000d	/* symbol auxiliary name */
+#define	DT_SUNW_RTLDINF		0x6000000e	/* ld.so.1 info (private) */
+#define	DT_SUNW_FILTER		0x6000000f	/* symbol filter name */
+#define	DT_SUNW_CAP		0x60000010	/* hardware/software */
+#define	DT_HIOS		0x6ffff000	/* Last OS-specific */
+
+/*
+ * DT_* entries which fall between DT_VALRNGHI & DT_VALRNGLO use the
+ * Dyn.d_un.d_val field of the Elf*_Dyn structure.
+ */
+#define	DT_VALRNGLO	0x6ffffd00
+#define	DT_CHECKSUM	0x6ffffdf8	/* elf checksum */
+#define	DT_PLTPADSZ	0x6ffffdf9	/* pltpadding size */
+#define	DT_MOVEENT	0x6ffffdfa	/* move table entry size */
+#define	DT_MOVESZ	0x6ffffdfb	/* move table size */
+#define	DT_FEATURE_1	0x6ffffdfc	/* feature holder */
+#define	DT_POSFLAG_1	0x6ffffdfd	/* flags for DT_* entries, effecting */
+					/*	the following DT_* entry. */
+					/*	See DF_P1_* definitions */
+#define	DT_SYMINSZ	0x6ffffdfe	/* syminfo table size (in bytes) */
+#define	DT_SYMINENT	0x6ffffdff	/* syminfo entry size (in bytes) */
+#define	DT_VALRNGHI	0x6ffffdff
+
+/*
+ * DT_* entries which fall between DT_ADDRRNGHI & DT_ADDRRNGLO use the
+ * Dyn.d_un.d_ptr field of the Elf*_Dyn structure.
+ *
+ * If any adjustment is made to the ELF object after it has been
+ * built, these entries will need to be adjusted.
+ */
+#define	DT_ADDRRNGLO	0x6ffffe00
+#define	DT_CONFIG	0x6ffffefa	/* configuration information */
+#define	DT_DEPAUDIT	0x6ffffefb	/* dependency auditing */
+#define	DT_AUDIT	0x6ffffefc	/* object auditing */
+#define	DT_PLTPAD	0x6ffffefd	/* pltpadding (sparcv9) */
+#define	DT_MOVETAB	0x6ffffefe	/* move table */
+#define	DT_SYMINFO	0x6ffffeff	/* syminfo table */
+#define	DT_ADDRRNGHI	0x6ffffeff
+
+#define	DT_VERSYM	0x6ffffff0	/* Address of versym section. */
+#define	DT_RELACOUNT	0x6ffffff9	/* number of RELATIVE relocations */
+#define	DT_RELCOUNT	0x6ffffffa	/* number of RELATIVE relocations */
+#define	DT_FLAGS_1	0x6ffffffb	/* state flags - see DF_1_* defs */
+#define	DT_VERDEF	0x6ffffffc	/* Address of verdef section. */
+#define	DT_VERDEFNUM	0x6ffffffd	/* Number of elems in verdef section */
+#define	DT_VERNEED	0x6ffffffe	/* Address of verneed section. */
+#define	DT_VERNEEDNUM	0x6fffffff	/* Number of elems in verneed section */
+
+#define	DT_LOPROC	0x70000000	/* First processor-specific type. */
+#define	DT_DEPRECATED_SPARC_REGISTER	0x7000001
+#define	DT_AUXILIARY	0x7ffffffd	/* shared library auxiliary name */
+#define	DT_USED		0x7ffffffe	/* ignored - same as needed */
+#define	DT_FILTER	0x7fffffff	/* shared library filter name */
+#define	DT_HIPROC	0x7fffffff	/* Last processor-specific type. */
+
+/* Values for DT_FLAGS */
+#define	DF_ORIGIN	0x0001	/* Indicates that the object being loaded may
+				   make reference to the $ORIGIN substitution
+				   string */
+#define	DF_SYMBOLIC	0x0002	/* Indicates "symbolic" linking. */
+#define	DF_TEXTREL	0x0004	/* Indicates there may be relocations in
+				   non-writable segments. */
+#define	DF_BIND_NOW	0x0008	/* Indicates that the dynamic linker should
+				   process all relocations for the object
+				   containing this entry before transferring
+				   control to the program. */
+#define	DF_STATIC_TLS	0x0010	/* Indicates that the shared object or
+				   executable contains code using a static
+				   thread-local storage scheme. */
+
+/* Values for n_type.  Used in core files. */
+#define NT_PRSTATUS	1	/* Process status. */
+#define NT_FPREGSET	2	/* Floating point registers. */
+#define NT_PRPSINFO	3	/* Process state info. */
+
+/* Symbol Binding - ELFNN_ST_BIND - st_info */
+#define STB_LOCAL	0	/* Local symbol */
+#define STB_GLOBAL	1	/* Global symbol */
+#define STB_WEAK	2	/* like global - lower precedence */
+#define STB_LOOS	10	/* Reserved range for operating system */
+#define STB_HIOS	12	/*   specific semantics. */
+#define STB_LOPROC	13	/* reserved range for processor */
+#define STB_HIPROC	15	/*   specific semantics. */
+
+/* Symbol type - ELFNN_ST_TYPE - st_info */
+#define STT_NOTYPE	0	/* Unspecified type. */
+#define STT_OBJECT	1	/* Data object. */
+#define STT_FUNC	2	/* Function. */
+#define STT_SECTION	3	/* Section. */
+#define STT_FILE	4	/* Source file. */
+#define STT_COMMON	5	/* Uninitialized common block. */
+#define STT_TLS		6	/* TLS object. */
+#define STT_NUM		7
+#define STT_LOOS	10	/* Reserved range for operating system */
+#define STT_HIOS	12	/*   specific semantics. */
+#define STT_LOPROC	13	/* reserved range for processor */
+#define STT_HIPROC	15	/*   specific semantics. */
+
+/* Symbol visibility - ELFNN_ST_VISIBILITY - st_other */
+#define STV_DEFAULT	0x0	/* Default visibility (see binding). */
+#define STV_INTERNAL	0x1	/* Special meaning in relocatable objects. */
+#define STV_HIDDEN	0x2	/* Not visible. */
+#define STV_PROTECTED	0x3	/* Visible but not preemptible. */
+#define STV_EXPORTED	0x4
+#define STV_SINGLETON	0x5
+#define STV_ELIMINATE	0x6
+
+/* Special symbol table indexes. */
+#define STN_UNDEF	0	/* Undefined symbol index. */
+
+/* Symbol versioning flags. */
+#define	VER_DEF_CURRENT	1
+#define VER_DEF_IDX(x)	VER_NDX(x)
+
+#define	VER_FLG_BASE	0x01
+#define	VER_FLG_WEAK	0x02
+
+#define	VER_NEED_CURRENT	1
+#define VER_NEED_WEAK	(1u << 15)
+#define VER_NEED_HIDDEN	VER_NDX_HIDDEN
+#define VER_NEED_IDX(x)	VER_NDX(x)
+
+#define	VER_NDX_LOCAL	0
+#define	VER_NDX_GLOBAL	1
+#define VER_NDX_GIVEN	2
+
+#define VER_NDX_HIDDEN	(1u << 15)
+#define VER_NDX(x)	((x) & ~(1u << 15))
+
+#define	CA_SUNW_NULL	0
+#define	CA_SUNW_HW_1	1		/* first hardware capabilities entry */
+#define	CA_SUNW_SF_1	2		/* first software capabilities entry */
+
+/*
+ * Syminfo flag values
+ */
+#define	SYMINFO_FLG_DIRECT	0x0001	/* symbol ref has direct association */
+					/*	to object containing defn. */
+#define	SYMINFO_FLG_PASSTHRU	0x0002	/* ignored - see SYMINFO_FLG_FILTER */
+#define	SYMINFO_FLG_COPY	0x0004	/* symbol is a copy-reloc */
+#define	SYMINFO_FLG_LAZYLOAD	0x0008	/* object containing defn should be */
+					/*	lazily-loaded */
+#define	SYMINFO_FLG_DIRECTBIND	0x0010	/* ref should be bound directly to */
+					/*	object containing defn. */
+#define	SYMINFO_FLG_NOEXTDIRECT	0x0020	/* don't let an external reference */
+					/*	directly bind to this symbol */
+#define	SYMINFO_FLG_FILTER	0x0002	/* symbol ref is associated to a */
+#define	SYMINFO_FLG_AUXILIARY	0x0040	/* 	standard or auxiliary filter */
+
+/*
+ * Syminfo.si_boundto values.
+ */
+#define	SYMINFO_BT_SELF		0xffff	/* symbol bound to self */
+#define	SYMINFO_BT_PARENT	0xfffe	/* symbol bound to parent */
+#define	SYMINFO_BT_NONE		0xfffd	/* no special symbol binding */
+#define	SYMINFO_BT_EXTERN	0xfffc	/* symbol defined as external */
+#define	SYMINFO_BT_LOWRESERVE	0xff00	/* beginning of reserved entries */
+
+/*
+ * Syminfo version values.
+ */
+#define	SYMINFO_NONE		0	/* Syminfo version */
+#define	SYMINFO_CURRENT		1
+#define	SYMINFO_NUM		2
+
+/*
+ * Relocation types.
+ *
+ * All machine architectures are defined here to allow tools on one to
+ * handle others.
+ */
+
+#define	R_386_NONE		0	/* No relocation. */
+#define	R_386_32		1	/* Add symbol value. */
+#define	R_386_PC32		2	/* Add PC-relative symbol value. */
+#define	R_386_GOT32		3	/* Add PC-relative GOT offset. */
+#define	R_386_PLT32		4	/* Add PC-relative PLT offset. */
+#define	R_386_COPY		5	/* Copy data from shared object. */
+#define	R_386_GLOB_DAT		6	/* Set GOT entry to data address. */
+#define	R_386_JMP_SLOT		7	/* Set GOT entry to code address. */
+#define	R_386_RELATIVE		8	/* Add load address of shared object. */
+#define	R_386_GOTOFF		9	/* Add GOT-relative symbol address. */
+#define	R_386_GOTPC		10	/* Add PC-relative GOT table address. */
+#define	R_386_TLS_TPOFF		14	/* Negative offset in static TLS block */
+#define	R_386_TLS_IE		15	/* Absolute address of GOT for -ve static TLS */
+#define	R_386_TLS_GOTIE		16	/* GOT entry for negative static TLS block */
+#define	R_386_TLS_LE		17	/* Negative offset relative to static TLS */
+#define	R_386_TLS_GD		18	/* 32 bit offset to GOT (index,off) pair */
+#define	R_386_TLS_LDM		19	/* 32 bit offset to GOT (index,zero) pair */
+#define	R_386_TLS_GD_32		24	/* 32 bit offset to GOT (index,off) pair */
+#define	R_386_TLS_GD_PUSH	25	/* pushl instruction for Sun ABI GD sequence */
+#define	R_386_TLS_GD_CALL	26	/* call instruction for Sun ABI GD sequence */
+#define	R_386_TLS_GD_POP	27	/* popl instruction for Sun ABI GD sequence */
+#define	R_386_TLS_LDM_32	28	/* 32 bit offset to GOT (index,zero) pair */
+#define	R_386_TLS_LDM_PUSH	29	/* pushl instruction for Sun ABI LD sequence */
+#define	R_386_TLS_LDM_CALL	30	/* call instruction for Sun ABI LD sequence */
+#define	R_386_TLS_LDM_POP	31	/* popl instruction for Sun ABI LD sequence */
+#define	R_386_TLS_LDO_32	32	/* 32 bit offset from start of TLS block */
+#define	R_386_TLS_IE_32		33	/* 32 bit offset to GOT static TLS offset entry */
+#define	R_386_TLS_LE_32		34	/* 32 bit offset within static TLS block */
+#define	R_386_TLS_DTPMOD32	35	/* GOT entry containing TLS index */
+#define	R_386_TLS_DTPOFF32	36	/* GOT entry containing TLS offset */
+#define	R_386_TLS_TPOFF32	37	/* GOT entry of -ve static TLS offset */
+
+#define	R_ARM_NONE		0	/* No relocation. */
+#define	R_ARM_PC24		1
+#define	R_ARM_ABS32		2
+#define	R_ARM_REL32		3
+#define	R_ARM_PC13		4
+#define	R_ARM_ABS16		5
+#define	R_ARM_ABS12		6
+#define	R_ARM_THM_ABS5		7
+#define	R_ARM_ABS8		8
+#define	R_ARM_SBREL32		9
+#define	R_ARM_THM_PC22		10
+#define	R_ARM_THM_PC8		11
+#define	R_ARM_AMP_VCALL9	12
+#define	R_ARM_SWI24		13
+#define	R_ARM_THM_SWI8		14
+#define	R_ARM_XPC25		15
+#define	R_ARM_THM_XPC22		16
+#define	R_ARM_COPY		20	/* Copy data from shared object. */
+#define	R_ARM_GLOB_DAT		21	/* Set GOT entry to data address. */
+#define	R_ARM_JUMP_SLOT		22	/* Set GOT entry to code address. */
+#define	R_ARM_RELATIVE		23	/* Add load address of shared object. */
+#define	R_ARM_GOTOFF		24	/* Add GOT-relative symbol address. */
+#define	R_ARM_GOTPC		25	/* Add PC-relative GOT table address. */
+#define	R_ARM_GOT32		26	/* Add PC-relative GOT offset. */
+#define	R_ARM_PLT32		27	/* Add PC-relative PLT offset. */
+#define	R_ARM_GNU_VTENTRY	100
+#define	R_ARM_GNU_VTINHERIT	101
+#define	R_ARM_RSBREL32		250
+#define	R_ARM_THM_RPC22		251
+#define	R_ARM_RREL32		252
+#define	R_ARM_RABS32		253
+#define	R_ARM_RPC24		254
+#define	R_ARM_RBASE		255
+
+/*	Name			Value	   Field	Calculation */
+#define	R_IA_64_NONE		0	/* None */
+#define	R_IA_64_IMM14		0x21	/* immediate14	S + A */
+#define	R_IA_64_IMM22		0x22	/* immediate22	S + A */
+#define	R_IA_64_IMM64		0x23	/* immediate64	S + A */
+#define	R_IA_64_DIR32MSB	0x24	/* word32 MSB	S + A */
+#define	R_IA_64_DIR32LSB	0x25	/* word32 LSB	S + A */
+#define	R_IA_64_DIR64MSB	0x26	/* word64 MSB	S + A */
+#define	R_IA_64_DIR64LSB	0x27	/* word64 LSB	S + A */
+#define	R_IA_64_GPREL22		0x2a	/* immediate22	@gprel(S + A) */
+#define	R_IA_64_GPREL64I	0x2b	/* immediate64	@gprel(S + A) */
+#define	R_IA_64_GPREL32MSB	0x2c	/* word32 MSB	@gprel(S + A) */
+#define	R_IA_64_GPREL32LSB	0x2d	/* word32 LSB	@gprel(S + A) */
+#define	R_IA_64_GPREL64MSB	0x2e	/* word64 MSB	@gprel(S + A) */
+#define	R_IA_64_GPREL64LSB	0x2f	/* word64 LSB	@gprel(S + A) */
+#define	R_IA_64_LTOFF22		0x32	/* immediate22	@ltoff(S + A) */
+#define	R_IA_64_LTOFF64I	0x33	/* immediate64	@ltoff(S + A) */
+#define	R_IA_64_PLTOFF22	0x3a	/* immediate22	@pltoff(S + A) */
+#define	R_IA_64_PLTOFF64I	0x3b	/* immediate64	@pltoff(S + A) */
+#define	R_IA_64_PLTOFF64MSB	0x3e	/* word64 MSB	@pltoff(S + A) */
+#define	R_IA_64_PLTOFF64LSB	0x3f	/* word64 LSB	@pltoff(S + A) */
+#define	R_IA_64_FPTR64I		0x43	/* immediate64	@fptr(S + A) */
+#define	R_IA_64_FPTR32MSB	0x44	/* word32 MSB	@fptr(S + A) */
+#define	R_IA_64_FPTR32LSB	0x45	/* word32 LSB	@fptr(S + A) */
+#define	R_IA_64_FPTR64MSB	0x46	/* word64 MSB	@fptr(S + A) */
+#define	R_IA_64_FPTR64LSB	0x47	/* word64 LSB	@fptr(S + A) */
+#define	R_IA_64_PCREL60B	0x48	/* immediate60 form1 S + A - P */
+#define	R_IA_64_PCREL21B	0x49	/* immediate21 form1 S + A - P */
+#define	R_IA_64_PCREL21M	0x4a	/* immediate21 form2 S + A - P */
+#define	R_IA_64_PCREL21F	0x4b	/* immediate21 form3 S + A - P */
+#define	R_IA_64_PCREL32MSB	0x4c	/* word32 MSB	S + A - P */
+#define	R_IA_64_PCREL32LSB	0x4d	/* word32 LSB	S + A - P */
+#define	R_IA_64_PCREL64MSB	0x4e	/* word64 MSB	S + A - P */
+#define	R_IA_64_PCREL64LSB	0x4f	/* word64 LSB	S + A - P */
+#define	R_IA_64_LTOFF_FPTR22	0x52	/* immediate22	@ltoff(@fptr(S + A)) */
+#define	R_IA_64_LTOFF_FPTR64I	0x53	/* immediate64	@ltoff(@fptr(S + A)) */
+#define	R_IA_64_LTOFF_FPTR32MSB	0x54	/* word32 MSB	@ltoff(@fptr(S + A)) */
+#define	R_IA_64_LTOFF_FPTR32LSB	0x55	/* word32 LSB	@ltoff(@fptr(S + A)) */
+#define	R_IA_64_LTOFF_FPTR64MSB	0x56	/* word64 MSB	@ltoff(@fptr(S + A)) */
+#define	R_IA_64_LTOFF_FPTR64LSB	0x57	/* word64 LSB	@ltoff(@fptr(S + A)) */
+#define	R_IA_64_SEGREL32MSB	0x5c	/* word32 MSB	@segrel(S + A) */
+#define	R_IA_64_SEGREL32LSB	0x5d	/* word32 LSB	@segrel(S + A) */
+#define	R_IA_64_SEGREL64MSB	0x5e	/* word64 MSB	@segrel(S + A) */
+#define	R_IA_64_SEGREL64LSB	0x5f	/* word64 LSB	@segrel(S + A) */
+#define	R_IA_64_SECREL32MSB	0x64	/* word32 MSB	@secrel(S + A) */
+#define	R_IA_64_SECREL32LSB	0x65	/* word32 LSB	@secrel(S + A) */
+#define	R_IA_64_SECREL64MSB	0x66	/* word64 MSB	@secrel(S + A) */
+#define	R_IA_64_SECREL64LSB	0x67	/* word64 LSB	@secrel(S + A) */
+#define	R_IA_64_REL32MSB	0x6c	/* word32 MSB	BD + A */
+#define	R_IA_64_REL32LSB	0x6d	/* word32 LSB	BD + A */
+#define	R_IA_64_REL64MSB	0x6e	/* word64 MSB	BD + A */
+#define	R_IA_64_REL64LSB	0x6f	/* word64 LSB	BD + A */
+#define	R_IA_64_LTV32MSB	0x74	/* word32 MSB	S + A */
+#define	R_IA_64_LTV32LSB	0x75	/* word32 LSB	S + A */
+#define	R_IA_64_LTV64MSB	0x76	/* word64 MSB	S + A */
+#define	R_IA_64_LTV64LSB	0x77	/* word64 LSB	S + A */
+#define	R_IA_64_PCREL21BI	0x79	/* immediate21 form1 S + A - P */
+#define	R_IA_64_PCREL22		0x7a	/* immediate22	S + A - P */
+#define	R_IA_64_PCREL64I	0x7b	/* immediate64	S + A - P */
+#define	R_IA_64_IPLTMSB		0x80	/* function descriptor MSB special */
+#define	R_IA_64_IPLTLSB		0x81	/* function descriptor LSB speciaal */
+#define	R_IA_64_SUB		0x85	/* immediate64	A - S */
+#define	R_IA_64_LTOFF22X	0x86	/* immediate22	special */
+#define	R_IA_64_LDXMOV		0x87	/* immediate22	special */
+#define	R_IA_64_TPREL14		0x91	/* imm14	@tprel(S + A) */
+#define	R_IA_64_TPREL22		0x92	/* imm22	@tprel(S + A) */
+#define	R_IA_64_TPREL64I	0x93	/* imm64	@tprel(S + A) */
+#define	R_IA_64_TPREL64MSB	0x96	/* word64 MSB	@tprel(S + A) */
+#define	R_IA_64_TPREL64LSB	0x97	/* word64 LSB	@tprel(S + A) */
+#define	R_IA_64_LTOFF_TPREL22	0x9a	/* imm22	@ltoff(@tprel(S+A)) */
+#define	R_IA_64_DTPMOD64MSB	0xa6	/* word64 MSB	@dtpmod(S + A) */
+#define	R_IA_64_DTPMOD64LSB	0xa7	/* word64 LSB	@dtpmod(S + A) */
+#define	R_IA_64_LTOFF_DTPMOD22	0xaa	/* imm22	@ltoff(@dtpmod(S+A)) */
+#define	R_IA_64_DTPREL14	0xb1	/* imm14	@dtprel(S + A) */
+#define	R_IA_64_DTPREL22	0xb2	/* imm22	@dtprel(S + A) */
+#define	R_IA_64_DTPREL64I	0xb3	/* imm64	@dtprel(S + A) */
+#define	R_IA_64_DTPREL32MSB	0xb4	/* word32 MSB	@dtprel(S + A) */
+#define	R_IA_64_DTPREL32LSB	0xb5	/* word32 LSB	@dtprel(S + A) */
+#define	R_IA_64_DTPREL64MSB	0xb6	/* word64 MSB	@dtprel(S + A) */
+#define	R_IA_64_DTPREL64LSB	0xb7	/* word64 LSB	@dtprel(S + A) */
+#define	R_IA_64_LTOFF_DTPREL22	0xba	/* imm22	@ltoff(@dtprel(S+A)) */
+
+#define	R_MIPS_NONE	0	/* No reloc */
+#define	R_MIPS_16	1	/* Direct 16 bit */
+#define	R_MIPS_32	2	/* Direct 32 bit */
+#define	R_MIPS_REL32	3	/* PC relative 32 bit */
+#define	R_MIPS_26	4	/* Direct 26 bit shifted */
+#define	R_MIPS_HI16	5	/* High 16 bit */
+#define	R_MIPS_LO16	6	/* Low 16 bit */
+#define	R_MIPS_GPREL16	7	/* GP relative 16 bit */
+#define	R_MIPS_LITERAL	8	/* 16 bit literal entry */
+#define	R_MIPS_GOT16	9	/* 16 bit GOT entry */
+#define	R_MIPS_PC16	10	/* PC relative 16 bit */
+#define	R_MIPS_CALL16	11	/* 16 bit GOT entry for function */
+#define	R_MIPS_GPREL32	12	/* GP relative 32 bit */
+#define	R_MIPS_GOTHI16	21	/* GOT HI 16 bit */
+#define	R_MIPS_GOTLO16	22	/* GOT LO 16 bit */
+#define	R_MIPS_CALLHI16 30	/* upper 16 bit GOT entry for function */
+#define	R_MIPS_CALLLO16 31	/* lower 16 bit GOT entry for function */
+
+#define	R_PPC_NONE		0	/* No relocation. */
+#define	R_PPC_ADDR32		1
+#define	R_PPC_ADDR24		2
+#define	R_PPC_ADDR16		3
+#define	R_PPC_ADDR16_LO		4
+#define	R_PPC_ADDR16_HI		5
+#define	R_PPC_ADDR16_HA		6
+#define	R_PPC_ADDR14		7
+#define	R_PPC_ADDR14_BRTAKEN	8
+#define	R_PPC_ADDR14_BRNTAKEN	9
+#define	R_PPC_REL24		10
+#define	R_PPC_REL14		11
+#define	R_PPC_REL14_BRTAKEN	12
+#define	R_PPC_REL14_BRNTAKEN	13
+#define	R_PPC_GOT16		14
+#define	R_PPC_GOT16_LO		15
+#define	R_PPC_GOT16_HI		16
+#define	R_PPC_GOT16_HA		17
+#define	R_PPC_PLTREL24		18
+#define	R_PPC_COPY		19
+#define	R_PPC_GLOB_DAT		20
+#define	R_PPC_JMP_SLOT		21
+#define	R_PPC_RELATIVE		22
+#define	R_PPC_LOCAL24PC		23
+#define	R_PPC_UADDR32		24
+#define	R_PPC_UADDR16		25
+#define	R_PPC_REL32		26
+#define	R_PPC_PLT32		27
+#define	R_PPC_PLTREL32		28
+#define	R_PPC_PLT16_LO		29
+#define	R_PPC_PLT16_HI		30
+#define	R_PPC_PLT16_HA		31
+#define	R_PPC_SDAREL16		32
+#define	R_PPC_SECTOFF		33
+#define	R_PPC_SECTOFF_LO	34
+#define	R_PPC_SECTOFF_HI	35
+#define	R_PPC_SECTOFF_HA	36
+
+/*
+ * TLS relocations
+ */
+#define R_PPC_TLS		67
+#define R_PPC_DTPMOD32		68
+#define R_PPC_TPREL16		69
+#define R_PPC_TPREL16_LO	70
+#define R_PPC_TPREL16_HI	71
+#define R_PPC_TPREL16_HA	72
+#define R_PPC_TPREL32		73
+#define R_PPC_DTPREL16		74
+#define R_PPC_DTPREL16_LO	75
+#define R_PPC_DTPREL16_HI	76
+#define R_PPC_DTPREL16_HA	77
+#define R_PPC_DTPREL32		78
+#define R_PPC_GOT_TLSGD16	79
+#define R_PPC_GOT_TLSGD16_LO	80
+#define R_PPC_GOT_TLSGD16_HI	81
+#define R_PPC_GOT_TLSGD16_HA	82
+#define R_PPC_GOT_TLSLD16	83
+#define R_PPC_GOT_TLSLD16_LO	84
+#define R_PPC_GOT_TLSLD16_HI	85
+#define R_PPC_GOT_TLSLD16_HA	86
+#define R_PPC_GOT_TPREL16	87
+#define R_PPC_GOT_TPREL16_LO	88
+#define R_PPC_GOT_TPREL16_HI	89
+#define R_PPC_GOT_TPREL16_HA	90
+
+/*
+ * The remaining relocs are from the Embedded ELF ABI, and are not in the
+ *  SVR4 ELF ABI.
+ */
+
+#define	R_PPC_EMB_NADDR32	101
+#define	R_PPC_EMB_NADDR16	102
+#define	R_PPC_EMB_NADDR16_LO	103
+#define	R_PPC_EMB_NADDR16_HI	104
+#define	R_PPC_EMB_NADDR16_HA	105
+#define	R_PPC_EMB_SDAI16	106
+#define	R_PPC_EMB_SDA2I16	107
+#define	R_PPC_EMB_SDA2REL	108
+#define	R_PPC_EMB_SDA21		109
+#define	R_PPC_EMB_MRKREF	110
+#define	R_PPC_EMB_RELSEC16	111
+#define	R_PPC_EMB_RELST_LO	112
+#define	R_PPC_EMB_RELST_HI	113
+#define	R_PPC_EMB_RELST_HA	114
+#define	R_PPC_EMB_BIT_FLD	115
+#define	R_PPC_EMB_RELSDA	116
+
+#define	R_SPARC_NONE		0
+#define	R_SPARC_8		1
+#define	R_SPARC_16		2
+#define	R_SPARC_32		3
+#define	R_SPARC_DISP8		4
+#define	R_SPARC_DISP16		5
+#define	R_SPARC_DISP32		6
+#define	R_SPARC_WDISP30		7
+#define	R_SPARC_WDISP22		8
+#define	R_SPARC_HI22		9
+#define	R_SPARC_22		10
+#define	R_SPARC_13		11
+#define	R_SPARC_LO10		12
+#define	R_SPARC_GOT10		13
+#define	R_SPARC_GOT13		14
+#define	R_SPARC_GOT22		15
+#define	R_SPARC_PC10		16
+#define	R_SPARC_PC22		17
+#define	R_SPARC_WPLT30		18
+#define	R_SPARC_COPY		19
+#define	R_SPARC_GLOB_DAT	20
+#define	R_SPARC_JMP_SLOT	21
+#define	R_SPARC_RELATIVE	22
+#define	R_SPARC_UA32		23
+#define	R_SPARC_PLT32		24
+#define	R_SPARC_HIPLT22		25
+#define	R_SPARC_LOPLT10		26
+#define	R_SPARC_PCPLT32		27
+#define	R_SPARC_PCPLT22		28
+#define	R_SPARC_PCPLT10		29
+#define	R_SPARC_10		30
+#define	R_SPARC_11		31
+#define	R_SPARC_64		32
+#define	R_SPARC_OLO10		33
+#define	R_SPARC_HH22		34
+#define	R_SPARC_HM10		35
+#define	R_SPARC_LM22		36
+#define	R_SPARC_PC_HH22		37
+#define	R_SPARC_PC_HM10		38
+#define	R_SPARC_PC_LM22		39
+#define	R_SPARC_WDISP16		40
+#define	R_SPARC_WDISP19		41
+#define	R_SPARC_GLOB_JMP	42
+#define	R_SPARC_7		43
+#define	R_SPARC_5		44
+#define	R_SPARC_6		45
+#define	R_SPARC_DISP64		46
+#define	R_SPARC_PLT64		47
+#define	R_SPARC_HIX22		48
+#define	R_SPARC_LOX10		49
+#define	R_SPARC_H44		50
+#define	R_SPARC_M44		51
+#define	R_SPARC_L44		52
+#define	R_SPARC_REGISTER	53
+#define	R_SPARC_UA64		54
+#define	R_SPARC_UA16		55
+#define	R_SPARC_TLS_GD_HI22	56
+#define	R_SPARC_TLS_GD_LO10	57
+#define	R_SPARC_TLS_GD_ADD	58
+#define	R_SPARC_TLS_GD_CALL	59
+#define	R_SPARC_TLS_LDM_HI22	60
+#define	R_SPARC_TLS_LDM_LO10	61
+#define	R_SPARC_TLS_LDM_ADD	62
+#define	R_SPARC_TLS_LDM_CALL	63
+#define	R_SPARC_TLS_LDO_HIX22	64
+#define	R_SPARC_TLS_LDO_LOX10	65
+#define	R_SPARC_TLS_LDO_ADD	66
+#define	R_SPARC_TLS_IE_HI22	67
+#define	R_SPARC_TLS_IE_LO10	68
+#define	R_SPARC_TLS_IE_LD	69
+#define	R_SPARC_TLS_IE_LDX	70
+#define	R_SPARC_TLS_IE_ADD	71
+#define	R_SPARC_TLS_LE_HIX22	72
+#define	R_SPARC_TLS_LE_LOX10	73
+#define	R_SPARC_TLS_DTPMOD32	74
+#define	R_SPARC_TLS_DTPMOD64	75
+#define	R_SPARC_TLS_DTPOFF32	76
+#define	R_SPARC_TLS_DTPOFF64	77
+#define	R_SPARC_TLS_TPOFF32	78
+#define	R_SPARC_TLS_TPOFF64	79
+
+#define	R_X86_64_NONE		0	/* No relocation. */
+#define	R_X86_64_64		1	/* Add 64 bit symbol value. */
+#define	R_X86_64_PC32		2	/* PC-relative 32 bit signed sym value. */
+#define	R_X86_64_GOT32		3	/* PC-relative 32 bit GOT offset. */
+#define	R_X86_64_PLT32		4	/* PC-relative 32 bit PLT offset. */
+#define	R_X86_64_COPY		5	/* Copy data from shared object. */
+#define	R_X86_64_GLOB_DAT	6	/* Set GOT entry to data address. */
+#define	R_X86_64_JMP_SLOT	7	/* Set GOT entry to code address. */
+#define	R_X86_64_RELATIVE	8	/* Add load address of shared object. */
+#define	R_X86_64_GOTPCREL	9	/* Add 32 bit signed pcrel offset to GOT. */
+#define	R_X86_64_32		10	/* Add 32 bit zero extended symbol value */
+#define	R_X86_64_32S		11	/* Add 32 bit sign extended symbol value */
+#define	R_X86_64_16		12	/* Add 16 bit zero extended symbol value */
+#define	R_X86_64_PC16		13	/* Add 16 bit signed extended pc relative symbol value */
+#define	R_X86_64_8		14	/* Add 8 bit zero extended symbol value */
+#define	R_X86_64_PC8		15	/* Add 8 bit signed extended pc relative symbol value */
+#define	R_X86_64_DTPMOD64	16	/* ID of module containing symbol */
+#define	R_X86_64_DTPOFF64	17	/* Offset in TLS block */
+#define	R_X86_64_TPOFF64	18	/* Offset in static TLS block */
+#define	R_X86_64_TLSGD		19	/* PC relative offset to GD GOT entry */
+#define	R_X86_64_TLSLD		20	/* PC relative offset to LD GOT entry */
+#define	R_X86_64_DTPOFF32	21	/* Offset in TLS block */
+#define	R_X86_64_GOTTPOFF	22	/* PC relative offset to IE GOT entry */
+#define	R_X86_64_TPOFF32	23	/* Offset in static TLS block */
+
+
+#endif /* !_SYS_ELF_COMMON_H_ */

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/pthread.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/pthread.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/sys/mman.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/sys/mman.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/sys/syscall.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/sys/syscall.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/sys/ucontext.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/sys/ucontext.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/ucontext.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/ucontext.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/cross-dac/unistd.h
+++ b/src/coreclr/src/pal/src/libunwind/src/cross-dac/unistd.h
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "cross-dac.h"

--- a/src/coreclr/src/pal/src/libunwind/src/mi/Gget_accessors.c
+++ b/src/coreclr/src/pal/src/libunwind/src/mi/Gget_accessors.c
@@ -35,3 +35,12 @@ unw_get_accessors (unw_addr_space_t as)
     tdep_init ();
   return &as->acc;
 }
+
+#ifdef DACCESS_COMPILE
+// ALIAS not supported
+unw_accessors_t *
+unw_get_accessors_int (unw_addr_space_t as)
+{
+  return unw_get_accessors(as);
+}
+#endif

--- a/src/coreclr/src/pal/src/libunwind/src/mi/flush_cache.c
+++ b/src/coreclr/src/pal/src/libunwind/src/mi/flush_cache.c
@@ -53,7 +53,9 @@ unw_flush_cache (unw_addr_space_t as, unw_word_t lo, unw_word_t hi)
 #ifdef HAVE_FETCH_AND_ADD
   fetch_and_add1 (&as->cache_generation);
 #else
+#ifndef DACCESS_COMPILE
 # warning unw_flush_cache(): need a way to atomically increment an integer.
+#endif
   ++as->cache_generation;
 #endif
 }

--- a/src/coreclr/src/pal/src/libunwind/src/os-linux.h
+++ b/src/coreclr/src/pal/src/libunwind/src/os-linux.h
@@ -38,7 +38,7 @@ struct map_iterator
   };
 
 static inline char *
-ltoa (char *buf, long val)
+unw_ltoa(char *buf, long val)
 {
   char *cp = buf, tmp;
   ssize_t i, len;
@@ -68,7 +68,7 @@ maps_init (struct map_iterator *mi, pid_t pid)
   char path[sizeof ("/proc/0123456789/maps")], *cp;
 
   memcpy (path, "/proc/", 6);
-  cp = ltoa (path + 6, pid);
+  cp = unw_ltoa (path + 6, pid);
   assert (cp + 6 < path + sizeof (path));
   memcpy (cp, "/maps", 6);
 

--- a/src/coreclr/src/pal/src/libunwind/src/x86_64/Gglobal.c
+++ b/src/coreclr/src/pal/src/libunwind/src/x86_64/Gglobal.c
@@ -90,9 +90,9 @@ tdep_init (void)
 
     dwarf_init ();
 
+#ifndef UNW_REMOTE_ONLY
     tdep_init_mem_validate ();
 
-#ifndef UNW_REMOTE_ONLY
     x86_64_local_addr_space_init ();
 #endif
     tdep_init_done = 1; /* signal that we're initialized... */

--- a/src/coreclr/src/pal/src/libunwind/src/x86_64/Gtrace.c
+++ b/src/coreclr/src/pal/src/libunwind/src/x86_64/Gtrace.c
@@ -50,8 +50,8 @@ static pthread_once_t trace_cache_once = PTHREAD_ONCE_INIT;
 static sig_atomic_t trace_cache_once_happen;
 static pthread_key_t trace_cache_key;
 static struct mempool trace_cache_pool;
-static __thread  unw_trace_cache_t *tls_cache;
-static __thread  int tls_cache_destroyed;
+static THREAD unw_trace_cache_t *tls_cache;
+static THREAD int tls_cache_destroyed;
 
 /* Free memory for a thread's trace cache. */
 static void


### PR DESCRIPTION
Add libunwind_xdac

Revise CMake files to enable compiling libunwind for UNW_REMOTE_ONLY

Add minimum set of posix prototypes and constants to enable compilation
Add minimum implementation of posix functions to satisfy linker.

Copy freebsd-elf headers from mono include directory
Cleanup comment

Fix GCC constructs not supported by VC++

Use TARGET variables to configure libunwind

Add PAL_VirtualUnwindOutOfProc to libunwind_xdac

/cc @hoyosjs