### PR TITLE
Add JIT EventCounters

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -300,7 +300,7 @@ namespace System.Runtime.CompilerServices
         internal static extern long GetILBytesJitted();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern long GetMethodsJittedCount();
+        internal static extern int GetMethodsJittedCount();
     }
     // Helper class to assist with unsafe pinning of arbitrary objects.
     // It's used by VM code.

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -295,6 +295,12 @@ namespace System.Runtime.CompilerServices
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static unsafe extern TailCallTls* GetTailCallInfo(IntPtr retAddrSlot, IntPtr* retAddr);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern long GetILBytesJitted();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal static extern long GetMethodsJittedCount();
     }
     // Helper class to assist with unsafe pinning of arbitrary objects.
     // It's used by VM code.

--- a/src/coreclr/src/vm/ecalllist.h
+++ b/src/coreclr/src/vm/ecalllist.h
@@ -909,6 +909,8 @@ FCFuncStart(gRuntimeHelpers)
     FCFuncElement("AllocTailCallArgBuffer", TailCallHelp::AllocTailCallArgBuffer)
     FCFuncElement("FreeTailCallArgBuffer", TailCallHelp::FreeTailCallArgBuffer)
     FCFuncElement("GetTailCallInfo", TailCallHelp::GetTailCallInfo)
+    FCFuncElement("GetILBytesJitted", GetJittedBytes)
+    FCFuncElement("GetMethodsJittedCount", GetJittedMethodsCount)
 FCFuncEnd()
 
 FCFuncStart(gContextSynchronizationFuncs)

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -105,6 +105,7 @@ uint32_t g_cMethodsJitted = 0;
 FCIMPL0(INT64, GetJittedBytes)
 {
     FCALL_CONTRACT;
+
     return g_cbILJitted;
 }
 FCIMPLEND
@@ -12603,10 +12604,6 @@ void ThrowExceptionForJit(HRESULT res)
  }
 
 // ********************************************************************
-#ifdef _DEBUG
-LONG g_JitCount = 0;
-#endif
-
 //#define PERF_TRACK_METHOD_JITTIMES
 #ifdef TARGET_AMD64
 BOOL g_fAllowRel32 = TRUE;
@@ -12983,7 +12980,6 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
     }
 
 #ifdef _DEBUG
-    FastInterlockIncrement(&g_JitCount);
     static BOOL fHeartbeat = -1;
 
     if (fHeartbeat == -1)

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12954,9 +12954,6 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
             "Jitted Entry at" FMT_ADDR "method %s::%s %s\n", DBG_ADDR(nativeEntry),
              ftn->m_pszDebugClassName, ftn->m_pszDebugMethodName, ftn->m_pszDebugMethodSignature));
 
-        g_cbILJitted += methodInfo.ILCodeSize;
-        g_cMethodsJitted++;
-
 #if defined(FEATURE_CORESYSTEM)
 
 #ifdef _DEBUG
@@ -12995,6 +12992,9 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
     if (fHeartbeat)
         printf(".");
 #endif // _DEBUG
+
+    FastInterlockExchangeAddLong((LONG64*)&g_cbILJitted, methodInfo.ILCodeSize);
+    FastInterlockIncrement((LONG*)&g_cMethodsJitted);
 
     COOPERATIVE_TRANSITION_END();
     return ret;

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -99,6 +99,40 @@ GARY_IMPL(VMHELPDEF, hlpDynamicFuncTable, DYNAMIC_CORINFO_HELP_COUNT);
 
 #else // DACCESS_COMPILE
 
+#ifdef FEATURE_EVENT_TRACE
+long g_cbILJitted = 0;
+long g_cMethodsJitted = 0;
+
+long GetJittedBytes()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    return g_cbILJitted;
+}
+
+long GetJittedMethodsCount()
+{
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    return g_cMethodsJitted;
+}
+
+
+#endif
+
+
 /*********************************************************************/
 
 inline CORINFO_MODULE_HANDLE GetScopeHandle(MethodDesc* method)
@@ -12864,6 +12898,11 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
                                                   &sizeOfCode,
                                                   nativeCodeVersion);
             LOG((LF_CORDB, LL_EVERYTHING, "Got through CallCompile MethodWithSEHWrapper\n"));
+
+#ifdef FEATURE_EVENT_TRACE
+            g_cbILJitted += methodInfo.ILCodeSize;
+            g_cMethodsJitted++;
+#endif
 
 #if FEATURE_PERFMAP
             // Save the code size so that it can be reported to the perfmap.

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -102,6 +102,7 @@ GARY_IMPL(VMHELPDEF, hlpDynamicFuncTable, DYNAMIC_CORINFO_HELP_COUNT);
 uint64_t g_cbILJitted = 0;
 uint32_t g_cMethodsJitted = 0;
 
+#ifndef CROSSGEN_COMPILE
 FCIMPL0(INT64, GetJittedBytes)
 {
     FCALL_CONTRACT;
@@ -117,6 +118,7 @@ FCIMPL0(INT32, GetJittedMethodsCount)
     return g_cMethodsJitted;
 }
 FCIMPLEND
+#endif
 
 /*********************************************************************/
 

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -12883,9 +12883,6 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
                                                   nativeCodeVersion);
             LOG((LF_CORDB, LL_EVERYTHING, "Got through CallCompile MethodWithSEHWrapper\n"));
 
-            g_cbILJitted += methodInfo.ILCodeSize;
-            g_cMethodsJitted++;
-
 #if FEATURE_PERFMAP
             // Save the code size so that it can be reported to the perfmap.
             if (pSizeOfCode != NULL)
@@ -12956,6 +12953,9 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
         LOG((LF_JIT, LL_INFO10000,
             "Jitted Entry at" FMT_ADDR "method %s::%s %s\n", DBG_ADDR(nativeEntry),
              ftn->m_pszDebugClassName, ftn->m_pszDebugMethodName, ftn->m_pszDebugMethodSignature));
+
+        g_cbILJitted += methodInfo.ILCodeSize;
+        g_cMethodsJitted++;
 
 #if defined(FEATURE_CORESYSTEM)
 

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -101,7 +101,7 @@ GARY_IMPL(VMHELPDEF, hlpDynamicFuncTable, DYNAMIC_CORINFO_HELP_COUNT);
 
 #ifdef FEATURE_EVENT_TRACE
 long g_cbILJitted = 0;
-long g_cMethodsJitted = 0;
+int g_cMethodsJitted = 0;
 
 long GetJittedBytes()
 {

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -115,7 +115,7 @@ long GetJittedBytes()
     return g_cbILJitted;
 }
 
-long GetJittedMethodsCount()
+int GetJittedMethodsCount()
 {
     CONTRACTL
     {
@@ -127,7 +127,6 @@ long GetJittedMethodsCount()
 
     return g_cMethodsJitted;
 }
-
 
 /*********************************************************************/
 

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -99,34 +99,23 @@ GARY_IMPL(VMHELPDEF, hlpDynamicFuncTable, DYNAMIC_CORINFO_HELP_COUNT);
 
 #else // DACCESS_COMPILE
 
-long g_cbILJitted = 0;
-int g_cMethodsJitted = 0;
+uint64_t g_cbILJitted = 0;
+uint32_t g_cMethodsJitted = 0;
 
-long GetJittedBytes()
+FCIMPL0(INT64, GetJittedBytes)
 {
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
-
+    FCALL_CONTRACT;
     return g_cbILJitted;
 }
+FCIMPLEND
 
-int GetJittedMethodsCount()
+FCIMPL0(INT32, GetJittedMethodsCount)
 {
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_ANY;
-    }
-    CONTRACTL_END;
+    FCALL_CONTRACT;
 
     return g_cMethodsJitted;
 }
+FCIMPLEND
 
 /*********************************************************************/
 

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -99,7 +99,6 @@ GARY_IMPL(VMHELPDEF, hlpDynamicFuncTable, DYNAMIC_CORINFO_HELP_COUNT);
 
 #else // DACCESS_COMPILE
 
-#ifdef FEATURE_EVENT_TRACE
 long g_cbILJitted = 0;
 int g_cMethodsJitted = 0;
 
@@ -128,9 +127,6 @@ long GetJittedMethodsCount()
 
     return g_cMethodsJitted;
 }
-
-
-#endif
 
 
 /*********************************************************************/
@@ -12899,10 +12895,8 @@ PCODE UnsafeJitFunction(PrepareCodeConfig* config,
                                                   nativeCodeVersion);
             LOG((LF_CORDB, LL_EVERYTHING, "Got through CallCompile MethodWithSEHWrapper\n"));
 
-#ifdef FEATURE_EVENT_TRACE
             g_cbILJitted += methodInfo.ILCodeSize;
             g_cMethodsJitted++;
-#endif
 
 #if FEATURE_PERFMAP
             // Save the code size so that it can be reported to the perfmap.

--- a/src/coreclr/src/vm/jitinterface.h
+++ b/src/coreclr/src/vm/jitinterface.h
@@ -1684,5 +1684,8 @@ CORJIT_FLAGS GetDebuggerCompileFlags(Module* pModule, CORJIT_FLAGS flags);
 
 bool __stdcall TrackAllocationsEnabled();
 
+long GetJittedBytes();
+long GetJittedMethodsCount();
+
 #endif // JITINTERFACE_H
 

--- a/src/coreclr/src/vm/jitinterface.h
+++ b/src/coreclr/src/vm/jitinterface.h
@@ -1684,8 +1684,8 @@ CORJIT_FLAGS GetDebuggerCompileFlags(Module* pModule, CORJIT_FLAGS flags);
 
 bool __stdcall TrackAllocationsEnabled();
 
-long GetJittedBytes();
-int GetJittedMethodsCount();
+FCDECL0(INT64, GetJittedBytes);
+FCDECL0(INT32, GetJittedMethodsCount);
 
 #endif // JITINTERFACE_H
 

--- a/src/coreclr/src/vm/jitinterface.h
+++ b/src/coreclr/src/vm/jitinterface.h
@@ -1685,7 +1685,7 @@ CORJIT_FLAGS GetDebuggerCompileFlags(Module* pModule, CORJIT_FLAGS flags);
 bool __stdcall TrackAllocationsEnabled();
 
 long GetJittedBytes();
-long GetJittedMethodsCount();
+int GetJittedMethodsCount();
 
 #endif // JITINTERFACE_H
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -36,6 +36,8 @@ namespace System.Diagnostics.Tracing
         private PollingCounter? _gen2SizeCounter;
         private PollingCounter? _lohSizeCounter;
         private PollingCounter? _assemblyCounter;
+        private PollingCounter? _totalJittedBytesCounter;
+        private PollingCounter? _totalMethodsJittedCounter;
 #endif
 
         public static void Initialize()
@@ -77,6 +79,8 @@ namespace System.Diagnostics.Tracing
                 _gen2SizeCounter ??= new PollingCounter("gen-2-size", this, () => GC.GetGenerationSize(2)) { DisplayName = "Gen 2 Size", DisplayUnits = "B" };
                 _lohSizeCounter ??= new PollingCounter("loh-size", this, () => GC.GetGenerationSize(3)) { DisplayName = "LOH Size", DisplayUnits = "B" };
                 _assemblyCounter ??= new PollingCounter("assembly-count", this, () => System.Reflection.Assembly.GetAssemblyCount()) { DisplayName = "Number of Assemblies Loaded" };
+                _totalJittedBytesCounter ??= new PollingCounter("jitted-bytes-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted" };
+                _totalMethodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "# of Methods Jitted" };
 #endif
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -36,7 +36,7 @@ namespace System.Diagnostics.Tracing
         private PollingCounter? _gen2SizeCounter;
         private PollingCounter? _lohSizeCounter;
         private PollingCounter? _assemblyCounter;
-        private PollingCounter? _totalJittedBytesCounter;
+        private PollingCounter? _ILBytesJittedCounter;
         private PollingCounter? _totalMethodsJittedCounter;
 #endif
 
@@ -70,7 +70,6 @@ namespace System.Diagnostics.Tracing
                 _completedItemsCounter ??= new IncrementingPollingCounter("threadpool-completed-items-count", this, () => ThreadPool.CompletedWorkItemCount) { DisplayName = "ThreadPool Completed Work Item Count", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
                 _allocRateCounter ??= new IncrementingPollingCounter("alloc-rate", this, () => GC.GetTotalAllocatedBytes()) { DisplayName = "Allocation Rate", DisplayUnits = "B", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
                 _timerCounter ??= new PollingCounter("active-timer-count", this, () => Timer.ActiveCount) { DisplayName = "Number of Active Timers" };
-
 #if !MONO
                 _exceptionCounter ??= new IncrementingPollingCounter("exception-count", this, () => Exception.GetExceptionCount()) { DisplayName = "Exception Count", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
                 _gcTimeCounter ??= new PollingCounter("time-in-gc", this, () => GC.GetLastGCPercentTimeInGC()) { DisplayName = "% Time in GC since last GC", DisplayUnits = "%" };
@@ -79,8 +78,8 @@ namespace System.Diagnostics.Tracing
                 _gen2SizeCounter ??= new PollingCounter("gen-2-size", this, () => GC.GetGenerationSize(2)) { DisplayName = "Gen 2 Size", DisplayUnits = "B" };
                 _lohSizeCounter ??= new PollingCounter("loh-size", this, () => GC.GetGenerationSize(3)) { DisplayName = "LOH Size", DisplayUnits = "B" };
                 _assemblyCounter ??= new PollingCounter("assembly-count", this, () => System.Reflection.Assembly.GetAssemblyCount()) { DisplayName = "Number of Assemblies Loaded" };
-                _totalJittedBytesCounter ??= new PollingCounter("jitted-bytes-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted" };
-                _totalMethodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "# of Methods Jitted" };
+                _ILBytesJittedCounter ??= new IncrementingPollingCounter("il-bytes-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
+                _totalMethodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "Number of Methods Jitted" };
 #endif
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -36,8 +36,8 @@ namespace System.Diagnostics.Tracing
         private PollingCounter? _gen2SizeCounter;
         private PollingCounter? _lohSizeCounter;
         private PollingCounter? _assemblyCounter;
-        private IncrementingPollingCounter? _ILBytesJittedCounter;
-        private PollingCounter? _totalMethodsJittedCounter;
+        private PollingCounter? _ilBytesJittedCounter;
+        private PollingCounter? _methodsJittedCounter;
 #endif
 
         public static void Initialize()
@@ -78,8 +78,8 @@ namespace System.Diagnostics.Tracing
                 _gen2SizeCounter ??= new PollingCounter("gen-2-size", this, () => GC.GetGenerationSize(2)) { DisplayName = "Gen 2 Size", DisplayUnits = "B" };
                 _lohSizeCounter ??= new PollingCounter("loh-size", this, () => GC.GetGenerationSize(3)) { DisplayName = "LOH Size", DisplayUnits = "B" };
                 _assemblyCounter ??= new PollingCounter("assembly-count", this, () => System.Reflection.Assembly.GetAssemblyCount()) { DisplayName = "Number of Assemblies Loaded" };
-                _ILBytesJittedCounter ??= new IncrementingPollingCounter("il-bytes-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted", DisplayRateTimeScale = new TimeSpan(0, 0, 1) };
-                _totalMethodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "Number of Methods Jitted" };
+                _ilBytesJittedCounter ??= new PollingCounter("il-bytes-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted" };
+                _methodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "Number of Methods Jitted" };
 #endif
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -78,7 +78,7 @@ namespace System.Diagnostics.Tracing
                 _gen2SizeCounter ??= new PollingCounter("gen-2-size", this, () => GC.GetGenerationSize(2)) { DisplayName = "Gen 2 Size", DisplayUnits = "B" };
                 _lohSizeCounter ??= new PollingCounter("loh-size", this, () => GC.GetGenerationSize(3)) { DisplayName = "LOH Size", DisplayUnits = "B" };
                 _assemblyCounter ??= new PollingCounter("assembly-count", this, () => System.Reflection.Assembly.GetAssemblyCount()) { DisplayName = "Number of Assemblies Loaded" };
-                _ilBytesJittedCounter ??= new PollingCounter("il-bytes-jitted", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted" };
+                _ilBytesJittedCounter ??= new PollingCounter("il-bytes-jitted", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted", DisplayUnits = "B" };
                 _methodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "Number of Methods Jitted" };
 #endif
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -36,7 +36,7 @@ namespace System.Diagnostics.Tracing
         private PollingCounter? _gen2SizeCounter;
         private PollingCounter? _lohSizeCounter;
         private PollingCounter? _assemblyCounter;
-        private PollingCounter? _ILBytesJittedCounter;
+        private IncrementingPollingCounter? _ILBytesJittedCounter;
         private PollingCounter? _totalMethodsJittedCounter;
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/RuntimeEventSource.cs
@@ -78,7 +78,7 @@ namespace System.Diagnostics.Tracing
                 _gen2SizeCounter ??= new PollingCounter("gen-2-size", this, () => GC.GetGenerationSize(2)) { DisplayName = "Gen 2 Size", DisplayUnits = "B" };
                 _lohSizeCounter ??= new PollingCounter("loh-size", this, () => GC.GetGenerationSize(3)) { DisplayName = "LOH Size", DisplayUnits = "B" };
                 _assemblyCounter ??= new PollingCounter("assembly-count", this, () => System.Reflection.Assembly.GetAssemblyCount()) { DisplayName = "Number of Assemblies Loaded" };
-                _ilBytesJittedCounter ??= new PollingCounter("il-bytes-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted" };
+                _ilBytesJittedCounter ??= new PollingCounter("il-bytes-jitted", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetILBytesJitted()) { DisplayName = "IL Bytes Jitted" };
                 _methodsJittedCounter ??= new PollingCounter("methods-jitted-count", this, () => System.Runtime.CompilerServices.RuntimeHelpers.GetMethodsJittedCount()) { DisplayName = "Number of Methods Jitted" };
 #endif
             }


### PR DESCRIPTION
This is for https://github.com/dotnet/runtime/issues/1098

It adds two runtime JIT counters:
- IL bytes jitted as a rate (per second)
- Number of methods jitted
