### PR TITLE
Revert "Revert "Remove superflous CheckReleased call which will slow down Event Log R…""

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/ProviderMetadataCachedInformation.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/Reader/ProviderMetadataCachedInformation.cs
@@ -156,7 +156,6 @@ namespace System.Diagnostics.Eventing.Reader
 
                 try
                 {
-                    pm.CheckReleased();
                     UpdateCacheValueInfoForHit(cacheItem);
                 }
                 catch (EventLogException)


### PR DESCRIPTION
Reverts dotnet/runtime#36143

Per the comment, https://github.com/dotnet/runtime/issues/34568#issuecomment-626215652 looks this change is not the direct cause of the failed test. We are reverting the revert again and applying the original fix. We should look at fixing the test or disabling it.