### PR TITLE
[runtime] Add remaining runtime events and fix some existing ones on netcore

### DIFF
--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -909,7 +909,7 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16246", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34030", TestRuntimes.Mono)]
         public void AssemblyResolve_FirstChanceException()
         {
             RemoteExecutor.Invoke(() => {

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -607,7 +607,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16246", TestRuntimes.Mono)]
         public void AssemblyResolve_IsNotCalledForCoreLibResources()
         {
             RemoteExecutor.Invoke(() =>

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -167,7 +167,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16246", TestRuntimes.Mono)]
         public void FirstChanceException_Called()
         {
             RemoteExecutor.Invoke(() => {

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -670,7 +670,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/mono/mono/issues/16246", TestRuntimes.Mono)]
         public void ResourceResolve()
         {
             RemoteExecutor.Invoke(() => {

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -13,8 +13,10 @@
 
 #ifndef ENABLE_NETCORE
 #define MONO_ASSEMBLY_CORLIB_NAME "mscorlib"
+#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME "mscorlib.resources"
 #else
 #define MONO_ASSEMBLY_CORLIB_NAME "System.Private.CoreLib"
+#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME "System.Private.CoreLib.resources"
 #endif
 
 /* Flag bits for mono_assembly_names_equal_flags (). */

--- a/src/mono/mono/metadata/assembly-internals.h
+++ b/src/mono/mono/metadata/assembly-internals.h
@@ -13,11 +13,10 @@
 
 #ifndef ENABLE_NETCORE
 #define MONO_ASSEMBLY_CORLIB_NAME "mscorlib"
-#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME "mscorlib.resources"
 #else
 #define MONO_ASSEMBLY_CORLIB_NAME "System.Private.CoreLib"
-#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME "System.Private.CoreLib.resources"
 #endif
+#define MONO_ASSEMBLY_CORLIB_RESOURCE_NAME (MONO_ASSEMBLY_CORLIB_NAME ".resources")
 
 /* Flag bits for mono_assembly_names_equal_flags (). */
 typedef enum {

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1712,8 +1712,9 @@ netcore_load_reference (MonoAssemblyName *aname, MonoAssemblyLoadContext *alc, M
 	if (reference)
 		goto leave;
 
+	// Looking up corlib resources here can cause an infinite loop
 	// See: https://github.com/dotnet/coreclr/blob/0a762eb2f3a299489c459da1ddeb69e042008f07/src/vm/appdomain.cpp#L5178-L5239
-	if (!(strcmp (aname->name, MONO_ASSEMBLY_CORLIB_NAME) == 0 && is_satellite) && postload) {
+	if (!(strcmp (aname->name, MONO_ASSEMBLY_CORLIB_RESOURCE_NAME) == 0 && is_satellite) && postload) {
 		reference = mono_assembly_invoke_search_hook_internal (alc, requesting, aname, FALSE, TRUE);
 		if (reference)
 			goto leave;

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -973,6 +973,10 @@ typedef struct {
 	MonoClass *critical_finalizer_object; /* MAYBE NULL */
 	MonoClass *generic_ireadonlylist_class;
 	MonoClass *generic_ienumerator_class;
+#ifdef ENABLE_NETCORE
+	MonoClass *alc_class;
+	MonoClass *appcontext_class;
+#endif
 #ifndef ENABLE_NETCORE
 	MonoMethod *threadpool_perform_wait_callback_method;
 #endif

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -813,6 +813,11 @@ mono_init_internal (const char *filename, const char *exe_filename, const char *
 	mono_defaults.generic_ienumerator_class = mono_class_load_from_name (
 	        mono_defaults.corlib, "System.Collections.Generic", "IEnumerator`1");
 
+#ifdef ENABLE_NETCORE
+	mono_defaults.alc_class = mono_class_get_assembly_load_context_class ();
+	mono_defaults.appcontext_class = mono_class_try_load_from_name (mono_defaults.corlib, "System", "AppContext");
+#endif
+
 #ifndef ENABLE_NETCORE
 	MonoClass *threadpool_wait_callback_class = mono_class_load_from_name (
 		mono_defaults.corlib, "System.Threading", "_ThreadPoolWaitCallback");

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1920,6 +1920,11 @@ mono_runtime_unhandled_exception_policy_set (MonoRuntimeUnhandledExceptionPolicy
 void
 mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error);
 
+#ifdef ENABLE_NETCORE
+void
+mono_first_chance_exception_checked (MonoObjectHandle exc, MonoError *error);
+#endif
+
 MonoVTable *
 mono_class_try_get_vtable (MonoDomain *domain, MonoClass *klass);
 

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -1923,6 +1923,9 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error);
 #ifdef ENABLE_NETCORE
 void
 mono_first_chance_exception_checked (MonoObjectHandle exc, MonoError *error);
+
+void
+mono_first_chance_exception_internal (MonoObject *exc_raw);
 #endif
 
 MonoVTable *

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -5066,9 +5066,6 @@ mono_first_chance_exception_checked (MonoObjectHandle exc, MonoError *error)
 	return_if_nok (error);
 	delegate_handle = MONO_HANDLE_NEW (MonoObject, delegate);
 
-	// TODO: is this necessary here?
-	mono_threads_begin_abort_protected_block ();
-
 	if (MONO_HANDLE_BOOL (delegate_handle)) {
 		gpointer args [2];
 		args [0] = domain->domain;
@@ -5076,8 +5073,6 @@ mono_first_chance_exception_checked (MonoObjectHandle exc, MonoError *error)
 		mono_error_assert_ok (error);
 		mono_runtime_delegate_try_invoke_handle (delegate_handle, args, error);
 	}
-
-	mono_threads_end_abort_protected_block ();
 }
 #endif
 
@@ -5160,9 +5155,6 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
 	goto_if_nok (error, leave);
 	delegate_handle = MONO_HANDLE_NEW (MonoObject, delegate);
 
-	// Unhandled exception callbacks must not be aborted
-	mono_threads_begin_abort_protected_block ();
-
 	if (MONO_HANDLE_IS_NULL (delegate_handle)) {
 		mono_print_unhandled_exception_internal (MONO_HANDLE_RAW (exc)); // TODO: use handles
 	} else {
@@ -5172,8 +5164,6 @@ mono_unhandled_exception_checked (MonoObjectHandle exc, MonoError *error)
 		mono_error_assert_ok (error);
 		mono_runtime_delegate_try_invoke_handle (delegate_handle, args, error);
 	}
-
-	mono_threads_end_abort_protected_block ();
 
 leave:
 #endif

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -5041,6 +5041,23 @@ leave:
 }
 
 void
+mono_first_chance_exception_internal (MonoObject *exc_raw)
+{
+	ERROR_DECL (error);
+
+	HANDLE_FUNCTION_ENTER ();
+
+	MONO_HANDLE_DCL (MonoObject, exc);
+
+	mono_first_chance_exception_checked (exc, error);
+
+	if (!is_ok (error))
+		g_warning ("Invoking the FirstChanceException event failed: %s", mono_error_get_message (error));
+
+	HANDLE_FUNCTION_RETURN ();
+}
+
+void
 mono_first_chance_exception_checked (MonoObjectHandle exc, MonoError *error)
 {
 	MonoClass *klass = mono_handle_class (exc);

--- a/src/mono/mono/metadata/runtime.c
+++ b/src/mono/mono/metadata/runtime.c
@@ -58,13 +58,9 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 	MonoObject *exc;
 
 #if ENABLE_NETCORE
-	MonoClass *appcontext_class;
 	MonoMethod *procexit_method;
 
-	appcontext_class = mono_class_try_load_from_name (mono_defaults.corlib, "System", "AppContext");
-	g_assert (appcontext_class);
-	
-	procexit_method = mono_class_get_method_from_name_checked (appcontext_class, "OnProcessExit", 0, 0, error);
+	procexit_method = mono_class_get_method_from_name_checked (mono_defaults.appcontext_class, "OnProcessExit", 0, 0, error);
 	g_assert (procexit_method);
 	
 	mono_runtime_try_invoke (procexit_method, NULL, NULL, &exc, error);

--- a/src/mono/mono/metadata/runtime.c
+++ b/src/mono/mono/metadata/runtime.c
@@ -58,9 +58,13 @@ fire_process_exit_event (MonoDomain *domain, gpointer user_data)
 	MonoObject *exc;
 
 #if ENABLE_NETCORE
-	MonoMethod *procexit_method;
+	MONO_STATIC_POINTER_INIT (MonoMethod, procexit_method)
 
-	procexit_method = mono_class_get_method_from_name_checked (mono_defaults.appcontext_class, "OnProcessExit", 0, 0, error);
+		procexit_method = mono_class_get_method_from_name_checked (mono_defaults.appcontext_class, "OnProcessExit", 0, 0, error);
+		mono_error_assert_ok (error);
+
+	MONO_STATIC_POINTER_INIT_END (MonoMethod, procexit_method)
+
 	g_assert (procexit_method);
 	
 	mono_runtime_try_invoke (procexit_method, NULL, NULL, &exc, error);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2693,6 +2693,9 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		MONO_PROFILER_RAISE (exception_throw, (obj));
 		jit_tls->orig_ex_ctx_set = FALSE;
 
+		mono_first_chance_exception_checked (MONO_HANDLE_NEW (MonoObject, obj), error);
+		mono_error_assert_ok (error); // Is this safe to assert? Or will it just hide managed exceptions in weird scenarios?
+
 		StackFrameInfo catch_frame;
 		MonoFirstPassResult res;
 		res = handle_exception_first_pass (&ctx_cp, obj, &first_filter_idx, &ji, &prev_ji, non_exception, &catch_frame, &last_mono_wrapper_runtime_invoke);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2694,11 +2694,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		jit_tls->orig_ex_ctx_set = FALSE;
 
 #ifdef ENABLE_NETCORE
-		mono_first_chance_exception_checked (MONO_HANDLE_NEW (MonoObject, obj), error);
-		if (!is_ok (error)) {
-			g_warning ("Invokeing the FirstChanceException event failed: %s", mono_error_get_message (error));
-			mono_error_cleanup (error);
-		}
+		mono_first_chance_exception_internal (obj);
 #endif
 
 		StackFrameInfo catch_frame;

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2695,7 +2695,10 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 
 #ifdef ENABLE_NETCORE
 		mono_first_chance_exception_checked (MONO_HANDLE_NEW (MonoObject, obj), error);
-		mono_error_assert_ok (error); // Should we swallow any errors here instead?
+		if (!is_ok (error)) {
+			g_warning ("Invokeing the FirstChanceException event failed: %s", mono_error_get_message (error));
+			mono_error_cleanup (error);
+		}
 #endif
 
 		StackFrameInfo catch_frame;

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2694,7 +2694,7 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		jit_tls->orig_ex_ctx_set = FALSE;
 
 		mono_first_chance_exception_checked (MONO_HANDLE_NEW (MonoObject, obj), error);
-		mono_error_assert_ok (error); // Is this safe to assert? Or will it just hide managed exceptions in weird scenarios?
+		mono_error_assert_ok (error); // Should we swallow any errors here instead?
 
 		StackFrameInfo catch_frame;
 		MonoFirstPassResult res;

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2693,8 +2693,10 @@ mono_handle_exception_internal (MonoContext *ctx, MonoObject *obj, gboolean resu
 		MONO_PROFILER_RAISE (exception_throw, (obj));
 		jit_tls->orig_ex_ctx_set = FALSE;
 
+#ifdef ENABLE_NETCORE
 		mono_first_chance_exception_checked (MONO_HANDLE_NEW (MonoObject, obj), error);
 		mono_error_assert_ok (error); // Should we swallow any errors here instead?
+#endif
 
 		StackFrameInfo catch_frame;
 		MonoFirstPassResult res;

--- a/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -739,6 +739,8 @@
 			<method name="get_BaseDirectory"/>
 			<!-- object.c: mono_unhandled_exception_checked -->
 			<field name="UnhandledException"/>
+			<!-- object.c: mono_first_chance_exception_checked -->
+			<field name="FirstChanceException"/>
 		</type>
 
 		<type fullname="Mono.NullByRefReturnException">

--- a/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -23,17 +23,19 @@
 		  <!-- assembly-load-context.c: mono_alc_invoke_resolve_using_resolve_satellite -->
 		  <method name="MonoResolveUsingResolveSatelliteAssembly" />
 		  <!-- appdomain.c: mono_try_assembly_resolve_handle () -->
-		  <method name="OnAssemblyResolve"/>
+		  <method name="OnAssemblyResolve" />
 		  <!-- appdomain.c: mono_domain_fire_assembly_load_event () -->
-		  <method name="OnAssemblyLoad"/>
+		  <method name="OnAssemblyLoad" />
 		  <!-- native-library.c: netcore_resolve_with_load () -->
-		  <method name="MonoResolveUnmanagedDll"/>
+		  <method name="MonoResolveUnmanagedDll" />
 		  <!-- native-library.c: netcore_resolve_with_resolving_event () -->
-		  <method name="MonoResolveUnmanagedDllUsingEvent"/>
+		  <method name="MonoResolveUnmanagedDllUsingEvent" />
 		  <!-- appdomain.c: mono_domain_fire_assembly_load_event -->
-		  <method name="OnAssemblyLoad"/>
+		  <method name="OnAssemblyLoad" />
 		  <!-- appdomain.c: mono_domain_try_type_resolve_name -->
-		  <method name="OnTypeResolve"/>
+		  <method name="OnTypeResolve" />
+		  <!-- icall.c: try_resource_resolve_name -->
+		  <method name="OnResourceResolve" />
 		</type>
 		
 		<!-- marshal.c: emit_marshal_custom (should not be used on devices)

--- a/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -4,7 +4,6 @@
 		<!-- domain.c: mono_defaults.appdomain_class -->
 		<type fullname="Mono.MonoDomain">
 			<field name="_mono_app_domain"/>
-			<field name="UnhandledException"/>
 		</type>
 
 		<!-- appdomain.c: mono_runtime_init -->
@@ -738,6 +737,8 @@
 			<method name="OnProcessExit"/>
 			<!-- appdomain.c: get_app_context_base_directory -->
 			<method name="get_BaseDirectory"/>
+			<!-- object.c: mono_unhandled_exception_checked -->
+			<field name="UnhandledException"/>
 		</type>
 
 		<type fullname="Mono.NullByRefReturnException">

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
@@ -17,7 +17,5 @@ namespace Mono
 #pragma warning restore 169
 
         public event UnhandledExceptionEventHandler? UnhandledException;
-
-        public event EventHandler? ProcessExit;
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/Mono/MonoDomain.cs
@@ -15,7 +15,5 @@ namespace Mono
         private IntPtr _mono_app_domain;
         #endregion
 #pragma warning restore 169
-
-        public event UnhandledExceptionEventHandler? UnhandledException;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mono/mono/issues/16246

Contributes to https://github.com/mono/mono/issues/14788

The commits here should be reasonably chunked up, but a summary of what this accomplishes:

* Wires up OnResourceResolve
* Fixes our corlib satellite assembly check in netcore_load_reference (we were previously comparing "System.Private.Corelib" to "System.Private.Corelib.resources", which does not work)
* Adds some useful classes to mono_defaults
* Removes legacy events from MonoDomain and prevents calling them on netcore
* Fixes UnhandledException to call the correct event
* Wires up FirstChanceException

`AppDomainTests.AssemblyResolve_FirstChanceException` is now failing because of the exception type, so it should work once I sort out https://github.com/dotnet/runtime/issues/34030. Until then, keep it disabled.