### PR TITLE
Add QCALL_CONTRACT_NO_GC_TRANSITION

### DIFF
--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -1385,8 +1385,7 @@ void ComWrappersNative::MarkWrapperAsComActivated(_In_ IUnknown* wrapperMaybe)
 
 void QCALLTYPE GlobalComWrappersForMarshalling::SetGlobalInstanceRegisteredForMarshalling()
 {
-    // QCALL contracts are not used here because the managed declaration
-    // uses the SuppressGCTransition attribute
+    QCALL_CONTRACT_NO_GC_TRANSITION;
 
     _ASSERTE(!g_IsGlobalComWrappersRegisteredForMarshalling);
     g_IsGlobalComWrappersRegisteredForMarshalling = true;
@@ -1455,8 +1454,7 @@ bool GlobalComWrappersForMarshalling::TryGetOrCreateObjectForComInstance(
 
 void QCALLTYPE GlobalComWrappersForTrackerSupport::SetGlobalInstanceRegisteredForTrackerSupport()
 {
-    // QCALL contracts are not used here because the managed declaration
-    // uses the SuppressGCTransition attribute
+    QCALL_CONTRACT_NO_GC_TRANSITION;
 
     _ASSERTE(!g_IsGlobalComWrappersRegisteredForTrackerSupport);
     g_IsGlobalComWrappersRegisteredForTrackerSupport = true;

--- a/src/coreclr/src/vm/qcall.h
+++ b/src/coreclr/src/vm/qcall.h
@@ -137,7 +137,13 @@
     GC_TRIGGERS;                \
     MODE_PREEMPTIVE;            \
 
+#define QCALL_CHECK_NO_GC_TRANSITION    \
+    THROWS;                             \
+    GC_TRIGGERS;                        \
+    MODE_COOPERATIVE;                   \
+
 #define QCALL_CONTRACT CONTRACTL { QCALL_CHECK; } CONTRACTL_END;
+#define QCALL_CONTRACT_NO_GC_TRANSITION CONTRACTL { QCALL_CHECK_NO_GC_TRANSITION; } CONTRACTL_END;
 
 //
 // Scope class for QCall helper methods and types


### PR DESCRIPTION
New QCall macro for APIs that use `SuppressGCTransitionAttribute`.

Fixes #36238 

/cc @jkoritzinsky @elinor-fung 