### PR TITLE
[Proposal] remove lock from SocketAsyncEngine

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1189,6 +1189,8 @@ namespace System.Net.Sockets
             _sendQueue.Init();
         }
 
+        internal IntPtr GetSocketFileDescriptor() => _socket.DangerousGetHandle();
+
         private void Register()
         {
             Debug.Assert(_nonBlockingSet);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1175,7 +1175,7 @@ namespace System.Net.Sockets
         private readonly SafeSocketHandle _socket;
         private OperationQueue<ReadOperation> _receiveQueue;
         private OperationQueue<WriteOperation> _sendQueue;
-        private SocketAsyncEngine.Token _asyncEngineToken;
+        private SocketAsyncEngine.Token? _asyncEngineToken;
         private bool _registered;
         private bool _nonBlockingSet;
 
@@ -1184,6 +1184,7 @@ namespace System.Net.Sockets
         public SocketAsyncContext(SafeSocketHandle socket)
         {
             _socket = socket;
+            _asyncEngineToken = null;
 
             _receiveQueue.Init();
             _sendQueue.Init();
@@ -1198,7 +1199,7 @@ namespace System.Net.Sockets
             {
                 if (!_registered)
                 {
-                    Debug.Assert(!_asyncEngineToken.WasAllocated);
+                    Debug.Assert(_asyncEngineToken == null);
                     var token = new SocketAsyncEngine.Token(this, _socket);
 
                     Interop.Error errorCode;
@@ -1235,7 +1236,8 @@ namespace System.Net.Sockets
             {
                 // Freeing the token will prevent any future event delivery.  This socket will be unregistered
                 // from the event port automatically by the OS when it's closed.
-                _asyncEngineToken.Free();
+                _asyncEngineToken?.Free();
+                _asyncEngineToken = null;
             }
 
             return aborted;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1205,7 +1205,6 @@ namespace System.Net.Sockets
                     Interop.Error errorCode;
                     if (!token.TryRegister(out errorCode))
                     {
-                        token.Free();
                         if (errorCode == Interop.Error.ENOMEM || errorCode == Interop.Error.ENOSPC)
                         {
                             throw new OutOfMemoryException();

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1199,10 +1199,10 @@ namespace System.Net.Sockets
                 if (!_registered)
                 {
                     Debug.Assert(!_asyncEngineToken.WasAllocated);
-                    var token = new SocketAsyncEngine.Token(this);
+                    var token = new SocketAsyncEngine.Token(this, _socket);
 
                     Interop.Error errorCode;
-                    if (!token.TryRegister(_socket, out errorCode))
+                    if (!token.TryRegister(out errorCode))
                     {
                         token.Free();
                         if (errorCode == Interop.Error.ENOMEM || errorCode == Interop.Error.ENOSPC)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1190,8 +1190,6 @@ namespace System.Net.Sockets
             _sendQueue.Init();
         }
 
-        internal IntPtr GetSocketFileDescriptor() => _socket.DangerousGetHandle();
-
         private void Register()
         {
             Debug.Assert(_nonBlockingSet);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -26,7 +26,13 @@ namespace System.Net.Sockets
 
             internal bool WasAllocated => _engine != null;
 
-            internal void Free() => _engine.RemoveFromMap(_context);
+            internal void Free()
+            {
+                if (WasAllocated)
+                {
+                    _engine.RemoveFromMap(_context);
+                }
+            }
 
             internal bool TryRegister(SafeSocketHandle socket, out Interop.Error error) => _engine.TryRegister(socket, out error);
         }


### PR DESCRIPTION
While working on #36019 I've noticed that we could simplify the `SocketAsyncEngine` by doing two things:

* create the engines up-front and avoid locks when getting engine for a given context. It's a clear win for the majority of the cases (having a single engine), but an extra cost for scenarios with multiple (`n`) engines: the first async call is going to create `n` engines (and `n` epolls)
* use existing socket file descriptors, don't generate our own ids using `IntPtr`s, and avoid lock when adding new context to the engine. 

I don't know why we are generating new ids instead of using existing socket file descriptors (there was probably a good reason for that), so this is just a proposal.

/cc @tmds @stephentoub 