### PR TITLE
Use a different approach to optimize the indirect calls for R2R

### DIFF
--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3282,11 +3282,19 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
 
         case IAT_PVALUE:
         {
-            // Non-virtual direct calls to addresses accessed by
-            // a single indirection.
-            GenTree* cellAddr = AddrGen(addr);
-            GenTree* indir    = Ind(cellAddr);
-            result            = indir;
+            bool isR2RRelativeIndir = false;
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+            isR2RRelativeIndir = call->IsR2RRelativeIndir();
+#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
+
+            if (!isR2RRelativeIndir)
+            {
+                // Non-virtual direct calls to addresses accessed by
+                // a single indirection.
+                GenTree* cellAddr = AddrGen(addr);
+                GenTree* indir    = Ind(cellAddr);
+                result            = indir;
+            }
             break;
         }
 

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -173,6 +173,12 @@ int LinearScan::BuildCall(GenTreeCall* call)
             ctrlExprCandidates = RBM_FASTTAILCALL_TARGET;
         }
     }
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+    else if (call->IsR2RRelativeIndir())
+    {
+        buildInternalIntRegisterDefForNode(call);
+    }
+#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
 #ifdef TARGET_ARM
     else
     {


### PR DESCRIPTION
During lowering, don't create a controlExpr for indirect call. Instead use
temp register for such calls and during codegen, load the indirect from x11
into that temp register before calling the address in that temp register.