### PR TITLE
Single-File: Run from Bundle

### DIFF
--- a/src/coreclr/src/binder/assemblybinder.cpp
+++ b/src/coreclr/src/binder/assemblybinder.cpp
@@ -394,7 +394,7 @@ namespace BINDER_SPACE
         // At run-time, System.Private.CoreLib.dll is expected to be the NI image.
         // System.Private.CoreLib.dll is expected to be found at one of the following locations:
         //   * Non-single-file app: In systemDirectory, beside coreclr.dll
-        //   * Framework-dependent single-file app: In system directory, beside coreclr.dll
+        //   * Framework-dependent single-file app: In systemDirectory, beside coreclr.dll
         //   * Self-contained single-file app: Within the single-file bundle.
         IF_FAIL_GO(AssemblyBinder::GetAssembly(sCoreLib,
             TRUE /* fIsInGAC */,

--- a/src/coreclr/src/binder/coreclrbindercommon.cpp
+++ b/src/coreclr/src/binder/coreclrbindercommon.cpp
@@ -7,6 +7,7 @@
 #include "assemblybinder.hpp"
 #include "coreclrbindercommon.h"
 #include "clrprivbindercoreclr.h"
+#include "bundle.h"
 
 using namespace BINDER_SPACE;
 

--- a/src/coreclr/src/binder/inc/assembly.hpp
+++ b/src/coreclr/src/binder/inc/assembly.hpp
@@ -27,15 +27,18 @@
 #include "clrprivbinderassemblyloadcontext.h"
 #endif // !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
 
-STDAPI BinderAcquirePEImage(LPCTSTR   szAssemblyPath,
-                            PEImage **ppPEImage,
-                            PEImage **ppNativeImage,
-                            BOOL      fExplicitBindToNativeImage);
+#include "bundle.h"
 
-STDAPI BinderAcquireImport(PEImage                  *pPEImage,
-                           IMDInternalImport       **pIMetaDataAssemblyImport,
-                           DWORD                    *pdwPAFlags,
-                           BOOL                     bNativeImage);
+STDAPI BinderAcquirePEImage(LPCTSTR            szAssemblyPath,
+                            PEImage          **ppPEImage,
+                            PEImage          **ppNativeImage,
+                            BOOL               fExplicitBindToNativeImage,
+                            BundleFileLocation bundleFileLocation);
+
+STDAPI BinderAcquireImport(PEImage            *pPEImage,
+                           IMDInternalImport **pIMetaDataAssemblyImport,
+                           DWORD              *pdwPAFlags,
+                           BOOL                bNativeImage);
 
 STDAPI BinderHasNativeHeader(PEImage *pPEImage,
                              BOOL    *result);

--- a/src/coreclr/src/binder/inc/assemblybinder.hpp
+++ b/src/coreclr/src/binder/inc/assemblybinder.hpp
@@ -18,6 +18,7 @@
 #include "bindertypes.hpp"
 #include "bindresult.hpp"
 #include "coreclrbindercommon.h"
+#include "bundle.h"
 
 class CLRPrivBinderAssemblyLoadContext;
 class CLRPrivBinderCoreCLR;
@@ -54,7 +55,8 @@ namespace BINDER_SPACE
                                    /* in */  BOOL         fIsInGAC,
                                    /* in */  BOOL         fExplicitBindToNativeImage,
                                    /* out */ Assembly   **ppAssembly,
-                                   /* in */  LPCTSTR      szMDAssemblyPath = NULL);
+                                   /* in */  LPCTSTR      szMDAssemblyPath = NULL,
+                                   /* in */  BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
 
 #if !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
         static HRESULT BindUsingHostAssemblyResolver (/* in */ INT_PTR pManagedAssemblyLoadContextToBindWithin,

--- a/src/coreclr/src/binder/inc/bindertracing.h
+++ b/src/coreclr/src/binder/inc/bindertracing.h
@@ -180,7 +180,8 @@ namespace BinderTracing
         AppNativeImagePaths,
         AppPaths,
         PlatformResourceRoots,
-        SatelliteSubdirectory
+        SatelliteSubdirectory,
+        Bundle
     };
 
     void PathProbed(const WCHAR *path, PathSource source, HRESULT hr);

--- a/src/coreclr/src/binder/utils.cpp
+++ b/src/coreclr/src/binder/utils.cpp
@@ -80,7 +80,7 @@ namespace BINDER_SPACE
         SString platformPathSeparator(SString::Literal, GetPlatformPathSeparator());
         combinedPath.Set(pathA);
 
-        if (!combinedPath.EndsWith(platformPathSeparator))
+        if (!combinedPath.IsEmpty() && !combinedPath.EndsWith(platformPathSeparator))
         {
             combinedPath.Append(platformPathSeparator);
         }

--- a/src/coreclr/src/inc/bundle.h
+++ b/src/coreclr/src/inc/bundle.h
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*****************************************************************************
+ **                                                                         **
+ ** bundle.h - Information about applications bundled as a single-file  **
+ **                                                                         **
+ *****************************************************************************/
+
+#ifndef _BUNDLE_H_
+#define _BUNDLE_H_
+
+#include <sstring.h>
+
+class Bundle;
+
+struct BundleFileLocation
+{
+    INT64 Size;
+    INT64 Offset;
+
+    BundleFileLocation()
+    { 
+        LIMITED_METHOD_CONTRACT;
+
+        Size = 0; 
+        Offset = 0; 
+    }
+
+    static BundleFileLocation Invalid() { LIMITED_METHOD_CONTRACT; return BundleFileLocation(); }
+
+    const SString &Path() const;
+
+    bool IsValid() const { LIMITED_METHOD_CONTRACT; return Offset != 0; }
+};
+
+typedef bool(__stdcall BundleProbe)(LPCWSTR, INT64*, INT64*);
+
+class Bundle
+{
+public:
+    Bundle(LPCWSTR bundlePath, BundleProbe *probe);
+    BundleFileLocation Probe(LPCWSTR path, bool pathIsBundleRelative = false) const;
+
+    const SString &Path() const { LIMITED_METHOD_CONTRACT; return m_path; }
+    const SString &BasePath() const { LIMITED_METHOD_CONTRACT; return m_basePath; }
+
+    static Bundle* AppBundle; // The BundleInfo for the current app, initialized by coreclr_initialize.
+    static bool AppIsBundle() { LIMITED_METHOD_CONTRACT; return AppBundle != nullptr; }
+    static BundleFileLocation ProbeAppBundle(LPCWSTR path, bool pathIsBundleRelative = false);
+
+private:
+
+    SString m_path; // The path to single-file executable
+    BundleProbe *m_probe;
+
+    SString m_basePath; // The prefix to denote a path within the bundle
+};
+
+#endif // _BUNDLE_H_
+// EOF =======================================================================

--- a/src/coreclr/src/pal/inc/pal.h
+++ b/src/coreclr/src/pal/inc/pal.h
@@ -47,6 +47,9 @@ Abstract:
 #include <string.h>
 #include <errno.h>
 #include <ctype.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #endif
 
 #ifdef  __cplusplus
@@ -2543,6 +2546,7 @@ Abstract
 
 Parameters:
     IN hFile    - The file to load
+    IN offset - offset within hFile where the PE "file" is located
 
 Return value:
     A valid base address if successful.
@@ -2551,7 +2555,7 @@ Return value:
 PALIMPORT
 PVOID
 PALAPI
-PAL_LOADLoadPEFile(HANDLE hFile);
+PAL_LOADLoadPEFile(HANDLE hFile, size_t offset);
 
 /*++
     PAL_LOADUnloadPEFile

--- a/src/coreclr/src/pal/src/include/pal/map.hpp
+++ b/src/coreclr/src/pal/src/include/pal/map.hpp
@@ -79,13 +79,14 @@ extern "C"
 
     Parameters:
         IN hFile - file to map
+        IN offset - offset within hFile where the PE "file" is located
 
     Return value:
         non-NULL - the base address of the mapped image
         NULL - error, with last error set.
     --*/
 
-    void * MAPMapPEFile(HANDLE hFile);
+    void* MAPMapPEFile(HANDLE hFile, off_t offset);
 
     /*++
     Function :

--- a/src/coreclr/src/pal/src/include/pal/module.h
+++ b/src/coreclr/src/pal/src/include/pal/module.h
@@ -145,12 +145,13 @@ Abstract
 
 Parameters:
     IN hFile    - The file to load
+    IN offset - offset within hFile where the PE "file" is located
 
 Return value:
     A valid base address if successful.
     0 if failure
 --*/
-void * PAL_LOADLoadPEFile(HANDLE hFile);
+void* PAL_LOADLoadPEFile(HANDLE hFile, size_t offset);
 
 /*++
     PAL_LOADUnloadPEFile

--- a/src/coreclr/src/pal/src/loader/module.cpp
+++ b/src/coreclr/src/pal/src/loader/module.cpp
@@ -752,6 +752,7 @@ PAL_UnregisterModule(
 
 Parameters:
     IN hFile - file to map
+    IN offset - offset within hFile where the PE "file" is located
 
 Return value:
     non-NULL - the base address of the mapped image
@@ -759,11 +760,11 @@ Return value:
 --*/
 PVOID
 PALAPI
-PAL_LOADLoadPEFile(HANDLE hFile)
+PAL_LOADLoadPEFile(HANDLE hFile, size_t offset)
 {
-    ENTRY("PAL_LOADLoadPEFile (hFile=%p)\n", hFile);
+    ENTRY("PAL_LOADLoadPEFile (hFile=%p, offset=%zx)\n", hFile, offset);
 
-    void * loadedBase = MAPMapPEFile(hFile);
+    void* loadedBase = MAPMapPEFile(hFile, offset);
 
 #ifdef _DEBUG
     if (loadedBase != nullptr)
@@ -775,7 +776,7 @@ PAL_LOADLoadPEFile(HANDLE hFile)
             {
                 TRACE("Forcing failure of PE file map, and retry\n");
                 PAL_LOADUnloadPEFile(loadedBase); // unload it
-                loadedBase = MAPMapPEFile(hFile); // load it again
+                loadedBase = MAPMapPEFile(hFile, offset); // load it again
             }
 
             free(envVar);
@@ -1547,7 +1548,8 @@ static MODSTRUCT *LOADAddModule(NATIVE_LIBRARY_HANDLE dl_handle, LPCSTR libraryN
         {
             /* found the handle. increment the refcount and return the
                existing module structure */
-            TRACE("Found matching module %p for module name %s\n", module, libraryNameOrPath);
+            TRACE("Found matching module %p for module name %s\n", module,
+                (libraryNameOrPath != nullptr) ? libraryNameOrPath : "nullptr");
 
             if (module->refcount != -1)
             {

--- a/src/coreclr/src/vm/CMakeLists.txt
+++ b/src/coreclr/src/vm/CMakeLists.txt
@@ -42,6 +42,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     assemblyloadcontext.cpp
     baseassemblyspec.cpp
     binder.cpp
+    bundle.cpp
     castcache.cpp
     callcounting.cpp
     ceeload.cpp

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -1761,7 +1761,7 @@ void SystemDomain::Init()
         sizeof(MethodDesc),
         sizeof(FieldDesc),
         sizeof(Module)
-    ));
+        ));
 #endif // _DEBUG
 
     // The base domain is initialized in SystemDomain::Attach()
@@ -1775,7 +1775,7 @@ void SystemDomain::Init()
     m_pSystemAssembly = NULL;
 
     DWORD size = 0;
-
+    AppDomain* pAppDomain = ::GetAppDomain();
 
     // Get the install directory so we can find mscorlib
     hr = GetInternalSystemDirectory(NULL, &size);
@@ -1783,19 +1783,19 @@ void SystemDomain::Init()
         ThrowHR(hr);
 
     // GetInternalSystemDirectory returns a size, including the null!
-    WCHAR *buffer = m_SystemDirectory.OpenUnicodeBuffer(size-1);
+    WCHAR* buffer = m_SystemDirectory.OpenUnicodeBuffer(size - 1);
     IfFailThrow(GetInternalSystemDirectory(buffer, &size));
     m_SystemDirectory.CloseBuffer();
     m_SystemDirectory.Normalize();
 
     // At this point m_SystemDirectory should already be canonicalized
 
-
     m_BaseLibrary.Append(m_SystemDirectory);
     if (!m_BaseLibrary.EndsWith(DIRECTORY_SEPARATOR_CHAR_W))
     {
         m_BaseLibrary.Append(DIRECTORY_SEPARATOR_CHAR_W);
     }
+
     m_BaseLibrary.Append(g_pwBaseLibrary);
     m_BaseLibrary.Normalize();
 
@@ -1825,7 +1825,7 @@ void SystemDomain::Init()
 #ifdef _DEBUG
     BOOL fPause = EEConfig::GetConfigDWORD_DontUse_(CLRConfig::INTERNAL_PauseOnLoad, FALSE);
 
-    while(fPause)
+    while (fPause)
     {
         ClrSleepEx(20, TRUE);
     }

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -1775,7 +1775,6 @@ void SystemDomain::Init()
     m_pSystemAssembly = NULL;
 
     DWORD size = 0;
-    AppDomain* pAppDomain = ::GetAppDomain();
 
     // Get the install directory so we can find mscorlib
     hr = GetInternalSystemDirectory(NULL, &size);
@@ -1789,13 +1788,11 @@ void SystemDomain::Init()
     m_SystemDirectory.Normalize();
 
     // At this point m_SystemDirectory should already be canonicalized
-
     m_BaseLibrary.Append(m_SystemDirectory);
     if (!m_BaseLibrary.EndsWith(DIRECTORY_SEPARATOR_CHAR_W))
     {
         m_BaseLibrary.Append(DIRECTORY_SEPARATOR_CHAR_W);
     }
-
     m_BaseLibrary.Append(g_pwBaseLibrary);
     m_BaseLibrary.Normalize();
 

--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -29,6 +29,7 @@
 #include "gchandleutilities.h"
 #include "../binder/inc/applicationcontext.hpp"
 #include "rejit.h"
+#include "bundle.h"
 
 #ifdef FEATURE_MULTICOREJIT
 #include "multicorejit.h"

--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -29,7 +29,6 @@
 #include "gchandleutilities.h"
 #include "../binder/inc/applicationcontext.hpp"
 #include "rejit.h"
-#include "bundle.h"
 
 #ifdef FEATURE_MULTICOREJIT
 #include "multicorejit.h"

--- a/src/coreclr/src/vm/assemblynative.cpp
+++ b/src/coreclr/src/vm/assemblynative.cpp
@@ -239,7 +239,9 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
 
     if (pwzILPath != NULL)
     {
-        pILImage = PEImage::OpenImage(pwzILPath);
+        pILImage = PEImage::OpenImage(pwzILPath,
+                                      MDInternalImport_Default,
+                                      Bundle::ProbeAppBundle(pwzILPath));
 
         // Need to verify that this is a valid CLR assembly.
         if (!pILImage->CheckILFormat())
@@ -257,7 +259,9 @@ void QCALLTYPE AssemblyNative::LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext
     // Form the PEImage for the NI assembly, if specified
     if (pwzNIPath != NULL)
     {
-        pNIImage = PEImage::OpenImage(pwzNIPath, MDInternalImport_TrustedNativeImage);
+        pNIImage = PEImage::OpenImage(pwzNIPath,
+                                      MDInternalImport_TrustedNativeImage,
+                                      Bundle::ProbeAppBundle(pwzNIPath));
 
         if (pNIImage->HasReadyToRunHeader())
         {

--- a/src/coreclr/src/vm/bundle.cpp
+++ b/src/coreclr/src/vm/bundle.cpp
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//*****************************************************************************
+// Bundle.cpp
+//
+// Helpers to access meta-data stored in single-file bundles
+//
+//*****************************************************************************
+
+#include "common.h"
+#include "bundle.h"
+#include <utilcode.h>
+#include <corhost.h>
+#include <sstring.h>
+
+Bundle *Bundle::AppBundle = nullptr;
+
+const SString &BundleFileLocation::Path() const
+{
+    LIMITED_METHOD_CONTRACT;
+
+    // Currently, there is only one bundle -- the bundle for the main App.
+    // Therefore, obtain the path from the global AppBundle.
+    // If there is more than one bundle in one application (ex: single file plugins)
+    // the BundlePath may be stored in the BundleFileLocation structure.
+
+    _ASSERTE(IsValid());
+    _ASSERTE(Bundle::AppBundle != nullptr);
+
+    return Bundle::AppBundle->Path();
+}
+
+Bundle::Bundle(LPCWSTR bundlePath, BundleProbe *probe)
+{
+    STANDARD_VM_CONTRACT;
+
+    _ASSERTE(probe != nullptr);
+
+    m_path.Set(bundlePath);
+    m_probe = probe;
+
+    // The bundle-base path is the directory containing the single-file bundle.
+    // When the Probe() function searches within the bundle, it masks out the basePath from the assembly-path (if found).
+
+    LPCWSTR pos = wcsrchr(bundlePath, DIRECTORY_SEPARATOR_CHAR_W);
+    _ASSERTE(pos != nullptr);
+    size_t baseLen = pos - bundlePath + 1; // Include DIRECTORY_SEPARATOR_CHAR_W in m_basePath
+    m_basePath.Set(bundlePath, (COUNT_T)baseLen);
+}
+
+BundleFileLocation Bundle::Probe(LPCWSTR path, bool pathIsBundleRelative) const
+{
+    STANDARD_VM_CONTRACT;
+
+    BundleFileLocation loc;
+
+    // Skip over m_base_path, if any. For example: 
+    //    Bundle.Probe("lib.dll") => m_probe("lib.dll")
+    //    Bundle.Probe("path/to/exe/lib.dll") => m_probe("lib.dll")
+    //    Bundle.Probe("path/to/exe/and/some/more/lib.dll") => m_probe("and/some/more/lib.dll")
+
+    if (!pathIsBundleRelative)
+    {
+        size_t baseLen = m_basePath.GetCount();
+
+#ifdef TARGET_UNIX
+        if (wcsncmp(m_basePath, path, baseLen) == 0)
+#else
+        if (_wcsnicmp(m_basePath, path, baseLen) == 0)
+#endif // TARGET_UNIX
+        {
+            path += baseLen; // m_basePath includes count for DIRECTORY_SEPARATOR_CHAR_W
+        }
+        else
+        {
+            // This is not a file within the bundle
+            return loc;
+        }
+    }
+
+    m_probe(path, &loc.Offset, &loc.Size);
+
+    return loc;
+}
+
+BundleFileLocation Bundle::ProbeAppBundle(LPCWSTR path, bool pathIsBundleRelative)
+{
+    STANDARD_VM_CONTRACT;
+
+    return AppIsBundle() ? AppBundle->Probe(path, pathIsBundleRelative) : BundleFileLocation::Invalid();
+}
+

--- a/src/coreclr/src/vm/coreassemblyspec.cpp
+++ b/src/coreclr/src/vm/coreassemblyspec.cpp
@@ -19,7 +19,7 @@
 #include "domainfile.h"
 #include "holder.h"
 #include "../binder/inc/assemblybinder.hpp"
-
+#include "bundle.h"
 #include "strongnameinternal.h"
 #include "strongnameholders.h"
 
@@ -174,10 +174,11 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
 }
 
 
-STDAPI BinderAcquirePEImage(LPCWSTR   wszAssemblyPath,
-                            PEImage **ppPEImage,
-                            PEImage **ppNativeImage,
-                            BOOL      fExplicitBindToNativeImage)
+STDAPI BinderAcquirePEImage(LPCWSTR             wszAssemblyPath,
+                            PEImage           **ppPEImage,
+                            PEImage           **ppNativeImage,
+                            BOOL                fExplicitBindToNativeImage,
+                            BundleFileLocation  bundleFileLocation)
 {
     HRESULT hr = S_OK;
 
@@ -187,12 +188,13 @@ STDAPI BinderAcquirePEImage(LPCWSTR   wszAssemblyPath,
     {
         PEImageHolder pImage = NULL;
         PEImageHolder pNativeImage = NULL;
+        AppDomain* pDomain = ::GetAppDomain(); // DEAD ? ? 
 
 #ifdef FEATURE_PREJIT
         // fExplicitBindToNativeImage is set on Phone when we bind to a list of native images and have no IL on device for an assembly
         if (fExplicitBindToNativeImage)
         {
-            pNativeImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_TrustedNativeImage);
+            pNativeImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_TrustedNativeImage, bundleFileLocation);
 
             // Make sure that the IL image can be opened if the native image is not available.
             hr=pNativeImage->TryOpenFile();
@@ -204,7 +206,7 @@ STDAPI BinderAcquirePEImage(LPCWSTR   wszAssemblyPath,
         else
 #endif
         {
-            pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default);
+            pImage = PEImage::OpenImage(wszAssemblyPath, MDInternalImport_Default, bundleFileLocation);
 
             // Make sure that the IL image can be opened if the native image is not available.
             hr=pImage->TryOpenFile();

--- a/src/coreclr/src/vm/crossgen/CMakeLists.txt
+++ b/src/coreclr/src/vm/crossgen/CMakeLists.txt
@@ -6,6 +6,7 @@ set(VM_CROSSGEN_SOURCES
   ../assemblyspec.cpp
   ../baseassemblyspec.cpp
   ../binder.cpp
+  ../bundle.cpp
   ../castcache.cpp
   ../ceeload.cpp
   ../ceemain.cpp

--- a/src/coreclr/src/vm/pefile.cpp
+++ b/src/coreclr/src/vm/pefile.cpp
@@ -295,12 +295,15 @@ void PEFile::LoadLibrary(BOOL allowNativeSkip/*=TRUE*/) // if allowNativeSkip==F
             if (GetILimage()->IsFile())
             {
 #ifdef TARGET_UNIX
-                if (GetILimage()->IsILOnly())
+                bool loadILImage = GetILimage()->IsILOnly();
+#else // TARGET_UNIX
+                bool loadILImage = GetILimage()->IsILOnly() && GetILimage()->IsInBundle();
+#endif // TARGET_UNIX
+                if (loadILImage)
                 {
                     GetILimage()->Load();
                 }
                 else
-#endif // TARGET_UNIX
                 {
                     GetILimage()->LoadFromMapped();
                 }

--- a/src/coreclr/src/vm/peimage.cpp
+++ b/src/coreclr/src/vm/peimage.cpp
@@ -973,7 +973,10 @@ PTR_PEImageLayout PEImage::GetLayoutInternal(DWORD imageLayoutMask,DWORD flags)
         BOOL bIsFlatLayoutSuitable = ((imageLayoutMask & PEImageLayout::LAYOUT_FLAT) != 0);
 
 #if !defined(TARGET_UNIX)
-        bIsFlatLayoutSuitable = IsInBundle() || !bIsMappedLayoutSuitable;
+        if (!IsInBundle() && bIsMappedLayoutSuitable)
+        {
+            bIsFlatLayoutSuitable = FALSE;
+        }
 #endif // !TARGET_UNIX
 
         _ASSERTE(bIsMappedLayoutSuitable || bIsFlatLayoutSuitable);

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -19,6 +19,7 @@
 #include "peimagelayout.h"
 #include "sstring.h"
 #include "holder.h"
+#include <bundle.h>
 
 class SimpleRWLock;
 // --------------------------------------------------------------------------------
@@ -102,7 +103,8 @@ public:
 #endif // !TARGET_UNIX
     static PTR_PEImage OpenImage(
         LPCWSTR pPath,
-        MDInternalImportFlags flags = MDInternalImport_Default);
+        MDInternalImportFlags flags = MDInternalImport_Default,
+        BundleFileLocation bundleFileLocation = BundleFileLocation::Invalid());
 
 
     // clones the image with new flags (this is pretty much about cached / noncached difference)
@@ -146,8 +148,13 @@ public:
 
     // Accessors
     const SString &GetPath();
+    const SString& GetPathToLoad();
     BOOL IsFile();
+    BOOL IsInBundle() const;
     HANDLE GetFileHandle();
+    INT64 GetOffset() const;
+    INT64 GetSize() const;
+
     void SetFileHandle(HANDLE hFile);
     HRESULT TryOpenFile();
 
@@ -237,7 +244,7 @@ private:
     // Private routines
     // ------------------------------------------------------------
 
-    void  Init(LPCWSTR pPath);
+    void  Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation);
     void  Init(IStream* pStream, UINT64 uStreamAsmId,
                DWORD dwModuleId, BOOL resourceFile);
 
@@ -272,6 +279,10 @@ private:
 
     SString     m_path;
     LONG        m_refCount;
+
+    BundleFileLocation m_bundleFileLocation; // If this image is located within a single-file bundle, 
+                                             // the location within the bundle. If m_bundleFileLocation is vaild, 
+                                             // it takes precedence over m_path for loading.
 
     // This variable will have the data of module name.
     // It is only used by DAC to remap fusion loaded modules back to

--- a/src/coreclr/src/vm/peimagelayout.h
+++ b/src/coreclr/src/vm/peimagelayout.h
@@ -54,6 +54,7 @@ public:
     static PEImageLayout* LoadFromFlat(PEImageLayout* pflatimage);
     static PEImageLayout* Load(PEImage* pOwner, BOOL bNTSafeLoad, BOOL bThrowOnError = TRUE);
     static PEImageLayout* LoadFlat(PEImage* pOwner);
+    static PEImageLayout* LoadConverted(PEImage* pOwner);
     static PEImageLayout* LoadNative(LPCWSTR fullPath);
     static PEImageLayout* Map(PEImage* pOwner);
 #endif

--- a/src/installer/corehost/cli/bundle/file_entry.cpp
+++ b/src/installer/corehost/cli/bundle/file_entry.cpp
@@ -38,10 +38,9 @@ bool file_entry_t::needs_extraction() const
 {
     switch (m_type)
     {
-    // Once the runtime can load assemblies from bundle,
-    // file_type_t::assembly should be in this category
     case file_type_t::deps_json:
     case file_type_t::runtime_config_json:
+    case file_type_t::assembly:
         return false;
 
     default:

--- a/src/installer/corehost/cli/bundle/runner.cpp
+++ b/src/installer/corehost/cli/bundle/runner.cpp
@@ -79,8 +79,7 @@ bool runner_t::probe(const pal::string_t& relative_path, int64_t* offset, int64_
     return true;
 }
 
-
-bool runner_t::locate(const pal::string_t& relative_path, pal::string_t& full_path) const
+bool runner_t::locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const
 {
     const bundle::file_entry_t* entry = probe(relative_path);
 
@@ -90,11 +89,9 @@ bool runner_t::locate(const pal::string_t& relative_path, pal::string_t& full_pa
         return false;
     }
 
-    // Currently, all files except deps.json and runtimeconfig.json are extracted to disk.
-    // The json files are not queried by the host using this method.
-    assert(entry->needs_extraction());
+    extracted_to_disk = entry->needs_extraction();
+    full_path.assign(extracted_to_disk ? extraction_path() : base_path());
 
-    full_path.assign(extraction_path());
     append_path(&full_path, relative_path.c_str());
 
     return true;

--- a/src/installer/corehost/cli/bundle/runner.h
+++ b/src/installer/corehost/cli/bundle/runner.h
@@ -21,26 +21,31 @@ namespace bundle
     {
     public:
         runner_t(const pal::char_t* bundle_path,
-                 const pal::char_t *app_path,
-                 int64_t header_offset)
+            const pal::char_t* app_path,
+            int64_t header_offset)
             : info_t(bundle_path, app_path, header_offset) {}
 
         const pal::string_t& extraction_path() const { return m_extraction_path; }
 
         bool probe(const pal::string_t& relative_path, int64_t* offset, int64_t* size) const;
-        bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const;
+        const file_entry_t* probe(const pal::string_t& relative_path) const;
+        bool locate(const pal::string_t& relative_path, pal::string_t& full_path, bool& extracted_to_disk) const;
+        bool locate(const pal::string_t& relative_path, pal::string_t& full_path) const
+        {
+            bool extracted_to_disk;
+            return locate(relative_path, full_path, extracted_to_disk);
+        }
 
         static StatusCode process_manifest_and_extract()
         {
             return ((runner_t*) the_app)->extract();
         }
-
+        
         static const runner_t* app() { return (const runner_t*)the_app; }
 
     private:
 
         StatusCode extract();
-        const file_entry_t* probe(const pal::string_t& relative_path) const;
 
         manifest_t m_manifest;
         pal::string_t m_extraction_path;

--- a/src/installer/corehost/cli/deps_entry.h
+++ b/src/installer/corehost/cli/deps_entry.h
@@ -53,7 +53,7 @@ struct deps_entry_t
     bool is_rid_specific;
 
     // Given a "base" dir, yield the file path within this directory or single-file bundle.
-    bool to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str) const;
+    bool to_dir_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str, bool& loaded_from_bundle) const;
 
     // Given a "base" dir, yield the relative path in the package layout.
     bool to_rel_path(const pal::string_t& base, bool look_in_bundle, pal::string_t* str) const;
@@ -64,7 +64,7 @@ struct deps_entry_t
 private:
     // Given a "base" dir, yield the filepath within this directory or relative to this directory based on "look_in_base"
     // Returns a path within the single-file bundle, or a file on disk,
-    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, pal::string_t* str) const;
+    bool to_path(const pal::string_t& base, const pal::string_t& ietf_code, bool look_in_base, bool look_in_bundle, pal::string_t* str, bool & loaded_from_bundle) const;
 };
 
 #endif // __DEPS_ENTRY_H_

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -282,7 +282,7 @@ void deps_resolver_t::setup_additional_probes(const std::vector<pal::string_t>& 
  *   -- When a deps json based probe is performed, the deps entry's package name and version must match.
  *   -- When looking into a published dir, for rid specific assets lookup rid split folders; for non-rid assets lookup the layout dir.
  * The path to the resolved file is returned in candidate out parameter
- * If the candidate is embedded within the single-file bundle (rather than an actual file on disk), found_in_bundle will be set to true.
+ * If the candidate is embedded within the single-file bundle (rather than an actual file on disk), loaded_from_bundle will be set to true.
  */
 bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::string_t& deps_dir, int fx_level, pal::string_t* candidate, bool & loaded_from_bundle)
 {

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.cpp
@@ -281,10 +281,13 @@ void deps_resolver_t::setup_additional_probes(const std::vector<pal::string_t>& 
  *   -- When servicing directories are looked up, look up only if the deps file marks the entry as serviceable.
  *   -- When a deps json based probe is performed, the deps entry's package name and version must match.
  *   -- When looking into a published dir, for rid specific assets lookup rid split folders; for non-rid assets lookup the layout dir.
+ * The path to the resolved file is returned in candidate out parameter
+ * If the candidate is embedded within the single-file bundle (rather than an actual file on disk), found_in_bundle will be set to true.
  */
-bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::string_t& deps_dir, int fx_level, pal::string_t* candidate)
+bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::string_t& deps_dir, int fx_level, pal::string_t* candidate, bool & loaded_from_bundle)
 {
     candidate->clear();
+    loaded_from_bundle = false;
 
     for (const auto& config : m_probes)
     {
@@ -316,8 +319,9 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 // If the deps json has the package name and version, then someone has already done rid selection and
                 // put the right asset in the dir. So checking just package name and version would suffice.
                 // No need to check further for the exact asset relative sub path.
-                if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && entry.to_dir_path(probe_dir, false, candidate))
+                if (config.probe_deps_json->has_package(entry.library_name, entry.library_version) && entry.to_dir_path(probe_dir, false, candidate, loaded_from_bundle))
                 {
+                    assert(!loaded_from_bundle);
                     trace::verbose(_X("    Probed deps json and matched '%s'"), candidate->c_str());
                     return true;
                 }
@@ -343,7 +347,7 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
                 else
                 {
                     // Non-rid assets, lookup in the published dir.
-                    if (entry.to_dir_path(deps_dir, true, candidate))
+                    if (entry.to_dir_path(deps_dir, true, candidate, loaded_from_bundle))
                     {
                         trace::verbose(_X("    Probed deps dir and matched '%s'"), candidate->c_str());
                         return true;
@@ -437,10 +441,17 @@ bool deps_resolver_t::resolve_tpa_list(
         name_to_resolved_asset_map_t::iterator existing = items.find(entry.asset.name);
         if (existing == items.end())
         {
-            if (probe_deps_entry(entry, deps_dir, fx_level, &resolved_path))
+            bool loaded_from_bundle = false;
+            if (probe_deps_entry(entry, deps_dir, fx_level, &resolved_path, loaded_from_bundle))
             {
-                deps_resolved_asset_t resolved_asset(entry.asset, resolved_path);
-                add_tpa_asset(resolved_asset, &items);
+                // Assemblies loaded directly from the bundle are not added to the TPA list.
+                // The runtime directly probes the bundle-manifest using a host-callback.
+                if (!loaded_from_bundle)
+                {
+                    deps_resolved_asset_t resolved_asset(entry.asset, resolved_path);
+                    add_tpa_asset(resolved_asset, &items);
+                }
+
                 return true;
             }
 
@@ -468,7 +479,8 @@ bool deps_resolver_t::resolve_tpa_list(
             if (entry.asset.assembly_version > existing_entry->asset.assembly_version ||
                 (entry.asset.assembly_version == existing_entry->asset.assembly_version && entry.asset.file_version >= existing_entry->asset.file_version))
             {
-                if (probe_deps_entry(entry, deps_dir, fx_level, &resolved_path))
+                bool loaded_from_bundle = false;
+                if (probe_deps_entry(entry, deps_dir, fx_level, &resolved_path, loaded_from_bundle))
                 {
                     // If the path is the same, then no need to replace
                     if (resolved_path != existing_entry->resolved_path)
@@ -480,9 +492,12 @@ bool deps_resolver_t::resolve_tpa_list(
                         existing_entry = nullptr;
                         items.erase(existing);
 
-                        deps_asset_t asset(entry.asset.name, entry.asset.relative_path, entry.asset.assembly_version, entry.asset.file_version);
-                        deps_resolved_asset_t resolved_asset(asset, resolved_path);
-                        add_tpa_asset(resolved_asset, &items);
+                        if (!loaded_from_bundle)
+                        {
+                            deps_asset_t asset(entry.asset.name, entry.asset.relative_path, entry.asset.assembly_version, entry.asset.file_version);
+                            deps_resolved_asset_t resolved_asset(asset, resolved_path);
+                            add_tpa_asset(resolved_asset, &items);
+                        }
                     }
                 }
                 else if (fx_level != 0)
@@ -505,9 +520,17 @@ bool deps_resolver_t::resolve_tpa_list(
         // First add managed assembly to the TPA.
         // TODO: Remove: the deps should contain the managed DLL.
         // Workaround for: csc.deps.json doesn't have the csc.dll
-        deps_asset_t asset(get_filename_without_ext(m_managed_app), get_filename(m_managed_app), version_t(), version_t());
-        deps_resolved_asset_t resolved_asset(asset, m_managed_app);
-        add_tpa_asset(resolved_asset, &items);
+
+        // If this is a single-file bundle, app.dll is expected to be within the bundle, unless it is explicitly excluded from the bundle.
+        // In all other cases, add its path to the TPA list.
+        pal::string_t managed_app_name = get_filename(m_managed_app);
+        if (!bundle::info_t::is_single_file_bundle() ||
+            bundle::runner_t::app()->probe(managed_app_name) == nullptr)
+        {
+            deps_asset_t asset(get_filename_without_ext(m_managed_app), managed_app_name, version_t(), version_t());
+            deps_resolved_asset_t resolved_asset(asset, m_managed_app);
+            add_tpa_asset(resolved_asset, &items);
+        }
 
         // Add the app's entries
         const auto& deps_entries = get_deps().get_entries(deps_entry_t::asset_types::runtime);
@@ -783,10 +806,14 @@ bool deps_resolver_t::resolve_probe_dirs(
         trace::verbose(_X("Processing native/culture for deps entry [%s, %s, %s]"), 
             entry.library_name.c_str(), entry.library_version.c_str(), entry.asset.relative_path.c_str());
 
-        if (probe_deps_entry(entry, deps_dir, fx_level, &candidate))
+        bool loaded_from_bundle = false;
+        if (probe_deps_entry(entry, deps_dir, fx_level, &candidate, loaded_from_bundle))
         {
-            init_known_entry_path(entry, candidate);
-            add_unique_path(asset_type, action(candidate), &items, output, &non_serviced, core_servicing);
+            if (!loaded_from_bundle)
+            {
+                init_known_entry_path(entry, candidate);
+                add_unique_path(asset_type, action(candidate), &items, output, &non_serviced, core_servicing);
+            }
         }
         else
         {

--- a/src/installer/corehost/cli/hostpolicy/deps_resolver.h
+++ b/src/installer/corehost/cli/hostpolicy/deps_resolver.h
@@ -228,7 +228,8 @@ private:
         const deps_entry_t& entry,
         const pal::string_t& deps_dir,
         int fx_level,
-        pal::string_t* candidate);
+        pal::string_t* candidate,
+        bool &loaded_from_bundle);
 
     fx_definition_vector_t& m_fx_definitions;
 

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy_context.cpp
@@ -113,17 +113,24 @@ int hostpolicy_context_t::initialize(hostpolicy_init_t &hostpolicy_init, const a
     // Get path in which CoreCLR is present.
     clr_dir = get_directory(clr_path);
 
+    // If this is a self-contained single-file bundle,
+    // System.Private.CoreLib.dll is expected to be within the bundle, unless it is explicitly excluded from the bundle.
+    // In all other cases, 
     // System.Private.CoreLib.dll is expected to be next to CoreCLR.dll - add its path to the TPA list.
-    pal::string_t corelib_path = clr_dir;
-    append_path(&corelib_path, CORELIB_NAME);
-
-    // Append CoreLib path
-    if (!probe_paths.tpa.empty() && probe_paths.tpa.back() != PATH_SEPARATOR)
+    if (!bundle::info_t::is_single_file_bundle() ||
+        bundle::runner_t::app()->probe(CORELIB_NAME) == nullptr)
     {
-        probe_paths.tpa.push_back(PATH_SEPARATOR);
-    }
+        pal::string_t corelib_path = clr_dir;
+        append_path(&corelib_path, CORELIB_NAME);
 
-    probe_paths.tpa.append(corelib_path);
+        // Append CoreLib path
+        if (!probe_paths.tpa.empty() && probe_paths.tpa.back() != PATH_SEPARATOR)
+        {
+            probe_paths.tpa.push_back(PATH_SEPARATOR);
+        }
+
+        probe_paths.tpa.append(corelib_path);
+    }
 
     const fx_definition_vector_t &fx_definitions = resolver.get_fx_definitions();
 

--- a/src/installer/test/Assets/TestProjects/AppWithWait/Program.cs
+++ b/src/installer/test/Assets/TestProjects/AppWithWait/Program.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using System.Reflection;
 
 namespace AppWithSubDirs
 {
@@ -20,6 +21,10 @@ namespace AppWithSubDirs
             {
                 string waitFile = args[0];
                 string resumeFile = args[1];
+
+                // Once this app creates the waitFile and yeilds control, the test-harness renames this single-file app bundle.
+                // Therefore, any assemblies loaded directly from the bundle, should be loaded before creating the waitFile.
+                Assembly.Load("System.Memory");
 
                 File.Create(waitFile).Close();
 

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -30,7 +30,7 @@ namespace AppHost.Bundle.Tests
 
             // Publish the bundle
             string singleFile;
-            Bundler bundler = BundleHelper.BundleApp(fixture, out singleFile);
+            Bundler bundler = BundleHelper.BundleApp(fixture, out singleFile, options: BundleOptions.BundleNativeBinaries);
 
             // Verify expected files in the bundle directory
             var bundleDir = BundleHelper.GetBundleDir(fixture);
@@ -156,7 +156,6 @@ namespace AppHost.Bundle.Tests
 
             extractDir.Should().HaveFiles(extractedFiles);
         }
-
 
         public class SharedTestState : IDisposable
         {

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundledAppWithSubDirs.cs
@@ -32,9 +32,7 @@ namespace AppHost.Bundle.Tests
                 .HaveStdOutContaining("Wow! We now say hello to the big world and you.");
         }
 
-        // BundleOptions.BundleNativeBinaries: Test when the payload data files are unbundled, and beside the single-file app.
-        // BundleOptions.BundleAllContent: Test when the payload data files are bundled and extracted to temporary directory. 
-        // Once the runtime can load assemblies from the bundle, BundleOptions.None can be used in place of BundleOptions.BundleNativeBinaries.
+        [InlineData(BundleOptions.None)]
         [InlineData(BundleOptions.BundleNativeBinaries)]
         [InlineData(BundleOptions.BundleAllContent)]
         [Theory]
@@ -50,6 +48,7 @@ namespace AppHost.Bundle.Tests
             RunTheApp(singleFile);
         }
 
+        [InlineData(BundleOptions.None)]
         [InlineData(BundleOptions.BundleNativeBinaries)]
         [InlineData(BundleOptions.BundleAllContent)]
         [Theory]
@@ -65,6 +64,7 @@ namespace AppHost.Bundle.Tests
             RunTheApp(singleFile);
         }
 
+        [InlineData(BundleOptions.None)]
         [InlineData(BundleOptions.BundleNativeBinaries)]
         [InlineData(BundleOptions.BundleAllContent)]
         [Theory]

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Helpers/BundleHelper.cs
@@ -53,8 +53,7 @@ namespace BundleTests.Helpers
 
         public static string[] GetExtractedFiles(TestProjectFixture fixture)
         {
-            string appBaseName = GetAppBaseName(fixture);
-            return new string[] { $"{appBaseName}.dll" };
+            return new string[] { Path.GetFileName(fixture.TestProject.CoreClrDll) };
         }
 
         public static string[] GetFilesNeverExtracted(TestProjectFixture fixture)
@@ -62,6 +61,7 @@ namespace BundleTests.Helpers
             string appBaseName = GetAppBaseName(fixture);
             return new string[] { $"{appBaseName}.deps.json",
                                   $"{appBaseName}.runtimeconfig.json",
+                                  $"{appBaseName}.dll",
                                   Path.GetFileName(fixture.TestProject.HostFxrDll),
                                   Path.GetFileName(fixture.TestProject.HostPolicyDll) };
         }
@@ -139,7 +139,7 @@ namespace BundleTests.Helpers
         // which may not (yet) be available in the SDK.
         public static Bundler BundleApp(TestProjectFixture fixture,
                                         out string singleFile,
-                                        BundleOptions options = BundleOptions.BundleNativeBinaries,
+                                        BundleOptions options = BundleOptions.None,
                                         Version targetFrameworkVersion = null,
                                         bool copyExcludedFiles = true)
         {
@@ -153,11 +153,8 @@ namespace BundleTests.Helpers
             return bundler;
         }
 
-        // The defaut option for Bundling apps is BundleOptions.BundleNativeBinaries
-        // Until CoreCLR runtime can learn how to process assemblies from the bundle.
-        // This is because CoreCLR expects System.Private.Corelib.dll to be beside CoreCLR.dll
         public static string BundleApp(TestProjectFixture fixture,
-                                       BundleOptions options = BundleOptions.BundleNativeBinaries,
+                                       BundleOptions options = BundleOptions.None,
                                        Version targetFrameworkVersion = null)
         {
             string singleFile;

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleAndRun.cs
@@ -32,7 +32,7 @@ namespace Microsoft.NET.HostModel.Tests
                 .HaveStdOutContaining("Wow! We now say hello to the big world and you.");
         }
 
-        private void BundleRun(TestProjectFixture fixture, string publishPath, string singleFileDir)
+        private void BundleRun(TestProjectFixture fixture, string publishPath)
         {
             var hostName = BundleHelper.GetHostName(fixture);
 
@@ -56,33 +56,24 @@ namespace Microsoft.NET.HostModel.Tests
         public void TestWithAbsolutePaths()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-
             string publishDir = BundleHelper.GetPublishPath(fixture);
-            string outputDir = BundleHelper.GetBundleDir(fixture).FullName;
-
-            BundleRun(fixture, publishDir, outputDir);
+            BundleRun(fixture, publishDir);
         }
 
         [Fact]
         public void TestWithRelativePaths()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-
             string publishDir = RelativePath(BundleHelper.GetPublishPath(fixture));
-            string outputDir = RelativePath(BundleHelper.GetBundleDir(fixture).FullName);
-
-            BundleRun(fixture, publishDir, outputDir);
+            BundleRun(fixture, publishDir);
         }
 
         [Fact]
         public void TestWithRelativePathsDirSeparator()
         {
             var fixture = sharedTestState.TestFixture.Copy();
-
             string publishDir = RelativePath(BundleHelper.GetPublishPath(fixture)) + Path.DirectorySeparatorChar;
-            string outputDir = RelativePath(BundleHelper.GetBundleDir(fixture).FullName) + Path.DirectorySeparatorChar;
-
-            BundleRun(fixture, publishDir, outputDir);
+            BundleRun(fixture, publishDir);
         }
 
         public class SharedTestState : IDisposable

--- a/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleLegacy.cs
+++ b/src/installer/test/Microsoft.NET.HostModel.Tests/Microsoft.NET.HostModel.Bundle.Tests/BundleLegacy.cs
@@ -27,8 +27,7 @@ namespace Microsoft.NET.HostModel.Tests
         {
             var fixture = (minorVersion == 0) ? sharedTestState.TestFixture30.Copy() : sharedTestState.TestFixture31.Copy();
 
-            // Targetting netcoreap3.x implies BundleOption.BundleAllContent
-            var singleFile = BundleHelper.BundleApp(fixture, BundleOptions.None, new Version(3, minorVersion));
+            var singleFile = BundleHelper.BundleApp(fixture, targetFrameworkVersion: new Version(3, minorVersion));
 
             Command.Create(singleFile)
                 .CaptureStdErr()
@@ -49,7 +48,6 @@ namespace Microsoft.NET.HostModel.Tests
 
             return fixture;
         }
-
 
         public class SharedTestState : IDisposable
         {


### PR DESCRIPTION
This change implements:

* Runtime changes necessary to load assemblies directly from the bundle:
    * Design notes about [Load from Bundle](https://github.com/dotnet/designs/blob/master/accepted/2020/single-file/design.md#peimage-loader)
    * Most of these changes are directly from https://github.com/dotnet/coreclr/pull/26504 and https://github.com/dotnet/coreclr/pull/26904

* Hostpolicy change to not add bundled assemblies to TPA list:
    * Design notes about [Dependency Resolution](https://github.com/dotnet/designs/blob/master/accepted/2020/single-file/design.md#dependency-resolution)
    * TBD (separately) items: Fix for hammer servicing #36031

Fixes #32822