### PR TITLE
Set ExactSpelling=true on P/Invokes in System.Private.CoreLib that already specify the unicode W suffix

### DIFF
--- a/src/coreclr/src/vm/method.cpp
+++ b/src/coreclr/src/vm/method.cpp
@@ -5307,6 +5307,23 @@ FARPROC NDirectMethodDesc::FindEntryPointWithMangling(NATIVE_LIBRARY_HANDLE hMod
 
     return pFunc;
 }
+
+FARPROC NDirectMethodDesc::FindEntryPointWithSuffix(NATIVE_LIBRARY_HANDLE hMod, PTR_CUTF8 entryPointName, char suffix) const
+{
+    // Allocate space for a copy of the entry point name.
+    DWORD entryPointWithSuffixLen = (DWORD)(strlen(entryPointName) + 1); // +1 for charset decorations
+    int dstbufsize = (int)(sizeof(char) * (entryPointWithSuffixLen + 1)); // +1 for the null terminator
+    LPSTR entryPointWithSuffix = ((LPSTR)_alloca(dstbufsize));
+
+    // Copy the name so we can mangle it.
+    strcpy_s(entryPointWithSuffix, dstbufsize, entryPointName);
+    entryPointWithSuffix[entryPointWithSuffixLen] = '\0'; // Null terminator
+    entryPointWithSuffix[entryPointWithSuffixLen - 1] = suffix; // Charset suffix
+
+    // Look for entry point with the suffix based on charset
+    return FindEntryPointWithMangling(hMod, entryPointWithSuffix);
+}
+
 #endif
 
 //*******************************************************************************
@@ -5332,31 +5349,27 @@ LPVOID NDirectMethodDesc::FindEntryPoint(NATIVE_LIBRARY_HANDLE hMod) const
         return reinterpret_cast<LPVOID>(GetProcAddress(hMod, (LPCSTR)(size_t)((UINT16)ordinal)));
     }
 
-    // Just look for the user-provided name without charset suffixes.
-    // If it is a unicode function, we are going
-    // to need to check for the 'W' API because it takes precedence over the
-    // unmangled one (on NT some APIs have unmangled ANSI exports).
-    FARPROC pFunc = FindEntryPointWithMangling(hMod, funcName);
-    if ((pFunc != NULL && IsNativeAnsi()) || IsNativeNoMangled())
+    FARPROC pFunc = NULL;
+    if (IsNativeNoMangled())
     {
-        return reinterpret_cast<LPVOID>(pFunc);
+        // Look for the user-provided entry point name only
+        pFunc = FindEntryPointWithMangling(hMod, funcName);
     }
-
-    // Allocate space for a copy of the entry point name.
-    DWORD probedEntrypointNameLength = (DWORD)(strlen(funcName) + 1); // +1 for charset decorations
-    int dstbufsize = (int)(sizeof(char) * (probedEntrypointNameLength + 1)); // +1 for the null terminator
-    LPSTR szProbedEntrypointName = ((LPSTR)_alloca(dstbufsize));
-
-    // Copy the name so we can mangle it.
-    strcpy_s(szProbedEntrypointName, dstbufsize, funcName);
-    szProbedEntrypointName[probedEntrypointNameLength] = '\0'; // Null terminator
-    szProbedEntrypointName[probedEntrypointNameLength - 1] = IsNativeAnsi() ? 'A' : 'W'; // Charset suffix
-
-    // Look for entry point with the suffix based on charset
-    FARPROC pProbedFunc = FindEntryPointWithMangling(hMod, szProbedEntrypointName);
-    if (pProbedFunc != NULL)
+    else if (IsNativeAnsi())
     {
-        pFunc = pProbedFunc;
+        // For ANSI, look for the user-provided entry point name first.
+        // If that does not exist, try the charset suffix.
+        pFunc = FindEntryPointWithMangling(hMod, funcName);
+        if (pFunc == NULL)
+            pFunc = FindEntryPointWithSuffix(hMod, funcName, 'A');
+    }
+    else
+    {
+        // For Unicode, look for the entry point name with the charset suffix first.
+        // The 'W' API takes precedence over the undecorated one.
+        pFunc = FindEntryPointWithSuffix(hMod, funcName, 'W');
+        if (pFunc == NULL)
+            pFunc = FindEntryPointWithMangling(hMod, funcName);
     }
 
     return reinterpret_cast<LPVOID>(pFunc);

--- a/src/coreclr/src/vm/method.hpp
+++ b/src/coreclr/src/vm/method.hpp
@@ -3150,6 +3150,7 @@ public:
 #ifdef TARGET_WINDOWS
 private:
     FARPROC FindEntryPointWithMangling(NATIVE_LIBRARY_HANDLE mod, PTR_CUTF8 entryPointName) const;
+    FARPROC FindEntryPointWithSuffix(NATIVE_LIBRARY_HANDLE mod, PTR_CUTF8 entryPointName, char suffix) const;
 #endif
 public:
 

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCreateKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegCreateKeyEx.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
     {
         // Note: RegCreateKeyEx won't set the last error on failure - it returns
         // an error code if it fails.
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegCreateKeyExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegCreateKeyExW", ExactSpelling = true)]
         internal static extern int RegCreateKeyEx(
             SafeRegistryHandle hKey,
             string lpSubKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteKeyEx.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegDeleteKeyExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegDeleteKeyExW", ExactSpelling = true)]
         internal static extern int RegDeleteKeyEx(SafeRegistryHandle hKey, string lpSubKey, int samDesired, int Reserved);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegDeleteValue.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegDeleteValueW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegDeleteValueW", ExactSpelling = true)]
         internal static extern int RegDeleteValue(SafeRegistryHandle hKey, string? lpValueName);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumKeyEx.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumKeyExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumKeyExW", ExactSpelling = true)]
         internal static extern unsafe int RegEnumKeyEx(
             SafeRegistryHandle hKey,
             int dwIndex,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegEnumValue.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumValueW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegEnumValueW", ExactSpelling = true)]
         internal static extern unsafe int RegEnumValue(
             SafeRegistryHandle hKey,
             int dwIndex,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegOpenKeyEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegOpenKeyEx.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegOpenKeyExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegOpenKeyExW", ExactSpelling = true)]
         internal static extern int RegOpenKeyEx(
             SafeRegistryHandle hKey,
             string? lpSubKey,
@@ -24,7 +24,7 @@ internal static partial class Interop
             out SafeRegistryHandle hkResult);
 
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegOpenKeyExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegOpenKeyExW", ExactSpelling = true)]
         internal static extern int RegOpenKeyEx(
             IntPtr hKey,
             string? lpSubKey,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegQueryValueEx.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
         internal static extern int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -23,7 +23,7 @@ internal static partial class Interop
             [Out] byte[]? lpData,
             ref int lpcbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
         internal static extern int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -32,7 +32,7 @@ internal static partial class Interop
             ref int lpData,
             ref int lpcbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
         internal static extern int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -41,7 +41,7 @@ internal static partial class Interop
             ref long lpData,
             ref int lpcbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegQueryValueExW", ExactSpelling = true)]
         internal static extern int RegQueryValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,

--- a/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegSetValueEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Advapi32/Interop.RegSetValueEx.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
 {
     internal static partial class Advapi32
     {
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
         internal static extern int RegSetValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -23,7 +23,7 @@ internal static partial class Interop
             byte[]? lpData,
             int cbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
         internal static extern int RegSetValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -32,7 +32,7 @@ internal static partial class Interop
             char[]? lpData,
             int cbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
         internal static extern int RegSetValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -41,7 +41,7 @@ internal static partial class Interop
             ref int lpData,
             int cbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
         internal static extern int RegSetValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,
@@ -50,7 +50,7 @@ internal static partial class Interop
             ref long lpData,
             int cbData);
 
-        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW")]
+        [DllImport(Libraries.Advapi32, CharSet = CharSet.Unicode, BestFitMapping = false, EntryPoint = "RegSetValueExW", ExactSpelling = true)]
         internal static extern int RegSetValueEx(
             SafeRegistryHandle hKey,
             string? lpValueName,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EventWaitHandle.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.EventWaitHandle.cs
@@ -20,10 +20,10 @@ internal static partial class Interop
         [DllImport(Libraries.Kernel32, SetLastError = true)]
         internal static extern bool ResetEvent(SafeWaitHandle handle);
 
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateEventExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateEventExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern SafeWaitHandle CreateEventEx(IntPtr lpSecurityAttributes, string? name, uint flags, uint desiredAccess);
 
-        [DllImport(Libraries.Kernel32, EntryPoint = "OpenEventW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "OpenEventW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern SafeWaitHandle OpenEvent(uint desiredAccess, bool inheritHandle, string name);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ExpandEnvironmentStrings.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.ExpandEnvironmentStrings.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "ExpandEnvironmentStringsW", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "ExpandEnvironmentStringsW", CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
         internal static extern uint ExpandEnvironmentStrings(string lpSrc, ref char lpDst, uint nSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindFirstFileEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FindFirstFileEx.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use FindFirstFile.
         /// </summary>
-        [DllImport(Libraries.Kernel32, EntryPoint = "FindFirstFileExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "FindFirstFileExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         private static extern SafeFindHandle FindFirstFileExPrivate(string lpFileName, FINDEX_INFO_LEVELS fInfoLevelId, ref WIN32_FIND_DATA lpFindFileData, FINDEX_SEARCH_OPS fSearchOp, IntPtr lpSearchFilter, int dwAdditionalFlags);
 
         internal static SafeFindHandle FindFirstFile(string fileName, ref WIN32_FIND_DATA data)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FormatMessage.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         private const int FORMAT_MESSAGE_ALLOCATE_BUFFER = 0x00000100;
         private const int ERROR_INSUFFICIENT_BUFFER = 0x7A;
 
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, BestFitMapping = true)]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "FormatMessageW", SetLastError = true, BestFitMapping = true, ExactSpelling = true)]
         private static extern unsafe int FormatMessage(
             int dwFlags,
             IntPtr lpSource,

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FreeEnvironmentStrings.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.FreeEnvironmentStrings.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "FreeEnvironmentStringsW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "FreeEnvironmentStringsW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         internal static extern unsafe bool FreeEnvironmentStrings(char* lpszEnvironmentBlock);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetComputerName.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameW")]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "GetComputerNameW", ExactSpelling = true)]
         private static extern unsafe int GetComputerName(ref char lpBuffer, ref uint nSize);
 
         // maximum length of the NETBIOS name (not including NULL)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetCurrentDirectory.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetCurrentDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "GetCurrentDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         internal static extern uint GetCurrentDirectory(uint nBufferLength, ref char lpBuffer);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetEnvironmentStrings.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetEnvironmentStrings.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetEnvironmentStringsW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "GetEnvironmentStringsW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         internal static extern unsafe char* GetEnvironmentStrings();
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetEnvironmentVariable.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetEnvironmentVariable.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetEnvironmentVariableW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "GetEnvironmentVariableW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         private static extern unsafe int GetEnvironmentVariable(string lpName, char* lpBuffer, int nSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetFileAttributesEx.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         /// <summary>
         /// WARNING: This method does not implicitly handle long paths. Use GetFileAttributesEx.
         /// </summary>
-        [DllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "GetFileAttributesExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         private static extern bool GetFileAttributesExPrivate(string? name, GET_FILEEX_INFO_LEVELS fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
 
         internal static bool GetFileAttributesEx(string? name, GET_FILEEX_INFO_LEVELS fileInfoLevel, ref WIN32_FILE_ATTRIBUTE_DATA lpFileInformation)

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemDirectoryW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetSystemDirectoryW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
         internal static extern uint GetSystemDirectoryW(ref char lpBuffer, uint uSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetTempFileNameW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, SetLastError = true, BestFitMapping = false, ExactSpelling = true)]
         internal static extern uint GetTempFileNameW(ref char lpPathName, string lpPrefixString, uint uUnique, ref char lpTempFileName);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.GetTempPathW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         internal static extern uint GetTempPathW(int bufferLen, ref char buffer);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibraryEx_IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.LoadLibraryEx_IntPtr.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         internal const int LOAD_LIBRARY_AS_DATAFILE = 0x00000002;
         internal const int LOAD_LIBRARY_SEARCH_SYSTEM32 = 0x00000800;
 
-        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryExW", SetLastError = true)]
+        [DllImport(Libraries.Kernel32, CharSet = CharSet.Unicode, EntryPoint = "LoadLibraryExW", SetLastError = true, ExactSpelling = true)]
         internal static extern IntPtr LoadLibraryEx(string libFilename, IntPtr reserved, int flags);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Mutex.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Mutex.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
     {
         internal const uint CREATE_MUTEX_INITIAL_OWNER = 0x1;
 
-        [DllImport(Libraries.Kernel32, EntryPoint = "OpenMutexW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "OpenMutexW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern SafeWaitHandle OpenMutex(uint desiredAccess, bool inheritHandle, string name);
 
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateMutexExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateMutexExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern SafeWaitHandle CreateMutexEx(IntPtr lpMutexAttributes, string? name, uint flags, uint desiredAccess);
 
         [DllImport(Libraries.Kernel32, SetLastError = true)]

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Semaphore.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.Semaphore.cs
@@ -11,10 +11,10 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "OpenSemaphoreW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "OpenSemaphoreW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern SafeWaitHandle OpenSemaphore(uint desiredAccess, bool inheritHandle, string name);
 
-        [DllImport(Libraries.Kernel32, EntryPoint = "CreateSemaphoreExW", SetLastError = true, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "CreateSemaphoreExW", SetLastError = true, CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern SafeWaitHandle CreateSemaphoreEx(IntPtr lpSecurityAttributes, int initialCount, int maximumCount, string? name, uint flags, uint desiredAccess);
 
         [DllImport(Libraries.Kernel32, SetLastError = true)]

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCurrentDirectory.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetCurrentDirectory.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "SetCurrentDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "SetCurrentDirectoryW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         internal static extern bool SetCurrentDirectory(string path);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetEnvironmentVariable.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.SetEnvironmentVariable.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
-        [DllImport(Libraries.Kernel32, EntryPoint = "SetEnvironmentVariableW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false)]
+        [DllImport(Libraries.Kernel32, EntryPoint = "SetEnvironmentVariableW", SetLastError = true, CharSet = CharSet.Unicode, BestFitMapping = false, ExactSpelling = true)]
         internal static extern bool SetEnvironmentVariable(string lpName, string? lpValue);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Secur32/Interop.GetUserNameExW.cs
+++ b/src/libraries/Common/src/Interop/Windows/Secur32/Interop.GetUserNameExW.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Secur32
     {
-        [DllImport(Libraries.Secur32, CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Libraries.Secur32, CharSet = CharSet.Unicode, SetLastError = true, ExactSpelling = true)]
         internal static extern BOOLEAN GetUserNameExW(int NameFormat, ref char lpNameBuffer, ref uint lpnSize);
 
         internal const int NameSamCompatible = 2;

--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.LoadString.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.LoadString.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class User32
     {
-        [DllImport(Libraries.User32, SetLastError = true, EntryPoint = "LoadStringW", CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.User32, SetLastError = true, EntryPoint = "LoadStringW", CharSet = CharSet.Unicode, ExactSpelling = true)]
         internal static extern unsafe int LoadString(IntPtr hInstance, uint uID, char* lpBuffer, int cchBufferMax);
     }
 }


### PR DESCRIPTION
If a p/invoke is declared with `CharSet.Unicode` and `ExactSpelling=false`, the runtime will (on Windows) look for both the specified entry point name and the name with the `W` suffix. We explicitly specify the `W` suffix for the entry point name in a number of cases without setting `ExactSpelling=true`, resulting in the runtime looking for entry points that we know will not exist (e.g. looking for `GetEnvironmentVariableWW` in kernel32).

This change updates such cases in `System.Private.CoreLib` to set `ExactSpelling=true`.

cc @AaronRobinsonMSFT @jkoritzinsky @stephentoub 