### PR TITLE
Fixing test failing on arm64

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/BerConverterTests.cs
@@ -30,8 +30,8 @@ namespace System.DirectoryServices.Protocols.Tests
             yield return new object[] { "[]", new object[] { "a" }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 49, 132, 0, 0, 0, 0 } : new byte[] { 49, 0 } };
             yield return new object[] { "n", new object[] { "a" }, new byte[] { 5, 0 } };
 
-            yield return new object[] { "tetie", new object[] { -1, 0, 1, 2, 3 }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 255, 1, 0, 1, 1, 2, 10, 1, 3 } : new byte[] { 10, 1, 0, 1, 1, 2, 10, 1, 3 } };
-            yield return new object[] { "{tetie}", new object[] { -1, 0, 1, 2, 3 }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 48, 132, 0, 0, 0, 9, 255, 1, 0, 1, 1, 2, 10, 1, 3 } : new byte[] { 48, 9, 10, 1, 0, 1, 1, 2, 10, 1, 3 } };
+            yield return new object[] { "tetie", new object[] { 128, 0, 133, 2, 3 }, new byte[] { 128, 1, 0, 133, 1, 2, 10, 1, 3 } };
+            yield return new object[] { "{tetie}", new object[] { 128, 0, 133, 2, 3 }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 48, 132, 0, 0, 0, 9, 128, 1, 0, 133, 1, 2, 10, 1, 3 } : new byte[] { 48, 9, 128, 1, 0, 133, 1, 2, 10, 1, 3 } };
 
             yield return new object[] { "bb", new object[] { true, false }, new byte[] { 1, 1, 255, 1, 1, 0 } };
             yield return new object[] { "{bb}", new object[] { true, false }, (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) ? new byte[] { 48, 132, 0, 0, 0, 6, 1, 1, 255, 1, 1, 0 } : new byte[] { 48, 6, 1, 1, 255, 1, 1, 0 } };
@@ -43,15 +43,10 @@ namespace System.DirectoryServices.Protocols.Tests
             yield return new object[] { "VVVV", new object[] { null, new byte[][] { new byte[] { 0, 1, 2, 3 }, null }, new byte[][] { new byte[0] }, new byte[0][] }, new byte[] { 4, 4, 0, 1, 2, 3, 4, 0, 4, 0 } };
         }
 
-        [ConditionalTheory]
+        [Theory]
         [MemberData(nameof(Encode_TestData))]
         public void Encode_Objects_ReturnsExpected(string format, object[] values, byte[] expected)
         {
-            if (PlatformDetection.IsArm64Process && format.Contains("tetie"))
-            {
-                throw new SkipTestException("Active issue: https://github.com/dotnet/runtime/issues/36087");
-            }
-
             AssertExtensions.Equal(expected, BerConverter.Encode(format, values));
         }
 


### PR DESCRIPTION
Fixes #36087 

The test was sending the wrong object which made it behave differently on arm64 and x64 archs. This fix will now send a valid payload that matches the format, which could now be converted and should have the same expected values across OSes and platforms.

cc: @bartonjs 