### PR TITLE
Experiment with compiler support for nint and nuint **NOMERGE**

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/CompilerServices/Unsafe.cs
@@ -10,11 +10,11 @@ using System.Runtime.Versioning;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
 #if TARGET_64BIT
-using nuint = System.UInt64;
-using nint = System.Int64;
+using nuint_t = System.UInt64;
+using nint_t = System.Int64;
 #else
-using nuint = System.UInt32;
-using nint = System.Int32;
+using nuint_t = System.UInt32;
+using nint_t = System.Int32;
 #endif
 
 //
@@ -109,7 +109,7 @@ namespace Internal.Runtime.CompilerServices
             typeof(T).ToString(); // Type token used by the actual method body
             throw new PlatformNotSupportedException();
 #else
-            return ref AddByteOffset(ref source, (IntPtr)(elementOffset * (nint)SizeOf<T>()));
+            return ref AddByteOffset(ref source, (IntPtr)(elementOffset * (nint_t)SizeOf<T>()));
 #endif
         }
 
@@ -125,7 +125,7 @@ namespace Internal.Runtime.CompilerServices
             typeof(T).ToString(); // Type token used by the actual method body
             throw new PlatformNotSupportedException();
 #else
-            return ref AddByteOffset(ref source, (IntPtr)((nint)elementOffset * (nint)SizeOf<T>()));
+            return ref AddByteOffset(ref source, (IntPtr)((nint_t)elementOffset * (nint_t)SizeOf<T>()));
 #endif
         }
 
@@ -141,7 +141,7 @@ namespace Internal.Runtime.CompilerServices
             typeof(T).ToString(); // Type token used by the actual method body
             throw new PlatformNotSupportedException();
 #else
-            return (byte*)source + (elementOffset * (nint)SizeOf<T>());
+            return (byte*)source + (elementOffset * (nint_t)SizeOf<T>());
 #endif
         }
 
@@ -152,11 +152,22 @@ namespace Internal.Runtime.CompilerServices
         [Intrinsic]
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static ref T Add<T>(ref T source, nint elementOffset)
+        internal static ref T Add<T>(ref T source, nint_t elementOffset)
         {
             return ref Unsafe.Add(ref source, (IntPtr)(void*)elementOffset);
         }
 #endif
+
+        /// <summary>
+        /// Adds an byte offset to the given reference.
+        /// </summary>
+        [Intrinsic]
+        [NonVersionable]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ref T AddByteOffset<T>(ref T source, nuint_t byteOffset)
+        {
+            return ref AddByteOffset(ref source, (IntPtr)(void*)byteOffset);
+        }
 
         /// <summary>
         /// Adds an byte offset to the given reference.

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -13,13 +13,6 @@ using Internal.Runtime.CompilerServices;
 
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
 
-#pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if TARGET_64BIT
-using nuint = System.UInt64;
-#else
-using nuint = System.UInt32;
-#endif
-
 namespace System
 {
     /// <summary>
@@ -282,7 +275,7 @@ namespace System
 
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (uint)_length);
             }
             else
             {
@@ -303,7 +296,7 @@ namespace System
             bool retVal = false;
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (uint)_length);
                 retVal = true;
             }
             return retVal;
@@ -387,7 +380,7 @@ namespace System
                 return Array.Empty<T>();
 
             var destination = new T[_length];
-            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (nuint)_length);
+            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (uint)_length);
             return destination;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -13,13 +13,6 @@ using Internal.Runtime.CompilerServices;
 
 #pragma warning disable 0809  //warning CS0809: Obsolete member 'Span<T>.Equals(object)' overrides non-obsolete member 'object.Equals(object)'
 
-#pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
-#if TARGET_64BIT
-using nuint = System.UInt64;
-#else
-using nuint = System.UInt32;
-#endif
-
 namespace System
 {
     /// <summary>
@@ -277,11 +270,11 @@ namespace System
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                SpanHelpers.ClearWithReferences(ref Unsafe.As<T, IntPtr>(ref _pointer.Value), (nuint)_length * (nuint)(Unsafe.SizeOf<T>() / sizeof(nuint)));
+                SpanHelpers.ClearWithReferences(ref Unsafe.As<T, IntPtr>(ref _pointer.Value), (uint)_length * (nuint)(Unsafe.SizeOf<T>() / Unsafe.SizeOf<nuint>()));
             }
             else
             {
-                SpanHelpers.ClearWithoutReferences(ref Unsafe.As<T, byte>(ref _pointer.Value), (nuint)_length * (nuint)Unsafe.SizeOf<T>());
+                SpanHelpers.ClearWithoutReferences(ref Unsafe.As<T, byte>(ref _pointer.Value), (uint)_length * (nuint)Unsafe.SizeOf<T>());
             }
         }
 
@@ -356,7 +349,7 @@ namespace System
 
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (uint)_length);
             }
             else
             {
@@ -377,7 +370,7 @@ namespace System
             bool retVal = false;
             if ((uint)_length <= (uint)destination.Length)
             {
-                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (nuint)_length);
+                Buffer.Memmove(ref destination._pointer.Value, ref _pointer.Value, (uint)_length);
                 retVal = true;
             }
             return retVal;
@@ -473,7 +466,7 @@ namespace System
                 return Array.Empty<T>();
 
             var destination = new T[_length];
-            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (nuint)_length);
+            Buffer.Memmove(ref MemoryMarshal.GetArrayDataReference(destination), ref _pointer.Value, (uint)_length);
             return destination;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.cs
@@ -8,9 +8,9 @@ using Internal.Runtime.CompilerServices;
 
 #pragma warning disable SA1121 // explicitly using type aliases instead of built-in types
 #if TARGET_64BIT
-using nuint = System.UInt64;
+using nuint_t = System.UInt64;
 #else
-using nuint = System.UInt32;
+using nuint_t = System.UInt32;
 #endif
 
 namespace System
@@ -18,6 +18,11 @@ namespace System
     internal static partial class SpanHelpers
     {
         public static unsafe void ClearWithoutReferences(ref byte b, nuint byteLength)
+        {
+            ClearWithoutReferences(ref b, (nuint_t)byteLength);
+        }
+
+        public static unsafe void ClearWithoutReferences(ref byte b, nuint_t byteLength)
         {
             if (byteLength == 0)
                 return;
@@ -232,15 +237,15 @@ namespace System
             // P/Invoke into the native version for large lengths
             if (byteLength >= 512) goto PInvoke;
 
-            nuint i = 0; // byte offset at which we're copying
+            nuint_t i = 0; // byte offset at which we're copying
 
-            if (((nuint)Unsafe.AsPointer(ref b) & 3) != 0)
+            if (((nuint_t)Unsafe.AsPointer(ref b) & 3) != 0)
             {
-                if (((nuint)Unsafe.AsPointer(ref b) & 1) != 0)
+                if (((nuint_t)Unsafe.AsPointer(ref b) & 1) != 0)
                 {
                     b = 0;
                     i += 1;
-                    if (((nuint)Unsafe.AsPointer(ref b) & 2) != 0)
+                    if (((nuint_t)Unsafe.AsPointer(ref b) & 2) != 0)
                         goto IntAligned;
                 }
                 Unsafe.As<byte, short>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
@@ -257,13 +262,13 @@ namespace System
             // The thing 1, 2, 3, and 4 have in common that the others don't is that if you
             // subtract one from them, their 3rd lsb will not be set. Hence, the below check.
 
-            if ((((nuint)Unsafe.AsPointer(ref b) - 1) & 4) == 0)
+            if ((((nuint_t)Unsafe.AsPointer(ref b) - 1) & 4) == 0)
             {
                 Unsafe.As<byte, int>(ref Unsafe.AddByteOffset<byte>(ref b, i)) = 0;
                 i += 4;
             }
 
-            nuint end = byteLength - 16;
+            nuint_t end = byteLength - 16;
             byteLength -= i; // lower 4 bits of byteLength represent how many bytes are left *after* the unrolled loop
 
             // We know due to the above switch-case that this loop will always run 1 iteration; max
@@ -274,7 +279,7 @@ namespace System
             // This is separated out into a different variable, so the i + 16 addition can be
             // performed at the start of the pipeline and the loop condition does not have
             // a dependency on the writes.
-            nuint counter;
+            nuint_t counter;
 
             do
             {
@@ -339,6 +344,11 @@ namespace System
         }
 
         public static unsafe void ClearWithReferences(ref IntPtr ip, nuint pointerSizeLength)
+        {
+            ClearWithReferences(ref ip, (nuint_t)pointerSizeLength);
+        }
+
+        public static unsafe void ClearWithReferences(ref IntPtr ip, nuint_t pointerSizeLength)
         {
             Debug.Assert((int)Unsafe.AsPointer(ref ip) % sizeof(IntPtr) == 0, "Should've been aligned on natural word boundary.");
 


### PR DESCRIPTION
We now have a compiler toolchain that supports `nint` and `nuint` natively.

The remaining `nint` / `nuint` usages in `Span<T>` and `ReadOnlySpan<T>` are using the compiler shortcuts for `IntPtr` and `UIntPtr`. I created some experimental overloads of APIs in `Buffer` and `Unsafe` to act as the targets.

__This is not intended to represent production code and will not be committed.__
It is meant to exercise CI code paths to see if anything falls over unexpectedly on other architectures.