### PR TITLE
Incorrect CALLSITE macro usage.

### DIFF
--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -470,7 +470,7 @@ namespace
         args[ARGNUM_1]  = OBJECTREF_TO_ARGHOLDER(*implPROTECTED);
         args[ARGNUM_2]  = PTR_TO_ARGHOLDER(externalComObject);
         args[ARGNUM_3]  = DWORD_TO_ARGHOLDER(flags);
-        CALL_MANAGED_METHOD(retObjRef, OBJECTREF, args);
+        CALL_MANAGED_METHOD_RETREF(retObjRef, OBJECTREF, args);
 
         return retObjRef;
     }


### PR DESCRIPTION
Fixes #36202 
Fixes #36203 

This failure is related to the DEBUG validation that is done on `OBJECTREF` instances. There is no product issue here.

/cc @jkoritzinsky @elinor-fung 