### PR TITLE
Add tests for changes in #34438

### DIFF
--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongDatePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongDatePattern.cs
@@ -37,6 +37,17 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        public void LongDatePattern_Set_InvalidatesDerivedPattern()
+        {
+            const string Pattern = "#$";
+            var format = new DateTimeFormatInfo();
+            var d = DateTimeOffset.Now;
+            d.ToString("F", format); // FullDateTimePattern
+            format.LongDatePattern = Pattern;
+            Assert.Contains(Pattern, d.ToString("F", format));
+        }
+
+        [Fact]
         public void LongDatePattern_SetNullValue_ThrowsArgumentNullException()
         {
             var format = new DateTimeFormatInfo();

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoLongTimePattern.cs
@@ -36,6 +36,21 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        public void LongTimePattern_Set_InvalidatesDerivedPatterns()
+        {
+            const string Pattern = "#$";
+            var format = new DateTimeFormatInfo();
+            var d = DateTimeOffset.Now;
+            d.ToString("F", format); // FullDateTimePattern
+            d.ToString("G", format); // GeneralLongTimePattern
+            d.ToString(format); // DateTimeOffsetPattern
+            format.LongTimePattern = Pattern;
+            Assert.Contains(Pattern, d.ToString("F", format));
+            Assert.Contains(Pattern, d.ToString("G", format));
+            Assert.Contains(Pattern, d.ToString(format));
+        }
+
+        [Fact]
         public void LongTimePattern_SetNullValue_ThrowsArgumentNullException()
         {
             var format = new DateTimeFormatInfo();

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortDatePattern.cs
@@ -34,6 +34,21 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        public void ShortDatePattern_Set_InvalidatesDerivedPatterns()
+        {
+            const string Pattern = "#$";
+            var format = new DateTimeFormatInfo();
+            var d = DateTimeOffset.Now;
+            d.ToString("G", format); // GeneralLongTimePattern
+            d.ToString("g", format); // GeneralShortTimePattern
+            d.ToString(format); // DateTimeOffsetPattern
+            format.ShortDatePattern = Pattern;
+            Assert.Contains(Pattern, d.ToString("G", format));
+            Assert.Contains(Pattern, d.ToString("g", format));
+            Assert.Contains(Pattern, d.ToString(format));
+        }
+
+        [Fact]
         public void ShortDatePattern_SetNullValue_ThrowsArgumentNullException()
         {
             var format = new DateTimeFormatInfo();

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoShortTimePattern.cs
@@ -34,6 +34,17 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        public void ShortTimePattern_Set_InvalidatesDerivedPattern()
+        {
+            const string Pattern = "#$";
+            var format = new DateTimeFormatInfo();
+            var d = DateTimeOffset.Now;
+            d.ToString("g", format); // GeneralShortTimePattern
+            format.ShortTimePattern = Pattern;
+            Assert.Contains(Pattern, d.ToString("g", format));
+        }
+
+        [Fact]
         public void ShortTimePattern_SetNull_ThrowsArgumentNullException()
         {
             var format = new DateTimeFormatInfo();


### PR DESCRIPTION
Verify that all respective composite patterns cached in DateTimeFormatInfo are invalidated after setting LongDatePattern, LongTimePattern, ShortDatePattern, or ShortTimePattern.