### PR TITLE
Adding the support of reusing machine-wide credentials in the case where the machine is already domain-joined to the LDAP Server.

### DIFF
--- a/THIRD-PARTY-NOTICES.TXT
+++ b/THIRD-PARTY-NOTICES.TXT
@@ -820,3 +820,16 @@ Unless required by applicable law or agreed to in writing, software distributed
 under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
+
+License notice for ldap4net
+---------------------------
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Alexander Chermyanin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/libraries/Common/src/Interop/Interop.Ldap.cs
+++ b/src/libraries/Common/src/Interop/Interop.Ldap.cs
@@ -9,6 +9,8 @@ internal static partial class Interop
     public const int SEC_WINNT_AUTH_IDENTITY_UNICODE = 0x2;
     public const int SEC_WINNT_AUTH_IDENTITY_VERSION = 0x200;
     public const string MICROSOFT_KERBEROS_NAME_W = "Kerberos";
+    public const uint LDAP_SASL_QUIET = 2;
+    public const string KerberosDefaultMechanism = "GSSAPI";
 }
 
 namespace System.DirectoryServices.Protocols
@@ -94,7 +96,10 @@ namespace System.DirectoryServices.Protocols
         LDAP_OPT_SASL_METHOD = 0x97,
         LDAP_OPT_AREC_EXCLUSIVE = 0x98, // Not Supported in Linux
         LDAP_OPT_SECURITY_CONTEXT = 0x99,
-        LDAP_OPT_ROOTDSE_CACHE = 0x9a // Not Supported in Linux
+        LDAP_OPT_ROOTDSE_CACHE = 0x9a, // Not Supported in Linux
+        LDAP_OPT_X_SASL_REALM = 0x6101,
+        LDAP_OPT_X_SASL_AUTHCID = 0x6102,
+        LDAP_OPT_X_SASL_AUTHZID = 0x6103
     }
 
     internal enum ResultAll

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
@@ -44,8 +44,7 @@ namespace System.DirectoryServices.Protocols
             Marshal.StructureToPtr(defaults, ptrToDefaults, false);
             try
             {
-                int error = Interop.ldap_sasl_interactive_bind(_ldapHandle, null, Interop.KerberosDefaultMechanism, IntPtr.Zero, IntPtr.Zero, Interop.LDAP_SASL_QUIET, LdapPal.SaslInteractionProcedure, ptrToDefaults);
-                return error;
+                return Interop.ldap_sasl_interactive_bind(_ldapHandle, null, Interop.KerberosDefaultMechanism, IntPtr.Zero, IntPtr.Zero, Interop.LDAP_SASL_QUIET, LdapPal.SaslInteractionProcedure, ptrToDefaults);
             }
             finally
             {

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.Linux.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Net;
+using System.Runtime.InteropServices;
 
 namespace System.DirectoryServices.Protocols
 {
@@ -24,9 +25,9 @@ namespace System.DirectoryServices.Protocols
         private int InternalBind(NetworkCredential tempCredential, SEC_WINNT_AUTH_IDENTITY_EX cred, BindMethod method)
         {
             int error;
-            if (tempCredential == null && AuthType == AuthType.External)
+            if (tempCredential == null && (AuthType == AuthType.External || AuthType == AuthType.Kerberos))
             {
-                error = Interop.ldap_simple_bind(_ldapHandle, null, null);
+                error = BindSasl();
             }
             else
             {
@@ -34,6 +35,45 @@ namespace System.DirectoryServices.Protocols
             }
 
             return error;
+        }
+
+        private int BindSasl()
+        {
+            SaslDefaultCredentials defaults = GetSaslDefaults();
+            IntPtr ptrToDefaults = Marshal.AllocHGlobal(Marshal.SizeOf(defaults));
+            Marshal.StructureToPtr(defaults, ptrToDefaults, false);
+            try
+            {
+                int error = Interop.ldap_sasl_interactive_bind(_ldapHandle, null, Interop.KerberosDefaultMechanism, IntPtr.Zero, IntPtr.Zero, Interop.LDAP_SASL_QUIET, LdapPal.SaslInteractionProcedure, ptrToDefaults);
+                return error;
+            }
+            finally
+            {
+                GC.KeepAlive(defaults); //Making sure we keep it in scope as we will still use ptrToDefaults
+                Marshal.FreeHGlobal(ptrToDefaults);
+            }
+        }
+
+        private SaslDefaultCredentials GetSaslDefaults()
+        {
+            var defaults = new SaslDefaultCredentials { mech = Interop.KerberosDefaultMechanism };
+            IntPtr outValue = IntPtr.Zero;
+            int error = Interop.ldap_get_option_ptr(_ldapHandle, LdapOption.LDAP_OPT_X_SASL_REALM, ref outValue);
+            if (error == 0 && outValue != IntPtr.Zero)
+            {
+                defaults.realm = Marshal.PtrToStringAnsi(outValue);
+            }
+            error = Interop.ldap_get_option_ptr(_ldapHandle, LdapOption.LDAP_OPT_X_SASL_AUTHCID, ref outValue);
+            if (error == 0 && outValue != IntPtr.Zero)
+            {
+                defaults.authcid = Marshal.PtrToStringAnsi(outValue);
+            }
+            error = Interop.ldap_get_option_ptr(_ldapHandle, LdapOption.LDAP_OPT_X_SASL_AUTHZID, ref outValue);
+            if (error == 0 && outValue != IntPtr.Zero)
+            {
+                defaults.authzid = Marshal.PtrToStringAnsi(outValue);
+            }
+            return defaults;
         }
     }
 }


### PR DESCRIPTION
Contributes to #23944

This PR will add support of reusing the credentials a machine has stored when it has already domain-joined to an ActiveDirectory from a Linux machine. In order for this to work, you will need to:
- Make sure you have installed package `libsasl2-modules-gssapi-mit` which will make the sasl interaction to use GSSAPI as the connection mechanism if machine-wide credentials are present.
- Be able to run succesfully ldap tools commands that reuse machine-wide credentials like `ldapwhoami -h REALM` for example. This will confirm that you have correctly joined the domain with your domain controller and Active Directory.
After validating that, then people should now simply be able to write something like:
```c#
// LdapDirectoryIdentifier directoryIdentifier = ...
using (LdapConnection connection = new LdapConnection(directoryIdentifier))
{
  connection.AuthType = AuthType.Kerberos;
  connection.SessionOptions.ProtocolVersion = 3;
  connection.Bind(); //This will now use GSSAPI to bind to the LDAP Server.

  // Use your ldap connection object
}
```

I want to add special thanks to @flamencist (co-author of the commit) whose help with both the implementation and ensuring we were able to setup a test environment correctly was vital to getting this PR ready. @flamencist developed a library called [ldap4net](https://github.com/flamencist/ldap4net) which is a library that provides ldap functionalities that works cross platform.

cc: @Tratcher @JunTaoLuo @davidsh @bartonjs @ericstj 

Assuming this question will be asked on the PR: I haven't found a good way of adding testing for this as it requires a very specific setup which is hard to achieve with our current testing infrastructure. I'm evaluating options to use environments similar to @davidsh enterprise scenarios to add some coverage for this.