### PR TITLE
Fix mono file name on iOS/Browser

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -14,15 +14,11 @@
     <CoreClrFileName Condition="'$(TargetsWindows)' == 'true'">coreclr.dll</CoreClrFileName>
     <CoreClrFileName Condition="'$(TargetsOSX)' == 'true'">libcoreclr.dylib</CoreClrFileName>
     <CoreClrFileName Condition="'$(CoreClrFileName)' == ''">libcoreclr.so</CoreClrFileName>
-    <MonoFileName Condition="'$(TargetsiOS)' == 'true'">libmono.dylib</MonoFileName>
-    <MonoFileName Condition="'$(TargetstvOS)' == 'true'">libmono.dylib</MonoFileName>
+    <MonoFileName Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'">libmonosgen-2.0.dylib</MonoFileName>
     <MonoFileName Condition="'$(TargetsAndroid)' == 'true'">libmonosgen-2.0.so</MonoFileName>
-    <MonoStaticFileName Condition="'$(TargetsiOS)' == 'true'">libmono.a</MonoStaticFileName>
-    <MonoStaticFileName Condition="'$(TargetstvOS)' == 'true'">libmono.a</MonoStaticFileName>
-    <MonoStaticFileName Condition="'$(TargetsAndroid)' == 'true'">libmonosgen-2.0.a</MonoStaticFileName>
-    <MonoFileName Condition="'$(TargetsBrowser)' == 'true'">libmono.a</MonoFileName>
-    <MonoStaticFileName Condition="'$(TargetsBrowser)' == 'true'">libmono.a</MonoStaticFileName>
+    <MonoFileName Condition="'$(TargetsBrowser)' == 'true'">libmonosgen-2.0.a</MonoFileName>
     <MonoFileName Condition="'$(MonoFileName)' == ''">$(CoreClrFileName)</MonoFileName>
+    <MonoStaticFileName Condition="'$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true' or '$(TargetsAndroid)' == 'true'">libmonosgen-2.0.a</MonoStaticFileName>
     <CoreClrTestConfig Condition="'$(CoreClrTestConfig)' == ''">$(Configuration)</CoreClrTestConfig>
     <LibrariesTestConfig Condition="'$(LibrariesTestConfig)' == ''">$(Configuration)</LibrariesTestConfig>
     <CoreClrTestCoreRoot>$(ArtifactsDir)tests\coreclr\$(TargetOS).$(Platform).$(CoreClrTestConfig)\Tests\Core_Root</CoreClrTestCoreRoot>

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -35,7 +35,7 @@
   <ItemGroup>
     <AppAssemblies Include="$(OutputPath)\*.dll"/>
     <BclAssemblies Include="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\*.dll;$(RuntimePackDir)\native\System.Private.CoreLib.dll" Exclude="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)\System.Runtime.WindowsRuntime.dll" />
-    <MonoRuntimeBinaries Include="$(RuntimePackDir)\native\*.*" Exclude="$(RuntimePackDir)\native\System.Private.CoreLib.dll;$(RuntimePackDir)\native\libmono.dylib" />
+    <MonoRuntimeBinaries Include="$(RuntimePackDir)\native\*.*" Exclude="$(RuntimePackDir)\native\System.Private.CoreLib.dll;$(RuntimePackDir)\native\libmonosgen-2.0.dylib" />
   </ItemGroup>
 
   <Import Project="$(MonoAOTCompilerProjDirectory)MonoAOTCompiler.props" />

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -43,7 +43,7 @@ emsdk_env.sh: | provision-wasm
 	cd $(EMSDK_PATH) && ./emsdk construct_env $(CURDIR)/emsdk_env.sh
 
 MONO_OBJ_DIR=$(OBJDIR)/mono/Browser.wasm.$(CONFIG)
-MONO_LIBS = $(MONO_BIN_DIR)/{libmono-ee-interp.a,libmono.a,libmono-ilgen.a,libmono-icall-table.a} ${SYS_NATIVE_DIR}/libSystem.Native.a
+MONO_LIBS = $(MONO_BIN_DIR)/{libmono-ee-interp.a,libmonosgen-2.0.a,libmono-ilgen.a,libmono-icall-table.a} ${SYS_NATIVE_DIR}/libSystem.Native.a
 MONO_INCLUDE_DIR=$(MONO_BIN_DIR)/include/mono-2.0
 BUILDS_BIN_DIR=$(MONO_BIN_DIR)/wasm/runtimes
 BUILDS_OBJ_DIR=$(MONO_OBJ_DIR)/wasm/runtimes

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/Xcode.cs
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/Xcode.cs
@@ -59,7 +59,7 @@ internal class Xcode
         {
             string libName = Path.GetFileNameWithoutExtension(lib);
             // libmono must always be statically linked, for other librarires we can use dylibs
-            bool dylibExists = libName != "libmono" && dylibs.Any(dylib => Path.GetFileName(dylib) == libName + ".dylib");
+            bool dylibExists = libName != "libmonosgen-2.0" && dylibs.Any(dylib => Path.GetFileName(dylib) == libName + ".dylib");
 
             if (!preferDylibs || !dylibExists)
             {


### PR DESCRIPTION
We initially intended to just use libmono.so/dylib as the name to simplify and follow the libcoreclr.dylib pattern and we did that by just copying to a different name after the build.

However that didn't work on Android since the name gets embedded inside the binary and Android checks that these match, so we'd either have to change the (auto)make to use the correct library name (and possibly creates complex conditionals in the Makefile for netcore) or go back to using `libmonosgen-2.0` on iOS.

We decided to do the latter.