### PR TITLE
Make depproj intermediate output paths unique again

### DIFF
--- a/src/libraries/restore/Directory.Build.props
+++ b/src/libraries/restore/Directory.Build.props
@@ -2,10 +2,13 @@
   <Import Project="..\Directory.Build.props" />
 
   <PropertyGroup>
-      <!-- We need configuration-specific assets files. -->
+    <!-- We need configuration-specific assets files which requires the IntermeidateOutputPath to be set. -->
+    <IntermediateOutputPath>$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetFramework)-$(TargetFrameworkSuffix)-$(Configuration)'))</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(TargetFrameworkSuffix)' == ''">$([MSBuild]::NormalizeDirectory('$(BaseIntermediateOutputPath)', '$(TargetFramework)-$(Configuration)'))</IntermediateOutputPath>
     <RestoreOutputPath>$(IntermediateOutputPath)</RestoreOutputPath>
     <ProjectAssetsFile>$(RestoreOutputPath)/project.assets.json</ProjectAssetsFile>
     <MSBuildProjectExtensionsPath>$(IntermediateOutputPath)</MSBuildProjectExtensionsPath>
+
     <SkipDeriveTargetFrameworks>true</SkipDeriveTargetFrameworks>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <AdditionalBuildTargetFrameworks Condition="'$(BuildAllProjects)' == 'true'">netstandard2.0</AdditionalBuildTargetFrameworks>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36255

Depprojs depend on IntermediateOutputPath being set in a props file early enough as restore is happening per configuration. Even though it isn't recommended that the TargetFramework property is read before the project is loaded, we currently encode the TargetFramework in the IntermediateOutputPath for depproj files. The long-term fix is to get rid of per configuration restores by getting rid of our depproj files.