### PR TITLE
More HTTP/2 performance (and a few functional) improvements

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -437,7 +437,7 @@ namespace System.Net.Http.Functional.Tests
                 bool called = false;
                 var content = new StreamContent(new DelegateStream(
                     canReadFunc: () => true,
-                    readAsyncFunc: (buffer, offset, count, cancellationToken) =>
+                    readAsyncFunc: async (buffer, offset, count, cancellationToken) =>
                     {
                         int result = 1;
                         if (called)
@@ -445,11 +445,17 @@ namespace System.Net.Http.Functional.Tests
                             result = 0;
                             Assert.False(cancellationToken.IsCancellationRequested);
                             tokenSource.Cancel();
-                            Assert.True(cancellationToken.IsCancellationRequested);
+
+                            // Wait for cancellation to occur.  It should be very quickly after it's been requested.
+                            var tcs = new TaskCompletionSource<bool>();
+                            using (cancellationToken.Register(() => tcs.SetResult(true)))
+                            {
+                                await tcs.Task;
+                            }
                         }
 
                         called = true;
-                        return Task.FromResult(result);
+                        return result;
                     }
                 ));
                 yield return new object[] { content, tokenSource };
@@ -467,7 +473,7 @@ namespace System.Net.Http.Functional.Tests
                     lengthFunc: () => 1,
                     positionGetFunc: () => 0,
                     positionSetFunc: _ => {},
-                    readAsyncFunc: (buffer, offset, count, cancellationToken) =>
+                    readAsyncFunc: async (buffer, offset, count, cancellationToken) =>
                     {
                         int result = 1;
                         if (called)
@@ -475,11 +481,17 @@ namespace System.Net.Http.Functional.Tests
                             result = 0;
                             Assert.False(cancellationToken.IsCancellationRequested);
                             tokenSource.Cancel();
-                            Assert.True(cancellationToken.IsCancellationRequested);
+
+                            // Wait for cancellation to occur.  It should be very quickly after it's been requested.
+                            var tcs = new TaskCompletionSource<bool>();
+                            using (cancellationToken.Register(() => tcs.SetResult(true)))
+                            {
+                                await tcs.Task;
+                            }
                         }
 
                         called = true;
-                        return Task.FromResult(result);
+                        return result;
                     }
                 )));
                 yield return new object[] { content, tokenSource };
@@ -497,7 +509,7 @@ namespace System.Net.Http.Functional.Tests
                     lengthFunc: () => 1,
                     positionGetFunc: () => 0,
                     positionSetFunc: _ => {},
-                    readAsyncFunc: (buffer, offset, count, cancellationToken) =>
+                    readAsyncFunc: async (buffer, offset, count, cancellationToken) =>
                     {
                         int result = 1;
                         if (called)
@@ -505,11 +517,17 @@ namespace System.Net.Http.Functional.Tests
                             result = 0;
                             Assert.False(cancellationToken.IsCancellationRequested);
                             tokenSource.Cancel();
-                            Assert.True(cancellationToken.IsCancellationRequested);
+
+                            // Wait for cancellation to occur.  It should be very quickly after it's been requested.
+                            var tcs = new TaskCompletionSource<bool>();
+                            using (cancellationToken.Register(() => tcs.SetResult(true)))
+                            {
+                                await tcs.Task;
+                            }
                         }
 
                         called = true;
-                        return Task.FromResult(result);
+                        return result;
                     }
                 )));
                 yield return new object[] { content, tokenSource };

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
@@ -147,6 +147,8 @@ namespace System.Net.Http.Headers
             _containsTrailingHeaders = containsTrailingHeaders;
         }
 
+        internal bool ContainsTrailingHeaders => _containsTrailingHeaders;
+
         internal override void AddHeaders(HttpHeaders sourceHeaders)
         {
             base.AddHeaders(sourceHeaders);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1773,27 +1773,25 @@ namespace System.Net.Http
 
             lock (SyncObject)
             {
-                if (!_httpStreams.Remove(http2Stream.StreamId, out Http2Stream? removed))
+                if (!_httpStreams.Remove(http2Stream.StreamId))
                 {
                     Debug.Fail($"Stream {http2Stream.StreamId} not found in dictionary during RemoveStream???");
                     return;
                 }
 
-                _concurrentStreams.AdjustCredit(1);
-
-                Debug.Assert(removed == http2Stream, "_httpStreams.TryRemove returned unexpected stream");
-
                 if (_httpStreams.Count == 0)
                 {
                     // If this was last pending request, get timestamp so we can monitor idle time.
                     _idleSinceTickCount = Environment.TickCount64;
-                }
 
-                if (_disposed || _lastStreamId != -1)
-                {
-                    CheckForShutdown();
+                    if (_disposed || _lastStreamId != -1)
+                    {
+                        CheckForShutdown();
+                    }
                 }
             }
+
+            _concurrentStreams.AdjustCredit(1);
         }
 
         public sealed override string ToString() => $"{nameof(Http2Connection)}({_pool})"; // Description for diagnostic purposes

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1207,7 +1207,7 @@ namespace System.Net.Http
                     {
                         // Wake up the wait.  It will then immediately check whether cancellation was requested and throw if it was.
                         thisRef._waitSource.SetException(ExceptionDispatchInfo.SetCurrentStackTrace(
-                            CancellationHelper.CreateOperationCanceledException(null, _waitSourceCancellation.Token)));
+                            CancellationHelper.CreateOperationCanceledException(null, thisRef._waitSourceCancellation.Token)));
                     }
                 }, this);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
                 1024;
 #endif
 
-            private static readonly byte[] s_statusHeaderName = Encoding.ASCII.GetBytes(":status");
+            private static ReadOnlySpan<byte> StatusHeaderName => new byte[] { (byte)':', (byte)'s', (byte)'t', (byte)'a', (byte)'t', (byte)'u', (byte)'s' };
 
             private readonly Http2Connection _connection;
             private readonly int _streamId;
@@ -436,7 +436,7 @@ namespace System.Net.Http
             public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
             {
                 if (NetEventSource.IsEnabled) Trace($"{Encoding.ASCII.GetString(name)}: {Encoding.ASCII.GetString(value)}");
-                Debug.Assert(name != null && name.Length > 0);
+                Debug.Assert(name.Length > 0);
 
                 _headerBudgetRemaining -= name.Length + value.Length;
                 if (_headerBudgetRemaining < 0)
@@ -462,7 +462,7 @@ namespace System.Net.Http
                             throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
                         }
 
-                        if (name.SequenceEqual(s_statusHeaderName))
+                        if (name.SequenceEqual(StatusHeaderName))
                         {
                             if (_responseProtocolState != ResponseProtocolState.ExpectingStatus)
                             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
 {
     internal sealed partial class Http2Connection
     {
-        private sealed class Http2Stream : IValueTaskSource, IHttpTrace, IHttpHeadersHandler
+        private sealed class Http2Stream : IValueTaskSource, IHttpHeadersHandler, IHttpTrace
         {
             private const int InitialStreamBufferSize =
 #if DEBUG

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -781,8 +781,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(Monitor.IsEntered(SyncObject));
 
-                Exception? resetException = _resetException;
-                if (resetException != null)
+                if (_resetException is Exception resetException)
                 {
                     if (_canRetry)
                     {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -129,6 +129,13 @@ namespace System.Net.Http
                     }
                 }
 
+                _response = new HttpResponseMessage()
+                {
+                    Version = HttpVersion.Version20,
+                    RequestMessage = _request,
+                    Content = new HttpConnectionResponseContent()
+                };
+
                 if (NetEventSource.IsEnabled) Trace($"{request}, {nameof(initialWindowSize)}={initialWindowSize}");
             }
 
@@ -472,13 +479,8 @@ namespace System.Net.Http
                             }
 
                             int statusValue = ParseStatusCode(value);
-                            _response = new HttpResponseMessage()
-                            {
-                                Version = HttpVersion.Version20,
-                                RequestMessage = _request,
-                                Content = new HttpConnectionResponseContent(),
-                                StatusCode = (HttpStatusCode)statusValue
-                            };
+                            Debug.Assert(_response != null);
+                            _response.StatusCode = (HttpStatusCode)statusValue;
 
                             if (statusValue < 200)
                             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http.Headers;
@@ -117,11 +118,27 @@ namespace System.Net.Http
         }
 
         /// <summary>Awaits a task, logging any resulting exceptions (which are otherwise ignored).</summary>
-        internal void LogExceptions(Task task) =>
-            task.ContinueWith(t =>
+        internal void LogExceptions(Task task)
+        {
+            if (task.IsCompleted)
             {
-                Exception? e = t.Exception?.InnerException; // Access Exception even if not tracing, to avoid TaskScheduler.UnobservedTaskException firing
-                if (NetEventSource.IsEnabled) Trace($"Exception from asynchronous processing: {e}");
-            }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+                if (task.IsFaulted)
+                {
+                    LogFaulted(this, task);
+                }
+            }
+            else
+            {
+                task.ContinueWith((t, state) => LogFaulted((HttpConnectionBase)state!, t), this,
+                    CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted, TaskScheduler.Default);
+            }
+
+            static void LogFaulted(HttpConnectionBase connection, Task task)
+            {
+                Debug.Assert(task.IsFaulted);
+                Exception? e = task.Exception!.InnerException; // Access Exception even if not tracing, to avoid TaskScheduler.UnobservedTaskException firing
+                if (NetEventSource.IsEnabled) connection.Trace($"Exception from asynchronous processing: {e}");
+            }
+        }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Threading/AsyncMutex.cs
+++ b/src/libraries/System.Net.Http/src/System/Threading/AsyncMutex.cs
@@ -42,9 +42,11 @@ namespace System.Threading
         /// with an initial count of 0.
         /// </remarks>
         private bool _lockedSemaphoreFull = true;
-        /// <summary>The head of the double-linked waiting queue.  Waiters are dequeued from the head.</summary>
-        private Waiter? _waitersHead;
-        /// <summary>The tail of the double-linked waiting queue.  Waiters are added at the tail.</summary>
+        /// <summary>The tail of the double-linked circular waiting queue.</summary>
+        /// <remarks>
+        /// Waiters are added at the tail.
+        /// Items are dequeued from the head (tail.Prev).
+        /// </remarks>
         private Waiter? _waitersTail;
         /// <summary>A pool of waiter objects that are ready to be reused.</summary>
         /// <remarks>
@@ -89,30 +91,36 @@ namespace System.Threading
                     w = new Waiter(this);
                 }
 
+                bool acquired = false;
                 lock (SyncObj)
                 {
                     // Now that we're holding the lock, check to see whether the async lock is acquirable.
                     if (!_lockedSemaphoreFull)
                     {
-                        _lockedSemaphoreFull = true;
-                        return default;
+                        _lockedSemaphoreFull = acquired = true;
                     }
                     else
                     {
                         // Add it to the linked list of waiters.
                         if (_waitersTail is null)
                         {
-                            Debug.Assert(_waitersHead is null);
-                            _waitersTail = _waitersHead = w;
+                            w.Next = w.Prev = w;
                         }
                         else
                         {
-                            Debug.Assert(_waitersHead != null);
-                            w.Prev = _waitersTail;
-                            _waitersTail.Next = w;
-                            _waitersTail = w;
+                            Debug.Assert(_waitersTail.Next != null && _waitersTail.Prev != null);
+                            w.Next = _waitersTail;
+                            w.Prev = _waitersTail.Prev;
+                            w.Prev.Next = w.Next.Prev = w;
                         }
+                        _waitersTail = w;
                     }
+                }
+
+                // If we were able to acquire the lock, we're done.
+                if (acquired)
+                {
+                    return default;
                 }
 
                 // At this point the waiter was added to the list of waiters, so we want to
@@ -136,14 +144,11 @@ namespace System.Threading
 
                     lock (m.SyncObj)
                     {
-                        bool inList = w.Next != null || w.Prev != null || m._waitersHead == w;
+                        bool inList = w.Next != null;
                         if (inList)
                         {
-                            // The waiter was still in the list.
-                            Debug.Assert(
-                                m._waitersHead == w ||
-                                (m._waitersTail == w && w.Prev != null && w.Next is null) ||
-                                (w.Next != null && w.Prev != null));
+                            // The waiter is in the list.
+                            Debug.Assert(w.Prev != null);
 
                             // The gate counter was decremented when this waiter was added.  We need
                             // to undo that.  Since the waiter is still in the list, the lock must
@@ -156,33 +161,19 @@ namespace System.Threading
                             // release it, they will appropriately update state.
                             Interlocked.Increment(ref m._gate);
 
-                            // Remove it from the list.
-                            if (m._waitersHead == w && m._waitersTail == w)
+                            if (w.Next == w)
                             {
-                                // It's the only node in the list.
-                                m._waitersHead = m._waitersTail = null;
-                            }
-                            else if (m._waitersTail == w)
-                            {
-                                // It's the most recently queued item in the list.
-                                m._waitersTail = w.Prev;
-                                Debug.Assert(m._waitersTail != null);
-                                m._waitersTail.Next = null;
-                            }
-                            else if (m._waitersHead == w)
-                            {
-                                // It's the next item to be removed from the list.
-                                m._waitersHead = w.Next;
-                                Debug.Assert(m._waitersHead != null);
-                                m._waitersHead.Prev = null;
+                                Debug.Assert(m._waitersTail == w);
+                                m._waitersTail = null;
                             }
                             else
                             {
-                                // It's in the middle of the list.
-                                Debug.Assert(w.Next != null);
-                                Debug.Assert(w.Prev != null);
-                                w.Next.Prev = w.Prev;
+                                w.Next!.Prev = w.Prev;
                                 w.Prev.Next = w.Next;
+                                if (m._waitersTail == w)
+                                {
+                                    m._waitersTail = w.Next;
+                                }
                             }
 
                             // Remove it from the list.
@@ -217,33 +208,36 @@ namespace System.Threading
             void Contended()
             {
                 Waiter? w;
-
                 lock (SyncObj)
                 {
                     Debug.Assert(_lockedSemaphoreFull);
 
-                    // Wake up the next waiter in the list.
-                    w = _waitersHead;
-                    if (w != null)
+                    w = _waitersTail;
+                    if (w is null)
                     {
-                        // Remove the waiter.
-                        _waitersHead = w.Next;
-                        if (w.Next != null)
-                        {
-                            w.Next.Prev = null;
-                        }
-                        else
-                        {
-                            Debug.Assert(_waitersTail == w);
-                            _waitersTail = null;
-                        }
-                        w.Next = w.Prev = null;
+                        _lockedSemaphoreFull = false;
                     }
                     else
                     {
-                        // There wasn't a waiter.  Mark that the async lock is no longer full.
-                        Debug.Assert(_waitersTail is null);
-                        _lockedSemaphoreFull = false;
+                        Debug.Assert(w.Next != null && w.Prev != null);
+                        Debug.Assert(w.Next != w || w.Prev == w);
+                        Debug.Assert(w.Prev != w || w.Next == w);
+
+                        if (w.Next == w)
+                        {
+                            _waitersTail = null;
+                        }
+                        else
+                        {
+                            w = w.Prev; // get the head
+                            Debug.Assert(w.Next != null && w.Prev != null);
+                            Debug.Assert(w.Next != w && w.Prev != w);
+
+                            w.Next.Prev = w.Prev;
+                            w.Prev.Next = w.Next;
+                        }
+
+                        w.Next = w.Prev = null;
                     }
                 }
 


### PR DESCRIPTION
Continuing to look at https://github.com/dotnet/runtime/issues/35184.  On the same repro, this appears to add another 7-10% RPS, though I'm seeing a lot of variation and it's hard to narrow down well.  It reduces allocation by ~15%.

There are two functional fixes here:
- We weren't respecting the supplied cancellation token while waiting for an Expect: 100-continue response or timeout.
- We weren't always unregistering from the supplied cancellation token when sending the request body.

The main perf improvements:
- Removed some linked CancellationTokenSources we were creating, instead achieving the same goal a different way.
- Removed some accidental delegate/closure allocations
- Removed a list allocation used to store trailing headers
- Avoid registering with the supplied cancellation token unless the operation being waited for is going to complete asynchronously

And a few ancillary things:
- Cleaning up some code to use switches instead of cascading if/elses
- Consolidating a bunch of identical or very similar throws into throw helper methods

cc: @scalablecory, @JamesNK 