### PR TITLE
Remove MinHandles and OutstandingHandles logic from SocketAsyncEngine

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -194,7 +194,6 @@ namespace System.Net.Sockets
             Debug.Assert(added, "Add should always succeed");
             _nextHandle = IntPtr.Add(_nextHandle, 1);
 
-            Debug.Assert(handle != ShutdownHandle, $"Expected handle != ShutdownHandle: {handle}");
             return handle;
         }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -167,21 +167,7 @@ namespace System.Net.Sockets
                 engine = s_currentEngines[s_allocateFromEngine];
                 if (engine == null)
                 {
-                    // We minimize the number of engines on applications that have a low number of concurrent sockets.
-                    for (int i = 0; i < s_allocateFromEngine; i++)
-                    {
-                        var previousEngine = s_currentEngines[i];
-                        if (previousEngine == null)
-                        {
-                            s_allocateFromEngine = i;
-                            engine = previousEngine;
-                            break;
-                        }
-                    }
-                    if (engine == null)
-                    {
-                        s_currentEngines[s_allocateFromEngine] = engine = new SocketAsyncEngine();
-                    }
+                    s_currentEngines[s_allocateFromEngine] = engine = new SocketAsyncEngine();
                 }
 
                 handle = engine.AllocateHandle(context);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -204,8 +204,8 @@ namespace System.Net.Sockets
 
             IntPtr handle = _nextHandle;
             Debug.Assert(handle != ShutdownHandle, "ShutdownHandle must not be added to the dictionary");
-            _handleToContextMap.TryAdd(handle, new SocketAsyncContextWrapper(context));
-
+            bool added = _handleToContextMap.TryAdd(handle, new SocketAsyncContextWrapper(context));
+            Debug.Assert(added, "Add should always succeed");
             _nextHandle = IntPtr.Add(_nextHandle, 1);
 
             Debug.Assert(handle != ShutdownHandle, $"Expected handle != ShutdownHandle: {handle}");


### PR DESCRIPTION
@tmds here is the promised removal of MinHandles logic. I am going to run some benchmarks for it tomorrow.