### PR TITLE
configure.ac: check for sockaddr_in6 on Win32

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -3921,6 +3921,8 @@ else
 	AC_CHECK_LIB(advapi32, main, LIBS="$LIBS -ladvapi32", AC_ERROR(bad mingw install?))
 	AC_CHECK_LIB(version, main, LIBS="$LIBS -lversion", AC_ERROR(bad mingw install?))
 
+	AC_CHECK_TYPES([struct sockaddr_in6], [AC_DEFINE(HAVE_STRUCT_SOCKADDR_IN6)], , [#include <ws2tcpip.h>])
+
 	dnl *********************************
 	dnl *** Check for struct ip_mreqn ***
 	dnl *********************************


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19812,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>HAVE_STRUCT_SOCKADDR_IN6 needs to be defined to enable IPv6 features in
mono/metadata/w32socket.c.

Fixes TcpListener issues in wine-mono.

----

I've noticed ZusiDisplay fails under wine-mono while trying to use TcpListener, because of an exception that says something along the lines of "operation completed successfully" (I don't have the details right now, but I could reproduce again if you need more info).

It turned out that this was because the IPv6-related code in mono/metadata/w32socket.c is compiled conditionally. However, HAVE_STRUCT_SOCKADDR_IN6 was not defined during configure, even though my mingw cross-compile setup has that struct available. This PR adds a check for that struct's existence in the "Checks for Windows compilation" section of configure.ac.

I've only tested that building this PR in a cross-compilation environment on Linux completes successfully, and that the patched wine-mono repo runs the ZusiDisplay network code without throwing the exception. The wine-mono repository does not use the latest mono git master though. I have not tested anything in a proper Windows environment.