### PR TITLE
Fix HttpClient SSL3.0 test on newer Windows OS

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.SslProtocols.cs
@@ -151,9 +151,7 @@ namespace System.Net.Http.Functional.Tests
         public static IEnumerable<object[]> SupportedSSLVersionServers()
         {
 #pragma warning disable 0618 // SSL2/3 are deprecated
-            if (PlatformDetection.IsWindows ||
-                PlatformDetection.IsOSX ||
-                (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && PlatformDetection.OpenSslVersion < new Version(1, 0, 2) && !PlatformDetection.IsDebian))
+            if (PlatformDetection.SupportsSsl3)
             {
                 yield return new object[] { SslProtocols.Ssl3, Configuration.Http.SSLv3RemoteServer };
             }


### PR DESCRIPTION
When I upgraded my dev machine to Windows 10 Version 2004 Preview, I noticed that the
HttpClient GetAsync_SupportedSSLVersion_Succeeds test was failing when using SSL 3.0.

This new version of Windows changes the default setting of SSL 3.0. So, by default,
SSL 3.0 is no longer enabled.

The problem was that this specific test wasn't using our PlatformDetection.SupportsSsl30
logic. Fixed the test so that it will properly detect whether SSL 3.0 is enabled on
the machine.