### PR TITLE
BitOperations.IsPow2 for all supported integral types

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -53,7 +53,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(int value) => (value & (value - 1)) == 0 && value >= 0;
+        public static bool IsPow2(int value) => (value & (value - 1)) == 0 && value > 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
@@ -68,7 +68,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(long value) => (value & (value - 1)) == 0 && value >= 0;
+        public static bool IsPow2(long value) => (value & (value - 1)) == 0 && value > 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -53,7 +53,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(int value) => (value & (value - 1)) == 0 && value >= 0;
+        public static bool IsPow2(int value) => value >= 0 && (value & (value - 1)) == 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
@@ -61,24 +61,14 @@ namespace System.Numerics
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static bool IsPow2(uint value)
-        {
-            if (Popcnt.IsSupported)
-            {
-                return PopCount(value) == 1;
-            }
-
-            return SoftwareFallback(value);
-
-            static bool SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value != 0;
-        }
+        public static bool IsPow2(uint value) => value != 0 && (value & (value - 1)) == 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(long value) => (value & (value - 1)) == 0 && value >= 0;
+        public static bool IsPow2(long value) => value >= 0 && (value & (value - 1)) == 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
@@ -86,17 +76,7 @@ namespace System.Numerics
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static bool IsPow2(ulong value)
-        {
-            if (Popcnt.X64.IsSupported)
-            {
-                return PopCount(value) == 1;
-            }
-
-            return SoftwareFallback(value);
-
-            static bool SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value != 0;
-        }
+        public static bool IsPow2(ulong value) => value != 0 && (value & (value - 1)) == 0;
 
         /// <summary>
         /// Count the number of leading zero bits in a mask.

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -64,7 +64,7 @@ namespace System.Numerics
 
             return SoftwareFallback((uint)value << 1);
 
-            static bool SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value != 0;
+            static bool SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value >= 0;
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace System.Numerics
 
             return SoftwareFallback((ulong)value << 1);
 
-            static bool SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value != 0;
+            static bool SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value >= 0;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -53,7 +53,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(int value) => value >= 0 && (value & (value - 1)) == 0;
+        public static bool IsPow2(int value) => (value & (value - 1)) == 0 && value >= 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
@@ -61,14 +61,14 @@ namespace System.Numerics
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static bool IsPow2(uint value) => value != 0 && (value & (value - 1)) == 0;
+        public static bool IsPow2(uint value) => (value & (value - 1)) == 0 && value != 0 ;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(long value) => value >= 0 && (value & (value - 1)) == 0;
+        public static bool IsPow2(long value) => (value & (value - 1)) == 0 && value >= 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
@@ -76,7 +76,7 @@ namespace System.Numerics
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static bool IsPow2(ulong value) => value != 0 && (value & (value - 1)) == 0;
+        public static bool IsPow2(ulong value) => (value & (value - 1)) == 0 && value != 0;
 
         /// <summary>
         /// Count the number of leading zero bits in a mask.

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -53,19 +53,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(int value)
-        {
-            if (Popcnt.IsSupported)
-            {
-                // 1 set bit means number is a power of 2 unless it is the sign bit, so get rid of that
-                // Cast to unsigned type so logic shift not signed arithmetic shift
-                return PopCount((uint)value << 1) == 1;
-            }
-
-            return SoftwareFallback((uint)value << 1);
-
-            static bool SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value >= 0;
-        }
+        public static bool IsPow2(int value) => (value & (value - 1)) == 0 && value >= 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.
@@ -90,19 +78,7 @@ namespace System.Numerics
         /// </summary>
         /// <param name="value">The value.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPow2(long value)
-        {
-            if (Popcnt.X64.IsSupported)
-            {
-                // 1 set bit means number is a power of 2 unless it is the sign bit, so get rid of that
-                // Cast to unsigned type so logic shift not signed arithmetic shift
-                return PopCount((ulong)value << 1) == 1;
-            }
-
-            return SoftwareFallback((ulong)value << 1);
-
-            static bool SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value >= 0;
-        }
+        public static bool IsPow2(long value) => (value & (value - 1)) == 0 && value >= 0;
 
         /// <summary>
         /// Evaluate whether a given integral value is a power of 2.

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -62,7 +62,9 @@ namespace System.Numerics
                 return PopCount((uint)value << 1) == 1;
             }
 
-            return IsPow2SoftwareFallback((uint)value << 1);
+            return SoftwareFallback((uint)value << 1);
+
+            static bool SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value != 0;
         }
 
         /// <summary>
@@ -78,7 +80,9 @@ namespace System.Numerics
                 return PopCount(value) == 1;
             }
 
-            return IsPow2SoftwareFallback(value);
+            return SoftwareFallback(value);
+
+            static bool SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value != 0;
         }
 
         /// <summary>
@@ -95,7 +99,9 @@ namespace System.Numerics
                 return PopCount((ulong)value << 1) == 1;
             }
 
-            return IsPow2SoftwareFallback((ulong)value << 1);
+            return SoftwareFallback((ulong)value << 1);
+
+            static bool SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value != 0;
         }
 
         /// <summary>
@@ -111,12 +117,10 @@ namespace System.Numerics
                 return PopCount(value) == 1;
             }
 
-            return IsPow2SoftwareFallback(value);
-        }
+            return SoftwareFallback(value);
 
-        // These are faster than the PopCount software fallbacks
-        private static bool IsPow2SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value != 0;
-        private static bool IsPow2SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value != 0;
+            static bool SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value != 0;
+        }
 
         /// <summary>
         /// Count the number of leading zero bits in a mask.

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -49,6 +49,76 @@ namespace System.Numerics
         };
 
         /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPow2(int value)
+        {
+            if (Popcnt.IsSupported)
+            {
+                // 1 set bit means number is a power of 2 unless it is the sign bit, so get rid of that
+                // Cast to unsigned type so logic shift not signed arithmetic shift
+                return PopCount((uint)value << 1) == 1;
+            }
+
+            return IsPow2SoftwareFallback((uint)value << 1);
+        }
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static bool IsPow2(uint value)
+        {
+            if (Popcnt.IsSupported)
+            {
+                return PopCount(value) == 1;
+            }
+
+            return IsPow2SoftwareFallback(value);
+        }
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPow2(long value)
+        {
+            if (Popcnt.X64.IsSupported)
+            {
+                // 1 set bit means number is a power of 2 unless it is the sign bit, so get rid of that
+                // Cast to unsigned type so logic shift not signed arithmetic shift
+                return PopCount((ulong)value << 1) == 1;
+            }
+
+            return IsPow2SoftwareFallback((ulong)value << 1);
+        }
+
+        /// <summary>
+        /// Evaluate whether a given integral value is a power of 2.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CLSCompliant(false)]
+        public static bool IsPow2(ulong value)
+        {
+            if (Popcnt.X64.IsSupported)
+            {
+                return PopCount(value) == 1;
+            }
+
+            return IsPow2SoftwareFallback(value);
+        }
+
+        // These are faster than the PopCount software fallbacks
+        private static bool IsPow2SoftwareFallback(uint value) => (value & (value - 1)) == 0 && value != 0;
+        private static bool IsPow2SoftwareFallback(ulong value) => (value & (value - 1)) == 0 && value != 0;
+
+        /// <summary>
         /// Count the number of leading zero bits in a mask.
         /// Similar in behavior to the x86 instruction LZCNT.
         /// </summary>

--- a/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
@@ -11,6 +11,90 @@ namespace System.Numerics.Tests
     public static class BitOperationsTests
     {
         [Theory]
+        [InlineData(0, false)]
+        [InlineData(0b1, true)]
+        [InlineData(0b10, true)]
+        [InlineData(0b100, true)]
+        [InlineData(0b1000, true)]
+        [InlineData(0b10000, true)]
+        [InlineData(0b100000, true)]
+        [InlineData(0b1000000, true)]
+        [InlineData(-0b1000000, false)]
+        [InlineData(0b1000001, false)]
+        [InlineData(0b1010001, false)]
+        [InlineData(0b1111111, false)]
+        [InlineData(-1, false)]
+        [InlineData(int.MaxValue, false)]
+        [InlineData(int.MinValue, false)]
+        public static void BitOps_IsPow2_int(int n, bool expected)
+        {
+            bool actual = BitOperations.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0u, false)]
+        [InlineData(0b1u, true)]
+        [InlineData(0b10u, true)]
+        [InlineData(0b100u, true)]
+        [InlineData(0b1000u, true)]
+        [InlineData(0b10000u, true)]
+        [InlineData(0b100000u, true)]
+        [InlineData(0b1000000u, true)]
+        [InlineData(0b1000001u, false)]
+        [InlineData(0b1010001u, false)]
+        [InlineData(0b1111111u, false)]
+        [InlineData(uint.MaxValue, false)]
+        [InlineData(unchecked((uint)int.MinValue), true)]
+        public static void BitOps_IsPow2_uint(uint n, bool expected)
+        {
+            bool actual = BitOperations.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0L, false)]
+        [InlineData(0b1L, true)]
+        [InlineData(0b10L, true)]
+        [InlineData(0b100L, true)]
+        [InlineData(0b1000L, true)]
+        [InlineData(0b10000L, true)]
+        [InlineData(0b100000L, true)]
+        [InlineData(0b1000000L, true)]
+        [InlineData(-0b1000000L, false)]
+        [InlineData(0b1000001L, false)]
+        [InlineData(0b1010001L, false)]
+        [InlineData(0b1111111L, false)]
+        [InlineData(-1L, false)]
+        [InlineData(long.MaxValue, false)]
+        [InlineData(long.MinValue, false)]
+        public static void BitOps_IsPow2_long(long n, bool expected)
+        {
+            bool actual = BitOperations.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(0ul, false)]
+        [InlineData(0b1ul, true)]
+        [InlineData(0b10ul, true)]
+        [InlineData(0b100ul, true)]
+        [InlineData(0b1000ul, true)]
+        [InlineData(0b10000ul, true)]
+        [InlineData(0b100000ul, true)]
+        [InlineData(0b1000000ul, true)]
+        [InlineData(0b1000001ul, false)]
+        [InlineData(0b1010001ul, false)]
+        [InlineData(0b1111111ul, false)]
+        [InlineData(ulong.MaxValue, false)]
+        [InlineData(unchecked((ulong)long.MinValue), true)]
+        public static void BitOps_IsPow2_ulong(ulong n, bool expected)
+        {
+            bool actual = BitOperations.IsPow2(n);
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
         [InlineData(0u, 32)]
         [InlineData(0b1u, 31)]
         [InlineData(0b10u, 30)]

--- a/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Numerics/BitOperationsTests.cs
@@ -94,6 +94,7 @@ namespace System.Numerics.Tests
             Assert.Equal(expected, actual);
         }
 
+
         [Theory]
         [InlineData(0u, 32)]
         [InlineData(0b1u, 31)]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -7411,6 +7411,12 @@ namespace System.Numerics
 {
     public static partial class BitOperations
     {
+        public static bool IsPow2(int value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool IsPow2(uint value) { throw null; }
+        public static bool IsPow2(long value) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public static bool IsPow2(ulong value) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static int LeadingZeroCount(uint value) { throw null; }
         [System.CLSCompliantAttribute(false)]


### PR DESCRIPTION
Fixes #31297 

Currently writing tests locally