### PR TITLE
add platform restriction to two socket tests to avoid test skip on Unix

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/KeepAliveTest.cs
@@ -54,6 +54,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalFact(typeof(KeepAliveTest), nameof(IsWindowsBelow1703))] // RetryCount not supported by earlier versions of Windows
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void Socket_KeepAlive_RetryCount_Failure()
         {
             using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -484,6 +484,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalFact(nameof(IsSubWindows10))]
+        [PlatformSpecific(TestPlatforms.Windows)]
         public void Socket_CreateUnixDomainSocket_Throws_OnWindows()
         {
             AssertExtensions.Throws<ArgumentNullException>("path", () => new UnixDomainSocketEndPoint(null));


### PR DESCRIPTION
I noticed this on Linux
```

Microsoft.DotNet.XUnitConsoleRunner v2.5.0 (64-bit .NET 5.0.0-dev)
  Discovering: System.Net.Sockets.Tests (method display = ClassAndMethod, method display options = None)
  Discovered:  System.Net.Sockets.Tests (found 824 of 1201 test cases)
  Starting:    System.Net.Sockets.Tests (parallel test collections = on, max threads = 4)
    System.Net.Sockets.Tests.UnixDomainSocketTest.Socket_CreateUnixDomainSocket_Throws_OnWindows [SKIP]
      Condition(s) not met: "IsSubWindows10"
    System.Net.Sockets.Tests.KeepAliveTest.Socket_KeepAlive_RetryCount_Failure [SKIP]
      Condition(s) not met: "IsWindowsBelow1703"
    System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Supported_Success [SKIP]
      Condition(s) not met: "SupportsRawSockets"
  Finished:    System.Net.Sockets.Tests
=== TEST EXECUTION SUMMARY ===
   System.Net.Sockets.Tests  Total: 1097, Errors: 0, Failed: 0, Skipped: 3, Time: 20.084s
```

Since first two conditions will never be true outside Windows, it will log and create Kusto entry for each Unix run. 
With the change:
```
  ~/github/wfurt-runtime/artifacts/bin/System.Net.Sockets.Tests/net5.0-Unix-Debug ~/github/wfurt-runtime/src/libraries/System.Net.Sockets/tests/FunctionalTests
    Discovering: System.Net.Sockets.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Sockets.Tests (found 1081 of 1201 test cases)
    Starting:    System.Net.Sockets.Tests (parallel test collections = on, max threads = 4)
      System.Net.Sockets.Tests.CreateSocket.Ctor_Raw_Supported_Success [SKIP]
        Condition(s) not met: "SupportsRawSockets"
    Finished:    System.Net.Sockets.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Sockets.Tests  Total: 1608, Errors: 0, Failed: 0, Skipped: 1, Time: 44.620s
```