### PR TITLE
Remove unnecessary recursive locking from Http2Stream.Complete

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -329,14 +329,11 @@ namespace System.Net.Http
 
                 _connection.RemoveStream(this);
 
-                lock (SyncObject)
+                CreditWaiter? w = _creditWaiter;
+                if (w != null)
                 {
-                    CreditWaiter? w = _creditWaiter;
-                    if (w != null)
-                    {
-                        w.Dispose();
-                        _creditWaiter = null;
-                    }
+                    w.Dispose();
+                    _creditWaiter = null;
                 }
             }
 


### PR DESCRIPTION
We just asserted we're holding the lock.  We don't need to take it again.

cc: @scalablecory 