### PR TITLE
Rework rejit test to ensure subprocess environment is suitable

### DIFF
--- a/src/coreclr/tests/src/profiler/common/ProfilerTestRunner.cs
+++ b/src/coreclr/tests/src/profiler/common/ProfilerTestRunner.cs
@@ -15,7 +15,7 @@ namespace Profiler.Tests
     public enum ProfileeOptions
     {
         None = 0,
-        DisableTieredCompilation,
+        OptimizationSensitive,
         NoStartupAttach
     }
 
@@ -41,10 +41,12 @@ namespace Profiler.Tests
                 envVars.Add("CORECLR_PROFILER", "{" + profilerClsid + "}");
             }
 
-            if (profileeOptions.HasFlag(ProfileeOptions.DisableTieredCompilation))
+            if (profileeOptions.HasFlag(ProfileeOptions.OptimizationSensitive))
             {
-                Console.WriteLine("Disabling tiered compilation.");
+                Console.WriteLine("Disabling tiered compilation, jitstress, and minopts.");
                 envVars.Add("COMPlus_TieredCompilation", "0");
+                envVars.Add("COMPlus_JitStress", "0");
+                envVars.Add("COMPlus_JITMinOpts", "0");
             }
 
             string profilerPath = GetProfilerPath();

--- a/src/coreclr/tests/src/profiler/rejit/rejit.cs
+++ b/src/coreclr/tests/src/profiler/rejit/rejit.cs
@@ -100,7 +100,7 @@ namespace Profiler.Tests
             return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
                                           testName: "ReJITWithInlining",
                                           profilerClsid: ReJitProfilerGuid,
-                                          profileeOptions: ProfileeOptions.DisableTieredCompilation);
+                                          profileeOptions: ProfileeOptions.OptimizationSensitive);
         }
     }
 }


### PR DESCRIPTION
This test is optimization sensitive, but it invokes a subprocess that
will inherit environment variables like `COMPlus_JITMinOpts` that can impact
optimization of code jitted in the subprocess and cause the test to fail.

So, update the parent process code to override `COMPlus_JITMinOpts` and
`COMPlus_JitStress` for the child process.

Closes ~~#35742.~~ #35472.