### PR TITLE
[cominterop] Support ClassInterfaceType and auto-dual class interfaces

### DIFF
--- a/src/mono/mono/metadata/cominterop.c
+++ b/src/mono/mono/metadata/cominterop.c
@@ -150,6 +150,7 @@ static GENERATE_GET_CLASS_WITH_CACHE (interface_type_attribute, "System.Runtime.
 static GENERATE_GET_CLASS_WITH_CACHE (guid_attribute, "System.Runtime.InteropServices", "GuidAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (com_visible_attribute, "System.Runtime.InteropServices", "ComVisibleAttribute")
 static GENERATE_GET_CLASS_WITH_CACHE (com_default_interface_attribute, "System.Runtime.InteropServices", "ComDefaultInterfaceAttribute")
+static GENERATE_GET_CLASS_WITH_CACHE (class_interface_attribute, "System.Runtime.InteropServices", "ClassInterfaceAttribute")
 
 /* Upon creation of a CCW, only allocate a weak handle and set the
  * reference count to 0. If the unmanaged client code decides to addref and
@@ -546,6 +547,27 @@ cominterop_com_visible (MonoClass* klass)
 	}
 	return visible;
 
+}
+
+static gboolean
+cominterop_method_com_visible (MonoMethod *method)
+{
+	ERROR_DECL (error);
+	MonoCustomAttrInfo *cinfo;
+	MonoBoolean visible = 1;
+
+	cinfo = mono_custom_attrs_from_method_checked (method, error);
+	mono_error_assert_ok (error);
+	if (cinfo) {
+		MonoReflectionComVisibleAttribute *attr = (MonoReflectionComVisibleAttribute*)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_com_visible_attribute_class (), error);
+		mono_error_assert_ok (error); /*FIXME proper error handling*/
+
+		if (attr)
+			visible = attr->visible;
+		if (!cinfo->cached)
+			mono_custom_attrs_free (cinfo);
+	}
+	return visible;
 }
 
 static void
@@ -2078,6 +2100,140 @@ cominterop_get_ccw_default_mspec (const MonoType *param_type)
 	return result;
 }
 
+static MonoClass*
+cominterop_get_default_iface (MonoClass *klass)
+{
+	if (mono_class_is_interface (klass))
+		return klass;
+
+	ERROR_DECL (error);
+	MonoCustomAttrInfo *cinfo = mono_custom_attrs_from_class_checked (klass, error);
+	mono_error_assert_ok (error);
+
+	if (!cinfo)
+		return mono_class_get_idispatch_class ();
+
+	MonoClassInterfaceAttribute *class_attr = (MonoClassInterfaceAttribute *)mono_custom_attrs_get_attr_checked (cinfo, mono_class_get_class_interface_attribute_class (), error);
+	MonoClass *ret;
+
+	if (class_attr)
+	{
+		if (class_attr->intType == 0) {
+			ret = mono_defaults.object_class;
+			for (guint16 i = 0; i < m_class_get_interface_count (klass); i++) {
+				MonoClass *iface = m_class_get_interfaces (klass) [i];
+				if (cominterop_com_visible (iface)) {
+					ret = iface;
+					break;
+				}
+			}
+		}
+		else if (class_attr->intType == 1)
+			ret = mono_class_get_idispatch_class ();
+		else
+			ret = klass;
+	} else
+		ret = mono_class_get_idispatch_class ();
+
+	if (!cinfo->cached)
+		mono_custom_attrs_free (cinfo);
+	return ret;
+}
+
+static gboolean
+cominterop_class_method_is_visible (MonoMethod *method)
+{
+	guint16 flags = method->flags;
+
+	if ((flags & METHOD_ATTRIBUTE_MEMBER_ACCESS_MASK) != METHOD_ATTRIBUTE_PUBLIC)
+		return FALSE;
+
+	if (flags & METHOD_ATTRIBUTE_STATIC)
+		return FALSE;
+
+	if (flags & METHOD_ATTRIBUTE_RT_SPECIAL_NAME)
+		return FALSE;
+
+	if (!cominterop_method_com_visible (method))
+		return FALSE;
+
+	/* if the method is an override, ignore it and use the original definition */
+	if ((flags & METHOD_ATTRIBUTE_VIRTUAL) && !(flags & METHOD_ATTRIBUTE_NEW_SLOT))
+		return FALSE;
+
+	return TRUE;
+}
+
+static gpointer
+cominterop_get_ccw_method (MonoClass *iface, MonoMethod *method, MonoError *error)
+{
+	int param_index = 0;
+	MonoMethodBuilder *mb;
+	MonoMarshalSpec ** mspecs;
+	MonoMethod *wrapper_method, *adjust_method;
+	MonoMethodSignature* sig_adjusted;
+	MonoMethodSignature* sig = mono_method_signature_internal (method);
+	gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
+	EmitMarshalContext m;
+
+	mb = mono_mb_new (iface, method->name, MONO_WRAPPER_NATIVE_TO_MANAGED);
+	adjust_method = cominterop_get_managed_wrapper_adjusted (method);
+	sig_adjusted = mono_method_signature_internal (adjust_method);
+
+	mspecs = g_new (MonoMarshalSpec*, sig_adjusted->param_count + 1);
+	mono_method_get_marshal_info (method, mspecs);
+
+	/* move managed args up one */
+	for (param_index = sig->param_count; param_index >= 1; param_index--) {
+		int mspec_index = param_index+1;
+		mspecs [mspec_index] = mspecs [param_index];
+
+		if (mspecs[mspec_index] == NULL) {
+			mspecs[mspec_index] = cominterop_get_ccw_default_mspec (sig_adjusted->params[param_index]);
+		} else {
+			/* increase SizeParamIndex since we've added a param */
+			if (sig_adjusted->params[param_index]->type == MONO_TYPE_ARRAY ||
+			    sig_adjusted->params[param_index]->type == MONO_TYPE_SZARRAY)
+				if (mspecs[mspec_index]->data.array_data.param_num != -1)
+					mspecs[mspec_index]->data.array_data.param_num++;
+		}
+	}
+
+	/* first arg is IntPtr for interface */
+	mspecs [1] = NULL;
+
+	/* move return spec to last param */
+	if (!preserve_sig && !MONO_TYPE_IS_VOID (sig->ret)) {
+		if (mspecs [0] == NULL)
+			mspecs[0] = cominterop_get_ccw_default_mspec (sig_adjusted->params[sig_adjusted->param_count-1]);
+
+		mspecs [sig_adjusted->param_count] = mspecs [0];
+		mspecs [0] = NULL;
+	}
+
+#ifndef DISABLE_JIT
+	/* skip visiblity since we call internal methods */
+	mb->skip_visibility = TRUE;
+#endif
+
+	cominterop_setup_marshal_context (&m, adjust_method);
+	m.mb = mb;
+	mono_marshal_emit_managed_wrapper (mb, sig_adjusted, mspecs, &m, adjust_method, 0);
+	mono_cominterop_lock ();
+	wrapper_method = mono_mb_create_method (mb, m.csig, m.csig->param_count + 16);
+	mono_cominterop_unlock ();
+
+	gpointer ret = mono_compile_method_checked (wrapper_method, error);
+
+	mono_mb_free (mb);
+	for (param_index = sig_adjusted->param_count; param_index >= 0; param_index--)
+		if (mspecs [param_index])
+			mono_metadata_free_marshal_spec (mspecs [param_index]);
+	g_free (mspecs);
+
+	return ret;
+}
+
 /**
  * cominterop_get_ccw_checked:
  * @object: a pointer to the object
@@ -2091,12 +2247,11 @@ cominterop_get_ccw_default_mspec (const MonoType *param_type)
 static gpointer
 cominterop_get_ccw_checked (MonoObjectHandle object, MonoClass* itf, MonoError *error)
 {
-	int i;
+	int i, j;
 	MonoCCW *ccw = NULL;
 	MonoCCWInterface* ccw_entry = NULL;
 	gpointer *vtable = NULL;
 	MonoClass* iface = NULL;
-	EmitMarshalContext m;
 	int start_slot = 3;
 	int method_count = 0;
 	GList *ccw_list, *ccw_list_item;
@@ -2166,17 +2321,35 @@ cominterop_get_ccw_checked (MonoObjectHandle object, MonoClass* itf, MonoError *
 			mono_custom_attrs_free (cinfo);
 	}
 
-	iface = itf;
+	iface = cominterop_get_default_iface(itf);
 	if (iface == mono_class_get_iunknown_class ()) {
 		start_slot = 3;
 	}
 	else if (iface == mono_class_get_idispatch_class ()) {
 		start_slot = 7;
 	}
-	else {
+	else if (mono_class_is_interface (iface)) {
 		method_count += mono_class_get_method_count (iface);
 		start_slot = cominterop_get_com_slot_begin (iface);
-		iface = NULL;
+	}
+	else {
+		/* auto-dual object */
+		start_slot = 7;
+
+		MonoClass *klass_iter;
+		for (klass_iter = iface; klass_iter; klass_iter = m_class_get_parent (klass_iter)) {
+			int mcount = mono_class_get_method_count (klass_iter);
+			if (mcount && !m_class_get_methods (klass_iter))
+				mono_class_setup_methods (klass_iter);
+
+			for (i = 0; i < mcount; ++i) {
+				MonoMethod *method = m_class_get_methods (klass_iter) [i];
+				if (cominterop_class_method_is_visible (method))
+					++method_count;
+			}
+
+			/* FIXME: accessors for public fields */
+		}
 	}
 
 	ccw_entry = (MonoCCWInterface *)g_hash_table_lookup (ccw->vtable_hash, itf);
@@ -2194,77 +2367,78 @@ cominterop_get_ccw_checked (MonoObjectHandle object, MonoClass* itf, MonoError *
 			vtable [6] = (gpointer)cominterop_ccw_invoke;
 		}
 
-		iface = itf;
-		method_count = mono_class_get_method_count (iface);
-		if (method_count && !m_class_get_methods (iface))
-			mono_class_setup_methods (iface);
+		if (mono_class_is_interface (iface)) {
+			if (method_count && !m_class_get_methods (iface))
+				mono_class_setup_methods (iface);
 
-		for (i = method_count - 1; i >= 0; i--) {
-			int param_index = 0;
-			MonoMethodBuilder *mb;
-			MonoMarshalSpec ** mspecs;
-			MonoMethod *wrapper_method, *adjust_method;
-			MonoMethod *method = m_class_get_methods (iface) [i];
-			MonoMethodSignature* sig_adjusted;
-			MonoMethodSignature* sig = mono_method_signature_internal (method);
-			gboolean const preserve_sig = (method->iflags & METHOD_IMPL_ATTRIBUTE_PRESERVE_SIG) != 0;
+			for (i = method_count - 1; i >= 0; i--) {
+				vtable [vtable_index--] = cominterop_get_ccw_method (iface, m_class_get_methods (iface) [i], error);
+				return_val_if_nok (error, NULL);
+			}
+		}
+		else {
+			/* Auto-dual object. The methods on an auto-dual interface are
+			 * exposed starting from the innermost parent (i.e. Object) and
+			 * proceeding outwards. The methods within each interfaces are
+			 * exposed in the following order:
+			 *
+			 * 1. Virtual methods
+			 * 2. Interface methods
+			 * 3. Nonvirtual methods
+			 * 4. Fields (get, then put)
+			 *
+			 * Interface methods are exposed in the order that the interface
+			 * was declared. Child interface methods are exposed before parents.
+			 *
+			 * Because we need to expose superclass methods starting from the
+			 * innermost parent, we expose methods in reverse order, so that
+			 * we can just iterate using m_class_get_parent (). */
 
-			mb = mono_mb_new (iface, method->name, MONO_WRAPPER_NATIVE_TO_MANAGED);
-			adjust_method = cominterop_get_managed_wrapper_adjusted (method);
-			sig_adjusted = mono_method_signature_internal (adjust_method);
-			
-			mspecs = g_new (MonoMarshalSpec*, sig_adjusted->param_count + 1);
-			mono_method_get_marshal_info (method, mspecs);
+			mono_class_setup_vtable (iface);
 
-			
-			/* move managed args up one */
-			for (param_index = sig->param_count; param_index >= 1; param_index--) {
-				int mspec_index = param_index+1;
-				mspecs [mspec_index] = mspecs [param_index];
+			MonoClass *klass_iter;
+			for (klass_iter = iface; klass_iter; klass_iter = m_class_get_parent (klass_iter)) {
+				mono_class_setup_vtable (klass_iter);
 
-				if (mspecs[mspec_index] == NULL) {
-					mspecs[mspec_index] = cominterop_get_ccw_default_mspec (sig_adjusted->params[param_index]);
-				} else {
-					/* increase SizeParamIndex since we've added a param */
-					if (sig_adjusted->params[param_index]->type == MONO_TYPE_ARRAY ||
-					    sig_adjusted->params[param_index]->type == MONO_TYPE_SZARRAY)
-						if (mspecs[mspec_index]->data.array_data.param_num != -1)
-							mspecs[mspec_index]->data.array_data.param_num++;
+				/* 3. Nonvirtual methods */
+				for (i = mono_class_get_method_count (klass_iter) - 1; i >= 0; i--) {
+					MonoMethod *method = m_class_get_methods (klass_iter) [i];
+					if (cominterop_class_method_is_visible (method) && !(method->flags & METHOD_ATTRIBUTE_VIRTUAL)) {
+						vtable [vtable_index--] = cominterop_get_ccw_method (iface, method, error);
+						return_val_if_nok (error, NULL);
+					}
+				}
+
+				/* 2. Interface methods */
+				GPtrArray *ifaces = mono_class_get_implemented_interfaces (klass_iter, error);
+				mono_error_assert_ok (error);
+				if (ifaces) {
+					for (i = ifaces->len - 1; i >= 0; i--) {
+						MonoClass *ic = (MonoClass *)g_ptr_array_index (ifaces, i);
+						int offset = mono_class_interface_offset (iface, ic);
+						g_assert (offset >= 0);
+						for (j = mono_class_get_method_count (ic) - 1; j >= 0; j--) {
+							MonoMethod *method = m_class_get_methods (ic) [j];
+							vtable [vtable_index--] = cominterop_get_ccw_method (iface, m_class_get_vtable (iface) [offset + method->slot], error);
+							if (!is_ok (error)) {
+								g_ptr_array_free (ifaces, TRUE);
+								return NULL;
+							}
+						}
+					}
+					g_ptr_array_free (ifaces, TRUE);
+				}
+
+				/* 1. Virtual methods */
+				for (i = mono_class_get_method_count (klass_iter) - 1; i >= 0; i--) {
+					MonoMethod *method = m_class_get_methods (klass_iter) [i];
+					if (cominterop_class_method_is_visible (method) && (method->flags & METHOD_ATTRIBUTE_VIRTUAL)
+						&& !cominterop_get_method_interface (method)) {
+						vtable [vtable_index--] = cominterop_get_ccw_method (iface, m_class_get_vtable (iface) [method->slot], error);
+						return_val_if_nok (error, NULL);
+					}
 				}
 			}
-
-			/* first arg is IntPtr for interface */
-			mspecs [1] = NULL;
-
-			/* move return spec to last param */
-			if (!preserve_sig && !MONO_TYPE_IS_VOID (sig->ret)) {
-				if (mspecs [0] == NULL)
-					mspecs[0] = cominterop_get_ccw_default_mspec (sig_adjusted->params[sig_adjusted->param_count-1]);
-
-				mspecs [sig_adjusted->param_count] = mspecs [0];
-				mspecs [0] = NULL;
-			}
-
-#ifndef DISABLE_JIT
-			/* skip visiblity since we call internal methods */
-			mb->skip_visibility = TRUE;
-#endif
-
-			cominterop_setup_marshal_context (&m, adjust_method);
-			m.mb = mb;
-			mono_marshal_emit_managed_wrapper (mb, sig_adjusted, mspecs, &m, adjust_method, 0);
-			mono_cominterop_lock ();
-			wrapper_method = mono_mb_create_method (mb, m.csig, m.csig->param_count + 16);
-			mono_cominterop_unlock ();
-
-			vtable [vtable_index--] = mono_compile_method_checked (wrapper_method, error);
-
-			// cleanup, then error out if compile_method failed
-			for (param_index = sig_adjusted->param_count; param_index >= 0; param_index--)
-				if (mspecs [param_index])
-					mono_metadata_free_marshal_spec (mspecs [param_index]);
-			g_free (mspecs);
-			return_val_if_nok (error, NULL);
 		}
 
 		ccw_entry = g_new0 (MonoCCWInterface, 1);

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -801,6 +801,11 @@ typedef struct {
 	guint32 intType;
 } MonoInterfaceTypeAttribute;
 
+typedef struct {
+	MonoObject object;
+	guint32 intType;
+} MonoClassInterfaceAttribute;
+
 /* Safely access System.Delegate from native code */
 TYPED_HANDLE_DECL (MonoDelegate);
 

--- a/src/mono/mono/tests/Makefile.am
+++ b/src/mono/mono/tests/Makefile.am
@@ -728,6 +728,7 @@ TESTS_CS_SRC=		\
 	null-blob-main.cs \
 	last-error.cs \
 	rgctx-thread-static.cs \
+	ccw-class-iface.cs \
 	bug-gh-17285.cs
 
 # some tests fail to compile on mcs
@@ -1431,6 +1432,7 @@ PROFILE_DISABLED_TESTS += \
 	dynamic-method-delegate.exe \
 	dynamic-method-churn.exe \
 	bug-666008.exe \
+	ccw-class-iface.exe \
 	bug-685908.exe
 
 # Test which needs System.Web support
@@ -1950,6 +1952,7 @@ INTERP_DISABLED_TESTS += localloc-noinit.exe
 INTERP_DISABLED_TESTS += dim-diamondshape.exe
 INTERP_DISABLED_TESTS += pinvoke3.exe
 INTERP_DISABLED_TESTS += cominterop.exe
+INTERP_DISABLED_TESTS += ccw-class-iface.exe
 # bug-60862.exe: missing support to map IP->method; only works on platforms with altstack support.
 INTERP_DISABLED_TESTS += bug-60862.exe
 # bug-48015.exe: remoting test that fails on fullaotinterp scenarios
@@ -2750,7 +2753,7 @@ test-unhandled-exception: unhandled-exception-test-runner.2.exe
 safehandle.2.exe winx64structs.exe thunks.exe pinvoke3.exe pinvoke2.exe pinvoke-2.2.exe pinvoke17.exe pinvoke13.exe \
 	pinvoke11.exe pinvoke_ppcs.exe pinvoke_ppci.exe pinvoke_ppcf.exe pinvoke_ppcd.exe pinvoke_ppcc.exe pinvoke.exe \
 	marshalbool.exe marshal9.exe marshal5.exe marshal.exe handleref.exe cominterop.exe bug-Xamarin-5278.exe \
-	bug-58782-plain-throw.exe bug-58782-capture-and-throw.exe install_eh_callback.exe: libtest.la
+	bug-58782-plain-throw.exe bug-58782-capture-and-throw.exe install_eh_callback.exe ccw-class-iface.exe: libtest.la
 
 EXTRA_DIST += event-il.il
 

--- a/src/mono/mono/tests/ccw-class-iface.cs
+++ b/src/mono/mono/tests/ccw-class-iface.cs
@@ -1,0 +1,207 @@
+// Test the ClassInterfaceType attribute.
+
+using System;
+using System.Runtime.InteropServices;
+
+[ComVisible(false)]
+public interface IInvisible
+{
+    int invisible_iface();
+}
+
+public interface IApple
+{
+    int iface1_parent_method();
+}
+
+[Guid ("12345678-0000-0000-0000-000000000002")]
+public interface IBanana : IApple
+{
+    int iface1_method();
+}
+
+public interface ICherry
+{
+    int iface2_method();
+}
+
+public interface IDrupe
+{
+    int parent_iface_method();
+}
+
+public class TestParent : IDrupe
+{
+    public virtual int parent_method_virtual()
+    {
+        return 101;
+    }
+
+    public int parent_iface_method()
+    {
+        return 112;
+    }
+
+    public int parent_method()
+    {
+        return 104;
+    }
+
+    public virtual int parent_property {get {return 102;}}
+
+    public virtual int parent_method_override()
+    {
+        return 103;
+    }
+}
+
+[ClassInterface(ClassInterfaceType.AutoDual)]
+public class TestAutoDual : TestParent, IBanana, ICherry
+{
+    internal int invisible_internal()
+    {
+        return 0;
+    }
+
+    protected int invisible_protected()
+    {
+        return 0;
+    }
+
+    [ComVisible(false)]
+    public int invisible_hidden()
+    {
+        return 0;
+    }
+
+    public static int invisible_static()
+    {
+        return 0;
+    }
+
+    public TestAutoDual(int arg)
+    {
+    }
+
+    public int iface2_method()
+    {
+        return 109;
+    }
+
+    public int child_method()
+    {
+        return 110;
+    }
+
+    public virtual int child_method_virtual()
+    {
+        return 106;
+    }
+
+    public int iface1_method()
+    {
+        return 107;
+    }
+
+    public override int parent_method_override()
+    {
+        return 203;
+    }
+
+    public int iface1_parent_method()
+    {
+        return 108;
+    }
+}
+
+[ClassInterface(ClassInterfaceType.None)]
+public class TestNone : TestParent, IInvisible, IBanana, ICherry
+{
+    public int iface2_method()
+    {
+        return 1;
+    }
+
+    public int child_method()
+    {
+        return 2;
+    }
+
+    public int iface1_method()
+    {
+        return 3;
+    }
+
+    public int iface1_parent_method()
+    {
+        return 4;
+    }
+
+    public int invisible_iface()
+    {
+        return 0;
+    }
+}
+
+[ClassInterface(ClassInterfaceType.AutoDispatch)]
+public class TestAutoDispatch : TestParent, IBanana, ICherry
+{
+    public int iface2_method()
+    {
+        return 1;
+    }
+
+    public int child_method()
+    {
+        return 2;
+    }
+
+    public int iface1_method()
+    {
+        return 3;
+    }
+
+    public int iface1_parent_method()
+    {
+        return 4;
+    }
+}
+
+public class Tests
+{
+    [DllImport("libtest")]
+    public static extern int mono_test_ccw_class_type_auto_dispatch([MarshalAs (UnmanagedType.Interface)] TestAutoDispatch obj);
+    [DllImport("libtest")]
+    public static extern int mono_test_ccw_class_type_auto_dual([MarshalAs (UnmanagedType.Interface)] TestAutoDual obj);
+    [DllImport("libtest")]
+    public static extern int mono_test_ccw_class_type_none([MarshalAs (UnmanagedType.Interface)] TestNone obj);
+
+    public static int Main()
+    {
+        TestAutoDual autodual = new TestAutoDual(105);
+        int hr;
+
+        hr = mono_test_ccw_class_type_auto_dual(autodual);
+        if (hr != 0)
+        {
+            Console.Error.WriteLine("TestAutoDual failed: {0}", hr);
+            return 1;
+        }
+
+        hr = mono_test_ccw_class_type_auto_dispatch(new TestAutoDispatch());
+        if (hr != 0)
+        {
+            Console.Error.WriteLine("TestAutoDispatch failed: {0}", hr);
+            return 4;
+        }
+
+        hr = mono_test_ccw_class_type_none(new TestNone());
+        if (hr != 0)
+        {
+            Console.Error.WriteLine("TestNone failed: {0}", hr);
+            return 5;
+        }
+
+        return 0;
+    }
+}

--- a/src/mono/mono/tests/libtest.c
+++ b/src/mono/mono/tests/libtest.c
@@ -2627,6 +2627,34 @@ mono_test_marshal_date_time (double d, double *d2)
 
 #ifndef WIN32
 
+typedef struct
+{
+	guint32 a;
+	guint16 b;
+	guint16 c;
+	guint8 d[8];
+} GUID;
+
+typedef const GUID *REFIID;
+
+typedef struct IDispatch IDispatch;
+
+typedef struct
+{
+	int (STDCALL *QueryInterface)(IDispatch *iface, REFIID iid, gpointer *out);
+	int (STDCALL *AddRef)(IDispatch *iface);
+	int (STDCALL *Release)(IDispatch *iface);
+	int (STDCALL *GetTypeInfoCount)(IDispatch *iface, unsigned int *count);
+	int (STDCALL *GetTypeInfo)(IDispatch *iface, unsigned int index, unsigned int lcid, gpointer *out);
+	int (STDCALL *GetIDsOfNames)(IDispatch *iface, REFIID iid, gpointer names, unsigned int count, unsigned int lcid, gpointer ids);
+	int (STDCALL *Invoke)(IDispatch *iface, unsigned int dispid, REFIID iid, unsigned int lcid, unsigned short flags, gpointer params, gpointer result, gpointer excepinfo, gpointer err_arg);
+} IDispatchVtbl;
+
+struct IDispatch
+{
+	const IDispatchVtbl *lpVtbl;
+};
+
 typedef struct {
 	guint16 vt;
 	guint16 wReserved1;
@@ -2709,14 +2737,6 @@ void VariantInit(VARIANT* vt)
 {
 	vt->vt = VT_EMPTY;
 }
-
-typedef struct
-{
-	guint32 a;
-	guint16 b;
-	guint16 c;
-	guint8 d[8];
-} GUID;
 
 #define S_OK 0
 
@@ -8072,6 +8092,163 @@ mono_test_MerpCrashSignalIll (void)
 #else
 	raise (SIGTERM);
 #endif
+}
+
+typedef struct _TestAutoDual _TestAutoDual;
+
+typedef struct
+{
+	int (STDCALL *QueryInterface)(_TestAutoDual *iface, REFIID iid, gpointer *out);
+	int (STDCALL *AddRef)(_TestAutoDual *iface);
+	int (STDCALL *Release)(_TestAutoDual *iface);
+	int (STDCALL *GetTypeInfoCount)(_TestAutoDual *iface, unsigned int *count);
+	int (STDCALL *GetTypeInfo)(_TestAutoDual *iface, unsigned int index, unsigned int lcid, gpointer *out);
+	int (STDCALL *GetIDsOfNames)(_TestAutoDual *iface, REFIID iid, gpointer names, unsigned int count, unsigned int lcid, gpointer ids);
+	int (STDCALL *Invoke)(_TestAutoDual *iface, unsigned int dispid, REFIID iid, unsigned int lcid, unsigned short flags, gpointer params, gpointer result, gpointer excepinfo, gpointer err_arg);
+	int (STDCALL *ToString)(_TestAutoDual *iface, gpointer string);
+	int (STDCALL *Equals)(_TestAutoDual *iface, VARIANT other, short *retval);
+	int (STDCALL *GetHashCode)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *GetType)(_TestAutoDual *iface, gpointer retval);
+	int (STDCALL *parent_method_virtual)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *get_parent_property)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *parent_method_override)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *parent_iface_method)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *parent_method)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *child_method_virtual)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *iface1_method)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *iface1_parent_method)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *iface2_method)(_TestAutoDual *iface, int *retval);
+	int (STDCALL *child_method)(_TestAutoDual *iface, int *retval);
+} _TestAutoDualVtbl;
+
+struct _TestAutoDual
+{
+	const _TestAutoDualVtbl *lpVtbl;
+};
+
+LIBTEST_API int STDCALL
+mono_test_ccw_class_type_auto_dual (_TestAutoDual *iface)
+{
+	int hr, retval;
+
+	hr = iface->lpVtbl->parent_method_virtual(iface, &retval);
+	if (hr != 0)
+		return 1;
+	if (retval != 101)
+		return 2;
+
+	hr = iface->lpVtbl->get_parent_property(iface, &retval);
+	if (hr != 0)
+		return 3;
+	if (retval != 102)
+		return 4;
+
+	hr = iface->lpVtbl->parent_method_override(iface, &retval);
+	if (hr != 0)
+		return 5;
+	if (retval != 203)
+		return 6;
+
+	hr = iface->lpVtbl->parent_method(iface, &retval);
+	if (hr != 0)
+		return 7;
+	if (retval != 104)
+		return 8;
+
+	hr = iface->lpVtbl->child_method_virtual(iface, &retval);
+	if (hr != 0)
+		return 11;
+	if (retval != 106)
+		return 12;
+
+	hr = iface->lpVtbl->iface1_method(iface, &retval);
+	if (hr != 0)
+		return 13;
+	if (retval != 107)
+		return 14;
+
+	hr = iface->lpVtbl->iface1_parent_method(iface, &retval);
+	if (hr != 0)
+		return 15;
+	if (retval != 108)
+		return 16;
+
+	hr = iface->lpVtbl->iface2_method(iface, &retval);
+	if (hr != 0)
+		return 17;
+	if (retval != 109)
+		return 18;
+
+	hr = iface->lpVtbl->child_method(iface, &retval);
+	if (hr != 0)
+		return 19;
+	if (retval != 110)
+		return 20;
+
+	hr = iface->lpVtbl->parent_iface_method(iface, &retval);
+	if (hr != 0)
+		return 23;
+	if (retval != 112)
+		return 24;
+
+	return 0;
+}
+
+static const GUID IID_IBanana = {0x12345678, 0, 0, {0, 0, 0, 0, 0, 0, 0, 2}};
+
+typedef struct IBanana IBanana;
+
+typedef struct
+{
+	int (STDCALL *QueryInterface)(IBanana *iface, REFIID iid, gpointer *out);
+	int (STDCALL *AddRef)(IBanana *iface);
+	int (STDCALL *Release)(IBanana *iface);
+	int (STDCALL *GetTypeInfoCount)(IBanana *iface, unsigned int *count);
+	int (STDCALL *GetTypeInfo)(IBanana *iface, unsigned int index, unsigned int lcid, gpointer *out);
+	int (STDCALL *GetIDsOfNames)(IBanana *iface, REFIID iid, gpointer names, unsigned int count, unsigned int lcid, gpointer ids);
+	int (STDCALL *Invoke)(IBanana *iface, unsigned int dispid, REFIID iid, unsigned int lcid, unsigned short flags, gpointer params, gpointer result, gpointer excepinfo, gpointer err_arg);
+	int (STDCALL *iface1_method)(IBanana *iface, int *retval);
+} IBananaVtbl;
+
+struct IBanana
+{
+	const IBananaVtbl *lpVtbl;
+};
+
+LIBTEST_API int STDCALL
+mono_test_ccw_class_type_none (IBanana *iface)
+{
+	int hr, retval;
+
+	hr = iface->lpVtbl->iface1_method(iface, &retval);
+	if (hr != 0)
+		return 1;
+	if (retval != 3)
+		return 2;
+	return 0;
+}
+
+LIBTEST_API int STDCALL
+mono_test_ccw_class_type_auto_dispatch (IDispatch *disp)
+{
+	IBanana *banana;
+	int hr, retval;
+
+#ifdef __cplusplus
+	hr = disp->QueryInterface (IID_IBanana, (void **)&banana);
+#else
+	hr = disp->lpVtbl->QueryInterface (disp, &IID_IBanana, (void **)&banana);
+#endif
+	if (hr != 0)
+		return 1;
+	hr = banana->lpVtbl->iface1_method(banana, &retval);
+	if (hr != 0)
+		return 2;
+	if (retval != 3)
+		return 3;
+	banana->lpVtbl->Release(banana);
+
+	return 0;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19768,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This helps the Windows 10 v1903 SDK installer run under wine-mono. It uses _AppDomain::CreateInstance to retrieve an ObjectHandle, and then tries to call _ObjectHandle::Unwrap() using the auto-dual interface. With these patches that call succeeds and it gets further, though it does not completely run (likely due to insufficiency in wine-mono's wpfgfx).

This patch set does not implement accessor methods for public fields, mostly because the necessary bits are missing in MonoMethodBuilder, and plumbing them seems decidedly nontrivial.