### PR TITLE
Fix execution of large version bubble composite images

### DIFF
--- a/src/coreclr/src/vm/ceeload.cpp
+++ b/src/coreclr/src/vm/ceeload.cpp
@@ -503,7 +503,7 @@ uint32_t Module::GetNativeMetadataAssemblyCount()
     NativeImage *compositeImage = GetCompositeNativeImage();
     if (compositeImage != NULL)
     {
-        return compositeImage->GetComponentAssemblyCount();
+        return compositeImage->GetManifestAssemblyCount();
     }
     else
     {

--- a/src/coreclr/src/vm/nativeimage.h
+++ b/src/coreclr/src/vm/nativeimage.h
@@ -65,6 +65,7 @@ private:
     
     IMAGE_DATA_DIRECTORY *m_pComponentAssemblies;
     uint32_t m_componentAssemblyCount;
+    uint32_t m_manifestAssemblyCount;
     SHash<AssemblyNameIndexHashTraits> m_assemblySimpleNameToIndexMap;
     
     Crst m_eagerFixupsLock;
@@ -93,8 +94,9 @@ public:
     uint32_t GetComponentAssemblyCount() const { return m_componentAssemblyCount; }
     ReadyToRunInfo *GetReadyToRunInfo() const { return m_pReadyToRunInfo; }
     IMDInternalImport *GetManifestMetadata() const { return m_pManifestMetadata; }
+    uint32_t GetManifestAssemblyCount() const { return m_manifestAssemblyCount; }
 
-    Assembly *LoadComponentAssembly(uint32_t rowid);
+    Assembly *LoadManifestAssembly(uint32_t rowid);
     
     PTR_READYTORUN_CORE_HEADER GetComponentAssemblyHeader(LPCUTF8 assemblySimpleName);
     

--- a/src/coreclr/src/vm/zapsig.cpp
+++ b/src/coreclr/src/vm/zapsig.cpp
@@ -650,7 +650,7 @@ Module *ZapSig::DecodeModuleFromIndex(Module *fromModule,
         {
             if (nativeImage != NULL)
             {
-                pAssembly = nativeImage->LoadComponentAssembly(index);
+                pAssembly = nativeImage->LoadManifestAssembly(index);
             }
             else
             {


### PR DESCRIPTION
Large-bubble composite images are special in having more entries
in the manifest metadata than in the component assembly table:
When the build starts, all component assemblies get hard-injected
into the manifest metadata and subsequently we lazily add those
additional reference assemblies (within the same version bubble)
as we need for encoding signatures.

Thanks

Tomas