### PR TITLE
Change to PathAssemblyResolver to properly allow overrides

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/PathAssemblyResolver.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/PathAssemblyResolver.cs
@@ -60,7 +60,7 @@ namespace System.Reflection
             {
                 return null;
             }
-            
+
             Assembly? candidateWithSamePkt = null;
             Assembly? candidateIgnoringPkt = null;
             ReadOnlySpan<byte> pktFromName = assemblyName.GetPublicKeyToken();


### PR DESCRIPTION
Changes to PathAssemblyResolver to make it extensible. 

The idea is to make the class more usable in different scenarios, as currently
it is as good as being sealed. 
Improved code quality in Resolve method to return fast.

Changed `_fileToPaths `from `private `to `protected`.
Changed `Resolve `method to fail/return fast.
Renamed `_fileToPaths `to `fileToPaths` to align naming with the change.

Fix #36753