### PR TITLE
Fix R2RTest parsing of the issues.targets

### DIFF
--- a/src/coreclr/src/tools/r2rtest/TestExclusion.cs
+++ b/src/coreclr/src/tools/r2rtest/TestExclusion.cs
@@ -163,7 +163,8 @@ namespace R2RTest
 
                 Project project = new Project();
                 project.SetGlobalProperty("XunitTestBinBase", "*");
-                project.SetGlobalProperty("BuildArch", "x64");
+                project.SetGlobalProperty("TargetArchitecture", "x64");
+                project.SetGlobalProperty("RuntimeFlavor", "coreclr");
                 // TODO: cross-OS CPAOT
                 project.SetGlobalProperty("TargetsWindows", (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "true" : "false"));
                 project.SetGlobalProperty("AltJitArch", "x64");


### PR DESCRIPTION
The format of the file has changed a bit some time ago, but the R2RTest
wasn't updated accordingly, so test exclusion stopped working. This
change fixes it.