### PR TITLE
Expose the parsed signature in structured format

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -15,7 +15,7 @@ namespace ILCompiler.Reflection.ReadyToRun
     /// <summary>
     /// This represents all possible signatures that is 
     /// </summary>
-    public interface ReadyToRunSignature
+    public class ReadyToRunSignature
     {
     }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -13,6 +13,30 @@ using Internal.ReadyToRunConstants;
 namespace ILCompiler.Reflection.ReadyToRun
 {
     /// <summary>
+    /// This represents all possible signatures that is 
+    /// </summary>
+    public interface ReadyToRunSignature
+    {
+    }
+
+    /// <summary>
+    /// For now, this means the signature is not parsed yet
+    /// </summary>
+    public class TodoSignature : ReadyToRunSignature
+    {
+    }
+
+    public class MethodDefEntrySignature : ReadyToRunSignature
+    {
+        public uint MethodDefToken { get; set; }
+    }
+
+    public class MethodRefEntrySignature : ReadyToRunSignature
+    {
+        public uint MethodRefToken { get; set; }
+    }
+
+    /// <summary>
     /// Helper class for converting metadata tokens into their textual representation.
     /// </summary>
     public class MetadataNameFormatter : DisassemblingTypeProvider
@@ -39,11 +63,11 @@ namespace ILCompiler.Reflection.ReadyToRun
             return formatter.EmitHandleName(handle, namespaceQualified, owningTypeOverride, signaturePrefix);
         }
 
-        public static string FormatSignature(IAssemblyResolver assemblyResolver, ReadyToRunReader r2rReader, int imageOffset)
+        public static string FormatSignature(IAssemblyResolver assemblyResolver, ReadyToRunReader r2rReader, int imageOffset, out ReadyToRunSignature result)
         {
             SignatureDecoder decoder = new SignatureDecoder(assemblyResolver, r2rReader.GetGlobalMetadataReader(), r2rReader, imageOffset);
-            string result = decoder.ReadR2RSignature();
-            return result;
+            string answer = decoder.ReadR2RSignature(out result);
+            return answer;
         }
 
         /// <summary>
@@ -518,13 +542,14 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// by custom encoding per fixup type.
         /// </summary>
         /// <returns></returns>
-        public string ReadR2RSignature()
+        public string ReadR2RSignature(out ReadyToRunSignature result)
         {
+            result = null;
             StringBuilder builder = new StringBuilder();
             int startOffset = _offset;
             try
             {
-                ParseSignature(builder);
+                result = ParseSignature(builder);
                 EmitSignatureBinaryFrom(builder, startOffset);
             }
             catch (Exception ex)
@@ -634,7 +659,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// Parse the signature into a given output string builder.
         /// </summary>
         /// <param name="builder">Output signature builder</param>
-        private void ParseSignature(StringBuilder builder)
+        private ReadyToRunSignature ParseSignature(StringBuilder builder)
         {
             uint fixupType = ReadByte();
             EmitInlineSignatureBinaryBytes(builder, 1);
@@ -650,8 +675,9 @@ namespace ILCompiler.Reflection.ReadyToRun
                 moduleDecoder = new SignatureDecoder(_options, refAsmEcmaReader, _image, _offset, refAsmEcmaReader, _contextReader);
             }
 
-            moduleDecoder.ParseSignature((ReadyToRunFixupKind)fixupType, builder);
+            ReadyToRunSignature result = moduleDecoder.ParseSignature((ReadyToRunFixupKind)fixupType, builder);
             _offset = moduleDecoder.Offset;
+            return result;
         }
 
         /// <summary>
@@ -659,14 +685,16 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         /// <param name="fixupType">Fixup type to parse</param>
         /// <param name="builder">Output signature builder</param>
-        private void ParseSignature(ReadyToRunFixupKind fixupType, StringBuilder builder)
+        private ReadyToRunSignature ParseSignature(ReadyToRunFixupKind fixupType, StringBuilder builder)
         {
+            ReadyToRunSignature result = new TodoSignature();
             switch (fixupType)
             {
                 case ReadyToRunFixupKind.ThisObjDictionaryLookup:
                     builder.Append("THISOBJ_DICTIONARY_LOOKUP @ ");
                     ParseType(builder);
                     builder.Append(": ");
+                    // It looks like ReadyToRunSignature is potentially a composite pattern
                     ParseSignature(builder);
                     break;
 
@@ -702,15 +730,17 @@ namespace ILCompiler.Reflection.ReadyToRun
                     break;
 
                 case ReadyToRunFixupKind.MethodEntry_DefToken:
-                    ParseMethodDefToken(builder, owningTypeOverride: null);
+                    uint methodDefToken = ParseMethodDefToken(builder, owningTypeOverride: null);
                     builder.Append(" (METHOD_ENTRY");
                     builder.Append(_options.Naked ? ")" : "_DEF_TOKEN)");
+                    result = new MethodDefEntrySignature { MethodDefToken = methodDefToken };
                     break;
 
                 case ReadyToRunFixupKind.MethodEntry_RefToken:
-                    ParseMethodRefToken(builder, owningTypeOverride: null);
+                    uint methodRefToken = ParseMethodRefToken(builder, owningTypeOverride: null);
                     builder.Append(" (METHOD_ENTRY");
                     builder.Append(_options.Naked ? ")" : "_REF_TOKEN)");
+                    result = new MethodRefEntrySignature { MethodRefToken = methodRefToken };
                     break;
 
 
@@ -909,6 +939,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     builder.Append(string.Format("Unknown fixup type: {0:X2}", fixupType));
                     break;
             }
+            return result;
         }
 
         /// <summary>
@@ -1235,7 +1266,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// Read a methodDef token from the signature and output the corresponding object to the builder.
         /// </summary>
         /// <param name="builder">Output string builder</param>
-        private void ParseMethodDefToken(StringBuilder builder, string owningTypeOverride)
+        private uint ParseMethodDefToken(StringBuilder builder, string owningTypeOverride)
         {
             StringBuilder signaturePrefixBuilder = new StringBuilder();
             uint methodDefToken = ReadUIntAndEmitInlineSignatureBinary(signaturePrefixBuilder) | (uint)CorTokenType.mdtMethodDef;
@@ -1245,6 +1276,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 namespaceQualified: true,
                 owningTypeOverride: owningTypeOverride,
                 signaturePrefix: signaturePrefixBuilder.ToString()));
+            return methodDefToken;
         }
 
         /// <summary>
@@ -1252,7 +1284,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         /// <param name="builder">Output string builder</param>
         /// <param name="owningTypeOverride">Explicit owning type override</param>
-        private void ParseMethodRefToken(StringBuilder builder, string owningTypeOverride)
+        private uint ParseMethodRefToken(StringBuilder builder, string owningTypeOverride)
         {
             StringBuilder signaturePrefixBuilder = new StringBuilder();
             uint methodRefToken = ReadUIntAndEmitInlineSignatureBinary(signaturePrefixBuilder) | (uint)CorTokenType.mdtMemberRef;
@@ -1262,6 +1294,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 namespaceQualified: false,
                 owningTypeOverride: owningTypeOverride,
                 signaturePrefix: signaturePrefixBuilder.ToString()));
+            return methodRefToken;
         }
 
         /// <summary>


### PR DESCRIPTION
It is my attempt to expose the raw token values implicit in the signature to ILSpy. This is to allow ILSpy to show clickable links when we annotate the disassembly with the import cell signature.

See https://github.com/icsharpcode/ILSpy/pull/1991 for more info on how the raw token values are used there.