### PR TITLE
Disable test GitHub_35821

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -324,6 +324,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/DevDiv_590771/DevDiv_590771/*">
             <Issue>needs triage</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_35821/GitHub_35821/*">
+            <Issue>https://github.com/dotnet/runtime/issues/36418</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracevalidation/inducedgc/inducedgc/*">
             <Issue>https://github.com/dotnet/runtime/issues/12216</Issue>
         </ExcludeList>


### PR DESCRIPTION
Opened https://github.com/dotnet/runtime/issues/36418 to re-enable it once we fix the core issue identified in https://github.com/dotnet/runtime/issues/36206.