### PR TITLE
assembly.c: mono_stringify_assembly_name,  reflection.c: assembly_nam…

### DIFF
--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1251,14 +1251,22 @@ mono_stringify_assembly_name (MonoAssemblyName *aname)
 {
 	const char *quote = (aname->name && g_ascii_isspace (aname->name [0])) ? "\"" : "";
 
-	return g_strdup_printf (
-		"%s%s%s, Version=%d.%d.%d.%d, Culture=%s, PublicKeyToken=%s%s",
-		quote, aname->name, quote,
-		aname->major, aname->minor, aname->build, aname->revision,
-		aname->culture && *aname->culture? aname->culture: "neutral",
-		aname->public_key_token [0] ? (char *)aname->public_key_token : "null",
-		(aname->flags & ASSEMBLYREF_RETARGETABLE_FLAG) ? ", Retargetable=Yes" : "");
+	GString *str;
+	str = g_string_new (NULL);
+	g_string_append_printf (str, "%s%s%s", quote, aname->name, quote);
+
+	if (aname->culture [0])
+		g_string_append_printf (str, ", Culture=%s", aname->culture);
+	if (aname->public_key_token [0])
+		g_string_append_printf (str,", PublicKeyToken=%s%s", aname->public_key_token, (aname->flags & ASSEMBLYREF_RETARGETABLE_FLAG) ? ", Retargetable=Yes" : "");
+	if (aname->has_version ==  TRUE)
+		g_string_append_printf (str,", Version=%d.%d.%d.%d", aname->major, aname->minor, aname->build, aname->revision);
+
+	char *result = g_string_free (str, FALSE); //  result is the final formatted string.
+
+	return result;
 }
+
 
 static gchar*
 assemblyref_public_tok (MonoImage *image, guint32 key_index, guint32 flags)

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -164,6 +164,7 @@ struct _MonoAssemblyName {
 	const char *culture;
 	const char *hash_value;
 	const mono_byte* public_key;
+	gboolean has_version;
 	// string of 16 hex chars + 1 NULL
 	mono_byte public_key_token [MONO_PUBLIC_KEY_TOKEN_LENGTH];
 	uint32_t hash_alg;

--- a/src/mono/mono/tests/assemblyresolve_event4.cs
+++ b/src/mono/mono/tests/assemblyresolve_event4.cs
@@ -25,7 +25,7 @@ class App
 	{
 		if (args.Name == "Test" && args.RequestingAssembly == null)
 			return Assembly.LoadFile (Path.Combine (Directory.GetCurrentDirectory (), "assemblyresolve_deps", "Test.dll"));
-		if (args.Name == "TestBase, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null" && args.RequestingAssembly.GetName ().Name == "Test")
+		if (args.Name == "TestBase" && args.RequestingAssembly.GetName ().Name == "Test")
 			return Assembly.LoadFile (Path.Combine (Directory.GetCurrentDirectory (), "assemblyresolve_deps", "TestBase.dll"));
 
 		throw new InvalidOperationException (String.Format ("Unexpected parameter combination Name=\"{0}\" RequestingAssembly=\"{1}\"", args.Name, args.RequestingAssembly));


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19804,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>…e_to_aname - Modify for good get assembly name from Type.GetType().  This change is released under the MIT license.

Good afternoon, I apologize if something is wrong, I am new to large projects, but faced with a problem: https://github.com/mono/mono/issues/19803
I modified, it seems to me, the code so that the problem disappears
