### PR TITLE
Return exit code 1 in android test runner if a test failed

### DIFF
--- a/src/mono/msbuild/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/mono/msbuild/AndroidAppBuilder/Templates/MonoRunner.java
@@ -57,7 +57,7 @@ public class MonoRunner extends Instrumentation
                 result.putInt("return-code", retcode);
                 // Xharness cli expects "test-results-path" with test results
                 result.putString("test-results-path", docsDir + "/testResults.xml");
-                finish(0, result);
+                finish(retcode, result);
             }
         });
     }

--- a/src/mono/msbuild/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/src/mono/msbuild/AndroidAppBuilder/Templates/MonoRunner.java
@@ -57,7 +57,7 @@ public class MonoRunner extends Instrumentation
                 result.putInt("return-code", retcode);
                 // Xharness cli expects "test-results-path" with test results
                 result.putString("test-results-path", docsDir + "/testResults.xml");
-                finish(retcode, result);
+                finish(0, result);
             }
         });
     }

--- a/src/mono/msbuild/AndroidTestRunner/AndroidTestRunner.cs
+++ b/src/mono/msbuild/AndroidTestRunner/AndroidTestRunner.cs
@@ -24,11 +24,18 @@ public class SimpleAndroidTestRunner : AndroidApplicationEntryPoint, IDevice
             Console.WriteLine($"Test libs were not found (*.Tests.dll was not found in {Environment.CurrentDirectory})");
             return -1;
         }
+        int exitCode = 0;
         s_MainTestName = Path.GetFileNameWithoutExtension(s_testLibs[0]);
         var simpleTestRunner = new SimpleAndroidTestRunner(true);
+        simpleTestRunner.TestsCompleted += (e, result) => 
+        {
+            if (result.FailedTests > 0)
+                exitCode = 1;
+        };
+
         await simpleTestRunner.RunAsync();
         Console.WriteLine("----- Done -----");
-        return 0;
+        return exitCode;
     }
 
     public SimpleAndroidTestRunner(bool verbose)


### PR DESCRIPTION
In order to fail the build we need to return a failing exit code if there were test failures. 