### PR TITLE
[CBOR] Implement a proof of concept for ECDsa COSE key serialization

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -217,7 +217,7 @@ namespace System.Formats.Cbor.Tests
             static ECCurve NormalizeCurveForPlatform(string friendlyName)
             {
                 ECCurve namedCurve = ECCurve.CreateFromFriendlyName(friendlyName);
-                ECDsa ecDsa = ECDsa.Create(namedCurve);
+                using ECDsa ecDsa = ECDsa.Create(namedCurve);
                 ECParameters platformParams = ecDsa.ExportParameters(includePrivateParameters: false);
                 return platformParams.Curve;
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -202,6 +202,8 @@ namespace System.Formats.Cbor.Tests
             ECPoint q = new ECPoint() { X = hexExpectedQx.HexToByteArray(), Y = hexExpectedQy.HexToByteArray() };
             (ECDsa ecDsa, HashAlgorithmName name) = CborCoseKeyHelpers.ParseECDsaPublicKey(hexEncoding.HexToByteArray());
 
+            using ECDsa _ = ecDsa;
+
             ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
 
             string? expectedCurveFriendlyName = NormalizeCurveForPlatform(curveFriendlyName).Oid.FriendlyName;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -200,9 +200,9 @@ namespace System.Formats.Cbor.Tests
         public static void CoseKeyReader_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string expectedHashAlgorithmName, string curveFriendlyName)
         {
             ECPoint q = new ECPoint() { X = hexExpectedQx.HexToByteArray(), Y = hexExpectedQy.HexToByteArray() };
-            (ECParameters ecParams, HashAlgorithmName name) = CborCoseKeyHelpers.ParseCosePublicKey(hexEncoding.HexToByteArray());
+            (ECDsa ecDsa, HashAlgorithmName name) = CborCoseKeyHelpers.ParseCosePublicKey(hexEncoding.HexToByteArray());
 
-            _ = ECDsa.Create(ecParams); // validate parameters
+            ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
 
             Assert.True(ecParams.Curve.IsNamed);
             Assert.Equal(curveFriendlyName, ecParams.Curve.Oid.FriendlyName);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Test.Cryptography;
 using Xunit;
 
@@ -182,5 +183,32 @@ namespace System.Formats.Cbor.Tests
 
         public static IEnumerable<object[]> EncodedValueInputs => CborReaderTests.SampleCborValues.Select(x => new[] { x });
         public static IEnumerable<object[]> EncodedValueInvalidInputs => CborReaderTests.InvalidCborValues.Select(x => new[] { x });
+
+        [Theory]
+        [InlineData("a501020326200121582065eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
+                    "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    "SHA256", "nistP256")]
+        [InlineData("a501020338222002215830ed57d8608c5734a5ed5d22026bad8700636823e45297306479beb61a5bd6b04688c34a2f0de51d91064355eef7548bdd22583024376b4fee60ba65db61de54234575eec5d37e1184fbafa1f49d71e1795bba6bda9cbe2ebb815f9b49b371486b38fa1b",
+                    "ed57d8608c5734a5ed5d22026bad8700636823e45297306479beb61a5bd6b04688c34a2f0de51d91064355eef7548bdd",
+                    "24376b4fee60ba65db61de54234575eec5d37e1184fbafa1f49d71e1795bba6bda9cbe2ebb815f9b49b371486b38fa1b",
+                    "SHA384", "nistP384")]
+        [InlineData("a50102033823200321584200b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c2258420114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
+                    "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
+                    "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
+                    "SHA512", "nistP521")]
+        public static void CoseKeyReader_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string expectedHashAlgorithmName, string curveFriendlyName)
+        {
+            ECPoint q = new ECPoint() { X = hexExpectedQx.HexToByteArray(), Y = hexExpectedQy.HexToByteArray() };
+            (ECParameters ecParams, HashAlgorithmName name) = CborCoseKeyHelpers.ParseCosePublicKey(hexEncoding.HexToByteArray());
+
+            _ = ECDsa.Create(ecParams); // validate parameters
+
+            Assert.True(ecParams.Curve.IsNamed);
+            Assert.Equal(curveFriendlyName, ecParams.Curve.Oid.FriendlyName);
+            Assert.Equal(q.X, ecParams.Q.X);
+            Assert.Equal(q.Y, ecParams.Q.Y);
+            Assert.Equal(expectedHashAlgorithmName, name.Name);
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -197,10 +197,14 @@ namespace System.Formats.Cbor.Tests
                     "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
                     "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
                     "SHA512", "ECDSA_P521")]
-        public static void CoseKeyHelpers_ECDsaParseCosePublicKey_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string expectedHashAlgorithmName, string curveFriendlyName)
+        [InlineData("a40102200121582065eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
+                    "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    null, "ECDSA_P256")]
+        public static void CoseKeyHelpers_ECDsaParseCosePublicKey_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string? expectedHashAlgorithmName, string curveFriendlyName)
         {
             ECPoint q = new ECPoint() { X = hexExpectedQx.HexToByteArray(), Y = hexExpectedQy.HexToByteArray() };
-            (ECDsa ecDsa, HashAlgorithmName name) = CborCoseKeyHelpers.ParseECDsaPublicKey(hexEncoding.HexToByteArray());
+            (ECDsa ecDsa, HashAlgorithmName? name) = CborCoseKeyHelpers.ParseECDsaPublicKey(hexEncoding.HexToByteArray());
 
             using ECDsa _ = ecDsa;
 
@@ -212,7 +216,7 @@ namespace System.Formats.Cbor.Tests
             Assert.Equal(expectedCurveFriendlyName, ecParams.Curve.Oid.FriendlyName);
             Assert.Equal(q.X, ecParams.Q.X);
             Assert.Equal(q.Y, ecParams.Q.Y);
-            Assert.Equal(expectedHashAlgorithmName, name.Name);
+            Assert.Equal(expectedHashAlgorithmName, name?.Name);
 
             static ECCurve NormalizeCurveForPlatform(string friendlyName)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -197,10 +197,10 @@ namespace System.Formats.Cbor.Tests
                     "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
                     "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
                     "SHA512", "nistP521")]
-        public static void CoseKeyReader_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string expectedHashAlgorithmName, string curveFriendlyName)
+        public static void CoseKeyHelpers_ECDsaParseCosePublicKey_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string expectedHashAlgorithmName, string curveFriendlyName)
         {
             ECPoint q = new ECPoint() { X = hexExpectedQx.HexToByteArray(), Y = hexExpectedQy.HexToByteArray() };
-            (ECDsa ecDsa, HashAlgorithmName name) = CborCoseKeyHelpers.ParseCosePublicKey(hexEncoding.HexToByteArray());
+            (ECDsa ecDsa, HashAlgorithmName name) = CborCoseKeyHelpers.ParseECDsaPublicKey(hexEncoding.HexToByteArray());
 
             ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -204,11 +204,26 @@ namespace System.Formats.Cbor.Tests
 
             ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
 
+            string? expectedCurveFriendlyName = CreateCurveFromFriendlyNameXPlat(curveFriendlyName).Oid.FriendlyName;
+
             Assert.True(ecParams.Curve.IsNamed);
-            Assert.Equal(curveFriendlyName, ecParams.Curve.Oid.FriendlyName);
+            Assert.Equal(expectedCurveFriendlyName, ecParams.Curve.Oid.FriendlyName);
             Assert.Equal(q.X, ecParams.Q.X);
             Assert.Equal(q.Y, ecParams.Q.Y);
             Assert.Equal(expectedHashAlgorithmName, name.Name);
+        }
+
+        public static ECCurve CreateCurveFromFriendlyNameXPlat(string friendlyName)
+        {
+            // Different platforms use different friendly names,
+            // so we hardcode a mapping using test input identifiers.
+            return friendlyName switch
+            {
+                "nistP256" => ECCurve.NamedCurves.nistP256,
+                "nistP384" => ECCurve.NamedCurves.nistP384,
+                "nistP521" => ECCurve.NamedCurves.nistP521,
+                _ => throw new ArgumentException(),
+            };
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -268,7 +268,7 @@ namespace System.Formats.Cbor.Tests
                     "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
                     "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
                     "SHA512", "nistP521")]
-        public static void CoseKeyWriter_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string hashAlgorithmName, string curveFriendlyName)
+        public static void CoseKeyHelpers_ECDsaExportCosePublicKey_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string hashAlgorithmName, string curveFriendlyName)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var hashAlgName = new HashAlgorithmName(hashAlgorithmName);
@@ -280,7 +280,7 @@ namespace System.Formats.Cbor.Tests
 
             ECDsa ecDsa = ECDsa.Create(ecParameters);
 
-            byte[] coseKeyEncoding = CborCoseKeyHelpers.ExportCosePublicKey(ecDsa, hashAlgName);
+            byte[] coseKeyEncoding = CborCoseKeyHelpers.ExportECDsaPublicKey(ecDsa, hashAlgName);
             AssertHelper.HexEqual(expectedEncoding, coseKeyEncoding);
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using Test.Cryptography;
 using Xunit;
 
@@ -253,5 +254,34 @@ namespace System.Formats.Cbor.Tests
 
         public static IEnumerable<object[]> EncodedValueInputs => CborReaderTests.SampleCborValues.Select(x => new [] { x });
         public static IEnumerable<object[]> EncodedValueBadInputs => CborReaderTests.InvalidCborValues.Select(x => new[] { x });
+
+        [Theory]
+        [InlineData("a501020326200121582065eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
+                    "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    "SHA256", "nistP256")]
+        [InlineData("a501020338222002215830ed57d8608c5734a5ed5d22026bad8700636823e45297306479beb61a5bd6b04688c34a2f0de51d91064355eef7548bdd22583024376b4fee60ba65db61de54234575eec5d37e1184fbafa1f49d71e1795bba6bda9cbe2ebb815f9b49b371486b38fa1b",
+                    "ed57d8608c5734a5ed5d22026bad8700636823e45297306479beb61a5bd6b04688c34a2f0de51d91064355eef7548bdd",
+                    "24376b4fee60ba65db61de54234575eec5d37e1184fbafa1f49d71e1795bba6bda9cbe2ebb815f9b49b371486b38fa1b",
+                    "SHA384", "nistP384")]
+        [InlineData("a50102033823200321584200b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c2258420114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
+                    "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
+                    "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
+                    "SHA512", "nistP521")]
+        public static void CoseKeyWriter_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string hashAlgorithmName, string curveFriendlyName)
+        {
+            byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
+            var hashAlgName = new HashAlgorithmName(hashAlgorithmName);
+            var ecParameters = new ECParameters()
+            {
+                Curve = ECCurve.CreateFromFriendlyName(curveFriendlyName),
+                Q = new ECPoint() { X = hexQx.HexToByteArray(), Y = hexQy.HexToByteArray() },
+            };
+
+            _ = ECDsa.Create(ecParameters); // validate EC parameters
+
+            byte[] coseKeyEncoding = CborCoseKeyHelpers.ExportCosePublicKey(ecParameters, hashAlgName);
+            AssertHelper.HexEqual(expectedEncoding, coseKeyEncoding);
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -278,9 +278,9 @@ namespace System.Formats.Cbor.Tests
                 Q = new ECPoint() { X = hexQx.HexToByteArray(), Y = hexQy.HexToByteArray() },
             };
 
-            _ = ECDsa.Create(ecParameters); // validate EC parameters
+            ECDsa ecDsa = ECDsa.Create(ecParameters);
 
-            byte[] coseKeyEncoding = CborCoseKeyHelpers.ExportCosePublicKey(ecParameters, hashAlgName);
+            byte[] coseKeyEncoding = CborCoseKeyHelpers.ExportCosePublicKey(ecDsa, hashAlgName);
             AssertHelper.HexEqual(expectedEncoding, coseKeyEncoding);
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -268,10 +268,14 @@ namespace System.Formats.Cbor.Tests
                     "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
                     "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
                     "SHA512", "ECDSA_P521")]
-        public static void CoseKeyHelpers_ECDsaExportCosePublicKey_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string hashAlgorithmName, string curveFriendlyName)
+        [InlineData("a40102200121582065eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
+                    "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
+                    null, "ECDSA_P256")]
+        public static void CoseKeyHelpers_ECDsaExportCosePublicKey_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string? hashAlgorithmName, string curveFriendlyName)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            var hashAlgName = new HashAlgorithmName(hashAlgorithmName);
+            var hashAlgName = hashAlgorithmName != null ? new HashAlgorithmName(hashAlgorithmName) : (HashAlgorithmName?)null;
             var ecParameters = new ECParameters()
             {
                 Curve = ECCurve.CreateFromFriendlyName(curveFriendlyName),

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -259,22 +259,22 @@ namespace System.Formats.Cbor.Tests
         [InlineData("a501020326200121582065eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d2258201e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
                     "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
                     "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
-                    "SHA256", "nistP256")]
+                    "SHA256", "ECDSA_P256")]
         [InlineData("a501020338222002215830ed57d8608c5734a5ed5d22026bad8700636823e45297306479beb61a5bd6b04688c34a2f0de51d91064355eef7548bdd22583024376b4fee60ba65db61de54234575eec5d37e1184fbafa1f49d71e1795bba6bda9cbe2ebb815f9b49b371486b38fa1b",
                     "ed57d8608c5734a5ed5d22026bad8700636823e45297306479beb61a5bd6b04688c34a2f0de51d91064355eef7548bdd",
                     "24376b4fee60ba65db61de54234575eec5d37e1184fbafa1f49d71e1795bba6bda9cbe2ebb815f9b49b371486b38fa1b",
-                    "SHA384", "nistP384")]
+                    "SHA384", "ECDSA_P384")]
         [InlineData("a50102033823200321584200b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c2258420114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
                     "00b03811bef65e330bb974224ec3ab0a5469f038c92177b4171f6f66f91244d4476e016ee77cf7e155a4f73567627b5d72eaf0cb4a6036c6509a6432d7cd6a3b325c",
                     "0114b597b6c271d8435cfa02e890608c93f5bc118ca7f47bf191e9f9e49a22f8a15962315f0729781e1d78b302970c832db2fa8f7f782a33f8e1514950dc7499035f",
-                    "SHA512", "nistP521")]
+                    "SHA512", "ECDSA_P521")]
         public static void CoseKeyHelpers_ECDsaExportCosePublicKey_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string hashAlgorithmName, string curveFriendlyName)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var hashAlgName = new HashAlgorithmName(hashAlgorithmName);
             var ecParameters = new ECParameters()
             {
-                Curve = CborReaderTests.CreateCurveFromFriendlyNameXPlat(curveFriendlyName),
+                Curve = ECCurve.CreateFromFriendlyName(curveFriendlyName),
                 Q = new ECPoint() { X = hexQx.HexToByteArray(), Y = hexQy.HexToByteArray() },
             };
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -274,7 +274,7 @@ namespace System.Formats.Cbor.Tests
             var hashAlgName = new HashAlgorithmName(hashAlgorithmName);
             var ecParameters = new ECParameters()
             {
-                Curve = ECCurve.CreateFromFriendlyName(curveFriendlyName),
+                Curve = CborReaderTests.CreateCurveFromFriendlyNameXPlat(curveFriendlyName),
                 Q = new ECPoint() { X = hexQx.HexToByteArray(), Y = hexQy.HexToByteArray() },
             };
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -278,7 +278,7 @@ namespace System.Formats.Cbor.Tests
                 Q = new ECPoint() { X = hexQx.HexToByteArray(), Y = hexQy.HexToByteArray() },
             };
 
-            ECDsa ecDsa = ECDsa.Create(ecParameters);
+            using ECDsa ecDsa = ECDsa.Create(ecParameters);
 
             byte[] coseKeyEncoding = CborCoseKeyHelpers.ExportECDsaPublicKey(ecDsa, hashAlgName);
             AssertHelper.HexEqual(expectedEncoding, coseKeyEncoding);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
@@ -160,22 +160,13 @@ namespace System.Formats.Cbor.Tests
 
             static bool IsValidKtyCrvCombination(CoseKeyType kty, CoseCrvId crv)
             {
-                switch (crv)
+                return (kty, crv) switch
                 {
-                    case CoseCrvId.P256:
-                    case CoseCrvId.P384:
-                    case CoseCrvId.P521:
-                        return kty == CoseKeyType.EC2;
-
-                    case CoseCrvId.X255519:
-                    case CoseCrvId.X448:
-                    case CoseCrvId.Ed25519:
-                    case CoseCrvId.Ed448:
-                        return kty == CoseKeyType.OKP;
-
-                    default:
-                        return false;
+                    (CoseKeyType.EC2, CoseCrvId.P256 or CoseCrvId.P384 or CoseCrvId.P521) => true,
+                    (CoseKeyType.OKP, CoseCrvId.X255519 or CoseCrvId.X448 or CoseCrvId.Ed25519 or CoseCrvId.Ed448) => true,
+                    _ => false,
                 };
+                ;
             }
 
             static ECCurve MapCoseCrvToECCurve(CoseCrvId crv)
@@ -185,10 +176,10 @@ namespace System.Formats.Cbor.Tests
                     CoseCrvId.P256 => ECCurve.NamedCurves.nistP256,
                     CoseCrvId.P384 => ECCurve.NamedCurves.nistP384,
                     CoseCrvId.P521 => ECCurve.NamedCurves.nistP521,
-                    //(CoseCrvId.X255519 or
-                    //CoseCrvId.X448 or
-                    //CoseCrvId.Ed25519 or
-                    //CoseCrvId.Ed448) => throw new NotImplementedException("OKP type curves not implemented."),
+                    CoseCrvId.X255519 or
+                    CoseCrvId.X448 or
+                    CoseCrvId.Ed25519 or
+                    CoseCrvId.Ed448 => throw new NotImplementedException("OKP type curves not implemented."),
                     _ => throw new FormatException("Unrecognized COSE crv value."),
                 };
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
@@ -1,0 +1,268 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Security.Cryptography;
+
+namespace System.Formats.Cbor.Tests
+{
+    public static class CborCoseKeyHelpers
+    {
+        public static byte[] ExportCosePublicKey(ECParameters ecParams, HashAlgorithmName name)
+        {
+            using var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
+            WriteECParametersAsCosePublicKey(writer, ecParams, name);
+            return writer.GetEncoding();
+        }
+
+        public static (ECParameters ecParams, HashAlgorithmName name) ParseCosePublicKey(byte[] coseKey)
+        {
+            var reader = new CborReader(coseKey, CborConformanceLevel.Ctap2Canonical);
+            return ReadECParametersAsCosePublicKey(reader);
+        }
+
+        public static void WriteECParametersAsCosePublicKey(CborWriter writer, ECParameters ecParams, HashAlgorithmName algorithmName)
+        {
+            Debug.Assert(writer.ConformanceLevel == CborConformanceLevel.Ctap2Canonical);
+
+            if (ecParams.Q.X is null || ecParams.Q.Y is null)
+            {
+                throw new ArgumentException("does not specify a public key point.", nameof(ecParams));
+            }
+
+            // run these first to perform necessary validation
+            (CoseKeyType kty, CoseCrvId crv) = MapECCurveToCoseKtyAndCrv(ecParams.Curve);
+            CoseKeyAlgorithm alg = MapHashAlgorithmNameToCoseKeyAlg(algorithmName);
+
+            // begin writing CBOR object
+            writer.WriteStartMap();
+
+            WriteCoseKeyLabel(writer, CoseKeyLabel.Kty);
+            writer.WriteInt32((int)kty);
+
+            WriteCoseKeyLabel(writer, CoseKeyLabel.Alg);
+            writer.WriteInt32((int)alg);
+
+            WriteCoseKeyLabel(writer, CoseKeyLabel.EcCrv);
+            writer.WriteInt32((int)crv);
+
+            WriteCoseKeyLabel(writer, CoseKeyLabel.EcX);
+            writer.WriteByteString(ecParams.Q.X);
+
+            WriteCoseKeyLabel(writer, CoseKeyLabel.EcY);
+            writer.WriteByteString(ecParams.Q.Y);
+
+            writer.WriteEndMap();
+
+            static (CoseKeyType kty, CoseCrvId crv) MapECCurveToCoseKtyAndCrv(ECCurve curve)
+            {
+                if (!curve.IsNamed)
+                {
+                    throw new ArgumentException("Only named curves supported in EC COSE keys.", nameof(curve));
+                }
+
+                if (MatchesOid(ECCurve.NamedCurves.nistP256))
+                {
+                    return (CoseKeyType.EC2, CoseCrvId.P256);
+                }
+
+                if (MatchesOid(ECCurve.NamedCurves.nistP384))
+                {
+                    return (CoseKeyType.EC2, CoseCrvId.P384);
+                }
+
+                if (MatchesOid(ECCurve.NamedCurves.nistP521))
+                {
+                    return (CoseKeyType.EC2, CoseCrvId.P521);
+                }
+
+                throw new ArgumentException("Unrecognized named curve", curve.Oid.Value);
+
+                bool MatchesOid(ECCurve namedCurve) => curve.Oid.Value == namedCurve.Oid.Value;
+            }
+
+            static CoseKeyAlgorithm MapHashAlgorithmNameToCoseKeyAlg(HashAlgorithmName name)
+            {
+                if (MatchesName(HashAlgorithmName.SHA256))
+                {
+                    return CoseKeyAlgorithm.ES256;
+                }
+
+                if (MatchesName(HashAlgorithmName.SHA384))
+                {
+                    return CoseKeyAlgorithm.ES384;
+                }
+
+                if (MatchesName(HashAlgorithmName.SHA512))
+                {
+                    return CoseKeyAlgorithm.ES512;
+                }
+
+                throw new ArgumentException("Unrecognized hash algorithm name.", nameof(HashAlgorithmName));
+
+                bool MatchesName(HashAlgorithmName candidate) => name.Name == candidate.Name;
+            }
+        }
+
+        public static (ECParameters, HashAlgorithmName) ReadECParametersAsCosePublicKey(CborReader reader)
+        {
+            Debug.Assert(reader.ConformanceLevel == CborConformanceLevel.Ctap2Canonical);
+
+            var ecParams = new ECParameters();
+
+            int? length = reader.ReadStartMap();
+            if (length != 5)
+            {
+                throw new FormatException("Unexpected number of elements in the CBOR cose key.");
+            }
+
+            // CTAP2 guarantees order of fields
+
+            try
+            {
+                ReadCoseKeyLabel(reader, CoseKeyLabel.Kty);
+                CoseKeyType kty = (CoseKeyType)reader.ReadInt32();
+
+                ReadCoseKeyLabel(reader, CoseKeyLabel.Alg);
+                CoseKeyAlgorithm alg = (CoseKeyAlgorithm)reader.ReadInt32();
+                HashAlgorithmName algName = MapCoseKeyAlgToHashAlgorithmName(alg);
+
+                ReadCoseKeyLabel(reader, CoseKeyLabel.EcCrv);
+                CoseCrvId crv = (CoseCrvId)reader.ReadInt32();
+
+                if (!IsValidKtyCrvCombination(kty, crv))
+                {
+                    throw new FormatException("Invalid kty/crv combination in COSE key.");
+                }
+
+                ecParams.Curve = MapCoseCrvToECCurve(crv);
+
+                ReadCoseKeyLabel(reader, CoseKeyLabel.EcX);
+                ecParams.Q.X = reader.ReadByteString();
+
+                ReadCoseKeyLabel(reader, CoseKeyLabel.EcY);
+                ecParams.Q.Y = reader.ReadByteString();
+
+                reader.ReadEndMap();
+
+                return (ecParams, algName);
+            }
+            catch (InvalidOperationException e)
+            {
+                throw new FormatException("Invalid COSE_key format in CBOR document", e);
+            }
+
+            static bool IsValidKtyCrvCombination(CoseKeyType kty, CoseCrvId crv)
+            {
+                switch (crv)
+                {
+                    case CoseCrvId.P256:
+                    case CoseCrvId.P384:
+                    case CoseCrvId.P521:
+                        return kty == CoseKeyType.EC2;
+
+                    case CoseCrvId.X255519:
+                    case CoseCrvId.X448:
+                    case CoseCrvId.Ed25519:
+                    case CoseCrvId.Ed448:
+                        return kty == CoseKeyType.OKP;
+
+                    default:
+                        return false;
+                };
+            }
+
+            static ECCurve MapCoseCrvToECCurve(CoseCrvId crv)
+            {
+                return crv switch
+                {
+                    CoseCrvId.P256 => ECCurve.NamedCurves.nistP256,
+                    CoseCrvId.P384 => ECCurve.NamedCurves.nistP384,
+                    CoseCrvId.P521 => ECCurve.NamedCurves.nistP521,
+                    //(CoseCrvId.X255519 or
+                    //CoseCrvId.X448 or
+                    //CoseCrvId.Ed25519 or
+                    //CoseCrvId.Ed448) => throw new NotImplementedException("OKP type curves not implemented."),
+                    _ => throw new FormatException("Unrecognized COSE crv value."),
+                };
+            }
+
+            static HashAlgorithmName MapCoseKeyAlgToHashAlgorithmName(CoseKeyAlgorithm alg)
+            {
+                return alg switch
+                {
+                    CoseKeyAlgorithm.ES256 => HashAlgorithmName.SHA256,
+                    CoseKeyAlgorithm.ES384 => HashAlgorithmName.SHA384,
+                    CoseKeyAlgorithm.ES512 => HashAlgorithmName.SHA512,
+                    _ => throw new FormatException("Unrecognized COSE alg value."),
+                };
+            }
+        }
+
+        private static void WriteCoseKeyLabel(CborWriter writer, CoseKeyLabel label)
+        {
+            writer.WriteInt32((int)label);
+        }
+
+        private static CoseKeyLabel ReadCoseKeyLabel(CborReader reader, CoseKeyLabel? expectedLabel = null)
+        {
+            var label = (CoseKeyLabel)reader.ReadInt32();
+            if (label != expectedLabel)
+            {
+                throw new FormatException("Unexpected COSE key label.");
+            }
+
+            return label;
+        }
+
+        private enum CoseKeyLabel : int
+        {
+            // cf. https://tools.ietf.org/html/rfc8152#section-7.1 table 3
+            Kty = 1,
+            Kid = 2,
+            Alg = 3,
+            KeyOps = 4,
+            BaseIv = 5,
+
+            // cf. https://tools.ietf.org/html/rfc8152#section-13.1.1 table 23
+            EcCrv = -1,
+            EcX = -2,
+            EcY = -3,
+            EcD = -4,
+        };
+
+        private enum CoseCrvId : int
+        {
+            // cf. https://tools.ietf.org/html/rfc8152#section-13.1 table 22
+            P256 = 1,
+            P384 = 2,
+            P521 = 3,
+            X255519 = 4,
+            X448 = 5,
+            Ed25519 = 6,
+            Ed448 = 7,
+        }
+
+        private enum CoseKeyType : int
+        {
+            // cf. https://tools.ietf.org/html/rfc8152#section-13 table 21
+            OKP = 1,
+            EC2 = 2,
+
+            Symmetric = 4,
+            Reserved = 0,
+        }
+
+        private enum CoseKeyAlgorithm : int
+        {
+            // cf. https://tools.ietf.org/html/rfc8152#section-8.1 table 5
+            ES256 = -7,
+            ES384 = -35,
+            ES512 = -36,
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
@@ -12,17 +12,19 @@ namespace System.Formats.Cbor.Tests
 {
     public static class CborCoseKeyHelpers
     {
-        public static byte[] ExportCosePublicKey(ECParameters ecParams, HashAlgorithmName name)
+        public static byte[] ExportCosePublicKey(ECDsa ecDsa, HashAlgorithmName hashAlgName)
         {
+            ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
             using var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
-            WriteECParametersAsCosePublicKey(writer, ecParams, name);
+            WriteECParametersAsCosePublicKey(writer, ecParams, hashAlgName);
             return writer.GetEncoding();
         }
 
-        public static (ECParameters ecParams, HashAlgorithmName name) ParseCosePublicKey(byte[] coseKey)
+        public static (ECDsa ecDsa, HashAlgorithmName hashAlgName) ParseCosePublicKey(byte[] coseKey)
         {
             var reader = new CborReader(coseKey, CborConformanceLevel.Ctap2Canonical);
-            return ReadECParametersAsCosePublicKey(reader);
+            (ECParameters ecParams, HashAlgorithmName hashAlgName) = ReadECParametersAsCosePublicKey(reader);
+            return (ECDsa.Create(ecParams), hashAlgName);
         }
 
         public static void WriteECParametersAsCosePublicKey(CborWriter writer, ECParameters ecParams, HashAlgorithmName algorithmName)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -76,5 +76,6 @@
     <Compile Include="Cbor.Tests\CborWriterTests.Integer.cs" />
     <Compile Include="Cbor.Tests\CborWriterTests.String.cs" />
     <Compile Include="Cbor.Tests\CborRoundtripTests.cs" />
+    <Compile Include="Cbor.Tests\CoseKeyHelpers.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Implements a proof-of-concept serializer for ECDsa COSE key serialization, as defined in https://www.w3.org/TR/webauthn/#sctn-encoded-credPubKey-examples.