### PR TITLE
Naricc/test mono is mono

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -125,6 +125,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/generics/Variance/Interfaces/Interfaces001/*">
             <Issue>https://github.com/dotnet/runtime/issues/3893</Issue>
         </ExcludeList>
+	<ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
+            <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
+	</ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->

--- a/src/coreclr/tests/src/baseservices/mono/runningmono.cs
+++ b/src/coreclr/tests/src/baseservices/mono/runningmono.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+
+namespace TestRunningMono
+{
+        public static int Main(string[] args)
+        {
+            const int Pass = 100, Fail = 1;
+            bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
+	
+	    if (isMono)
+            {
+		return Pass;
+	    }
+            else
+            {
+		returun Fail;
+            }
+         }
+}
+

--- a/src/coreclr/tests/src/baseservices/mono/runningmono.cs
+++ b/src/coreclr/tests/src/baseservices/mono/runningmono.cs
@@ -5,6 +5,8 @@ using System;
 
 namespace TestRunningMono
 {
+   class Program
+   {
         public static int Main(string[] args)
         {
             const int Pass = 100, Fail = 1;
@@ -16,8 +18,9 @@ namespace TestRunningMono
 	    }
             else
             {
-		returun Fail;
+		return Fail;
             }
-         }
+        }
+   }
 }
 

--- a/src/coreclr/tests/src/baseservices/mono/runningmono.cs
+++ b/src/coreclr/tests/src/baseservices/mono/runningmono.cs
@@ -5,21 +5,21 @@ using System;
 
 namespace TestRunningMono
 {
-   class Program
-   {
+    class Program
+    {
         public static int Main(string[] args)
         {
-            const int Pass = 100, Fail = 1;
-            bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
-	
-	    if (isMono)
-            {
-		return Pass;
-	    }
-            else
-            {
-		return Fail;
-            }
+             const int Pass = 100, Fail = 1;
+             bool isMono = typeof(object).Assembly.GetType("Mono.RuntimeStructs") != null;
+
+             if(isMono)
+             {
+                 return Pass;
+             }
+             else
+             {
+                 return Fail;
+             }
         }
    }
 }

--- a/src/coreclr/tests/src/baseservices/mono/runningmono.csproj
+++ b/src/coreclr/tests/src/baseservices/mono/runningmono.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <Optimize>false</Optimize>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="runningmono.cs" />
+  </ItemGroup>
+</Project>
+


### PR DESCRIPTION
Its surprisingly easy to accidentally create a binary that is intended to run Mono, but is actually running coreclr. To check for this, change adds a runtime test to checks if the test is being run by Mono, and also excludes that test when runtimeFlavor is coreclr.