### PR TITLE
JIT: fix no return call accounting

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -7861,6 +7861,15 @@ GenTreeCall* Compiler::gtCloneExprCallHelper(GenTreeCall* tree, unsigned addFlag
 
     copy->CopyOtherRegFlags(tree);
 
+    // We keep track of the number of no return calls, so if we've cloned
+    // one of these, update the tracking.
+    //
+    if (tree->IsNoReturn())
+    {
+        assert(copy->IsNoReturn());
+        setMethodHasNoReturnCalls();
+    }
+
     return copy;
 }
 

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36584/Runtime_36584.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36584/Runtime_36584.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+// Finally cloning creates new throw merge candidates that
+// need to be properly counted.
+
+class Runtime_36584
+{
+    static int x;
+
+    static void ThrowHelper()
+    {
+        throw new Exception();
+    }
+
+    public static int Main()
+    {
+        x = 100;
+
+        if (x != 100)
+        {
+            ThrowHelper();
+        }
+
+        if (x != 100)
+        {
+            ThrowHelper();
+        }
+
+        if (x != 100)
+        {
+            try 
+            {
+                x++;
+            }
+            // This finally will be cloned
+            finally 
+            {
+                if (x != 100)
+                {
+                    ThrowHelper();
+                }
+
+                if (x != 100)
+                {
+                    ThrowHelper();
+                }
+            }
+        }
+
+        return x;
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36584/Runtime_36584.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36584/Runtime_36584.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The jit tracks the number of no return calls to determine if it should run
throw helper merging and to decide if no return calls should tail called.

The accounting is currently done when the calls are initially imported,
so if code is duplicated (by say finally cloning) the count may end up being
an under-estimate. While not a correctness issue, it is better for the count
to be accurate (or an over-estimate).

So, update the count when cloning a no-return call.

Closes #36584.