### PR TITLE
[testing] Rename Prop AppleTestBuilderDir to AppleAppBuilderDir

### DIFF
--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -22,7 +22,7 @@
 
   <PropertyGroup>
     <MobileHelpersDirSuffix>$(NetCoreAppCurrent)-$(MonoConfiguration)</MobileHelpersDirSuffix>
-    <AppleTestBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', '$(MobileHelpersDirSuffix)'))</AppleTestBuilderDir>
+    <AppleAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', '$(MobileHelpersDirSuffix)'))</AppleAppBuilderDir>
     <AppleTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleTestRunner', '$(MobileHelpersDirSuffix)'))</AppleTestRunnerDir>
     <AndroidAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder', '$(MobileHelpersDirSuffix)'))</AndroidAppBuilderDir>
     <AndroidTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidTestRunner', '$(MobileHelpersDirSuffix)'))</AndroidTestRunnerDir>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -164,7 +164,7 @@
   <!-- Generate a self-contained app bundle for iOS with tests.
        This target is executed once build is done for a test lib (after CopyFilesToOutputDirectory target) -->
   <UsingTask TaskName="AppleAppBuilderTask" 
-             AssemblyFile="$(AppleTestBuilderDir)AppleAppBuilder.dll" />
+             AssemblyFile="$(AppleAppBuilderDir)AppleAppBuilder.dll" />
   <Target Condition="'$(TargetOS)' == 'iOS'" Name="BundleTestAppleApp" AfterTargets="CopyFilesToOutputDirectory">
     <PropertyGroup>
       <BundleDir>$(OutDir)\Bundle</BundleDir>


### PR DESCRIPTION
This PR make a small renaming change to a property in `testing/tests.props`