### PR TITLE
Minor MethodTable building optimization

### DIFF
--- a/src/coreclr/src/vm/methodtable.cpp
+++ b/src/coreclr/src/vm/methodtable.cpp
@@ -8617,7 +8617,7 @@ MethodDesc *MethodTable::MethodDataInterfaceImpl::GetImplMethodDesc(UINT32 slotN
     if (implSlotNumber == INVALID_SLOT_NUMBER) {
         return NULL;
     }
-    return m_pImpl->GetImplMethodDesc(MapToImplSlotNumber(slotNumber));
+    return m_pImpl->GetImplMethodDesc(implSlotNumber);
 }
 
 //==========================================================================================
@@ -8628,7 +8628,7 @@ void MethodTable::MethodDataInterfaceImpl::InvalidateCachedVirtualSlot(UINT32 sl
     if (implSlotNumber == INVALID_SLOT_NUMBER) {
         return;
     }
-    return m_pImpl->InvalidateCachedVirtualSlot(MapToImplSlotNumber(slotNumber));
+    return m_pImpl->InvalidateCachedVirtualSlot(implSlotNumber);
 }
 
 //==========================================================================================


### PR DESCRIPTION
When learning on how virtual method overriding is implemented in the
runtime, I've bumped into two places where we were calling
MapToImplSlotNumber twice in a row without any reason. Since this method
isn't trivial, it seems worth fixing.