### PR TITLE
Fix StackTraceTests to work with JIT optimization

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -313,7 +313,9 @@ namespace System.Diagnostics.Tests
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         private static StackTrace Generic<T, U>() => new StackTrace();
 
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         private static StackTrace InvokeIgnoredMethod() => Ignored.Method();
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         private static StackTrace InvokeIgnoredMethodWithException() => Ignored.MethodWithException();
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -335,6 +337,8 @@ namespace System.Diagnostics.Tests
         private class ClassWithConstructor
         {
             public StackTrace StackTrace { get; }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
             public ClassWithConstructor() => StackTrace = new StackTrace();
         }
 


### PR DESCRIPTION
Disable optimization/inlining on methods that are expected to
remain on the stack.

Fixes https://github.com/dotnet/runtime/issues/36585