### PR TITLE
Use a Brewfile for installing brew packages

### DIFF
--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -16,7 +16,7 @@ Install Apple Xcode developer tools from the Mac App Store ([link](https://apps.
 Toolchain Setup
 ---------------
 
-Building dotnet/runtime depends on several tools to be installed. You can download them individually or use [Homebrew](http://brew.sh) for easier toolchain setup.
+Building dotnet/runtime depends on several tools to be installed. You can download them individually or use [Homebrew](https://brew.sh) for easier toolchain setup.
 
 Install the following packages:
 
@@ -29,8 +29,8 @@ Install the following packages:
 - pkg-config
 - python3
 
-The lines to install all the packages above using Homebrew.
+You can install all the packages above using Homebrew by running this command in the repository root:
 
 ```
-brew install cmake autoconf automake icu4c libtool openssl@1.1 pkg-config python3
+brew bundle --no-lock --file eng/Brewfile
 ```

--- a/eng/Brewfile
+++ b/eng/Brewfile
@@ -1,0 +1,8 @@
+brew "autoconf"
+brew "automake"
+brew "cmake"
+brew "icu4c"
+brew "libtool"
+brew "openssl@1.1"
+brew "pkg-config"
+brew "python3"

--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 if [ "$1" = "Linux" ]; then
     sudo apt update
@@ -9,36 +9,9 @@ if [ "$1" = "Linux" ]; then
     if [ "$?" != "0" ]; then
         exit 1;
     fi
-elif [ "$1" = "OSX" ]; then
-    brew update
-    brew upgrade
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-    brew install autoconf automake icu4c libtool openssl@1.1 pkg-config python3
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-elif [ "$1" = "tvOS" ]; then
-    brew update
-    brew upgrade
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-    brew install autoconf automake libtool openssl@1.1 pkg-config python3
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-elif [ "$1" = "iOS" ]; then
-    brew update
-    brew upgrade
-    if [ "$?" != "0" ]; then
-        exit 1;
-    fi
-    brew install autoconf automake libtool openssl@1.1 pkg-config python3
+elif [ "$1" = "OSX" ] || [ "$1" = "tvOS" ] || [ "$1" = "iOS" ]; then
+    engdir=$(dirname "${BASH_SOURCE[0]}")
+    brew bundle --no-lock --file "${engdir}/Brewfile"
     if [ "$?" != "0" ]; then
         exit 1;
     fi

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -28,7 +28,7 @@ jobs:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-      - script: sh $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
         displayName: Install Build Dependencies
 
       - script: |

--- a/eng/pipelines/common/templates/runtimes/build-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/build-test-job.yml
@@ -85,7 +85,7 @@ jobs:
 
     # Install test build dependencies
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
-      - script: sh $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       # Necessary to install correct cmake version

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -106,7 +106,7 @@ jobs:
     # and FreeBSD builds use a build agent with dependencies
     # preinstalled, so we only need this step for OSX and Windows.
     - ${{ if eq(parameters.osGroup, 'OSX') }}:
-      - script: sh $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       # Necessary to install python

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -457,7 +457,7 @@ jobs:
         cleanUnpackFolder: false
 
   - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-    - script: sh $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
+    - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
       displayName: Install Build Dependencies
 
     - script: |

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -78,7 +78,7 @@ jobs:
           - template: /eng/pipelines/common/restore-internal-tools.yml
 
         - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-          - script: sh $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
+          - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
             displayName: Install Build Dependencies
 
           - script: |

--- a/eng/pipelines/mono/templates/build-job.yml
+++ b/eng/pipelines/mono/templates/build-job.yml
@@ -89,7 +89,7 @@ jobs:
     # and FreeBSD builds use a build agent with dependencies
     # preinstalled, so we only need this step for OSX and Windows.
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
-      - script: sh $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
+      - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh $(osGroup)
         displayName: Install native dependencies
     - ${{ if eq(parameters.osGroup, 'Windows_NT') }}:
       # Necessary to install python


### PR DESCRIPTION
This means we won't be upgrading existing packages on the system that we don't need for the build.
Marks `install-native-dependencies.sh` as executable (+x) so we don't need to start it with `sh` in the build .yml

Fixes https://github.com/dotnet/runtime/issues/36727