### PR TITLE
Improve Uri.Equals by removing unsafe code

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1553,9 +1553,6 @@ namespace System
             return _info.String;
         }
 
-        //
-        //  A static shortcut to Uri.Equals
-        //
         public static bool operator ==(Uri? uri1, Uri? uri2)
         {
             if (ReferenceEquals(uri1, uri2))
@@ -1571,9 +1568,6 @@ namespace System
             return uri1.Equals(uri2);
         }
 
-        //
-        //  A static shortcut to !Uri.Equals
-        //
         public static bool operator !=(Uri? uri1, Uri? uri2)
         {
             if (ReferenceEquals(uri1, uri2))
@@ -1595,7 +1589,7 @@ namespace System
         //  Overrides default function (in Object class)
         //
         // Assumes:
-        //  <comparand> is an object of class Uri
+        //  <comparand> is an object of class Uri or String
         //
         // Returns:
         //  true if objects have the same value, else false
@@ -1617,11 +1611,9 @@ namespace System
 
             Uri? obj = comparand as Uri;
 
-            //
             // we allow comparisons of Uri and String objects only. If a string
             // is passed, convert to Uri. This is inefficient, but allows us to
             // canonicalize the comparand, making comparison possible
-            //
             if (obj is null)
             {
                 if (!(comparand is string s))
@@ -1634,9 +1626,6 @@ namespace System
                     return false;
             }
 
-            // Since v1.0 two Uris are equal if everything but fragment and UserInfo does match
-
-            // This check is for a case where we already fixed up the equal references
             if (ReferenceEquals(OriginalString, obj.OriginalString))
             {
                 return true;

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1558,15 +1558,17 @@ namespace System
         //
         public static bool operator ==(Uri? uri1, Uri? uri2)
         {
-            if ((object?)uri1 == (object?)uri2)
+            if (ReferenceEquals(uri1, uri2))
             {
                 return true;
             }
-            if ((object?)uri1 == null || (object?)uri2 == null)
+
+            if (uri1 is null || uri2 is null)
             {
                 return false;
             }
-            return uri2.Equals(uri1);
+
+            return uri1.Equals(uri2);
         }
 
         //
@@ -1574,17 +1576,17 @@ namespace System
         //
         public static bool operator !=(Uri? uri1, Uri? uri2)
         {
-            if ((object?)uri1 == (object?)uri2)
+            if (ReferenceEquals(uri1, uri2))
             {
                 return false;
             }
 
-            if ((object?)uri1 == null || (object?)uri2 == null)
+            if (uri1 is null || uri2 is null)
             {
                 return true;
             }
 
-            return !uri2.Equals(uri1);
+            return !uri1.Equals(uri2);
         }
 
         //
@@ -1603,12 +1605,12 @@ namespace System
         //
         public override bool Equals(object? comparand)
         {
-            if ((object?)comparand == null)
+            if (comparand is null)
             {
                 return false;
             }
 
-            if ((object?)this == (object?)comparand)
+            if (ReferenceEquals(this, comparand))
             {
                 return true;
             }
@@ -1620,12 +1622,13 @@ namespace System
             // is passed, convert to Uri. This is inefficient, but allows us to
             // canonicalize the comparand, making comparison possible
             //
-            if ((object?)obj == null)
+            if (obj is null)
             {
-                string? s = comparand as string;
-
-                if ((object?)s == null)
+                if (!(comparand is string s))
                     return false;
+
+                if (ReferenceEquals(s, OriginalString))
+                    return true;
 
                 if (!TryCreate(s, UriKind.RelativeOrAbsolute, out obj))
                     return false;
@@ -1634,7 +1637,7 @@ namespace System
             // Since v1.0 two Uris are equal if everything but fragment and UserInfo does match
 
             // This check is for a case where we already fixed up the equal references
-            if ((object)_string == (object)obj._string)
+            if (ReferenceEquals(OriginalString, obj.OriginalString))
             {
                 return true;
             }
@@ -1648,36 +1651,7 @@ namespace System
             if (NotAny(Flags.AllUriInfoSet) || obj.NotAny(Flags.AllUriInfoSet))
             {
                 // Try raw compare for _strings as the last chance to keep the working set small
-                if (!IsUncOrDosPath)
-                {
-                    if (_string.Length == obj._string.Length)
-                    {
-                        unsafe
-                        {
-                            // Try case sensitive compare on _strings
-                            fixed (char* selfPtr = _string)
-                            {
-                                fixed (char* otherPtr = obj._string)
-                                {
-                                    // This will never go negative since _string is checked to be a valid URI
-                                    int i = (_string.Length - 1);
-                                    for (; i >= 0; --i)
-                                    {
-                                        if (*(selfPtr + i) != *(otherPtr + i))
-                                        {
-                                            break;
-                                        }
-                                    }
-                                    if (i == -1)
-                                    {
-                                        return true;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                else if (string.Equals(_string, obj._string, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(_string, obj._string, IsUncOrDosPath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 {
                     return true;
                 }
@@ -1753,44 +1727,12 @@ namespace System
             MoreInfo selfInfo = _info.MoreInfo;
             MoreInfo otherInfo = obj._info.MoreInfo;
 
+            // Fragment AND UserInfo are ignored
             string selfUrl = selfInfo.RemoteUrl ??= GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
             string otherUrl = otherInfo.RemoteUrl ??= obj.GetParts(UriComponents.HttpRequestUrl, UriFormat.SafeUnescaped);
 
-            if (!IsUncOrDosPath)
-            {
-                if (selfUrl.Length != otherUrl.Length)
-                {
-                    return false;
-                }
-                unsafe
-                {
-                    // Try case sensitive compare on _strings
-                    fixed (char* seltPtr = selfUrl)
-                    {
-                        fixed (char* otherPtr = otherUrl)
-                        {
-                            char* endSelf = seltPtr + selfUrl.Length;
-                            char* endOther = otherPtr + selfUrl.Length;
-                            while (endSelf != seltPtr)
-                            {
-                                if (*--endSelf != *--endOther)
-                                {
-                                    return false;
-                                }
-                            }
-                            return true;
-                        }
-                    }
-                }
-            }
-
             // if IsUncOrDosPath is true then we ignore case in the path comparison
-            // Get Unescaped form as most safe for the comparison
-            // Fragment AND UserInfo are ignored
-            //
-            return (string.Compare(selfUrl,
-                                   otherUrl,
-                                   IsUncOrDosPath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal) == 0);
+            return string.Equals(selfUrl, otherUrl, IsUncOrDosPath ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
         }
 
         public Uri MakeRelativeUri(Uri uri)


### PR DESCRIPTION
Removed two hand-written unsafe string compares.