### PR TITLE
Disable Microsoft.Extensions.Caching.Memory.Tests on Mono

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AssemblyAttributes.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/AssemblyAttributes.cs
@@ -1,0 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35970", TestRuntimes.Mono)]


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/35970

cc: @dotnet/runtime-infrastructure 