### PR TITLE
Disable NonDisposedSocket_SafeHandlesCollected in AnyUnix

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -751,7 +751,7 @@ namespace System.Net.Sockets.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         [InlineData(false)]
         [InlineData(true)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/35846", TestPlatforms.Linux)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/35846", TestPlatforms.AnyUnix)]
         public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)
         {
             List<WeakReference> handles = await CreateHandlesAsync(clientAsync);


### PR DESCRIPTION
Related to: https://github.com/dotnet/runtime/issues/35846

It now failed on OSX in: https://github.com/dotnet/runtime/pull/36083

cc: @dotnet/runtime-infrastructure @dotnet/ncl 