### PR TITLE
Log Formatting for Microsoft.Extensions.Logging

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.Logging.Console
         public ConsoleLoggerOptions() { }
         public bool DisableColors { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.Console.ConsoleLoggerFormat Format { get { throw null; } set { } }
+        public string Formatter { get { throw null; } set { } }
         public bool IncludeScopes { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
         public string TimestampFormat { get { throw null; } set { } }
@@ -33,9 +34,45 @@ namespace Microsoft.Extensions.Logging.Console
     [Microsoft.Extensions.Logging.ProviderAliasAttribute("Console")]
     public partial class ConsoleLoggerProvider : Microsoft.Extensions.Logging.ILoggerProvider, Microsoft.Extensions.Logging.ISupportExternalScope, System.IDisposable
     {
-        public ConsoleLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions> options) { }
+        public ConsoleLoggerProvider(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions> options, System.Collections.Generic.IEnumerable<Microsoft.Extensions.Logging.Console.ILogFormatter> formatters) { }
         public Microsoft.Extensions.Logging.ILogger CreateLogger(string name) { throw null; }
         public void Dispose() { }
         public void SetScopeProvider(Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { }
+    }
+    public partial class DefaultLogFormatter : Microsoft.Extensions.Logging.Console.ILogFormatter
+    {
+        public DefaultLogFormatter() { }
+        public string Name { get { throw null; } }
+        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception) { throw null; }
+    }
+    public partial class DefaultLogFormatterOptions
+    {
+        public DefaultLogFormatterOptions() { }
+    }
+    public partial interface ILogFormatter
+    {
+        string Name { get; }
+        Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception);
+    }
+    public readonly partial struct LogMessageEntry
+    {
+        public readonly System.ConsoleColor? LevelBackground;
+        public readonly System.ConsoleColor? LevelForeground;
+        public readonly string LevelString;
+        public readonly bool LogAsError;
+        public readonly string Message;
+        public readonly System.ConsoleColor? MessageColor;
+        public readonly string TimeStamp;
+        public LogMessageEntry(string message, string timeStamp = null, string levelString = null, System.ConsoleColor? levelBackground = default(System.ConsoleColor?), System.ConsoleColor? levelForeground = default(System.ConsoleColor?), System.ConsoleColor? messageColor = default(System.ConsoleColor?), bool logAsError = false) { throw null; }
+    }
+    public partial class SystemdLogFormatter : Microsoft.Extensions.Logging.Console.ILogFormatter
+    {
+        public SystemdLogFormatter() { }
+        public string Name { get { throw null; } }
+        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception) { throw null; }
+    }
+    public partial class SystemdLogFormatterOptions
+    {
+        public SystemdLogFormatterOptions() { }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Extensions.Logging.Console
         public Microsoft.Extensions.Logging.Console.ConsoleLoggerFormat Format { get { throw null; } set { } }
         public string Formatter { get { throw null; } set { } }
         public bool IncludeScopes { get { throw null; } set { } }
+        public System.Text.Json.JsonWriterOptions JsonWriterOptions { get { throw null; } set { } }
         public Microsoft.Extensions.Logging.LogLevel LogToStandardErrorThreshold { get { throw null; } set { } }
         public string TimestampFormat { get { throw null; } set { } }
         public bool UseUtcTimestamp { get { throw null; } set { } }
@@ -42,17 +43,37 @@ namespace Microsoft.Extensions.Logging.Console
     public partial class DefaultLogFormatter : Microsoft.Extensions.Logging.Console.ILogFormatter
     {
         public DefaultLogFormatter() { }
+        public Microsoft.Extensions.Logging.Console.DefaultLogFormatterOptions FormatterOptions { get { throw null; } set { } }
         public string Name { get { throw null; } }
-        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception) { throw null; }
+        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception, Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { throw null; }
     }
     public partial class DefaultLogFormatterOptions
     {
         public DefaultLogFormatterOptions() { }
     }
+    public partial interface IConsole
+    {
+        void Flush();
+        void Write(string message, System.ConsoleColor? background, System.ConsoleColor? foreground);
+        void WriteLine(string message, System.ConsoleColor? background, System.ConsoleColor? foreground);
+    }
     public partial interface ILogFormatter
     {
         string Name { get; }
-        Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception);
+        Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception, Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider);
+    }
+    public partial class JsonConsoleLogFormatter : Microsoft.Extensions.Logging.Console.ILogFormatter, System.IDisposable
+    {
+        public JsonConsoleLogFormatter(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.Console.JsonLogFormatterOptions> options) { }
+        public Microsoft.Extensions.Logging.Console.JsonLogFormatterOptions FormatterOptions { get { throw null; } set { } }
+        public string Name { get { throw null; } }
+        public void Dispose() { }
+        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception, Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { throw null; }
+    }
+    public partial class JsonLogFormatterOptions
+    {
+        public JsonLogFormatterOptions() { }
+        public System.Text.Json.JsonWriterOptions JsonWriterOptions { get { throw null; } set { } }
     }
     public readonly partial struct LogMessageEntry
     {
@@ -63,13 +84,15 @@ namespace Microsoft.Extensions.Logging.Console
         public readonly string Message;
         public readonly System.ConsoleColor? MessageColor;
         public readonly string TimeStamp;
-        public LogMessageEntry(string message, string timeStamp = null, string levelString = null, System.ConsoleColor? levelBackground = default(System.ConsoleColor?), System.ConsoleColor? levelForeground = default(System.ConsoleColor?), System.ConsoleColor? messageColor = default(System.ConsoleColor?), bool logAsError = false) { throw null; }
+        public readonly System.Action<Microsoft.Extensions.Logging.Console.IConsole> WriteCallback;
+        public LogMessageEntry(string message, string timeStamp = null, string levelString = null, System.ConsoleColor? levelBackground = default(System.ConsoleColor?), System.ConsoleColor? levelForeground = default(System.ConsoleColor?), System.ConsoleColor? messageColor = default(System.ConsoleColor?), bool logAsError = false, System.Action<Microsoft.Extensions.Logging.Console.IConsole> writeCallback = null) { throw null; }
     }
     public partial class SystemdLogFormatter : Microsoft.Extensions.Logging.Console.ILogFormatter
     {
-        public SystemdLogFormatter() { }
+        public SystemdLogFormatter(Microsoft.Extensions.Options.IOptionsMonitor<Microsoft.Extensions.Logging.Console.SystemdLogFormatterOptions> options) { }
+        public Microsoft.Extensions.Logging.Console.SystemdLogFormatterOptions FormatterOptions { get { throw null; } set { } }
         public string Name { get { throw null; } }
-        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception) { throw null; }
+        public Microsoft.Extensions.Logging.Console.LogMessageEntry Format(Microsoft.Extensions.Logging.LogLevel logLevel, string logName, int eventId, string message, System.Exception exception, Microsoft.Extensions.Logging.Console.ConsoleLoggerOptions options, Microsoft.Extensions.Logging.IExternalScopeProvider scopeProvider) { throw null; }
     }
     public partial class SystemdLogFormatterOptions
     {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/ref/Microsoft.Extensions.Logging.Console.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <Compile Include="Microsoft.Extensions.Logging.Console.cs" />
+    <ProjectReference Include="..\..\System.Text.Json\ref\System.Text.Json.csproj" />
     <ProjectReference Include="..\..\Microsoft.Extensions.Logging.Abstractions\ref\Microsoft.Extensions.Logging.Abstractions.csproj" />
     <ProjectReference Include="..\..\Microsoft.Extensions.Logging\ref\Microsoft.Extensions.Logging.csproj" />
     <ProjectReference Include="..\..\Microsoft.Extensions.Options\ref\Microsoft.Extensions.Options.csproj" />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
@@ -3,34 +3,19 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics;
-using System.Text;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.Extensions.Logging.Console
 {
     internal class ConsoleLogger : ILogger
     {
-        private static readonly string _loglevelPadding = ": ";
-        private static readonly string _messagePadding;
-        private static readonly string _newLineWithMessagePadding;
-
-        // ConsoleColor does not have a value to specify the 'Default' color
-        private readonly ConsoleColor? DefaultConsoleColor = null;
+        private readonly IEnumerable<ILogFormatter> _formatters;
 
         private readonly string _name;
         private readonly ConsoleLoggerProcessor _queueProcessor;
 
-        [ThreadStatic]
-        private static StringBuilder _logBuilder;
-
-        static ConsoleLogger()
-        {
-            var logLevelString = GetLogLevelString(LogLevel.Information);
-            _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
-            _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
-        }
-
-        internal ConsoleLogger(string name, ConsoleLoggerProcessor loggerProcessor)
+        internal ConsoleLogger(string name, ConsoleLoggerProcessor loggerProcessor, IEnumerable<ILogFormatter> formatters)
         {
             if (name == null)
             {
@@ -39,6 +24,7 @@ namespace Microsoft.Extensions.Logging.Console
 
             _name = name;
             _queueProcessor = loggerProcessor;
+            _formatters = formatters;
         }
 
         internal IExternalScopeProvider ScopeProvider { get; set; }
@@ -67,161 +53,11 @@ namespace Microsoft.Extensions.Logging.Console
 
         public virtual void WriteMessage(LogLevel logLevel, string logName, int eventId, string message, Exception exception)
         {
-            var format = Options.Format;
-            Debug.Assert(format >= ConsoleLoggerFormat.Default && format <= ConsoleLoggerFormat.Systemd);
-
-            var logBuilder = _logBuilder;
-            _logBuilder = null;
-
-            if (logBuilder == null)
-            {
-                logBuilder = new StringBuilder();
-            }
-
-            LogMessageEntry entry;
-            if (format == ConsoleLoggerFormat.Default)
-            {
-                entry = CreateDefaultLogMessage(logBuilder, logLevel, logName, eventId, message, exception);
-            }
-            else if (format == ConsoleLoggerFormat.Systemd)
-            {
-                entry = CreateSystemdLogMessage(logBuilder, logLevel, logName, eventId, message, exception);
-            }
-            else
-            {
-                entry = default;
-            }
+            var formatter = _formatters.Single(f => f.Name == (Options.Formatter ?? Options.Format.ToString()));
+            var entry = formatter.Format(logLevel, logName, eventId, message, exception);
             _queueProcessor.EnqueueMessage(entry);
-
-            logBuilder.Clear();
-            if (logBuilder.Capacity > 1024)
-            {
-                logBuilder.Capacity = 1024;
-            }
-            _logBuilder = logBuilder;
         }
 
-        private LogMessageEntry CreateDefaultLogMessage(StringBuilder logBuilder, LogLevel logLevel, string logName, int eventId, string message, Exception exception)
-        {
-            // Example:
-            // INFO: ConsoleApp.Program[10]
-            //       Request received
-
-            var logLevelColors = GetLogLevelConsoleColors(logLevel);
-            var logLevelString = GetLogLevelString(logLevel);
-            // category and event id
-            logBuilder.Append(_loglevelPadding);
-            logBuilder.Append(logName);
-            logBuilder.Append('[');
-            logBuilder.Append(eventId);
-            logBuilder.AppendLine("]");
-
-            // scope information
-            GetScopeInformation(logBuilder, multiLine: true);
-
-            if (!string.IsNullOrEmpty(message))
-            {
-                // message
-                logBuilder.Append(_messagePadding);
-
-                var len = logBuilder.Length;
-                logBuilder.AppendLine(message);
-                logBuilder.Replace(Environment.NewLine, _newLineWithMessagePadding, len, message.Length);
-            }
-
-            // Example:
-            // System.InvalidOperationException
-            //    at Namespace.Class.Function() in File:line X
-            if (exception != null)
-            {
-                // exception message
-                logBuilder.AppendLine(exception.ToString());
-            }
-
-            string timestamp = null;
-            var timestampFormat = Options.TimestampFormat;
-            if (timestampFormat != null)
-            {
-                var dateTime = GetCurrentDateTime();
-                timestamp = dateTime.ToString(timestampFormat);
-            }
-
-            return new LogMessageEntry(
-                message: logBuilder.ToString(),
-                timeStamp: timestamp,
-                levelString: logLevelString,
-                levelBackground: logLevelColors.Background,
-                levelForeground: logLevelColors.Foreground,
-                messageColor: DefaultConsoleColor,
-                logAsError: logLevel >= Options.LogToStandardErrorThreshold
-            );
-        }
-
-        private LogMessageEntry CreateSystemdLogMessage(StringBuilder logBuilder, LogLevel logLevel, string logName, int eventId, string message, Exception exception)
-        {
-            // systemd reads messages from standard out line-by-line in a '<pri>message' format.
-            // newline characters are treated as message delimiters, so we must replace them.
-            // Messages longer than the journal LineMax setting (default: 48KB) are cropped.
-            // Example:
-            // <6>ConsoleApp.Program[10] Request received
-
-            // loglevel
-            var logLevelString = GetSyslogSeverityString(logLevel);
-            logBuilder.Append(logLevelString);
-
-            // timestamp
-            var timestampFormat = Options.TimestampFormat;
-            if (timestampFormat != null)
-            {
-                var dateTime = GetCurrentDateTime();
-                logBuilder.Append(dateTime.ToString(timestampFormat));
-            }
-
-            // category and event id
-            logBuilder.Append(logName);
-            logBuilder.Append('[');
-            logBuilder.Append(eventId);
-            logBuilder.Append(']');
-
-            // scope information
-            GetScopeInformation(logBuilder, multiLine: false);
-
-            // message
-            if (!string.IsNullOrEmpty(message))
-            {
-                logBuilder.Append(' ');
-                // message
-                AppendAndReplaceNewLine(logBuilder, message);
-            }
-
-            // exception
-            // System.InvalidOperationException at Namespace.Class.Function() in File:line X
-            if (exception != null)
-            {
-                logBuilder.Append(' ');
-                AppendAndReplaceNewLine(logBuilder, exception.ToString());
-            }
-
-            // newline delimiter
-            logBuilder.Append(Environment.NewLine);
-
-            return new LogMessageEntry(
-                message: logBuilder.ToString(),
-                logAsError: logLevel >= Options.LogToStandardErrorThreshold
-            );
-
-            static void AppendAndReplaceNewLine(StringBuilder sb, string message)
-            {
-                var len = sb.Length;
-                sb.Append(message);
-                sb.Replace(Environment.NewLine, " ", len, message.Length);
-            }
-        }
-
-        private DateTime GetCurrentDateTime()
-        {
-            return Options.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
-        }
 
         public bool IsEnabled(LogLevel logLevel)
         {
@@ -229,118 +65,5 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         public IDisposable BeginScope<TState>(TState state) => ScopeProvider?.Push(state) ?? NullScope.Instance;
-
-        private static string GetLogLevelString(LogLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LogLevel.Trace:
-                    return "trce";
-                case LogLevel.Debug:
-                    return "dbug";
-                case LogLevel.Information:
-                    return "info";
-                case LogLevel.Warning:
-                    return "warn";
-                case LogLevel.Error:
-                    return "fail";
-                case LogLevel.Critical:
-                    return "crit";
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(logLevel));
-            }
-        }
-
-        private static string GetSyslogSeverityString(LogLevel logLevel)
-        {
-            // 'Syslog Message Severities' from https://tools.ietf.org/html/rfc5424.
-            switch (logLevel)
-            {
-                case LogLevel.Trace:
-                case LogLevel.Debug:
-                    return "<7>"; // debug-level messages
-                case LogLevel.Information:
-                    return "<6>"; // informational messages
-                case LogLevel.Warning:
-                    return "<4>"; // warning conditions
-                case LogLevel.Error:
-                    return "<3>"; // error conditions
-                case LogLevel.Critical:
-                    return "<2>"; // critical conditions
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(logLevel));
-            }
-        }
-
-        private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
-        {
-            if (Options.DisableColors)
-            {
-                return new ConsoleColors(null, null);
-            }
-
-            // We must explicitly set the background color if we are setting the foreground color,
-            // since just setting one can look bad on the users console.
-            switch (logLevel)
-            {
-                case LogLevel.Critical:
-                    return new ConsoleColors(ConsoleColor.White, ConsoleColor.Red);
-                case LogLevel.Error:
-                    return new ConsoleColors(ConsoleColor.Black, ConsoleColor.Red);
-                case LogLevel.Warning:
-                    return new ConsoleColors(ConsoleColor.Yellow, ConsoleColor.Black);
-                case LogLevel.Information:
-                    return new ConsoleColors(ConsoleColor.DarkGreen, ConsoleColor.Black);
-                case LogLevel.Debug:
-                    return new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black);
-                case LogLevel.Trace:
-                    return new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black);
-                default:
-                    return new ConsoleColors(DefaultConsoleColor, DefaultConsoleColor);
-            }
-        }
-
-        private void GetScopeInformation(StringBuilder stringBuilder, bool multiLine)
-        {
-            var scopeProvider = ScopeProvider;
-            if (Options.IncludeScopes && scopeProvider != null)
-            {
-                var initialLength = stringBuilder.Length;
-
-                scopeProvider.ForEachScope((scope, state) =>
-                {
-                    var (builder, paddAt) = state;
-                    var padd = paddAt == builder.Length;
-                    if (padd)
-                    {
-                        builder.Append(_messagePadding);
-                        builder.Append("=> ");
-                    }
-                    else
-                    {
-                        builder.Append(" => ");
-                    }
-                    builder.Append(scope);
-                }, (stringBuilder, multiLine ? initialLength : -1));
-
-                if (stringBuilder.Length > initialLength && multiLine)
-                {
-                    stringBuilder.AppendLine();
-                }
-            }
-        }
-
-        private readonly struct ConsoleColors
-        {
-            public ConsoleColors(ConsoleColor? foreground, ConsoleColor? background)
-            {
-                Foreground = foreground;
-                Background = background;
-            }
-
-            public ConsoleColor? Foreground { get; }
-
-            public ConsoleColor? Background { get; }
-        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Extensions.Logging
         {
             builder.AddConfiguration();
 
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILogFormatter, DefaultLogFormatter>());
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILogFormatter, SystemdLogFormatter>());
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ConsoleLoggerProvider>());
             LoggerProviderOptions.RegisterProviderOptions<ConsoleLoggerOptions, ConsoleLoggerProvider>(builder.Services);
             return builder;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFactoryExtensions.cs
@@ -5,8 +5,16 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Configuration;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.Extensions.Logging
 {
@@ -20,10 +28,18 @@ namespace Microsoft.Extensions.Logging
         {
             builder.AddConfiguration();
 
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILogFormatter, JsonConsoleLogFormatter>());
+            LoggerProviderOptions.RegisterProviderOptions<JsonLogFormatterOptions, JsonConsoleLogFormatter>(builder.Services);
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILogFormatter, DefaultLogFormatter>());
+            LoggerProviderOptions.RegisterProviderOptions<DefaultLogFormatterOptions, DefaultLogFormatter>(builder.Services);
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILogFormatter, SystemdLogFormatter>());
+            LoggerProviderOptions.RegisterProviderOptions<SystemdLogFormatterOptions, SystemdLogFormatter>(builder.Services);
+
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, ConsoleLoggerProvider>());
             LoggerProviderOptions.RegisterProviderOptions<ConsoleLoggerOptions, ConsoleLoggerProvider>(builder.Services);
+
             return builder;
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Produces messages in a format suitable for console output to the systemd journal.
         /// </summary>
-        Systemd
+        Systemd,
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerFormat.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Extensions.Logging.Console
         /// <summary>
         /// Produces messages in a format suitable for console output to the systemd journal.
         /// </summary>
-        Systemd,
+        Systemd
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Text.Json;
 
 namespace Microsoft.Extensions.Logging.Console
 {
@@ -11,8 +12,6 @@ namespace Microsoft.Extensions.Logging.Console
     /// </summary>
     public class ConsoleLoggerOptions
     {
-        private ConsoleLoggerFormat _format = ConsoleLoggerFormat.Default;
-
         /// <summary>
         /// Includes scopes when <see langword="true" />.
         /// </summary>
@@ -28,14 +27,25 @@ namespace Microsoft.Extensions.Logging.Console
         /// </summary>
         public ConsoleLoggerFormat Format
         {
-            get => _format;
+            get
+            {
+                try {
+                    return (ConsoleLoggerFormat) Enum.Parse(typeof(ConsoleLoggerFormat), Formatter);
+                }
+                catch (ArgumentException) {
+                    return ConsoleLoggerFormat.Default;
+                }
+            }
             set
             {
-                if (value < ConsoleLoggerFormat.Default || value > ConsoleLoggerFormat.Systemd)
+                if (value == ConsoleLoggerFormat.Systemd)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value));
+                    Formatter = Enum.GetName(typeof(ConsoleLoggerFormat), ConsoleLoggerFormat.Systemd);
                 }
-                _format = value;
+                else
+                {
+                    Formatter = Enum.GetName(typeof(ConsoleLoggerFormat), ConsoleLoggerFormat.Default);
+                }
             }
         }
 
@@ -43,7 +53,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// 
         /// </summary>
         public string Formatter { get; set; }
-
+        
         /// <summary>
         /// Gets or sets value indicating the minimum level of messaged that would get written to <c>Console.Error</c>.
         /// </summary>
@@ -58,5 +68,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// Gets or sets indication whether or not UTC timezone should be used to for timestamps in logging messages. Defaults to <c>false</c>.
         /// </summary>
         public bool UseUtcTimestamp { get; set; }
+
+        public JsonWriterOptions JsonWriterOptions { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerOptions.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Extensions.Logging.Console
         }
 
         /// <summary>
+        /// 
+        /// </summary>
+        public string Formatter { get; set; }
+
+        /// <summary>
         /// Gets or sets value indicating the minimum level of messaged that would get written to <c>Console.Error</c>.
         /// </summary>
         public LogLevel LogToStandardErrorThreshold { get; set; } = LogLevel.None;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProcessor.cs
@@ -53,19 +53,7 @@ namespace Microsoft.Extensions.Logging.Console
         internal virtual void WriteMessage(LogMessageEntry message)
         {
             var console = message.LogAsError ? ErrorConsole : Console;
-
-            if (message.TimeStamp != null)
-            {
-                console.Write(message.TimeStamp, message.MessageColor, message.MessageColor);
-            }
-
-            if (message.LevelString != null)
-            {
-                console.Write(message.LevelString, message.LevelBackground, message.LevelForeground);
-            }
-
-            console.Write(message.Message, message.MessageColor, message.MessageColor);
-            console.Flush();
+            message.WriteCallback(console);
         }
 
         private void ProcessLogQueue()

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLoggerProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Options;
 
@@ -18,6 +19,7 @@ namespace Microsoft.Extensions.Logging.Console
         private readonly IOptionsMonitor<ConsoleLoggerOptions> _options;
         private readonly ConcurrentDictionary<string, ConsoleLogger> _loggers;
         private readonly ConsoleLoggerProcessor _messageQueue;
+        private readonly IEnumerable<ILogFormatter> _formatters;
 
         private IDisposable _optionsReloadToken;
         private IExternalScopeProvider _scopeProvider = NullExternalScopeProvider.Instance;
@@ -26,10 +28,12 @@ namespace Microsoft.Extensions.Logging.Console
         /// Creates an instance of <see cref="ConsoleLoggerProvider"/>.
         /// </summary>
         /// <param name="options">The options to create <see cref="ConsoleLogger"/> instances with.</param>
-        public ConsoleLoggerProvider(IOptionsMonitor<ConsoleLoggerOptions> options)
+        /// <param name="formatters"></param>
+        public ConsoleLoggerProvider(IOptionsMonitor<ConsoleLoggerOptions> options, IEnumerable<ILogFormatter> formatters)
         {
             _options = options;
             _loggers = new ConcurrentDictionary<string, ConsoleLogger>();
+            _formatters = formatters;
 
             ReloadLoggerOptions(options.CurrentValue);
             _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
@@ -58,7 +62,7 @@ namespace Microsoft.Extensions.Logging.Console
         /// <inheritdoc />
         public ILogger CreateLogger(string name)
         {
-            return _loggers.GetOrAdd(name, loggerName => new ConsoleLogger(name, _messageQueue)
+            return _loggers.GetOrAdd(name, loggerName => new ConsoleLogger(name, _messageQueue, _formatters)
             {
                 Options = _options.CurrentValue,
                 ScopeProvider = _scopeProvider

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/CompactLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/CompactLogFormatter.cs
@@ -7,7 +7,7 @@ using System.Text;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    public class DefaultLogFormatter : ILogFormatter
+    internal class CompactLogFormatter : ILogFormatter
     {
         private static readonly string _loglevelPadding = ": ";
         private static readonly string _messagePadding;
@@ -19,21 +19,20 @@ namespace Microsoft.Extensions.Logging.Console
         [ThreadStatic]
         private static StringBuilder _logBuilder;
 
-        static DefaultLogFormatter()
+        static CompactLogFormatter()
         {
             var logLevelString = GetLogLevelString(LogLevel.Information);
             _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
             _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
         }
 
-        public DefaultLogFormatter() { }
+        public CompactLogFormatter() { }
 
-        public string Name => "Default";
-
-        public DefaultLogFormatterOptions FormatterOptions { get; set; }
+        public string Name => "Compact";
 
         public LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception, ConsoleLoggerOptions options, IExternalScopeProvider scopeProvider)
         {
+            // todo fix later:
             var logBuilder = _logBuilder;
             _logBuilder = null;
 
@@ -53,7 +52,8 @@ namespace Microsoft.Extensions.Logging.Console
             logBuilder.Append(logName);
             logBuilder.Append("[");
             logBuilder.Append(eventId);
-            logBuilder.AppendLine("]");
+            logBuilder.Append("]");
+            // logBuilder.AppendLine("]");
 
             // scope information
             GetScopeInformation(logBuilder, options, scopeProvider);
@@ -65,7 +65,6 @@ namespace Microsoft.Extensions.Logging.Console
 
                 var len = logBuilder.Length;
                 logBuilder.AppendLine(message);
-                logBuilder.Replace(Environment.NewLine, _newLineWithMessagePadding, len, message.Length);
             }
 
             // Example:
@@ -74,7 +73,8 @@ namespace Microsoft.Extensions.Logging.Console
             if (exception != null)
             {
                 // exception message
-                logBuilder.AppendLine(exception.ToString());
+                logBuilder.Append(exception.ToString());
+                // logBuilder.AppendLine(exception.ToString());
             }
 
             string timestamp = null;
@@ -129,17 +129,17 @@ namespace Microsoft.Extensions.Logging.Console
             switch (logLevel)
             {
                 case LogLevel.Trace:
-                    return "trce";
+                    return "compact_trce";
                 case LogLevel.Debug:
-                    return "dbug";
+                    return "compact_dbug";
                 case LogLevel.Information:
-                    return "info";
+                    return "compact_info";
                 case LogLevel.Warning:
-                    return "warn";
+                    return "compact_warn";
                 case LogLevel.Error:
-                    return "fail";
+                    return "compact_fail";
                 case LogLevel.Critical:
-                    return "crit";
+                    return "compact_crit";
                 default:
                     throw new ArgumentOutOfRangeException(nameof(logLevel));
             }
@@ -186,18 +186,15 @@ namespace Microsoft.Extensions.Logging.Console
                     if (padd)
                     {
                         builder.Append(_messagePadding);
-                        builder.Append("=> ");
                     }
-                    else
-                    {
-                        builder.Append(" => ");
-                    }
+                    builder.Append("=> ");
                     builder.Append(scope);
+                    builder.Append(" ");
                 }, (stringBuilder, initialLength));
 
                 if (stringBuilder.Length > initialLength)
                 {
-                    stringBuilder.AppendLine();
+                    // stringBuilder.AppendLine();
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultLogFormatter.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public class DefaultLogFormatter : ILogFormatter
+    {
+        private static readonly string _loglevelPadding = ": ";
+        private static readonly string _messagePadding;
+        private static readonly string _newLineWithMessagePadding;
+
+        // ConsoleColor does not have a value to specify the 'Default' color
+        private readonly ConsoleColor? DefaultConsoleColor = null;
+
+        [ThreadStatic]
+        private static StringBuilder _logBuilder;
+
+        static DefaultLogFormatter()
+        {
+            var logLevelString = GetLogLevelString(LogLevel.Information);
+            _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
+            _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
+        }
+
+        public string Name => "Default";
+
+        internal IExternalScopeProvider ScopeProvider { get; set; }
+
+        internal ConsoleLoggerOptions Options { get; set; }
+
+        public LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception)
+        {
+            var logBuilder = _logBuilder;
+            _logBuilder = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+
+            // Example:
+            // INFO: ConsoleApp.Program[10]
+            //       Request received
+
+            var logLevelColors = GetLogLevelConsoleColors(logLevel);
+            var logLevelString = GetLogLevelString(logLevel);
+            // category and event id
+            logBuilder.Append(_loglevelPadding);
+            logBuilder.Append(logName);
+            logBuilder.Append("[");
+            logBuilder.Append(eventId);
+            logBuilder.AppendLine("]");
+
+            // scope information
+            GetScopeInformation(logBuilder);
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                // message
+                logBuilder.Append(_messagePadding);
+
+                var len = logBuilder.Length;
+                logBuilder.AppendLine(message);
+                logBuilder.Replace(Environment.NewLine, _newLineWithMessagePadding, len, message.Length);
+            }
+
+            // Example:
+            // System.InvalidOperationException
+            //    at Namespace.Class.Function() in File:line X
+            if (exception != null)
+            {
+                // exception message
+                logBuilder.AppendLine(exception.ToString());
+            }
+
+            string timestamp = null;
+            var timestampFormat = Options.TimestampFormat;
+            if (timestampFormat != null)
+            {
+                var dateTime = GetCurrentDateTime();
+                timestamp = dateTime.ToString(timestampFormat);
+            }
+
+            var formattedMessage = logBuilder.ToString();
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _logBuilder = logBuilder;
+
+            return new LogMessageEntry(
+                message: formattedMessage,
+                timeStamp: timestamp,
+                levelString: logLevelString,
+                levelBackground: logLevelColors.Background,
+                levelForeground: logLevelColors.Foreground,
+                messageColor: DefaultConsoleColor,
+                logAsError: logLevel >= Options.LogToStandardErrorThreshold
+            );
+        }
+
+        private DateTime GetCurrentDateTime()
+        {
+            return Options.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+        }
+
+        private static string GetLogLevelString(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                    return "trce";
+                case LogLevel.Debug:
+                    return "dbug";
+                case LogLevel.Information:
+                    return "info";
+                case LogLevel.Warning:
+                    return "warn";
+                case LogLevel.Error:
+                    return "fail";
+                case LogLevel.Critical:
+                    return "crit";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        private ConsoleColors GetLogLevelConsoleColors(LogLevel logLevel)
+        {
+            if (Options.DisableColors)
+            {
+                return new ConsoleColors(null, null);
+            }
+
+            // We must explicitly set the background color if we are setting the foreground color,
+            // since just setting one can look bad on the users console.
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    return new ConsoleColors(ConsoleColor.White, ConsoleColor.Red);
+                case LogLevel.Error:
+                    return new ConsoleColors(ConsoleColor.Black, ConsoleColor.Red);
+                case LogLevel.Warning:
+                    return new ConsoleColors(ConsoleColor.Yellow, ConsoleColor.Black);
+                case LogLevel.Information:
+                    return new ConsoleColors(ConsoleColor.DarkGreen, ConsoleColor.Black);
+                case LogLevel.Debug:
+                    return new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black);
+                case LogLevel.Trace:
+                    return new ConsoleColors(ConsoleColor.Gray, ConsoleColor.Black);
+                default:
+                    return new ConsoleColors(DefaultConsoleColor, DefaultConsoleColor);
+            }
+        }
+
+        private void GetScopeInformation(StringBuilder stringBuilder)
+        {
+            var scopeProvider = ScopeProvider;
+            if (Options.IncludeScopes && scopeProvider != null)
+            {
+                var initialLength = stringBuilder.Length;
+
+                scopeProvider.ForEachScope((scope, state) =>
+                {
+                    var (builder, paddAt) = state;
+                    var padd = paddAt == builder.Length;
+                    if (padd)
+                    {
+                        builder.Append(_messagePadding);
+                        builder.Append("=> ");
+                    }
+                    else
+                    {
+                        builder.Append(" => ");
+                    }
+                    builder.Append(scope);
+                }, (stringBuilder, initialLength));
+
+                if (stringBuilder.Length > initialLength)
+                {
+                    stringBuilder.AppendLine();
+                }
+            }
+        }
+
+        private readonly struct ConsoleColors
+        {
+            public ConsoleColors(ConsoleColor? foreground, ConsoleColor? background)
+            {
+                Foreground = foreground;
+                Background = background;
+            }
+
+            public ConsoleColor? Foreground { get; }
+
+            public ConsoleColor? Background { get; }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/DefaultLogFormatterOptions.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public class DefaultLogFormatterOptions
+    {
+
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/ILogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/ILogFormatter.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public interface ILogFormatter
+    {
+        string Name { get; }
+        LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception);
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/ILogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/ILogFormatter.cs
@@ -1,5 +1,6 @@
-// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 
@@ -8,6 +9,6 @@ namespace Microsoft.Extensions.Logging.Console
     public interface ILogFormatter
     {
         string Name { get; }
-        LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception);
+        LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception, ConsoleLoggerOptions options, IExternalScopeProvider scopeProvider);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonLogFormatter.cs
@@ -1,0 +1,405 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    internal sealed class PooledByteBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        private byte[] _rentedBuffer;
+        private int _index;
+
+        private const int MinimumBufferSize = 256;
+
+        public PooledByteBufferWriter(int initialCapacity)
+        {
+            Debug.Assert(initialCapacity > 0);
+
+            _rentedBuffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+            _index = 0;
+        }
+
+        public ReadOnlyMemory<byte> WrittenMemory
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                Debug.Assert(_index <= _rentedBuffer.Length);
+                return _rentedBuffer.AsMemory(0, _index);
+            }
+        }
+
+        public int WrittenCount
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                return _index;
+            }
+        }
+
+        public int Capacity
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                return _rentedBuffer.Length;
+            }
+        }
+
+        public int FreeCapacity
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                return _rentedBuffer.Length - _index;
+            }
+        }
+
+        public void Clear()
+        {
+            ClearHelper();
+        }
+
+        private void ClearHelper()
+        {
+            Debug.Assert(_rentedBuffer != null);
+            Debug.Assert(_index <= _rentedBuffer.Length);
+
+            _rentedBuffer.AsSpan(0, _index).Clear();
+            _index = 0;
+        }
+
+        // Returns the rented buffer back to the pool
+        public void Dispose()
+        {
+            if (_rentedBuffer == null)
+            {
+                return;
+            }
+
+            ClearHelper();
+            ArrayPool<byte>.Shared.Return(_rentedBuffer);
+            _rentedBuffer = null!;
+        }
+
+        public void Advance(int count)
+        {
+            Debug.Assert(_rentedBuffer != null);
+            Debug.Assert(count >= 0);
+            Debug.Assert(_index <= _rentedBuffer.Length - count);
+
+            _index += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _rentedBuffer.AsMemory(_index);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = 0)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _rentedBuffer.AsSpan(_index);
+        }
+
+#if BUILDING_INBOX_LIBRARY
+        internal ValueTask WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            return destination.WriteAsync(WrittenMemory, cancellationToken);
+        }
+#else
+        internal Task WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            return destination.WriteAsync(_rentedBuffer, 0, _index, cancellationToken);
+        }
+#endif
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            Debug.Assert(_rentedBuffer != null);
+            Debug.Assert(sizeHint >= 0);
+
+            if (sizeHint == 0)
+            {
+                sizeHint = MinimumBufferSize;
+            }
+
+            int availableSpace = _rentedBuffer.Length - _index;
+
+            if (sizeHint > availableSpace)
+            {
+                int currentLength = _rentedBuffer.Length;
+                int growBy = Math.Max(sizeHint, currentLength);
+
+                int newSize = currentLength + growBy;
+
+                if ((uint)newSize > int.MaxValue)
+                {
+                    newSize = currentLength + sizeHint;
+                    if ((uint)newSize > int.MaxValue)
+                    {
+                        throw new OutOfMemoryException("(uint)newSize _BufferMaximumSizeExceeded");
+                    }
+                }
+
+                byte[] oldBuffer = _rentedBuffer;
+
+                _rentedBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+
+                Debug.Assert(oldBuffer.Length >= _index);
+                Debug.Assert(_rentedBuffer.Length >= _index);
+
+                Span<byte> previousBuffer = oldBuffer.AsSpan(0, _index);
+                previousBuffer.CopyTo(_rentedBuffer);
+                previousBuffer.Clear();
+                ArrayPool<byte>.Shared.Return(oldBuffer);
+            }
+
+            Debug.Assert(_rentedBuffer.Length - _index > 0);
+            Debug.Assert(_rentedBuffer.Length - _index >= sizeHint);
+        }
+    }
+
+    public class JsonConsoleLogFormatter : ILogFormatter, IDisposable
+    {
+        private readonly IOptionsMonitor<JsonLogFormatterOptions> _options;
+        private IDisposable _optionsReloadToken;
+
+        private static readonly string _loglevelPadding = ": ";
+        private static readonly string _messagePadding;
+        private static readonly string _newLineWithMessagePadding;
+
+        [ThreadStatic]
+        private static StringBuilder _logBuilder;
+        [ThreadStatic]
+        private static IDictionary<string, object> _xBuilder;
+
+        static JsonConsoleLogFormatter()
+        {
+            var logLevelString = GetLogLevelString(LogLevel.Information);
+            _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
+            _newLineWithMessagePadding = Environment.NewLine + _messagePadding;
+        }
+
+        public JsonLogFormatterOptions FormatterOptions { get; set; }
+
+        public JsonConsoleLogFormatter(IOptionsMonitor<JsonLogFormatterOptions> options)
+        {
+            _options = options;
+            ReloadLoggerOptions(options.CurrentValue);
+            _optionsReloadToken = _options.OnChange(ReloadLoggerOptions);
+        }
+
+        private void ReloadLoggerOptions(JsonLogFormatterOptions options)
+        {
+            FormatterOptions = options;
+        }
+
+        public string Name => "Json";
+
+        internal IDictionary<string, object> Scope { get; } = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            _optionsReloadToken?.Dispose();
+        }
+
+        public LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception, ConsoleLoggerOptions options, IExternalScopeProvider scopeProvider)
+        {
+            var logBuilder = _logBuilder;
+            var xBuilder = _xBuilder;
+            _logBuilder = null;
+            _xBuilder = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+                xBuilder = new Dictionary<string, object>();
+            }
+
+            // Example:
+            // INFO: ConsoleApp.Program[10]
+            //       Request received
+
+            var logLevelString = GetLogLevelString(logLevel);
+
+            if (!string.IsNullOrEmpty(message))
+            {
+                const int DefaultBufferSize = 16384;
+                
+                using (var output = new PooledByteBufferWriter(DefaultBufferSize))
+                {
+                    using (var writer = new Utf8JsonWriter(output, options.JsonWriterOptions))
+                    {
+                        writer.WriteStartObject();
+                        // TimeStamp
+                        writer.WriteNumber("EventId", eventId);
+                        writer.WriteString("LogLevel", logLevelString);
+                        writer.WriteString("Category", logName);
+                        writer.WriteString("Message", message);
+
+                        GetScopeInformation(writer, options, scopeProvider);
+
+                        writer.WriteEndObject();
+                    }
+                    logBuilder.AppendLine(Encoding.UTF8.GetString(output.WrittenMemory.Span));
+                }
+            }
+
+            // Example:
+            // System.InvalidOperationException
+            //    at Namespace.Class.Function() in File:line X
+            if (exception != null)
+            {
+                // exception message
+                // logBuilder.AppendLine(exception.ToString());
+                const int DefaultBufferSize = 16384;
+                
+                using (var output = new PooledByteBufferWriter(DefaultBufferSize))
+                {
+                    using (var writer = new Utf8JsonWriter(output, FormatterOptions.JsonWriterOptions))
+                    {
+                        writer.WriteStartObject();
+                        writer.WriteString("Message", exception.Message.ToString());
+                        writer.WriteString("Type", exception.GetType().ToString());
+                        writer.WriteStartArray("StackTrace");
+                        foreach (var xx in exception?.StackTrace?.Split(Environment.NewLine))
+                        {
+                            JsonSerializer.Serialize<string>(writer, xx);
+                        }
+                        writer.WriteEndArray();
+                        writer.WriteNumber("HResult", exception.HResult);
+                        writer.WriteEndObject();
+                    }
+
+                    logBuilder.AppendLine(Encoding.UTF8.GetString(output.WrittenMemory.Span));
+                }
+            }
+
+            string timestamp = null;
+            var timestampFormat = options.TimestampFormat;
+            if (timestampFormat != null)
+            {
+                var dateTime = GetCurrentDateTime(options);
+                timestamp = dateTime.ToString(timestampFormat);
+            }
+
+            var formattedMessage = logBuilder.ToString();
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _logBuilder = logBuilder;
+            _xBuilder = xBuilder;
+
+            return new LogMessageEntry(
+                message: formattedMessage,
+                timeStamp: timestamp,
+                levelString: string.Empty,
+                levelBackground: null,
+                levelForeground: null,
+                messageColor: null,
+                logAsError: logLevel >= options.LogToStandardErrorThreshold,
+                writeCallback : console =>
+                {
+                    if (timestamp != null)
+                    {
+                        console.Write(timestamp, null, null);
+                    }
+                    
+                    console.Write(formattedMessage, null, null);
+                    console.Flush();
+                }
+            );
+        }
+
+        private DateTime GetCurrentDateTime(ConsoleLoggerOptions options)
+        {
+            return options.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+        }
+
+        private static string GetLogLevelString(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                    return "json_trce";
+                case LogLevel.Debug:
+                    return "json_dbug";
+                case LogLevel.Information:
+                    return "json_info";
+                case LogLevel.Warning:
+                    return "json_warn";
+                case LogLevel.Error:
+                    return "json_fail";
+                case LogLevel.Critical:
+                    return "json_crit";
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        private void GetScopeInformation(Utf8JsonWriter writer, ConsoleLoggerOptions options, IExternalScopeProvider scopeProvider)
+        {
+            try
+            {
+                if (options.IncludeScopes && scopeProvider != null)
+                {
+                    writer.WriteStartArray("Scopes");
+                    scopeProvider.ForEachScope((scope, state) =>
+                    {
+                        if (scope is IReadOnlyList<KeyValuePair<string, object>>)// kvps)
+                        {
+                            //foreach (var kvp in kvps)
+                            //{
+                            //    //state.WritePropertyName(kvp.Key);
+                            //    JsonSerializer.Serialize(kvp.Value);
+                            //}
+                            //state is the writer
+                            JsonSerializer.Serialize(state, scope);
+                        }
+                    }, (writer));
+                    writer.WriteEndArray();
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Console.WriteLine("Something went wrong" + ex.Message);
+            }
+        }
+
+        private readonly struct ConsoleColors
+        {
+            public ConsoleColors(ConsoleColor? foreground, ConsoleColor? background)
+            {
+                Foreground = foreground;
+                Background = background;
+            }
+
+            public ConsoleColor? Foreground { get; }
+
+            public ConsoleColor? Background { get; }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/JsonLogFormatterOptions.cs
@@ -3,13 +3,15 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Text;
+using System.Text.Json;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    public class DefaultLogFormatterOptions
+    public class JsonLogFormatterOptions
     {
-        public DefaultLogFormatterOptions() { }
+        public JsonLogFormatterOptions() { }
+        public JsonWriterOptions JsonWriterOptions { get; set; }
+        // or public JsonSerializerOptions JsonSerializerOptions { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdLogFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdLogFormatter.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public class SystemdLogFormatter : ILogFormatter
+    {
+        private static readonly string _loglevelPadding = ": ";
+        private static readonly string _messagePadding;
+
+        [ThreadStatic]
+        private static StringBuilder _logBuilder;
+
+        static SystemdLogFormatter()
+        {
+            var logLevelString = GetSyslogSeverityString(LogLevel.Information);
+            _messagePadding = new string(' ', logLevelString.Length + _loglevelPadding.Length);
+        }
+
+        public string Name => "Systemd";
+
+        internal IExternalScopeProvider ScopeProvider { get; set; }
+
+        internal ConsoleLoggerOptions Options { get; set; }
+
+        public LogMessageEntry Format(LogLevel logLevel, string logName, int eventId, string message, Exception exception)
+        {
+            var logBuilder = _logBuilder;
+            _logBuilder = null;
+
+            if (logBuilder == null)
+            {
+                logBuilder = new StringBuilder();
+            }
+
+            // systemd reads messages from standard out line-by-line in a '<pri>message' format.
+            // newline characters are treated as message delimiters, so we must replace them.
+            // Messages longer than the journal LineMax setting (default: 48KB) are cropped.
+            // Example:
+            // <6>ConsoleApp.Program[10] Request received
+
+            // loglevel
+            var logLevelString = GetSyslogSeverityString(logLevel);
+            logBuilder.Append(logLevelString);
+
+            // timestamp
+            var timestampFormat = Options.TimestampFormat;
+            if (timestampFormat != null)
+            {
+                var dateTime = GetCurrentDateTime();
+                logBuilder.Append(dateTime.ToString(timestampFormat));
+            }
+
+            // category and event id
+            logBuilder.Append(logName);
+            logBuilder.Append("[");
+            logBuilder.Append(eventId);
+            logBuilder.Append("]");
+
+            // scope information
+            GetScopeInformation(logBuilder);
+
+            // message
+            if (!string.IsNullOrEmpty(message))
+            {
+                logBuilder.Append(' ');
+                // message
+                AppendAndReplaceNewLine(logBuilder, message);
+            }
+
+            // exception
+            // System.InvalidOperationException at Namespace.Class.Function() in File:line X
+            if (exception != null)
+            {
+                logBuilder.Append(' ');
+                AppendAndReplaceNewLine(logBuilder, exception.ToString());
+            }
+
+            // newline delimiter
+            logBuilder.Append(Environment.NewLine);
+
+
+            var formattedMessage = logBuilder.ToString();
+            logBuilder.Clear();
+            if (logBuilder.Capacity > 1024)
+            {
+                logBuilder.Capacity = 1024;
+            }
+            _logBuilder = logBuilder;
+
+            return new LogMessageEntry(
+                message: formattedMessage,
+                logAsError: logLevel >= Options.LogToStandardErrorThreshold
+            );
+
+            static void AppendAndReplaceNewLine(StringBuilder sb, string message)
+            {
+                var len = sb.Length;
+                sb.Append(message);
+                sb.Replace(Environment.NewLine, " ", len, message.Length);
+            }
+        }
+
+        private DateTime GetCurrentDateTime()
+        {
+            return Options.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+        }
+
+        private static string GetSyslogSeverityString(LogLevel logLevel)
+        {
+            // 'Syslog Message Severities' from https://tools.ietf.org/html/rfc5424.
+            switch (logLevel)
+            {
+                case LogLevel.Trace:
+                case LogLevel.Debug:
+                    return "<7>"; // debug-level messages
+                case LogLevel.Information:
+                    return "<6>"; // informational messages
+                case LogLevel.Warning:
+                    return "<4>"; // warning conditions
+                case LogLevel.Error:
+                    return "<3>"; // error conditions
+                case LogLevel.Critical:
+                    return "<2>"; // critical conditions
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel));
+            }
+        }
+
+        private void GetScopeInformation(StringBuilder stringBuilder)
+        {
+            var scopeProvider = ScopeProvider;
+            if (Options.IncludeScopes && scopeProvider != null)
+            {
+                var initialLength = stringBuilder.Length;
+
+                scopeProvider.ForEachScope((scope, state) =>
+                {
+                    var (builder, paddAt) = state;
+                    var padd = paddAt == builder.Length;
+                    if (padd)
+                    {
+                        builder.Append(_messagePadding);
+                        builder.Append("=> ");
+                    }
+                    else
+                    {
+                        builder.Append(" => ");
+                    }
+                    builder.Append(scope);
+                }, (stringBuilder, -1));
+            }
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdLogFormatterOptions.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Text;
+
+namespace Microsoft.Extensions.Logging.Console
+{
+    public class SystemdLogFormatterOptions
+    {
+    }
+}

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdLogFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Formatter/SystemdLogFormatterOptions.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System;
 using System.Text;
 
@@ -5,5 +9,6 @@ namespace Microsoft.Extensions.Logging.Console
 {
     public class SystemdLogFormatterOptions
     {
+        public SystemdLogFormatterOptions() { }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/IConsole.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/IConsole.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    internal interface IConsole
+    public interface IConsole
     {
         void Write(string message, ConsoleColor? background, ConsoleColor? foreground);
         void WriteLine(string message, ConsoleColor? background, ConsoleColor? foreground);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/LogMessageEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/LogMessageEntry.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace Microsoft.Extensions.Logging.Console
 {
-    internal readonly struct LogMessageEntry
+    public readonly struct LogMessageEntry
     {
         public LogMessageEntry(string message, string timeStamp = null, string levelString = null, ConsoleColor? levelBackground = null, ConsoleColor? levelForeground = null, ConsoleColor? messageColor = null, bool logAsError = false)
         {

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/LogMessageEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/LogMessageEntry.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.Logging.Console
 {
     public readonly struct LogMessageEntry
     {
-        public LogMessageEntry(string message, string timeStamp = null, string levelString = null, ConsoleColor? levelBackground = null, ConsoleColor? levelForeground = null, ConsoleColor? messageColor = null, bool logAsError = false)
+        public LogMessageEntry(string message, string timeStamp = null, string levelString = null, ConsoleColor? levelBackground = null, ConsoleColor? levelForeground = null, ConsoleColor? messageColor = null, bool logAsError = false, Action<IConsole> writeCallback = null)
         {
             TimeStamp = timeStamp;
             LevelString = levelString;
@@ -17,6 +17,7 @@ namespace Microsoft.Extensions.Logging.Console
             MessageColor = messageColor;
             Message = message;
             LogAsError = logAsError;
+            WriteCallback = writeCallback;
         }
 
         public readonly string TimeStamp;
@@ -26,5 +27,6 @@ namespace Microsoft.Extensions.Logging.Console
         public readonly ConsoleColor? MessageColor;
         public readonly string Message;
         public readonly bool LogAsError;
+        public readonly Action<IConsole> WriteCallback;
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -24,7 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Collections" />
     <Reference Include="System.Linq" />
+    <Reference Include="System.Memory" />
+    <Reference Include="System.Text.Json" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/Microsoft.Extensions.Logging.Console.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.Linq" />
     <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <Reference Include="Microsoft.Extensions.Logging" />
     <Reference Include="Microsoft.Extensions.Logging.Abstractions" />

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/ConsoleLoggerTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.Logging.Test
         private const string _loggerName = "test";
         private const string _state = "This is a test, and {curly braces} are just fine!";
         private readonly Func<object, Exception, string> _defaultFormatter = (state, exception) => state.ToString();
+        private readonly IEnumerable<ILogFormatter> _formatters = new ILogFormatter[] { new DefaultLogFormatter { Options = new ConsoleLoggerOptions() }, new SystemdLogFormatter { Options = new ConsoleLoggerOptions() } };
 
         private static (ConsoleLogger Logger, ConsoleSink Sink, ConsoleSink ErrorSink, Func<LogLevel, string> GetLevelPrefix, int WritesPerMsg) SetUp(ConsoleLoggerOptions options = null)
         {
@@ -33,9 +34,24 @@ namespace Microsoft.Extensions.Logging.Test
             consoleLoggerProcessor.Console = console;
             consoleLoggerProcessor.ErrorConsole = errorConsole;
 
-            var logger = new ConsoleLogger(_loggerName, consoleLoggerProcessor);
-            logger.ScopeProvider = new LoggerExternalScopeProvider();
-            logger.Options = options ?? new ConsoleLoggerOptions();
+            var testOptions = options ?? new ConsoleLoggerOptions();
+            var scopeProvider = new LoggerExternalScopeProvider();
+            var formatters = new ILogFormatter[]
+            {
+                new DefaultLogFormatter
+                {
+                    Options = testOptions,
+                    ScopeProvider = scopeProvider
+                },
+                new SystemdLogFormatter
+                {
+                    Options = testOptions,
+                    ScopeProvider = scopeProvider
+                }
+            };
+            var logger = new ConsoleLogger(_loggerName, consoleLoggerProcessor, formatters);
+            logger.ScopeProvider = scopeProvider;
+            logger.Options = testOptions;
             Func<LogLevel, string> levelAsString;
             int writesPerMsg;
             switch (logger.Options.Format)
@@ -994,7 +1010,7 @@ namespace Microsoft.Extensions.Logging.Test
             var processor = new ConsoleLoggerProcessor();
             processor.Console = console;
 
-            var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor);
+            var logger = new ConsoleLogger(_loggerName, loggerProcessor: processor, _formatters);
             logger.Options = new ConsoleLoggerOptions();
             // Act
             processor.Dispose();
@@ -1023,7 +1039,7 @@ namespace Microsoft.Extensions.Logging.Test
         {
             // Arrange
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions() { DisableColors = true });
-            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var loggerProvider = new ConsoleLoggerProvider(monitor, _formatters);
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert
@@ -1054,7 +1070,7 @@ namespace Microsoft.Extensions.Logging.Test
         {
             // Arrange
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
-            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var loggerProvider = new ConsoleLoggerProvider(monitor, _formatters);
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert
@@ -1084,7 +1100,7 @@ namespace Microsoft.Extensions.Logging.Test
         public void ConsoleLoggerOptions_TimeStampFormat_MultipleReloads()
         {
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
-            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var loggerProvider = new ConsoleLoggerProvider(monitor, _formatters);
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             Assert.Null(logger.Options.TimestampFormat);
@@ -1099,7 +1115,7 @@ namespace Microsoft.Extensions.Logging.Test
         {
             // Arrange
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions() { IncludeScopes = true });
-            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var loggerProvider = new ConsoleLoggerProvider(monitor, _formatters);
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert
@@ -1130,7 +1146,7 @@ namespace Microsoft.Extensions.Logging.Test
         {
             // Arrange
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
-            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var loggerProvider = new ConsoleLoggerProvider(monitor, _formatters);
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert
@@ -1144,7 +1160,7 @@ namespace Microsoft.Extensions.Logging.Test
         {
             // Arrange
             var monitor = new TestOptionsMonitor(new ConsoleLoggerOptions());
-            var loggerProvider = new ConsoleLoggerProvider(monitor);
+            var loggerProvider = new ConsoleLoggerProvider(monitor, _formatters);
             var logger = (ConsoleLogger)loggerProvider.CreateLogger("Name");
 
             // Act & Assert


### PR DESCRIPTION
Updated prototype for APIs needed to customize log formatting.

From appsettings.json 
```
{
  "Logging": {
    "LogLevel": {
      "Default": "Information",
      "Microsoft": "Warning",
      "Microsoft.Hosting.Lifetime": "Information"
    },
    "Console": {
      "Format": "Systemd", <--- To be deprecated: Making sure Format toggling continues to work
      "Formatter": "Json", <--- Making sure Formatter can be used to toggle btw available formatters
      "JsonWriterOptions" : <--- To be picked up by *FormatterOptions
      {
        "Indented" : true
      }
    }
  },
  "AllowedHosts": "*"
}
```