### PR TITLE
Remove several unnecessary arrays used with String.Split

### DIFF
--- a/src/libraries/Common/src/System/Net/Mail/MailBnfHelper.cs
+++ b/src/libraries/Common/src/System/Net/Mail/MailBnfHelper.cs
@@ -45,8 +45,6 @@ namespace System.Net.Mime
         internal const char Comma = ',';
         internal const char Dot = '.';
 
-        private static readonly char[] s_colonSeparator = new char[] { ':' };
-
         // NOTE: See RFC 2822 for more detail.  By default, every value in the array is false and only
         // those values which are allowed in that particular set are then set to true.  The numbers
         // annotating each definition below are the range of ASCII values which are allowed in that definition.
@@ -317,7 +315,7 @@ namespace System.Net.Mime
                 localBuilder.Append(' ');
             }
 
-            string[] offsetFields = offset.Split(s_colonSeparator);
+            string[] offsetFields = offset.Split(':');
             localBuilder.Append(offsetFields[0]);
             localBuilder.Append(offsetFields[1]);
             return (builder != null ? null : localBuilder.ToString());

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesignerOptionService.cs
@@ -14,7 +14,6 @@ namespace System.ComponentModel.Design
     public abstract class DesignerOptionService : IDesignerOptionService
     {
         private DesignerOptionCollection _options;
-        private static readonly char[] s_slash = { '\\' };
 
         /// <summary>
         /// Returns the options collection for this service. There is
@@ -70,7 +69,7 @@ namespace System.ComponentModel.Design
                 throw new ArgumentNullException(nameof(valueName));
             }
 
-            string[] optionNames = pageName.Split(s_slash);
+            string[] optionNames = pageName.Split('\\');
 
             DesignerOptionCollection options = Options;
             foreach (string optionName in optionNames)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/EnumConverter.cs
@@ -16,8 +16,6 @@ namespace System.ComponentModel
     /// </summary>
     public class EnumConverter : TypeConverter
     {
-        private static readonly char[] s_separators = { ',' };
-
         /// <summary>
         /// Initializes a new instance of the <see cref='System.ComponentModel.EnumConverter'/> class for the given
         /// type.
@@ -83,7 +81,7 @@ namespace System.ComponentModel
                     {
                         bool isUnderlyingTypeUInt64 = Enum.GetUnderlyingType(EnumType) == typeof(ulong);
                         long convertedValue = 0;
-                        string[] values = strValue.Split(s_separators);
+                        string[] values = strValue.Split(',');
                         foreach (string v in values)
                         {
                             convertedValue |= GetEnumValue(isUnderlyingTypeUInt64, (Enum)Enum.Parse(EnumType, v, true), culture);

--- a/src/libraries/System.Data.Common/src/System/Data/XDRSchema.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/XDRSchema.cs
@@ -16,7 +16,6 @@ namespace System.Data
         internal string _schemaUri;
         internal XmlElement _schemaRoot;
         internal DataSet _ds;
-        private static readonly char[] s_colonArray = new char[] { ':' };
 
         internal XDRSchema(DataSet ds, bool fInline)
         {
@@ -294,7 +293,7 @@ namespace System.Data
         private Type ParseDataType(string dt, string dtValues)
         {
             string strType = dt;
-            string[] parts = dt.Split(s_colonArray);  // ":"
+            string[] parts = dt.Split(':');
 
             if (parts.Length > 2)
             {

--- a/src/libraries/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -11,8 +11,6 @@ namespace System.Diagnostics
 {
     public sealed partial class FileVersionInfo
     {
-        private static readonly char[] s_versionSeparators = new char[] { '.' };
-
         private FileVersionInfo(string fileName)
         {
             _fileName = fileName;
@@ -204,7 +202,7 @@ namespace System.Diagnostics
 
             if (versionString != null)
             {
-                string[] parts = versionString.Split(s_versionSeparators);
+                string[] parts = versionString.Split('.');
                 if (parts.Length <= 4 && parts.Length > 0)
                 {
                     major = ParseUInt16UntilNonDigit(parts[0], out bool endedEarly);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintingServices.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Printing/PrintingServices.Unix.cs
@@ -422,9 +422,9 @@ namespace System.Drawing.Printing
             int x_resolution, y_resolution;
             try
             {
-                if (resolution.Contains("x")) // string.Contains(char) is .NetCore2.1+ specific
+                if (resolution.Contains('x'))
                 {
-                    string[] resolutions = resolution.Split(new[] { 'x' });
+                    string[] resolutions = resolution.Split('x');
                     x_resolution = Convert.ToInt32(resolutions[0]);
                     y_resolution = Convert.ToInt32(resolutions[1]);
                 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/CryptoConfig.cs
@@ -38,8 +38,6 @@ namespace System.Security.Cryptography
         private static readonly ConcurrentDictionary<string, Type> appNameHT = new ConcurrentDictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentDictionary<string, string> appOidHT = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        private static readonly char[] SepArray = { '.' }; // valid ASN.1 separators
-
         // .NET Core does not support AllowOnlyFipsAlgorithms
         public static bool AllowOnlyFipsAlgorithms => false;
 
@@ -503,7 +501,7 @@ namespace System.Security.Cryptography
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
 
-            string[] oidString = str.Split(SepArray);
+            string[] oidString = str.Split('.'); // valid ASN.1 separator
             uint[] oidNums = new uint[oidString.Length];
             for (int i = 0; i < oidString.Length; i++)
             {


### PR DESCRIPTION
Now that we have a Split overload that takes a single char, the previous optimization to cache an array and reuse that array with the array-based overload isn't needed.