### PR TITLE
Add staticapphost template entry to signexclusion file

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -11,3 +11,4 @@
 *comhost.dll;;Template, https://github.com/dotnet/core-setup/pull/7549
 *apphosttemplateapphostexe.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
 *comhosttemplatecomhostdll.dll;;Template, https://github.com/dotnet/core-setup/pull/7549
+*staticapphosttemplateapphostexe.exe;;Template, https://github.com/dotnet/core-setup/pull/7549


### PR DESCRIPTION
This is the generated template for the new `singlefilehost` we added and we need to exclude it from signing. 

cc: @dotnet/runtime-infrastructure 