### PR TITLE
Pipelines return MemoryPool blocks out of lock

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System.IO.Pipelines.csproj
+++ b/src/libraries/System.IO.Pipelines/src/System.IO.Pipelines.csproj
@@ -45,6 +45,12 @@
     <Compile Include="System\IO\Pipelines\ThreadPoolScheduler.netstandard.cs" />
     <Compile Include="System\IO\Pipelines\CancellationTokenExtensions.netstandard.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+    <Compile Include="System\IO\Pipelines\BufferSegment.netstandard.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Compile Include="System\IO\Pipelines\BufferSegment.netcoreapp.cs" />
+  </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Buffers" />
     <Reference Include="System.Collections" />
@@ -57,5 +63,8 @@
     <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Threading.ThreadPool" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Reference Include="System.Runtime.CompilerServices.Unsafe" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -72,15 +72,21 @@ namespace System.IO.Pipelines
                 ArrayPool<byte>.Shared.Return(poolArray);
             }
 
-            // Order of below field clears is significant as it clears in a sequential order
-            // https://github.com/dotnet/corefx/pull/35256#issuecomment-462800477
-            Next = null;
             RunningIndex = 0;
             Memory = default;
             _memoryOwner = null;
-            _next = null;
             _end = 0;
             AvailableMemory = default;
+        }
+
+        public void ResetSegmentLinks()
+        {
+            // Memory should have already been reset
+            Debug.Assert(_memoryOwner == null);
+            Debug.Assert(_end == 0);
+            Debug.Assert(RunningIndex == 0);
+
+            Next = null;
         }
 
         // Exposed for testing

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.netcoreapp.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.netcoreapp.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.IO.Pipelines
+{
+    internal sealed partial class BufferSegment : ReadOnlySequenceSegment<byte>
+    {
+        public void ResetMemory()
+        {
+            object? memoryOwner = Interlocked.Exchange(ref _memoryOwner, null);
+            if (memoryOwner is null)
+            {
+                // Already returned block; this can happen from benign race between Advance and Complete
+                // as block return is done outside a lock.
+                return;
+            }
+
+            // Use a fast exact type check rather than checking the inheritance hierarchy
+            // or following the interface mapping.
+            if (memoryOwner.GetType() == typeof(byte[]))
+            {
+                byte[] poolArray = Unsafe.As<byte[]>(memoryOwner);
+                ArrayPool<byte>.Shared.Return(poolArray);
+            }
+            else
+            {
+                Debug.Assert(memoryOwner is IMemoryOwner<byte>);
+                Unsafe.As<IMemoryOwner<byte>>(memoryOwner).Dispose();
+            }
+
+            RunningIndex = 0;
+            Memory = default;
+            _end = 0;
+            AvailableMemory = default;
+        }
+    }
+}

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.netstandard.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.netstandard.cs
@@ -1,0 +1,41 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.IO.Pipelines
+{
+    internal sealed partial class BufferSegment : ReadOnlySequenceSegment<byte>
+    {
+        public void ResetMemory()
+        {
+            object? memoryOwner = Interlocked.Exchange(ref _memoryOwner, null);
+            if (memoryOwner is null)
+            {
+                // Already returned block; this can happen from benign race between Advance and Complete
+                // as block return is done outside a lock.
+                return;
+            }
+
+            if (memoryOwner is IMemoryOwner<byte> owner)
+            {
+                owner.Dispose();
+            }
+            else
+            {
+                Debug.Assert(memoryOwner is byte[]);
+                byte[] poolArray = (byte[])memoryOwner;
+                ArrayPool<byte>.Shared.Return(poolArray);
+            }
+
+            RunningIndex = 0;
+            Memory = default;
+            _end = 0;
+            AvailableMemory = default;
+        }
+    }
+}

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -35,15 +35,17 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void EndRead()
+        public bool TryEndRead()
         {
             if ((_state & State.Reading) != State.Reading &&
                 (_state & State.ReadingTentative) != State.ReadingTentative)
             {
-                ThrowHelper.ThrowInvalidOperationException_NoReadToComplete();
+                return false;
             }
 
             _state &= ~(State.Reading | State.ReadingTentative);
+
+            return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -150,7 +150,6 @@ namespace System.IO.Pipelines
             while (returnStart != returnEnd)
             {
                 BufferSegment next = returnStart.NextSegment!;
-                returnStart.ResetMemory();
                 ReturnSegmentUnsynchronized(returnStart);
                 returnStart = next;
             }
@@ -178,6 +177,7 @@ namespace System.IO.Pipelines
                 BufferSegment returnSegment = segment;
                 segment = segment.NextSegment;
 
+                // Return the Memory to the Pool.
                 returnSegment.ResetMemory();
             }
 
@@ -352,8 +352,13 @@ namespace System.IO.Pipelines
             Debug.Assert(segment != _readHead, "Returning _readHead segment that's in use!");
             Debug.Assert(segment != _readTail, "Returning _readTail segment that's in use!");
 
+            // Always return the Memory.
+            segment.ResetMemory();
+
             if (_bufferSegmentPool.Count < MaxSegmentPoolSize)
             {
+                // Reset the segment if we are pooling it.
+                segment.ResetSegmentLinks();
                 _bufferSegmentPool.Push(segment);
             }
         }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -190,8 +190,13 @@ namespace System.IO.Pipelines
 
         private void ReturnSegmentUnsynchronized(BufferSegment segment)
         {
+            // Always return the Memory.
+            segment.ResetMemory();
+
             if (_bufferSegmentPool.Count < MaxSegmentPoolSize)
             {
+                // Reset the segment if we are pooling it.
+                segment.ResetSegmentLinks();
                 _bufferSegmentPool.Push(segment);
             }
         }
@@ -296,7 +301,6 @@ namespace System.IO.Pipelines
                             await InnerStream.WriteAsync(returnSegment.Memory, localToken).ConfigureAwait(false);
                         }
 
-                        returnSegment.ResetMemory();
                         ReturnSegmentUnsynchronized(returnSegment);
 
                         // Update the head segment after we return the current segment
@@ -363,7 +367,6 @@ namespace System.IO.Pipelines
 #endif
                 }
 
-                returnSegment.ResetMemory();
                 ReturnSegmentUnsynchronized(returnSegment);
 
                 // Update the head segment after we return the current segment


### PR DESCRIPTION
Resetting the blocks and returning them to the MemoryPool is expensive (and inert as the segments are disconnect), so do that out of the lock.

Then reacquire the lock to reset the segments and pool them (which is fast)

Hopefully will reduce contention in Pipelines

/cc @halter73 