### PR TITLE
Remove duplicated tests from System.Text.Json.Tests

### DIFF
--- a/src/libraries/System.Text.Json/tests/JsonDateTimeTestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonDateTimeTestData.cs
@@ -42,7 +42,6 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.6666660\"", "1997-07-16T19:20:30.666666" };
 
             // Test fraction truncation.
-            yield return new object[] { "\"1997-07-16T19:20:30.0000000\"", "1997-07-16T19:20:30" };
             yield return new object[] { "\"1997-07-16T19:20:30.00000001\"", "1997-07-16T19:20:30" };
             yield return new object[] { "\"1997-07-16T19:20:30.000000001\"", "1997-07-16T19:20:30" };
             yield return new object[] { "\"1997-07-16T19:20:30.77777770\"", "1997-07-16T19:20:30.7777777" };
@@ -153,7 +152,6 @@ namespace System.Text.Json.Tests
             // Invalid fractions.
             yield return new object[] { "\"1997-07-16T19.45\"" };
             yield return new object[] { "\"1997-07-16T19:20.45\"" };
-            yield return new object[] { "\"1997-07-16T19:20:30a\"" };
             yield return new object[] { "\"1997-07-16T19:20:30,45\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.a\"" };
@@ -168,7 +166,6 @@ namespace System.Text.Json.Tests
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+01Z\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+01:\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555 +01:00\"" };
-            yield return new object[] { "\"1997-07-16T19:20:30.4555555+01:\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555- 01:00\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555+04 :30\"" };
             yield return new object[] { "\"1997-07-16T19:20:30.4555555-04: 30\"" };

--- a/src/libraries/System.Text.Json/tests/JsonGuidTestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonGuidTestData.cs
@@ -35,15 +35,39 @@ namespace System.Text.Json.Tests
 
         public static IEnumerable<object[]> InvalidGuidTests()
         {
+            // Invalid formats
+            Guid testGuid = new Guid(s_guidStr);
+            yield return new object[] { testGuid.ToString("B", CultureInfo.InvariantCulture) };
+            yield return new object[] { testGuid.ToString("P", CultureInfo.InvariantCulture) };
+            yield return new object[] { testGuid.ToString("N", CultureInfo.InvariantCulture) };
+
+            yield return new object[] { new string('$', 1) };
+            yield return new object[] { new string(' ', 1) };
+            yield return new object[] { new string('$', s_guidStr.Length) };
+            yield return new object[] { new string(' ', s_guidStr.Length) };
+
+            for (int truncationPoint = 1; truncationPoint < s_guidStr.Length - 1; truncationPoint++)
+            {
+                string truncatedText = s_guidStr.Substring(0, truncationPoint);
+
+                // Stop short
+                yield return new object[] { truncatedText };
+
+                // Append junk
+                yield return new object[] { truncatedText.PadRight(s_guidStr.Length, '$') };
+                yield return new object[] { truncatedText.PadRight(s_guidStr.Length, ' ') };
+                yield return new object[] { truncatedText.PadRight(truncatedText.Length + 1, '$') };
+                yield return new object[] { truncatedText.PadRight(truncatedText.Length + 1, ' ') };
+                // Prepend junk
+                yield return new object[] { truncatedText.PadLeft(s_guidStr.Length, '$') };
+                yield return new object[] { truncatedText.PadLeft(s_guidStr.Length, ' ') };
+                yield return new object[] { truncatedText.PadLeft(truncatedText.Length + 1, '$') };
+                yield return new object[] { truncatedText.PadLeft(truncatedText.Length + 1, ' ') };
+            }
+
             foreach (object[] guid in ValidGuidTests())
             {
                 string guidStr = (string)guid[0];
-
-                // Invalid formats
-                Guid testGuid = new Guid(guidStr);
-                yield return new object[] { testGuid.ToString("B", CultureInfo.InvariantCulture) };
-                yield return new object[] { testGuid.ToString("P", CultureInfo.InvariantCulture) };
-                yield return new object[] { testGuid.ToString("N", CultureInfo.InvariantCulture) };
 
                 for (int i = 0; i < guidStr.Length; i++)
                 {
@@ -70,25 +94,6 @@ namespace System.Text.Json.Tests
                         bad[i] = '!';
                         yield return new object[] { new string(bad) };
                     }
-                }
-
-                for (int truncationPoint = 0; truncationPoint < guidStr.Length; truncationPoint++)
-                {
-                    string truncatedText = guidStr.Substring(0, truncationPoint);
-
-                    // Stop short
-                    yield return new object[] { truncatedText };
-
-                    // Append junk
-                    yield return new object[] { truncatedText.PadRight(guidStr.Length, '$') };
-                    yield return new object[] { truncatedText.PadRight(guidStr.Length, ' ') };
-                    yield return new object[] { truncatedText.PadRight(truncatedText.Length + 1, '$') };
-                    yield return new object[] { truncatedText.PadRight(truncatedText.Length + 1, ' ') };
-                    // Prepend junk
-                    yield return new object[] { truncatedText.PadLeft(guidStr.Length, '$') };
-                    yield return new object[] { truncatedText.PadLeft(guidStr.Length, ' ') };
-                    yield return new object[] { truncatedText.PadLeft(truncatedText.Length + 1, '$') };
-                    yield return new object[] { truncatedText.PadLeft(truncatedText.Length + 1, ' ') };
                 }
 
                 // Too long

--- a/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonReaderTests.cs
@@ -4380,7 +4380,6 @@ namespace System.Text.Json.Tests
                     new object[] {"+0", 0, 0},
                     new object[] {"+1", 0, 0},
                     new object[] {"0e", 0, 2},
-                    new object[] {"0.", 0, 2},
                     new object[] {"0.1e", 0, 4},
                     new object[] {"01", 0, 1},
                     new object[] {"1a", 0, 1},


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/35845

The mayor responsible for the duplicated (and unnecessary) theories was this code block on `InvalidGuidTests`.

```cs
foreach (object[] guid in ValidGuidTests())
{
    for (int truncationPoint = 0; truncationPoint < guidStr.Length; truncationPoint++)
    {
        string truncatedText = guidStr.Substring(0, truncationPoint);

        // Stop short
        yield return new object[] { truncatedText };

        // Append junk
        yield return new object[] { truncatedText.PadRight(guidStr.Length, '$') };
        yield return new object[] { truncatedText.PadRight(guidStr.Length, ' ') };
        yield return new object[] { truncatedText.PadRight(truncatedText.Length + 1, '$') };
        yield return new object[] { truncatedText.PadRight(truncatedText.Length + 1, ' ') };
        // Prepend junk
        yield return new object[] { truncatedText.PadLeft(guidStr.Length, '$') };
        yield return new object[] { truncatedText.PadLeft(guidStr.Length, ' ') };
        yield return new object[] { truncatedText.PadLeft(truncatedText.Length + 1, '$') };
        yield return new object[] { truncatedText.PadLeft(truncatedText.Length + 1, ' ') };
    }
}
```

`ValidGuidTests` returns 4 guids, 3 of them are practically the same guid, with a lowercase and a mixed case version, the fourth is a `Guid.NewGuid`.

Above piece of code was generating 1,296 (9 * 36 * 4) returns, and some of them were duplicated because of substrings that overlap. On top of that, `InvalidGuidTests` is being used as MemberData on 3 methods.

To avoid that I moved above code outside of the `ValidGuidTests` foreach and separated the edge cases, only one Guid is used to get the truncated ones.

InvalidGuidTests now returns 631 theories, it was returning 1626 before, from which 1474 were unique. We did loss a huge amount of unique tests but all of them are related to the truncatedText scenario, IMO iterating over only one Guid should suffice to test truncation.

Before: 
```
  ===========================================================================================================
    Discovering: System.Text.Json.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Text.Json.Tests (found 1841 of 1872 test cases)
    Starting:    System.Text.Json.Tests (parallel test collections = on, max threads = 12)
    Finished:    System.Text.Json.Tests
  === TEST EXECUTION SUMMARY ===
     System.Text.Json.Tests  Total: 11330, Errors: 0, Failed: 0, Skipped: 0, Time: 29.744s

```

Now:
```
  ===========================================================================================================
    Discovering: System.Text.Json.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Text.Json.Tests (found 1841 of 1872 test cases)
    Starting:    System.Text.Json.Tests (parallel test collections = on, max threads = 12)
    Finished:    System.Text.Json.Tests
  === TEST EXECUTION SUMMARY ===
     System.Text.Json.Tests  Total: 8332, Errors: 0, Failed: 0, Skipped: 0, Time: 24.759s
```
