### PR TITLE
Allow DynamicallyAccessedMembersAttribute on methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMembersAttribute.cs
@@ -16,10 +16,15 @@ namespace System.Diagnostics.CodeAnalysis
     ///
     /// When this attribute is applied to a location of type <see cref="string"/>, the assumption is
     /// that the string represents a fully qualified type name.
+    ///
+    /// If the attribute is applied to a method it's treated as a special case and it implies
+    /// the attribute should be applied to the "this" parameter of the method. As such the attribute
+    /// should only be used on instance methods of types assignable to System.Type (or string, but no methods
+    /// will use it there).
     /// </remarks>
     [AttributeUsage(
         AttributeTargets.Field | AttributeTargets.ReturnValue | AttributeTargets.GenericParameter |
-        AttributeTargets.Parameter | AttributeTargets.Property,
+        AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.Method,
         Inherited = false)]
     public sealed class DynamicallyAccessedMembersAttribute : Attribute
     {

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5628,7 +5628,7 @@ namespace System.Diagnostics.CodeAnalysis
         public string? AssemblyName { get { throw null; } }
         public string? Condition { get { throw null; } set { } }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.GenericParameter | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.GenericParameter | System.AttributeTargets.Method | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited = false)]
     public sealed class DynamicallyAccessedMembersAttribute : System.Attribute
     {
         public DynamicallyAccessedMembersAttribute(DynamicallyAccessedMemberTypes memberTypes) { }


### PR DESCRIPTION
We need a way to add `DynamicallyAccessedMembersAttribute` to the "this" parameter for calls like `Type.GetFields`. There's no way in C# to do this (and in fact even IL is a bit tricky in that regard), so the linker supports recognizing the attribute on a method itself, but only for `System.Type` class. It then treats that attribute as if it's put on the "this" parameter.

Fixes #36708