### PR TITLE
Fix empty ParamName in ArgumentException

### DIFF
--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -2397,7 +2397,7 @@ FCIMPL1(Object *, ReflectionEnum::InternalGetEnumUnderlyingType, ReflectClassBas
     VALIDATEOBJECT(target);
     TypeHandle th = target->GetType();
     if (!th.IsEnum())
-        FCThrowArgument(NULL, NULL);
+        FCThrowArgument("enumType", NULL);
 
     OBJECTREF result = NULL;
 

--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -2396,14 +2396,11 @@ FCIMPL1(Object *, ReflectionEnum::InternalGetEnumUnderlyingType, ReflectClassBas
 
     VALIDATEOBJECT(target);
     TypeHandle th = target->GetType();
-
+    _ASSERTE(th.IsEnum());
+    
     OBJECTREF result = NULL;
 
     HELPER_METHOD_FRAME_BEGIN_RET_0();
-    
-    if (!th.IsEnum())
-        COMPlusThrow(kArgumentException, W("Arg_MustBeEnum"), W("enumType"));
-    
     MethodTable *pMT = MscorlibBinder::GetElementType(th.AsMethodTable()->GetInternalCorElementType());
     result = pMT->GetManagedClassObject();
     HELPER_METHOD_FRAME_END();

--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -2397,7 +2397,7 @@ FCIMPL1(Object *, ReflectionEnum::InternalGetEnumUnderlyingType, ReflectClassBas
     VALIDATEOBJECT(target);
     TypeHandle th = target->GetType();
     if (!th.IsEnum())
-        FCThrowArgument("enumType", NULL);
+        FCThrowArgument(W("enumType"), NULL);
 
     OBJECTREF result = NULL;
 

--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -2396,12 +2396,14 @@ FCIMPL1(Object *, ReflectionEnum::InternalGetEnumUnderlyingType, ReflectClassBas
 
     VALIDATEOBJECT(target);
     TypeHandle th = target->GetType();
-    if (!th.IsEnum())
-        FCThrowArgument(W("enumType"), NULL);
 
     OBJECTREF result = NULL;
 
     HELPER_METHOD_FRAME_BEGIN_RET_0();
+    
+    if (!th.IsEnum())
+        COMPlusThrow(kArgumentException, W("Arg_MustBeEnum"), W("enumType"));
+    
     MethodTable *pMT = MscorlibBinder::GetElementType(th.AsMethodTable()->GetInternalCorElementType());
     result = pMT->GetManagedClassObject();
     HELPER_METHOD_FRAME_END();

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/EnumConverterTest.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/EnumConverterTest.cs
@@ -109,7 +109,7 @@ namespace System.ComponentModel.Tests
         public static void ConvertTo_WithContext_Negative()
         {
             AssertExtensions.Throws<ArgumentException>(null, () => EnumConverterTests.s_someEnumConverter.ConvertTo(TypeConverterTests.s_context, null, 3, typeof(string)));
-            AssertExtensions.Throws<ArgumentException>(null, "enumType", () => new EnumConverter(typeof(Enum)).ConvertTo(TypeConverterTests.s_context, null, SomeFlagsEnum.Option1, typeof(string)));
+            AssertExtensions.Throws<ArgumentException>("enumType", () => new EnumConverter(typeof(Enum)).ConvertTo(TypeConverterTests.s_context, null, SomeFlagsEnum.Option1, typeof(string)));
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -236,6 +236,9 @@ namespace System
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
+                
+            if (!IsEnum)
+                throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
 
             // Check if both of them are of the same type
             RuntimeType valueType = (RuntimeType)value.GetType();

--- a/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/RuntimeType.cs
@@ -236,7 +236,7 @@ namespace System
         {
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
-                
+
             if (!IsEnum)
                 throw new ArgumentException(SR.Arg_MustBeEnum, "enumType");
 

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -474,6 +474,7 @@ namespace System.Reflection.Tests
         public void IsEnumDefined_Invalid()
         {
             AssertExtensions.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
+            AssertExtensions.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined("10"));
             Assert.Throws<ArgumentNullException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(null));
             Assert.Throws<InvalidOperationException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(new NonGenericClassWithNoInterfaces()));
         }

--- a/src/libraries/System.Reflection/tests/TypeInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/TypeInfoTests.cs
@@ -471,10 +471,9 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/15028", TestRuntimes.Mono)]
         public void IsEnumDefined_Invalid()
         {
-            AssertExtensions.Throws<ArgumentException>("", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
+            AssertExtensions.Throws<ArgumentException>("enumType", () => typeof(NonGenericClassWithNoInterfaces).GetTypeInfo().IsEnumDefined(10));
             Assert.Throws<ArgumentNullException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(null));
             Assert.Throws<InvalidOperationException>(() => typeof(IntEnum).GetTypeInfo().IsEnumDefined(new NonGenericClassWithNoInterfaces()));
         }


### PR DESCRIPTION
Not too much sure if this is correct to be honest.

Fixes #27491
Fixes https://github.com/mono/mono/issues/15028
