### PR TITLE
Fix mobile testing and do some extra cleanup in variables

### DIFF
--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -21,10 +21,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AppleAppBuilder>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder'))</AppleAppBuilder>
-    <AppleTestRunner>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleTestRunner'))</AppleTestRunner>
-    <AndroidAppBuilder>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder'))</AndroidAppBuilder>
-    <AndroidTestRunner>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidTestRunner'))</AndroidTestRunner>
+    <MobileHelpersDirSuffix>$(NetCoreAppCurrent)-$(MonoConfiguration)</MobileHelpersDirSuffix>
+    <AppleTestBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', '$(MobileHelpersDirSuffix)'))</AppleTestBuilderDir>
+    <AppleTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleTestRunner', '$(MobileHelpersDirSuffix)'))</AppleTestRunnerDir>
+    <AndroidAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder', '$(MobileHelpersDirSuffix)'))</AndroidAppBuilderDir>
+    <AndroidTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidTestRunner', '$(MobileHelpersDirSuffix)'))</AndroidTestRunnerDir>
   </PropertyGroup>
 
   <!--

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -104,7 +104,7 @@
  <!-- Generate a self-contained app bundle for Android with tests.
        This target is executed once build is done for a test lib (after CopyFilesToOutputDirectory target) -->
   <UsingTask TaskName="AndroidAppBuilderTask" 
-             AssemblyFile="$(AndroidAppBuilder)\$(HostArch)\$(Configuration)\AndroidAppBuilder.dll" />
+             AssemblyFile="$(AndroidAppBuilderDir)AndroidAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'Android'" Name="BundleTestAndroidApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
       <BundleDir>$(OutDir)\Bundle</BundleDir>
@@ -119,18 +119,18 @@
       -->
     <ItemGroup>
       <TestBinaries Include="$(OutDir)\*.*"/>
-      <AndroidTestRunnerBinaries Include="$(AndroidTestRunner)\*.*" />
-      <BclBinaries Include="$(NETCoreAppRuntimePackLibPath)\*.*"
-                   Exclude="$(NETCoreAppRuntimePackLibPath)\System.Runtime.WindowsRuntime.dll" />
-      <BclBinaries Include="$(NETCoreAppRuntimePackNativePath)\*.*" Exclude="$(NETCoreAppRuntimePackNativePath)\libmono.dylib" />
+      <AndroidTestRunnerBinaries Include="$(AndroidTestRunnerDir)*.*" />
+      <BclBinaries Include="$(RuntimePackLibDir)\*.*"
+                   Exclude="$(RuntimePackLibDir)\System.Runtime.WindowsRuntime.dll" />
+      <BclBinaries Include="$(RuntimePackNativeDir)\*.*" Exclude="$(RuntimePackNativeDir)\libmono.dylib" />
       
       <!-- remove PDBs and DBGs to save some space until we integrate ILLink -->
-      <BclBinaries Remove="$(NETCoreAppRuntimePackLibPath)\*.pdb" />
-      <BclBinaries Remove="$(NETCoreAppRuntimePackLibPath)\*.dbg" />
+      <BclBinaries Remove="$(RuntimePackLibDir)\*.pdb" />
+      <BclBinaries Remove="$(RuntimePackLibDir)\*.dbg" />
     </ItemGroup>
 
-    <Error Condition="!Exists('$(AndroidTestRunner)')" Text="AndroidTestRunner=$(AndroidTestRunner) doesn't exist" />
-    <Error Condition="!Exists('$(NETCoreAppRuntimePackRIDPath)')" Text="NETCoreAppRuntimePackRIDPath=$(NETCoreAppRuntimePackRIDPath) doesn't exist" />
+    <Error Condition="'@(AndroidTestRunnerBinaries)' == ''" Text="Could not find AndroidTestRunner in $(AndroidTestRunnerDir)" />
+    <Error Condition="!Exists('$(RuntimePackRidDir)')" Text="RuntimePackRidDir=$(RuntimePackRidDir) doesn't exist" />
     <RemoveDir Directories="$(BundleDir)" />
     <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(AndroidTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
@@ -149,7 +149,7 @@
     <AndroidAppBuilderTask 
         Abi="$(AndroidAbi)"
         ProjectName="$(AssemblyName)"
-        MonoRuntimeHeaders="$(NETCoreAppRuntimePackNativePath)\include\mono-2.0"
+        MonoRuntimeHeaders="$(RuntimePackNativeDir)\include\mono-2.0"
         MainLibraryFileName="AndroidTestRunner.dll"
         OutputDir="$(BundleDir)"
         SourceDir="$(BundleDir)">
@@ -164,7 +164,7 @@
   <!-- Generate a self-contained app bundle for iOS with tests.
        This target is executed once build is done for a test lib (after CopyFilesToOutputDirectory target) -->
   <UsingTask TaskName="AppleAppBuilderTask" 
-             AssemblyFile="$(AppleAppBuilder)\$(HostArch)\$(Configuration)\AppleAppBuilder.dll" />
+             AssemblyFile="$(AppleTestBuilderDir)AppleAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'iOS'" Name="BundleTestAppleApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
       <BundleDir>$(OutDir)\Bundle</BundleDir>
@@ -174,16 +174,16 @@
          2) Test Runner (with xharness client-side lib)
       -->
     <ItemGroup>
-      <TestBinaries Include="$(OutDir)\*.*"/>
-      <AppleTestRunnerBinaries Include="$(AppleTestRunner)\*.*" />
-      <BclBinaries Include="$(NETCoreAppRuntimePackLibPath)\*.*" Exclude="$(NETCoreAppRuntimePackLibPath)\System.Runtime.WindowsRuntime.dll" />
-      <BclBinaries Include="$(NETCoreAppRuntimePackNativePath)\*.*" Exclude="$(NETCoreAppRuntimePackNativePath)\libmono.dylib" /> <!-- we use static libmono.a -->
+      <TestBinaries Include="$(OutDir)*.*"/>
+      <AppleTestRunnerBinaries Include="$(AppleTestRunnerDir)*.*" />
+      <BclBinaries Include="$(RuntimePackLibDir)*.*" Exclude="$(RuntimePackLibDir)\System.Runtime.WindowsRuntime.dll" />
+      <BclBinaries Include="$(RuntimePackNativeDir)*.*" Exclude="$(RuntimePackNativeDir)\libmono.dylib" /> <!-- we use static libmono.a -->
       
       <!-- remove PDBs to save some space until we integrate ILLink -->
-      <BclBinaries Remove="$(NETCoreAppRuntimePackLibPath)\*.pdb" />
+      <BclBinaries Remove="$(RuntimePackLibDir)\*.pdb" />
     </ItemGroup>
-    <Error Condition="!Exists('$(AppleTestRunner)')" Text="AppleTestRunner=$(AppleTestRunner) doesn't exist" />
-    <Error Condition="!Exists('$(NETCoreAppRuntimePackRIDPath)')" Text="NETCoreAppRuntimePackRIDPath=$(NETCoreAppRuntimePackRIDPath) doesn't exist" />
+    <Error Condition="'@(AppleTestRunnerBinaries)' == ''" Text="Could not find AppleTestRunner in $(AppleTestRunnerDir) doesn't exist" />
+    <Error Condition="!Exists('$(RuntimePackRidDir)')" Text="RuntimePackRidDir=$(RuntimePackRidDir) doesn't exist" />
     <RemoveDir Directories="$(BundleDir)" />
     <Copy SourceFiles="@(TestBinaries)" DestinationFolder="$(BundleDir)" SkipUnchangedFiles="true"/>
     <Copy SourceFiles="@(AppleTestRunnerBinaries)" DestinationFolder="$(BundleDir)\%(RecursiveDir)" SkipUnchangedFiles="true"/>
@@ -195,15 +195,15 @@
     <AppleAppBuilderTask 
         Arch="$(TargetArchitecture)"
         ProjectName="$(AssemblyName)"
-        MonoRuntimeHeaders="$(NETCoreAppRuntimePackNativePath)\include\mono-2.0"
-        CrossCompiler="$(NETCoreAppRuntimePackNativePath)\cross\mono-aot-cross"
+        MonoRuntimeHeaders="$(RuntimePackNativeDir)\include\mono-2.0"
+        CrossCompiler="$(RuntimePackNativeDir)\cross\mono-aot-cross"
         MainLibraryFileName="AppleTestRunner.dll"
         UseConsoleUITemplate="True"
         GenerateXcodeProject="True"
         BuildAppBundle="True"
         Optimized="True"
         UseLlvm="$(MonoEnableLLVM)"
-        LlvmPath="$(NETCoreAppRuntimePackNativePath)\cross"
+        LlvmPath="$(RuntimePackNativeDir)\cross"
         DevTeamProvisioning="$(DevTeamProvisioning)"
         OutputDirectory="$(BundleDir)"
         AppDir="$(BundleDir)">

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -272,10 +272,10 @@
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
 
-    <NETCoreAppRuntimePackPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'lib-runtime-packs'))</NETCoreAppRuntimePackPath>
-    <NETCoreAppRuntimePackRIDPath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackPath)', 'runtimes', '$(PackageRID)'))</NETCoreAppRuntimePackRIDPath>
-    <NETCoreAppRuntimePackLibPath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackRIDPath)' 'lib', '$(NETCoreAppFramework)'))</NETCoreAppRuntimePackLibPath>
-    <NETCoreAppRuntimePackNativePath>$([MSBuild]::NormalizeDirectory('$(NETCoreAppRuntimePackRIDPath)', 'native'))</NETCoreAppRuntimePackNativePath>
+    <RuntimePackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'lib-runtime-packs', '$(BuildSettings)'))</RuntimePackDir>
+    <RuntimePackRidDir>$([MSBuild]::NormalizeDirectory('$(RuntimePackDir)', 'runtimes', '$(PackageRID)'))</RuntimePackRidDir>
+    <RuntimePackLibDir>$([MSBuild]::NormalizeDirectory('$(RuntimePackRidDir)', 'lib', '$(NetCoreAppCurrent)'))</RuntimePackLibDir>
+    <RuntimePackNativeDir>$([MSBuild]::NormalizeDirectory('$(RuntimePackRidDir)', 'native'))</RuntimePackNativeDir>
     <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -95,11 +95,11 @@
     <!-- Setup the runtime pack structure for mobile platforms (for testing and installer) -->
     <!-- Corresponding assemblies are added to lib -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
-      <RuntimePath>$(NETCoreAppRuntimePackLibPath)</RuntimePath>
+      <RuntimePath>$(RuntimePackLibDir)</RuntimePath>
     </BinPlaceTargetFrameworks>
     <!-- Corresponding libMono and system.native libraries are added to native -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
-      <RuntimePath>$(NETCoreAppRuntimePackNativePath)</RuntimePath>
+      <RuntimePath>$(RuntimePackNativeDir)</RuntimePath>
       <ItemName>NativeBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>
     <!-- Corresponding libMono and system.native libraries are added to testhost shared framework -->

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -78,15 +78,15 @@
           AfterTargets="RestoreTestHost">
     <PropertyGroup>
       <FrameworkListFilename>RuntimeList.xml</FrameworkListFilename>
-      <FrameworkListFile>$(NETCoreAppRuntimePackPath)/data/$(FrameworkListFilename)</FrameworkListFile>
+      <FrameworkListFile>$(RuntimePackDir)/data/$(FrameworkListFilename)</FrameworkListFile>
     </PropertyGroup>
 
     <ItemGroup>
-      <_runtimePackLibFiles Include="$(NETCoreAppRuntimePackLibPath)*.*">
+      <_runtimePackLibFiles Include="$(RuntimePackLibDir)*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/lib/$(NETCoreAppFramework)</TargetPath>
         <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
       </_runtimePackLibFiles>
-      <_runtimePackNativeFiles Include="$(NETCoreAppRuntimePackNativePath)*.*">
+      <_runtimePackNativeFiles Include="$(RuntimePackNativeDir)*.*">
         <TargetPath>$(RuntimePackTargetFrameworkPath)/native</TargetPath>
         <IsNative>true</IsNative>
       </_runtimePackNativeFiles>

--- a/src/mono/msbuild/AndroidAppBuilder/AndroidAppBuilder.csproj
+++ b/src/mono/msbuild/AndroidAppBuilder/AndroidAppBuilder.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <OutputPath>$(AndroidAppBuilder)</OutputPath>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>

--- a/src/mono/msbuild/AndroidTestRunner/AndroidTestRunner.csproj
+++ b/src/mono/msbuild/AndroidTestRunner/AndroidTestRunner.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <OutputPath>$(AndroidTestRunner)</OutputPath>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />

--- a/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.csproj
+++ b/src/mono/msbuild/AppleAppBuilder/AppleAppBuilder.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <OutputPath>$(AppleAppBuilder)</OutputPath>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
   </PropertyGroup>

--- a/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
+++ b/src/mono/msbuild/AppleTestRunner/AppleTestRunner.csproj
@@ -1,9 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <OutputPath>$(AppleTestRunner)</OutputPath>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />

--- a/src/mono/msbuild/Directory.Build.props
+++ b/src/mono/msbuild/Directory.Build.props
@@ -1,0 +1,9 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+    <OutputPath>$([MSBuild]::NormalizeDirectory('$(BaseOutputPath)', '$(TargetFramework)-$(MonoConfiguration)'))</OutputPath>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
While working on publishing the tests using runtime packs as standalone apps, I noticed that the tests can't build after: https://github.com/dotnet/runtime/commit/741e9054d25adc8a93fd2695b0848adcecaaffb0

This is because the OutputPath set in the Apple/Android runners and builders was set to empty because the property they're using is not set in that context, only in tests.props, and the app builder is failing to find the runner dll.

Also, there was a missing `,` in one of the paths for the runtime packs + I renamed those variables because NETCoreApp prefix doesn't make much sense in that context.

I also added the `BuildSettings` as a subdir of the runtime packs dir so that you can build libraries for Release and Debug or different archs without having to clean the repo and have both runtime packs in your artifacts.