### PR TITLE
Remove some `= null!`s from corelib

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -21,6 +21,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.SymbolStore;
 using System.Globalization;
 using System.IO;
@@ -125,7 +126,7 @@ namespace System.Reflection.Emit
         // This is only valid in the "external" AssemblyBuilder
         internal AssemblyBuilderData _assemblyData;
         private readonly InternalAssemblyBuilder _internalAssemblyBuilder;
-        private ModuleBuilder _manifestModuleBuilder = null!;
+        private ModuleBuilder _manifestModuleBuilder;
         // Set to true if the manifest module was returned by code:DefineDynamicModule to the user
         private bool _isManifestModuleUsedAsDefinedModule;
 
@@ -208,6 +209,7 @@ namespace System.Reflection.Emit
             }
         }
 
+        [MemberNotNull(nameof(_manifestModuleBuilder))]
         private void InitManifestModule()
         {
             InternalModuleBuilder modBuilder = (InternalModuleBuilder)GetInMemoryAssemblyModule(GetNativeHandle());

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/ConstructorBuilder.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.Emit
             m_methodBuilder = new MethodBuilder(name, attributes, callingConvention, null, null, null,
                 parameterTypes, requiredCustomModifiers, optionalCustomModifiers, mod, type);
 
-            type.m_listMethods.Add(m_methodBuilder);
+            type.m_listMethods!.Add(m_methodBuilder);
 
             m_methodBuilder.GetMethodSignature().InternalGetSignature(out _);
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -14,14 +14,19 @@
 ===========================================================*/
 
 using System.Buffers.Binary;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
-using System.Diagnostics;
 
 namespace System.Reflection.Emit
 {
     public class CustomAttributeBuilder
     {
+        internal ConstructorInfo m_con;
+        internal object?[] m_constructorArgs;
+        internal byte[] m_blob;
+
         // public constructor to form the custom attribute with constructor and constructor
         // parameters.
         public CustomAttributeBuilder(ConstructorInfo con, object?[] constructorArgs)
@@ -96,6 +101,9 @@ namespace System.Reflection.Emit
             return t == typeof(object);
         }
 
+        [MemberNotNull(nameof(m_con))]
+        [MemberNotNull(nameof(m_constructorArgs))]
+        [MemberNotNull(nameof(m_blob))]
         internal void InitCustomAttributeBuilder(ConstructorInfo con, object?[] constructorArgs,
                                                  PropertyInfo[] namedProperties, object?[] propertyValues,
                                                  FieldInfo[] namedFields, object?[] fieldValues)
@@ -549,9 +557,5 @@ namespace System.Reflection.Emit
             TypeBuilder.DefineCustomAttribute(mod, tkOwner, tkAttrib, m_blob, toDisk,
                                                       typeof(System.Diagnostics.DebuggableAttribute) == m_con.DeclaringType);
         }
-
-        internal ConstructorInfo m_con = null!;
-        internal object?[] m_constructorArgs = null!;
-        internal byte[] m_blob = null!;
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -345,7 +345,7 @@ namespace System.Reflection.Emit
             if (CurrExcStackCount == 0)
                 throw new NotSupportedException(SR.Argument_NotInExceptionBlock);
 
-            __ExceptionInfo current = CurrExcStack[CurrExcStackCount - 1];
+            __ExceptionInfo current = CurrExcStack![CurrExcStackCount - 1];
 
             Label endLabel = current.GetEndLabel();
             Emit(OpCodes.Leave, endLabel);
@@ -359,7 +359,7 @@ namespace System.Reflection.Emit
             if (CurrExcStackCount == 0)
                 throw new NotSupportedException(SR.Argument_NotInExceptionBlock);
 
-            __ExceptionInfo current = CurrExcStack[CurrExcStackCount - 1];
+            __ExceptionInfo current = CurrExcStack![CurrExcStackCount - 1];
 
             RuntimeType? rtType = exceptionType as RuntimeType;
 
@@ -558,7 +558,7 @@ namespace System.Reflection.Emit
     internal class DynamicResolver : Resolver
     {
         #region Private Data Members
-        private __ExceptionInfo[] m_exceptions = null!;
+        private __ExceptionInfo[]? m_exceptions;
         private byte[]? m_exceptionHeader;
         private DynamicMethod m_method;
         private byte[] m_code;
@@ -586,7 +586,6 @@ namespace System.Reflection.Emit
             m_code = dynamicILInfo.Code;
             m_localSignature = dynamicILInfo.LocalSignature;
             m_exceptionHeader = dynamicILInfo.Exceptions;
-            // m_exceptions = dynamicILInfo.Exceptions;
             m_scope = dynamicILInfo.DynamicScope;
 
             m_method = dynamicILInfo.DynamicMethod;
@@ -740,6 +739,11 @@ namespace System.Reflection.Emit
 
         internal override unsafe void GetEHInfo(int excNumber, void* exc)
         {
+            if (m_exceptions is null)
+            {
+                return;
+            }
+
             CORINFO_EH_CLAUSE* exception = (CORINFO_EH_CLAUSE*)exc;
             for (int i = 0; i < m_exceptions.Length; i++)
             {
@@ -819,11 +823,13 @@ namespace System.Reflection.Emit
             {
                 if (vaMeth.m_dynamicMethod == null)
                 {
-                    methodHandle = vaMeth.m_method.MethodHandle.Value;
+                    methodHandle = vaMeth.m_method!.MethodHandle.Value;
                     typeHandle = vaMeth.m_method.GetDeclaringTypeInternal().GetTypeHandleInternal().Value;
                 }
                 else
+                {
                     methodHandle = vaMeth.m_dynamicMethod.GetMethodDescriptor().Value;
+                }
 
                 return;
             }
@@ -1098,8 +1104,8 @@ namespace System.Reflection.Emit
 
     internal sealed class VarArgMethod
     {
-        internal RuntimeMethodInfo m_method = null!;
-        internal DynamicMethod m_dynamicMethod = null!;
+        internal RuntimeMethodInfo? m_method;
+        internal DynamicMethod? m_dynamicMethod;
         internal SignatureHelper m_signature;
 
         internal VarArgMethod(DynamicMethod dm, SignatureHelper signature)

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -571,7 +571,7 @@ namespace System.Reflection.Emit
         internal DynamicResolver(DynamicILGenerator ilGenerator)
         {
             m_stackSize = ilGenerator.GetMaxStackSize();
-            m_exceptions = ilGenerator.GetExceptions()!;
+            m_exceptions = ilGenerator.GetExceptions();
             m_code = ilGenerator.BakeByteArray()!;
             m_localSignature = ilGenerator.m_localSignature.InternalGetSignatureArray();
             m_scope = ilGenerator.m_scope;
@@ -739,10 +739,7 @@ namespace System.Reflection.Emit
 
         internal override unsafe void GetEHInfo(int excNumber, void* exc)
         {
-            if (m_exceptions is null)
-            {
-                return;
-            }
+            Debug.Assert(m_exceptions != null);
 
             CORINFO_EH_CLAUSE* exception = (CORINFO_EH_CLAUSE*)exc;
             for (int i = 0; i < m_exceptions.Length; i++)

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -12,9 +13,9 @@ namespace System.Reflection.Emit
 {
     public sealed class DynamicMethod : MethodInfo
     {
-        private RuntimeType[] m_parameterTypes = null!;
+        private RuntimeType[] m_parameterTypes;
         internal IRuntimeMethodInfo? m_methodHandle;
-        private RuntimeType m_returnType = null!;
+        private RuntimeType m_returnType;
         private DynamicILGenerator? m_ilGenerator;
         private DynamicILInfo? m_DynamicILInfo;
         private bool m_fInitLocals;
@@ -28,7 +29,7 @@ namespace System.Reflection.Emit
         // If we allowed use of RTDynamicMethod, the creator of the DynamicMethod would
         // not be able to bound access to the DynamicMethod. Hence, we need to ensure that
         // we do not allow direct use of RTDynamicMethod.
-        private RTDynamicMethod m_dynMethod = null!;
+        private RTDynamicMethod m_dynMethod;
 
         // needed to keep the object alive during jitting
         // assigned by the DynamicResolver ctor
@@ -249,6 +250,9 @@ namespace System.Reflection.Emit
             return s_anonymouslyHostedDynamicMethodsModule;
         }
 
+        [MemberNotNull(nameof(m_parameterTypes))]
+        [MemberNotNull(nameof(m_returnType))]
+        [MemberNotNull(nameof(m_dynMethod))]
         private void Init(string name,
                                  MethodAttributes attributes,
                                  CallingConventions callingConvention,

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -620,7 +620,7 @@ namespace System.Reflection.Emit
             // We need to lock here to prevent a method from being "tokenized" twice.
             // We don't need to synchronize this with Type.DefineMethod because it only appends newly
             // constructed MethodBuilders to the end of m_listMethods
-            lock (m_containingType.m_listMethods)
+            lock (m_containingType.m_listMethods!)
             {
                 if (m_tkMethod.Token != 0)
                 {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -2,10 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Text;
 using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace System.Reflection.Emit
 {
@@ -185,7 +186,7 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Private Data Members
-        private byte[] m_signature = null!;
+        private byte[] m_signature;
         private int m_currSig; // index into m_signature buffer for next available byte
         private int m_sizeLoc; // index into m_signature buffer to put m_argCount (will be NO_SIZE_IN_SIG if no arg count is needed)
         private ModuleBuilder? m_module;
@@ -225,6 +226,7 @@ namespace System.Reflection.Emit
             AddOneArgTypeHelper(type);
         }
 
+        [MemberNotNull(nameof(m_signature))]
         private void Init(Module? mod)
         {
             m_signature = new byte[32];
@@ -238,11 +240,13 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(SR.NotSupported_MustBeModuleBuilder);
         }
 
+        [MemberNotNull(nameof(m_signature))]
         private void Init(Module? mod, MdSigCallingConvention callingConvention)
         {
             Init(mod, callingConvention, 0);
         }
 
+        [MemberNotNull(nameof(m_signature))]
         private void Init(Module? mod, MdSigCallingConvention callingConvention, int cGenericParam)
         {
             Init(mod);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -396,15 +396,15 @@ namespace System.Reflection.Emit
         #region Private Data Members
         private List<CustAttr>? m_ca;
         private TypeToken m_tdType;
-        private readonly ModuleBuilder m_module = null!;
+        private readonly ModuleBuilder m_module;
         private readonly string? m_strName;
         private readonly string? m_strNameSpace;
         private string? m_strFullQualName;
         private Type? m_typeParent;
-        private List<Type> m_typeInterfaces = null!;
+        private List<Type>? m_typeInterfaces;
         private readonly TypeAttributes m_iAttr;
         private GenericParameterAttributes m_genParamAttributes;
-        internal List<MethodBuilder> m_listMethods = null!;
+        internal List<MethodBuilder>? m_listMethods;
         internal int m_lastTokenizedMethod;
         private int m_constructorCount;
         private readonly int m_iTypeSize;
@@ -430,7 +430,7 @@ namespace System.Reflection.Emit
         {
             m_tdType = new TypeToken((int)MetadataTokenType.TypeDef);
             m_isHiddenGlobalType = true;
-            m_module = (ModuleBuilder)module;
+            m_module = module;
             m_listMethods = new List<MethodBuilder>();
             // No token has been created so let's initialize it to -1
             // The first time we call MethodBuilder.GetToken this will incremented.
@@ -438,8 +438,13 @@ namespace System.Reflection.Emit
         }
 
         // ctor for generic method parameter
-        internal TypeBuilder(string szName, int genParamPos, MethodBuilder declMeth) : this(szName, genParamPos)
+        internal TypeBuilder(string szName, int genParamPos, MethodBuilder declMeth)
         {
+            m_strName = szName;
+            m_genParamPos = genParamPos;
+            m_bIsGenParam = true;
+            m_typeInterfaces = new List<Type>();
+
             Debug.Assert(declMeth != null);
             m_declMeth = declMeth;
             m_DeclaringType = m_declMeth.GetTypeBuilder();
@@ -447,20 +452,16 @@ namespace System.Reflection.Emit
         }
 
         // ctor for generic type parameter
-        private TypeBuilder(string szName, int genParamPos, TypeBuilder declType) : this(szName, genParamPos)
-        {
-            Debug.Assert(declType != null);
-            m_DeclaringType = declType;
-            m_module = declType.GetModuleBuilder();
-        }
-
-        // only for delegating to by other ctors
-        private TypeBuilder(string szName, int genParamPos)
+        private TypeBuilder(string szName, int genParamPos, TypeBuilder declType)
         {
             m_strName = szName;
             m_genParamPos = genParamPos;
             m_bIsGenParam = true;
             m_typeInterfaces = new List<Type>();
+
+            Debug.Assert(declType != null);
+            m_DeclaringType = declType;
+            m_module = declType.GetModuleBuilder();
         }
 
         internal TypeBuilder(
@@ -1295,7 +1296,7 @@ namespace System.Reflection.Emit
                 }
             }
 
-            m_listMethods.Add(method);
+            m_listMethods!.Add(method);
 
             return method;
         }
@@ -1381,7 +1382,7 @@ namespace System.Reflection.Emit
                 // and our equals check won't work.
                 _ = method.GetMethodSignature().InternalGetSignature(out _);
 
-                if (m_listMethods.Contains(method))
+                if (m_listMethods!.Contains(method))
                 {
                     throw new ArgumentException(SR.Argument_MethodRedefined);
                 }
@@ -1954,7 +1955,7 @@ namespace System.Reflection.Emit
                 }
             }
 
-            int size = m_listMethods.Count;
+            int size = m_listMethods!.Count;
 
             for (int i = 0; i < size; i++)
             {
@@ -2032,12 +2033,12 @@ namespace System.Reflection.Emit
             m_hasBeenCreated = true;
 
             // Terminate the process.
-            RuntimeType cls = null!;
+            RuntimeType? cls = null;
             TermCreateClass(new QCallModule(ref module), m_tdType.Token, ObjectHandleOnStack.Create(ref cls));
 
             if (!m_isHiddenGlobalType)
             {
-                m_bakedRuntimeType = cls;
+                m_bakedRuntimeType = cls!;
 
                 // if this type is a nested type, we need to invalidate the cached nested runtime type on the nesting type
                 if (m_DeclaringType != null && m_DeclaringType.m_bakedRuntimeType != null)
@@ -2105,7 +2106,7 @@ namespace System.Reflection.Emit
             ModuleBuilder module = m_module;
             AddInterfaceImpl(new QCallModule(ref module), m_tdType.Token, tkInterface.Token);
 
-            m_typeInterfaces.Add(interfaceType);
+            m_typeInterfaces!.Add(interfaceType);
         }
 
         public TypeToken TypeToken

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/MethodBase.CoreCLR.cs
@@ -69,7 +69,7 @@ namespace System.Reflection
             // copy the arguments in a different array so we detach from any user changes
             object[] copyOfParameters = new object[parameters.Length];
 
-            ParameterInfo[] p = null!;
+            ParameterInfo[]? p = null;
             for (int i = 0; i < parameters.Length; i++)
             {
                 object arg = parameters[i];

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -18,11 +18,11 @@ namespace System.Reflection
         private RuntimeTypeCache m_reflectedTypeCache;
         private string? m_toString;
         private ParameterInfo[]? m_parameters; // Created lazily when GetParameters() is called.
-#pragma warning disable CA1823, 414
-        private object _empty1 = null!; // These empties are used to ensure that RuntimeConstructorInfo and RuntimeMethodInfo are have a layout which is sufficiently similar
-        private object _empty2 = null!;
-        private object _empty3 = null!;
-#pragma warning restore CA1823, 414
+#pragma warning disable CA1823, 414, 169
+        private object? _empty1; // These empties are used to ensure that RuntimeConstructorInfo and RuntimeMethodInfo are have a layout which is sufficiently similar
+        private object? _empty2;
+        private object? _empty3;
+#pragma warning restore CA1823, 414, 169
         private IntPtr m_handle;
         private MethodAttributes m_methodAttributes;
         private BindingFlags m_bindingFlags;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeEventInfo.cs
@@ -15,20 +15,16 @@ namespace System.Reflection
         private EventAttributes m_flags;
         private string? m_name;
         private void* m_utf8name;
-        private RuntimeTypeCache m_reflectedTypeCache = null!;
+        private RuntimeTypeCache m_reflectedTypeCache;
         private RuntimeMethodInfo? m_addMethod;
         private RuntimeMethodInfo? m_removeMethod;
         private RuntimeMethodInfo? m_raiseMethod;
         private MethodInfo[]? m_otherMethod;
-        private RuntimeType m_declaringType = null!;
+        private RuntimeType m_declaringType;
         private BindingFlags m_bindingFlags;
         #endregion
 
         #region Constructor
-        internal RuntimeEventInfo()
-        {
-            // Used for dummy head node during population
-        }
         internal RuntimeEventInfo(int tkEvent, RuntimeType declaredType, RuntimeTypeCache reflectedTypeCache, out bool isPrivate)
         {
             Debug.Assert(declaredType != null);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeFieldInfo.cs
@@ -11,15 +11,11 @@ namespace System.Reflection
     {
         #region Private Data Members
         private BindingFlags m_bindingFlags;
-        protected RuntimeTypeCache m_reflectedTypeCache = null!;
-        protected RuntimeType m_declaringType = null!;
+        protected RuntimeTypeCache m_reflectedTypeCache;
+        protected RuntimeType m_declaringType;
         #endregion
 
         #region Constructor
-        protected RuntimeFieldInfo()
-        {
-            // Used for dummy head node during population
-        }
         protected RuntimeFieldInfo(RuntimeTypeCache reflectedTypeCache, RuntimeType declaringType, BindingFlags bindingFlags)
         {
             m_bindingFlags = bindingFlags;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -113,7 +113,7 @@ namespace System.Reflection
         #region Private Data Members
         private int m_tkParamDef;
         private MetadataImport m_scope;
-        private Signature m_signature = null!;
+        private Signature? m_signature;
         private volatile bool m_nameIsCached = false;
         private readonly bool m_noMetadata = false;
         private bool m_noDefaultValue = false;
@@ -217,6 +217,8 @@ namespace System.Reflection
                 // only instance of ParameterInfo has ClassImpl, all its subclasses don't
                 if (ClassImpl == null)
                 {
+                    Debug.Assert(m_signature != null);
+
                     RuntimeType parameterType;
                     if (PositionImpl == -1)
                         parameterType = m_signature.ReturnType;
@@ -481,12 +483,16 @@ namespace System.Reflection
 
         public override Type[] GetRequiredCustomModifiers()
         {
-            return m_signature.GetCustomModifiers(PositionImpl + 1, true);
+            return m_signature is null ?
+                Type.EmptyTypes :
+                m_signature.GetCustomModifiers(PositionImpl + 1, true);
         }
 
         public override Type[] GetOptionalCustomModifiers()
         {
-            return m_signature.GetCustomModifiers(PositionImpl + 1, false);
+            return m_signature is null ?
+                Type.EmptyTypes :
+                m_signature.GetCustomModifiers(PositionImpl + 1, false);
         }
 
         #endregion

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CrossLoaderAllocatorHashHelpers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/CrossLoaderAllocatorHashHelpers.cs
@@ -30,7 +30,7 @@ namespace System.Runtime.CompilerServices
     [StructLayout(LayoutKind.Sequential)]
     internal class LAHashKeyToTrackers
     {
-        private object _trackerOrTrackerSet = null!;
-        private object _laLocalKeyValueStore = null!;
+        private object? _trackerOrTrackerSet;
+        private object? _laLocalKeyValueStore;
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/GCHeapHash.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/GCHeapHash.cs
@@ -13,7 +13,7 @@ namespace System.Runtime.CompilerServices
     [StructLayout(LayoutKind.Sequential)]
     internal class GCHeapHash
     {
-        private Array _data = null!;
+        private Array? _data;
         private int _count;
         private int _deletedCount;
     }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -446,10 +446,10 @@ namespace System
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException(null, nameof(name));
 
-            RuntimeType type = null!;
+            RuntimeType? type = null;
             GetTypeByNameUsingCARules(name, new QCallModule(ref scope), ObjectHandleOnStack.Create(ref type));
 
-            return type;
+            return type!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -457,18 +457,18 @@ namespace System
 
         internal RuntimeType[] GetInstantiationInternal()
         {
-            RuntimeType[] types = null!;
+            RuntimeType[]? types = null;
             RuntimeTypeHandle nativeHandle = GetNativeHandle();
             GetInstantiation(new QCallTypeHandle(ref nativeHandle), ObjectHandleOnStack.Create(ref types), Interop.BOOL.TRUE);
-            return types;
+            return types!;
         }
 
         internal Type[] GetInstantiationPublic()
         {
-            Type[] types = null!;
+            Type[]? types = null;
             RuntimeTypeHandle nativeHandle = GetNativeHandle();
             GetInstantiation(new QCallTypeHandle(ref nativeHandle), ObjectHandleOnStack.Create(ref types), Interop.BOOL.FALSE);
-            return types;
+            return types!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -481,11 +481,11 @@ namespace System
 
             fixed (IntPtr* pInst = instHandles)
             {
-                RuntimeType type = null!;
+                RuntimeType? type = null;
                 RuntimeTypeHandle nativeHandle = GetNativeHandle();
                 Instantiate(new QCallTypeHandle(ref nativeHandle), pInst, instCount, ObjectHandleOnStack.Create(ref type));
                 GC.KeepAlive(inst);
-                return type;
+                return type!;
             }
         }
 
@@ -494,10 +494,10 @@ namespace System
 
         internal RuntimeType MakeArray(int rank)
         {
-            RuntimeType type = null!;
+            RuntimeType? type = null;
             RuntimeTypeHandle nativeHandle = GetNativeHandle();
             MakeArray(new QCallTypeHandle(ref nativeHandle), rank, ObjectHandleOnStack.Create(ref type));
-            return type;
+            return type!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -505,10 +505,10 @@ namespace System
 
         internal RuntimeType MakeSZArray()
         {
-            RuntimeType type = null!;
+            RuntimeType? type = null;
             RuntimeTypeHandle nativeHandle = GetNativeHandle();
             MakeSZArray(new QCallTypeHandle(ref nativeHandle), ObjectHandleOnStack.Create(ref type));
-            return type;
+            return type!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -516,10 +516,10 @@ namespace System
 
         internal RuntimeType MakeByRef()
         {
-            RuntimeType type = null!;
+            RuntimeType? type = null;
             RuntimeTypeHandle nativeHandle = GetNativeHandle();
             MakeByRef(new QCallTypeHandle(ref nativeHandle), ObjectHandleOnStack.Create(ref type));
-            return type;
+            return type!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -527,10 +527,10 @@ namespace System
 
         internal RuntimeType MakePointer()
         {
-            RuntimeType type = null!;
+            RuntimeType? type = null;
             RuntimeTypeHandle nativeHandle = GetNativeHandle();
             MakePointer(new QCallTypeHandle(ref nativeHandle), ObjectHandleOnStack.Create(ref type));
-            return type;
+            return type!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -665,15 +665,15 @@ namespace System
         private readonly object m_keepalive;
 
         // These unused variables are used to ensure that this class has the same layout as RuntimeMethodInfo
-#pragma warning disable CA1823, 414
-        private object m_a = null!;
-        private object m_b = null!;
-        private object m_c = null!;
-        private object m_d = null!;
-        private object m_e = null!;
-        private object m_f = null!;
-        private object m_g = null!;
-#pragma warning restore CA1823, 414
+#pragma warning disable CA1823, 414, 169
+        private object? m_a;
+        private object? m_b;
+        private object? m_c;
+        private object? m_d;
+        private object? m_e;
+        private object? m_f;
+        private object? m_g;
+#pragma warning restore CA1823, 414, 169
 
         public RuntimeMethodHandleInternal m_value;
 
@@ -861,25 +861,25 @@ namespace System
 
         internal static RuntimeType[] GetMethodInstantiationInternal(IRuntimeMethodInfo method)
         {
-            RuntimeType[] types = null!;
+            RuntimeType[]? types = null;
             GetMethodInstantiation(EnsureNonNullMethodInfo(method).Value, ObjectHandleOnStack.Create(ref types), Interop.BOOL.TRUE);
             GC.KeepAlive(method);
-            return types;
+            return types!;
         }
 
         internal static RuntimeType[] GetMethodInstantiationInternal(RuntimeMethodHandleInternal method)
         {
-            RuntimeType[] types = null!;
+            RuntimeType[]? types = null;
             GetMethodInstantiation(method, ObjectHandleOnStack.Create(ref types), Interop.BOOL.TRUE);
-            return types;
+            return types!;
         }
 
         internal static Type[] GetMethodInstantiationPublic(IRuntimeMethodInfo method)
         {
-            RuntimeType[] types = null!;
+            RuntimeType[]? types = null;
             GetMethodInstantiation(EnsureNonNullMethodInfo(method).Value, ObjectHandleOnStack.Create(ref types), Interop.BOOL.FALSE);
             GC.KeepAlive(method);
-            return types;
+            return types!;
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -1000,14 +1000,14 @@ namespace System
     internal class RuntimeFieldInfoStub : IRuntimeFieldInfo
     {
         // These unused variables are used to ensure that this class has the same layout as RuntimeFieldInfo
-#pragma warning disable 414
-        private object m_keepalive = null!;
-        private object m_c = null!;
-        private object m_d = null!;
+#pragma warning disable 414, 169
+        private object? m_keepalive;
+        private object? m_c;
+        private object? m_d;
         private int m_b;
-        private object m_e = null!;
+        private object? m_e;
         private RuntimeFieldHandleInternal m_fieldHandle;
-#pragma warning restore 414
+#pragma warning restore 414, 169
 
         RuntimeFieldHandleInternal IRuntimeFieldInfo.Value => m_fieldHandle;
     }
@@ -1209,11 +1209,11 @@ namespace System
 
             fixed (IntPtr* typeInstArgs = typeInstantiationContextHandles, methodInstArgs = methodInstantiationContextHandles)
             {
-                RuntimeType type = null!;
+                RuntimeType? type = null;
                 ResolveType(new QCallModule(ref module), typeToken, typeInstArgs, typeInstCount, methodInstArgs, methodInstCount, ObjectHandleOnStack.Create(ref type));
                 GC.KeepAlive(typeInstantiationContext);
                 GC.KeepAlive(methodInstantiationContext);
-                return type;
+                return type!;
             }
         }
 
@@ -1288,11 +1288,11 @@ namespace System
 
             fixed (IntPtr* typeInstArgs = typeInstantiationContextHandles, methodInstArgs = methodInstantiationContextHandles)
             {
-                IRuntimeFieldInfo field = null!;
+                IRuntimeFieldInfo? field = null;
                 ResolveField(new QCallModule(ref module), fieldToken, typeInstArgs, typeInstCount, methodInstArgs, methodInstCount, ObjectHandleOnStack.Create(ref field));
                 GC.KeepAlive(typeInstantiationContext);
                 GC.KeepAlive(methodInstantiationContext);
-                return field;
+                return field!;
             }
         }
 
@@ -1318,9 +1318,9 @@ namespace System
 
         internal static RuntimeType GetModuleType(RuntimeModule module)
         {
-            RuntimeType type = null!;
+            RuntimeType? type = null;
             GetModuleType(new QCallModule(ref module), ObjectHandleOnStack.Create(ref type));
-            return type;
+            return type!;
         }
 
         [DllImport(RuntimeHelpers.QCall, CharSet = CharSet.Unicode)]
@@ -1375,6 +1375,8 @@ namespace System
         #endregion
 
         #region FCalls
+        [MemberNotNull(nameof(m_arguments))]
+        [MemberNotNull(nameof(m_returnTypeORfieldType))]
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void GetSignature(
             void* pCorSig, int cCorSig,
@@ -1386,9 +1388,9 @@ namespace System
         //
         // Keep the layout in sync with SignatureNative in the VM
         //
-        internal RuntimeType[] m_arguments = null!;
-        internal RuntimeType m_declaringType = null!; // seems not used
-        internal RuntimeType m_returnTypeORfieldType = null!;
+        internal RuntimeType[] m_arguments;
+        internal RuntimeType? m_declaringType;
+        internal RuntimeType m_returnTypeORfieldType;
         internal object? m_keepalive;
         internal void* m_sig;
         internal int m_managedCallingConventionAndArgIteratorFlags; // lowest byte is CallingConvention, upper 3 bytes are ArgIterator flags

--- a/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -244,14 +244,17 @@ namespace System
                     switch (cacheType)
                     {
                         case CacheType.Method:
-                            list = (T[])(object)new RuntimeMethodInfo[1] {
-                            new RuntimeMethodInfo(method, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags, null)
-                        };
+                            list = (T[])(object)new RuntimeMethodInfo[1]
+                            {
+                                new RuntimeMethodInfo(method, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags, null)
+                            };
                             break;
+
                         case CacheType.Constructor:
-                            list = (T[])(object)new RuntimeConstructorInfo[1] {
-                            new RuntimeConstructorInfo(method, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags)
-                        };
+                            list = (T[])(object)new RuntimeConstructorInfo[1]
+                            {
+                                new RuntimeConstructorInfo(method, declaringType, m_runtimeTypeCache, methodAttributes, bindingFlags)
+                            };
                             break;
                     }
 
@@ -4062,7 +4065,7 @@ namespace System
 
             // Handle arguments that are passed as ByRef and those
             // arguments that need to be wrapped.
-            ParameterModifier[] aParamMod = null!;
+            ParameterModifier[]? aParamMod = null;
             if (cArgs > 0)
             {
                 ParameterModifier paramMod = new ParameterModifier(cArgs);
@@ -4087,7 +4090,7 @@ namespace System
             for (int i = 0; i < cArgs; i++)
             {
                 // Determine if the parameter is ByRef.
-                if (aParamMod[0][i] && aArgs[i] != null)
+                if (aParamMod![0][i] && aArgs[i] != null)
                 {
                     Type argType = aArgsTypes[i];
                     if (!ReferenceEquals(argType, aArgs[i].GetType()))

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ArrayList.cs
@@ -28,17 +28,11 @@ namespace System.Collections
     [System.Runtime.CompilerServices.TypeForwardedFrom("mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class ArrayList : IList, ICloneable
     {
-        private object?[] _items = null!; // Do not rename (binary serialization)
+        private object?[] _items; // Do not rename (binary serialization)
         private int _size; // Do not rename (binary serialization)
         private int _version; // Do not rename (binary serialization)
 
         private const int _defaultCapacity = 4;
-
-        // Note: this constructor is a bogus constructor that does nothing
-        // and is for use only with SyncArrayList.
-        internal ArrayList(bool trash)
-        {
-        }
 
         // Constructs a ArrayList. The list is initially empty and has a capacity
         // of zero. Upon adding the first element to the list the capacity is
@@ -1196,7 +1190,6 @@ namespace System.Collections
             private readonly object _root;
 
             internal SyncArrayList(ArrayList list)
-                : base(false)
             {
                 _list = list;
                 _root = list.SyncRoot;
@@ -2215,7 +2208,7 @@ namespace System.Collections
             private int _baseSize;
             private int _baseVersion;
 
-            internal Range(ArrayList list, int index, int count) : base(false)
+            internal Range(ArrayList list, int index, int count)
             {
                 _baseList = list;
                 _baseIndex = index;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 #endif
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 
 #if ES_BUILD_STANDALONE
@@ -135,9 +136,10 @@ namespace System.Diagnostics.Tracing
         // Values buffering
         private const int BufferedSize = 10;
         private const double UnusedBufferSlotValue = double.NegativeInfinity;
-        private volatile double[] _bufferedValues = null!;
+        private volatile double[] _bufferedValues;
         private volatile int _bufferedValuesIndex;
 
+        [MemberNotNull(nameof(_bufferedValues))]
         private void InitializeBuffer()
         {
             _bufferedValues = new double[BufferedSize];

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -45,7 +45,7 @@ namespace System.Globalization
         private IntPtr _sortHandle;
 
         [NonSerialized]
-        private string _sortName = null!; // The name that defines our behavior
+        private string _sortName; // The name that defines our behavior
 
         [OptionalField(VersionAdded = 3)]
         private SortVersion? m_SortVersion; // Do not rename (binary serialization)
@@ -181,6 +181,7 @@ namespace System.Globalization
             return IsSortable(valueAsUtf16.Slice(0, charCount));
         }
 
+        [MemberNotNull(nameof(_sortName))]
         private void InitSort(CultureInfo culture)
         {
             _sortName = culture.SortName;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace System.Globalization
@@ -87,7 +88,7 @@ namespace System.Globalization
         private const string sortableDateTimePattern = "yyyy'-'MM'-'dd'T'HH':'mm':'ss";
         private const string universalSortableDateTimePattern = "yyyy'-'MM'-'dd HH':'mm':'ss'Z'";
 
-        private Calendar calendar = null!; // initialized in helper called by ctors
+        private Calendar calendar;
 
         private int firstDayOfWeek = -1;
         private int calendarWeekRule = -1;
@@ -389,6 +390,7 @@ namespace System.Globalization
                 Debug.Assert(calendar != null, "DateTimeFormatInfo.Calendar: calendar != null");
                 return calendar;
             }
+            [MemberNotNull(nameof(calendar))]
             set
             {
                 if (IsReadOnly)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/StringInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/StringInfo.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Unicode;
 
 namespace System.Globalization
@@ -15,7 +16,7 @@ namespace System.Globalization
     /// </summary>
     public class StringInfo
     {
-        private string _str = null!; // initialized in helper called by ctors
+        private string _str;
 
         private int[]? _indexes;
 
@@ -56,6 +57,7 @@ namespace System.Globalization
         public string String
         {
             get => _str;
+            [MemberNotNull(nameof(_str))]
             set
             {
                 _str = value ?? throw new ArgumentNullException(nameof(value));

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs
@@ -23,7 +23,7 @@ namespace System.IO
     /// this gives better throughput; benchmarks showed about 12-15% better.
     public class UnmanagedMemoryAccessor : IDisposable
     {
-        private SafeBuffer _buffer = null!; // initialized in helper called by ctor
+        private SafeBuffer _buffer = null!; // initialized in helper called by ctor, but also not initialized by protected ctor
         private long _offset;
         private long _capacity;
         private FileAccess _access;

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.IO;
-using System.Globalization;
-using System.Reflection;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
 
 namespace System.Resources
 {
@@ -120,7 +121,7 @@ namespace System.Resources
         private Version? _satelliteContractVersion;
         private bool _lookedForSatelliteContractVersion;
 
-        private IResourceGroveler _resourceGroveler = null!;
+        private IResourceGroveler _resourceGroveler;
 
         public static readonly int MagicNumber = unchecked((int)0xBEEFCACE);  // If only hex had a K...
 
@@ -234,6 +235,7 @@ namespace System.Resources
 
         // Trying to unify code as much as possible, even though having to do a
         // security check in each constructor prevents it.
+        [MemberNotNull(nameof(_resourceGroveler))]
         private void CommonAssemblyInit()
         {
 #if FEATURE_APPX

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -75,7 +75,7 @@ namespace System
         public override MemberInfo[] GetDefaultMembers()
         {
             // See if we have cached the default member name
-            MemberInfo[] members = null!;
+            MemberInfo[]? members = null;
 
             string? defaultMemberName = GetDefaultMemberName();
             if (defaultMemberName != null)

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecurityElement.cs
@@ -10,7 +10,7 @@ namespace System.Security
 {
     public sealed class SecurityElement
     {
-        internal string _tag = null!;
+        internal string _tag;
         internal string? _text;
         private ArrayList? _children;
         internal ArrayList? _attributes;
@@ -33,10 +33,6 @@ namespace System.Security
         };
 
         //-------------------------- Constructors ---------------------------
-
-        internal SecurityElement()
-        {
-        }
 
         public SecurityElement(string tag)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -118,8 +118,8 @@ namespace System.Text
         private bool _isReadOnly = true;
 
         // Encoding (encoder) fallback
-        internal EncoderFallback encoderFallback = null!;
-        internal DecoderFallback decoderFallback = null!;
+        internal EncoderFallback encoderFallback;
+        internal DecoderFallback decoderFallback;
 
         protected Encoding() : this(0)
         {
@@ -159,6 +159,8 @@ namespace System.Text
         }
 
         // Default fallback that we'll use.
+        [MemberNotNull(nameof(encoderFallback))]
+        [MemberNotNull(nameof(decoderFallback))]
         internal virtual void SetDefaultFallbacks()
         {
             // For UTF-X encodings, we use a replacement fallback with an "\xFFFD" string,

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
@@ -7,6 +7,7 @@
 //
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 
 namespace System.Text
@@ -31,15 +32,15 @@ namespace System.Text
         internal static readonly UTF7Encoding s_default = new UTF7Encoding();
 
         // The set of base 64 characters.
-        private byte[] _base64Bytes = null!;
+        private byte[] _base64Bytes;
         // The decoded bits for every base64 values. This array has a size of 128 elements.
         // The index is the code point value of the base 64 characters.  The value is -1 if
         // the code point is not a valid base 64 character.  Otherwise, the value is a value
         // from 0 ~ 63.
-        private sbyte[] _base64Values = null!;
+        private sbyte[] _base64Values;
         // The array to decide if a Unicode code point below 0x80 can be directly encoded in UTF7.
         // This array has a size of 128.
-        private bool[] _directEncode = null!;
+        private bool[] _directEncode;
 
         private readonly bool _allowOptionals;
 
@@ -60,6 +61,9 @@ namespace System.Text
             MakeTables();
         }
 
+        [MemberNotNull(nameof(_base64Bytes))]
+        [MemberNotNull(nameof(_base64Values))]
+        [MemberNotNull(nameof(_directEncode))]
         private void MakeTables()
         {
             // Build our tables

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Threading.Tasks;
 
@@ -695,7 +696,7 @@ namespace System.Threading
     {
         private const uint MAX_SUPPORTED_TIMEOUT = (uint)0xfffffffe;
 
-        private TimerHolder _timer = null!; // initialized in helper called by ctors
+        private TimerHolder _timer;
 
         public Timer(TimerCallback callback,
                      object? state,
@@ -774,6 +775,7 @@ namespace System.Threading
             TimerSetup(callback, this, DueTime, Period);
         }
 
+        [MemberNotNull(nameof(_timer))]
         private void TimerSetup(TimerCallback callback,
                                 object? state,
                                 uint dueTime,

--- a/src/libraries/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
+++ b/src/libraries/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
@@ -43,6 +43,12 @@ namespace System.Reflection.Emit.Tests
 
             Assert.Equal(ParameterAttributes.In, parameters[0].Attributes);
             Assert.Equal(ParameterAttributes.Out, parameters[1].Attributes);
+
+            Assert.Empty(parameters[0].GetRequiredCustomModifiers());
+            Assert.Empty(parameters[1].GetRequiredCustomModifiers());
+
+            Assert.Empty(parameters[0].GetOptionalCustomModifiers());
+            Assert.Empty(parameters[1].GetOptionalCustomModifiers());
         }
     }
 }

--- a/src/libraries/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
+++ b/src/libraries/System.Reflection.Emit.Lightweight/tests/DynamicMethodDefineParameter.cs
@@ -44,11 +44,14 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal(ParameterAttributes.In, parameters[0].Attributes);
             Assert.Equal(ParameterAttributes.Out, parameters[1].Attributes);
 
-            Assert.Empty(parameters[0].GetRequiredCustomModifiers());
-            Assert.Empty(parameters[1].GetRequiredCustomModifiers());
+            if (!PlatformDetection.IsMonoRuntime) // [ActiveIssue("https://github.com/dotnet/runtime/issues/36271")]
+            {
+                Assert.Empty(parameters[0].GetRequiredCustomModifiers());
+                Assert.Empty(parameters[1].GetRequiredCustomModifiers());
 
-            Assert.Empty(parameters[0].GetOptionalCustomModifiers());
-            Assert.Empty(parameters[1].GetOptionalCustomModifiers());
+                Assert.Empty(parameters[0].GetOptionalCustomModifiers());
+                Assert.Empty(parameters[1].GetOptionalCustomModifiers());
+            }
         }
     }
 }


### PR DESCRIPTION
In some cases, this was achieved by:
- Using [MemberNotNull] when it could be used to enable the compiler to appropriately follow the initialization
- Making the field nullable and using `!`s at usage sites in cases where the `= null!` wasn't appropriate because the field could actually be null
- Making the field nullable and adding null checks sparingly
- Suppressing warnings in cases where fields weren't accessed in managed code
- Removing stale cases where it wasn't necessary anymore anyway
- Removing unnecessary empty internal/private ctors