### PR TITLE
Fix failing Sockets tests after argument exception changes

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1649,7 +1649,7 @@ namespace System.Net.Sockets.Tests
                 args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, UnusedPort);
                 args.SetBuffer(new byte[1], 0, 1);
 
-                AssertExtensions.Throws<ArgumentException>("RemoteEndPoint", () =>
+                AssertExtensions.Throws<ArgumentException>("e", () =>
                 {
                     socket.ReceiveFromAsync(args);
                 });
@@ -2188,7 +2188,7 @@ namespace System.Net.Sockets.Tests
                 args.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, UnusedPort);
                 args.SetBuffer(new byte[1], 0, 1);
 
-                AssertExtensions.Throws<ArgumentException>("RemoteEndPoint", () =>
+                AssertExtensions.Throws<ArgumentException>("e", () =>
                 {
                     socket.ReceiveMessageFromAsync(args);
                 });

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LingerStateTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LingerStateTest.cs
@@ -19,7 +19,7 @@ namespace System.Net.Sockets.Tests
 
         private void TestLingerState_ArgumentException(Socket sock, bool enabled, int lingerTime)
         {
-            AssertExtensions.Throws<ArgumentException>("optionValue.LingerTime", () =>
+            AssertExtensions.Throws<ArgumentException>("optionValue", () =>
             {
                 sock.LingerState = new LingerOption(enabled, lingerTime);
             });

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendPacketsAsync.cs
@@ -111,7 +111,7 @@ namespace System.Net.Sockets.Tests
         [InlineData(SocketImplementationType.Async)]
         public void NullList_Throws(SocketImplementationType type)
         {
-            AssertExtensions.Throws<ArgumentNullException>("e.SendPacketsElements", () => SendPackets(type, (SendPacketsElement[])null, SocketError.Success, 0));
+            AssertExtensions.Throws<ArgumentException>("e", () => SendPackets(type, (SendPacketsElement[])null, SocketError.Success, 0));
         }
 
         [OuterLoop]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36641
Fixes https://github.com/dotnet/runtime/issues/36640
cc: @buyaa-n 