### PR TITLE
Add configurations for SunOS in installer

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -233,7 +233,7 @@ if (CLR_CMAKE_HOST_UNIX)
     message("Detected NetBSD amd64")
   elseif(CLR_CMAKE_HOST_SUNOS)
     message("Detected SunOS amd64")
-  endif(CLR_CMAKE_HOST_SUNOS)
+  endif(CLR_CMAKE_HOST_OSX)
 endif(CLR_CMAKE_HOST_UNIX)
 
 if (CLR_CMAKE_HOST_WIN32)

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/StructABI.csproj
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/StructABI.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <Compile Include="StructABI.cs" />
     <Compile Include="StructABI.Windows.cs" Condition="'$(TargetOS)' == 'Windows_NT'" />
-    <Compile Include="StructABI.Unix.cs" Condition="'$(TargetOS)' == 'Linux' Or '$(TargetOS)' == 'FreeBSD' Or '$(TargetOS)' == 'SunOS'" />
+    <Compile Include="StructABI.Unix.cs" Condition="'$(TargetOS)' == 'Linux' Or '$(TargetOS)' == 'FreeBSD' Or '$(TargetOS)' == 'NetBSD' Or '$(TargetOS)' == 'SunOS'" />
     <Compile Include="StructABI.OSX.cs" Condition="'$(TargetOS)' == 'OSX'" />
   </ItemGroup>
   <ItemGroup>

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -86,6 +86,8 @@
     <OutputRid Condition="'$(TargetOS)' == 'OSX'">osx-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'Linux'">linux-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(TargetOS)' == 'NetBSD'">netbsd-$(TargetArchitecture)</OutputRid>
+    <OutputRid Condition="'$(TargetOS)' == 'SunOS'">sunos-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'iOS'">ios-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'tvOS'">tvos-$(TargetArchitecture)</OutputRid>
     <OutputRid Condition="'$(TargetOS)' == 'Android'">android-$(TargetArchitecture)</OutputRid>
@@ -128,8 +130,8 @@
   <PropertyGroup>
     <DisableCrossgen>false</DisableCrossgen>
     <DisableCrossgen Condition="'$(RuntimeFlavor)' == 'Mono'">true</DisableCrossgen>
-    <!-- Disable cross-gen on FreeBSD for now. This can be revisited when we have full support. -->
-    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD'">true</DisableCrossgen>
+    <!-- Disable cross-gen on FreeBSD, NetBSD and SunOS for now. This can be revisited when we have full support. -->
+    <DisableCrossgen Condition="'$(TargetOS)'=='FreeBSD' Or '$(TargetOS)'=='NetBSD' Or '$(TargetOS)'=='SunOS'">true</DisableCrossgen>
     <OutputVersionBadge>$(AssetOutputPath)sharedfx_$(OutputRid)_$(Configuration)_version_badge.svg</OutputVersionBadge>
   </PropertyGroup>
 
@@ -285,6 +287,18 @@
     <When Condition="$(OutputRid.StartsWith('freebsd'))">
       <PropertyGroup>
         <TargetsFreeBSD>true</TargetsFreeBSD>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(OutputRid.StartsWith('netbsd'))">
+      <PropertyGroup>
+        <TargetsNetBSD>true</TargetsNetBSD>
+        <TargetsUnix>true</TargetsUnix>
+      </PropertyGroup>
+    </When>
+    <When Condition="$(OutputRid.StartsWith('sunos'))">
+      <PropertyGroup>
+        <TargetsSunOS>true</TargetsSunOS>
         <TargetsUnix>true</TargetsUnix>
       </PropertyGroup>
     </When>

--- a/src/installer/pkg/projects/netcoreapp/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/Directory.Build.props
@@ -14,6 +14,8 @@
     <CoreCLRTargetOS Condition="'$(TargetsAndroid)' == 'true'">Android</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsBrowser)' == 'true'">Browser</CoreCLRTargetOS>
     <CoreCLRTargetOS Condition="'$(TargetsFreeBSD)' == 'true'">FreeBSD</CoreCLRTargetOS>
+    <CoreCLRTargetOS Condition="'$(TargetsNetBSD)' == 'true'">NetBSD</CoreCLRTargetOS>
+    <CoreCLRTargetOS Condition="'$(TargetsSunOS)' == 'true'">SunOS</CoreCLRTargetOS>
     <LibrariesTargetOS>$(CoreCLRTargetOS)</LibrariesTargetOS>
   </PropertyGroup>
 

--- a/src/installer/pkg/projects/netcoreappRIDs.props
+++ b/src/installer/pkg/projects/netcoreappRIDs.props
@@ -11,6 +11,8 @@
     <OfficialBuildRID Include="osx-x64" />
     <!-- Not currently built by CoreFX. -->
     <!-- <OfficialBuildRID Include="freebsd-x64" /> -->
+    <!-- <OfficialBuildRID Include="netbsd-x64" /> -->
+    <!-- <OfficialBuildRID Include="sunos-x64" /> -->
     <OfficialBuildRID Include="win-x86">
       <Platform>x86</Platform>
     </OfficialBuildRID>


### PR DESCRIPTION
* Add configurations for SunOS and NetBSD, aligns with FreeBSD.
* Fix a build warning in a cmake `elseif` case.

Contributes to #34944.