### PR TITLE
Fix two issues with hosting on SunOS

### DIFF
--- a/src/installer/corehost/CMakeLists.txt
+++ b/src/installer/corehost/CMakeLists.txt
@@ -9,6 +9,10 @@ if(MSVC)
 
     # Host components don't try to handle asynchronous exceptions
     add_compile_options(/EHsc)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    # Prevents libc from calling pthread_cond_destroy on static objects in
+    # dlopen()'ed library which we dlclose() in pal::unload_library.
+    add_compile_options(-fno-use-cxa-atexit)
 endif()
 
 add_subdirectory(cli)

--- a/src/installer/corehost/cli/json_parser.h
+++ b/src/installer/corehost/cli/json_parser.h
@@ -5,6 +5,14 @@
 #ifndef __JSON_PARSER_H__
 #define __JSON_PARSER_H__
 
+#ifdef __sun
+// This optimization relies on zeros in higher 16-bits, whereas SunOS has 1s. More details at
+// https://github.com/Tencent/rapidjson/issues/1596.
+// The impact here was that runtimeOptions key available in hwapp.runtimeconfig.json was not
+// located by RapidJson's FindMember() API from runtime_config_t::ensure_parsed().
+#define RAPIDJSON_48BITPOINTER_OPTIMIZATION 0
+#endif
+
 #include "pal.h"
 #include "rapidjson/document.h"
 #include "rapidjson/fwd.h"


### PR DESCRIPTION
* Compile without [`use-cxa-atexit`](https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Dialect-Options.html) in case of gcc
  * libc tries to invoke `pthread_cond_destroy()` in `dlclose()`ed fxr library in the consumer code. PR disables this feature.
  * Backtrace available at http://sprunge.us/bx4dlk. This happens _after_ the main() exits.
* Disable RapidJson's 48-bit pointer optimization on SunOS.
  * This optimization relies on zeros in higher 16-bits, whereas SunOS has 1s. More details at https://github.com/Tencent/rapidjson/issues/1596.
  * The impact here was that `runtimeOptions` key available in `hwapp.runtimeconfig.json` was not located by RapidJson's `FindMember()` API and we were getting `false` from: https://github.com/dotnet/runtime/blob/78b303df8fbb242985d049a277d0d199cafd51b5/src/installer/corehost/cli/runtime_config.cpp#L416-L422

 Contributes to: #34944.