### PR TITLE
Add build information to libraries helix jobs

### DIFF
--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -77,7 +77,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <HelixProperties Condition="'$(BUILD_BUILDURI)' != ''" Include="build" Value="$(BUILD_BUILDURI)" />
     <HelixProperties Condition="'$(RuntimeFlavor)' != ''" Include="runtimeFlavor" Value="$(RuntimeFlavor)" />
   </ItemGroup>
 

--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -76,6 +76,11 @@
     <_RuntimeInputs Include="$(TestHostRootPath)**/*.dll" />
   </ItemGroup>
 
+  <ItemGroup>
+    <HelixProperties Condition="'$(BUILD_BUILDURI)' != ''" Include="build" Value="$(BUILD_BUILDURI)" />
+    <HelixProperties Condition="'$(RuntimeFlavor)' != ''" Include="runtimeFlavor" Value="$(RuntimeFlavor)" />
+  </ItemGroup>
+
   <Target Name="CompressRuntimeDirectory"
           Inputs="@(_RuntimeInputs);@(TestArchiveRuntimeDependency)"
           Outputs="$(TestArchiveRuntimeFile)"


### PR DESCRIPTION
This allows us to go from a helix job to the build uri and also to reason about which runtime the run happened on when reading the kusto data.

cc: @dotnet/runtime-infrastructure @MattGal 