### PR TITLE
[interp] Fix interp entry for methods with lots of arguments in llvmonly+interp mode.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2531,8 +2531,6 @@ copy_varargs_vtstack (MonoMethodSignature *csig, stackval *sp, guchar *vt_sp_sta
  * this/static * ret/void * 16 arguments -> 64 functions.
  */
 
-#define MAX_INTERP_ENTRY_ARGS 8
-
 #define INTERP_ENTRY_BASE(_method, _this_arg, _res) \
 	InterpEntryData data; \
 	(data).rmethod = (_method); \
@@ -2819,8 +2817,14 @@ interp_create_method_pointer_llvmonly (MonoMethod *method, gboolean unbox, MonoE
 	 * to use a ftndesc. The caller uses a normal signature, while the
 	 * entry functions use a gsharedvt_in signature, so wrap the entry function in
 	 * a gsharedvt_in_sig wrapper.
+	 * We use a gsharedvt_in_sig wrapper instead of an interp_in wrapper, because they
+	 * are mostly the same, and they are already generated. The exception is the
+	 * wrappers for methods with more than 8 arguments, those are different.
 	 */
-	wrapper = mini_get_gsharedvt_in_sig_wrapper (sig);
+	if (sig->param_count > MAX_INTERP_ENTRY_ARGS)
+		wrapper = mini_get_interp_in_wrapper (sig);
+	else
+		wrapper = mini_get_gsharedvt_in_sig_wrapper (sig);
 
 	entry_wrapper = mono_jit_compile_method_jit_only (wrapper, error);
 	mono_error_assertf_ok (error, "couldn't compile wrapper \"%s\" for \"%s\"",
@@ -2828,8 +2832,7 @@ interp_create_method_pointer_llvmonly (MonoMethod *method, gboolean unbox, MonoE
 			mono_method_get_name_full (method,  TRUE, TRUE, MONO_TYPE_NAME_FORMAT_IL));
 
 	if (sig->param_count > MAX_INTERP_ENTRY_ARGS) {
-		g_assert_not_reached ();
-		//entry_func = (gpointer)interp_entry_general;
+		entry_func = (gpointer)interp_entry_general;
 	} else if (sig->hasthis) {
 		if (sig->ret->type == MONO_TYPE_VOID)
 			entry_func = entry_funcs_instance [sig->param_count];

--- a/src/mono/mono/mini/interp/interp.h
+++ b/src/mono/mono/mini/interp/interp.h
@@ -14,6 +14,8 @@
 #define INTERP_ICALL_TRAMP_FARGS 4
 #endif
 
+#define MAX_INTERP_ENTRY_ARGS 8
+
 struct _InterpMethodArguments {
 	size_t ilen;
 	gpointer *iargs;

--- a/src/mono/mono/mini/mini-generic-sharing.c
+++ b/src/mono/mono/mini/mini-generic-sharing.c
@@ -26,6 +26,7 @@
 #include "aot-runtime.h"
 #include "mini-runtime.h"
 #include "llvmonly-runtime.h"
+#include "interp/interp.h"
 
 #define ALLOW_PARTIAL_SHARING TRUE
 //#define ALLOW_PARTIAL_SHARING FALSE
@@ -1711,7 +1712,7 @@ mini_get_interp_in_wrapper (MonoMethodSignature *sig)
 		return res;
 	}
 
-	if (sig->param_count > 8)
+	if (sig->param_count > MAX_INTERP_ENTRY_ARGS)
 		/* Call the generic interpreter entry point, the specialized ones only handle a limited number of arguments */
 		generic = TRUE;
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19802,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes https://github.com/mono/mono/issues/19801.




<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->