### PR TITLE
Revert unintentional alignment change for Vector256<T>

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/src/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -90,7 +90,8 @@ namespace ILCompiler
 
         public override ValueTypeShapeCharacteristics ComputeValueTypeShapeCharacteristics(DefType type)
         {
-            if (type.Context.Target.Architecture == TargetArchitecture.ARM64)
+            if (type.Context.Target.Architecture == TargetArchitecture.ARM64 &&
+                type.Instantiation[0].IsPrimitiveNumeric)
             {
                 return type.InstanceFieldSize.AsInt switch
                 {
@@ -106,8 +107,9 @@ namespace ILCompiler
         {
             return type.IsIntrinsic &&
                 type.Namespace == "System.Runtime.Intrinsics" &&
-                ((type.Name == "Vector64`1") || (type.Name == "Vector128`1")) &&
-                type.Instantiation[0].IsPrimitive;
+                (type.Name == "Vector64`1" ||
+                type.Name == "Vector128`1" ||
+                type.Name == "Vector256`1");
         }
     }
 }

--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1759,23 +1759,10 @@ namespace Internal.JitInterface
         {
             var type = HandleToObject(cls);
 
-            switch (type.Category)
-            {
-                case TypeFlags.Byte:
-                case TypeFlags.SByte:
-                case TypeFlags.UInt16:
-                case TypeFlags.Int16:
-                case TypeFlags.UInt32:
-                case TypeFlags.Int32:
-                case TypeFlags.UInt64:
-                case TypeFlags.Int64:
-                case TypeFlags.Single:
-                case TypeFlags.Double:
-                    return asCorInfoType(type);
+            if (type.IsPrimitiveNumeric)
+                return asCorInfoType(type);
 
-                default:
-                    return CorInfoType.CORINFO_TYPE_UNDEF;
-            }
+            return CorInfoType.CORINFO_TYPE_UNDEF;
         }
 
         private bool canCast(CORINFO_CLASS_STRUCT_* child, CORINFO_CLASS_STRUCT_* parent)

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -188,13 +188,41 @@ namespace Internal.TypeSystem
 
         /// <summary>
         /// Gets a value indicating whether this is one of the primitive types (boolean, char, void,
-        /// a floating point, or an integer type).
+        /// a floating-point, or an integer type).
         /// </summary>
         public bool IsPrimitive
         {
             get
             {
                 return GetTypeFlags(TypeFlags.CategoryMask) < TypeFlags.ValueType;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this is one of the primitive numeric types
+        /// (a floating-point or an integer type).
+        /// </summary>
+        public bool IsPrimitiveNumeric
+        {
+            get
+            {
+                switch (GetTypeFlags(TypeFlags.CategoryMask))
+                {
+                    case TypeFlags.SByte:
+                    case TypeFlags.Byte:
+                    case TypeFlags.Int16:
+                    case TypeFlags.UInt16:
+                    case TypeFlags.Int32:
+                    case TypeFlags.UInt32:
+                    case TypeFlags.Int64:
+                    case TypeFlags.UInt64:
+                    case TypeFlags.Single:
+                    case TypeFlags.Double:
+                        return true;
+
+                    default:
+                        return false;
+                }
             }
         }
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/runtime/pull/35864#issuecomment-629803015.  In an earlier change I also added the `type.Instantiation[0].IsPrimitive` condition to the `IsVectorType` predicate.  Revert that part as well and allow only primitive numeric types for HFA/HVA purpose.  The same list of types is recognized in `MethodTable::GetVectorSize` and `Compiler::getBaseTypeAndSizeOfSIMDType`. @dotnet/crossgen-contrib 