### PR TITLE
Fix non-ascii absolute file path handling in Uri

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3262,7 +3262,8 @@ namespace System
             // For iri parsing if we found unicode the idx has offset into _originalUnicodeString..
             // so restart parsing from there and make _info.Offset.Path as _string.Length
 
-            idx = origIdx = _info.Offset.Path;
+            idx = _info.Offset.Path;
+            origIdx = _info.Offset.Path;
 
             //Some uris do not have a query
             //    When '?' is passed as delimiter, then it's special case

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3262,16 +3262,17 @@ namespace System
             // For iri parsing if we found unicode the idx has offset into _originalUnicodeString..
             // so restart parsing from there and make _info.Offset.Path as _string.Length
 
-            idx = _info.Offset.Path;
-            origIdx = _info.Offset.Path;
+            idx = origIdx = _info.Offset.Path;
 
             //Some uris do not have a query
             //    When '?' is passed as delimiter, then it's special case
             //    so both '?' and '#' will work as delimiters
             if (buildIriStringFromPath)
             {
-                // Dos paths have no host.  Other schemes cleared/set _string with host information in PrivateParseMinimal.
-                if (IsDosPath)
+                DebugAssertInCtor();
+
+                // Dos/Unix paths have no host.  Other schemes cleared/set _string with host information in PrivateParseMinimal.
+                if (IsFile && !IsUncPath)
                 {
                     if (IsImplicitFile)
                     {
@@ -3314,19 +3315,7 @@ namespace System
                     origIdx = index == -1 ? _originalUnicodeString.Length : (index + origIdx);
                 }
 
-                // Correctly escape unescape
-                string escapedPath = EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Path);
-
-                // Normalize path
-                try
-                {
-                    _string += escapedPath;
-                }
-                catch (ArgumentException)
-                {
-                    UriFormatException e = GetException(ParsingError.BadFormat)!;
-                    throw e;
-                }
+                _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Path);
 
                 if (_string.Length > ushort.MaxValue)
                 {
@@ -3445,6 +3434,8 @@ namespace System
             //
             if (buildIriStringFromPath)
             {
+                DebugAssertInCtor();
+
                 int offset = origIdx;
 
                 if (origIdx < _originalUnicodeString.Length && _originalUnicodeString[origIdx] == '?')
@@ -3460,19 +3451,7 @@ namespace System
                         origIdx = _originalUnicodeString.Length;
                     }
 
-                    // Correctly escape unescape
-                    string escapedPath = EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Query);
-
-                    // Normalize path
-                    try
-                    {
-                        _string += escapedPath;
-                    }
-                    catch (ArgumentException)
-                    {
-                        UriFormatException e = GetException(ParsingError.BadFormat)!;
-                        throw e;
-                    }
+                    _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Query);
 
                     if (_string.Length > ushort.MaxValue)
                     {
@@ -3521,25 +3500,15 @@ namespace System
             //
             if (buildIriStringFromPath)
             {
+                DebugAssertInCtor();
+
                 int offset = origIdx;
 
                 if (origIdx < _originalUnicodeString.Length && _originalUnicodeString[origIdx] == '#')
                 {
                     origIdx = _originalUnicodeString.Length;
 
-                    // Correctly escape unescape
-                    string escapedPath = EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Fragment);
-
-                    // Normalize path
-                    try
-                    {
-                        _string += escapedPath;
-                    }
-                    catch (ArgumentException)
-                    {
-                        UriFormatException e = GetException(ParsingError.BadFormat)!;
-                        throw e;
-                    }
+                    _string += EscapeUnescapeIri(_originalUnicodeString, offset, origIdx, UriComponents.Fragment);
 
                     if (_string.Length > ushort.MaxValue)
                     {

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -790,6 +790,13 @@ namespace System.PrivateUri.Tests
             Assert.Equal(absolutePath, uri.AbsolutePath);
             Assert.Equal(absoluteUri, uri.AbsoluteUri);
             Assert.Equal(localPath, uri.LocalPath);
+
+            var uri2 = new Uri(uri.AbsoluteUri);
+
+            Assert.Equal(toString, uri2.ToString());
+            Assert.Equal(absolutePath, uri2.AbsolutePath);
+            Assert.Equal(absoluteUri, uri2.AbsoluteUri);
+            Assert.Equal(localPath, uri2.LocalPath);
         }
     }
 }

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -744,8 +744,8 @@ namespace System.PrivateUri.Tests
             if (PlatformDetection.IsNotWindows)
             {
                 // Unix absolute file path
-                yield return new object[] { "/\u00FCri/", "/\u00FCri/", "/%C3%BCri/", "file:///%C3%BCri/", "/\u00FCri/" };
-                yield return new object[] { "/a/b\uD83D\uDE1F/Foo.cs", "/a/b\uD83D\uDE1F/Foo.cs", "/a/b%F0%9F%98%9F/Foo.cs", "file:///a/b%F0%9F%98%9F/Foo.cs", "a/b\uD83D\uDE1F/Foo.cs" };
+                yield return new object[] { "/\u00FCri/", "file:///\u00FCri/", "/%C3%BCri/", "file:///%C3%BCri/", "/\u00FCri/" };
+                yield return new object[] { "/a/b\uD83D\uDE1F/Foo.cs", "file:///a/b\uD83D\uDE1F/Foo.cs", "/a/b%F0%9F%98%9F/Foo.cs", "file:///a/b%F0%9F%98%9F/Foo.cs", "/a/b\uD83D\uDE1F/Foo.cs" };
             }
 
             // Absolute fie path
@@ -770,13 +770,13 @@ namespace System.PrivateUri.Tests
             }
             else
             {
-                yield return new object[] { "/a/?b/c\u00FC/", "/a/?b/c\u00FC/", "/a/?b/c%C3%BC/", "file:///a/?b/c%C3%BC/", "/a/?b/c\u00FC/" };
-                yield return new object[] { "/a/#b/c\u00FC/", "/a/#b/c\u00FC/", "/a/#b/c%C3%BC/", "file:///a/#b/c%C3%BC/", "/a/#b/c\u00FC/" };
-                yield return new object[] { "/a/?b/#c/d\u00FC/", "/a/#b/c\u00FC/", "/a/?b/#c/d%C3%BC/", "file:///a/?b/#c/d%C3%BC/", "/a/?b/#c/d\u00FC/" };
+                yield return new object[] { "/a/?b/c\u00FC/", "file:///a/%3Fb/c\u00FC/", "/a/%3Fb/c%C3%BC/", "file:///a/%3Fb/c%C3%BC/", "/a/?b/c\u00FC/" };
+                yield return new object[] { "/a/#b/c\u00FC/", "file:///a/%23b/c\u00FC/", "/a/%23b/c%C3%BC/", "file:///a/%23b/c%C3%BC/", "/a/#b/c\u00FC/" };
+                yield return new object[] { "/a/?b/#c/d\u00FC/", "file:///a/%3Fb/%23c/d\u00FC/", "/a/%3Fb/%23c/d%C3%BC/", "file:///a/%3Fb/%23c/d%C3%BC/", "/a/?b/#c/d\u00FC/" };
 
-                yield return new object[] { "file:///a/?b/c\u00FC/", "file:///a/?b/c\u00FC/", "/a/?b/c%C3%BC/", "file:///a/?b/c%C3%BC/", "/a/?b/c\u00FC/" };
-                yield return new object[] { "file:///a/#b/c\u00FC/", "file:///a/#b/c\u00FC/", "/a/#b/c%C3%BC/", "file:///a/#b/c%C3%BC/", "/a/#b/c\u00FC/" };
-                yield return new object[] { "file:///a/?b/#c/d\u00FC/", "file:///a/?b/#c/d\u00FC/", "/a/?b/#c/d%C3%BC/", "file:///a/?b/#c/d%C3%BC/", "/a/?b/#c/d\u00FC/" };
+                yield return new object[] { "file:///a/?b/c\u00FC/", "file:///a/?b/c\u00FC/", "/a/", "file:///a/?b/c%C3%BC/", "/a/" };
+                yield return new object[] { "file:///a/#b/c\u00FC/", "file:///a/#b/c\u00FC/", "/a/", "file:///a/#b/c%C3%BC/", "/a/" };
+                yield return new object[] { "file:///a/?b/#c/d\u00FC/", "file:///a/?b/#c/d\u00FC/", "/a/", "file:///a/?b/#c/d%C3%BC/", "/a/" };
             }
         }
 


### PR DESCRIPTION
Fixes #1061

Actual fix is changing `IsDosPath` to `IsFile && !IsUncPath` when calculating path offsets.