### PR TITLE
Enable VS Test Explorer without the -vs switch

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -61,6 +61,7 @@ if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $
 
 # VS Test Explorer support for libraries
 if ($vs) {
+  Write-Host "!!! VS Test Explorer now works without the -vs switch. The switch will be removed eventually. !!! "
   . $PSScriptRoot\common\tools.ps1
 
   # Microsoft.DotNet.CoreSetup.sln is special - hosting tests are currently meant to run on the

--- a/eng/testing/coverage.targets
+++ b/eng/testing/coverage.targets
@@ -4,7 +4,7 @@
       We need to filter the data to only the assembly being tested. Otherwise we will gather tons of data about other assemblies.
       If the code being tested is part of the runtime itself, it requires special treatment.
     -->
-    <PropertyGroup Condition="'$(AssemblyBeingTested)' == ''">
+    <PropertyGroup Condition="'$(AssemblyBeingTested)' == '' and '$(CreateIntermediateRunSettingsFile)' != 'true'">
       <_ProjectDirectoryUnderSourceDir>$(MSBuildProjectDirectory.SubString($(LibrariesProjectRoot.Length)))</_ProjectDirectoryUnderSourceDir>
       <AssemblyBeingTested>$(_ProjectDirectoryUnderSourceDir.SubString(0, $(_ProjectDirectoryUnderSourceDir.IndexOfAny("\\/"))))</AssemblyBeingTested>
     </PropertyGroup>
@@ -73,5 +73,17 @@
     </PropertyGroup>
 
     <Exec Command="$(CoverageReportCommand)" />
+  </Target>
+
+  
+  <!--
+    Clean the test results directory to guarantee that a report is generated from the
+    newest coverage results file.
+    Tracking issue https://github.com/microsoft/vstest/issues/2378.
+  -->
+  <Target Name="ClearTestResults"
+          BeforeTargets="VSTest"
+          Condition="'$(Coverage)' == 'true'">
+    <RemoveDir Directories="$(OutDir)TestResults" />
   </Target>
 </Project>

--- a/eng/testing/runsettings.targets
+++ b/eng/testing/runsettings.targets
@@ -1,9 +1,18 @@
 <Project>
   <PropertyGroup>
-    <RunSettingsInputFilePath Condition="'$(RunSettingsInputFilePath)' == ''">$(MSBuildThisFileDirectory).runsettings</RunSettingsInputFilePath>
-    <RunSettingsOutputFilePath Condition="'$(RunSettingsOutputFilePath)' == ''">$(OutDir).runsettings</RunSettingsOutputFilePath>
+    <RunSettingsInputFilePath>$(MSBuildThisFileDirectory).runsettings</RunSettingsInputFilePath>
+    <RunSettingsIntermediateOutputFilePath>$(ArtifactsObjDir)$(TargetOS)-$(Configuration)-$(TargetArchitecture).runsettings</RunSettingsIntermediateOutputFilePath>
+    <RunSettingsAppOutputFilePath>$(OutDir).runsettings</RunSettingsAppOutputFilePath>
+
+    <CreateIntermediateRunSettingsFile Condition="'$(CreateIntermediateRunSettingsFile)' == ''">false</CreateIntermediateRunSettingsFile>
+    <RunSettingsOutputFilePath Condition="'$(CreateIntermediateRunSettingsFile)' == 'true'">$(RunSettingsIntermediateOutputFilePath)</RunSettingsOutputFilePath>
+    <RunSettingsOutputFilePath Condition="'$(CreateIntermediateRunSettingsFile)' != 'true'">$(RunSettingsAppOutputFilePath)</RunSettingsOutputFilePath>
+
     <!-- Set RunSettingsFilePath property which is read by VSTest. -->
-    <RunSettingsFilePath Condition="Exists('$(RunSettingsOutputFilePath)')">$(RunSettingsOutputFilePath)</RunSettingsFilePath>
+    <RunSettingsFilePath Condition="Exists('$(RunSettingsAppOutputFilePath)')">$(RunSettingsAppOutputFilePath)</RunSettingsFilePath>
+    <!-- Use an intermediate runsettings file if the app hasn't been built yet to enable VSTest discovery. -->
+    <RunSettingsFilePath Condition="'$(RunSettingsFilePath)' == '' and Exists('$(RunSettingsIntermediateOutputFilePath)')">$(RunSettingsIntermediateOutputFilePath)</RunSettingsFilePath>
+
     <PrepareForRunDependsOn>GenerateRunSettingsFile;$(PrepareForRunDependsOn)</PrepareForRunDependsOn>
   </PropertyGroup>
 
@@ -40,16 +49,5 @@
     <PropertyGroup>
       <RunSettingsFilePath>$(RunSettingsOutputFilePath)</RunSettingsFilePath>
     </PropertyGroup>
-  </Target>
-
-  <!--
-    Clean the test results directory to guarantee that a report is generated from the
-    newest coverage results file.
-    Tracking issue https://github.com/microsoft/vstest/issues/2378.
-  -->
-  <Target Name="ClearTestResults"
-          BeforeTargets="VSTest"
-          Condition="'$(Coverage)' == 'true'">
-    <RemoveDir Directories="$(OutDir)TestResults" />
   </Target>
 </Project>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -217,7 +217,6 @@
     <!-- This app is now can be consumed by xharness CLI to deploy on a device or simulator -->
   </Target>
 
-  <Import Project="$(MSBuildThisFileDirectory)runsettings.targets" />
   <Import Project="$(MSBuildThisFileDirectory)xunit\xunit.targets" Condition="'$(TestFramework)' == 'xunit'" />
 
   <!-- Main test targets -->

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -327,8 +327,9 @@
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <EnableTestSupport>true</EnableTestSupport>
-    <EnableRunSettingsSupport>true</EnableRunSettingsSupport>
-    <EnableCoverageSupport>true</EnableCoverageSupport>
+    <!-- TODO: Remove these conditions when VSTest is used in CI. -->
+    <EnableRunSettingsSupport Condition="'$(ContinuousIntegrationBuild)' != 'true'">true</EnableRunSettingsSupport>
+    <EnableCoverageSupport Condition="'$(ContinuousIntegrationBuild)' != 'true'">true</EnableCoverageSupport>
   </PropertyGroup>
 
   <Import Project="$(RepositoryEngineeringDir)testing\tests.props" Condition="'$(EnableTestSupport)' == 'true'" />

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -327,6 +327,7 @@
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">
     <EnableTestSupport>true</EnableTestSupport>
+    <EnableRunSettingsSupport>true</EnableRunSettingsSupport>
     <EnableCoverageSupport>true</EnableCoverageSupport>
   </PropertyGroup>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -136,9 +136,10 @@
   <Import Project="$(RepositoryEngineeringDir)codeOptimization.targets" />
   <Import Project="$(RepositoryEngineeringDir)references.targets" />
   <Import Project="$(RepositoryEngineeringDir)resolveContract.targets" />
-  <Import Project="$(RepositoryEngineeringDir)testing\runtimeConfiguration.targets" />
   <Import Project="$(RepositoryEngineeringDir)testing\tests.targets" Condition="'$(EnableTestSupport)' == 'true'" />
-  <Import Project="$(RepositoryEngineeringDir)testing\coverage.targets" Condition="'$(EnableCoverageSupport)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)testing\runtimeConfiguration.targets" />
+  <Import Project="$(RepositoryEngineeringDir)testing\runsettings.targets" Condition="'$(EnableRunSettingsSupport)' == 'true'" />
+  <Import Project="$(RepositoryEngineeringDir)testing\coverage.targets" Condition="'$(EnableRunSettingsSupport)' == 'true' or '$(EnableCoverageSupport)' == 'true'" />
 
   <Import Sdk="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Project="Sdk.targets" />
   <Import Project="$(RepositoryEngineeringDir)restore\repoRestore.targets" Condition="'$(DisableProjectRestore)' == 'true'" />

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -4,6 +4,10 @@
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
     <NETCoreAppFrameworkIdentifier>$(TargetFrameworkIdentifier)</NETCoreAppFrameworkIdentifier>
+
+    <!-- Create an intermediate runsettings file to enable VSTest discovery. -->
+    <EnableRunSettingsSupport>true</EnableRunSettingsSupport>
+    <CreateIntermediateRunSettingsFile>true</CreateIntermediateRunSettingsFile>
   </PropertyGroup>
 
   <!-- Explicitly build the runtime.depproj project first to correctly set up the testhost. -->
@@ -18,6 +22,11 @@
              Projects="@(RuntimeProject)"
              Properties="$(TraversalGlobalProperties)" />
   </Target>
+
+  <Target Name="CreateIntermediateRunSettingsFile"
+          Condition="'$(ContinuousIntegrationBuild)' != 'true'"
+          DependsOnTargets="GenerateRunSettingsFile"
+          BeforeTargets="Build" />
 
   <!-- Microsoft.XmlSerializer.Generator should not be marked as a platform item and be copy-local instead. -->
   <Target Name="CollectSharedFrameworkRuntimeFiles"

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -4,7 +4,9 @@
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
     <NETCoreAppFrameworkIdentifier>$(TargetFrameworkIdentifier)</NETCoreAppFrameworkIdentifier>
+  </PropertyGroup>
 
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
     <!-- Create an intermediate runsettings file to enable VSTest discovery. -->
     <EnableRunSettingsSupport>true</EnableRunSettingsSupport>
     <CreateIntermediateRunSettingsFile>true</CreateIntermediateRunSettingsFile>
@@ -24,7 +26,7 @@
   </Target>
 
   <Target Name="CreateIntermediateRunSettingsFile"
-          Condition="'$(ContinuousIntegrationBuild)' != 'true'"
+          Condition="'$(CreateIntermediateRunSettingsFile)' == 'true'"
           DependsOnTargets="GenerateRunSettingsFile"
           BeforeTargets="Build" />
 


### PR DESCRIPTION
Creating an intermediate runsettings file outside of the app's OutDir to enable VS Test Explorer support without the -vs switch.

I'll remove the -vs switch in the next batched rollout and for now added a warning that the switch will be removed eventually.

_Either a clean build or a libs.pretest (subset) build is necessary to consume the change locally._

cc @ericstj @danmosemsft @stephentoub @ManickaP 