### PR TITLE
R2RTest - Partial composite images

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -30,6 +30,7 @@ namespace R2RTest
         public bool Release { get; set; }
         public bool LargeBubble { get; set; }
         public bool Composite { get; set; }
+        public bool PartialComposite { get; set; }
         public int Crossgen2Parallelism { get; set; }
         public int CompilationTimeoutMinutes { get; set; }
         public int ExecutionTimeoutMinutes { get; set; }

--- a/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
@@ -158,6 +158,7 @@ namespace R2RTest
                         CoreRootDirectory(),
                         AspNetPath(),
                         Composite(),
+                        PartialComposite(),
                     },
                     handler: CommandHandler.Create<BuildOptions>(CompileSerpCommand.CompileSerpAssemblies));
 
@@ -267,6 +268,9 @@ namespace R2RTest
             //
             Option AspNetPath() =>
                 new Option(new[] { "--asp-net-path", "-asp" }, "Path to SERP's ASP.NET Core folder", new Argument<DirectoryInfo>().ExistingOnly());
+
+            Option PartialComposite() =>
+                new Option(new[] { "--partial-composite", "-pc" }, "Add references to framework and asp.net instead of unrooted inputs", new Argument<bool>());
         }
     }
 }

--- a/src/coreclr/src/tools/r2rtest/Commands/CompileSerpCommand.cs
+++ b/src/coreclr/src/tools/r2rtest/Commands/CompileSerpCommand.cs
@@ -110,12 +110,26 @@ namespace R2RTest
             referenceAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "mscorlib.dll"));
             referenceAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "netstandard.dll"));
 
+            //
+            // binFiles is now all the assemblies that we want to compile (either individually or as composite)
+            // referenceAssemblies is all managed assemblies that are referenceable
+            //
+
+            // Remove all bin files except serp.dll so they're just referenced (eventually we'll be able to compile all these in a single composite)
+            foreach (string item in new HashSet<string>(File.ReadAllLines(whiteListFilePath)))
+            {
+                if (item == "Serp.dll")
+                    continue;
+
+                binFiles.Remove(Path.Combine(binDir, item));
+            }
+
             List<ProcessInfo> fileCompilations = new List<ProcessInfo>();
             if (options.Composite)
             {
                 string serpDll = Path.Combine(binDir, "Serp.dll");
                 var runner = new CpaotRunner(options, referenceAssemblies);
-                var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, Path.ChangeExtension(serpDll, ".ni.dll"), referenceAssemblies));
+                var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, Path.ChangeExtension(serpDll, ".ni.dll"), binFiles));
                 fileCompilations.Add(compilationProcess);
             }
             else

--- a/src/coreclr/src/tools/r2rtest/CpaotRunner.cs
+++ b/src/coreclr/src/tools/r2rtest/CpaotRunner.cs
@@ -137,7 +137,7 @@ namespace R2RTest
                 // This is useful for crossgen2-specific scenarios since crossgen2 expects a list of files unlike crossgen1
                 foreach (var reference in _referenceFiles)
                 {
-                    yield return (_options.Composite ? "-u:" : "-r:") + reference;
+                    yield return (_options.Composite && !_options.PartialComposite ? "-u:" : "-r:") + reference;
                 }
             }
         }


### PR DESCRIPTION
Allow compiling composite R2R images which reference assemblies not in the composite. For example, this would allow compiling a set of application assemblies with references to ASP.NET / Framework. Currently R2RTest treats all references as unrooted inputs for the composite image.

We'll probably want to adjust this more as we create crazy multi-composites with large version bubbles but it's enough for now in my investigations.

cc @dotnet/crossgen-contrib 