### PR TITLE
Prevent empty array allocation in collections

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -48,7 +48,11 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
-            _array = new T[capacity];
+            
+            if (capacity == 0)
+                _array = Array.Empty<T>();
+            else
+                _array = new T[capacity];
         }
 
         // Fills a Queue with the elements of an ICollection.  Uses the enumerator

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -94,7 +94,7 @@ namespace System.Collections.Generic
             if (capacity == 0)
             {
                 keys = Array.Empty<TKey>();
-                keys = Array.Empty<TValue>();
+                values = Array.Empty<TValue>();
             }
             else
             {

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -90,8 +90,17 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
-            keys = new TKey[capacity];
-            values = new TValue[capacity];
+
+            if (capacity == 0)
+            {
+                keys = Array.Empty<TKey>();
+                keys = Array.Empty<TValue>();
+            }
+            else
+            {
+                keys = new TKey[capacity];
+                values = new TValue[capacity];
+            }
             comparer = Comparer<TKey>.Default;
         }
 

--- a/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -44,7 +44,11 @@ namespace System.Collections.Generic
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), capacity, SR.ArgumentOutOfRange_NeedNonNegNum);
-            _array = new T[capacity];
+
+            if (capacity == 0)
+                _array = Array.Empty<T>();
+            else
+                _array = new T[capacity];
         }
 
         // Fills a Stack with the contents of a particular collection.  The items are


### PR DESCRIPTION
Based on the information provided in https://github.com/dotnet/runtime/pull/36228#discussion_r423249845
special-casing the length of zero is good to avoid allocating a new empty array.

@stephentoub, Can you confirm if this is correct in that context?