### PR TITLE
Change required CMake version for AppleAppBuilder to 3.16

### DIFF
--- a/src/mono/msbuild/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/mono/msbuild/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(%ProjectName%)
 enable_language(OBJC ASM)


### PR DESCRIPTION
It turns out `CMakeDetermineOBJCCompiler` was added in 3.16