### PR TITLE
Implement GetEntrypointExecutableAbsPath on SunOS

### DIFF
--- a/src/coreclr/src/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/src/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -116,6 +116,43 @@ bool GetEntrypointExecutableAbsolutePath(std::string& entrypointExecutable)
     {
         result = false;
     }
+#elif defined(__sun)
+    const char *path;
+    if ((path = getexecname()) == NULL)
+    {
+        result = false;
+    }
+    else if (*path != '/')
+    {
+        char *cwd;
+        if ((cwd = getcwd(NULL, PATH_MAX)) == NULL)
+        {
+            result = false;
+        }
+        else
+        {
+            char *joined;
+            if (asprintf(&joined, "%s/%s", cwd, path) < 0)
+            {
+                result = false;
+            }
+            else
+            {
+                entrypointExecutable.assign(joined);
+                result = true;
+                free(joined);
+            }
+
+            free(cwd);
+        }
+    }
+    else
+    {
+        entrypointExecutable.assign(path);
+        result = true;
+    }
+
+    free((void*)path);
 #else
 
 #if HAVE_GETAUXVAL && defined(AT_EXECFN)

--- a/src/coreclr/src/nativeresources/processrc.awk
+++ b/src/coreclr/src/nativeresources/processrc.awk
@@ -51,7 +51,7 @@ BEGIN {
         var = var + 0;
 
         # Extract string content starting with either " or L"
-        idx = match($0, /L?\"/);
+        idx = match($0, /L?"/);
         content = substr($0, idx);
 
         # remove the L prefix from strings


### PR DESCRIPTION
* Implement `GetEntrypointExecutableAbsolutePath`.
* Fix a warning from newer gawk (v5.0.1 from 2019):
  > ```sh
  > awk: /runtime/src/coreclr/src/nativeresources/processrc.awk:54:
  > warning: regexp escape sequence `\"' is not a known regexp operator
  > ```

Contributes to: #34944.