### PR TITLE
Fix reverse marshalling of refs to blittable types (#8140)

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -909,7 +909,7 @@ namespace Internal.TypeSystem.Interop
 
         protected override void EmitMarshalArgumentNativeToManaged()
         {
-            if (Out)
+            if (Out && !IsNativeByRef)
             {
                 base.EmitMarshalArgumentNativeToManaged();
             }


### PR DESCRIPTION
Hit in selfhosted ilc.exe. In JitInterface we have a couple cases where we do reverse p/invoke with a delegate that has a ref parameter. Sometimes the `ref` is null (and we don't touch it).

The marshaller was trying to make a copy of the pointed to value, NullRefing in the process because the pointer was null. We don't actually need to make a copy because the value is blittable.