### PR TITLE
increase FailingTestTimeoutMiliseconds for Ssl server tests.

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -63,6 +63,7 @@ namespace System
 
         public static bool IsInContainer => GetIsInContainer();
         public static bool SupportsSsl3 => GetSsl3Support();
+        public static bool SupportsSsl2 => IsWindows && !PlatformDetection.IsWindows10Version1607OrGreater;
 
 #if NETCOREAPP
         public static bool IsReflectionEmitSupported = RuntimeFeature.IsDynamicCodeSupported;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -92,6 +92,7 @@ namespace System.Net.Security
         private static byte[] s_protocolMismatch12 = new byte[] { (byte)TlsContentType.Alert, 3, 3, 0, 2, 2, 70 };
         private static byte[] s_protocolMismatch11 = new byte[] { (byte)TlsContentType.Alert, 3, 2, 0, 2, 2, 70 };
         private static byte[] s_protocolMismatch10 = new byte[] { (byte)TlsContentType.Alert, 3, 1, 0, 2, 2, 70 };
+        private static byte[] s_protocolMismatch30 = new byte[] { (byte)TlsContentType.Alert, 3, 0, 0, 2, 2, 40 };
 
         public static bool TryGetFrameHeader(ReadOnlySpan<byte> frame, ref TlsFrameHeader header)
         {
@@ -200,6 +201,9 @@ namespace System.Net.Security
                 SslProtocols.Tls12 => s_protocolMismatch12,
                 SslProtocols.Tls11 => s_protocolMismatch11,
                 SslProtocols.Tls => s_protocolMismatch10,
+#pragma warning disable 0618
+                SslProtocols.Ssl3 => s_protocolMismatch30,
+#pragma warning restore 0618
                 _ => Array.Empty<byte>(),
             };
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -19,9 +19,9 @@ namespace System.Net.Security.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public ClientAsyncAuthenticateTest()
+        public ClientAsyncAuthenticateTest(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         [Fact]

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -17,9 +17,9 @@ namespace System.Net.Security.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public ServerAllowNoEncryptionTest()
+        public ServerAllowNoEncryptionTest(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         // The following method is invoked by the RemoteCertificateValidationDelegate.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -23,9 +23,9 @@ namespace System.Net.Security.Tests
         private readonly ITestOutputHelper _logVerbose;
         private readonly X509Certificate2 _serverCertificate;
 
-        public ServerAsyncAuthenticateTest()
+        public ServerAsyncAuthenticateTest(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
             _logVerbose = VerboseTestLogging.GetInstance();
             _serverCertificate = Configuration.Certificates.GetServerCertificate();
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -72,11 +72,18 @@ namespace System.Net.Security.Tests
 
         public static IEnumerable<object[]> ProtocolMismatchData()
         {
+            if (PlatformDetection.SupportsSsl3)
+            {
 #pragma warning disable 0618
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(Exception) };
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(Exception) };
-            yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls12, typeof(Exception) };
+                yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls12, typeof(Exception) };
+                if (PlatformDetection.SupportsSsl2)
+                {
+                    yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(Exception) };
+                    yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(Exception) };
+                }
 #pragma warning restore 0618
+            }
+
             yield return new object[] { SslProtocols.Tls, SslProtocols.Tls11, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls, SslProtocols.Tls12, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls, typeof(AuthenticationException) };

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -17,9 +17,9 @@ namespace System.Net.Security.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public ServerNoEncryptionTest()
+        public ServerNoEncryptionTest(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         // The following method is invoked by the RemoteCertificateValidationDelegate.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -17,9 +17,9 @@ namespace System.Net.Security.Tests
     {
         private readonly ITestOutputHelper _log;
 
-        public ServerRequireEncryptionTest()
+        public ServerRequireEncryptionTest(ITestOutputHelper output)
         {
-            _log = TestLogging.GetInstance();
+            _log = output;
         }
 
         // The following method is invoked by the RemoteCertificateValidationDelegate.

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -16,7 +16,7 @@ namespace System.Net.Security.Tests
     internal static class TestConfiguration
     {
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
-        public const int FailingTestTimeoutMiliseconds = 250;
+        public const int FailingTestTimeoutMiliseconds = 3 * 1000;
 
         public const string Realm = "TEST.COREFX.NET";
         public const string KerberosUser = "krb_user";

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -16,7 +16,7 @@ namespace System.Net.Security.Tests
     internal static class TestConfiguration
     {
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
-        public const int FailingTestTimeoutMiliseconds = 3 * 1000;
+        public const int FailingTestTimeoutMiliseconds = 500;
 
         public const string Realm = "TEST.COREFX.NET";
         public const string KerberosUser = "krb_user";


### PR DESCRIPTION
After looking at recent failure of ServerAsyncAuthenticate_MismatchProtocols_Fails I noticed that the test failed with timeout after ~1s. With the expectation of TLS alert, we need to receive Hello, process it, send response, read it from socket, give it to OS and then throw. 
All the failures were on debug builds and existing 250ms seems pretty short. 
I could not reproduce the failure locally and proposed 3s is just a guess for upper limit. 
(test will finish faster if expected failure happen faster) 
The value is only used by ServerAsyncSslHelper() and tests using it.

fixes #29642 (another attempt) 