### PR TITLE
Adding OSX support for System.DirectoryServices.Protocols

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -14,6 +14,7 @@ internal static partial class Interop
         internal const string LibSystemCommonCrypto = "/usr/lib/system/libcommonCrypto";
         internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel";
         internal const string Odbc32 = "libodbc.2.dylib";
+        internal const string OpenLdap = "libldap";
         internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
         internal const string AppleCryptoNative = "System.Security.Cryptography.Native.Apple";
         internal const string MsQuic = "msquic";

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);0649;CA1810</NoWarn>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Linux;netcoreapp2.0-Linux;$(NetCoreAppCurrent)-Windows_NT;netstandard2.0;netcoreapp2.0-Windows_NT;_$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-OSX;netcoreapp2.0-OSX;$(NetCoreAppCurrent)-Linux;netcoreapp2.0-Linux;$(NetCoreAppCurrent)-Windows_NT;netstandard2.0;netcoreapp2.0-Windows_NT;_$(NetFrameworkCurrent)</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
@@ -57,21 +57,28 @@
       <Link>Common\Interop\Windows\Wldap32\Interop.Ber.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\DirectoryServices\Protocols\common\BerConverter.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\LdapPal.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\BerPal.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\ldap\LdapConnection.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\ldap\LdapSessionOptions.Linux.cs" />
     <Compile Include="System\DirectoryServices\Protocols\Interop\SafeHandles.Linux.cs" />
-    <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs">
-      <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)Interop\Linux\OpenLdap\Interop.Ldap.cs">
       <Link>Common\Interop\Linux\OpenLdap\Interop.Ldap.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)Interop\Linux\OpenLdap\Interop.Ber.cs">
       <Link>Common\Interop\Linux\OpenLdap\Interop.Ber.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsLinux)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\Linux\Interop.Libraries.cs">
+      <Link>Common\Interop\Linux\Interop.Libraries.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsOSX)' == 'true'">
+    <Compile Include="$(CommonPath)Interop\OSX\Interop.Libraries.cs">
+      <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -3,7 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);0649;CA1810</NoWarn>
     <IncludeDllSafeSearchPathAttribute>true</IncludeDllSafeSearchPathAttribute>
-    <TargetFrameworks>$(NetCoreAppCurrent)-OSX;netcoreapp2.0-OSX;$(NetCoreAppCurrent)-Linux;netcoreapp2.0-Linux;$(NetCoreAppCurrent)-Windows_NT;netstandard2.0;netcoreapp2.0-Windows_NT;_$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;netcoreapp2.0-Windows_NT;$(NetCoreAppCurrent)-OSX;netcoreapp2.0-OSX;$(NetCoreAppCurrent)-Linux;netcoreapp2.0-Linux;netstandard2.0;_$(NetFrameworkCurrent)</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
@@ -36,8 +36,9 @@ namespace System.DirectoryServices.Protocols.Tests
                     }
                 }
                 return _isLibLdapInstalled.Value;
-#else // In .NET Framework ldap is always installed.
-                return true;
+#else
+                _isLibLdapInstalled = true; // In .NET Framework ldap is always installed.
+                return _isLibLdapInstalled.Value;
 #endif
             }
         }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
@@ -16,6 +16,9 @@ namespace System.DirectoryServices.Protocols.Tests
         // Cache the check once we have performed it once
         private static bool? _isLibLdapInstalled = null;
 
+        /// <summary>
+        /// Returns true if able to PInvoke into Linux or OSX, false otherwise
+        /// </summary>
         public static bool IsLibLdapInstalled
         {
             get
@@ -24,26 +27,43 @@ namespace System.DirectoryServices.Protocols.Tests
                 {
                     try
                     {
-                        // Attempt PInvoking into libldap
-                        IntPtr handle = ber_alloc(1);
-                        ber_free(handle, 1);
+                        // Attempt PInvoking into libldap on Linux
+                        IntPtr handle = ber_alloc_Linux(1);
+                        ber_free_Linux(handle, 1);
                         _isLibLdapInstalled = true;
                     }
                     catch (Exception)
                     {
-                        _isLibLdapInstalled = false;
+                        try
+                        {
+                            // Attempt PInvoking into libldap on OSX
+                            IntPtr handle = ber_alloc_OSX(1);
+                            ber_free_OSX(handle, 1);
+                            _isLibLdapInstalled = true;
+                        }
+                        catch (Exception)
+                        {
+                            _isLibLdapInstalled = false;
+                        }
                     }
                 }
                 return _isLibLdapInstalled.Value;
             }
         }
 
-        internal const string OpenLdap = "libldap-2.4.so.2";
+        internal const string OpenLdapLinux = "libldap-2.4.so.2";
+        internal const string OpenLdapOSX = "libldap";
 
-        [DllImport(OpenLdap, EntryPoint = "ber_alloc_t", CharSet = CharSet.Ansi)]
-        internal static extern IntPtr ber_alloc(int option);
+        [DllImport(OpenLdapLinux, EntryPoint = "ber_alloc_t", CharSet = CharSet.Ansi)]
+        internal static extern IntPtr ber_alloc_Linux(int option);
 
-        [DllImport(OpenLdap, EntryPoint = "ber_free", CharSet = CharSet.Ansi)]
-        public static extern IntPtr ber_free([In] IntPtr berelement, int option);
+        [DllImport(OpenLdapLinux, EntryPoint = "ber_free", CharSet = CharSet.Ansi)]
+        public static extern IntPtr ber_free_Linux([In] IntPtr berelement, int option);
+
+        [DllImport(OpenLdapOSX, EntryPoint = "ber_alloc_t", CharSet = CharSet.Ansi)]
+        internal static extern IntPtr ber_alloc_OSX(int option);
+
+        [DllImport(OpenLdapOSX, EntryPoint = "ber_free", CharSet = CharSet.Ansi)]
+        public static extern IntPtr ber_free_OSX([In] IntPtr berelement, int option);
     }
 }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/System.DirectoryServices.Protocols.Tests.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/System.DirectoryServices.Protocols.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-Windows_NT;$(NetFrameworkCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BerConverterTests.cs" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/23944

cc: @ericstj @tarekgh @safern @flamencist 

In OSX openldap library is called libldap only so this PR is adding a new build configuration to build a OSX flavor of the library which uses that for PInvokes instead. This is also adding test runs for the library on OSX.

Note: I attempted to do something similar to what we today do in System.Drawing.Common where we use NativeLibrary to intercept the DllImport resolver and pick the different library name depending on the platform, but unfortunately that functionality was added to .NET Core until 3.0 and this library crosscompiles for .NET Core 2.0, so had to instead add a new configuration.