### PR TITLE
CMake: Point download URLs directly to https://

### DIFF
--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -38,7 +38,7 @@ The dotnet/runtime repository requires at least Visual Studio 2019 16.6 Preview 
 
 ## CMake
 
-- Install [CMake](http://www.cmake.org/download) for Windows.
+- Install [CMake](https://cmake.org/download) for Windows.
 - Add its location (e.g. C:\Program Files (x86)\CMake\bin) to the PATH environment variable.
   The installation script has a check box to do this, but you can do it yourself after the fact following the instructions at [Adding to the Default PATH variable](#adding-to-the-default-path-variable).
 

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -56,7 +56,7 @@ check_prereqs()
     local cmake_version="$(cmake --version | awk '/^cmake.* version [0-9]+\.[0-9]+\.[0-9]+$/ {print $3}')"
 
     if [[ "$(version "$cmake_version")" -lt "$(version 3.14.2)" ]]; then
-        echo "Please install CMake 3.14.2 or newer from http://www.cmake.org/download/ or https://apt.kitware.com and ensure it is on your path."; exit 1;
+        echo "Please install CMake 3.14.2 or newer from https://cmake.org/download/ or https://apt.kitware.com and ensure it is on your path."; exit 1;
     fi
 
     if [[ "$__HostOS" == "OSX" ]]; then

--- a/src/coreclr/src/pal/tools/set-cmake-path.ps1
+++ b/src/coreclr/src/pal/tools/set-cmake-path.ps1
@@ -33,7 +33,7 @@ function GetCMakeInfo($regKey)
 
 function LocateCMake
 {
-  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from http://www.cmake.org/download/ and ensure it is on your path."
+  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from https://cmake.org/download/ and ensure it is on your path."
   $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
   if ($inPathPath -ne $null) {
     # Resolve the first version of CMake if multiple commands are found
@@ -64,7 +64,7 @@ try {
   $version = [Version]$(& $cmakePath --version | Select-String -Pattern '\d+\.\d+\.\d+' | %{$_.Matches.Value})
 
   if ($version -lt [Version]"3.14.0") {
-      Throw "This repository requires CMake 3.14. The newest version of CMake installed is $version. Please install CMake 3.14 or newer from http://www.cmake.org/download/ and ensure it is on your path."
+      Throw "This repository requires CMake 3.14. The newest version of CMake installed is $version. Please install CMake 3.14 or newer from https://cmake.org/download/ and ensure it is on your path."
   }
 
   [System.Console]::WriteLine("set CMakePath=" + $cmakePath)

--- a/src/installer/corehost/Windows/probe-win.ps1
+++ b/src/installer/corehost/Windows/probe-win.ps1
@@ -34,7 +34,7 @@ function GetCMakeInfo($regKey)
 
 function LocateCMake
 {
-  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from http://www.cmake.org/download/ and ensure it is on your path."
+  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from https://cmake.org/download/ and ensure it is on your path."
   $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
   if ($inPathPath -ne $null) {
     # Resolve the first version of CMake if multiple commands are found

--- a/src/libraries/Native/Windows/probe-win.ps1
+++ b/src/libraries/Native/Windows/probe-win.ps1
@@ -34,7 +34,7 @@ function GetCMakeInfo($regKey)
 
 function LocateCMake
 {
-  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from http://www.cmake.org/download/ and ensure it is on your path."
+  $errorMsg = "CMake is a pre-requisite to build this repository but it was not found on the path. Please install CMake from https://cmake.org/download/ and ensure it is on your path."
   $inPathPath = (get-command cmake.exe -ErrorAction SilentlyContinue)
   if ($inPathPath -ne $null) {
     # Resolve the first version of CMake if multiple commands are found


### PR DESCRIPTION
Minor error-message only change. I just noticed this in setting up a new local.

We're pointing users to http://www.cmake.org/download/ when the ultimate location is secure now. This changes to directly point them at `https://`.
1. 301s to non-`www`
2. 301s to `https://`

Verification of the redirect chain:
![image](https://user-images.githubusercontent.com/454813/82156956-871d4400-984c-11ea-9e01-f573afa89bd5.png)
