### PR TITLE
Flow exit code from RunTests.sh in iOS

### DIFF
--- a/eng/testing/AppleRunnerTemplate.sh
+++ b/eng/testing/AppleRunnerTemplate.sh
@@ -45,4 +45,8 @@ dotnet xharness ios test --app="$APP_BUNDLE" \
     --targets=$TARGET \
     --output-directory=$XHARNESS_OUT
 
+_exitCode=$?
+
 echo "Xharness artifacts: $XHARNESS_OUT"
+
+exit $_exitCode


### PR DESCRIPTION
Currently we don't fail if the test run failed because we do an "echo" at the end and the exit code of that is 0. 

With this we will exit with whatever xharness exit code was. We need this because Helix relies on the test execution exit code to know if the workitem passed or failed.