### PR TITLE
Remove unsed variable in MsQuicApi

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -142,8 +142,6 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
             // - Otherwise, dial this in to reflect actual minimum requirements and add some sort of platform
             //   error code mapping when creating exceptions.
 
-            OperatingSystem ver = Environment.OSVersion;
-
             // TODO: try to initialize TLS 1.3 in SslStream.
 
             try


### PR DESCRIPTION
The code using this variable was removed with #32779.

The alternative would be to add back the OSVersion checks now that @stephentoub fixed #33643.