### PR TITLE
[WIP] Add mechanism for specifying compilation policy for crossgen2

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/src/tools/Common/Compiler/TypeExtensions.cs
@@ -171,6 +171,32 @@ namespace ILCompiler
         }
 
         /// <summary>
+        /// What is the maximum number of steps that need to be taken from this method to its most contained generic type.
+        /// i.e.
+        /// System.Int32 => 0
+        /// List&lt;System.Int32&gt; => 1
+        /// Dictionary&lt;System.Int32,System.Int32&gt; => 1
+        /// Dictionary&lt;List&lt;System.Int32&gt;,&lt;System.Int32&gt; => 2
+        /// </summary>
+        public static int GetGenericDepth(this MethodDesc method)
+        {
+            int maxGenericDepthInInstantiation = 0;
+
+            if (method.HasInstantiation)
+            {
+                foreach (TypeDesc instantiationType in method.Instantiation)
+                {
+                    maxGenericDepthInInstantiation = Math.Max(instantiationType.GetGenericDepth(), maxGenericDepthInInstantiation);
+                }
+                maxGenericDepthInInstantiation = maxGenericDepthInInstantiation + 1;
+            }
+
+            maxGenericDepthInInstantiation = Math.Max(maxGenericDepthInInstantiation, method.OwningType.GetGenericDepth());
+
+            return maxGenericDepthInInstantiation;
+        }
+
+        /// <summary>
         /// Determine if a type has a generic depth greater than a given value
         /// </summary>
         public static bool IsGenericDepthGreaterThan(this TypeDesc type, int depth)

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -62,6 +62,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public bool MarkingComplete => _markingComplete;
 
+        public ReadyToRunCompilationPolicy CompilationPolicy { get; }
+
         public void SetMarkingComplete()
         {
             _markingComplete = true;
@@ -149,8 +151,10 @@ namespace ILCompiler.DependencyAnalysis
             CopiedCorHeaderNode corHeaderNode,
             DebugDirectoryNode debugDirectoryNode,
             ResourceData win32Resources,
-            ReadyToRunFlags flags)
+            ReadyToRunFlags flags,
+            ReadyToRunCompilationPolicy compilationPolicy)
         {
+            CompilationPolicy = compilationPolicy;
             TypeSystemContext = context;
             CompilationModuleGroup = compilationModuleGroup;
             Target = context.Target;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/NoMethodsCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/NoMethodsCompilationModuleGroup.cs
@@ -37,7 +37,7 @@ namespace ILCompiler
             return false;
         }
 
-        public override void ApplyProfilerGuidedCompilationRestriction(ProfileDataManager profileGuidedCompileRestriction)
+        public sealed override void ApplyProfilerGuidedInformation(ProfileDataManager profileGuidedInfo)
         {
             return;
         }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -311,7 +311,8 @@ namespace ILCompiler
                 debugDirectory,
                 win32Resources: new Win32Resources.ResourceData(inputModule),
                 Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_Component |
-                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs);
+                Internal.ReadyToRunConstants.ReadyToRunFlags.READYTORUN_FLAG_NonSharedPInvokeStubs,
+                null);
 
             IComparer<DependencyNodeCore<NodeFactory>> comparer = new SortableDependencyNode.ObjectNodeComparer(new CompilerComparer());
             DependencyAnalyzerBase<NodeFactory> componentGraph = new DependencyAnalyzer<NoLogStrategy<NodeFactory>, NodeFactory>(componentFactory, comparer);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -26,6 +26,7 @@ namespace ILCompiler
         private bool _generateMapFile;
         private int _parallelism;
         private InstructionSetSupport _instructionSetSupport;
+        private ReadyToRunCompilationPolicy _compilationPolicy;
 
         private string _jitPath;
 
@@ -115,6 +116,12 @@ namespace ILCompiler
             return this;
         }
 
+        public ReadyToRunCodegenCompilationBuilder UseCompilationPolicy(ReadyToRunCompilationPolicy compilationPolicy)
+        {
+            _compilationPolicy = compilationPolicy;
+            return this;
+        }
+
         public override ICompilation ToCompilation()
         {
             // TODO: only copy COR headers for single-assembly build and for composite build with embedded MSIL
@@ -155,7 +162,8 @@ namespace ILCompiler
                 corHeaderNode,
                 debugDirectoryNode,
                 win32Resources,
-                flags);
+                flags,
+                _compilationPolicy);
 
             IComparer<DependencyNodeCore<NodeFactory>> comparer = new SortableDependencyNode.ObjectNodeComparer(new CompilerComparer());
             DependencyAnalyzerBase<NodeFactory> graph = CreateDependencyGraph(factory, comparer);

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationModuleGroupBase.cs
@@ -455,6 +455,6 @@ namespace ILCompiler
             }
         }
 
-        public abstract void ApplyProfilerGuidedCompilationRestriction(ProfileDataManager profileGuidedCompileRestriction);
+        public abstract void ApplyProfilerGuidedInformation(ProfileDataManager profileGuidedInfo);
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationPolicy.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilationPolicy.cs
@@ -1,0 +1,230 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+using Internal.TypeSystem;
+
+[Flags]
+public enum ReadyToRunCompilationPolicyFlags
+{
+    NoMethods = 0x1,
+    OnlyProfileSpecifiedMethods = 0x2,
+    IgnoreProfileData = 0x4,
+    RootNonGenericMethods = 0x08,
+    RootGenericCanonInstantiations = 0x10,
+    AllowGenericCanonInstantiations = 0x20,
+    AllowLocalGenericInstantiations = 0x40,
+    AllowPrimitiveGenericInstantiations = 0x80,
+    AllowAllGenericInstantiations = 0x100,
+    CompileVirtualMethodsOnReferencedTypes = 0x200,
+    CompileNonVirtualMethodsOnReferencedTypes = 0x400,
+}
+
+public class ReadyToRunCompilationSpecificPolicy
+{
+    public ReadyToRunCompilationSpecificPolicy Clone()
+    {
+        ReadyToRunCompilationSpecificPolicy clone = new ReadyToRunCompilationSpecificPolicy();
+        clone.Flags = Flags;
+        clone.MaxGenericDepth = MaxGenericDepth;
+        clone.MaxGenericDepthReferencedTypeExpansion = MaxGenericDepthReferencedTypeExpansion;
+        return clone;
+    }
+
+    public ReadyToRunCompilationPolicyFlags Flags;
+    public int MaxGenericDepth = 10;
+    public int MaxGenericDepthReferencedTypeExpansion = 10;
+}
+
+public class ReadyToRunCompilationPolicy
+{
+    public ReadyToRunCompilationPolicy(TypeSystemContext context, string policySpec)
+    {
+        string[] topLevelGroups = policySpec.Split(";");
+        foreach (string topLevelUntrimmed in topLevelGroups)
+        {
+            string topLevel = topLevelUntrimmed.Trim();
+            if (String.IsNullOrEmpty(topLevel))
+                continue;
+
+            ReadyToRunCompilationSpecificPolicy policyBeingAdjusted = Global;
+            int equalsIndex = topLevel.IndexOf('=');
+            if (equalsIndex != -1)
+            {
+                string moduleName = topLevel.Substring(0, equalsIndex);
+                topLevel = topLevel.Substring(equalsIndex + 1);
+                var module = context.ResolveAssembly(new AssemblyName(moduleName));
+                if (!_policies.TryGetValue(module, out policyBeingAdjusted))
+                {
+                    policyBeingAdjusted = Global.Clone(); 
+                    _policies.Add(module, policyBeingAdjusted);
+                }
+            }
+
+            foreach (string policyUntrimmed in topLevel.Split(','))
+            {
+                string policy = policyUntrimmed.Trim();
+                if (String.IsNullOrEmpty(policy))
+                    continue;
+                
+                switch (policy)
+                {
+                    case "+NoMethods":
+                    case "NoMethods":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.NoMethods;
+                        break;
+                    case "-NoMethods":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.NoMethods;
+                        break;
+
+                    case "+OnlyProfileSpecifiedMethods":
+                    case "OnlyProfileSpecifiedMethods":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.OnlyProfileSpecifiedMethods;
+                        break;
+                    case "-OnlyProfileSpecifiedMethods":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.OnlyProfileSpecifiedMethods;
+                        break;
+
+                    case "+IgnoreProfileData":
+                    case "IgnoreProfileData":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.IgnoreProfileData;
+                        break;
+                    case "-IgnoreProfileData":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.IgnoreProfileData;
+                        break;
+
+                    case "+RootNonGenericMethods":
+                    case "RootNonGenericMethods":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.RootNonGenericMethods;
+                        break;
+                    case "-RootNonGenericMethods":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.RootNonGenericMethods;
+                        break;
+
+                    case "+RootGenericCanonInstantiations":
+                    case "RootGenericCanonInstantiations":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.RootGenericCanonInstantiations;
+                        break;
+                    case "-RootGenericCanonInstantiations":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.RootGenericCanonInstantiations;
+                        break;
+
+                    case "+AllowGenericCanonInstantiations":
+                    case "AllowGenericCanonInstantiations":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.AllowGenericCanonInstantiations;
+                        break;
+                    case "-AllowGenericCanonInstantiations":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.AllowGenericCanonInstantiations;
+                        break;
+
+                    case "+AllowLocalGenericInstantiations":
+                    case "AllowLocalGenericInstantiations":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.AllowLocalGenericInstantiations;
+                        break;
+                    case "-AllowLocalGenericInstantiations":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.AllowLocalGenericInstantiations;
+                        break;
+
+                    case "+AllowPrimitiveGenericInstantiations":
+                    case "AllowPrimitiveGenericInstantiations":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.AllowPrimitiveGenericInstantiations;
+                        break;
+                    case "-AllowPrimitiveGenericInstantiations":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.AllowPrimitiveGenericInstantiations;
+                        break;
+
+                    case "+AllowAllGenericInstantiations":
+                    case "AllowAllGenericInstantiations":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.AllowAllGenericInstantiations;
+                        break;
+                    case "-AllowAllGenericInstantiations":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.AllowAllGenericInstantiations;
+                        break;
+
+                    case "+CompileVirtualMethodsOnReferencedTypes":
+                    case "CompileVirtualMethodsOnReferencedTypes":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.CompileVirtualMethodsOnReferencedTypes;
+                        break;
+                    case "-CompileVirtualMethodsOnReferencedTypes":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.CompileVirtualMethodsOnReferencedTypes;
+                        break;
+
+                    case "+CompileNonVirtualMethodsOnReferencedTypes":
+                    case "CompileNonVirtualMethodsOnReferencedTypes":
+                        policyBeingAdjusted.Flags |= ReadyToRunCompilationPolicyFlags.CompileNonVirtualMethodsOnReferencedTypes;
+                        break;
+                    case "-CompileNonVirtualMethodsOnReferencedTypes":
+                        policyBeingAdjusted.Flags &= ~ReadyToRunCompilationPolicyFlags.CompileNonVirtualMethodsOnReferencedTypes;
+                        break;
+
+                    default:
+                    {
+                        var indexOfColon = policy.IndexOf(':');
+                        bool foundPolicy = false;
+                        if (indexOfColon != -1)
+                        {
+                            string numericPolicy = policy.Substring(0,indexOfColon);
+                            if (Int32.TryParse(policy.Substring(indexOfColon + 1).Trim(), out int numericValue))
+                            {
+                                foundPolicy = true;
+                                switch (numericPolicy)
+                                {
+                                    case "MaxGenericDepth":
+                                        policyBeingAdjusted.MaxGenericDepth = numericValue;
+                                        break;
+                                    case "MaxGenericDepthReferencedTypeExpansion":
+                                        policyBeingAdjusted.MaxGenericDepthReferencedTypeExpansion = numericValue;
+                                        break;
+
+                                    default:
+                                        foundPolicy = false;
+                                        break;
+                                }
+                            }
+                        }
+
+                        if (!foundPolicy)
+                        {
+                            throw new ArgumentException(policy);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private Dictionary<ModuleDesc, ReadyToRunCompilationSpecificPolicy> _policies = new Dictionary<ModuleDesc, ReadyToRunCompilationSpecificPolicy>();
+
+    public readonly ReadyToRunCompilationSpecificPolicy Global = new ReadyToRunCompilationSpecificPolicy();
+
+    public ReadyToRunCompilationSpecificPolicy For(MethodDesc method)
+    {
+        return For(method.OwningType);
+    }
+
+    public ReadyToRunCompilationSpecificPolicy For(TypeDesc type)
+    {
+        if (type is MetadataType typeWithModule)
+        {
+            return For(typeWithModule.Module);
+        }
+        else
+        {
+            return Global;
+        }
+    }
+
+    public ReadyToRunCompilationSpecificPolicy For(ModuleDesc module)
+    {
+        if (_policies.TryGetValue(module, out var policy))
+        {
+            return policy;
+        }
+        return Global;
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunSingleAssemblyCompilationModuleGroup.cs
@@ -14,8 +14,9 @@ namespace ILCompiler
 {
     public class ReadyToRunSingleAssemblyCompilationModuleGroup : ReadyToRunCompilationModuleGroupBase
     {
-        private ProfileDataManager _profileGuidedCompileRestriction;
-        private bool _profileGuidedCompileRestrictionSet;
+        private ProfileDataManager _profileGuidedCompileInfo;
+        private bool _profileGuidedInfoSet;
+        private ReadyToRunCompilationPolicy _compilationPolicy;
 
         public ReadyToRunSingleAssemblyCompilationModuleGroup(
             TypeSystemContext context,
@@ -23,7 +24,8 @@ namespace ILCompiler
             bool isInputBubble,
             IEnumerable<EcmaModule> compilationModuleSet,
             IEnumerable<ModuleDesc> versionBubbleModuleSet,
-            bool compileGenericDependenciesFromVersionBubbleModuleSet) :
+            bool compileGenericDependenciesFromVersionBubbleModuleSet,
+            ReadyToRunCompilationPolicy compilationPolicy) :
                 base(context,
                      isCompositeBuildMode,
                      isInputBubble,
@@ -31,17 +33,19 @@ namespace ILCompiler
                      versionBubbleModuleSet,
                      compileGenericDependenciesFromVersionBubbleModuleSet)
         {
+            _compilationPolicy = compilationPolicy;
         }
 
         public sealed override bool ContainsMethodBody(MethodDesc method, bool unboxingStub)
         {
-            if (!_profileGuidedCompileRestrictionSet)
+            if (!_profileGuidedInfoSet)
                 throw new InternalCompilerErrorException("Called ContainsMethodBody without setting profile guided restriction");
 
-            if (_profileGuidedCompileRestriction != null)
+            var policy = _compilationPolicy.For(method);
+
+            if ((policy.Flags & ReadyToRunCompilationPolicyFlags.NoMethods) != 0)
             {
-                if (!_profileGuidedCompileRestriction.IsMethodInProfileData(method))
-                    return false;
+                return false;
             }
 
             if (method is ArrayMethod)
@@ -51,24 +55,124 @@ namespace ILCompiler
                 return false;
             }
 
-            return (ContainsType(method.OwningType) && VersionsWithMethodBody(method)) || CompileVersionBubbleGenericsIntoCurrentModule(method);
+            if (!((ContainsType(method.OwningType) && VersionsWithMethodBody(method)) || CompileVersionBubbleGenericsIntoCurrentModule(method)))
+            {
+                // If the method can't be compiled in this compilation, skip
+                return false;
+            }
+
+            bool methodInProfileData = false;
+
+            if ((_profileGuidedCompileInfo != null) && !((policy.Flags & ReadyToRunCompilationPolicyFlags.IgnoreProfileData) != 0))
+            {
+                methodInProfileData = _profileGuidedCompileInfo.IsMethodInProfileData(method);
+            }
+
+            if ((policy.Flags & ReadyToRunCompilationPolicyFlags.OnlyProfileSpecifiedMethods) != 0)
+            {
+                if (!methodInProfileData)
+                    return false;
+            }
+
+            MethodDesc typicalMethod = method.GetTypicalMethodDefinition();
+
+            if (!methodInProfileData && (method != typicalMethod))
+            {
+                // If profile data is not present to indicate a generic is interesting, check to see if its allowed via the policy rules
+                if ((policy.Flags & ReadyToRunCompilationPolicyFlags.AllowAllGenericInstantiations) != 0)
+                {
+                    // The generic instantiation is allowed. No complex policy required
+                }
+                else
+                {
+                    bool outOfPolicyInstantiationFound = false;
+                    ModuleDesc localModule = ((MetadataType)typicalMethod.OwningType).Module;
+                    bool allowPrimitives = ((policy.Flags & ReadyToRunCompilationPolicyFlags.AllowPrimitiveGenericInstantiations) != 0);
+                    bool allowLocal = ((policy.Flags & ReadyToRunCompilationPolicyFlags.AllowLocalGenericInstantiations) != 0);
+                    bool allowCanon = ((policy.Flags & ReadyToRunCompilationPolicyFlags.AllowGenericCanonInstantiations) != 0);
+
+                    foreach (var type in method.Instantiation)
+                    {
+                        if (!IsTypeInPolicy(type, localModule, allowPrimitives, allowCanon, allowLocal))
+                        {
+                            outOfPolicyInstantiationFound = true;
+                            break;
+                        }
+                    }
+                    if (!outOfPolicyInstantiationFound)
+                    {
+                        foreach (var type in method.OwningType.Instantiation)
+                        {
+                            if (!IsTypeInPolicy(type, localModule, allowPrimitives, allowCanon, allowLocal))
+                            {
+                                outOfPolicyInstantiationFound = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (outOfPolicyInstantiationFound)
+                        return false; // Only allow instantiations defined within policy
+                }
+            }
+
+            if (method.GetGenericDepth() > policy.MaxGenericDepth)
+            {
+                return false;
+            }
+
+            return true;
+
+            static bool IsTypeInPolicy(TypeDesc type, ModuleDesc localModule, bool allowPrimitives, bool allowCanon, bool allowLocal)
+            {
+                if (allowPrimitives)
+                {
+                    if (type.IsPrimitive)
+                        return true;
+                }
+                if (allowCanon)
+                {
+                    if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
+                        return true;
+                }
+                if (allowLocal)
+                {
+                    if (type is MetadataType metadataType)
+                    {
+                        if (metadataType.Module == localModule)
+                        {
+                            foreach (TypeDesc instantiationType in type.Instantiation)
+                            {
+                                if (!IsTypeInPolicy(instantiationType, localModule, allowPrimitives, allowCanon, allowLocal))
+                                {
+                                    return false;
+                                }
+                            }
+
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
         }
 
-        public sealed override void ApplyProfilerGuidedCompilationRestriction(ProfileDataManager profileGuidedCompileRestriction)
+        public sealed override void ApplyProfilerGuidedInformation(ProfileDataManager profileGuidedInfo)
         {
-            if (_profileGuidedCompileRestrictionSet)
-                throw new InternalCompilerErrorException("Called ApplyProfilerGuidedCompilationRestriction twice.");
+            if (_profileGuidedInfoSet)
+                throw new InternalCompilerErrorException("Called ApplyProfilerGuidedInformation twice.");
 
-            _profileGuidedCompileRestrictionSet = true;
-            _profileGuidedCompileRestriction = profileGuidedCompileRestriction;
+            _profileGuidedInfoSet = true;
+            _profileGuidedCompileInfo = profileGuidedInfo;
         }
 
         public override ReadyToRunFlags GetReadyToRunFlags()
         {
-            Debug.Assert(_profileGuidedCompileRestrictionSet);
+            Debug.Assert(_profileGuidedInfoSet);
 
             ReadyToRunFlags flags = 0;
-            if (_profileGuidedCompileRestriction != null)
+            if ((_compilationPolicy.Global.Flags & ReadyToRunCompilationPolicyFlags.OnlyProfileSpecifiedMethods) != 0)
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_Partial;
 
             return flags;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/SingleMethodCompilationModuleGroup.cs
@@ -40,9 +40,9 @@ namespace ILCompiler
             return method == _method;
         }
 
-        public override void ApplyProfilerGuidedCompilationRestriction(ProfileDataManager profileGuidedCompileRestriction)
+        public sealed override void ApplyProfilerGuidedInformation(ProfileDataManager profileGuidedInfo)
         {
-            // Profiler guided restrictions are ignored for single method compilation
+            // Profiler guided data is ignored for single method compilation
             return;
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Compiler\ReadyToRunLibraryRootProvider.cs" />
     <Compile Include="Compiler\ReadyToRunCompilerContext.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilation.cs" />
+    <Compile Include="Compiler\ReadyToRunCompilationPolicy.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilationBuilder.cs" />
     <Compile Include="Compiler\ReadyToRunMetadataFieldLayoutAlgorithm.cs" />
     <Compile Include="Compiler\ReadyToRunSingleAssemblyCompilationModuleGroup.cs" />

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -38,7 +38,7 @@ namespace ILCompiler
         public bool Resilient { get; set; }
         public bool Map { get; set; }
         public int Parallelism { get; set; }
-
+        public string CompilationPolicy { get; set; }
 
         public string SingleMethodTypeName { get; set; }
         public string SingleMethodName { get; set; }
@@ -47,6 +47,7 @@ namespace ILCompiler
         public string[] CodegenOptions { get; set; }
 
         public bool CompositeOrInputBubble => Composite || InputBubble;
+
 
         public static Command RootCommand()
         {
@@ -177,6 +178,10 @@ namespace ILCompiler
                 new Option(new[] { "--map" }, SR.MapFileOption)
                 {
                     Argument = new Argument<bool>()
+                },
+                new Option(new[] { "--compilation-policy" }, SR.CompilationPolicyOption)
+                {
+                    Argument = new Argument<string>()
                 },
             };
         }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Properties/Resources.resx
@@ -168,6 +168,9 @@
   <data name="MapFileOption" xml:space="preserve">
     <value>Generate the map file</value>
   </data>
+  <data name="CompilationPolicyOption" xml:space="preserve">
+    <value>Specify the compilation policy. The compilation policy is specified as a set of flags and numeric values, optionally associated with a specific module. For instance '-AllowAllGenericInstantiations,MaxGenericDepth:5;System.Private.CoreLib=+AllowAllGenericInstantiations' Valid flags include: NoMethods, OnlyProfileSpecifiedMethods, IgnoreProfileData, RootNonGenericMethods, RootGenericCanonInstantiations, AllowGenericCanonInstantiations, AllowLocalGenericInstantiations, AllowPrimitiveGenericInstantiations, AllowAllGenericInstantiations, CompileVirtualMethodsOnReferencedTypes, and CompileNonVirtualMethodsOnReferencedTypes. Valid numeric values include: MaxGenericDepth and MaxGenericDepthReferencedTypeExpansion.</value>
+  </data>
   <data name="MethodNotFoundOnType" xml:space="preserve">
     <value>Method '{0}' not found in '{1}'</value>
   </data>


### PR DESCRIPTION
- New command line switch to control compilation policy (which methods get compiled, and such)
- Switch allows adjusting the following flags in a global or per module sense
 NoMethods
 OnlyProfileSpecifiedMethods
 IgnoreProfileData
 RootNonGenericMethods
 RootGenericCanonInstantiations
 AllowGenericCanonInstantiations
 AllowLocalGenericInstantiations
 AllowPrimitiveGenericInstantiations
 AllowAllGenericInstantiations
 CompileVirtualMethodsOnReferencedTypes
 CompileNonVirtualMethodsOnReferencedTypes
- It also permits adjusting the numeric value of
 MaxGenericDepth (default 10)
 MaxGenericDepthReferencedTypeExpansion (default 10)

At the moment all of the rooting and compilation flags are enabled by default, to match existing behavior, but I've been experimenting with a policy like: "-AllowAllGenericInstantiations,-CompileNonVirtualMethodsOnReferencedTypes;System.Private.CoreLib=+AllowAllGenericInstantiations" to see what the impact might be.