### PR TITLE
Remove per enqueue volatile check in TheadPool 

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -302,23 +302,11 @@ namespace System.Threading
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped) =>
             PostQueuedCompletionStatus(overlapped);
 
-        // The thread pool maintains a per-appdomain managed work queue.
-        // New thread pool entries are added in the managed queue.
-        // The VM is responsible for the actual growing/shrinking of
-        // threads.
-        private static void EnsureInitialized()
-        {
-            if (!ThreadPoolGlobals.threadPoolInitialized)
-            {
-                EnsureVMInitializedCore(); // separate out to help with inlining
-            }
-        }
-
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private static void EnsureVMInitializedCore()
+        internal static bool InitializeThreadPool()
         {
             InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);
-            ThreadPoolGlobals.threadPoolInitialized = true;
+            return true;
         }
 
         // Native methods:

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -18,12 +18,6 @@ using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
-    internal static partial class ThreadPoolGlobals
-    {
-        public static bool enableWorkerTracking;
-        public static bool ThreadPoolInitialized { get; } = ThreadPool.InitializeThreadPool();
-    }
-
     //
     // This type is necessary because VS 2010's debugger looks for a method named _ThreadPoolWaitCallbacck.PerformWaitCallback
     // on the stack to determine if a thread is a ThreadPool thread or not.  We have a better way to do this for .NET 4.5, but
@@ -198,6 +192,13 @@ namespace System.Threading
         // Time in ms for which ThreadPoolWorkQueue.Dispatch keeps executing work items before returning to the OS
         private const uint DispatchQuantum = 30;
 
+        private static bool GetEnableWorkerTracking()
+        {
+            bool enableWorkerTracking = false;
+            InitializeVMTp(ref enableWorkerTracking);
+            return enableWorkerTracking;
+        }
+
         internal static bool KeepDispatching(int startTickCount)
         {
             // Note: this function may incorrectly return false due to TickCount overflow
@@ -308,12 +309,6 @@ namespace System.Threading
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped) =>
             PostQueuedCompletionStatus(overlapped);
 
-        internal static bool InitializeThreadPool()
-        {
-            InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);
-            return true;
-        }
-
         // Native methods:
 
         [MethodImpl(MethodImplOptions.InternalCall)]
@@ -339,7 +334,6 @@ namespace System.Threading
 
         internal static void NotifyWorkItemProgress()
         {
-            EnsureInitialized();
             NotifyWorkItemProgressNative();
         }
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/ThreadPool.CoreCLR.cs
@@ -18,6 +18,12 @@ using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
+    internal static partial class ThreadPoolGlobals
+    {
+        public static bool enableWorkerTracking;
+        public static bool ThreadPoolInitialized { get; } = ThreadPool.InitializeThreadPool();
+    }
+
     //
     // This type is necessary because VS 2010's debugger looks for a method named _ThreadPoolWaitCallbacck.PerformWaitCallback
     // on the stack to determine if a thread is a ThreadPool thread or not.  We have a better way to do this for .NET 4.5, but
@@ -302,7 +308,6 @@ namespace System.Threading
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped) =>
             PostQueuedCompletionStatus(overlapped);
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         internal static bool InitializeThreadPool()
         {
             InitializeVMTp(ref ThreadPoolGlobals.enableWorkerTracking);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -105,7 +105,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPoolGlobals.s_invokeAsyncStateMachineBox, box, _value._token,
+                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
                 else
@@ -210,7 +210,7 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPoolGlobals.s_invokeAsyncStateMachineBox, box, _value._token,
+                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
                 }
                 else

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -95,7 +95,7 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPoolGlobals.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
             {
@@ -177,7 +177,7 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPoolGlobals.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -22,11 +22,8 @@ using Internal.Runtime.CompilerServices;
 
 namespace System.Threading
 {
-    internal static class ThreadPoolGlobals
+    internal static partial class ThreadPoolGlobals
     {
-        public static bool enableWorkerTracking;
-        public static bool ThreadPoolInitialized { get; } = ThreadPool.InitializeThreadPool();
-
         public static readonly ThreadPoolWorkQueue workQueue = new ThreadPoolWorkQueue();
 
         /// <summary>Shim used to invoke <see cref="IAsyncStateMachineBox.MoveNext"/> of the supplied <see cref="IAsyncStateMachineBox"/>.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -938,28 +938,16 @@ namespace System.Threading
         internal static readonly bool s_enableWorkerTracking = GetEnableWorkerTracking();
 
         /// <summary>Shim used to invoke <see cref="IAsyncStateMachineBox.MoveNext"/> of the supplied <see cref="IAsyncStateMachineBox"/>.</summary>
-        internal static readonly Action<object?> s_invokeAsyncStateMachineBox = new Action<object?>(Invoke.Instance.AsyncStateMachineBox);
-
-        private class Invoke
+        internal static readonly Action<object?> s_invokeAsyncStateMachineBox = state =>
         {
-            // Invoking an instance method as a delegate is faster than a static method (statics need to go via a stub to handle `this`)
-            public static Invoke Instance { get; } = new Invoke();
-
-            private Invoke() { }
-
-            // Method used rather than lambda as it shows up more clearly in profiler and stack traces
-            public void AsyncStateMachineBox(object? state)
+            if (!(state is IAsyncStateMachineBox box))
             {
-                if (!(state is IAsyncStateMachineBox box))
-                {
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
-                    return;
-                }
-
-                box.MoveNext();
+                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
+                return;
             }
-        }
 
+            box.MoveNext();
+        };
 
         [CLSCompliant(false)]
         public static RegisteredWaitHandle RegisterWaitForSingleObject(

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -416,13 +416,6 @@ namespace System
             throw new ArgumentOutOfRangeException("symbol", SR.Argument_BadFormatSpecifier);
         }
 
-        [DoesNotReturn]
-        internal static void ThrowInvalidOperationException_ThreadPoolNotInitialized()
-        {
-            // Should never occur at runtime.
-            throw new InvalidOperationException("ThreadPool Not Initialized");
-        }
-
         private static Exception GetArraySegmentCtorValidationFailedException(Array? array, int offset, int count)
         {
             if (array == null)

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -416,6 +416,13 @@ namespace System
             throw new ArgumentOutOfRangeException("symbol", SR.Argument_BadFormatSpecifier);
         }
 
+        [DoesNotReturn]
+        internal static void ThrowInvalidOperationException_ThreadPoolNotInitialized()
+        {
+            // Should never occur at runtime.
+            throw new InvalidOperationException("ThreadPool Not Initialized");
+        }
+
         private static Exception GetArraySegmentCtorValidationFailedException(Array? array, int offset, int count)
         {
             if (array == null)

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
@@ -8,10 +8,10 @@ namespace System.Threading
 {
     public static partial class ThreadPool
     {
-        private static void EnsureInitialized()
+        internal static bool InitializeThreadPool()
         {
-            ThreadPoolGlobals.threadPoolInitialized = true;
             ThreadPoolGlobals.enableWorkerTracking = false;
+            return true;
         }
 
         internal static void ReportThreadStatus(bool isWorking)

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
@@ -6,14 +6,14 @@ using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
+    internal static partial class ThreadPoolGlobals
+    {
+        public const bool enableWorkerTracking = false;
+        public static bool ThreadPoolInitialized => true;
+    }
+
     public static partial class ThreadPool
     {
-        internal static bool InitializeThreadPool()
-        {
-            ThreadPoolGlobals.enableWorkerTracking = false;
-            return true;
-        }
-
         internal static void ReportThreadStatus(bool isWorking)
         {
         }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Mono.cs
@@ -6,14 +6,10 @@ using System.Runtime.InteropServices;
 
 namespace System.Threading
 {
-    internal static partial class ThreadPoolGlobals
-    {
-        public const bool enableWorkerTracking = false;
-        public static bool ThreadPoolInitialized => true;
-    }
-
     public static partial class ThreadPool
     {
+        private static bool GetEnableWorkerTracking() => false;
+
         internal static void ReportThreadStatus(bool isWorking)
         {
         }


### PR DESCRIPTION
Remove unnecessary volatile initialization checks that are currently happening for every ThreadPool Enqueue; this is very expensive on ARM.

/cc @adamsitnik @stephentoub @kouvel 