### PR TITLE
JIT: simple sideloaded profile support

### DIFF
--- a/src/coreclr/src/jit/CMakeLists.txt
+++ b/src/coreclr/src/jit/CMakeLists.txt
@@ -18,6 +18,9 @@ endif ()
 # JIT_BUILD disables certain PAL_TRY debugging features
 add_definitions(-DJIT_BUILD)
 
+# enable ad-hoc profile
+add_definitions(-DJIT_ADHOC_PROFILE)
+
 if(CLR_CMAKE_TARGET_WIN32)
   set(JIT_RESOURCES Native.rc)
 endif(CLR_CMAKE_TARGET_WIN32)
@@ -69,6 +72,7 @@ set( JIT_SOURCES
   optimizer.cpp
   patchpoint.cpp
   phase.cpp
+  profile.cpp
   rangecheck.cpp
   rationalize.cpp
   regalloc.cpp
@@ -161,6 +165,7 @@ if (CLR_CMAKE_TARGET_WIN32)
     objectalloc.h
     opcode.h
     phase.h
+    profile.h
     rangecheck.h
     rationalize.h
     regalloc.h

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4399,9 +4399,17 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
         DoPhase(this, PHASE_IBCINSTR, &Compiler::fgInstrumentMethod);
     }
 #if defined(JIT_ADHOC_PROFILE)
-    else if ((JitConfig.JitWriteProfileData() != nullptr) ||
-             (JitConfig.JitTieredPGO() && opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0)))
+    else if (JitConfig.JitTieredPGO() > 0)
     {
+        // Only instrument tier0 methods
+        if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_TIER0))
+        {
+            fgInstrumentMethodJitProfile();
+        }
+    }
+    else if (JitConfig.JitWriteProfileData() != nullptr)
+    {
+        // Instrument all jitted methods
         fgInstrumentMethodJitProfile();
     }
 #endif // defined(JIT_ADHOC_PROBES)

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -5547,7 +5547,7 @@ int Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
         return param.result;
 }
 
-#if defined(DEBUG) || defined(INLINE_DATA) || defined(JIT_ADHOC_PROFILE)
+#if defined(DEBUG)
 unsigned Compiler::Info::compMethodHash() const
 {
     if (compMethodHashPrivate == 0)
@@ -5561,7 +5561,16 @@ unsigned Compiler::Info::compMethodHash() const
     }
     return compMethodHashPrivate;
 }
-#endif // defined(DEBUG) || defined(INLINE_DATA) || defined(JIT_ADHOC_PROFILE)
+#elif defined(INLINE_DATA) || defined(JIT_ADHOC_PROFILE)
+unsigned Compiler::Info::compMethodHash() const
+{
+    if (compMethodHashPrivate == 0)
+    {
+        compMethodHashPrivate = compCompHnd->getMethodHash(compMethodHnd);
+    }
+    return compMethodHashPrivate;
+}
+#endif
 
 void Compiler::compCompileFinish()
 {

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5334,6 +5334,13 @@ protected:
     bool fgGetProfileWeightForBasicBlock(IL_OFFSET offset, unsigned* weight);
     void fgInstrumentMethod();
 
+#if defined(JIT_ADHOC_PROFILE)
+
+    void fgInstrumentMethodJitProfile();
+    void findProfileData();
+
+#endif // defined(JIT_ADHOC_PROFILE)
+
 public:
     // fgIsUsingProfileWeights - returns true if we have real profile data for this method
     //                           or if we have some fake profile data for the stress mode
@@ -9020,12 +9027,12 @@ public:
         double      compPerfScore;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
-#if defined(DEBUG) || defined(INLINE_DATA)
+#if defined(DEBUG) || defined(INLINE_DATA) || defined(JIT_ADHOC_PROFILE)
         // Method hash is logcally const, but computed
         // on first demand.
         mutable unsigned compMethodHashPrivate;
         unsigned         compMethodHash() const;
-#endif // defined(DEBUG) || defined(INLINE_DATA)
+#endif // defined(DEBUG) || defined(INLINE_DATA) || defined(JIT_ADHOC_PROFILE)
 
 #ifdef PSEUDORANDOM_NOP_INSERTION
         // things for pseudorandom nop insertion

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -472,7 +472,8 @@ void Compiler::fgInstrumentMethodJitProfile()
         // Each Record is (IL offset, count).
         // IL offset is static so we write it now.
         //
-        blockBuffer[count].ILOffset = block->bbCodeOffs;
+        blockBuffer[count].ILOffset       = block->bbCodeOffs;
+        blockBuffer[count].ExecutionCount = 0;
 
         // Add code to increment the count at runtime.
         //

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -445,6 +445,17 @@ CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 1) // Allow 
                                                                        // when possible.
 #endif                                                                 // FEATURE_MULTIREG_RET
 
+#if defined(DEBUG) || defined(JIT_ADHOC_PROFILE)
+// instrument all jitted code and write profile data to
+// indicated file at jit shutdown
+CONFIG_STRING(JitWriteProfileData, W("JitWriteProfileData"))
+// read profile data from indicated file
+CONFIG_STRING(JitReadProfileData, W("JitReadProfileData"))
+// instrument tier0 code and write profile data to memory, read
+// profile data during tier1
+CONFIG_INTEGER(JitTieredPGO, W("JitTieredPGO"), 0)
+#endif // defined(DEBUG) || defined(JIT_ADHOC_PROFILE)
+
 #undef CONFIG_INTEGER
 #undef CONFIG_STRING
 #undef CONFIG_METHODSET

--- a/src/coreclr/src/jit/profile.cpp
+++ b/src/coreclr/src/jit/profile.cpp
@@ -131,7 +131,7 @@ void Profile::writeProfileData()
         // Sanity checks -- note asserting here leads to hangs at runtime.
         if ((header->recordCount < MIN_RECORD_COUNT) || (header->recordCount > MAX_RECORD_COUNT))
         {
-            fprintf(profileDataFile, "Unreasonable record count %u at index %u\n", header[0], index);
+            fprintf(profileDataFile, "Unreasonable record count %u at index %u\n", header->recordCount, index);
             break;
         }
 

--- a/src/coreclr/src/jit/profile.cpp
+++ b/src/coreclr/src/jit/profile.cpp
@@ -33,7 +33,7 @@ void Profile::allocateProfileData(unsigned maxIndex)
     }
 
     ICorJitInfo::BlockCounts* const profileBuffer =
-        (ICorJitInfo::BlockCounts*)calloc(maxIndex, sizeof(ICorJitInfo::BlockCounts));
+        new (HostAllocator::getHostAllocator()) ICorJitInfo::BlockCounts[maxIndex];
 
     if (profileBuffer == nullptr)
     {
@@ -81,7 +81,7 @@ ICorJitInfo::BlockCounts* Profile::allocateMethodData(unsigned recordCount)
             return nullptr;
         }
 
-        const unsigned updatedIndex = InterlockedCompareExchange(&s_ProfileIndex, newIndex, oldIndex);
+        const unsigned updatedIndex = InterlockedCompareExchangeT(&s_ProfileIndex, newIndex, oldIndex);
 
         if (updatedIndex == oldIndex)
         {

--- a/src/coreclr/src/jit/profile.cpp
+++ b/src/coreclr/src/jit/profile.cpp
@@ -1,0 +1,313 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "jitpch.h"
+#ifdef _MSC_VER
+#pragma hdrstop
+#endif
+
+#include "profile.h"
+
+#if defined(JIT_ADHOC_PROFILE)
+
+ICorJitInfo::BlockCounts* Profile::s_ProfileData;
+unsigned                  Profile::s_ProfileIndex;
+const char* const         Profile::s_FileHeaderString  = "*** START Jit profile data, max index = %u ***\n";
+const char* const         Profile::s_FileTrailerString = "*** END Jit profile data ***\n";
+const char* const         Profile::s_MethodHeaderString =
+    "@@@ token 0x%08X hash 0x%08X ilSize 0x%08X records 0x%08X index %u\n";
+const char* const Profile::s_RecordString = "ilOffs %u count %u\n";
+
+//------------------------------------------------------------------------
+// allocateProfileData: allocate in-memory profile data buffer
+//
+// todo: multithreaded protection
+// todo: persistent failure
+//
+void Profile::allocateProfileData(unsigned maxIndex)
+{
+    if (s_ProfileData != nullptr)
+    {
+        return;
+    }
+
+    ICorJitInfo::BlockCounts* const profileBuffer =
+        (ICorJitInfo::BlockCounts*)calloc(maxIndex, sizeof(ICorJitInfo::BlockCounts));
+
+    if (profileBuffer == nullptr)
+    {
+        return;
+    }
+
+    s_ProfileData  = profileBuffer;
+    s_ProfileIndex = 0;
+}
+
+//------------------------------------------------------------------------
+// allocateMethodData: allocate in-memory profile buffer for a method
+//
+// Argments:
+//    recordCount - number of records needed for the method, including
+//                     the header record(s)
+//
+// Returns:
+//    profile buffer to use for the method
+//
+ICorJitInfo::BlockCounts* Profile::allocateMethodData(unsigned recordCount)
+{
+    allocateProfileData();
+
+    if (s_ProfileData == nullptr)
+    {
+        return nullptr;
+    }
+
+    unsigned methodIndex = 0;
+
+    // Look for space in the profile buffer for this method.
+    // Note other jit invocations may be vying for space concurrently.
+    //
+    while (true)
+    {
+        const unsigned oldIndex = s_ProfileIndex;
+        const unsigned newIndex = oldIndex + recordCount;
+
+        // If there is no room left for this method,
+        // that's ok, we just won't profile this method.
+        //
+        if (newIndex >= BUFFER_SIZE)
+        {
+            return nullptr;
+        }
+
+        const unsigned updatedIndex = InterlockedCompareExchange(&s_ProfileIndex, newIndex, oldIndex);
+
+        if (updatedIndex == oldIndex)
+        {
+            // Found space
+            methodIndex = oldIndex;
+            break;
+        }
+    }
+
+    return &s_ProfileData[methodIndex];
+}
+
+//------------------------------------------------------------------------
+// writeProfileData: save in-process profile data to a text file
+//
+// Notes:
+//   When the jit is collecting in-process profile data, profile data is
+//   saved to the file specified by JitWriteProfileData.
+//
+void Profile::writeProfileData()
+{
+    if (s_ProfileData == nullptr)
+    {
+        return;
+    }
+
+    if (JitConfig.JitWriteProfileData() == nullptr)
+    {
+        return;
+    }
+
+    FILE* const profileDataFile = _wfopen(JitConfig.JitWriteProfileData(), W("w"));
+
+    if (profileDataFile == nullptr)
+    {
+        return;
+    }
+
+    fprintf(profileDataFile, s_FileHeaderString, s_ProfileIndex);
+    unsigned       index    = 0;
+    const unsigned maxIndex = s_ProfileIndex;
+
+    while (index < maxIndex)
+    {
+        const Header* const header = (Header*)&s_ProfileData[index];
+
+        // Sanity checks -- note asserting here leads to hangs at runtime.
+        if ((header->recordCount < MIN_RECORD_COUNT) || (header->recordCount > MAX_RECORD_COUNT))
+        {
+            fprintf(profileDataFile, "Unreasonable record count %u at index %u\n", header[0], index);
+            break;
+        }
+
+        fprintf(profileDataFile, s_MethodHeaderString, header->token, header->hash, header->ilSize, header->recordCount,
+                index);
+
+        index += 2;
+
+        ICorJitInfo::BlockCounts* records     = &s_ProfileData[index];
+        unsigned                  recordCount = header->recordCount - 2;
+        unsigned                  lastOffset  = 0;
+        for (unsigned i = 0; i < recordCount; i++)
+        {
+            const unsigned thisOffset = records[i].ILOffset;
+            assert((thisOffset > lastOffset) || (lastOffset == 0));
+            lastOffset = thisOffset;
+
+            // We probably could suppress writing zero records here,
+            // if we default to zero fill when recovering data and
+            // propagating to the flow graph.
+            fprintf(profileDataFile, s_RecordString, records[i].ILOffset, records[i].ExecutionCount);
+        }
+
+        index += recordCount;
+    }
+
+    fprintf(profileDataFile, s_FileTrailerString);
+    fclose(profileDataFile);
+}
+
+//------------------------------------------------------------------------
+// readProfileData: read profile data from a text file
+//
+// Notes:
+//   This method allocates and fills in the internal profile buffer by
+//   reading information from a text file.
+//
+//   If the jit is also collecting profile data then reading profile
+//   data is inhibited.
+//
+void Profile::readProfileData()
+{
+    // If we're already writing profile data or doing tiered pgo, defer reading data.
+    //
+    if ((JitConfig.JitWriteProfileData() != nullptr) || (JitConfig.JitTieredPGO() > 0))
+    {
+        return;
+    }
+
+    // If we've already read profile data, we're done.
+    //
+    if (s_ProfileData != nullptr)
+    {
+        assert(s_ProfileIndex >= MIN_RECORD_COUNT);
+        return;
+    }
+
+    FILE* const profileDataFile = _wfopen(JitConfig.JitReadProfileData(), W("r"));
+
+    if (profileDataFile == nullptr)
+    {
+        return;
+    }
+
+    char     buffer[256];
+    unsigned maxIndex = 0;
+
+    // Header must be first line
+    //
+    if (fgets(buffer, sizeof(buffer), profileDataFile) == nullptr)
+    {
+        return;
+    }
+
+    if (sscanf_s(buffer, s_FileHeaderString, &maxIndex) != 1)
+    {
+        return;
+    }
+
+    // Sanity check
+    //
+    if ((maxIndex == 0) || (maxIndex >= MAX_RECORD_COUNT))
+    {
+        return;
+    }
+
+    // Allocate the profile data
+    //
+    Profile::allocateProfileData(maxIndex);
+
+    if (s_ProfileData == nullptr)
+    {
+        return;
+    }
+
+    // Fill in the data
+    //
+    unsigned index   = 0;
+    unsigned methods = 0;
+
+    bool failed = false;
+    while (!failed)
+    {
+        if (fgets(buffer, sizeof(buffer), profileDataFile) == nullptr)
+        {
+            break;
+        }
+
+        // Find the next method entry line
+        //
+        unsigned recordCount = 0;
+        unsigned token       = 0;
+        unsigned hash        = 0;
+        unsigned ilSize      = 0;
+        unsigned rIndex      = 0;
+
+        if (sscanf_s(buffer, s_MethodHeaderString, &token, &hash, &ilSize, &recordCount, &rIndex) != 5)
+        {
+            continue;
+        }
+
+        assert(index == rIndex);
+        methods++;
+
+        Profile::Header* const header = (Profile::Header*)&s_ProfileData[index];
+
+        header->recordCount = recordCount;
+        header->token       = token;
+        header->hash        = hash;
+        header->ilSize      = ilSize;
+
+        // Sanity check
+        //
+        if ((recordCount < MIN_RECORD_COUNT) || (recordCount > MAX_RECORD_COUNT))
+        {
+            failed = true;
+            break;
+        }
+
+        index += 2;
+
+        // Read il data
+        //
+        for (unsigned i = 0; i < recordCount - 2; i++)
+        {
+            if (fgets(buffer, sizeof(buffer), profileDataFile) == nullptr)
+            {
+                failed = true;
+                break;
+            }
+
+            if (sscanf_s(buffer, Profile::s_RecordString, &s_ProfileData[index].ILOffset,
+                         &s_ProfileData[index].ExecutionCount) != 2)
+            {
+                failed = true;
+                break;
+            }
+
+            index++;
+        }
+    }
+
+    // JITDUMPs here not all that useful.
+    if (failed)
+    {
+        // todo: inhibit other attempts
+        JITDUMP("Failed to parse profile data from %ws : record %u line '%s'\n", JitConfig.JitReadProfileData(), index,
+                buffer);
+    }
+    else
+    {
+        JITDUMP("Profile Data read from %s successfully, %u records %u methods\n", JitConfig.JitReadProfileData(),
+                maxIndex, methods);
+
+        s_ProfileIndex = maxIndex;
+    }
+}
+
+#endif // #if defined(JIT_ADHOC_PROFILE)

--- a/src/coreclr/src/jit/profile.h
+++ b/src/coreclr/src/jit/profile.h
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _PROFILE_H_
+#define _PROFILE_H_
+
+#if defined(JIT_ADHOC_PROFILE)
+
+// Support for in-memory profile buffer that can
+// be saved to a file or restored from a file
+//
+class Profile
+{
+public:
+    struct Header
+    {
+        unsigned recordCount;
+        unsigned token;
+        unsigned hash;
+        unsigned ilSize;
+    };
+
+    enum
+    {
+        // Number of ICorJitInfo::BlockCount records in the in-process buffer.
+        BUFFER_SIZE      = 64 * 1024,
+        MIN_RECORD_COUNT = 3,
+        MAX_RECORD_COUNT = BUFFER_SIZE
+    };
+
+    static void allocateProfileData(unsigned maxIndex = BUFFER_SIZE);
+    static ICorJitInfo::BlockCounts* allocateMethodData(unsigned recordCount);
+    static void writeProfileData();
+    static void readProfileData();
+
+    static const char* const s_FileHeaderString;
+    static const char* const s_FileTrailerString;
+    static const char* const s_MethodHeaderString;
+    static const char* const s_RecordString;
+
+    // The in-process buffer
+    static ICorJitInfo::BlockCounts* s_ProfileData;
+
+    // Next free record slot in the buffer
+    static unsigned s_ProfileIndex;
+};
+
+#endif // defined(JIT_ADHOC_PROFILE)
+
+#endif // _PROFILE_H_


### PR DESCRIPTION
1. Add code so the jit can read profile data from a text file, so it will be
easier to test the jit's behavior when profile data is available.
2. Add code so the jit can create profile text files by inserting probes
into jitted code that write into a persistent buffer. This is mainly intended
to make creation of these files easier, since their internal structure must
exactly match artifacts from jitted methods.
3. Add a mode where instrumented Tier0 code can feed counts into Tier1 jitting.
This is an experiment to see what benefit, if any, might accrue from having
profile data available for Tier1 jitting.

External format is text so it can be edited by hand or checked into the repo
alongside tests. Binary format would be more compact but opaque.

In all cases the jit internally sees a profile buffer similar to the one it
sees with IBC; the only real changes are in reading and writing the data
externally, and in the special instrumentation for an in-memory profile buffer.

Only root methods are instrumented, and only root method blocks are given
profile weights. Broadening to handle inlinees is future work, facilitated by
the new capabilites added here.

Addresses #36078.