### PR TITLE
[mono] Shrink Android APK size

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20254.3",
+      "version": "1.0.0-prerelease.20264.2",
       "commands": [
         "xharness"
       ]

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -36,6 +36,7 @@
         ProjectName="$(AssemblyName)"
         MonoRuntimeHeaders="$(RuntimePackNativeDir)include\mono-2.0"
         MainLibraryFileName="AndroidTestRunner.dll"
+        StripDebugSymbols="False"
         OutputDir="$(BundleDir)"
         SourceDir="$(PublishDir)">
         <Output TaskParameter="ApkPackageId"  PropertyName="ApkPackageId" />

--- a/src/mono/msbuild/AndroidAppBuilder/AndroidAppBuilder.cs
+++ b/src/mono/msbuild/AndroidAppBuilder/AndroidAppBuilder.cs
@@ -41,6 +41,8 @@ public class AndroidAppBuilderTask : Task
     
     public string? BuildToolsVersion { get; set; }
 
+    public bool StripDebugSymbols { get; set; }
+
     [Output]
     public string ApkBundlePath { get; set; } = ""!;
     
@@ -59,6 +61,7 @@ public class AndroidAppBuilderTask : Task
         apkBuilder.MinApiLevel = MinApiLevel;
         apkBuilder.BuildApiLevel = BuildApiLevel;
         apkBuilder.BuildToolsVersion = BuildToolsVersion;
+        apkBuilder.StripDebugSymbols = StripDebugSymbols;
         (ApkBundlePath, ApkPackageId) = apkBuilder.BuildApk(SourceDir, Abi, MainLibraryFileName, MonoRuntimeHeaders);
         
         return true;

--- a/src/mono/msbuild/AndroidAppBuilder/ApkBuilder.cs
+++ b/src/mono/msbuild/AndroidAppBuilder/ApkBuilder.cs
@@ -14,6 +14,7 @@ public class ApkBuilder
     public string? BuildApiLevel { get; set; }
     public string? BuildToolsVersion { get; set; }
     public string? OutputDir { get; set; }
+    public bool StripDebugSymbols { get; set; }
 
     public (string apk, string packageId) BuildApk(
         string sourceDir, string abi, string entryPointLib, string monoRuntimeHeaders)
@@ -81,15 +82,28 @@ public class ApkBuilder
         Directory.CreateDirectory(Path.Combine(OutputDir, "obj"));
         Directory.CreateDirectory(Path.Combine(OutputDir, "assets"));
         
+        var extensionsToIgnore = new List<string> { ".so", ".a", ".gz" };
+        if (StripDebugSymbols)
+        {
+            extensionsToIgnore.Add(".pdb");
+            extensionsToIgnore.Add(".dbg");
+        }
+
         // Copy AppDir to OutputDir/assets (ignore native files)
         Utils.DirectoryCopy(sourceDir, Path.Combine(OutputDir, "assets"), file =>
         {
             string fileName = Path.GetFileName(file);
             string extension = Path.GetExtension(file);
-            // ignore native files, those go to lib/%abi%
-            if (extension == ".so" || extension == ".a")
+
+            if (file.Any(s => s >= 128))
             {
-                // ignore ".pdb" and ".dbg" to make APK smaller
+                // non-ascii files/folders are not allowed
+                return false;
+            }
+            if (extensionsToIgnore.Contains(extension))
+            {
+                // ignore native files, those go to lib/%abi%
+                // also, aapt is not happy about zip files
                 return false;
             }
             if (fileName.StartsWith("."))
@@ -129,9 +143,17 @@ public class ApkBuilder
             .Replace("%EntryPointLibName%", Path.GetFileName(entryPointLib));
         File.WriteAllText(Path.Combine(OutputDir, "runtime-android.c"), runtimeAndroidSrc);
         
-        Utils.RunProcess(cmake, workingDir: OutputDir,
-            args: $"-DCMAKE_TOOLCHAIN_FILE={androidToolchain} -DANDROID_ABI=\"{abi}\" -DANDROID_STL=none " + 
-            $"-DANDROID_NATIVE_API_LEVEL={MinApiLevel} -B runtime-android");
+        string cmakeArgs = $"-DCMAKE_TOOLCHAIN_FILE={androidToolchain} -DANDROID_ABI=\"{abi}\" -DANDROID_STL=none " + 
+            $"-DANDROID_NATIVE_API_LEVEL={MinApiLevel} -B runtime-android";
+
+        if (StripDebugSymbols)
+        {
+            // Makefile prints a warrning "clang: warning: argument unused during compilation: '-s'"
+            // but it does use it and calls `android-%abi%-strip` from NDK
+            cmakeArgs+= " -DCMAKE_C_FLAGS=-s";
+        }
+
+        Utils.RunProcess(cmake, workingDir: OutputDir, args: cmakeArgs);
         Utils.RunProcess("make", workingDir: Path.Combine(OutputDir, "runtime-android"));
 
         // 2. Compile Java files
@@ -168,7 +190,14 @@ public class ApkBuilder
         Directory.CreateDirectory(Path.Combine(OutputDir, "lib", abi));
         foreach (var dynamicLib in dynamicLibs)
         {
-            string destRelative = Path.Combine("lib", abi, Path.GetFileName(dynamicLib));
+            string dynamicLibName = Path.GetFileName(dynamicLib);
+            if (dynamicLibName == "libmonosgen-2.0.so")
+            {
+                // we link mono runtime statically into libruntime-android.so
+                continue;
+            }
+
+            string destRelative = Path.Combine("lib", abi, dynamicLibName);
             File.Copy(dynamicLib, Path.Combine(OutputDir, destRelative), true);
             Utils.RunProcess(aapt, $"add {apkFile} {destRelative}", workingDir: OutputDir);
         }
@@ -193,6 +222,8 @@ public class ApkBuilder
 
         Utils.RunProcess(apksigner, $"sign --min-sdk-version {MinApiLevel} --ks debug.keystore " + 
             $"--ks-pass pass:android --key-pass pass:android {alignedApk}", workingDir: OutputDir);
+
+        Utils.LogInfo($"\nAPK size: {(new FileInfo(alignedApk).Length / 1000_000.0):0.#} Mb.\n");
 
         return (alignedApk, packageId);
     }


### PR DESCRIPTION
1) Don't copy `libmonosgen-2.0.so` since we link mono runtime statically into `libandroid-runtime.so`
2) Fix various `aapt` errors
3) Shrink native libraries using `android-%abi%-strip` utility via `-s` argument.

29 Mb -> 18.8 Mb for `System.Memory.Tests` apk **without** ILLink (it means it contains the whole BCL inside)

#### Top largest files: 
libruntime-android.so: **5.6 Mb** (Ok)
libcrypto.so: **3 Mb** (we should link both Crypto and OpenSSL statically into runtime)
libSystem.IO.Compression.Native.so: **1.3 Mb** (because of Brotli compression which is rarely used)
System.Private.Xml.dll: **3.8 Mb**
System.Private.CoreLib.dll **3.6 Mb**
System.Data.Common.dll **1.2 Mb** (shouldn't be needed, but ILLink is not enabled yet)
System.Memory.Tests.dll **1 Mb** (Ok)
...
(tested on x86_64 abi)

NOTE: `android-%abi%-strip` can be used for other libSystem* libs to shrink them too. Currently it's used only for runtime (16mb -> 5.6mb)