### PR TITLE
Move mobile test runners to libs.pretest instead of P2P

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -3,7 +3,7 @@
     <!-- OutDir is not set early enough to set this property in .props file. -->
     <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'AppBundle'))</BundleDir>
     <RunScriptOutputPath>$([MSBuild]::NormalizePath('$(BundleDir)', '$(RunScriptOutputName)'))</RunScriptOutputPath>
-    <RunAOTCompilation Condition="'$(TargetOS)' == 'iOS' and ('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm')">true</RunAOTCompilation>
+    <RunAOTCompilation Condition="'$(TargetOS)' == 'iOS' and $(TargetArchitecture.StartsWith('arm'))">true</RunAOTCompilation>
   </PropertyGroup>
 
   <!-- Generate a self-contained app bundle for Android with tests. -->
@@ -102,6 +102,16 @@
     <Message Importance="High" Text="Xcode: $(XcodeProjectPath)"/>
     <Message Importance="High" Text="App: $(AppBundlePath)"/>
     <!-- This app is now can be consumed by xharness CLI to deploy on a device or simulator -->
+  </Target>
+
+  <Target Name="AddTestRunnersToPublishedFiles"
+          AfterTargets="ComputeFilesToPublish">
+    <ItemGroup>
+      <_runnerFilesToPublish Include="$(AndroidTestRunnerDir)*" Condition="'$(TargetOS)' == 'Android'" />
+      <_runnerFilesToPublish Include="$(AppleTestRunnerDir)*" Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" />
+
+      <ResolvedFileToPublish Include="@(_runnerFilesToPublish)" RelativePath="%(FileName)%(Extension)" CopyToPublishDirectory="PreserveNewest" />
+    </ItemGroup>
   </Target>
 
   <Target Name="AddFrameworkReference">

--- a/eng/testing/tests.props
+++ b/eng/testing/tests.props
@@ -21,10 +21,15 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetsMobile)' == 'true'">
-    <MobileHelpersDirSuffix>$(NetCoreAppCurrent)-$(MonoConfiguration)</MobileHelpersDirSuffix>
-    <AppleAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', '$(MobileHelpersDirSuffix)'))</AppleAppBuilderDir>
-    <AndroidAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder', '$(MobileHelpersDirSuffix)'))</AndroidAppBuilderDir>
-    <MonoAOTCompilerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'MonoAOTCompiler', '$(MobileHelpersDirSuffix)'))</MonoAOTCompilerDir>
+    <MobileHelperTasksDirSuffix>$(NetCoreAppCurrent)-$(MonoConfiguration)</MobileHelperTasksDirSuffix>
+    <AppleAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleAppBuilder', '$(MobileHelperTasksDirSuffix)'))</AppleAppBuilderDir>
+    <AndroidAppBuilderDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidAppBuilder', '$(MobileHelperTasksDirSuffix)'))</AndroidAppBuilderDir>
+    <MonoAOTCompilerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'MonoAOTCompiler', '$(MobileHelperTasksDirSuffix)'))</MonoAOTCompilerDir>
+
+    <!-- Test runners are built as part of libs.pretest so we need to use libraries configuration -->
+    <MobileRunnersDirSuffix>$(NetCoreAppCurrent)-$(Configuration)</MobileRunnersDirSuffix>
+    <AppleTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AppleTestRunner', '$(MobileRunnersDirSuffix)'))</AppleTestRunnerDir>
+    <AndroidTestRunnerDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'AndroidTestRunner', '$(MobileRunnersDirSuffix)'))</AndroidTestRunnerDir>
 
     <RuntimeIdentifier>$(PackageRID)</RuntimeIdentifier>
     <SelfContained>true</SelfContained>

--- a/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
+++ b/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
@@ -92,7 +92,9 @@ public class SimpleAndroidTestRunner : AndroidApplicationEntryPoint, IDevice
 
     public string? Locale { get; }
 
+#pragma warning disable CS8764
     public override TextWriter? Logger => null;
+#pragma warning restore CS8764
 
     public override string TestsResultsFinalPath
     {

--- a/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.csproj
+++ b/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.csproj
@@ -2,11 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
-  <!-- Since this is referenced by test projects that are restored for NetFrameworkCurrent, we need to suppor it for restored
-  at runtime this is a no-op as tests can't run in NetFrameworkCurrent on Android so we will never build this for that tfm. -->
-  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+  <ItemGroup>
     <Compile Include="AndroidTestRunner.cs" />
     <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />
   </ItemGroup>

--- a/src/libraries/Common/tests/AppleTestRunner/AppleTestRunner.csproj
+++ b/src/libraries/Common/tests/AppleTestRunner/AppleTestRunner.csproj
@@ -2,11 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>
-  <!-- Since this is referenced by test projects that are restored for NetFrameworkCurrent, we need to suppor it for restored
-  at runtime this is a no-op as tests can't run in NetFrameworkCurrent on iOS so we will never build this for that tfm. -->
-  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+  <ItemGroup>
     <Compile Include="AppleTestRunner.cs" />
     <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />
   </ItemGroup>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -323,9 +323,6 @@
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
     <ProjectReference Include="$(CommonTestPath)TestUtilities\TestUtilities.csproj" />
-    
-    <ProjectReference Include="$(CommonTestPath)AppleTestRunner\AppleTestRunner.csproj" Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'" />
-    <ProjectReference Include="$(CommonTestPath)AndroidTestRunner\AndroidTestRunner.csproj" Condition="'$(TargetOS)' == 'Android'" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true'">

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -16,6 +16,9 @@
   <ItemGroup>
     <RuntimeProject Include="restore\runtime\runtime.depproj" />
     <ProjectReference Include="@(RuntimeProject)" Condition="'$(MSBuildRestoreSessionId)' != ''" />
+
+    <ProjectReference Include="$(CommonTestPath)AppleTestRunner\AppleTestRunner.csproj" Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'"/>
+    <ProjectReference Include="$(CommonTestPath)AndroidTestRunner\AndroidTestRunner.csproj" Condition="'$(TargetOS)' == 'Android'" />
   </ItemGroup>
 
   <Target Name="RestoreTestHost"


### PR DESCRIPTION
Follow up feedback from: https://github.com/dotnet/runtime/pull/36411