### PR TITLE
Fix cross-compiling argument validation for Linux

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -5,7 +5,7 @@ Param(
   [ValidateSet("Debug","Release","Checked")][string[]][Alias('c')]$configuration = @("Debug"),
   [string][Alias('f')]$framework,
   [string]$vs,
-  [ValidateSet("Windows_NT","Linux")][string]$os,
+  [ValidateSet("Windows_NT","Linux","OSX")][string]$os,
   [switch]$allconfigurations,
   [switch]$coverage,
   [string]$testscope,
@@ -21,7 +21,7 @@ function Get-Help() {
   Write-Host "Common settings:"
   Write-Host "  -subset                   Build a subset, print available subsets with -subset help (short: -s)"
   Write-Host "  -vs                       Open the solution with VS for Test Explorer support. Path or solution name (ie -vs Microsoft.CSharp)"
-  Write-Host "  -os                       Build operating system: Windows_NT or Linux"
+  Write-Host "  -os                       Build operating system: Windows_NT, Linux or OSX"
   Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -a). Pass a comma-separated list to build for multiple architectures."
   Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c). Pass a comma-separated list to build for multiple configurations"
   Write-Host "  -runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked (short: -rc)"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -5,7 +5,7 @@ Param(
   [ValidateSet("Debug","Release","Checked")][string[]][Alias('c')]$configuration = @("Debug"),
   [string][Alias('f')]$framework,
   [string]$vs,
-  [ValidateSet("Windows_NT","Unix")][string]$os,
+  [ValidateSet("Windows_NT","Linux")][string]$os,
   [switch]$allconfigurations,
   [switch]$coverage,
   [string]$testscope,
@@ -21,7 +21,7 @@ function Get-Help() {
   Write-Host "Common settings:"
   Write-Host "  -subset                   Build a subset, print available subsets with -subset help (short: -s)"
   Write-Host "  -vs                       Open the solution with VS for Test Explorer support. Path or solution name (ie -vs Microsoft.CSharp)"
-  Write-Host "  -os                       Build operating system: Windows_NT or Unix"
+  Write-Host "  -os                       Build operating system: Windows_NT or Linux"
   Write-Host "  -arch                     Build platform: x86, x64, arm or arm64 (short: -a). Pass a comma-separated list to build for multiple architectures."
   Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c). Pass a comma-separated list to build for multiple configurations"
   Write-Host "  -runtimeConfiguration     Runtime build configuration: Debug, Release or [CoreCLR]Checked (short: -rc)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/core-eng/issues/9832

https://github.com/dotnet/runtime/commit/7c66b6fb6fb00dd86d969ec622a9bb2830016375 added a ValidateSet for Windows_NT and Unix even though we don't support building for just "Unix" but for the more concrete OS which is "Linux".