### PR TITLE
Emit DWARF debug_abbrev offset for compile units as a label instead of 0

### DIFF
--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -182,6 +182,12 @@ emit_int32 (MonoDwarfWriter *w, int value)
 }
 
 static void
+emit_symbol (MonoDwarfWriter *w, const char *symbol)
+{
+	mono_img_writer_emit_symbol (w->w, symbol);
+}
+
+static void
 emit_symbol_diff (MonoDwarfWriter *w, const char *end, const char* start, int offset) 
 { 
 	mono_img_writer_emit_symbol_diff (w->w, end, start, offset); 
@@ -799,6 +805,7 @@ mono_dwarf_writer_emit_base_info (MonoDwarfWriter *w, const char *cu_name, GSLis
 	w->cie_program = base_unwind_program;
 
 	emit_section_change (w, ".debug_abbrev", 0);
+	emit_label (w, ".Ldebug_abbrev_start");
 	emit_dwarf_abbrev (w, ABBREV_COMPILE_UNIT, DW_TAG_compile_unit, TRUE, 
 					   compile_unit_attr, G_N_ELEMENTS (compile_unit_attr));
 	emit_dwarf_abbrev (w, ABBREV_SUBPROGRAM, DW_TAG_subprogram, TRUE, 
@@ -842,7 +849,7 @@ mono_dwarf_writer_emit_base_info (MonoDwarfWriter *w, const char *cu_name, GSLis
 	emit_symbol_diff (w, ".Ldebug_info_end", ".Ldebug_info_begin", 0); /* length */
 	emit_label (w, ".Ldebug_info_begin");
 	emit_int16 (w, 0x2); /* DWARF version 2 */
-	emit_int32 (w, 0); /* .debug_abbrev offset */
+	emit_symbol (w, ".Ldebug_abbrev_start"); /* .debug_abbrev offset */
 	emit_byte (w, sizeof (target_mgreg_t)); /* address size */
 
 	/* Compilation unit */

--- a/src/mono/mono/mini/image-writer.h
+++ b/src/mono/mono/mini/image-writer.h
@@ -98,6 +98,8 @@ void mono_img_writer_emit_int16 (MonoImageWriter *w, int value);
 
 void mono_img_writer_emit_int32 (MonoImageWriter *w, int value);
 
+void mono_img_writer_emit_symbol (MonoImageWriter *w, const char *symbol);
+
 void mono_img_writer_emit_symbol_diff (MonoImageWriter *w, const char *end, const char* start, int offset);
 
 void mono_img_writer_emit_zero_bytes (MonoImageWriter *w, int num);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19770,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>When outputting DWARF code to start a compilation unit in .debug_info, the standard expect a 4-byte offset from the .debug_abbrev code. Mono has always output an offset of 0.

However, this doesn't work in every cases. When we have linux+fullaot, we link two object files (one from Mono, one from LLVM). Both have their .debug_abbrev section. If we use 0 as an offset, it seems possible that the linker will keep thinking that our offset is 0, no matter the circumstances. Since the offset is always 0, it can be using the wrong abbreviation table (i.e. the one from the LLVM assembly instead of the one from the Mono assembly). The consequence of this is that the linked file is not valid DWARF (dwarfdump and objdump will complain about invalid offsets). At best, some tools will be able to work with a part of what we have, but any program requiring entirely valid DWARF will fail.

To fix this, we generate a label for the start of our debug_abbrev section and we instead generate it by generating a long with that label. This matches existing behavior seen in the LLVM generated code, and makes dwarfdump and objdump react properly to the linked product.

## Notes

I tested this fix in two ways :
- Linux + fullaot
- Xamarin.Android (which was my initial issue to begin with)
  - I didn't test the emission of the label (I didn't want to build Xamarin.Android in full to try the change)
  - However, I did replicate the change myself on the generated .s file and applied the commands normally done by Xamarin.Android to confirm that the fix worked properly (that's how I found the solution in the first place)

I'm not 100% convinced this is the right fix, since the DWARF spec mentions an offset in the debug_abbrev section and I'm not sure if they mean relative to the start of the debug_abbrev section or an address in the file (I would guess that if it's 0, they treat it as relative and absolute otherwise but I'm really not sure).

For the emission of the label, there wasn't a functionnality available to do as such, so I added one. I based myself on emit_symbol_diff.

## Fixes

Fixes mono/mono#8806