### PR TITLE
Improve ExecutionContext fast-paths

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -56,16 +56,16 @@ namespace System.Threading
         public static ExecutionContext? Capture()
         {
             ExecutionContext? executionContext = Thread.CurrentThread._executionContext;
-            if (executionContext == null)
+            if (executionContext is null)
             {
-                executionContext = Default;
+                return Default;
             }
-            else if (executionContext.m_isFlowSuppressed)
+            else if (!executionContext.m_isFlowSuppressed)
             {
-                executionContext = null;
+                return executionContext;
             }
 
-            return executionContext;
+            return null;
         }
 
         private ExecutionContext? ShallowClone(bool isFlowSuppressed)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -425,21 +425,23 @@ namespace System.Threading
             }
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void RestoreDefaultContextThrowIfNeeded(Thread currentThread, SynchronizationContext? previousSyncCtx, ExceptionDispatchInfo? edi)
         {
             ExecutionContext? currentExecutionCtx = currentThread._executionContext;
 
             // Reset to Default
             currentThread._executionContext = null;
-            currentThread._synchronizationContext = previousSyncCtx;
+            if (currentThread._synchronizationContext != previousSyncCtx)
+            {
+                currentThread._synchronizationContext = previousSyncCtx;
+            }
 
             if (currentExecutionCtx != null && currentExecutionCtx.HasChangeNotifications)
             {
                 OnValuesChanged(currentExecutionCtx, nextExecutionCtx: null);
 
                 // Reset to defaults again without change notifications in case the Change handler changed the contexts
-                currentThread._synchronizationContext = null;
+                currentThread._synchronizationContext = previousSyncCtx;
                 currentThread._executionContext = null;
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2234,9 +2234,7 @@ namespace System.Threading.Tasks
         /// can override to customize their behavior, which is usually done by promises
         /// that want to reuse the same object as a queued work item.
         /// </summary>
-        internal virtual void ExecuteFromThreadPool(Thread threadPoolThread) => ExecuteEntryUnsafe(threadPoolThread);
-
-        internal void ExecuteEntryUnsafe(Thread? threadPoolThread) // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
+        internal virtual void ExecuteFromThreadPool(Thread threadPoolThread)
         {
             // Remember that we started running the task delegate.
             m_stateFlags |= TASK_STATE_DELEGATE_INVOKED;
@@ -2244,6 +2242,21 @@ namespace System.Threading.Tasks
             if (!IsCancellationRequested & !IsCanceled)
             {
                 ExecuteWithThreadLocal(ref t_currentTask, threadPoolThread);
+            }
+            else
+            {
+                ExecuteEntryCancellationRequestedOrCanceled();
+            }
+        }
+
+        internal void ExecuteEntryUnsafe() // used instead of ExecuteEntry() when we don't have to worry about double-execution prevent
+        {
+            // Remember that we started running the task delegate.
+            m_stateFlags |= TASK_STATE_DELEGATE_INVOKED;
+
+            if (!IsCancellationRequested & !IsCanceled)
+            {
+                ExecuteWithThreadLocal(ref t_currentTask);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -33,7 +33,7 @@ namespace System.Threading.Tasks
         private static readonly ParameterizedThreadStart s_longRunningThreadWork = s =>
         {
             Debug.Assert(s is Task);
-            ((Task)s).ExecuteEntryUnsafe(threadPoolThread: null);
+            ((Task)s).ExecuteEntryUnsafe();
         };
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace System.Threading.Tasks
 
             try
             {
-                task.ExecuteEntryUnsafe(threadPoolThread: null); // handles switching Task.Current etc.
+                task.ExecuteEntryUnsafe(); // handles switching Task.Current etc.
             }
             finally
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Runtime.ConstrainedExecution;
 using System.Security.Principal;
 
@@ -154,7 +155,22 @@ namespace System.Threading
             }
         }
 
-        public static Thread CurrentThread => t_currentThread ?? InitializeCurrentThread();
+        public static Thread CurrentThread
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                // Arranged like this the conditional is a not predicted branch, with conditional ?? it switches.
+                // However needs to be aggressively inlined in this arrangement.
+                Thread? currentThread = t_currentThread;
+                if (currentThread != null)
+                {
+                    return currentThread;
+                }
+
+                return InitializeCurrentThread();
+            }
+        }
 
         public ExecutionContext? ExecutionContext => ExecutionContext.Capture();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -683,6 +683,15 @@ namespace System.Threading
                 // If we get here, it's because our quantum expired.  Tell the VM we're returning normally.
                 return true;
             }
+            catch
+            {
+                // We want to stop the first pass of EH here. That way we can restore the
+                // previous context before any of our callers' EH filters run.
+
+                // Return to clean ExecutionContext and SynchronizationContext
+                ExecutionContext.ResetThreadPoolThread(Thread.CurrentThread);
+                throw;
+            }
             finally
             {
                 //

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -631,7 +631,14 @@ namespace System.Threading
             {
                 if (isThreadPool)
                 {
-                    ExecutionContext.RunFromThreadPoolDispatchLoop(Thread.CurrentThread, context, s_callCallbackInContext, this);
+                    if (context.IsDefault)
+                    {
+                        _timerCallback(_state);
+                    }
+                    else
+                    {
+                        ExecutionContext.RunForThreadPoolUnsafe(context, s_callCallbackInContext, this);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Improve some of the ThreadPool fast-paths, reduce indirect calls for `AsyncValueTaskMethodBuilder<T>`; `AsyncTaskMethodBuilder<T>` and `Timer`; by calling `.MoveNext()` directly call rather via the indirect chain `EC.Run -> delegate -> .MoveNext()` which should help with the CPU's instruction cache and indirect branch prediction (Intel only tries to predict one indirect call, not chains?).

Split merged methods switched on if into their respective callers:

* Remove extra call for `AsyncValueTaskMethodBuilder<T>` and `AsyncTaskMethodBuilder<T>` for `MoveNext()` and `IThreadPoolWorkItem.Execute()` (since they are top level virtual/interface and their callee is too big to inline into them)

Optimize invocations from `ThreadPoolWorkQueue.Dispatch`:

* `AsyncValueTaskMethodBuilder<T>`; `AsyncTaskMethodBuilder<T>` and `Timer` can call `.MoveNext()` directly if Default context and called from `ThreadPoolWorkQueue.Dispatch`.
* `AsyncValueTaskMethodBuilder<T>`; `AsyncTaskMethodBuilder<T>` and `Timer` don't need to touch `ThreadStatic` CurrentThread called from `ThreadPoolWorkQueue.Dispatch`.
* `AsyncValueTaskMethodBuilder<T>`; `AsyncTaskMethodBuilder<T>` and `Timer` can use simpler EC run when not-Default context and called from `ThreadPoolWorkQueue.Dispatch`.

Optimize invocations for Default context:

* `AsyncValueTaskMethodBuilder<T>`; `AsyncTaskMethodBuilder<T>` and `Timer` can call `.MoveNext()` directly if Default context and thread currently on Default context.

Json callers (on Default context; which become extra fast-pathed)

![image](https://user-images.githubusercontent.com/1142958/82152584-2432a980-985a-11ea-8719-77b92e809b46.png)

Fortunes callers (on Default context; which become extra fast-pathed)

![image](https://user-images.githubusercontent.com/1142958/82152587-301e6b80-985a-11ea-985d-91446fdb641d.png)
