### PR TITLE
Enable eliding some bounds checks in the jit

### DIFF
--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -1796,7 +1796,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         optCreateComplementaryAssertion(index, nullptr, nullptr);
         return index;
     }
-    // Cases where op1 holds the ulhs of the condition and op2 holds the bound arithmatic.
+    // Cases where op1 holds the lhs of the condition and op2 holds the bound arithmatic.
     // Loop condition like: "i < bnd +/-k"
     // Assertion: "i < bnd +/- k != 0"
     else if (vnStore->IsVNCompareCheckedBoundArith(relopVN))

--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -854,7 +854,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree*         op1,
     if (op2 == nullptr)
     {
         //
-        // Must an OAK_NOT_EQUAL assertion
+        // Must be an OAK_NOT_EQUAL assertion
         //
         noway_assert(assertionKind == OAK_NOT_EQUAL);
 
@@ -1788,6 +1788,23 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         dsc.assertionKind    = relop->gtOper == GT_EQ ? OAK_EQUAL : OAK_NOT_EQUAL;
         dsc.op1.kind         = O1K_BOUND_OPER_BND;
         dsc.op1.vn           = op1VN;
+        dsc.op2.kind         = O2K_CONST_INT;
+        dsc.op2.vn           = vnStore->VNZeroForType(op2->TypeGet());
+        dsc.op2.u1.iconVal   = 0;
+        dsc.op2.u1.iconFlags = 0;
+        AssertionIndex index = optAddAssertion(&dsc);
+        optCreateComplementaryAssertion(index, nullptr, nullptr);
+        return index;
+    }
+    // Cases where op1 holds the ulhs of the condition and op2 holds the bound arithmatic.
+    // Loop condition like: "i < bnd +/-k"
+    // Assertion: "i < bnd +/- k != 0"
+    else if (vnStore->IsVNCompareCheckedBoundArith(relopVN))
+    {
+        AssertionDsc dsc;
+        dsc.assertionKind    = OAK_NOT_EQUAL;
+        dsc.op1.kind         = O1K_BOUND_OPER_BND;
+        dsc.op1.vn           = relopVN;
         dsc.op2.kind         = O2K_CONST_INT;
         dsc.op2.vn           = vnStore->VNZeroForType(op2->TypeGet());
         dsc.op2.u1.iconVal   = 0;

--- a/src/coreclr/src/jit/assertionprop.cpp
+++ b/src/coreclr/src/jit/assertionprop.cpp
@@ -1796,7 +1796,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         optCreateComplementaryAssertion(index, nullptr, nullptr);
         return index;
     }
-    // Cases where op1 holds the lhs of the condition and op2 holds the bound arithmatic.
+    // Cases where op1 holds the lhs of the condition and op2 holds the bound arithmetic.
     // Loop condition like: "i < bnd +/-k"
     // Assertion: "i < bnd +/- k != 0"
     else if (vnStore->IsVNCompareCheckedBoundArith(relopVN))

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -420,6 +420,10 @@ bool RangeCheck::IsMonotonicallyIncreasing(GenTree* expr, bool rejectNegativeCon
         }
         return true;
     }
+    else if (expr->OperGet() == GT_COMMA)
+    {
+        return IsMonotonicallyIncreasing(expr->gtEffectiveVal(), rejectNegativeConst);
+    }
     JITDUMP("Unknown tree type\n");
     return false;
 }
@@ -1216,6 +1220,10 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
         }
 
         JITDUMP("%s\n", range.ToString(m_pCompiler->getAllocatorDebugOnly()));
+    }
+    else if(expr->OperGet() == GT_COMMA)
+    {
+        range = GetRange(block, expr->gtEffectiveVal(), monIncreasing DEBUGARG(indent + 1));
     }
     else
     {

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -348,7 +348,13 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
             return IsMonotonicallyIncreasing(op1, true) && IsMonotonicallyIncreasing(op2, true);
 
         case GT_CNS_INT:
-            return (op2->AsIntConCommon()->IconValue() >= 0) && IsMonotonicallyIncreasing(op1, false);
+            if (op2->AsIntConCommon()->IconValue() < 0)
+            {
+                JITDUMP("Not monotonically increasing because of encountered negative constant");
+                return false;
+            }
+
+            return IsMonotonicallyIncreasing(op1, false);
 
         default:
             JITDUMP("Not monotonically increasing because expression is not recognized.\n");

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -350,7 +350,7 @@ bool RangeCheck::IsBinOpMonotonicallyIncreasing(GenTreeOp* binop)
         case GT_CNS_INT:
             if (op2->AsIntConCommon()->IconValue() < 0)
             {
-                JITDUMP("Not monotonically increasing because of encountered negative constant");
+                JITDUMP("Not monotonically increasing because of encountered negative constant\n");
                 return false;
             }
 

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -1227,7 +1227,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
 
         JITDUMP("%s\n", range.ToString(m_pCompiler->getAllocatorDebugOnly()));
     }
-    else if(expr->OperGet() == GT_COMMA)
+    else if (expr->OperGet() == GT_COMMA)
     {
         range = GetRange(block, expr->gtEffectiveVal(), monIncreasing DEBUGARG(indent + 1));
     }

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -729,7 +729,7 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
 }
 
 // Merge assertions from the pred edges of the block, i.e., check for any assertions about "op's" value numbers for phi
-// arguments. If not a phi argument, check if we assertions about local variables.
+// arguments. If not a phi argument, check if we have assertions about local variables.
 void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DEBUGARG(int indent))
 {
     JITDUMP("Merging assertions from pred edges of " FMT_BB " for op [%06d] " FMT_VN "\n", block->bbNum,


### PR DESCRIPTION
- For loop conditionals like i < bnd +- k, fix up assertion prop to generate Bound Oper Bnd assertions instead of Const Loop Bnd assertions. 

- When checking the range of a tree, handle comma nodes.

- Add logging for when the jit bails due to encountering a negative constant.

This removes bound checks from the first two cases in https://github.com/dotnet/runtime/issues/31638.
I also see it enabling removing a couple of other bounds check types, like the ones here with the index casted to a byte: https://github.com/dotnet/runtime/blob/6a48efaaf9ee549a9d5f52ad5a74eacf5de20c62/src/libraries/Common/src/System/Net/CaseInsensitiveAscii.cs#L90-L97

The assembly diff is available [here](https://gist.github.com/nathan-moore/7426f14eac098dd7dc1f522d13dc5f0c).

The two method regressions seem to be caused by register allocation. One of them is [here](https://www.diffchecker.com/6pmvnwlL) if you wish to peruse through it.