### PR TITLE
Delete LINQ OrderBy(...).First{OrDefault}(...) optimization

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/First.cs
+++ b/src/libraries/System.Linq/src/System/Linq/First.cs
@@ -89,11 +89,6 @@ namespace System.Linq
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.predicate);
             }
 
-            if (source is OrderedEnumerable<TSource> ordered)
-            {
-                return ordered.TryGetFirst(predicate, out found);
-            }
-
             foreach (TSource element in source)
             {
                 if (predicate(element))

--- a/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/libraries/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -74,40 +74,6 @@ namespace System.Linq
             new OrderedEnumerable<TElement, TKey>(_source, keySelector, comparer, @descending, this);
 
         [return: MaybeNull]
-        public TElement TryGetFirst(Func<TElement, bool> predicate, out bool found)
-        {
-            CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = _source.GetEnumerator())
-            {
-                TElement value;
-                do
-                {
-                    if (!e.MoveNext())
-                    {
-                        found = false;
-                        return default!;
-                    }
-
-                    value = e.Current;
-                }
-                while (!predicate(value));
-
-                comparer.SetElement(value);
-                while (e.MoveNext())
-                {
-                    TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, true) < 0)
-                    {
-                        value = x;
-                    }
-                }
-
-                found = true;
-                return value;
-            }
-        }
-
-        [return: MaybeNull]
         public TElement TryGetLast(Func<TElement, bool> predicate, out bool found)
         {
             CachingComparer<TElement> comparer = GetComparer();

--- a/src/libraries/System.Linq/tests/OrderByTests.cs
+++ b/src/libraries/System.Linq/tests/OrderByTests.cs
@@ -292,12 +292,76 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void FirstWithPredicateOnOrdered()
+        {
+            IEnumerable<int> orderBy = Enumerable.Range(0, 10).Shuffle().OrderBy(i => i);
+            IEnumerable<int> orderByDescending = Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i);
+            int counter;
+
+            counter = 0;
+            Assert.Equal(0, orderBy.First(i => { counter++; return true; }));
+            Assert.Equal(1, counter);
+
+            counter = 0;
+            Assert.Equal(9, orderBy.First(i => { counter++; return i == 9; }));
+            Assert.Equal(10, counter);
+
+            counter = 0;
+            Assert.Throws<InvalidOperationException>(() => orderBy.First(i => { counter++; return false; }));
+            Assert.Equal(10, counter);
+
+            counter = 0;
+            Assert.Equal(9, orderByDescending.First(i => { counter++; return true; }));
+            Assert.Equal(1, counter);
+
+            counter = 0;
+            Assert.Equal(0, orderByDescending.First(i => { counter++; return i == 0; }));
+            Assert.Equal(10, counter);
+
+            counter = 0;
+            Assert.Throws<InvalidOperationException>(() => orderByDescending.First(i => { counter++; return false; }));
+            Assert.Equal(10, counter);
+        }
+
+        [Fact]
         public void FirstOrDefaultOnOrdered()
         {
             Assert.Equal(0, Enumerable.Range(0, 10).Shuffle().OrderBy(i => i).FirstOrDefault());
             Assert.Equal(9, Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i).FirstOrDefault());
             Assert.Equal(10, Enumerable.Range(0, 100).Shuffle().OrderByDescending(i => i.ToString().Length).ThenBy(i => i).FirstOrDefault());
             Assert.Equal(0, Enumerable.Empty<int>().OrderBy(i => i).FirstOrDefault());
+        }
+
+        [Fact]
+        public void FirstOrDefaultWithPredicateOnOrdered()
+        {
+            IEnumerable<int> orderBy = Enumerable.Range(0, 10).Shuffle().OrderBy(i => i);
+            IEnumerable<int> orderByDescending = Enumerable.Range(0, 10).Shuffle().OrderByDescending(i => i);
+            int counter;
+
+            counter = 0;
+            Assert.Equal(0, orderBy.FirstOrDefault(i => { counter++; return true; }));
+            Assert.Equal(1, counter);
+
+            counter = 0;
+            Assert.Equal(9, orderBy.FirstOrDefault(i => { counter++; return i == 9; }));
+            Assert.Equal(10, counter);
+
+            counter = 0;
+            Assert.Equal(0, orderBy.FirstOrDefault(i => { counter++; return false; }));
+            Assert.Equal(10, counter);
+
+            counter = 0;
+            Assert.Equal(9, orderByDescending.FirstOrDefault(i => { counter++; return true; }));
+            Assert.Equal(1, counter);
+
+            counter = 0;
+            Assert.Equal(0, orderByDescending.FirstOrDefault(i => { counter++; return i == 0; }));
+            Assert.Equal(10, counter);
+
+            counter = 0;
+            Assert.Equal(0, orderByDescending.FirstOrDefault(i => { counter++; return false; }));
+            Assert.Equal(10, counter);
         }
 
         [Fact]


### PR DESCRIPTION
The optimization removes the O(N log N) cost of the OrderBy. But it can result in executing the predicate passed to First{OrDefault} more than in .NET Framework; it would always execute it N times, whereas in .NET Framework it would execute it <= N times.  Developers have expressed concern about the change, in particular when using a relatively expensive predicate on a relatively short list, or when unadvisedly relying on side-effecting predicates.

This optimization has been in .NET Core since 1.0.  If the original optimization is considered breaking from .NET Framework, then undoing it is breaking, too.

Closes https://github.com/dotnet/runtime/issues/31554