### PR TITLE
Implement unwrapping a ComWrappers CCW when dumping a stowed exception.

### DIFF
--- a/src/coreclr/src/debug/daccess/CMakeLists.txt
+++ b/src/coreclr/src/debug/daccess/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(BEFORE ${VM_DIR}/${ARCH_SOURCES_DIR})
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CLR_DIR}/src/debug/ee)
 include_directories(${CLR_DIR}/src/gcdump)
+include_directories(${CLR_DIR}/src/interop/inc)
 
 if(CLR_CMAKE_HOST_UNIX)
   include_directories(${GENERATED_INCLUDE_DIR})

--- a/src/coreclr/src/debug/daccess/dacimpl.h
+++ b/src/coreclr/src/debug/daccess/dacimpl.h
@@ -1456,6 +1456,10 @@ private:
     PTR_IUnknown DACGetCOMIPFromCCW(PTR_ComCallWrapper pCCW, int vtableIndex);
 #endif
 
+#ifdef FEATURE_COMWRAPPERS
+    HRESULT DACTryGetComWrappersObjectFromCCW(CLRDATA_ADDRESS ccwPtr, OBJECTREF* objRef);
+#endif
+
     static LONG s_procInit;
 
 public:

--- a/src/coreclr/src/inc/daccess.h
+++ b/src/coreclr/src/inc/daccess.h
@@ -629,6 +629,9 @@ typedef struct _DacGlobals
     ULONG fn__Unknown_AddRefSpecial;
     ULONG fn__Unknown_AddRefInner;
 #endif
+#ifdef FEATURE_COMWRAPPERS
+    ULONG fn__ManagedObjectWrapper_QueryInterface;
+#endif
 
     // Vtable pointer values for all classes that must
     // be instanted using vtable pointers as the identity.

--- a/src/coreclr/src/interop/comwrappers.cpp
+++ b/src/coreclr/src/interop/comwrappers.cpp
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 #include "comwrappers.hpp"
+#include <interoplibabi.h>
 #include <interoplibimports.h>
 
 #include <new> // placement new
@@ -47,8 +48,8 @@ namespace ABI
     };
     ABI_ASSERT(sizeof(ComInterfaceDispatch) == sizeof(void*));
 
-    const size_t DispatchAlignmentThisPtr = 16; // Should be a power of 2.
-    const intptr_t DispatchThisPtrMask = ~(DispatchAlignmentThisPtr - 1);
+    using InteropLib::ABI::DispatchAlignmentThisPtr;
+    using InteropLib::ABI::DispatchThisPtrMask;
     ABI_ASSERT(sizeof(void*) < DispatchAlignmentThisPtr);
 
     const intptr_t AlignmentThisPtrMaxPadding = DispatchAlignmentThisPtr - sizeof(void*);
@@ -179,16 +180,21 @@ namespace ABI
     }
 }
 
+// ManagedObjectWrapper_QueryInterface needs to be visible outside of this compilation unit
+// to support the DAC. See code:ClrDataAccess::DACTryGetComWrappersObjectFromCCW for the
+// usage in the DAC (look for the GetEEFuncEntryPoint call).
+
+HRESULT STDMETHODCALLTYPE ManagedObjectWrapper_QueryInterface(
+    _In_ ABI::ComInterfaceDispatch* disp,
+    /* [in] */ REFIID riid,
+    /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject)
+{
+    ManagedObjectWrapper* wrapper = ABI::ToManagedObjectWrapper(disp);
+    return wrapper->QueryInterface(riid, ppvObject);
+}
+
 namespace
 {
-    HRESULT STDMETHODCALLTYPE ManagedObjectWrapper_QueryInterface(
-        _In_ ABI::ComInterfaceDispatch* disp,
-        /* [in] */ REFIID riid,
-        /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR* __RPC_FAR* ppvObject)
-    {
-        ManagedObjectWrapper* wrapper = ABI::ToManagedObjectWrapper(disp);
-        return wrapper->QueryInterface(riid, ppvObject);
-    }
 
     ULONG STDMETHODCALLTYPE ManagedObjectWrapper_AddRef(_In_ ABI::ComInterfaceDispatch* disp)
     {
@@ -310,6 +316,7 @@ void ManagedObjectWrapper::GetIUnknownImpl(
     *fpRelease = ManagedObjectWrapper_IUnknownImpl.Release;
 }
 
+// The logic here should match code:ClrDataAccess::DACTryGetComWrappersObjectFromCCW in daccess/request.cpp
 ManagedObjectWrapper* ManagedObjectWrapper::MapFromIUnknown(_In_ IUnknown* pUnk)
 {
     _ASSERTE(pUnk != nullptr);

--- a/src/coreclr/src/interop/comwrappers.cpp
+++ b/src/coreclr/src/interop/comwrappers.cpp
@@ -183,7 +183,6 @@ namespace ABI
 // ManagedObjectWrapper_QueryInterface needs to be visible outside of this compilation unit
 // to support the DAC. See code:ClrDataAccess::DACTryGetComWrappersObjectFromCCW for the
 // usage in the DAC (look for the GetEEFuncEntryPoint call).
-
 HRESULT STDMETHODCALLTYPE ManagedObjectWrapper_QueryInterface(
     _In_ ABI::ComInterfaceDispatch* disp,
     /* [in] */ REFIID riid,
@@ -195,7 +194,6 @@ HRESULT STDMETHODCALLTYPE ManagedObjectWrapper_QueryInterface(
 
 namespace
 {
-
     ULONG STDMETHODCALLTYPE ManagedObjectWrapper_AddRef(_In_ ABI::ComInterfaceDispatch* disp)
     {
         ManagedObjectWrapper* wrapper = ABI::ToManagedObjectWrapper(disp);

--- a/src/coreclr/src/interop/inc/interoplibabi.h
+++ b/src/coreclr/src/interop/inc/interoplibabi.h
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include <stddef.h>
+
+namespace InteropLib
+{
+    namespace ABI
+    {
+        const size_t DispatchAlignmentThisPtr = 16; // Should be a power of 2.
+        const intptr_t DispatchThisPtrMask = ~(DispatchAlignmentThisPtr - 1);
+    }
+}


### PR DESCRIPTION
For the new WinRT support, stowed exceptions will be created using the new ComWrappers API. To preserve the diagnostics experience, we need to enable the DAC to be able to unwrap a ComWrappers-based CCW. This PR implements that work.

Contributes to #35318
Fixes #36048 (Doesn't implement all of the functions in the DAC, but does teach the DAC how to unwrap a ComWrappers CCW and how to dump a stowed exception)