### PR TITLE
Convert Extract(0) to ToScalar()

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -254,7 +254,7 @@ namespace System.Numerics
                 // Hence use Vector64.Create(ulong) to create Vector64<ulong> and operate on that.
                 Vector64<ulong> input = Vector64.Create((ulong)value);
                 Vector64<byte> aggregated = AdvSimd.Arm64.AddAcross(AdvSimd.PopCount(input.AsByte()));
-                return AdvSimd.Extract(aggregated, 0);
+                return aggregated.ToScalar();
             }
 
             return SoftwareFallback(value);
@@ -293,7 +293,7 @@ namespace System.Numerics
                 // PopCount works on vector so convert input value to vector first.
                 Vector64<ulong> input = Vector64.Create(value);
                 Vector64<byte> aggregated = AdvSimd.Arm64.AddAcross(AdvSimd.PopCount(input.AsByte()));
-                return AdvSimd.Extract(aggregated, 0);
+                return aggregated.ToScalar();
             }
 
 #if TARGET_32BIT

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -25,6 +25,7 @@ namespace System.Runtime.Intrinsics
         public static Vector128<uint> AsUInt32<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<ulong> AsUInt64<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static T GetElement<T>(this Vector128<T> vector, int index) where T : struct => throw new PlatformNotSupportedException();
+        public static T ToScalar<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector128<T>
         where T : struct
@@ -147,7 +148,6 @@ namespace System.Runtime.Intrinsics.Arm
         {
             public static Vector64<byte> AddAcross(Vector64<byte> value) => throw new PlatformNotSupportedException();
         }
-        public static byte Extract(Vector64<byte> vector, byte index) => throw new PlatformNotSupportedException();
         public static Vector64<byte> PopCount(Vector64<byte> value) => throw new PlatformNotSupportedException();
     }
 }


### PR DESCRIPTION
In PopCount, I used `.Extract(vector, 0)` because `ToScalar()` was not optimized. With https://github.com/dotnet/runtime/pull/36156, it is optimized. So use `ToScalar()` instead for better code readability.
