### PR TITLE
Update PerfEventSource.cs

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/PerfEventSource.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.DependencyAnalysisFramework/PerfEventSource.cs
@@ -10,7 +10,7 @@ using System.Diagnostics.Tracing;
 /// </summary>
 namespace ILCompiler.DependencyAnalysisFramework
 {
-    [EventSource(Name = "Microsoft-ILCompiler-Perf")]
+    [EventSource(Name = "Microsoft-ILCompiler-Graph")]
     public class PerfEventSource : EventSource
     {
         private PerfEventSource() { }


### PR DESCRIPTION
When crossgen2 is run with `Microsoft-ILCompiler-Perf` provider enabled, events are not named properly in PerfView (`Microsoft-ILCompiler-Perf/EventID(1)` instead of `Compilation/Start`) and an error event indicating multiple EventSource instances with the same GUID are enabled:
```
ERROR: Exception in Command Processing for EventSource Microsoft-ILCompiler-Perf: An instance of EventSource with Guid 607164a4-cacb-5f22-92fb-62a11541e285 already exists.
```

Name the dependency analysis EventSource `Microsoft-ILCompiler-Graph` to distinguish between the two.