### PR TITLE
Set TargetsMobile=true on Browser TargetOS and build the wasm runtimes earlier during the libs build

### DIFF
--- a/eng/Configurations.props
+++ b/eng/Configurations.props
@@ -52,7 +52,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetsMobile Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android' or '$(TargetOS)' == 'tvOS'">true</TargetsMobile>
+    <TargetsMobile Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'Android' or '$(TargetOS)' == 'tvOS' or '$(TargetOS)' == 'Browser'">true</TargetsMobile>
   </PropertyGroup>
 
   <!--Feature switches -->

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -38,7 +38,7 @@
 
   <PropertyGroup>
     <DefaultSubsets>clr+mono+libs+installer</DefaultSubsets>
-    <DefaultSubsets Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'Browser'">mono+libs+installer</DefaultSubsets>
+    <DefaultSubsets Condition="'$(TargetsMobile)' == 'true'">mono+libs+installer</DefaultSubsets>
   </PropertyGroup>
 
   <!-- Init _subset here in to allow RuntimeFlavor to be set as early as possible -->
@@ -48,7 +48,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <RuntimeFlavor Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'Browser'">Mono</RuntimeFlavor>
+    <RuntimeFlavor Condition="'$(TargetsMobile)' == 'true'">Mono</RuntimeFlavor>
     <RuntimeFlavor Condition="'$(RuntimeFlavor)' == '' and ($(_subset.Contains('+mono+')) or $(_subset.Contains('+mono.runtime+'))) and (!$(_subset.Contains('+clr+')) and !$(_subset.Contains('+clr.runtime+')))">Mono</RuntimeFlavor>
     <RuntimeFlavor Condition="'$(RuntimeFlavor)' == ''">CoreCLR</RuntimeFlavor>
   </PropertyGroup>

--- a/eng/codeOptimization.targets
+++ b/eng/codeOptimization.targets
@@ -9,7 +9,7 @@
            IBCMerge optimizations on Mac for now to unblock the offical build.
            See issue https://github.com/dotnet/runtime/issues/33303
       -->
-      <IsEligibleForNgenOptimization Condition="'$(TargetOS)' == 'OSX' or '$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'Browser'">false</IsEligibleForNgenOptimization>
+      <IsEligibleForNgenOptimization Condition="'$(TargetOS)' == 'OSX' or '$(TargetsMobile)' == 'true'">false</IsEligibleForNgenOptimization>
   </PropertyGroup>
 
   <Target Name="SetApplyNgenOptimization"

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -133,9 +133,9 @@
         <IsNative>true</IsNative>
       </RuntimeFiles>
 
-      <MonoCrossFiles Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'Browser'"
+      <MonoCrossFiles Condition="'$(TargetsMobile)' == 'true'"
         Include="$(MonoArtifactsPath)\cross\*.*" />
-      <MonoIncludeFiles Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'Browser'"
+      <MonoIncludeFiles Condition="'$(TargetsMobile)' == 'true'"
         Include="$(MonoArtifactsPath)\include\**\*.*" />
       <WasmDistFiles Condition="'$(TargetOS)' == 'Browser'"
         Include="$(MonoArtifactsPath)\wasm\runtimes\**\*.*" />

--- a/src/installer/Directory.Build.props
+++ b/src/installer/Directory.Build.props
@@ -217,6 +217,7 @@
       <PropertyGroup>
         <TargetsBrowser>true</TargetsBrowser>
         <TargetsUnix>true</TargetsUnix>
+        <TargetsMobile>true</TargetsMobile>
       </PropertyGroup>
     </When>
     <When Condition="$(OutputRid.StartsWith('debian'))">
@@ -362,7 +363,7 @@
     <CrossGenSymbolExtension>.map</CrossGenSymbolExtension>
     <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'Windows_NT'">.ni.pdb</CrossGenSymbolExtension>
     <!-- OSX doesn't have crossgen symbols, yet -->
-    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetsMobile)' == 'true' or '$(TargetsBrowser)' == 'true'"></CrossGenSymbolExtension>
+    <CrossGenSymbolExtension Condition="'$(TargetOS)' == 'OSX' or '$(TargetsMobile)' == 'true'"></CrossGenSymbolExtension>
   </PropertyGroup>
 
 </Project>

--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -26,7 +26,7 @@
     </PropertyGroup>
   </Target>
 
-  <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true' and '$(TargetsBrowser)' != 'true'">
+  <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true'">
     <RuntimeSpecificFrameworkSuffix>.Mono</RuntimeSpecificFrameworkSuffix>
   </PropertyGroup>
 

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -71,7 +71,7 @@
         Include="@(MonoCrossFiles)">
         <TargetPath>runtimes/$(PackageRID)/native/cross</TargetPath>
       </RuntimeFiles>
-      <RuntimeFiles Condition="'$(TargetsMobile)' == 'true' or '$(TargetsBrowser)' == 'true'"
+      <RuntimeFiles Condition="'$(TargetsMobile)' == 'true'"
         Include="@(MonoIncludeFiles)">
         <TargetPath>runtimes/$(PackageRID)/native/include/%(RecursiveDir)</TargetPath>
       </RuntimeFiles>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -41,9 +41,9 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == '' and '$(TargetsMobile)' == 'true'">x64</TargetArchitecture>
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">x64</TargetArchitecture>
 
-    <!-- RuntimeOS is calculated based on the build system OS, however if building for WebAssembly/iOS/Android we need to let
-         the build system to use webassembly/ios/android as the RuntimeOS for produced package RIDs. -->
-    <RuntimeOS Condition="'$(TargetOS)' == 'Browser' or '$(TargetsMobile)' == 'true'">$(TargetOS.ToLowerInvariant())</RuntimeOS>
+    <!-- RuntimeOS is calculated based on the build system OS, however if building for Browser/iOS/Android we need to let
+         the build system to use browser/ios/android as the RuntimeOS for produced package RIDs. -->
+    <RuntimeOS Condition="'$(TargetsMobile)' == 'true'">$(TargetOS.ToLowerInvariant())</RuntimeOS>
  
     <!-- Initialize BuildSettings from the individual properties if it wasn't already explicitly set -->
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -72,14 +72,6 @@
                                          TargetRuntimeIdentifier="$(PackageRID)" />
   </Target>
 
-  <!-- Wasm runtimes depend on the mono runtime and libs to be built, so they can only be built here -->
-  <Target Name="BuildWasmPackageDependency"
-          Condition="'$(TargetOS)' == 'Browser'"
-          AfterTargets="RestoreTestHost">
-    <MSBuild Projects="$(MonoProjectRoot)\wasm\wasm.proj"
-             Properties="Configuration=$(Configuration);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture)"/>
-  </Target>
-
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
   <Target Name="GenerateFrameworkListFile"
           Condition="'$(BinPlaceTestRuntimePack)' == 'true'"

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -46,4 +46,12 @@
              Properties="$(TraversalGlobalProperties)" />
   </Target>
 
+  <!-- Wasm runtimes depend on the mono runtime and libs to be built, so they can only be built here -->
+  <Target Name="BuildWasmPackageDependency"
+          Condition="'$(TargetOS)' == 'Browser'"
+          AfterTargets="Build">
+    <MSBuild Projects="$(MonoProjectRoot)\wasm\wasm.proj"
+             Properties="Configuration=$(Configuration);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture)"/>
+  </Target>
+
 </Project>

--- a/src/mono/wasm/.gitignore
+++ b/src/mono/wasm/.gitignore
@@ -1,0 +1,1 @@
+/emsdk_env.sh


### PR DESCRIPTION
 Ensures the wasm runtimes end up in lib-runtime-packs and the runtime pack nuget.