### PR TITLE
enable ServerAsyncAuthenticate_MismatchProtocols_Fails test

### DIFF
--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -103,9 +103,6 @@ namespace System.Net.Security.Tests
                 "Server: " + serverSslProtocols + "; Client: " + clientSslProtocols +
                 " expectedToFail: " + expectedToFail);
 
-            int timeOut = expectedToFail ? TestConfiguration.FailingTestTimeoutMiliseconds
-                : TestConfiguration.PassingTestTimeoutMilliseconds;
-
             (NetworkStream clientStream, NetworkStream serverStream) = TestHelper.GetConnectedTcpStreams();
 
             using (SslStream sslServerStream = new SslStream(
@@ -145,7 +142,7 @@ namespace System.Net.Security.Tests
 
                 try
                 {
-                    await clientAuthentication.TimeoutAfter(timeOut);
+                    await clientAuthentication.TimeoutAfter(TestConfiguration.PassingTestTimeoutMilliseconds);
                     _logVerbose.WriteLine("ServerAsyncAuthenticateTest.clientAuthentication complete.");
                 }
                 catch (Exception ex)
@@ -155,7 +152,7 @@ namespace System.Net.Security.Tests
                     clientStream.Socket.Shutdown(SocketShutdown.Send);
                 }
 
-                await serverAuthentication.TimeoutAfter(timeOut);
+                await serverAuthentication.TimeoutAfter(TestConfiguration.PassingTestTimeoutMilliseconds);
                 _logVerbose.WriteLine("ServerAsyncAuthenticateTest.serverAuthentication complete.");
 
                 _log.WriteLine(

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -44,7 +44,6 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(ProtocolMismatchData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36192", TestPlatforms.AnyUnix)]
         public async Task ServerAsyncAuthenticate_MismatchProtocols_Fails(
             SslProtocols serverProtocol,
             SslProtocols clientProtocol,
@@ -107,80 +106,69 @@ namespace System.Net.Security.Tests
             int timeOut = expectedToFail ? TestConfiguration.FailingTestTimeoutMiliseconds
                 : TestConfiguration.PassingTestTimeoutMilliseconds;
 
-            IPEndPoint endPoint = new IPEndPoint(IPAddress.Loopback, 0);
-            var server = new TcpListener(endPoint);
-            server.Start();
+            (NetworkStream clientStream, NetworkStream serverStream) = TestHelper.GetConnectedTcpStreams();
 
-            using (var clientConnection = new TcpClient())
+            using (SslStream sslServerStream = new SslStream(
+                serverStream,
+                false,
+                AllowEmptyClientCertificate))
+            using (SslStream sslClientStream = new SslStream(
+                clientStream,
+                false,
+                delegate {
+                    // Allow any certificate from the server.
+                    // Note that simply ignoring exceptions from AuthenticateAsClientAsync() is not enough
+                    // because in Mono, certificate validation is performed during the handshake and a failure
+                    // would result in the connection being terminated before the handshake completed, thus
+                    // making the server-side AuthenticateAsServerAsync() fail as well.
+                    return true;
+                }))
             {
-                IPEndPoint serverEndPoint = (IPEndPoint)server.LocalEndpoint;
+                string serverName = _serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
 
-                Task clientConnect = clientConnection.ConnectAsync(serverEndPoint.Address, serverEndPoint.Port);
-                Task<TcpClient> serverAccept = server.AcceptTcpClientAsync();
+                _log.WriteLine("Connected on {0} {1} ({2} {3})", clientStream.Socket.LocalEndPoint, clientStream.Socket.RemoteEndPoint, clientStream.Socket.Handle, serverStream.Socket.Handle);
+                _log.WriteLine("client SslStream#{0} server SslStream#{1}", sslClientStream.GetHashCode(),  sslServerStream.GetHashCode());
 
-                // We expect that the network-level connect will always complete.
-                await Task.WhenAll(new Task[] { clientConnect, serverAccept }).TimeoutAfter(
-                    TestConfiguration.PassingTestTimeoutMilliseconds);
+                _logVerbose.WriteLine("ServerAsyncAuthenticateTest.AuthenticateAsClientAsync start.");
+                Task clientAuthentication = sslClientStream.AuthenticateAsClientAsync(
+                    serverName,
+                    null,
+                    clientSslProtocols,
+                    false);
 
-                using (TcpClient serverConnection = await serverAccept)
-                using (SslStream sslServerStream = new SslStream(
-                    clientConnection.GetStream(),
-                    false,
-                    AllowEmptyClientCertificate))
-                using (SslStream sslClientStream = new SslStream(
-                    serverConnection.GetStream(),
-                    false,
-                    delegate {
-                        // Allow any certificate from the server.
-                        // Note that simply ignoring exceptions from AuthenticateAsClientAsync() is not enough
-                        // because in Mono, certificate validation is performed during the handshake and a failure
-                        // would result in the connection being terminated before the handshake completed, thus
-                        // making the server-side AuthenticateAsServerAsync() fail as well.
-                        return true;
-                    }))
+                _logVerbose.WriteLine("ServerAsyncAuthenticateTest.AuthenticateAsServerAsync start.");
+                Task serverAuthentication = sslServerStream.AuthenticateAsServerAsync(
+                    _serverCertificate,
+                    true,
+                    serverSslProtocols,
+                    false);
+
+                try
                 {
-                    string serverName = _serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
-
-                    _logVerbose.WriteLine("ServerAsyncAuthenticateTest.AuthenticateAsClientAsync start.");
-                    Task clientAuthentication = sslClientStream.AuthenticateAsClientAsync(
-                        serverName,
-                        null,
-                        clientSslProtocols,
-                        false);
-
-                    _logVerbose.WriteLine("ServerAsyncAuthenticateTest.AuthenticateAsServerAsync start.");
-                    Task serverAuthentication = sslServerStream.AuthenticateAsServerAsync(
-                        _serverCertificate,
-                        true,
-                        serverSslProtocols,
-                        false);
-
-                    try
-                    {
-                        await clientAuthentication.TimeoutAfter(timeOut);
-                        _logVerbose.WriteLine("ServerAsyncAuthenticateTest.clientAuthentication complete.");
-                    }
-                    catch (Exception ex)
-                    {
-                        // Ignore client-side errors: we're only interested in server-side behavior.
-                        _log.WriteLine("Client exception: " + ex);
-                    }
-
-                    await serverAuthentication.TimeoutAfter(timeOut);
-                    _logVerbose.WriteLine("ServerAsyncAuthenticateTest.serverAuthentication complete.");
-
-                    _log.WriteLine(
-                        "Server({0}) authenticated with encryption cipher: {1} {2}-bit strength",
-                        serverEndPoint,
-                        sslServerStream.CipherAlgorithm,
-                        sslServerStream.CipherStrength);
-
-                    Assert.True(
-                        sslServerStream.CipherAlgorithm != CipherAlgorithmType.Null,
-                        "Cipher algorithm should not be NULL");
-
-                    Assert.True(sslServerStream.CipherStrength > 0, "Cipher strength should be greater than 0");
+                    await clientAuthentication.TimeoutAfter(timeOut);
+                    _logVerbose.WriteLine("ServerAsyncAuthenticateTest.clientAuthentication complete.");
                 }
+                catch (Exception ex)
+                {
+                    // Ignore client-side errors: we're only interested in server-side behavior.
+                    _log.WriteLine("Client exception : " + ex);
+                    clientStream.Socket.Shutdown(SocketShutdown.Send);
+                }
+
+                await serverAuthentication.TimeoutAfter(timeOut);
+                _logVerbose.WriteLine("ServerAsyncAuthenticateTest.serverAuthentication complete.");
+
+                _log.WriteLine(
+                    "Server({0}) authenticated with encryption cipher: {1} {2}-bit strength",
+                    serverStream.Socket.LocalEndPoint,
+                    sslServerStream.CipherAlgorithm,
+                    sslServerStream.CipherStrength);
+
+                Assert.True(
+                    sslServerStream.CipherAlgorithm != CipherAlgorithmType.Null,
+                    "Cipher algorithm should not be NULL");
+
+                Assert.True(sslServerStream.CipherStrength > 0, "Cipher strength should be greater than 0");
             }
         }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -16,7 +16,7 @@ namespace System.Net.Security.Tests
     internal static class TestConfiguration
     {
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
-        public const int FailingTestTimeoutMiliseconds = 500;
+        public const int FailingTestTimeoutMiliseconds = 5000;
 
         public const string Realm = "TEST.COREFX.NET";
         public const string KerberosUser = "krb_user";

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -16,7 +16,6 @@ namespace System.Net.Security.Tests
     internal static class TestConfiguration
     {
         public const int PassingTestTimeoutMilliseconds = 4 * 60 * 1000;
-        public const int FailingTestTimeoutMiliseconds = 5000;
 
         public const string Realm = "TEST.COREFX.NET";
         public const string KerberosUser = "krb_user";

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -33,6 +33,9 @@ namespace System.Net.Security.Tests
                 clientSocket.Connect(listener.LocalEndPoint);
                 Socket serverSocket = listener.Accept();
 
+                serverSocket.NoDelay = true;
+                clientSocket.NoDelay = true;
+
                 return (new NetworkStream(clientSocket, ownsSocket: true), new NetworkStream(serverSocket, ownsSocket: true));
             }
 


### PR DESCRIPTION
I was able to to reproduce the test failure locally on my VM with ~50 runs. 
It never failed when running the test alone but it fails once in a while when running whole set in parallel. 

I post traces to the original issue. I did not see anything suspicious in SslStream or test code. It seems like that once in a while it takes longer time for data to arrive on socket. I don't know if the 7 byte size contributes to that or if that is impacted by heavy CPU use during ssl tests. 

The main fix is increasing FailingTestTimeoutMiliseconds. With value set to 3s, I would see failures in 300-500 runs. With proposed value of 5s I did not see failure in 2500 full runs.
Note, that this does not impact actual test execution duration in normal case:
```
  ~/github/wfurt-runtime/artifacts/bin/System.Net.Security.Tests/net5.0-Unix-Debug ~/github/wfurt-runtime/src/libraries/System.Net.Security/tests/FunctionalTests
    Discovering: System.Net.Security.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Net.Security.Tests (found 1 of 366 test case)
    Starting:    System.Net.Security.Tests (parallel test collections = on, max threads = 4)
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls, clientProtocol: Tls11, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [STARTING]
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls, clientProtocol: Tls11, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [FINISHED] Time: 0.0928173s
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls, clientProtocol: Tls12, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [STARTING]
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls, clientProtocol: Tls12, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [FINISHED] Time: 0.0050643s
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls11, clientProtocol: Tls, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [STARTING]
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls11, clientProtocol: Tls, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [FINISHED] Time: 0.009108s
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls11, clientProtocol: Tls12, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [STARTING]
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls11, clientProtocol: Tls12, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [FINISHED] Time: 0.0038986s
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls12, clientProtocol: Tls, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [STARTING]
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls12, clientProtocol: Tls, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [FINISHED] Time: 0.0081004s
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls12, clientProtocol: Tls11, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [STARTING]
      System.Net.Security.Tests.ServerAsyncAuthenticateTest.ServerAsyncAuthenticate_MismatchProtocols_Fails(serverProtocol: Tls12, clientProtocol: Tls11, expectedException: typeof(System.Security.Authentication.AuthenticationException)) [FINISHED] Time: 0.006966s
    Finished:    System.Net.Security.Tests
  === TEST EXECUTION SUMMARY ===
     System.Net.Security.Tests  Total: 6, Errors: 0, Failed: 0, Skipped: 0, Time: 0.233s
``` 

 Since I did many variations and experiments with this test, I included some other improvements as well:
- use TestHelper to get connected streams to reduce craft
- disable Nagle's algorithm to reduce delays
- Shutdown socket after client failure to indicate the end
- add more logging so it is easier to correlate in case of failure.