### PR TITLE
Move app local ICU string length validation to native shim

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -59,22 +59,11 @@ namespace System.Globalization
             if (indexOfSeparator >= 0)
             {
                 icuSuffix = icuSuffixAndVersion.AsSpan().Slice(0, indexOfSeparator);
-
-                if (icuSuffix.Length > 35)
-                {
-                    Environment.FailFast($"The resolved \"{icuSuffix.ToString()}\" suffix from System.Globalization.AppLocalIcu switch has to be < 20 chars long.");
-                }
-
                 version = icuSuffixAndVersion.AsSpan().Slice(icuSuffix.Length + 1);
             }
             else
             {
                 version = icuSuffixAndVersion;
-            }
-
-            if (version.Length > 33)
-            {
-                Environment.FailFast($"The resolved version \"{version.ToString()}\" from System.Globalization.AppLocalIcu switch has to be < 33 chars long.");
             }
 
             if (suffixWithSeparator)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -432,10 +432,23 @@ void GlobalizationNative_InitICUFunctions(void* icuuc, void* icuin, const char* 
     char symbolVersion[MaxICUVersionStringWithSuffixLength + 1]="";
     char symbolSuffix[SYMBOL_CUSTOM_SUFFIX_SIZE]="";
 
+    if (strlen(version) > MaxICUVersionStringLength)
+    {
+        fprintf(stderr, "The resolved version \"%s\" from System.Globalization.AppLocalIcu switch has to be < %d chars long.\n", version, MaxICUVersionStringLength);
+        abort();
+    }
+
     sscanf(version, "%d.%d.%d", &major, &minor, &build);
 
     if (suffix != NULL)
     {
+        int suffixAllowedSize = SYMBOL_CUSTOM_SUFFIX_SIZE - 2; // SYMBOL_CUSTOM_SUFFIX_SIZE considers `_` and `\0`.
+        if (strlen(suffix) > suffixAllowedSize)
+        {
+            fprintf(stderr, "The resolved suffix \"%s\" from System.Globalization.AppLocalIcu switch has to be < %d chars long.\n", suffix, suffixAllowedSize);
+            abort();
+        }
+
         assert(strlen(suffix) + 1 <= SYMBOL_CUSTOM_SUFFIX_SIZE);
 
 #if defined(TARGET_WINDOWS)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -432,9 +432,9 @@ void GlobalizationNative_InitICUFunctions(void* icuuc, void* icuin, const char* 
     char symbolVersion[MaxICUVersionStringWithSuffixLength + 1]="";
     char symbolSuffix[SYMBOL_CUSTOM_SUFFIX_SIZE]="";
 
-    if (strlen(version) > MaxICUVersionStringLength)
+    if (strlen(version) > (size_t)MaxICUVersionStringLength)
     {
-        fprintf(stderr, "The resolved version \"%s\" from System.Globalization.AppLocalIcu switch has to be < %d chars long.\n", version, MaxICUVersionStringLength);
+        fprintf(stderr, "The resolved version \"%s\" from System.Globalization.AppLocalIcu switch has to be < %zu chars long.\n", version, (size_t)MaxICUVersionStringLength);
         abort();
     }
 
@@ -442,10 +442,10 @@ void GlobalizationNative_InitICUFunctions(void* icuuc, void* icuin, const char* 
 
     if (suffix != NULL)
     {
-        int suffixAllowedSize = SYMBOL_CUSTOM_SUFFIX_SIZE - 2; // SYMBOL_CUSTOM_SUFFIX_SIZE considers `_` and `\0`.
+        size_t suffixAllowedSize = SYMBOL_CUSTOM_SUFFIX_SIZE - 2; // SYMBOL_CUSTOM_SUFFIX_SIZE considers `_` and `\0`.
         if (strlen(suffix) > suffixAllowedSize)
         {
-            fprintf(stderr, "The resolved suffix \"%s\" from System.Globalization.AppLocalIcu switch has to be < %d chars long.\n", suffix, suffixAllowedSize);
+            fprintf(stderr, "The resolved suffix \"%s\" from System.Globalization.AppLocalIcu switch has to be < %zu chars long.\n", suffix, suffixAllowedSize);
             abort();
         }
 


### PR DESCRIPTION
I just realized that https://github.com/dotnet/runtime/pull/35383#discussion_r418928202 was not included in my merge. 

Somehow while switching OSs to validate the build and test the change, I messed up and deleted the change that addressed that feedback. 