### PR TITLE
Mix installer build configurations in PRs as all are Debug now

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -513,7 +513,7 @@ jobs:
 
 - template: /eng/pipelines/installer/installer-matrix.yml
   parameters:
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+    buildConfig: Release
     platforms:
       - OSX_x64
       - Linux_x64
@@ -527,7 +527,7 @@ jobs:
 
 - template: /eng/pipelines/installer/installer-matrix.yml
   parameters:
-    buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
+    buildConfig: Release
     runtimeFlavor: mono
     platforms:
     - Android_x64


### PR DESCRIPTION
I noticed that for installer we build all legs in Debug in PRs and all in Release in CI. Let's add some Release builds for PRs as we do in other parts of the produce to protect from potential regressions on Release only builds like: https://github.com/dotnet/runtime/issues/35967

cc: @dotnet/runtime-infrastructure 