### PR TITLE
Disable MemoryCacheTest.Trim in arm64 and enable Runtime.Caching tests on Unix

### DIFF
--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching.Tests.csproj
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AdditionalCacheTests\AdditionalCacheTests.cs" />

--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -969,7 +969,8 @@ namespace MonoTests.System.Runtime.Caching
         }
 
         // Due to internal implementation details Trim has very few easily verifiable scenarios
-        [Fact]
+        // ActiveIssue: https://github.com/dotnet/runtime/issues/36488
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
         public void Trim()
         {
             var config = new NameValueCollection();


### PR DESCRIPTION
Relates to: https://github.com/dotnet/runtime/issues/36488

While doing this I noticed that these tests are not run on Unix, but we do ship a Unix implementation:

https://github.com/dotnet/runtime/blob/77a383275f1f5dc062a113102856718fe6e8b2ab/src/libraries/System.Runtime.Caching/src/System.Runtime.Caching.csproj#L52-L64

cc: @ericstj 