### PR TITLE
Add logic to properly honor naming policy when serializing flag enums

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -16,6 +16,8 @@ namespace System.Text.Json.Serialization.Converters
         // Odd type codes are conveniently signed types (for enum backing types).
         private static readonly string? s_negativeSign = ((int)s_enumTypeCode % 2) == 0 ? null : NumberFormatInfo.CurrentInfo.NegativeSign;
 
+        private const string EnumValueSeparator = ", ";
+
         private readonly EnumConverterOptions _converterOptions;
         private readonly JsonNamingPolicy _namingPolicy;
         private readonly ConcurrentDictionary<string, string>? _nameCache;
@@ -166,7 +168,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if (IsValidIdentifier(original))
                 {
-                    transformed = _namingPolicy.ConvertName(original);
+                    transformed = FormatEnumValue(original);
                     writer.WriteStringValue(transformed);
                     if (_nameCache != null)
                     {
@@ -211,6 +213,23 @@ namespace System.Text.Json.Serialization.Converters
                     ThrowHelper.ThrowJsonException();
                     break;
             }
+        }
+
+        private string FormatEnumValue(string value)
+        {
+            if (value.IndexOf(EnumValueSeparator) == -1)
+            {
+                return _namingPolicy.ConvertName(value);
+            }
+
+            string[] enumValues = value.Split(EnumValueSeparator);
+
+            for (int i = 0; i < enumValues.Length; i++)
+            {
+                enumValues[i] = _namingPolicy.ConvertName(enumValues[i]);
+            }
+
+            return string.Join(EnumValueSeparator, enumValues);
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -226,7 +226,13 @@ namespace System.Text.Json.Serialization.Converters
             else
             {
                 // todo: optimize implementation here by leveraging https://github.com/dotnet/runtime/issues/934.
-                string[] enumValues = value.Split(ValueSeparator);
+                string[] enumValues = value.Split(
+#if BUILDING_INBOX_LIBRARY
+                    ValueSeparator
+#else
+                    new string[] { ValueSeparator }, StringSplitOptions.None
+#endif
+                    );
 
                 for (int i = 0; i < enumValues.Length; i++)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverterFactory.cs
@@ -19,7 +19,7 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         [PreserveDependency(
-            ".ctor(System.Text.Json.Serialization.Converters.EnumConverterOptions)",
+            ".ctor(System.Text.Json.Serialization.Converters.EnumConverterOptions, System.Text.Json.JsonSerializerOptions)",
             "System.Text.Json.Serialization.Converters.EnumConverter`1")]
         public override JsonConverter CreateConverter(Type type, JsonSerializerOptions options)
         {
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization.Converters
                 typeof(EnumConverter<>).MakeGenericType(type),
                 BindingFlags.Instance | BindingFlags.Public,
                 binder: null,
-                new object[] { EnumConverterOptions.AllowNumbers },
+                new object[] { EnumConverterOptions.AllowNumbers, options },
                 culture: null)!;
 
             return converter;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringEnumConverter.cs
@@ -55,7 +55,7 @@ namespace System.Text.Json.Serialization
 
         /// <inheritdoc />
         [PreserveDependency(
-            ".ctor(System.Text.Json.Serialization.Converters.EnumConverterOptions, System.Text.Json.JsonNamingPolicy)",
+            ".ctor(System.Text.Json.Serialization.Converters.EnumConverterOptions, System.Text.Json.JsonNamingPolicy, System.Text.Json.JsonSerializerOptions)",
             "System.Text.Json.Serialization.Converters.EnumConverter`1")]
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
@@ -63,7 +63,7 @@ namespace System.Text.Json.Serialization
                 typeof(EnumConverter<>).MakeGenericType(typeToConvert),
                 BindingFlags.Instance | BindingFlags.Public,
                 binder: null,
-                new object?[] { _converterOptions, _namingPolicy },
+                new object?[] { _converterOptions, _namingPolicy, options },
                 culture: null)!;
 
             return converter;

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -107,6 +107,21 @@ namespace System.Text.Json.Serialization.Tests
             options = new JsonSerializerOptions();
             options.Converters.Add(new JsonStringEnumConverter(allowIntegerValues: false));
             Assert.Throws<JsonException>(() => JsonSerializer.Serialize((FileAttributes)(-1), options));
+
+            // Flag values honor naming policy correctly
+            options = new JsonSerializerOptions();
+            options.Converters.Add(new JsonStringEnumConverter(new SimpleSnakeCasePolicy()));
+
+            json = JsonSerializer.Serialize(
+                FileAttributes.Directory | FileAttributes.Compressed | FileAttributes.IntegrityStream,
+                options);
+            Assert.Equal(@"""directory, compressed, integrity_stream""", json);
+
+            json = JsonSerializer.Serialize(FileAttributes.Compressed & FileAttributes.Device, options);
+            Assert.Equal(@"0", json);
+
+            json = JsonSerializer.Serialize(FileAttributes.Directory & FileAttributes.Compressed | FileAttributes.IntegrityStream, options);
+            Assert.Equal(@"""integrity_stream""", json);
         }
 
         public class FileState

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.Text.Json.Serialization.Tests
@@ -199,6 +200,91 @@ namespace System.Text.Json.Serialization.Tests
 
             obj = JsonSerializer.Deserialize<MyCustomEnum>("2");
             Assert.Equal(MyCustomEnum.Second, obj);
+        }
+
+        [Fact]
+        public static void EnumWithNoValues()
+        {
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() }
+            };
+
+            Assert.Equal("-1", JsonSerializer.Serialize((EmptyEnum)(-1), options));
+            Assert.Equal("1", JsonSerializer.Serialize((EmptyEnum)(1), options));
+        }
+
+        public enum EmptyEnum { };
+
+        [Fact]
+        public static void MoreThan64EnumValuesToSerialize()
+        {
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() }
+            };
+
+            for (int i = 0; i < 128; i++)
+            {
+                MyEnum value = (MyEnum)i;
+                string asStr = value.ToString();
+                string expected = char.IsLetter(asStr[0]) ? $@"""{asStr}""" : asStr;
+                Assert.Equal(expected, JsonSerializer.Serialize(value, options));
+            }
+        }
+
+        [Fact, OuterLoop]
+        public static void VeryLargeAmountOfEnumsToSerialize()
+        {
+            // Ensure we don't throw OutOfMemoryException.
+            // Multiple threads are used to ensure the approximate size limit
+            // for the name cache(a concurrent dictionary) is honored.
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() }
+            };
+
+            const int MaxValue = 33554432; // Value for MyEnum.Z
+            Task[] tasks = new Task[MaxValue];
+
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = Task.Run(() => JsonSerializer.Serialize((MyEnum)i, options));
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        [Flags]
+        public enum MyEnum
+        {
+            A = 1 << 0,
+            B = 1 << 1,
+            C = 1 << 2,
+            D = 1 << 3,
+            E = 1 << 4,
+            F = 1 << 5,
+            G = 1 << 6,
+            H = 1 << 7,
+            I = 1 << 8,
+            J = 1 << 9,
+            K = 1 << 10,
+            L = 1 << 11,
+            M = 1 << 12,
+            N = 1 << 13,
+            O = 1 << 14,
+            P = 1 << 15,
+            Q = 1 << 16,
+            R = 1 << 17,
+            S = 1 << 18,
+            T = 1 << 19,
+            U = 1 << 20,
+            V = 1 << 21,
+            W = 1 << 22,
+            X = 1 << 23,
+            Y = 1 << 24,
+            Z = 1 << 25,
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/31622.