### PR TITLE
Add options to ignore default values during serialization

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -213,6 +213,7 @@ namespace System.Text.Json
         public bool AllowTrailingCommas { get { throw null; } set { } }
         public System.Collections.Generic.IList<System.Text.Json.Serialization.JsonConverter> Converters { get { throw null; } }
         public int DefaultBufferSize { get { throw null; } set { } }
+        public System.Text.Json.Serialization.JsonIgnoreCondition DefaultIgnoreCondition { get { throw null; } set { } }
         public System.Text.Json.JsonNamingPolicy? DictionaryKeyPolicy { get { throw null; } set { } }
         public System.Text.Encodings.Web.JavaScriptEncoder? Encoder { get { throw null; } set { } }
         public bool IgnoreNullValues { get { throw null; } set { } }
@@ -465,9 +466,9 @@ namespace System.Text.Json.Serialization
 {
     public enum JsonIgnoreCondition
     {
-        Always = 0,
-        WhenNull = 1,
-        Never = 2,
+        Never = 0,
+        Always = 1,
+        WhenWritingDefault = 2,
     }
     public abstract partial class JsonAttribute : System.Attribute
     {

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -521,4 +521,10 @@
   <data name="CannotPopulateCollection" xml:space="preserve">
     <value>The collection type '{0}' is abstract, an interface, or is read only, and could not be instantiated and populated.</value>
   </data>
+  <data name="DefaultIgnoreConditionAlreadySpecified" xml:space="preserve">
+    <value>'IgnoreNullValues' and 'DefaultIgnoreCondition' cannot both be set to non-default values.</value>
+  </data>
+  <data name="DefaultIgnoreConditionInvalid" xml:space="preserve">
+    <value>The value cannot be 'JsonIgnoreCondition.Always'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -99,7 +99,7 @@ namespace System.Text.Json.Serialization.Converters
 
                         if (dataExtKey == null)
                         {
-                            jsonPropertyInfo.SetValueAsObject(obj, propValue);
+                            jsonPropertyInfo.SetExtensionDictionaryAsObject(obj, propValue);
                         }
                         else
                         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -73,6 +74,8 @@ namespace System.Text.Json.Serialization
         /// Is the converter built-in.
         /// </summary>
         internal bool IsInternalConverter { get; set; }
+
+        internal readonly EqualityComparer<T> _defaultComparer = EqualityComparer<T>.Default;
 
         // This non-generic API is sealed as it just forwards to the generic version.
         internal sealed override bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreCondition.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreCondition.cs
@@ -5,21 +5,22 @@
 namespace System.Text.Json.Serialization
 {
     /// <summary>
-    /// Controls how the <see cref="JsonIgnoreAttribute"/> ignores properties on serialization and deserialization.
+    /// When specified on <see cref="JsonSerializerOptions.DefaultIgnoreCondition"/>, controls whether properties with default values are ignored during serialization.
+    /// When specified on <see cref="JsonIgnoreAttribute.Condition"/>, controls whether a property is ignored during serialization and deserialization.
     /// </summary>
     public enum JsonIgnoreCondition
     {
         /// <summary>
-        /// Property will always be ignored.
+        /// Property will always be serialized and deserialized.
         /// </summary>
-        Always = 0,
+        Never = 0,
         /// <summary>
-        /// Property will only be ignored if it is null.
+        /// Property will never be serialized or deserialized.
         /// </summary>
-        WhenNull = 1,
+        Always = 1,
         /// <summary>
-        /// Property will always be serialized and deserialized, regardless of <see cref="JsonSerializerOptions.IgnoreNullValues"/> configuration.
+        /// Property will not be serialized if it is the default value.
         /// </summary>
-        Never = 2
+        WhenWritingDefault = 2,
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreCondition.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonIgnoreCondition.cs
@@ -5,21 +5,23 @@
 namespace System.Text.Json.Serialization
 {
     /// <summary>
-    /// When specified on <see cref="JsonSerializerOptions.DefaultIgnoreCondition"/>, controls whether properties with default values are ignored during serialization.
-    /// When specified on <see cref="JsonIgnoreAttribute.Condition"/>, controls whether a property is ignored during serialization and deserialization.
+    /// When specified on <see cref="JsonSerializerOptions.DefaultIgnoreCondition"/>,
+    /// <see cref="WhenWritingDefault"/> specifies that properties with default values are ignored during serialization.
+    /// When specified on <see cref="JsonIgnoreAttribute.Condition"/>, controls whether
+    /// a property is ignored during serialization and deserialization.
     /// </summary>
     public enum JsonIgnoreCondition
     {
         /// <summary>
-        /// Property will always be serialized and deserialized.
+        /// Property is never ignored during serialization or deserialization.
         /// </summary>
         Never = 0,
         /// <summary>
-        /// Property will never be serialized or deserialized.
+        /// Property is always ignored during serialization and deserialization.
         /// </summary>
         Always = 1,
         /// <summary>
-        /// Property will not be serialized if it is the default value.
+        /// If the value is the default, the property is ignored during serialization.
         /// </summary>
         WhenWritingDefault = 2,
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -132,14 +132,23 @@ namespace System.Text.Json
 
                 if (ignoreCondition != JsonIgnoreCondition.Never)
                 {
-                    Debug.Assert(ignoreCondition == JsonIgnoreCondition.WhenNull);
-                    IgnoreNullValues = true;
+                    Debug.Assert(ignoreCondition == JsonIgnoreCondition.WhenWritingDefault);
+                    IgnoreDefaultValuesOnWrite = true;
                 }
             }
-            else
+#pragma warning disable CS0618 // IgnoreNullValues is obsolete
+            else if (Options.IgnoreNullValues)
             {
-                IgnoreNullValues = Options.IgnoreNullValues;
+                Debug.Assert(Options.DefaultIgnoreCondition == JsonIgnoreCondition.Never);
+                IgnoreDefaultValuesOnRead = true;
+                IgnoreDefaultValuesOnWrite = true;
             }
+            else if (Options.DefaultIgnoreCondition == JsonIgnoreCondition.WhenWritingDefault)
+            {
+                Debug.Assert(!Options.IgnoreNullValues);
+                IgnoreDefaultValuesOnWrite = true;
+            }
+#pragma warning restore CS0618 // IgnoreNullValues is obsolete
         }
 
         public static TAttribute? GetAttribute<TAttribute>(PropertyInfo propertyInfo) where TAttribute : Attribute
@@ -183,7 +192,8 @@ namespace System.Text.Json
             Options = options;
         }
 
-        public bool IgnoreNullValues { get; private set; }
+        public bool IgnoreDefaultValuesOnRead { get; private set; }
+        public bool IgnoreDefaultValuesOnWrite { get; private set; }
 
         public bool IsPropertyPolicy { get; protected set; }
 
@@ -307,7 +317,7 @@ namespace System.Text.Json
 
         public Type? RuntimePropertyType { get; private set; } = null;
 
-        public abstract void SetValueAsObject(object obj, object? value);
+        public abstract void SetExtensionDictionaryAsObject(object obj, object? extensionDict);
 
         public bool ShouldSerialize { get; private set; }
         public bool ShouldDeserialize { get; private set; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 namespace System.Text.Json
@@ -15,6 +16,8 @@ namespace System.Text.Json
     /// or a type's converter, if the current instance is a <see cref="JsonClassInfo.PropertyInfoForClassInfo"/>.
     internal sealed class JsonPropertyInfo<T> : JsonPropertyInfo
     {
+        private static readonly T s_defaultValue = default!;
+
         public Func<object, T>? Get { get; private set; }
         public Action<object, T>? Set { get; private set; }
 
@@ -98,9 +101,13 @@ namespace System.Text.Json
 
             bool success;
             T value = Get!(obj);
+
             if (value == null)
             {
-                if (!IgnoreNullValues)
+                Debug.Assert(s_defaultValue == null && Converter.CanBeNull);
+
+                success = true;
+                if (!IgnoreDefaultValuesOnWrite)
                 {
                     if (!Converter.HandleNull)
                     {
@@ -108,6 +115,9 @@ namespace System.Text.Json
                     }
                     else
                     {
+                        // No object, collection, or re-entrancy converter handles null.
+                        Debug.Assert(Converter.ClassType == ClassType.Value);
+
                         if (state.Current.PropertyState < StackFramePropertyState.Name)
                         {
                             state.Current.PropertyState = StackFramePropertyState.Name;
@@ -122,7 +132,10 @@ namespace System.Text.Json
                         }
                     }
                 }
-
+            }
+            else if (IgnoreDefaultValuesOnWrite && Converter._defaultComparer.Equals(s_defaultValue, value))
+            {
+                Debug.Assert(s_defaultValue != null && !Converter.CanBeNull);
                 success = true;
             }
             else
@@ -159,45 +172,46 @@ namespace System.Text.Json
         public override bool ReadJsonAndSetMember(object obj, ref ReadStack state, ref Utf8JsonReader reader)
         {
             bool success;
+
             bool isNullToken = reader.TokenType == JsonTokenType.Null;
             if (isNullToken && !Converter.HandleNull && !state.IsContinuation)
             {
-                if (!IgnoreNullValues)
+                if (!Converter.CanBeNull)
                 {
-                    if (!Converter.CanBeNull)
-                    {
-                        ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Converter.TypeToConvert);
-                    }
+                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Converter.TypeToConvert);
+                }
 
+                Debug.Assert(s_defaultValue == null);
+
+                if (!IgnoreDefaultValuesOnRead)
+                {
                     T value = default;
                     Set!(obj, value!);
                 }
 
                 success = true;
             }
-            else
+            else if (Converter.CanUseDirectReadOrWrite)
             {
-                // Get the value from the converter and set the property.
-                if (Converter.CanUseDirectReadOrWrite)
+                if (!(isNullToken && IgnoreDefaultValuesOnRead && Converter.CanBeNull))
                 {
                     // Optimize for internal converters by avoiding the extra call to TryRead.
                     T fastvalue = Converter.Read(ref reader, RuntimePropertyType!, Options);
-                    if (!IgnoreNullValues || (!isNullToken && fastvalue != null))
-                    {
-                        Set!(obj, fastvalue!);
-                    }
-
-                    return true;
+                    Set!(obj, fastvalue!);
                 }
-                else
+
+                success = true;
+            }
+            else
+            {
+                success = true;
+
+                if (!(isNullToken && IgnoreDefaultValuesOnRead && Converter.CanBeNull))
                 {
                     success = Converter.TryRead(ref reader, RuntimePropertyType!, Options, ref state, out T value);
                     if (success)
                     {
-                        if (!IgnoreNullValues || (!isNullToken && value != null))
-                        {
-                            Set!(obj, value!);
-                        }
+                        Set!(obj, value!);
                     }
                 }
             }
@@ -225,7 +239,7 @@ namespace System.Text.Json
                 if (Converter.CanUseDirectReadOrWrite)
                 {
                     value = Converter.Read(ref reader, RuntimePropertyType!, Options);
-                    return true;
+                    success = true;
                 }
                 else
                 {
@@ -237,15 +251,11 @@ namespace System.Text.Json
             return success;
         }
 
-        public override void SetValueAsObject(object obj, object? value)
+        public override void SetExtensionDictionaryAsObject(object obj, object? extensionDict)
         {
             Debug.Assert(HasSetter);
-            T typedValue = (T)value!;
-
-            if (typedValue != null || !IgnoreNullValues)
-            {
-                Set!(obj, typedValue);
-            }
+            T typedValue = (T)extensionDict!;
+            Set!(obj, typedValue);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -41,6 +41,6 @@ namespace System.Text.Json.Serialization
             TryWrite(writer, value, options, ref state);
         }
 
-        public override bool HandleNull => false;
+        public sealed override bool HandleNull => false;
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -122,7 +122,7 @@ namespace System.Text.Json
                 }
 
                 extensionData = jsonPropertyInfo.RuntimeClassInfo.CreateObject();
-                jsonPropertyInfo.SetValueAsObject(obj, extensionData);
+                jsonPropertyInfo.SetExtensionDictionaryAsObject(obj, extensionData);
             }
 
             // We don't add the value to the dictionary here because we need to support the read-ahead functionality for Streams.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -3,10 +3,10 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 using System.Text.Encodings.Web;
-using System.Reflection;
 
 namespace System.Text.Json
 {
@@ -29,6 +29,7 @@ namespace System.Text.Json
         private JsonCommentHandling _readCommentHandling;
         private ReferenceHandling _referenceHandling = ReferenceHandling.Default;
         private JavaScriptEncoder? _encoder = null;
+        private JsonIgnoreCondition _defaultIgnoreCondition;
 
         private int _defaultBufferSize = BufferSizeDefault;
         private int _maxDepth;
@@ -61,12 +62,13 @@ namespace System.Text.Json
                 throw new ArgumentNullException(nameof(options));
             }
 
-            _memberAccessorStrategy = options.MemberAccessorStrategy;
+            _memberAccessorStrategy = options._memberAccessorStrategy;
             _dictionaryKeyPolicy = options._dictionaryKeyPolicy;
             _jsonPropertyNamingPolicy = options._jsonPropertyNamingPolicy;
             _readCommentHandling = options._readCommentHandling;
             _referenceHandling = options._referenceHandling;
             _encoder = options._encoder;
+            _defaultIgnoreCondition = options._defaultIgnoreCondition;
 
             _defaultBufferSize = options._defaultBufferSize;
             _maxDepth = options._maxDepth;
@@ -195,7 +197,10 @@ namespace System.Text.Json
         /// </summary>
         /// <exception cref="InvalidOperationException">
         /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// or <see cref="DefaultIgnoreCondition"/> has been set to a non-default value. These properties cannot be used together.
         /// </exception>
+        [Obsolete("Use DefaultIgnoreCondition instead.", error: false)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public bool IgnoreNullValues
         {
             get
@@ -205,7 +210,49 @@ namespace System.Text.Json
             set
             {
                 VerifyMutable();
+
+                if (value == true && _defaultIgnoreCondition != JsonIgnoreCondition.Never)
+                {
+                    Debug.Assert(_defaultIgnoreCondition == JsonIgnoreCondition.WhenWritingDefault);
+                    throw new InvalidOperationException(SR.DefaultIgnoreConditionAlreadySpecified);
+                }
+
                 _ignoreNullValues = value;
+            }
+        }
+
+        /// <summary>
+        /// Specifies a condition to determine when properties with default values are ignored during serialization or deserialization.
+        /// The default value is <see cref="JsonIgnoreCondition.Never" />.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown if this property is set to <see cref="JsonIgnoreCondition.Always"/>.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred,
+        /// or <see cref="IgnoreNullValues"/> has been set to <see langword="true"/>. These properties cannot be used together.
+        /// </exception>
+        public JsonIgnoreCondition DefaultIgnoreCondition
+        {
+            get
+            {
+                return _defaultIgnoreCondition;
+            }
+            set
+            {
+                VerifyMutable();
+
+                if (value == JsonIgnoreCondition.Always)
+                {
+                    throw new ArgumentException(SR.DefaultIgnoreConditionInvalid);
+                }
+
+                if (value != JsonIgnoreCondition.Never && _ignoreNullValues)
+                {
+                    throw new InvalidOperationException(SR.DefaultIgnoreConditionAlreadySpecified);
+                }
+
+                _defaultIgnoreCondition = value;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonValueConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonValueConverterOfT.cs
@@ -12,6 +12,8 @@ namespace System.Text.Json.Serialization
     {
         internal sealed override ClassType ClassType => ClassType.NewValue;
 
+        public sealed override bool HandleNull => false;
+
         [return: MaybeNull]
         public sealed override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {

--- a/src/libraries/System.Text.Json/tests/JsonTestHelper.cs
+++ b/src/libraries/System.Text.Json/tests/JsonTestHelper.cs
@@ -868,10 +868,14 @@ namespace System.Text.Json
                     Assert.Equal(expected.GetString(), actual.GetString());
                     break;
                 case JsonValueKind.Number:
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                case JsonValueKind.Null:
                     Assert.Equal(expected.GetRawText(), actual.GetRawText());
                     break;
                 default:
-                    throw new NotImplementedException();
+                    Debug.Fail($"Unexpected JsonValueKind: JsonValueKind.{valueKind}.");
+                    break;
             }
         }
     }

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.HandleNull.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.HandleNull.cs
@@ -523,7 +523,7 @@ namespace System.Text.Json.Serialization.Tests
             ClassWithInitializedUri obj = JsonSerializer.Deserialize<ClassWithInitializedUri>(json, options);
             Assert.Equal(new Uri("https://microsoft.com"), obj.MyUri);
 
-            // Baseline - setter is called if payload is not null and converter returns null.
+            // Test - setter is called if payload is not null and converter returns null.
             json = @"{""MyUri"":""https://default""}";
             obj = JsonSerializer.Deserialize<ClassWithInitializedUri>(json, options);
             Assert.Null(obj.MyUri);

--- a/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.HandleNull.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CustomConverterTests/CustomConverterTests.HandleNull.cs
@@ -380,17 +380,18 @@ namespace System.Text.Json.Serialization.Tests
             var options = new JsonSerializerOptions();
             options.Converters.Add(new UriNullConverter_NullOptIn());
 
-            // Converter is not called.
+            // Converter is called - JsonIgnoreCondition.WhenWritingDefault does not apply to deserialization.
             ClassWithIgnoredUri obj = JsonSerializer.Deserialize<ClassWithIgnoredUri>(@"{""MyUri"":null}", options);
-            Assert.Equal(new Uri("https://microsoft.com"), obj.MyUri);
+            Assert.Equal(new Uri("https://default"), obj.MyUri);
 
             obj.MyUri = null;
+            // Converter is not called - value is ignored on serialization.
             Assert.Equal("{}", JsonSerializer.Serialize(obj, options));
         }
 
         private class ClassWithIgnoredUri
         {
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public Uri MyUri { get; set; } = new Uri("https://microsoft.com");
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ExtensionDataTests.cs
@@ -56,7 +56,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void ExtensionPropertyIgnoredWhenNull()
+        public static void ExtensionPropertyIgnoredWhenWritingDefault()
         {
             string expected = @"{}";
             string actual = JsonSerializer.Serialize(new ClassWithExtensionPropertyAsObject());
@@ -64,7 +64,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void MultipleExtensionPropertyIgnoredWhenNull()
+        public static void MultipleExtensionPropertyIgnoredWhenWritingDefault()
         {
             var obj = new ClassWithMultipleDictionaries();
             string actual = JsonSerializer.Serialize(obj);

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.NonPublicAccessors.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.NonPublicAccessors.cs
@@ -88,7 +88,7 @@ namespace System.Text.Json.Serialization.Tests
             public int MyInt { get; private set; }
 
             [JsonInclude]
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public string MyString { get; internal set; } = "DefaultString";
 
             [JsonInclude]

--- a/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/PropertyVisibilityTests.cs
@@ -987,8 +987,8 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Theory]
-        [MemberData(nameof(JsonIgnoreConditionWhenNull_ClassProperty_TestData))]
-        public static void JsonIgnoreConditionWhenNull_ClassProperty(Type type, JsonSerializerOptions options)
+        [MemberData(nameof(JsonIgnoreConditionWhenWritingDefault_ClassProperty_TestData))]
+        public static void JsonIgnoreConditionWhenWritingDefault_ClassProperty(Type type, JsonSerializerOptions options)
         {
             // Property shouldn't be ignored if it isn't null.
             string json = @"{""Int1"":1,""MyString"":""Random"",""Int2"":2}";
@@ -1008,7 +1008,17 @@ namespace System.Text.Json.Serialization.Tests
 
             obj = JsonSerializer.Deserialize(json, type, options);
             Assert.Equal(1, (int)type.GetProperty("Int1").GetValue(obj));
-            Assert.Equal("DefaultString", (string)type.GetProperty("MyString").GetValue(obj));
+
+            if (options.IgnoreNullValues)
+            {
+                // Null values can be ignored on deserialization using IgnoreNullValues.
+                Assert.Equal("DefaultString", (string)type.GetProperty("MyString").GetValue(obj));
+            }
+            else
+            {
+                Assert.Null((string)type.GetProperty("MyString").GetValue(obj));
+            }
+
             Assert.Equal(2, (int)type.GetProperty("Int2").GetValue(obj));
 
             // Set property to be ignored to null.
@@ -1020,22 +1030,22 @@ namespace System.Text.Json.Serialization.Tests
             Assert.DoesNotContain(@"""MyString"":", serialized);
         }
 
-        private class ClassWithClassProperty_IgnoreConditionWhenNull
+        private class ClassWithClassProperty_IgnoreConditionWhenWritingDefault
         {
             public int Int1 { get; set; }
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public string MyString { get; set; } = "DefaultString";
             public int Int2 { get; set; }
         }
 
-        private class ClassWithClassProperty_IgnoreConditionWhenNull_Ctor
+        private class ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor
         {
             public int Int1 { get; set; }
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public string MyString { get; set; } = "DefaultString";
             public int Int2 { get; set; }
 
-            public ClassWithClassProperty_IgnoreConditionWhenNull_Ctor(string myString)
+            public ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor(string myString)
             {
                 if (myString != null)
                 {
@@ -1044,15 +1054,15 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        private static IEnumerable<object[]> JsonIgnoreConditionWhenNull_ClassProperty_TestData()
+        private static IEnumerable<object[]> JsonIgnoreConditionWhenWritingDefault_ClassProperty_TestData()
         {
-            yield return new object[] { typeof(ClassWithClassProperty_IgnoreConditionWhenNull), new JsonSerializerOptions() };
-            yield return new object[] { typeof(ClassWithClassProperty_IgnoreConditionWhenNull_Ctor), new JsonSerializerOptions { IgnoreNullValues = true } };
+            yield return new object[] { typeof(ClassWithClassProperty_IgnoreConditionWhenWritingDefault), new JsonSerializerOptions() };
+            yield return new object[] { typeof(ClassWithClassProperty_IgnoreConditionWhenWritingDefault_Ctor), new JsonSerializerOptions { IgnoreNullValues = true } };
         }
 
         [Theory]
-        [MemberData(nameof(JsonIgnoreConditionWhenNull_StructProperty_TestData))]
-        public static void JsonIgnoreConditionWhenNull_StructProperty(Type type, JsonSerializerOptions options)
+        [MemberData(nameof(JsonIgnoreConditionWhenWritingDefault_StructProperty_TestData))]
+        public static void JsonIgnoreConditionWhenWritingDefault_StructProperty(Type type, JsonSerializerOptions options)
         {
             // Property shouldn't be ignored if it isn't null.
             string json = @"{""Int1"":1,""MyInt"":3,""Int2"":2}";
@@ -1072,23 +1082,23 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize(json, type, options));
         }
 
-        private class ClassWithStructProperty_IgnoreConditionWhenNull
+        private class ClassWithStructProperty_IgnoreConditionWhenWritingDefault
         {
             public int Int1 { get; set; }
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public int MyInt { get; set; }
             public int Int2 { get; set; }
         }
 
-        private struct StructWithStructProperty_IgnoreConditionWhenNull_Ctor
+        private struct StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor
         {
             public int Int1 { get; set; }
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public int MyInt { get; }
             public int Int2 { get; set; }
 
             [JsonConstructor]
-            public StructWithStructProperty_IgnoreConditionWhenNull_Ctor(int myInt)
+            public StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor(int myInt)
             {
                 Int1 = 0;
                 MyInt = myInt;
@@ -1096,10 +1106,10 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
 
-        private static IEnumerable<object[]> JsonIgnoreConditionWhenNull_StructProperty_TestData()
+        private static IEnumerable<object[]> JsonIgnoreConditionWhenWritingDefault_StructProperty_TestData()
         {
-            yield return new object[] { typeof(ClassWithStructProperty_IgnoreConditionWhenNull), new JsonSerializerOptions() };
-            yield return new object[] { typeof(StructWithStructProperty_IgnoreConditionWhenNull_Ctor), new JsonSerializerOptions { IgnoreNullValues = true } };
+            yield return new object[] { typeof(ClassWithStructProperty_IgnoreConditionWhenWritingDefault), new JsonSerializerOptions() };
+            yield return new object[] { typeof(StructWithStructProperty_IgnoreConditionWhenWritingDefault_Ctor), new JsonSerializerOptions { IgnoreNullValues = true } };
         }
 
         [Theory]
@@ -1208,33 +1218,30 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void ClassWithComplexObjectsUsingIgnoreWhenNullAttribute()
+        public static void ClassWithComplexObjectsUsingIgnoreWhenWritingDefaultAttribute()
         {
             string json = @"{""Class"":{""MyInt16"":18}, ""Dictionary"":null}";
 
-            ClassUsingIgnoreWhenNullAttribute obj = JsonSerializer.Deserialize<ClassUsingIgnoreWhenNullAttribute>(json);
+            ClassUsingIgnoreWhenWritingDefaultAttribute obj = JsonSerializer.Deserialize<ClassUsingIgnoreWhenWritingDefaultAttribute>(json);
 
-            // Class is deserialized because it is not null in json.
+            // Class is deserialized.
             Assert.NotNull(obj.Class);
             Assert.Equal(18, obj.Class.MyInt16);
 
-            // Dictionary is left alone because it is null in json.
-            Assert.NotNull(obj.Dictionary);
-            Assert.Equal(1, obj.Dictionary.Count);
-            Assert.Equal("Value", obj.Dictionary["Key"]);
+            // Dictionary is deserialized as JsonIgnoreCondition.WhenWritingDefault only applies to deserialization.
+            Assert.Null(obj.Dictionary);
 
-
-            obj = new ClassUsingIgnoreWhenNullAttribute();
+            obj = new ClassUsingIgnoreWhenWritingDefaultAttribute();
             json = JsonSerializer.Serialize(obj);
             Assert.Equal(@"{""Dictionary"":{""Key"":""Value""}}", json);
         }
 
-        public class ClassUsingIgnoreWhenNullAttribute
+        public class ClassUsingIgnoreWhenWritingDefaultAttribute
         {
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public SimpleTestClass Class { get; set; }
 
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public Dictionary<string, string> Dictionary { get; set; } = new Dictionary<string, string> { ["Key"] = "Value" };
         }
 
@@ -1290,7 +1297,7 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public static void IgnoreConditionWhenNull_WinsOver_IgnoreReadOnlyValues()
+        public static void IgnoreConditionWhenWritingDefault_WinsOver_IgnoreReadOnlyValues()
         {
             var options = new JsonSerializerOptions { IgnoreReadOnlyProperties = true };
 
@@ -1299,10 +1306,10 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal("{}", json);
 
             // With condition to ignore when null
-            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreWhenNull("Hello"), options);
+            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreWhenWritingDefault("Hello"), options);
             Assert.Equal(@"{""MyString"":""Hello""}", json);
 
-            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreWhenNull(null), options);
+            json = JsonSerializer.Serialize(new ClassWithReadOnlyString_IgnoreWhenWritingDefault(null), options);
             Assert.Equal(@"{}", json);
         }
 
@@ -1321,12 +1328,12 @@ namespace System.Text.Json.Serialization.Tests
             public ClassWithReadOnlyString_IgnoreNever(string myString) => MyString = myString;
         }
 
-        private class ClassWithReadOnlyString_IgnoreWhenNull
+        private class ClassWithReadOnlyString_IgnoreWhenWritingDefault
         {
-            [JsonIgnore(Condition = JsonIgnoreCondition.WhenNull)]
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
             public string MyString { get; }
 
-            public ClassWithReadOnlyString_IgnoreWhenNull(string myString) => MyString = myString;
+            public ClassWithReadOnlyString_IgnoreWhenWritingDefault(string myString) => MyString = myString;
         }
 
         [Fact]
@@ -1351,6 +1358,82 @@ namespace System.Text.Json.Serialization.Tests
 
             internal float GetMyFloat => MyFloat;
             internal double GetMyDouble => MyDouble;
+        }
+
+        [Fact]
+        public static void IgnoreCondition_WhenWritingDefault_Globally_Works()
+        {
+            // Baseline - default values written.
+            string expected = @"{""MyString"":null,""MyInt"":0,""MyPoint"":{""X"":0,""Y"":0}}";
+            var obj = new ClassWithProps();
+            JsonTestHelper.AssertJsonEqual(expected, JsonSerializer.Serialize(obj));
+
+            // Default values ignored when specified.
+            Assert.Equal("{}", JsonSerializer.Serialize(obj, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault }));
+        }
+
+        private class ClassWithProps
+        {
+            public string MyString { get; set; }
+            public int MyInt { get; set; }
+            public Point_2D_Struct MyPoint { get; set; }
+        }
+
+        [Fact]
+        public static void IgnoreCondition_WhenWritingDefault_PerProperty_Works()
+        {
+            // Default values ignored when specified.
+            Assert.Equal(@"{""MyInt"":0}", JsonSerializer.Serialize(new ClassWithPropsAndIgnoreAttributes()));
+        }
+
+        private class ClassWithPropsAndIgnoreAttributes
+        {
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+            public string MyString { get; set; }
+            public int MyInt { get; set; }
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+            public Point_2D_Struct MyPoint { get; set; }
+        }
+
+        [Fact]
+        public static void IgnoreCondition_WhenWritingDefault_DoesNotApplyToCollections()
+        {
+            var list = new List<bool> { false, true };
+
+            var options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault };
+            Assert.Equal("[false,true]", JsonSerializer.Serialize(list, options));
+        }
+
+        [Fact]
+        public static void IgnoreCondition_WhenWritingDefault_DoesNotApplyToDeserialization()
+        {
+            // Baseline - null values are ignored on deserialization when using IgnoreNullValues (for compat with initial support).
+            string json = @"{""MyString"":null,""MyInt"":0,""MyPoint"":{""X"":0,""Y"":0}}";
+
+            var options = new JsonSerializerOptions { IgnoreNullValues = true };
+            ClassWithInitializedProps obj = JsonSerializer.Deserialize<ClassWithInitializedProps>(json, options);
+
+            Assert.Equal("Default", obj.MyString);
+            // Value types are not ignored.
+            Assert.Equal(0, obj.MyInt);
+            Assert.Equal(0, obj.MyPoint.X);
+            Assert.Equal(0, obj.MyPoint.X);
+
+            // Test - default values (both null and default for value types) are not ignored when using
+            // JsonIgnoreCondition.WhenWritingDefault (as the option name implies)
+            options = new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault };
+            obj = JsonSerializer.Deserialize<ClassWithInitializedProps>(json, options);
+            Assert.Null(obj.MyString);
+            Assert.Equal(0, obj.MyInt);
+            Assert.Equal(0, obj.MyPoint.X);
+            Assert.Equal(0, obj.MyPoint.X);
+        }
+
+        private class ClassWithInitializedProps
+        {
+            public string MyString { get; set; } = "Default";
+            public int MyInt { get; set; } = -1;
+            public Point_2D_Struct MyPoint { get; set; } = new Point_2D_Struct(-1, -1);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/779.

Breaking changes

- [between .NET 5 preview 5 & 6] `JsonIgnoreCondition.WhenNull` removed & replaced with `JsonIgnoreCondition.WhenWritingDefault`
- [between .NET Core 3.x and .NET 5] For edge case scenarios where a converter returns `null` when the token type is not `JsonTokenType.Null`, the property's setter is called (with the null arg). The setter was not called before.