### PR TITLE
Use dictionary to track PackageRelationships instead of searching a list

### DIFF
--- a/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
+++ b/src/libraries/System.IO.Packaging/src/System.IO.Packaging.csproj
@@ -31,6 +31,7 @@
     <Compile Include="System\IO\Packaging\FileFormatException.cs" />
     <Compile Include="System\IO\Packaging\IgnoreFlushAndCloseStream.cs" />
     <Compile Include="System\IO\Packaging\InternalRelationshipCollection.cs" />
+    <Compile Include="System\IO\Packaging\OrderedDictionary.cs" />
     <Compile Include="System\IO\Packaging\Package.cs" />
     <Compile Include="System\IO\Packaging\PackagePart.cs" />
     <Compile Include="System\IO\Packaging\PackagePartCollection.cs" />

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -47,16 +47,7 @@ namespace System.IO.Packaging
         /// Returns an enumerator over all the relationships for a Package or a PackagePart
         /// </summary>
         /// <returns></returns>
-        IEnumerator<PackageRelationship> IEnumerable<PackageRelationship>.GetEnumerator()
-        {
-            return _relationships.GetEnumerator();
-        }
-
-        /// <summary>
-        /// Returns an enumerator over all the relationships for a Package or a PackagePart
-        /// </summary>
-        /// <returns></returns>
-        public List<PackageRelationship>.Enumerator GetEnumerator()
+        public IEnumerator<PackageRelationship> GetEnumerator()
         {
             return _relationships.GetEnumerator();
         }
@@ -97,12 +88,7 @@ namespace System.IO.Packaging
         /// Return the relationship whose id is 'id', and null if not found.
         /// </summary>
         internal PackageRelationship GetRelationship(string id)
-        {
-            int index = GetRelationshipIndex(id);
-            if (index == -1)
-                return null;
-            return _relationships[index];
-        }
+            => _relationships.TryGetValue(id, out var result) ? result : null;
 
         /// <summary>
         /// Delete relationship with ID 'id'
@@ -110,12 +96,7 @@ namespace System.IO.Packaging
         /// <param name="id">ID of the relationship to remove</param>
         internal void Delete(string id)
         {
-            int index = GetRelationshipIndex(id);
-            if (index == -1)
-                return;
-
-            _relationships.RemoveAt(index);
-            _dirty = true;
+            _dirty |= _relationships.Remove(id);
         }
 
         /// <summary>
@@ -199,7 +180,7 @@ namespace System.IO.Packaging
 
             //_sourcePart may be null representing that the relationships are at the package level
             _uri = GetRelationshipPartUri(_sourcePart);
-            _relationships = new List<PackageRelationship>(4);
+            _relationships = new OrderedDictionary<string, PackageRelationship>(4, StringComparer.Ordinal);
 
             // Load if available (not applicable to write-only mode).
             if ((package.FileOpenAccess == FileAccess.Read ||
@@ -448,7 +429,7 @@ namespace System.IO.Packaging
 
             // create and add
             PackageRelationship relationship = new PackageRelationship(_package, _sourcePart, targetUri, targetMode, relationshipType, id);
-            _relationships.Add(relationship);
+            _relationships.Add(id, relationship);
 
             //If we are adding relationships as a part of Parsing the underlying relationship part, we should not set
             //the dirty flag to false.
@@ -600,7 +581,7 @@ namespace System.IO.Packaging
             do
             {
                 id = GenerateRelationshipId();
-            } while (GetRelationship(id) != null);
+            } while (_relationships.Contains(id));
             return id;
         }
 
@@ -619,20 +600,8 @@ namespace System.IO.Packaging
             ThrowIfInvalidXsdId(id);
 
             // Check for uniqueness.
-            if (GetRelationshipIndex(id) >= 0)
+            if (_relationships.Contains(id))
                 throw new XmlException(SR.Format(SR.NotAUniqueRelationshipId, id));
-        }
-
-
-        // Retrieve a relationship's index in _relationships given its id.
-        // Return a negative value if not found.
-        private int GetRelationshipIndex(string id)
-        {
-            for (int index = 0; index < _relationships.Count; ++index)
-                if (string.Equals(_relationships[index].Id, id, StringComparison.Ordinal))
-                    return index;
-
-            return -1;
         }
 
         #endregion
@@ -642,7 +611,7 @@ namespace System.IO.Packaging
         #endregion Private Properties
 
         #region Private Members
-        private readonly List<PackageRelationship> _relationships;
+        private readonly OrderedDictionary<string, PackageRelationship> _relationships;
         private bool _dirty;    // true if we have uncommitted changes to _relationships
         private readonly Package _package;     // our package - in case _sourcePart is null
         private readonly PackagePart _sourcePart;      // owning part - null if package is the owner

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/InternalRelationshipCollection.cs
@@ -180,7 +180,7 @@ namespace System.IO.Packaging
 
             //_sourcePart may be null representing that the relationships are at the package level
             _uri = GetRelationshipPartUri(_sourcePart);
-            _relationships = new OrderedDictionary<string, PackageRelationship>(4, StringComparer.Ordinal);
+            _relationships = new OrderedDictionary<string, PackageRelationship>(4);
 
             // Load if available (not applicable to write-only mode).
             if ((package.FileOpenAccess == FileAccess.Read ||

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/OrderedDictionary.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/OrderedDictionary.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace System.IO.Packaging
+{
+    /// <summary>
+    /// A collection that ensures uniqueness among a list of elements while maintaining the order in which the elements were added.
+    /// This is similar to <see cref="OrderedDictionary{TKey, TValue}"/>, but the items will not be sorted by a comparer but rather retain the
+    /// order in which they were added while still retaining good lookup, insertion, and removal.
+    /// </summary>
+    internal class OrderedDictionary<TKey, TValue> : IEnumerable<TValue>
+    {
+        private readonly Dictionary<TKey, LinkedListNode<TValue>> _dictionary;
+        private readonly LinkedList<TValue> _order;
+
+        public OrderedDictionary(int initialCapacity, IEqualityComparer<TKey> comparer)
+        {
+            _dictionary = new Dictionary<TKey, LinkedListNode<TValue>>(initialCapacity, comparer);
+            _order = new LinkedList<TValue>();
+        }
+
+        public bool Contains(TKey key) => _dictionary.ContainsKey(key);
+
+        public bool Add(TKey key, TValue value)
+        {
+            if (_dictionary.ContainsKey(key))
+            {
+                return false;
+            }
+
+            _dictionary.Add(key, _order.AddLast(value));
+            return true;
+        }
+
+        public void Clear()
+        {
+            _dictionary.Clear();
+            _order.Clear();
+        }
+
+        public bool Remove(TKey key)
+        {
+            if (_dictionary.TryGetValue(key, out var value))
+            {
+                _order.Remove(value);
+                _dictionary.Remove(key);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            if (_dictionary.TryGetValue(key, out var node))
+            {
+                value = node.Value;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public int Count => _dictionary.Count;
+
+        public IEnumerator<TValue> GetEnumerator() => _order.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/OrderedDictionary.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/OrderedDictionary.cs
@@ -17,9 +17,9 @@ namespace System.IO.Packaging
         private readonly Dictionary<TKey, LinkedListNode<TValue>> _dictionary;
         private readonly LinkedList<TValue> _order;
 
-        public OrderedDictionary(int initialCapacity, IEqualityComparer<TKey> comparer)
+        public OrderedDictionary(int initialCapacity)
         {
-            _dictionary = new Dictionary<TKey, LinkedListNode<TValue>>(initialCapacity, comparer);
+            _dictionary = new Dictionary<TKey, LinkedListNode<TValue>>(initialCapacity);
             _order = new LinkedList<TValue>();
         }
 
@@ -44,7 +44,7 @@ namespace System.IO.Packaging
 
         public bool Remove(TKey key)
         {
-            if (_dictionary.TryGetValue(key, out var value))
+            if (_dictionary.TryGetValue(key, out LinkedListNode<TValue> value))
             {
                 _order.Remove(value);
                 _dictionary.Remove(key);

--- a/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackageRelationshipCollection.cs
+++ b/src/libraries/System.IO.Packaging/src/System/IO/Packaging/PackageRelationshipCollection.cs
@@ -35,7 +35,7 @@ namespace System.IO.Packaging
         /// <returns></returns>
         public IEnumerator<PackageRelationship> GetEnumerator()
         {
-            List<PackageRelationship>.Enumerator relationshipsEnumerator = _relationships.GetEnumerator();
+            IEnumerator<PackageRelationship> relationshipsEnumerator = _relationships.GetEnumerator();
 
             if (_filter == null)
                 return relationshipsEnumerator;


### PR DESCRIPTION
This change adds an OrderedDictionary<TKey,TValue> type to System.IO.Packaging to keep a list of relationships that have been added, while ensuring that the ids are unique with decent performance characteristics. The current implementation searches a list which gets really slow with large numbers of relationships. A Dictionary by itself does not work for this as the order of addition is important. Thus, this combines a LinkedList to track the order, while a Dictionary is used to for quick look up of existing items.

Fixes #983