### PR TITLE
Add some edge case tests for Array.CreateInstance and fix Mono handling

### DIFF
--- a/src/coreclr/src/vm/array.h
+++ b/src/coreclr/src/vm/array.h
@@ -5,12 +5,11 @@
 #ifndef _ARRAY_H_
 #define _ARRAY_H_
 
-#define MAX_RANK 32        // If you make this bigger, you need to make MAX_CLASSNAME_LENGTH bigger too.
-                           // if you have an 32 dim array with at least 2 elements in each dim that
-                           // takes up 4Gig!!!  Thus this is a reasonable maximum.
-// (Note: at the time of the above comment, the rank was 32, and
-// MAX_CLASSNAME_LENGTH was 256.  I'm now changing MAX_CLASSNAME_LENGTH
-// to 1024, but not changing MAX_RANK.)
+// A 32 dimension array with at least 2 elements in each dimension requires
+// 4gb of memory. Limit the maximum number of dimensions to a value that 
+// requires 4gb of memory.
+// If you make this bigger, you need to make MAX_CLASSNAME_LENGTH bigger too.
+#define MAX_RANK 32
 
 class MethodTable;
 

--- a/src/coreclr/src/vm/clsload.cpp
+++ b/src/coreclr/src/vm/clsload.cpp
@@ -3260,7 +3260,6 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(TypeKey* pKey, AllocMemTracke
                 }
             }
 
-            // We really don't need this check anymore.
             if (rank > MAX_RANK)
             {
                 ThrowTypeLoadException(pKey, IDS_CLASSLOAD_RANK_TOOLARGE);

--- a/src/coreclr/src/vm/typestring.cpp
+++ b/src/coreclr/src/vm/typestring.cpp
@@ -368,7 +368,7 @@ HRESULT TypeNameBuilder::AddArray(DWORD rank)
         Append(W("[*]"));
     else if (rank > 64)
     {
-        // Only taken in an error path, runtime will not load arrays of more than 32 dimentions
+        // Only taken in an error path, runtime will not load arrays of more than 32 dimensions
         WCHAR wzDim[128];
         _snwprintf_s(wzDim, 128, _TRUNCATE, W("[%d]"), rank);
         Append(wzDim);

--- a/src/libraries/System.Runtime/tests/System/ArrayTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArrayTests.cs
@@ -1777,11 +1777,22 @@ namespace System.Tests
                 new object[] { typeof(IntPtr), default(IntPtr) },
                 new object[] { typeof(UIntPtr), default(UIntPtr) },
 
+                // Primitives enums
+                new object[] { typeof(SByteEnum), default(SByteEnum) },
+                new object[] { typeof(ByteEnum), default(ByteEnum) },
+                new object[] { typeof(Int16Enum), default(Int16Enum) },
+                new object[] { typeof(UInt16Enum), default(UInt16Enum) },
+                new object[] { typeof(Int32Enum), default(Int32Enum) },
+                new object[] { typeof(UInt32Enum), default(UInt32Enum) },
+                new object[] { typeof(Int64Enum), default(Int64Enum) },
+                new object[] { typeof(UInt64Enum), default(UInt64Enum) },
+
                 // Array, pointers
                 new object[] { typeof(int[]), default(int[]) },
+                new object[] { typeof(string[]), default(string[]) },
                 new object[] { typeof(int*), null },
 
-                // Classes, structs, interfaces, enums
+                // Classes, structs, interface
                 new object[] { typeof(NonGenericClass1), default(NonGenericClass1) },
                 new object[] { typeof(GenericClass<int>), default(GenericClass<int>) },
                 new object[] { typeof(NonGenericStruct), default(NonGenericStruct) },
@@ -1790,7 +1801,6 @@ namespace System.Tests
                 new object[] { typeof(GenericInterface<int>), default(GenericInterface<int>) },
                 new object[] { typeof(AbstractClass), default(AbstractClass) },
                 new object[] { typeof(StaticClass), default(StaticClass) },
-                new object[] { typeof(Int32Enum), default(Int32Enum) }
             };
         }
 
@@ -1871,6 +1881,10 @@ namespace System.Tests
             yield return new object[] { typeof(GenericClass<>) };
             yield return new object[] { typeof(GenericClass<>).MakeGenericType(typeof(GenericClass<>)) };
             yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GetGenericArguments()[0] };
+            yield return new object[] { typeof(TypedReference) };
+            yield return new object[] { typeof(ArgIterator) };
+            yield return new object[] { typeof(RuntimeArgumentHandle) };
+            yield return new object[] { typeof(Span<int>) };
         }
 
         [Theory]
@@ -1883,6 +1897,21 @@ namespace System.Tests
             Assert.Throws<NotSupportedException>(() => Array.CreateInstance(elementType, new int[1]));
             Assert.Throws<NotSupportedException>(() => Array.CreateInstance(elementType, new long[1]));
             Assert.Throws<NotSupportedException>(() => Array.CreateInstance(elementType, new int[1], new int[1]));
+        }
+
+        [Fact]
+        public void CreateInstance_TypeNotRuntimeType_ThrowsArgumentException()
+        {
+            // This cannot be a [Theory] due to https://github.com/xunit/xunit/issues/1325.
+            foreach (Type elementType in Helpers.NonRuntimeTypes)
+            {
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, 1));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, 1, 1));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, 1, 1, 1));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, new int[1]));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, new long[1]));
+                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, new int[1], new int[1]));
+            }
         }
 
         [Fact]
@@ -1946,6 +1975,18 @@ namespace System.Tests
         public void CreateInstance_LengthsAndLowerBoundsHaveDifferentLengths_ThrowsArgumentException(int length)
         {
             AssertExtensions.Throws<ArgumentException>(null, () => Array.CreateInstance(typeof(int), new int[1], new int[length]));
+        }
+
+        [Theory]
+        [InlineData(33)]
+        [InlineData(256)]
+        [InlineData(257)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39002", TestRuntimes.Mono)]
+        public void CreateInstance_RankMoreThanMaxRank_ThrowsTypeLoadException(int length)
+        {
+            var lengths = new int[length];
+            var lowerBounds = new int[length];
+            Assert.Throws<TypeLoadException>(() => Array.CreateInstance(typeof(int), lengths, lowerBounds));
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNonZeroLowerBoundArraySupported))]
@@ -4278,21 +4319,6 @@ namespace System.Tests
             Reverse(array, int.MinValue, 0, new int[] { 1, 2, 3 });
             Reverse(array, int.MinValue, 1, new int[] { 1, 2, 3 });
             Reverse(array, int.MinValue, 2, new int[] { 2, 1, 3 });
-        }
-
-        [Fact]
-        public void CreateInstance_TypeNotRuntimeType_ThrowsArgumentException()
-        {
-            // This cannot be a [Theory] due to https://github.com/xunit/xunit/issues/1325.
-            foreach (Type elementType in Helpers.NonRuntimeTypes)
-            {
-                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, 1));
-                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, 1, 1));
-                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, 1, 1, 1));
-                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, new int[1]));
-                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, new long[1]));
-                AssertExtensions.Throws<ArgumentException>("elementType", () => Array.CreateInstance(elementType, new int[1], new int[1]));
-            }
         }
 
         private static void VerifyArray(Array array, Type elementType, int[] lengths, int[] lowerBounds, object repeatedValue)

--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
@@ -191,8 +191,55 @@ namespace System.Tests
             AssertExtensions.Throws<ArgumentException>(null, () => t.GetArrayRank());
         }
 
+        public static IEnumerable<object[]> MakeArrayType_TestData()
+        {
+            return new object[][]
+            {
+                // Primitives
+                new object[] { typeof(string), typeof(string[]) },
+                new object[] { typeof(sbyte), typeof(sbyte[]) },
+                new object[] { typeof(byte), typeof(byte[]) },
+                new object[] { typeof(short), typeof(short[]) },
+                new object[] { typeof(ushort), typeof(ushort[]) },
+                new object[] { typeof(int), typeof(int[]) },
+                new object[] { typeof(uint), typeof(uint[]) },
+                new object[] { typeof(long), typeof(long[]) },
+                new object[] { typeof(ulong), typeof(ulong[]) },
+                new object[] { typeof(char), typeof(char[]) },
+                new object[] { typeof(bool), typeof(bool[]) },
+                new object[] { typeof(float), typeof(float[]) },
+                new object[] { typeof(double), typeof(double[]) },
+                new object[] { typeof(IntPtr), typeof(IntPtr[]) },
+                new object[] { typeof(UIntPtr), typeof(UIntPtr[]) },
+
+                // Primitives enums
+                new object[] { typeof(SByteEnum), typeof(SByteEnum[]) },
+                new object[] { typeof(ByteEnum), typeof(ByteEnum[]) },
+                new object[] { typeof(Int16Enum), typeof(Int16Enum[]) },
+                new object[] { typeof(UInt16Enum), typeof(UInt16Enum[]) },
+                new object[] { typeof(Int32Enum), typeof(Int32Enum[]) },
+                new object[] { typeof(UInt32Enum), typeof(UInt32Enum[]) },
+                new object[] { typeof(Int64Enum), typeof(Int64Enum[]) },
+                new object[] { typeof(UInt64Enum), typeof(UInt64Enum[]) },
+
+                // Array, pointers
+                new object[] { typeof(string[]), typeof(string[][]) },
+                new object[] { typeof(int[]), typeof(int[][]) },
+                new object[] { typeof(int*), typeof(int*[]) },
+
+                // Classes, structs, interfaces, enums
+                new object[] { typeof(NonGenericClass), typeof(NonGenericClass[]) },
+                new object[] { typeof(GenericClass<int>), typeof(GenericClass<int>[]) },
+                new object[] { typeof(NonGenericStruct), typeof(NonGenericStruct[]) },
+                new object[] { typeof(GenericStruct<int>), typeof(GenericStruct<int>[]) },
+                new object[] { typeof(NonGenericInterface), typeof(NonGenericInterface[]) },
+                new object[] { typeof(GenericInterface<int>), typeof(GenericInterface<int>[]) },
+                new object[] { typeof(AbstractClass), typeof(AbstractClass[]) }
+            };
+        }
+
         [Theory]
-        [InlineData(typeof(int), typeof(int[]))]
+        [MemberData(nameof(MakeArrayType_TestData))]
         public void MakeArrayType_Invoke_ReturnsExpected(Type t, Type tArrayExpected)
         {
             Type tArray = t.MakeArrayType();
@@ -202,10 +249,101 @@ namespace System.Tests
 
             Assert.True(tArray.IsArray);
             Assert.True(tArray.HasElementType);
+            Assert.Equal(1, tArray.GetArrayRank());
 
-            string s1 = t.ToString();
-            string s2 = tArray.ToString();
-            Assert.Equal(s2, s1 + "[]");
+            Assert.Equal(t.ToString() + "[]", tArray.ToString());
+        }
+
+        public static IEnumerable<object[]> MakeArray_UnusualTypes_TestData()
+        {
+            yield return new object[] { typeof(StaticClass) };
+            yield return new object[] { typeof(void) };
+            yield return new object[] { typeof(GenericClass<>) };
+            yield return new object[] { typeof(GenericClass<>).MakeGenericType(typeof(GenericClass<>)) };
+            yield return new object[] { typeof(GenericClass<>).GetTypeInfo().GetGenericArguments()[0] };
+        }
+
+        [Theory]
+        [MemberData(nameof(MakeArray_UnusualTypes_TestData))]
+        public void MakeArrayType_UnusualTypes_ReturnsExpected(Type t)
+        {
+            Type tArray = t.MakeArrayType();
+
+            Assert.Equal(t, tArray.GetElementType());
+
+            Assert.True(tArray.IsArray);
+            Assert.True(tArray.HasElementType);
+            Assert.Equal(1, tArray.GetArrayRank());
+
+            Assert.Equal(t.ToString() + "[]", tArray.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(MakeArrayType_TestData))]
+        public void MakeArrayType_InvokeRankOne_ReturnsExpected(Type t, Type tArrayExpected)
+        {
+            Type tArray = t.MakeArrayType(1);
+
+            Assert.NotEqual(tArrayExpected, tArray);
+            Assert.Equal(t, tArray.GetElementType());
+
+            Assert.True(tArray.IsArray);
+            Assert.True(tArray.HasElementType);
+            Assert.Equal(1, tArray.GetArrayRank());
+
+            Assert.Equal(t.ToString() + "[*]", tArray.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(MakeArrayType_TestData))]
+        public void MakeArrayType_InvokeRankTwo_ReturnsExpected(Type t, Type tArrayExpected)
+        {
+            Type tArray = t.MakeArrayType(2);
+
+            Assert.NotEqual(tArrayExpected, tArray);
+            Assert.Equal(t, tArray.GetElementType());
+
+            Assert.True(tArray.IsArray);
+            Assert.True(tArray.HasElementType);
+            Assert.Equal(2, tArray.GetArrayRank());
+
+            Assert.Equal(t.ToString() + "[,]", tArray.ToString());
+        }
+
+        public static IEnumerable<object[]> MakeArrayType_ByRef_TestData()
+        {
+            yield return new object[] { typeof(int).MakeByRefType() };
+            yield return new object[] { typeof(TypedReference) };
+            yield return new object[] { typeof(ArgIterator) };
+            yield return new object[] { typeof(RuntimeArgumentHandle) };
+            yield return new object[] { typeof(Span<int>) };
+        }
+
+        [Theory]
+        [MemberData(nameof(MakeArrayType_ByRef_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39001", TestRuntimes.Mono)]
+        public void MakeArrayType_ByRef_ThrowsTypeLoadException(Type t)
+        {
+            Assert.Throws<TypeLoadException>(() => t.MakeArrayType());
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(0)]
+        public void MakeArrayType_NegativeOrZeroArrayRank_ThrowsIndexOutOfRangeException(int rank)
+        {
+            Type t = typeof(int);
+            Assert.Throws<IndexOutOfRangeException>(() => t.MakeArrayType(rank));
+        }
+
+        [Theory]
+        [InlineData(33)]
+        [InlineData(256)]
+        [InlineData(257)]
+        public void MakeArrayType_InvalidArrayRank_ThrowsTypeLoadException(int rank)
+        {
+            Type t = typeof(int);
+            Assert.Throws<TypeLoadException>(() => t.MakeArrayType(rank));
         }
 
         [Theory]
@@ -747,6 +885,7 @@ namespace System.Tests
 
     public class GenericClass<T, U> { }
     public abstract class AbstractClass { }
+    public static class StaticClass { }
 
     public struct NonGenericStruct { }
 

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -1008,8 +1008,6 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 	char *name;
 	MonoImageSet* image_set;
 
-	g_assert (rank <= 255);
-
 	if (rank > 1)
 		/* bounded only matters for one-dimensional arrays */
 		bounded = FALSE;
@@ -1077,15 +1075,16 @@ mono_class_create_bounded_array (MonoClass *eclass, guint32 rank, gboolean bound
 	klass->class_kind = MONO_CLASS_ARRAY;
 
 	nsize = strlen (eclass->name);
-	name = (char *)g_malloc (nsize + 2 + rank + 1);
+	int maxrank = MIN (rank, 32);
+	name = (char *)g_malloc (nsize + 2 + maxrank + 1);
 	memcpy (name, eclass->name, nsize);
 	name [nsize] = '[';
-	if (rank > 1)
-		memset (name + nsize + 1, ',', rank - 1);
+	if (maxrank > 1)
+		memset (name + nsize + 1, ',', maxrank - 1);
 	if (bounded)
-		name [nsize + rank] = '*';
-	name [nsize + rank + bounded] = ']';
-	name [nsize + rank + bounded + 1] = 0;
+		name [nsize + maxrank] = '*';
+	name [nsize + maxrank + bounded] = ']';
+	name [nsize + maxrank + bounded + 1] = 0;
 	klass->name = image_set ? mono_image_set_strdup (image_set, name) : mono_image_strdup (image, name);
 	g_free (name);
 

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -372,8 +372,12 @@ mono_type_get_name_recurse (MonoType *type, GString *str, gboolean is_recursed,
 		g_string_append_c (str, '[');
 		if (rank == 1)
 			g_string_append_c (str, '*');
-		for (i = 1; i < rank; i++)
-			g_string_append_c (str, ',');
+		else if (rank > 64)
+			// Only taken in an error path, runtime will not load arrays of more than 32 dimensions
+			g_string_append_printf (str, "%d", rank);
+		else
+			for (i = 1; i < rank; i++)
+				g_string_append_c (str, ',');
 		g_string_append_c (str, ']');
 		
 		mono_type_name_check_byref (type, str);

--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -2197,8 +2197,9 @@ namespace System
 
         public override Type MakeArrayType(int rank)
         {
-            if (rank < 1 || rank > 255)
+            if (rank < 1)
                 throw new IndexOutOfRangeException();
+
             return make_array_type(rank);
         }
 


### PR DESCRIPTION
In https://github.com/dotnet/winforms/pull/3197 we were investigating what happens when you try to create an an array from SAFEARRAY with more than 32 dimensions.

Found out that this throws `TypeLoadException`.

Thought I'd come along and write some tests to validate this constraint in dotnet/runtime.

Note: in In https://github.com/dotnet/winforms/pull/3197 we wanted to `stackalloc` an `int` array to navigate through an n-dimensional array instead of manually allocating `int[]` which costs memory. Obviously we could only do this if `Array.Rank` is not something large such that `stackalloc` would cause `StackOverflowExceptions`. Is it safe to assume that we will not change `MAX_RANK`?

Updated the comment in https://github.com/dotnet/runtime/blob/80d8920a54b0d73eb8423fe705583a0fd7ad1723/src/coreclr/src/vm/clsload.cpp#L3327-L3331

I think we do need this check!

Note that I think mono will hit some assertions and (possibly?) crash: https://github.com/dotnet/runtime/blob/1cfccd2a7937117341b256847e613dd710a70adb/src/mono/mono/metadata/class-init.c#L920

/cc @akoeplinger for mono if it is relevant, @weltkante @JeremyKuhne @AaronRobinsonMSFT 