### PR TITLE
[CBOR] Add Bugfixes, XML Documentation and other refinements

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
@@ -77,10 +77,10 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9800")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "990000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9a00000000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9b0000000000000000")]
+        [InlineData(CborConformanceLevel.Canonical, "9800")]
+        [InlineData(CborConformanceLevel.Canonical, "990000")]
+        [InlineData(CborConformanceLevel.Canonical, "9a00000000")]
+        [InlineData(CborConformanceLevel.Canonical, "9b0000000000000000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "9800")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "990000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "9a00000000")]
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "9fff")]
+        [InlineData(CborConformanceLevel.Canonical, "9fff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "9fff")]
         public static void ReadArray_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Array.cs
@@ -132,9 +132,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -190,9 +190,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndArray());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -211,9 +211,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndArray());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -235,9 +235,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadEndArray();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndArray());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -264,9 +264,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -288,9 +288,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadEndArray();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -300,7 +300,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadStartArray());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -318,7 +318,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadStartArray());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -337,7 +337,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadStartArray());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -350,7 +350,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadStartArray());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -96,7 +96,7 @@ namespace System.Formats.Cbor.Tests
 
                     case string[] expectedChunks:
                         Assert.Equal(CborReaderState.StartTextString, reader.PeekState());
-                        reader.ReadStartTextStringIndefiniteLength();
+                        reader.ReadStartTextString();
                         foreach(string expectedChunk in expectedChunks)
                         {
                             Assert.Equal(CborReaderState.TextString, reader.PeekState());
@@ -104,12 +104,12 @@ namespace System.Formats.Cbor.Tests
                             Assert.Equal(expectedChunk, chunk);
                         }
                         Assert.Equal(CborReaderState.EndTextString, reader.PeekState());
-                        reader.ReadEndTextStringIndefiniteLength();
+                        reader.ReadEndTextString();
                         break;
 
                     case byte[][] expectedChunks:
                         Assert.Equal(CborReaderState.StartByteString, reader.PeekState());
-                        reader.ReadStartByteStringIndefiniteLength();
+                        reader.ReadStartByteString();
                         foreach (byte[] expectedChunk in expectedChunks)
                         {
                             Assert.Equal(CborReaderState.ByteString, reader.PeekState());
@@ -117,7 +117,7 @@ namespace System.Formats.Cbor.Tests
                             Assert.Equal(expectedChunk.ByteArrayToHex(), chunk.ByteArrayToHex());
                         }
                         Assert.Equal(CborReaderState.EndByteString, reader.PeekState());
-                        reader.ReadEndByteStringIndefiniteLength();
+                        reader.ReadEndByteString();
                         break;
 
                     case object[] nested when CborWriterTests.Helpers.IsCborMapRepresentation(nested):

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Helpers.cs
@@ -243,9 +243,10 @@ namespace System.Formats.Cbor.Tests
                 // tagged values
                 "c202",
                 "d82076687474703a2f2f7777772e6578616d706c652e636f6d",
-                // special values
+                // simple values
                 "f4",
                 "f6",
+                // floating point encodings
                 "fa47c35000",
             };
 
@@ -296,10 +297,8 @@ namespace System.Formats.Cbor.Tests
                 "f9ff",
                 "faffffff",
                 "fbffffffffffffff",
-                // special value missing data
+                // two-byte simple value missing data
                 "f8",
-                // invalid special value
-                "f81f",
             };
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
@@ -302,8 +302,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
-            Assert.Equal("Data item major type mismatch.", exn.Message);
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
 
             Assert.Equal(encoding.Length, reader.BytesRemaining);
         }
@@ -321,8 +320,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
-            Assert.Equal("Data item major type mismatch.", exn.Message);
+            Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
 
             Assert.Equal(encoding.Length, reader.BytesRemaining);
         }
@@ -340,8 +338,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => reader.ReadUInt32());
-            Assert.Equal("Data item major type mismatch.", exn.Message);
+            Assert.Throws<InvalidOperationException>(() => reader.ReadUInt32());
 
             Assert.Equal(encoding.Length, reader.BytesRemaining);
         }
@@ -359,8 +356,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => reader.ReadUInt64());
-            Assert.Equal("Data item major type mismatch.", exn.Message);
+            Assert.Throws<InvalidOperationException>(() => reader.ReadUInt64());
 
             Assert.Equal(encoding.Length, reader.BytesRemaining);
         }
@@ -380,8 +376,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => reader.ReadCborNegativeIntegerEncoding());
-            Assert.Equal("Data item major type mismatch.", exn.Message);
+            Assert.Throws<InvalidOperationException>(() => reader.ReadCborNegativeIntegerEncoding());
 
             Assert.Equal(encoding.Length, reader.BytesRemaining);
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
@@ -179,11 +179,11 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "1817")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "1900ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "1a0000ffff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "1b00000000ffffffff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "1b0000000000000001")]
+        [InlineData(CborConformanceLevel.Canonical, "1817")]
+        [InlineData(CborConformanceLevel.Canonical, "1900ff")]
+        [InlineData(CborConformanceLevel.Canonical, "1a0000ffff")]
+        [InlineData(CborConformanceLevel.Canonical, "1b00000000ffffffff")]
+        [InlineData(CborConformanceLevel.Canonical, "1b0000000000000001")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "1817")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "1900ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "1a0000ffff")]
@@ -218,11 +218,11 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "3817")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "3900ff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "3a0000ffff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "3b00000000ffffffff")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "3b0000000000000001")]
+        [InlineData(CborConformanceLevel.Canonical, "3817")]
+        [InlineData(CborConformanceLevel.Canonical, "3900ff")]
+        [InlineData(CborConformanceLevel.Canonical, "3a0000ffff")]
+        [InlineData(CborConformanceLevel.Canonical, "3b00000000ffffffff")]
+        [InlineData(CborConformanceLevel.Canonical, "3b0000000000000001")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "3817")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "3900ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "3a0000ffff")]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Integer.cs
@@ -247,7 +247,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<OverflowException>(() => reader.ReadInt64());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -262,7 +262,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<OverflowException>(() => reader.ReadInt32());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -274,7 +274,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<OverflowException>(() => reader.ReadUInt32());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -286,7 +286,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<OverflowException>(() => reader.ReadUInt64());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -304,7 +304,7 @@ namespace System.Formats.Cbor.Tests
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -322,7 +322,7 @@ namespace System.Formats.Cbor.Tests
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt32());
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -340,7 +340,7 @@ namespace System.Formats.Cbor.Tests
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadUInt32());
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -358,7 +358,7 @@ namespace System.Formats.Cbor.Tests
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadUInt64());
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -378,7 +378,7 @@ namespace System.Formats.Cbor.Tests
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadCborNegativeIntegerEncoding());
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -404,7 +404,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
             Assert.Throws<FormatException>(() => reader.ReadInt64());
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -423,7 +423,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadCborNegativeIntegerEncoding());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -435,7 +435,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -445,7 +445,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadUInt64());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadCborNegativeIntegerEncoding());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -80,7 +80,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "bfff")]
+        [InlineData(CborConformanceLevel.Canonical, "bfff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "bfff")]
         public static void ReadMap_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
         {
@@ -110,10 +110,10 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "b800")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "b90000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "ba00000000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "bb0000000000000000")]
+        [InlineData(CborConformanceLevel.Canonical, "b800")]
+        [InlineData(CborConformanceLevel.Canonical, "b90000")]
+        [InlineData(CborConformanceLevel.Canonical, "ba00000000")]
+        [InlineData(CborConformanceLevel.Canonical, "bb0000000000000000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "b800")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "b90000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "ba00000000")]
@@ -129,22 +129,22 @@ namespace System.Formats.Cbor.Tests
         [Theory]
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "a3010102020303")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 1, 1, 2, 2, 3, 3 }, "a3010102020303")]
         // indefinite length string payload
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5616200020061610082616360000100")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5616200020061610082616360000100")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new object[] { "c", "" }, 0 }, "a5010002006161006162008261636000")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new object[] { "c", "" }, 0 }, "a5010002006161006162008261636000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 1, 0, 2, 0, "a", 0, "b", 0, new object[] { "c", "" }, 0 }, "a5010002006161006162008261636000")]
         // CBOR sorting rules do not match canonical string sorting
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "z", 0, "aa", 0 }, "a2617a0062616100")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, "z", 0, "aa", 0 }, "a2617a0062616100")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "z", 0, "aa", 0 }, "a2617a0062616100")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 255, 0, "", 0 }, "a218ff006000")]
         public static void ReadMap_SimpleValues_ShouldAcceptKeysSortedAccordingToConformanceLevel(CborConformanceLevel level, object expectedValue, string hexEncoding)
         {
@@ -156,7 +156,7 @@ namespace System.Formats.Cbor.Tests
         [Theory]
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0, new object[] { Map, 2, 2, 1, 1 }, 0 }, "a52000a30303020201010061610019010000a20202010100")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0, new object[] { Map, 2, 2, 1, 1 }, 0 }, "a52000a30303020201010061610019010000a20202010100")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, -1, 0, "a", 0, 256, 0, new object[] { Map, 1, 1, 2, 2 }, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a5200061610019010000a20101020200a301010202030300")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, -1, 0, "a", 0, 256, 0, new object[] { Map, 1, 1, 2, 2 }, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a5200061610019010000a20101020200a301010202030300")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 256, 0, -1, 0, "a", 0, new object[] { Map, 1, 1, 2, 2 }, 0, new object[] { Map, 1, 1, 2, 2, 3, 3 }, 0 }, "a5190100002000616100a20101020200a301010202030300")]
         public static void ReadMap_NestedValues_ShouldAcceptKeysSortedAccordingToConformanceLevel(CborConformanceLevel level, object expectedValue, string hexEncoding)
         {
@@ -177,13 +177,13 @@ namespace System.Formats.Cbor.Tests
 
         [Theory]
         [InlineData(CborConformanceLevel.Strict, 42, "a2182a01182a02")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, 42, "a2182a01182a02")]
+        [InlineData(CborConformanceLevel.Canonical, 42, "a2182a01182a02")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, 42, "a2182a01182a02")]
         [InlineData(CborConformanceLevel.Strict, "foobar", "a266666f6f6261720166666f6f62617202")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "foobar", "a266666f6f6261720166666f6f62617202")]
+        [InlineData(CborConformanceLevel.Canonical, "foobar", "a266666f6f6261720166666f6f62617202")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "foobar", "a266666f6f6261720166666f6f62617202")]
         [InlineData(CborConformanceLevel.Strict, new object[] { new object[] { "x", "y" } }, "a28182617861790181826178617902")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new object[] { "x", "y" } }, "a28182617861790181826178617902")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { new object[] { "x", "y" } }, "a28182617861790181826178617902")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new object[] { "x", "y" } }, "a28182617861790181826178617902")]
         public static void ReadMap_DuplicateKeys_StrictConformance_ShouldThrowFormatException(CborConformanceLevel level, object dupeKey, string hexEncoding)
         {
@@ -223,9 +223,9 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { 1, 2, 3, 0 }, "a40101020203030000")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { 1, 2, 3, 0 }, "a40101020203030000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { 1, 2, 3, 0 }, "a40101020203030000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { 1, "", 25, "a", 2 }, "a5010060001819006161000200")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { 1, "", 25, "a", 2 }, "a5010060001819006161000200")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { 1, 25, "", "a", 2 }, "a5010018190060006161000200")]
         public static void ReadMap_UnsortedKeys_ConformanceRequiringSortedKeys_ShouldThrowFormatException(CborConformanceLevel level, object[] keySequence, string hexEncoding)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Map.cs
@@ -193,14 +193,12 @@ namespace System.Formats.Cbor.Tests
             reader.ReadInt32();
 
             int bytesRead = reader.BytesRead;
-            int bytesRemaining = reader.BytesRemaining;
             CborReaderState state = reader.PeekState();
 
             Assert.Throws<FormatException>(() => Helpers.VerifyValue(reader, dupeKey));
 
             // ensure reader state is preserved
             Assert.Equal(bytesRead, reader.BytesRead);
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
             Assert.Equal(state, reader.PeekState());
         }
 
@@ -238,7 +236,6 @@ namespace System.Formats.Cbor.Tests
             }
 
             int bytesRead = reader.BytesRead;
-            int bytesRemaining = reader.BytesRemaining;
             CborReaderState state = reader.PeekState();
 
             // the final element violates sorting invariant
@@ -246,7 +243,6 @@ namespace System.Formats.Cbor.Tests
 
             // ensure reader state is preserved
             Assert.Equal(bytesRead, reader.BytesRead);
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
             Assert.Equal(state, reader.PeekState());
         }
 
@@ -268,9 +264,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64(); // value
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -296,9 +292,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadEndMap();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -318,9 +314,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64(); // value
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndMap());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -345,9 +341,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadEndMap();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndMap());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -363,9 +359,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadStartArray();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndMap());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -385,9 +381,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64(); // value
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -421,12 +417,12 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
 
             Assert.Equal(CborReaderState.UnsignedInteger, reader.PeekState());
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndMap());
 
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -443,12 +439,12 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadInt64();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
 
             Assert.Equal(CborReaderState.FormatError, reader.PeekState()); // don't want this to fail
             Assert.Throws<FormatException>(() => reader.ReadEndMap());
 
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -472,9 +468,9 @@ namespace System.Formats.Cbor.Tests
                 reader.ReadEndArray();
             }
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -483,9 +479,9 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = Array.Empty<byte>();
             var reader = new CborReader(encoding);
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadStartMap());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -503,7 +499,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadStartMap());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -522,7 +518,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadStartMap());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -536,7 +532,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadStartMap());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Simple.cs
@@ -149,6 +149,34 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
+        [InlineData((CborSimpleValue)0, "f800")]
+        [InlineData((CborSimpleValue)23, "f817")]
+        [InlineData((CborSimpleValue)24, "f818")]
+        [InlineData((CborSimpleValue)31, "f81f")]
+        public static void ReadSimpleValue_UnsupportedRanges_LaxConformance_ShouldSucceed(CborSimpleValue expectedResult, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, CborConformanceLevel.Lax);
+            CborSimpleValue actualResult = reader.ReadSimpleValue();
+            Assert.Equal(expectedResult, actualResult);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Strict, "f800")]
+        [InlineData(CborConformanceLevel.Strict, "f801")]
+        [InlineData(CborConformanceLevel.Strict, "f818")]
+        [InlineData(CborConformanceLevel.Strict, "f81f")]
+        [InlineData(CborConformanceLevel.Canonical, "f801")]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "f800")]
+        public static void ReadSimpleValue_UnsupportedRanges_UnsupportedConformance_ShouldThrowFormatException(CborConformanceLevel conformanceLevel, string hexEncoding)
+        {
+            byte[] encoding = hexEncoding.HexToByteArray();
+            var reader = new CborReader(encoding, conformanceLevel);
+            Assert.Throws<FormatException>(() => reader.ReadSimpleValue());
+        }
+
+        [Theory]
         [InlineData("01")] // integer
         [InlineData("40")] // empty text string
         [InlineData("60")] // empty byte string

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Simple.cs
@@ -161,7 +161,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadSimpleValue());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -179,7 +179,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<InvalidOperationException>(() => reader.ReadBoolean());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -197,7 +197,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<InvalidOperationException>(() => reader.ReadNull());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -214,7 +214,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<InvalidOperationException>(() => reader.ReadSingle());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -231,7 +231,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<InvalidOperationException>(() => reader.ReadDouble());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -90,12 +89,24 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData("61ff")]
-        [InlineData("62f090")]
-        public static void SkipValue_ValidationEnabled_InvalidUtf8_ShouldThrowFormatException(string hexEncoding)
+        [InlineData(CborConformanceLevel.Lax)]
+        public static void SkipValue_ValidationEnabled_InvalidUtf8_LaxConformance_ShouldSucceed(CborConformanceLevel conformanceLevel)
         {
-            byte[] encoding = hexEncoding.HexToByteArray();
-            var reader = new CborReader(encoding);
+            byte[] encoding = "62f090".HexToByteArray();
+            var reader = new CborReader(encoding, conformanceLevel);
+
+            reader.SkipValue(validateConformance: true);
+            Assert.Equal(CborReaderState.Finished, reader.PeekState());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Strict)]
+        [InlineData(CborConformanceLevel.Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        public static void SkipValue_ValidationEnabled_InvalidUtf8_StrictConformance_ShouldThrowFormatException(CborConformanceLevel conformanceLevel)
+        {
+            byte[] encoding = "62f090".HexToByteArray();
+            var reader = new CborReader(encoding, conformanceLevel);
 
             FormatException exn = Assert.Throws<FormatException>(() => reader.SkipValue(validateConformance: true));
             Assert.NotNull(exn.InnerException);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -232,7 +232,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             reader.ReadStartMap();
-            reader.ReadStartTextStringIndefiniteLength();
+            reader.ReadStartTextString();
             for (int i = 0; i < skipOffset; i++)
             {
                 reader.ReadTextString();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -122,7 +122,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
 
-            reader.SkipValue(validateConformance: false);
+            reader.SkipValue(disableConformanceLevelChecks: true);
             Assert.Equal(CborReaderState.Finished, reader.PeekState());
         }
 
@@ -157,7 +157,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding, CborConformanceLevel.Ctap2Canonical);
 
             reader.ReadStartArray();
-            reader.SkipValue(validateConformance: false);
+            reader.SkipValue(disableConformanceLevelChecks: true);
             Assert.Throws<FormatException>(() => reader.ReadTextString());
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -59,9 +59,9 @@ namespace System.Formats.Cbor.Tests
 
             reader.ReadStartArray();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<InvalidOperationException>(() => reader.SkipValue());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -72,7 +72,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.SkipValue());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -112,7 +112,7 @@ namespace System.Formats.Cbor.Tests
             Assert.NotNull(exn.InnerException);
             Assert.IsType<DecoderFallbackException>(exn.InnerException);
 
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -172,16 +172,14 @@ namespace System.Formats.Cbor.Tests
 
             // capture current state
             int currentBytesRead = reader.BytesRead;
-            int currentBytesRemaining = reader.BytesRemaining;
 
             // make failing call
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.SkipValue());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
 
             // ensure reader state has reverted to original
             Assert.Equal(reader.BytesRead, currentBytesRead);
-            Assert.Equal(reader.BytesRemaining, currentBytesRemaining);
 
             // ensure we can read every value up to the format error
             Assert.Equal(CborReaderState.StartArray, reader.PeekState());

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -148,6 +148,7 @@ namespace System.Formats.Cbor.Tests
                 (CborConformanceLevel.Canonical, "a201020103"), // duplicate keys in map
                 (CborConformanceLevel.Ctap2Canonical, "a202020101"), // unsorted keys in map
                 (CborConformanceLevel.Ctap2Canonical, "c001"), // tagged value
+                (CborConformanceLevel.Strict, "f81f"), // non-canonical simple value
             }.Select(l => new object[] { l.Level, l.Encoding });
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -95,7 +95,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = "62f090".HexToByteArray();
             var reader = new CborReader(encoding, conformanceLevel);
 
-            reader.SkipValue(validateConformance: true);
+            reader.SkipValue();
             Assert.Equal(CborReaderState.Finished, reader.PeekState());
         }
 
@@ -108,7 +108,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = "62f090".HexToByteArray();
             var reader = new CborReader(encoding, conformanceLevel);
 
-            FormatException exn = Assert.Throws<FormatException>(() => reader.SkipValue(validateConformance: true));
+            FormatException exn = Assert.Throws<FormatException>(() => reader.SkipValue());
             Assert.NotNull(exn.InnerException);
             Assert.IsType<DecoderFallbackException>(exn.InnerException);
 
@@ -117,12 +117,12 @@ namespace System.Formats.Cbor.Tests
 
         [Theory]
         [MemberData(nameof(NonConformingSkipValueEncodings))]
-        public static void SkipValue_NonConformingValues_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        public static void SkipValue_ValidationDisabled_NonConformingValues_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
 
-            reader.SkipValue();
+            reader.SkipValue(validateConformance: false);
             Assert.Equal(CborReaderState.Finished, reader.PeekState());
         }
 
@@ -133,7 +133,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
 
-            Assert.Throws<FormatException>(() => reader.SkipValue(validateConformance: true));
+            Assert.Throws<FormatException>(() => reader.SkipValue());
         }
 
         public static IEnumerable<object[]> NonConformingSkipValueEncodings =>
@@ -157,7 +157,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding, CborConformanceLevel.Ctap2Canonical);
 
             reader.ReadStartArray();
-            reader.SkipValue();
+            reader.SkipValue(validateConformance: false);
             Assert.Throws<FormatException>(() => reader.ReadTextString());
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.SkipValue.cs
@@ -129,12 +129,12 @@ namespace System.Formats.Cbor.Tests
             new (CborConformanceLevel Level, string Encoding)[]
             {
                 (CborConformanceLevel.Ctap2Canonical, "1801"), // non-canonical integer representation
-                (CborConformanceLevel.Rfc7049Canonical, "5fff"), // indefinite-length byte string
-                (CborConformanceLevel.Rfc7049Canonical, "7fff"), // indefinite-length text string
-                (CborConformanceLevel.Rfc7049Canonical, "9fff"), // indefinite-length array
-                (CborConformanceLevel.Rfc7049Canonical, "bfff"), // indefinite-length map
+                (CborConformanceLevel.Canonical, "5fff"), // indefinite-length byte string
+                (CborConformanceLevel.Canonical, "7fff"), // indefinite-length text string
+                (CborConformanceLevel.Canonical, "9fff"), // indefinite-length array
+                (CborConformanceLevel.Canonical, "bfff"), // indefinite-length map
                 (CborConformanceLevel.Strict, "a201020103"), // duplicate keys in map
-                (CborConformanceLevel.Rfc7049Canonical, "a201020103"), // duplicate keys in map
+                (CborConformanceLevel.Canonical, "a201020103"), // duplicate keys in map
                 (CborConformanceLevel.Ctap2Canonical, "a202020101"), // unsorted keys in map
                 (CborConformanceLevel.Ctap2Canonical, "c001"), // tagged value
             }.Select(l => new object[] { l.Level, l.Encoding });

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -625,26 +625,24 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        // the input strings are not valid CBOR, however want the reader to throw as soon as the length has been read
         [InlineData("5b0000000100000000ff")]
         [InlineData("5bffffffffffffffff")]
-        public static void ReadByteString_StringLengthTooLarge_ShouldThrowOverflowException(string hexEncoding)
+        public static void ReadByteString_StringLengthTooLarge_ShouldThrowFormatException(string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
-            Assert.Throws<OverflowException>(() => reader.ReadByteString());
+            Assert.Throws<FormatException>(() => reader.ReadByteString());
             Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
-        // the input strings are not valid CBOR, however want the reader to throw as soon as the length has been read
         [InlineData("7b0000000100000000ff")]
         [InlineData("7bffffffffffffffff")]
-        public static void ReadTextString_StringLengthTooLarge_ShouldThrowOverflowException(string hexEncoding)
+        public static void ReadTextString_StringLengthTooLarge_ShouldThrowFormatException(string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
-            Assert.Throws<OverflowException>(() => reader.ReadTextString());
+            Assert.Throws<FormatException>(() => reader.ReadTextString());
             Assert.Equal(0, reader.BytesRead);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -466,7 +466,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadByteString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -484,7 +484,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
             
             Assert.Throws<InvalidOperationException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -503,7 +503,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.TryReadByteString(buffer, out int _));
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -522,7 +522,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.TryReadTextString(buffer, out int _));
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -546,7 +546,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<FormatException>(() => reader.ReadByteString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -570,7 +570,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<FormatException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -596,7 +596,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.TryReadByteString(buffer, out int _));
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -633,7 +633,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<OverflowException>(() => reader.ReadByteString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -645,7 +645,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<OverflowException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -672,7 +672,7 @@ namespace System.Formats.Cbor.Tests
             FormatException exn = Assert.Throws<FormatException>(() => reader.ReadTextString());
             Assert.NotNull(exn.InnerException);
             Assert.IsType<System.Text.DecoderFallbackException>(exn.InnerException);
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -705,7 +705,7 @@ namespace System.Formats.Cbor.Tests
             FormatException exn = Assert.Throws<FormatException>(() => reader.TryReadTextString(buffer, out int _));
             Assert.NotNull(exn.InnerException);
             Assert.IsType<System.Text.DecoderFallbackException>(exn.InnerException);
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -715,7 +715,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -725,7 +725,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadByteString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -737,11 +737,11 @@ namespace System.Formats.Cbor.Tests
             reader.ReadStartByteString();
             reader.ReadByteString();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Equal(CborReaderState.FormatError, reader.PeekState());
             // throws FormatException even if it's the right major type we're trying to read
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -753,11 +753,11 @@ namespace System.Formats.Cbor.Tests
             reader.ReadStartTextString();
             reader.ReadTextString();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Equal(CborReaderState.FormatError, reader.PeekState());
             // throws FormatException even if it's the right major type we're trying to read
             Assert.Throws<FormatException>(() => reader.ReadInt64());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -769,9 +769,9 @@ namespace System.Formats.Cbor.Tests
 
             reader.ReadStartByteString();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadStartByteString());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -782,7 +782,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadByteString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -794,9 +794,9 @@ namespace System.Formats.Cbor.Tests
 
             reader.ReadStartTextString();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Throws<FormatException>(() => reader.ReadStartTextString());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Fact]
@@ -807,7 +807,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -817,7 +817,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<FormatException>(() => reader.ReadByteString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -827,7 +827,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<FormatException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -858,7 +858,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, conformanceLevel);
             Assert.Throws<FormatException>(() => reader.ReadTextString());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -372,9 +372,9 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            reader.ReadStartByteStringIndefiniteLength();
+            reader.ReadStartByteString();
             reader.ReadByteString();
-            reader.ReadEndByteStringIndefiniteLength();
+            reader.ReadEndByteString();
         }
 
         [Theory]
@@ -394,7 +394,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            Assert.Throws<FormatException>(() => reader.ReadStartByteStringIndefiniteLength());
+            Assert.Throws<FormatException>(() => reader.ReadStartByteString());
             Assert.Equal(0, reader.BytesRead);
         }
 
@@ -416,9 +416,9 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            reader.ReadStartTextStringIndefiniteLength();
+            reader.ReadStartTextString();
             reader.ReadTextString();
-            reader.ReadEndTextStringIndefiniteLength();
+            reader.ReadEndTextString();
         }
 
         [Theory]
@@ -438,7 +438,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding, level);
-            Assert.Throws<FormatException>(() => reader.ReadStartTextStringIndefiniteLength());
+            Assert.Throws<FormatException>(() => reader.ReadStartTextString());
             Assert.Equal(0, reader.BytesRead);
         }
 
@@ -704,7 +704,7 @@ namespace System.Formats.Cbor.Tests
             string hexEncoding = "5f4001ff";
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
-            reader.ReadStartByteStringIndefiniteLength();
+            reader.ReadStartByteString();
             reader.ReadByteString();
 
             int bytesRemaining = reader.BytesRemaining;
@@ -720,7 +720,7 @@ namespace System.Formats.Cbor.Tests
             string hexEncoding = "7f6001ff";
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
-            reader.ReadStartTextStringIndefiniteLength();
+            reader.ReadStartTextString();
             reader.ReadTextString();
 
             int bytesRemaining = reader.BytesRemaining;
@@ -737,10 +737,10 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            reader.ReadStartByteStringIndefiniteLength();
+            reader.ReadStartByteString();
 
             int bytesRemaining = reader.BytesRemaining;
-            Assert.Throws<FormatException>(() => reader.ReadStartByteStringIndefiniteLength());
+            Assert.Throws<FormatException>(() => reader.ReadStartByteString());
             Assert.Equal(bytesRemaining, reader.BytesRemaining);
         }
 
@@ -762,10 +762,10 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
 
-            reader.ReadStartTextStringIndefiniteLength();
+            reader.ReadStartTextString();
 
             int bytesRemaining = reader.BytesRemaining;
-            Assert.Throws<FormatException>(() => reader.ReadStartTextStringIndefiniteLength());
+            Assert.Throws<FormatException>(() => reader.ReadStartTextString());
             Assert.Equal(bytesRemaining, reader.BytesRemaining);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.String.cs
@@ -314,10 +314,10 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5800")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "590000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5a00000000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5b0000000000000000")]
+        [InlineData(CborConformanceLevel.Canonical, "5800")]
+        [InlineData(CborConformanceLevel.Canonical, "590000")]
+        [InlineData(CborConformanceLevel.Canonical, "5a00000000")]
+        [InlineData(CborConformanceLevel.Canonical, "5b0000000000000000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "5800")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "590000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "5a00000000")]
@@ -349,10 +349,10 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7800")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "790000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7a00000000")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7b0000000000000000")]
+        [InlineData(CborConformanceLevel.Canonical, "7800")]
+        [InlineData(CborConformanceLevel.Canonical, "790000")]
+        [InlineData(CborConformanceLevel.Canonical, "7a00000000")]
+        [InlineData(CborConformanceLevel.Canonical, "7b0000000000000000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "7800")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "790000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "7a00000000")]
@@ -388,7 +388,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5f40ff")]
+        [InlineData(CborConformanceLevel.Canonical, "5f40ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "5f40ff")]
         public static void ReadByteString_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatExceptoin(CborConformanceLevel level, string hexEncoding)
         {
@@ -399,7 +399,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "5f40ff")]
+        [InlineData(CborConformanceLevel.Canonical, "5f40ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "5f40ff")]
         public static void ReadByteString_IndefiniteLength_AsSingleItem_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
         {
@@ -432,7 +432,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7f60ff")]
+        [InlineData(CborConformanceLevel.Canonical, "7f60ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "7f60ff")]
         public static void ReadTextString_IndefiniteLength_UnSupportedConformanceLevel_ShouldThrowFormatExceptoin(CborConformanceLevel level, string hexEncoding)
         {
@@ -443,7 +443,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "7f60ff")]
+        [InlineData(CborConformanceLevel.Canonical, "7f60ff")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "7f60ff")]
         public static void ReadTextString_IndefiniteLength_AsSingleItem_UnSupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
@@ -83,7 +83,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<InvalidOperationException>(() => reader.ReadTag());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -120,7 +120,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.PeekTag());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Fact]
@@ -132,11 +132,11 @@ namespace System.Formats.Cbor.Tests
             reader.ReadStartArray();
             reader.ReadTag();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
 
             Assert.Equal(CborReaderState.FormatError, reader.PeekState());
             Assert.Throws<FormatException>(() => reader.ReadEndArray());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -152,10 +152,10 @@ namespace System.Formats.Cbor.Tests
             reader.ReadInt64();
             reader.ReadTag();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Equal(CborReaderState.UnsignedInteger, reader.PeekState());
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndArray());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -171,10 +171,10 @@ namespace System.Formats.Cbor.Tests
             reader.ReadInt64();
             reader.ReadTag();
 
-            int bytesRemaining = reader.BytesRemaining;
+            int bytesRead = reader.BytesRead;
             Assert.Equal(CborReaderState.UnsignedInteger, reader.PeekState());
             Assert.Throws<InvalidOperationException>(() => reader.ReadEndArray());
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
+            Assert.Equal(bytesRead, reader.BytesRead);
         }
 
         [Theory]
@@ -203,7 +203,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadDateTimeOffset());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -215,7 +215,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadDateTimeOffset());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -227,7 +227,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadDateTimeOffset());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -239,11 +239,9 @@ namespace System.Formats.Cbor.Tests
 
             reader.ReadStartArray();
             int bytesRead = reader.BytesRead;
-            int bytesRemaining = reader.BytesRemaining;
             Assert.Throws<FormatException>(() => reader.ReadDateTimeOffset());
 
             Assert.Equal(bytesRead, reader.BytesRead);
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
             Assert.Equal(CborReaderState.Tag, reader.PeekState());
             Assert.Equal(CborTag.DateTimeString, reader.ReadTag());
         }
@@ -294,7 +292,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadUnixTimeSeconds());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -306,7 +304,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadUnixTimeSeconds());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -318,7 +316,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadUnixTimeSeconds());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -330,11 +328,9 @@ namespace System.Formats.Cbor.Tests
 
             reader.ReadStartArray();
             int bytesRead = reader.BytesRead;
-            int bytesRemaining = reader.BytesRemaining;
             Assert.Throws<FormatException>(() => reader.ReadUnixTimeSeconds());
 
             Assert.Equal(bytesRead, reader.BytesRead);
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
             Assert.Equal(CborReaderState.Tag, reader.PeekState());
             Assert.Equal(CborTag.UnixTimeSeconds, reader.ReadTag());
         }
@@ -376,7 +372,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<InvalidOperationException>(() => reader.ReadBigInteger());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -388,7 +384,7 @@ namespace System.Formats.Cbor.Tests
             var reader = new CborReader(encoding);
 
             Assert.Throws<FormatException>(() => reader.ReadBigInteger());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -400,11 +396,9 @@ namespace System.Formats.Cbor.Tests
 
             reader.ReadStartArray();
             int bytesRead = reader.BytesRead;
-            int bytesRemaining = reader.BytesRemaining;
             Assert.Throws<FormatException>(() => reader.ReadBigInteger());
 
             Assert.Equal(bytesRead, reader.BytesRead);
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
             Assert.Equal(CborReaderState.Tag, reader.PeekState());
         }
 
@@ -443,7 +437,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<OverflowException>(() => reader.ReadDecimal());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -453,7 +447,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<InvalidOperationException>(() => reader.ReadDecimal());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -467,7 +461,7 @@ namespace System.Formats.Cbor.Tests
             byte[] encoding = hexEncoding.HexToByteArray();
             var reader = new CborReader(encoding);
             Assert.Throws<FormatException>(() => reader.ReadDecimal());
-            Assert.Equal(encoding.Length, reader.BytesRemaining);
+            Assert.Equal(0, reader.BytesRead);
         }
 
         [Theory]
@@ -484,11 +478,9 @@ namespace System.Formats.Cbor.Tests
             reader.ReadStartArray();
 
             int bytesRead = reader.BytesRead;
-            int bytesRemaining = reader.BytesRemaining;
             Assert.Throws<FormatException>(() => reader.ReadDecimal());
 
             Assert.Equal(bytesRead, reader.BytesRead);
-            Assert.Equal(bytesRemaining, reader.BytesRemaining);
             Assert.Equal(CborReaderState.Tag, reader.PeekState());
             Assert.Equal(CborTag.DecimalFraction, reader.ReadTag());
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
@@ -513,14 +513,27 @@ namespace System.Formats.Cbor.Tests
             select new object[] { l, v.value, v.hexEncoding };
 
         [Theory]
-        [MemberData(nameof(TaggedValuesAnyConformance))]
-        public static void PeekTag_UnsupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
+        [MemberData(nameof(TaggedValuesSupportedConformance))]
+        public static void PeekTag_SupportedConformanceLevel_ShouldSucceed(CborConformanceLevel level, string hexEncoding)
         {
             var reader = new CborReader(hexEncoding.HexToByteArray(), level);
             reader.PeekTag();
         }
 
-        public static IEnumerable<object[]> TaggedValuesAnyConformance =>
+        public static IEnumerable<object[]> TaggedValuesSupportedConformance =>
+            from l in new[] { CborConformanceLevel.Lax, CborConformanceLevel.Strict, CborConformanceLevel.Canonical }
+            from v in TaggedValues
+            select new object[] { l, v.hexEncoding };
+
+        [Theory]
+        [MemberData(nameof(TaggedValuesUnsupportedConformance))]
+        public static void PeekTag_UnsupportedConformanceLevel_ShouldThrowFormatException(CborConformanceLevel level, string hexEncoding)
+        {
+            var reader = new CborReader(hexEncoding.HexToByteArray(), level);
+            Assert.Throws<FormatException>(() => reader.PeekTag());
+        }
+
+        public static IEnumerable<object[]> TaggedValuesUnsupportedConformance =>
             from l in new[] { CborConformanceLevel.Ctap2Canonical }
             from v in TaggedValues
             select new object[] { l, v.hexEncoding };

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
@@ -484,7 +484,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         public static IEnumerable<object[]> SupportedConformanceTaggedValues =>
-            from l in new[] { CborConformanceLevel.Lax, CborConformanceLevel.Strict, CborConformanceLevel.Rfc7049Canonical }
+            from l in new[] { CborConformanceLevel.Lax, CborConformanceLevel.Strict, CborConformanceLevel.Canonical }
             from v in TaggedValues
             select new object[] { l, v.value, v.hexEncoding };
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.Tag.cs
@@ -257,7 +257,7 @@ namespace System.Formats.Cbor.Tests
             reader.ReadInt32();
 
             Assert.Throws<FormatException>(() => reader.ReadDateTimeOffset());
-            reader.SkipValue(validateConformance: true); // skip the failed value, should not complain about duplicate keys
+            reader.SkipValue(disableConformanceLevelChecks: false); // skip the failed value, should not complain about duplicate keys
 
             reader.ReadInt32();
             reader.ReadEndMap();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -32,18 +32,18 @@ namespace System.Formats.Cbor.Tests
 
             for (int i = 0; i < depth; i++)
             {
-                Assert.Equal(i, reader.Depth);
+                Assert.Equal(i, reader.CurrentDepth);
                 reader.ReadStartArray();
             }
 
-            Assert.Equal(depth, reader.Depth);
+            Assert.Equal(depth, reader.CurrentDepth);
             reader.ReadInt32();
-            Assert.Equal(depth, reader.Depth);
+            Assert.Equal(depth, reader.CurrentDepth);
 
             for (int i = depth - 1; i >= 0; i--)
             {
                 reader.ReadEndArray();
-                Assert.Equal(i, reader.Depth);
+                Assert.Equal(i, reader.CurrentDepth);
             }
 
             Assert.Equal(CborReaderState.Finished, reader.PeekState());

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -79,7 +79,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(4, CborReaderState.StartArray)]
         [InlineData(5, CborReaderState.StartMap)]
         [InlineData(6, CborReaderState.Tag)]
-        [InlineData(7, CborReaderState.SpecialValue)]
+        [InlineData(7, CborReaderState.SimpleValue)]
         public static void Peek_SingleByteBuffer_ShouldReturnExpectedState(byte majorType, CborReaderState expectedResult)
         {
             ReadOnlyMemory<byte> buffer = new byte[] { (byte)(majorType << 5) };

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -134,6 +134,20 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Fact]
+        public static void CborReader_MultipleRootValuesAllowed_RootLevelBreakByte_ShouldReportAsFormatError()
+        {
+            string hexEncoding = "018101ff";
+            var reader = new CborReader(hexEncoding.HexToByteArray(), allowMultipleRootLevelValues: true);
+
+            reader.ReadInt32();
+            reader.ReadStartArray();
+            reader.ReadInt32();
+            reader.ReadEndArray();
+
+            Assert.Equal(CborReaderState.FormatError, reader.PeekState());
+        }
+
+        [Fact]
         public static void CborReader_MultipleRootValuesAllowed_ReadingBeyondEndOfBuffer_ShouldThrowInvalidOperationException()
         {
             string hexEncoding = "810102";

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborRoundtripTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborRoundtripTests.cs
@@ -58,7 +58,7 @@ namespace System.Formats.Cbor.Tests
         {
             var writer = new CborWriter();
             writer.WriteInt64(input);
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
 
             var reader = new CborReader(encoding);
             long result = reader.ReadInt64();
@@ -92,7 +92,7 @@ namespace System.Formats.Cbor.Tests
         {
             var writer = new CborWriter();
             writer.WriteUInt64(input);
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
 
             var reader = new CborReader(encoding);
             ulong result = reader.ReadUInt64();
@@ -115,7 +115,7 @@ namespace System.Formats.Cbor.Tests
 #endif
             var writer = new CborWriter();
             writer.WriteByteString(input);
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
 
             var reader = new CborReader(encoding);
             byte[] result = reader.ReadByteString();
@@ -139,7 +139,7 @@ namespace System.Formats.Cbor.Tests
         {
             var writer = new CborWriter();
             writer.WriteTextString(input);
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
 
             var reader = new CborReader(encoding);
             string result = reader.ReadTextString();
@@ -162,7 +162,7 @@ namespace System.Formats.Cbor.Tests
 #endif
             var writer = new CborWriter();
             writer.WriteByteString(input);
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
 
             int length = input?.Length ?? 0;
             int lengthEncodingLength = GetLengthEncodingLength(length);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborRoundtripTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborRoundtripTests.cs
@@ -56,7 +56,7 @@ namespace System.Formats.Cbor.Tests
 #endif
         public static void Roundtrip_Int64(long input)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteInt64(input);
             byte[] encoding = writer.GetEncoding();
 
@@ -90,7 +90,7 @@ namespace System.Formats.Cbor.Tests
 #endif
         public static void Roundtrip_UInt64(ulong input)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteUInt64(input);
             byte[] encoding = writer.GetEncoding();
 
@@ -113,7 +113,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[]? input = hexInput?.HexToByteArray();
 #endif
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteByteString(input);
             byte[] encoding = writer.GetEncoding();
 
@@ -137,7 +137,7 @@ namespace System.Formats.Cbor.Tests
 #endif
         public static void Roundtrip_TextString(string? input)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteTextString(input);
             byte[] encoding = writer.GetEncoding();
 
@@ -160,7 +160,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[]? input = hexInput?.HexToByteArray();
 #endif
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteByteString(input);
             byte[] encoding = writer.GetEncoding();
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -25,7 +25,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteArray_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteArray(writer, values);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -38,7 +38,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteArray_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteArray(writer, values);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -56,7 +56,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -71,7 +71,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -90,7 +90,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.GetEncoding();
@@ -119,7 +119,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void WriteArray_DefiniteLengthExceeded_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartArray(definiteLength);
             for (int i = 0; i < definiteLength; i++)
             {
@@ -136,7 +136,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void WriteArray_DefiniteLengthExceeded_WithNestedData_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartArray(definiteLength);
             for (int i = 0; i < definiteLength; i++)
             {
@@ -154,7 +154,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void WriteEndArray_DefiniteLengthNotMet_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartArray(definiteLength);
             for (int i = 1; i < definiteLength; i++)
             {
@@ -170,7 +170,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void WriteEndArray_DefiniteLengthNotMet_WithNestedData_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartArray(definiteLength);
             for (int i = 1; i < definiteLength; i++)
             {
@@ -188,7 +188,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(3)]
         public static void WriteEndArray_ImbalancedCall_ShouldThrowInvalidOperationException(int depth)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             for (int i = 0; i < depth; i++)
             {
                 writer.WriteStartMap(1);
@@ -203,7 +203,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(3)]
         public static void WriteEndArray_AfterStartMap_ShouldThrowInvalidOperationException(int depth)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
 
             for (int i = 0; i < depth; i++)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -56,7 +56,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: false);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.Encode();
@@ -71,7 +71,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: false);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.Encode();
@@ -90,7 +90,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            var writer = new CborWriter();
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.Encode();
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
 
-            var writer = new CborWriter();
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
             byte[] actualEncoding = writer.Encode();
@@ -219,6 +219,15 @@ namespace System.Formats.Cbor.Tests
 
             writer.WriteStartMap(definiteLength: 0);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndArray());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        public static void WriteStartArray_IndefiniteLength_NoPatching_UnsupportedConformance_ShouldThrowInvalidOperationException(CborConformanceLevel conformanceLevel)
+        {
+            var writer = new CborWriter(conformanceLevel, convertIndefiniteLengthEncodings: false);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartArray());
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Array.cs
@@ -27,7 +27,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteArray(writer, values);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -40,7 +40,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteArray(writer, values);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -59,7 +59,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -74,7 +74,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -93,7 +93,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -108,7 +108,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             Helpers.WriteArray(writer, values, useDefiniteLengthCollections: false);
 
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Integer.cs
@@ -48,7 +48,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteInt64(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -80,7 +80,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteInt32(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -107,7 +107,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteUInt64(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -131,7 +131,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteUInt32(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -149,7 +149,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteCborNegativeIntegerEncoding(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
     }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Integer.cs
@@ -46,7 +46,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteInt64_SingleValue_HappyPath(long input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteInt64(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -78,7 +78,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteInt32_SingleValue_HappyPath(int input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteInt32(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteUInt64_SingleValue_HappyPath(ulong input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteUInt64(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -129,7 +129,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteUInt32_SingleValue_HappyPath(uint input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteUInt32(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -147,7 +147,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteCborNegativeIntegerEncoding_SingleValue_HappyPath(ulong input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteCborNegativeIntegerEncoding(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -26,7 +26,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -39,7 +39,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -53,7 +53,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_NoPatching_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -66,7 +66,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_NoPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -80,7 +80,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_WithPatching_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -93,7 +93,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_WithPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -107,7 +107,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_WithPatching_Ctap2Sorting_HappyPath(object[] values, string expectedHexEncoding)
     {
         byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-        using var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
+        var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
         Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
         byte[] actualEncoding = writer.GetEncoding();
         AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -121,7 +121,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_NestedListValues_HappyPath(object value, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -150,7 +150,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_SimpleValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(level);
+            var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -165,7 +165,7 @@ namespace System.Formats.Cbor.Tests
         {
             object[] value = new object[] { Map, -1, 0, new object[] { Map, 3, 3, 2, 2, 1, 1 }, 0, "a", 0, 256, 0, new object[] { Map, 2, 2, 1, 1 }, 0 };
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(level);
+            var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -176,7 +176,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_DuplicateKeys_ShouldSucceed(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
             byte[] actualEncoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -194,7 +194,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new object[] { "x", "y" } })]
         public static void WriteMap_DuplicateKeys_StrictConformance_ShouldFail(CborConformanceLevel level, object dupeKey)
         {
-            using var writer = new CborWriter(level);
+            var writer = new CborWriter(level);
             writer.WriteStartMap(2);
             Helpers.WriteValue(writer, dupeKey);
             writer.WriteInt32(0);
@@ -219,7 +219,7 @@ namespace System.Formats.Cbor.Tests
 
             byte[] PerformWrite(bool attemptDuplicateWrite)
             {
-                using var writer = new CborWriter(level);
+                var writer = new CborWriter(level);
                 writer.WriteStartMap(2);
                 Helpers.WriteValue(writer, dupeKey);
                 writer.WriteInt32(0);
@@ -245,7 +245,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void WriteMap_DefiniteLengthExceeded_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartMap(definiteLength);
             for (int i = 0; i < definiteLength; i++)
             {
@@ -263,7 +263,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void WriteMap_DefiniteLengthExceeded_WithNestedData_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartMap(definiteLength);
             for (int i = 0; i < definiteLength; i++)
             {
@@ -283,7 +283,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void EndWriteMap_DefiniteLengthNotMet_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartMap(definiteLength);
             for (int i = 1; i < definiteLength; i++)
             {
@@ -300,7 +300,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void EndWriteMap_DefiniteLengthNotMet_WithNestedData_ShouldThrowInvalidOperationException(int definiteLength)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartMap(definiteLength);
             for (int i = 1; i < definiteLength; i++)
             {
@@ -320,7 +320,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(10)]
         public static void EndWriteMap_IndefiniteLength_OddItems_ShouldThrowInvalidOperationException(int length)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartMap();
 
             for (int i = 1; i < length; i++)
@@ -337,7 +337,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void EndWriteMap_ImbalancedCall_ShouldThrowInvalidOperationException()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndMap());
         }
 
@@ -347,7 +347,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(3)]
         public static void WriteEndMap_ImbalancedCall_ShouldThrowInvalidOperationException(int depth)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             for (int i = 0; i < depth; i++)
             {
                 writer.WriteStartArray(1);
@@ -362,7 +362,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(3)]
         public static void WriteEndMap_AfterStartArray_ShouldThrowInvalidOperationException(int depth)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
 
             for (int i = 0; i < depth; i++)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -130,22 +130,22 @@ namespace System.Formats.Cbor.Tests
         [Theory]
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3030302020101")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, 3, 3, 2, 2, 1, 1 }, "a3010102020303")]
         // nested array payload
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5616200020061610082616360000100")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5616200020061610082616360000100")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162008261636000")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162008261636000")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "b", 0, 2, 0, "a", 0, new object[] { "c", "" }, 0, 1, 0 }, "a5010002006161006162008261636000")]
         // CBOR sorting rules do not match canonical string sorting
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "aa", 0, "z", 0 }, "a262616100617a00")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "aa", 0, "z", 0 }, "a2617a0062616100")]
         // Test case distinguishing between RFC7049 and CTAP2 sorting rules
         [InlineData(CborConformanceLevel.Lax, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Strict, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { Map, "", 0, 255, 0 }, "a2600018ff00")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { Map, "", 0, 255, 0 }, "a218ff006000")]
         public static void WriteMap_SimpleValues_ShouldSortKeysAccordingToConformanceLevel(CborConformanceLevel level, object value, string expectedHexEncoding)
         {
@@ -159,7 +159,7 @@ namespace System.Formats.Cbor.Tests
         [Theory]
         [InlineData("a52000a30303020201010061610019010000a20202010100", CborConformanceLevel.Lax)]
         [InlineData("a52000a30303020201010061610019010000a20202010100", CborConformanceLevel.Strict)]
-        [InlineData("a5200061610019010000a20101020200a301010202030300", CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData("a5200061610019010000a20101020200a301010202030300", CborConformanceLevel.Canonical)]
         [InlineData("a5190100002000616100a20101020200a301010202030300", CborConformanceLevel.Ctap2Canonical)]
         public static void WriteMap_NestedValues_ShouldSortKeysAccordingToConformanceLevel(string expectedHexEncoding, CborConformanceLevel level)
         {
@@ -184,13 +184,13 @@ namespace System.Formats.Cbor.Tests
 
         [Theory]
         [InlineData(CborConformanceLevel.Strict, 42)]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, 42)]
+        [InlineData(CborConformanceLevel.Canonical, 42)]
         [InlineData(CborConformanceLevel.Ctap2Canonical, 42)]
         [InlineData(CborConformanceLevel.Strict, "foobar")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "foobar")]
+        [InlineData(CborConformanceLevel.Canonical, "foobar")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "foobar")]
         [InlineData(CborConformanceLevel.Strict, new object[] { new object[] { "x", "y" } })]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new object[] { "x", "y" } })]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { new object[] { "x", "y" } })]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new object[] { "x", "y" } })]
         public static void WriteMap_DuplicateKeys_StrictConformance_ShouldFail(CborConformanceLevel level, object dupeKey)
         {
@@ -203,13 +203,13 @@ namespace System.Formats.Cbor.Tests
 
         [Theory]
         [InlineData(CborConformanceLevel.Strict, 42)]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, 42)]
+        [InlineData(CborConformanceLevel.Canonical, 42)]
         [InlineData(CborConformanceLevel.Ctap2Canonical, 42)]
         [InlineData(CborConformanceLevel.Strict, "foobar")]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, "foobar")]
+        [InlineData(CborConformanceLevel.Canonical, "foobar")]
         [InlineData(CborConformanceLevel.Ctap2Canonical, "foobar")]
         [InlineData(CborConformanceLevel.Strict, new object[] { new object[] { "x", "y" } })]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical, new object[] { new object[] { "x", "y" } })]
+        [InlineData(CborConformanceLevel.Canonical, new object[] { new object[] { "x", "y" } })]
         [InlineData(CborConformanceLevel.Ctap2Canonical, new object[] { new object[] { "x", "y" } })]
         public static void WriteMap_DuplicateKeys_StrictConformance_ShouldBeRecoverableError(CborConformanceLevel level, object dupeKey)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -28,7 +28,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -41,7 +41,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -55,7 +55,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -68,7 +68,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -82,7 +82,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -95,7 +95,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -109,7 +109,7 @@ namespace System.Formats.Cbor.Tests
         byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
         var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
         Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
-        byte[] actualEncoding = writer.GetEncoding();
+        byte[] actualEncoding = writer.Encode();
         AssertHelper.HexEqual(expectedEncoding, actualEncoding);
     }
 
@@ -123,7 +123,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -152,7 +152,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -167,7 +167,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -178,7 +178,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
             var writer = new CborWriter();
             Helpers.WriteMap(writer, values);
-            byte[] actualEncoding = writer.GetEncoding();
+            byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
         }
 
@@ -234,7 +234,7 @@ namespace System.Formats.Cbor.Tests
                 writer.WriteInt32(0);
                 writer.WriteEndMap();
 
-                return writer.GetEncoding();
+                return writer.Encode();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Map.cs
@@ -53,7 +53,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_NoPatching_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: false);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -66,7 +66,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_NoPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: false);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -80,7 +80,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_WithPatching_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            var writer = new CborWriter();
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -93,7 +93,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_WithPatching_NestedValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            var writer = new CborWriter();
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
             Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
             byte[] actualEncoding = writer.Encode();
             AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -107,7 +107,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteMap_IndefiniteLength_WithPatching_Ctap2Sorting_HappyPath(object[] values, string expectedHexEncoding)
     {
         byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-        var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
+        var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
         Helpers.WriteMap(writer, values, useDefiniteLengthCollections: false);
         byte[] actualEncoding = writer.Encode();
         AssertHelper.HexEqual(expectedEncoding, actualEncoding);
@@ -378,6 +378,15 @@ namespace System.Formats.Cbor.Tests
 
             writer.WriteStartArray(definiteLength: 0);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEndMap());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        public static void WriteStartMap_IndefiniteLength_NoPatching_UnsupportedConformance_ShouldThrowInvalidOperationException(CborConformanceLevel conformanceLevel)
+        {
+            var writer = new CborWriter(conformanceLevel, convertIndefiniteLengthEncodings: false);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartMap());
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
@@ -79,5 +79,14 @@ namespace System.Formats.Cbor.Tests
             writer.WriteSimpleValue(input);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
+
+        [Theory]
+        [InlineData((CborSimpleValue)24)]
+        [InlineData((CborSimpleValue)31)]
+        public static void WriteSimpleValue_UnassignedValues_ShouldThrowArgumentOutOfRangeException(CborSimpleValue input)
+        {
+            var writer = new CborWriter();
+            Assert.Throws<ArgumentOutOfRangeException>(() => writer.WriteSimpleValue(input));
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
@@ -25,7 +25,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteSingle(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -41,7 +41,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteDouble(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = "f6".HexToByteArray();
             var writer = new CborWriter();
             writer.WriteNull();
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -61,7 +61,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteBoolean(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -77,7 +77,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteSimpleValue(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
@@ -23,7 +23,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteSingle_SingleValue_HappyPath(float input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteSingle(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -39,7 +39,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteDouble_SingleValue_HappyPath(double input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteDouble(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -48,7 +48,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteNull_SingleValue_HappyPath()
         {
             byte[] expectedEncoding = "f6".HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteNull();
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -59,7 +59,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteBoolean_SingleValue_HappyPath(bool input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteBoolean(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -75,7 +75,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteSimpleValue_SingleValue_HappyPath(CborSimpleValue input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteSimpleValue(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Simple.cs
@@ -81,11 +81,27 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData((CborSimpleValue)24)]
-        [InlineData((CborSimpleValue)31)]
-        public static void WriteSimpleValue_UnassignedValues_ShouldThrowArgumentOutOfRangeException(CborSimpleValue input)
+        [InlineData((CborSimpleValue)24, "f818")]
+        [InlineData((CborSimpleValue)31, "f81f")]
+        public static void WriteSimpleValue_InvalidValue_LaxConformance_ShouldSucceed(CborSimpleValue input, string hexExpectedEncoding)
         {
-            var writer = new CborWriter();
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+            var writer = new CborWriter(CborConformanceLevel.Lax);
+            writer.WriteSimpleValue(input);
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Strict, (CborSimpleValue)24)]
+        [InlineData(CborConformanceLevel.Canonical, (CborSimpleValue)24)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, (CborSimpleValue)24)]
+        [InlineData(CborConformanceLevel.Strict, (CborSimpleValue)31)]
+        [InlineData(CborConformanceLevel.Canonical, (CborSimpleValue)31)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical, (CborSimpleValue)31)]
+
+        public static void WriteSimpleValue_InvalidValue_UnsupportedConformance_ShouldThrowArgumentOutOfRangeException(CborConformanceLevel conformanceLevel, CborSimpleValue input)
+        {
+            var writer = new CborWriter(conformanceLevel);
             Assert.Throws<ArgumentOutOfRangeException>(() => writer.WriteSimpleValue(input));
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -22,7 +22,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             byte[] input = hexInput.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteByteString(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -37,7 +37,7 @@ namespace System.Formats.Cbor.Tests
             byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
 
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteChunkedByteString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -52,7 +52,7 @@ namespace System.Formats.Cbor.Tests
             byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
 
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteChunkedByteString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -68,7 +68,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTextString_SingleValue_HappyPath(string input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteTextString(input);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -81,7 +81,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTextString_IndefiniteLength_NoPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -94,7 +94,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTextString_IndefiniteLength_WithPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter(encodeIndefiniteLengths: false);
+            var writer = new CborWriter(encodeIndefiniteLengths: false);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
         }
@@ -104,7 +104,7 @@ namespace System.Formats.Cbor.Tests
         {
             // NB Xunit's InlineDataAttribute will corrupt string literals containing invalid unicode
             string invalidUnicodeString = "\ud800";
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             ArgumentException exn = Assert.Throws<ArgumentException>(() => writer.WriteTextString(invalidUnicodeString));
             Assert.NotNull(exn.InnerException);
             Assert.IsType<System.Text.EncoderFallbackException>(exn.InnerException);
@@ -119,7 +119,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(nameof(CborWriter.WriteStartMap))]
         public static void WriteTextString_IndefiniteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartTextString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
@@ -130,7 +130,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteTextString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartTextString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
@@ -147,7 +147,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteByteString_IndefiniteLength_NestedWrites_ShouldThrowInvalidOperationException(string opName)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartByteString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }
@@ -158,7 +158,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(nameof(CborWriter.WriteEndMap))]
         public static void WriteByteString_IndefiniteLength_ImbalancedWrites_ShouldThrowInvalidOperationException(string opName)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartByteString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -24,7 +24,7 @@ namespace System.Formats.Cbor.Tests
             byte[] input = hexInput.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteByteString(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -39,7 +39,7 @@ namespace System.Formats.Cbor.Tests
 
             var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteChunkedByteString(writer, chunkInputs);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -54,7 +54,7 @@ namespace System.Formats.Cbor.Tests
 
             var writer = new CborWriter();
             Helpers.WriteChunkedByteString(writer, chunkInputs);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -70,7 +70,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteTextString(input);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -83,7 +83,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter(encodeIndefiniteLengths: true);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -96,7 +96,7 @@ namespace System.Formats.Cbor.Tests
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter(encodeIndefiniteLengths: false);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.String.cs
@@ -36,7 +36,7 @@ namespace System.Formats.Cbor.Tests
             byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
 
-            var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: false);
             Helpers.WriteChunkedByteString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
@@ -51,7 +51,7 @@ namespace System.Formats.Cbor.Tests
             byte[][] chunkInputs = hexChunkInputs.Select(ch => ch.HexToByteArray()).ToArray();
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
 
-            var writer = new CborWriter();
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
             Helpers.WriteChunkedByteString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
@@ -80,7 +80,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTextString_IndefiniteLength_NoPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: false);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
@@ -93,7 +93,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTextString_IndefiniteLength_WithPatching_SingleValue_HappyPath(string[] chunkInputs, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            var writer = new CborWriter(encodeIndefiniteLengths: false);
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
             Helpers.WriteChunkedTextString(writer, chunkInputs);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
@@ -175,6 +175,24 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteStartByteString();
             Assert.Throws<InvalidOperationException>(() => Helpers.ExecOperation(writer, opName));
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        public static void WriteStartByteString_NoPatching_UnsupportedConformance_ShouldThrowInvalidOperationException(CborConformanceLevel conformanceLevel)
+        {
+            var writer = new CborWriter(conformanceLevel, convertIndefiniteLengthEncodings: false);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartByteString());
+        }
+
+        [Theory]
+        [InlineData(CborConformanceLevel.Canonical)]
+        [InlineData(CborConformanceLevel.Ctap2Canonical)]
+        public static void WriteStartTextString_NoPatching_UnsupportedConformance_ShouldThrowInvalidOperationException(CborConformanceLevel conformanceLevel)
+        {
+            var writer = new CborWriter(conformanceLevel, convertIndefiniteLengthEncodings: false);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteStartTextString());
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -200,7 +200,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         public static IEnumerable<object[]> SupportedConformanceTaggedValues =>
-            from l in new[] { CborConformanceLevel.Lax, CborConformanceLevel.Strict, CborConformanceLevel.Rfc7049Canonical }
+            from l in new[] { CborConformanceLevel.Lax, CborConformanceLevel.Strict, CborConformanceLevel.Canonical }
             from v in TaggedValues
             select new object[] { l, v };
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -32,7 +32,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteTag((CborTag)tag);
             Helpers.WriteValue(writer, value);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -50,7 +50,7 @@ namespace System.Formats.Cbor.Tests
                 writer.WriteTag((CborTag)tag);
             }
             Helpers.WriteValue(writer, value);
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace System.Formats.Cbor.Tests
                 writer.WriteTag((CborTag)tag);
             }
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => writer.GetEncoding());
+            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => writer.Encode());
 
             Assert.Equal("Buffer contains incomplete CBOR document.", exn.Message);
         }
@@ -90,7 +90,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteDateTimeOffset(value);
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteUnixTimeSeconds(value);
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -122,7 +122,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteUnixTimeSeconds(value);
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -155,7 +155,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteBigInteger(value);
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 
@@ -175,7 +175,7 @@ namespace System.Formats.Cbor.Tests
             decimal value = decimal.Parse(stringValue, Globalization.CultureInfo.InvariantCulture);
             var writer = new CborWriter();
             writer.WriteDecimal(value);
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -29,7 +29,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTag_SingleValue_HappyPath(ulong tag, object value, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteTag((CborTag)tag);
             Helpers.WriteValue(writer, value);
             AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
@@ -44,7 +44,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteTag_NestedTags_HappyPath(ulong[] tags, object value, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             foreach (ulong tag in tags)
             {
                 writer.WriteTag((CborTag)tag);
@@ -58,7 +58,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(new ulong[] { 1, 2, 3 })]
         public static void WriteTag_NoValue_ShouldThrowInvalidOperationException(ulong[] tags)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
 
             foreach (ulong tag in tags)
             {
@@ -73,7 +73,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void WriteTag_NoValueInNestedContext_ShouldThrowInvalidOperationException()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
 
             writer.WriteStartArray();
             writer.WriteTag(CborTag.Uri);
@@ -87,7 +87,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteDateTimeOffset_SingleValue_HappyPath(string valueString, string expectedHexEncoding)
         {
             DateTimeOffset value = DateTimeOffset.Parse(valueString);
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteDateTimeOffset(value);
 
             byte[] encoding = writer.GetEncoding();
@@ -102,7 +102,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(-315619200, "c13a12cff77f")]
         public static void WriteUnixTimeSeconds_Long_SingleValue_HappyPath(long value, string expectedHexEncoding)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteUnixTimeSeconds(value);
 
             byte[] encoding = writer.GetEncoding();
@@ -119,7 +119,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(15870467036.15, "c1fb420d8fa0dee13333")]
         public static void WriteUnixTimeSeconds_Double_SingleValue_HappyPath(double value, string expectedHexEncoding)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteUnixTimeSeconds(value);
 
             byte[] encoding = writer.GetEncoding();
@@ -132,7 +132,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(double.NegativeInfinity)]
         public static void WriteUnixTimeSeconds_Double_InvalidInput_ShouldThrowArgumentException(double value)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Throws<ArgumentException>(() => writer.WriteUnixTimeSeconds(value));
         }
 
@@ -152,7 +152,7 @@ namespace System.Formats.Cbor.Tests
         {
             BigInteger value = BigInteger.Parse(valueString);
 
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteBigInteger(value);
 
             byte[] encoding = writer.GetEncoding();
@@ -173,7 +173,7 @@ namespace System.Formats.Cbor.Tests
         public static void WriteDecimal_SingleValue_HappyPath(string stringValue, string expectedHexEncoding)
         {
             decimal value = decimal.Parse(stringValue, Globalization.CultureInfo.InvariantCulture);
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteDecimal(value);
             byte[] encoding = writer.GetEncoding();
             AssertHelper.HexEqual(expectedHexEncoding.HexToByteArray(), encoding);
@@ -183,7 +183,7 @@ namespace System.Formats.Cbor.Tests
         [MemberData(nameof(UnsupportedConformanceTaggedValues))]
         public static void WriteTaggedValue_UnsupportedConformance_ShouldThrowInvalidOperationException(CborConformanceLevel level, object value)
         {
-            using var writer = new CborWriter(level);
+            var writer = new CborWriter(level);
             Assert.Throws<InvalidOperationException>(() => Helpers.WriteValue(writer, value));
             Assert.Equal(0, writer.BytesWritten);
         }
@@ -197,7 +197,7 @@ namespace System.Formats.Cbor.Tests
         [MemberData(nameof(SupportedConformanceTaggedValues))]
         public static void WriteTaggedValue_SupportedConformance_ShouldSucceed(CborConformanceLevel level, object value)
         {
-            using var writer = new CborWriter(level);
+            var writer = new CborWriter(level);
             Helpers.WriteValue(writer, value);
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.Tag.cs
@@ -65,9 +65,7 @@ namespace System.Formats.Cbor.Tests
                 writer.WriteTag((CborTag)tag);
             }
 
-            InvalidOperationException exn = Assert.Throws<InvalidOperationException>(() => writer.Encode());
-
-            Assert.Equal("Buffer contains incomplete CBOR document.", exn.Message);
+            Assert.Throws<InvalidOperationException>(() => writer.Encode());
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -114,7 +114,7 @@ namespace System.Formats.Cbor.Tests
             Assert.Equal(11, writer.Depth);
             Assert.True(writer.BytesWritten > 11, "must have written a nontrivial number of bytes to the buffer");
 
-            writer.Reset(clearBuffer: true);
+            writer.Reset();
 
             Assert.Equal(0, writer.Depth);
             Assert.Equal(0, writer.BytesWritten);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -289,7 +289,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Theory]
-        [InlineData(CborConformanceLevel.Rfc7049Canonical)]
+        [InlineData(CborConformanceLevel.Canonical)]
         [InlineData(CborConformanceLevel.Ctap2Canonical)]
         public static void EncodeIndefiniteLengths_UnsupportedConformanceLevel_ShouldThrowArgumentException(CborConformanceLevel level)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -111,12 +111,12 @@ namespace System.Formats.Cbor.Tests
 
             // End set up
 
-            Assert.Equal(11, writer.Depth);
+            Assert.Equal(11, writer.CurrentDepth);
             Assert.True(writer.BytesWritten > 11, "must have written a nontrivial number of bytes to the buffer");
 
             writer.Reset();
 
-            Assert.Equal(0, writer.Depth);
+            Assert.Equal(0, writer.CurrentDepth);
             Assert.Equal(0, writer.BytesWritten);
 
             // Write an object from scratch and validate that it is correct

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -17,7 +17,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void IsWriteCompleted_OnWrittenPrimitive_ShouldBeTrue()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.False(writer.IsWriteCompleted);
             writer.WriteInt64(42);
             Assert.True(writer.IsWriteCompleted);
@@ -26,14 +26,14 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void GetEncoding_OnInCompleteValue_ShouldThrowInvalidOperationExceptoin()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Throws<InvalidOperationException>(() => writer.GetEncoding());
         }
 
         [Fact]
         public static void CborWriter_WritingTwoPrimitiveValues_ShouldThrowInvalidOperationException()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteInt64(42);
             int bytesWritten = writer.BytesWritten;
             Assert.Throws<InvalidOperationException>(() => writer.WriteTextString("lorem ipsum"));
@@ -47,7 +47,7 @@ namespace System.Formats.Cbor.Tests
         public static void CborWriter_MultipleRootLevelValuesAllowed_WritingMultipleRootValues_HappyPath(object value, int repetitions, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
-            using var writer = new CborWriter(allowMultipleRootLevelValues: true);
+            var writer = new CborWriter(allowMultipleRootLevelValues: true);
 
             for (int i = 0; i < repetitions; i++)
             {
@@ -60,7 +60,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void GetEncoding_MultipleRootLevelValuesAllowed_PartialRootValue_ShouldThrowInvalidOperationException()
         {
-            using var writer = new CborWriter(allowMultipleRootLevelValues: true);
+            var writer = new CborWriter(allowMultipleRootLevelValues: true);
 
             writer.WriteStartArray(1);
             writer.WriteDouble(3.14);
@@ -75,7 +75,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void BytesWritten_SingleValue_ShouldReturnBytesWritten()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Equal(0, writer.BytesWritten);
             writer.WriteTextString("test");
             Assert.Equal(5, writer.BytesWritten);
@@ -84,7 +84,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void ConformanceLevel_DefaultValue_ShouldEqualLax()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Equal(CborConformanceLevel.Lax, writer.ConformanceLevel);
         }
 
@@ -94,7 +94,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] encodedValue = hexEncodedValue.HexToByteArray();
 
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteEncodedValue(encodedValue);
 
             string hexResult = writer.GetEncoding().ByteArrayToHex();
@@ -108,7 +108,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(new object[] { new object[] { 1, 2, 3 } })]
         public static void TryWriteEncoding_HappyPath(object value)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
 
             byte[] encoding = writer.GetEncoding();
@@ -127,7 +127,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(new object[] { new object[] { 1, 2, 3 } })]
         public static void TryWriteEncoding_DestinationTooSmall_ShouldReturnFalse(object value)
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
 
             byte[] encoding = writer.GetEncoding();
@@ -146,7 +146,7 @@ namespace System.Formats.Cbor.Tests
         {
             byte[] encodedValue = hexEncodedValue.HexToByteArray();
 
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartArray(3);
             writer.WriteInt64(1);
             writer.WriteEncodedValue(encodedValue);
@@ -169,7 +169,7 @@ namespace System.Formats.Cbor.Tests
 
         public static void WriteEncodedValue_ContextScenaria_HappyPath(object value, bool useDefiniteLength, string hexExpectedEncoding)
         {
-            using var writer = new CborWriter(encodeIndefiniteLengths: !useDefiniteLength);
+            var writer = new CborWriter(encodeIndefiniteLengths: !useDefiniteLength);
 
             Helpers.WriteValue(writer, value, useDefiniteLengthCollections: useDefiniteLength);
 
@@ -180,7 +180,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void WriteEncodedValue_IndefiniteLengthTextString_HappyPath()
         {
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
 
             writer.WriteStartTextString();
             writer.WriteTextString("foo");
@@ -194,7 +194,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void WriteEncodedValue_IndefiniteLengthByteString_HappyPath()
         {
-            using var writer = new CborWriter(encodeIndefiniteLengths: true);
+            var writer = new CborWriter(encodeIndefiniteLengths: true);
 
             writer.WriteStartByteString();
             writer.WriteByteString(new byte[] { 1, 1, 1 });
@@ -208,7 +208,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void WriteEncodedValue_BadIndefiniteLengthStringValue_ShouldThrowInvalidOperationException()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteStartTextString();
             Assert.Throws<InvalidOperationException>(() => writer.WriteEncodedValue(new byte[] { 0x01 }));
         }
@@ -216,7 +216,7 @@ namespace System.Formats.Cbor.Tests
         [Fact]
         public static void WriteEncodedValue_AtEndOfDefiniteLengthCollection_ShouldThrowInvalidOperationException()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             writer.WriteInt64(0);
             Assert.Throws<InvalidOperationException>(() => writer.WriteEncodedValue(new byte[] { 0x01 }));
         }
@@ -226,14 +226,14 @@ namespace System.Formats.Cbor.Tests
         public static void WriteEncodedValue_InvalidCbor_ShouldThrowArgumentException(string hexEncodedInput)
         {
             byte[] encodedInput = hexEncodedInput.HexToByteArray();
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Throws<ArgumentException>(() => writer.WriteEncodedValue(encodedInput));
         }
 
         [Fact]
         public static void WriteEncodedValue_ValidPayloadWithTrailingBytes_ShouldThrowArgumentException()
         {
-            using var writer = new CborWriter();
+            var writer = new CborWriter();
             Assert.Throws<ArgumentException>(() => writer.WriteEncodedValue(new byte[] { 0x01, 0x01 }));
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -281,6 +281,17 @@ namespace System.Formats.Cbor.Tests
             Assert.Throws<ArgumentException>(() => writer.WriteEncodedValue(encodedInput));
         }
 
+        [Theory]
+        [InlineData(CborConformanceLevel.Strict, "a201010101")] // duplicate key encodings
+        [InlineData(CborConformanceLevel.Canonical, "9f01ff")]  // indefinite-length array
+        [InlineData(CborConformanceLevel.Ctap2Canonical, "a280800101")]  // unsorted key encodings
+        public static void WriteEncodedValue_InvalidConformance_ShouldThrowArgumentException(CborConformanceLevel conformanceLevel, string hexEncodedInput)
+        {
+            byte[] encodedInput = hexEncodedInput.HexToByteArray();
+            var writer = new CborWriter(conformanceLevel);
+            Assert.Throws<ArgumentException>(() => writer.WriteEncodedValue(encodedInput));
+        }
+
         [Fact]
         public static void WriteEncodedValue_ValidPayloadWithTrailingBytes_ShouldThrowArgumentException()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -27,7 +27,7 @@ namespace System.Formats.Cbor.Tests
         public static void GetEncoding_OnInCompleteValue_ShouldThrowInvalidOperationExceptoin()
         {
             var writer = new CborWriter();
-            Assert.Throws<InvalidOperationException>(() => writer.GetEncoding());
+            Assert.Throws<InvalidOperationException>(() => writer.Encode());
         }
 
         [Fact]
@@ -54,7 +54,7 @@ namespace System.Formats.Cbor.Tests
                 Helpers.WriteValue(writer, value);
             }
 
-            AssertHelper.HexEqual(expectedEncoding, writer.GetEncoding());
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace System.Formats.Cbor.Tests
             writer.WriteDouble(3.14);
             // misses writer.WriteEndArray();
 
-            Assert.Throws<InvalidOperationException>(() => writer.GetEncoding());
+            Assert.Throws<InvalidOperationException>(() => writer.Encode());
         }
 
         [Fact]
@@ -97,7 +97,7 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             writer.WriteEncodedValue(encodedValue);
 
-            string hexResult = writer.GetEncoding().ByteArrayToHex();
+            string hexResult = writer.Encode().ByteArrayToHex();
             Assert.Equal(hexEncodedValue, hexResult.ToLower());
         }
 
@@ -111,10 +111,10 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             byte[] target = new byte[encoding.Length];
 
-            bool result = writer.TryWriteEncoding(target, out int bytesWritten);
+            bool result = writer.TryEncode(target, out int bytesWritten);
 
             Assert.True(result);
             Assert.Equal(encoding.Length, bytesWritten);
@@ -130,10 +130,10 @@ namespace System.Formats.Cbor.Tests
             var writer = new CborWriter();
             Helpers.WriteValue(writer, value);
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             byte[] target = new byte[encoding.Length - 1];
 
-            bool result = writer.TryWriteEncoding(target, out int bytesWritten);
+            bool result = writer.TryEncode(target, out int bytesWritten);
 
             Assert.False(result);
             Assert.Equal(0, bytesWritten);
@@ -153,7 +153,7 @@ namespace System.Formats.Cbor.Tests
             writer.WriteTextString("");
             writer.WriteEndArray();
 
-            string hexResult = writer.GetEncoding().ByteArrayToHex();
+            string hexResult = writer.Encode().ByteArrayToHex();
             Assert.Equal("8301" + hexEncodedValue + "60", hexResult.ToLower());
         }
 
@@ -173,7 +173,7 @@ namespace System.Formats.Cbor.Tests
 
             Helpers.WriteValue(writer, value, useDefiniteLengthCollections: useDefiniteLength);
 
-            string hexEncoding = writer.GetEncoding().ByteArrayToHex().ToLower();
+            string hexEncoding = writer.Encode().ByteArrayToHex().ToLower();
             Assert.Equal(hexExpectedEncoding, hexEncoding);
         }
 
@@ -187,7 +187,7 @@ namespace System.Formats.Cbor.Tests
             writer.WriteEncodedValue("63626172".HexToByteArray());
             writer.WriteEndTextString();
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             Assert.Equal("7f63666f6f63626172ff", encoding.ByteArrayToHex().ToLower());
         }
 
@@ -201,7 +201,7 @@ namespace System.Formats.Cbor.Tests
             writer.WriteEncodedValue("43020202".HexToByteArray());
             writer.WriteEndByteString();
 
-            byte[] encoding = writer.GetEncoding();
+            byte[] encoding = writer.Encode();
             Assert.Equal("5f4301010143020202ff", encoding.ByteArrayToHex().ToLower());
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
@@ -155,7 +155,7 @@ namespace System.Formats.Cbor.Tests
                 if (TryReadCoseKeyLabel(CoseKeyLabel.KeyOps))
                 {
                     // No-op, simply tolerate potential key_ops labels
-                    reader.SkipValue(validateConformance: true);
+                    reader.SkipValue();
                 }
 
                 ReadCoseKeyLabel(CoseKeyLabel.EcCrv);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
@@ -16,9 +16,9 @@ namespace System.Formats.Cbor.Tests
         public static byte[] ExportECDsaPublicKey(ECDsa ecDsa, HashAlgorithmName? hashAlgName)
         {
             ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
-            using var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
+            var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
             WriteECParametersAsCosePublicKey(writer, ecParams, hashAlgName);
-            return writer.GetEncoding();
+            return writer.Encode();
         }
 
         public static (ECDsa ecDsa, HashAlgorithmName? hashAlgName) ParseECDsaPublicKey(byte[] coseKey)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CoseKeyHelpers.cs
@@ -16,7 +16,7 @@ namespace System.Formats.Cbor.Tests
         public static byte[] ExportECDsaPublicKey(ECDsa ecDsa, HashAlgorithmName? hashAlgName)
         {
             ECParameters ecParams = ecDsa.ExportParameters(includePrivateParameters: false);
-            var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical);
+            var writer = new CborWriter(CborConformanceLevel.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
             WriteECParametersAsCosePublicKey(writer, ecParams, hashAlgName);
             return writer.Encode();
         }
@@ -30,7 +30,7 @@ namespace System.Formats.Cbor.Tests
 
         private static void WriteECParametersAsCosePublicKey(CborWriter writer, ECParameters ecParams, HashAlgorithmName? algorithmName)
         {
-            Debug.Assert(writer.ConformanceLevel == CborConformanceLevel.Ctap2Canonical);
+            Debug.Assert(writer.ConformanceLevel == CborConformanceLevel.Ctap2Canonical && writer.ConvertIndefiniteLengthEncodings);
 
             if (ecParams.Q.X is null || ecParams.Q.Y is null)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -25,7 +25,7 @@ namespace System.Formats.Cbor
             }
         }
 
-        public static bool RequiresMinimalIntegerRepresentation(CborConformanceLevel conformanceLevel)
+        public static bool RequiresCanonicalIntegerRepresentation(CborConformanceLevel conformanceLevel)
         {
             switch (conformanceLevel)
             {
@@ -158,7 +158,7 @@ namespace System.Formats.Cbor
 
                 default:
                     Debug.Fail("Invalid conformance level used in encoding sort.");
-                    throw new Exception("Invalid conformance level used in encoding sort.");
+                    throw new Exception();
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Text;
 
 namespace System.Formats.Cbor
 {
@@ -53,6 +54,9 @@ namespace System.Formats.Cbor
 
     internal static class CborConformanceLevelHelpers
     {
+        private static readonly UTF8Encoding s_utf8EncodingLax    = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
+        private static readonly UTF8Encoding s_utf8EncodingStrict = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
         public static void Validate(CborConformanceLevel conformanceLevel)
         {
             if (conformanceLevel < CborConformanceLevel.Lax ||
@@ -77,6 +81,28 @@ namespace System.Formats.Cbor
                 default:
                     throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
             };
+        }
+
+        public static bool RequiresUtf8Validation(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                    return false;
+
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            };
+        }
+
+        public static Encoding GetUtf8Encoding(CborConformanceLevel conformanceLevel)
+        {
+            return conformanceLevel == CborConformanceLevel.Lax ? s_utf8EncodingLax : s_utf8EncodingStrict;
         }
 
         public static bool RequiresDefiniteLengthItems(CborConformanceLevel conformanceLevel)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -6,12 +6,49 @@ using System.Diagnostics;
 
 namespace System.Formats.Cbor
 {
+    /// <summary>
+    ///   Defines supported conformance levels for encoding and decoding CBOR data.
+    /// </summary>
     public enum CborConformanceLevel
     {
-        Lax = 0,
-        Strict = 1,
-        Rfc7049Canonical = 2,
-        Ctap2Canonical = 3,
+        /// <summary>
+        ///   Ensures that the CBOR data is well-formed, as specified in RFC7049.
+        /// </summary>
+        Lax,
+
+        /// <summary>
+        ///   Ensures that the CBOR data adheres to strict mode, as specified in RFC7049 section 3.10.
+        ///   Extends lax conformance with the following requirements:
+        ///   <list type="bullet">
+        ///   <item>Maps (major type 5) must not contain duplicate keys.</item>
+        ///   <item>UTF-8 string encodings must be valid.</item>
+        ///   </list>
+        /// </summary>
+        Strict,
+
+        /// <summary>
+        ///   Ensures that the CBOR data is canonical, as specified in RFC7049 section 3.9.
+        ///   Extends strict conformance with the following requirements:
+        ///   <list type="bullet">
+        ///   <item>Integers must be encoded as small as possible.</item>
+        ///   <item>Maps (major type 5) must contain keys sorted by encoding.</item>
+        ///   <item>Indefinite-length items must be made into definite-length items.</item>
+        ///   </list>
+        /// </summary>
+        Canonical,
+
+        /// <summary>
+        ///   Ensures that the CBOR data is canonical, as specified by the CTAP v2.0 standard, section 6.
+        ///   Extends strict conformance with the following requirements:
+        ///   <list type="bullet">
+        ///   <item>Maps (major type 5) must contain keys sorted by encoding.</item>
+        ///   <item>Indefinite-length items must be made into definite-length items.</item>
+        ///   <item>Integers must be encoded as small as possible.</item>
+        ///   <item>The representations of any floating-point values are not changed.</item>
+        ///   <item>CBOR tags are not permitted.</item>
+        ///   </list>
+        /// </summary>
+        Ctap2Canonical,
     }
 
     internal static class CborConformanceLevelHelpers
@@ -33,7 +70,7 @@ namespace System.Formats.Cbor
                 case CborConformanceLevel.Strict:
                     return false;
 
-                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Canonical:
                 case CborConformanceLevel.Ctap2Canonical:
                     return true;
 
@@ -50,7 +87,7 @@ namespace System.Formats.Cbor
                 case CborConformanceLevel.Strict:
                     return false;
 
-                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Canonical:
                 case CborConformanceLevel.Ctap2Canonical:
                     return true;
 
@@ -65,7 +102,7 @@ namespace System.Formats.Cbor
             {
                 case CborConformanceLevel.Lax:
                 case CborConformanceLevel.Strict:
-                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Canonical:
                     return true;
 
                 case CborConformanceLevel.Ctap2Canonical:
@@ -84,7 +121,7 @@ namespace System.Formats.Cbor
                     return false;
 
                 case CborConformanceLevel.Strict:
-                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Canonical:
                 case CborConformanceLevel.Ctap2Canonical:
                     return true;
 
@@ -101,7 +138,7 @@ namespace System.Formats.Cbor
                 case CborConformanceLevel.Lax:
                     return false;
 
-                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Canonical:
                 case CborConformanceLevel.Ctap2Canonical:
                     return true;
 
@@ -126,7 +163,7 @@ namespace System.Formats.Cbor
 
             switch (level)
             {
-                case CborConformanceLevel.Rfc7049Canonical:
+                case CborConformanceLevel.Canonical:
                     // Implements key sorting according to
                     // https://tools.ietf.org/html/rfc7049#section-3.9
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -22,6 +22,7 @@ namespace System.Formats.Cbor
         ///   Extends lax conformance with the following requirements:
         ///   <list type="bullet">
         ///   <item>Maps (major type 5) must not contain duplicate keys.</item>
+        ///   <item>Simple values (major type 7) be encoded as small a possible and exclude the reserved values 24-31.</item>
         ///   <item>UTF-8 string encodings must be valid.</item>
         ///   </list>
         /// </summary>
@@ -171,6 +172,23 @@ namespace System.Formats.Cbor
                 default:
                     throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
             };
+        }
+
+        public static bool RequireCanonicalSimpleValueEncodings(CborConformanceLevel conformanceLevel)
+        {
+            switch (conformanceLevel)
+            {
+                case CborConformanceLevel.Lax:
+                    return false;
+
+                case CborConformanceLevel.Strict:
+                case CborConformanceLevel.Canonical:
+                case CborConformanceLevel.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceLevel));
+            }
         }
 
         public static int GetKeyEncodingHashCode(ReadOnlySpan<byte> encoding)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -22,7 +22,7 @@ namespace System.Formats.Cbor
         ///   Extends lax conformance with the following requirements:
         ///   <list type="bullet">
         ///   <item>Maps (major type 5) must not contain duplicate keys.</item>
-        ///   <item>Simple values (major type 7) be encoded as small a possible and exclude the reserved values 24-31.</item>
+        ///   <item>Simple values (major type 7) must be encoded as small a possible and exclude the reserved values 24-31.</item>
         ///   <item>UTF-8 string encodings must be valid.</item>
         ///   </list>
         /// </summary>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborConformanceLevel.cs
@@ -47,7 +47,7 @@ namespace System.Formats.Cbor
         ///   <item>Indefinite-length items must be made into definite-length items.</item>
         ///   <item>Integers must be encoded as small as possible.</item>
         ///   <item>The representations of any floating-point values are not changed.</item>
-        ///   <item>CBOR tags are not permitted.</item>
+        ///   <item>CBOR tags (major type 6) are not permitted.</item>
         ///   </list>
         /// </summary>
         Ctap2Canonical,

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborInitialByte.cs
@@ -6,6 +6,9 @@ using System.Diagnostics;
 
 namespace System.Formats.Cbor
 {
+    /// <summary>
+    ///   Represents CBOR Major Types, as defined in RFC7049 section 2.1.
+    /// </summary>
     internal enum CborMajorType : byte
     {
         UnsignedInteger = 0,
@@ -18,12 +21,11 @@ namespace System.Formats.Cbor
         Simple = 7,
     }
 
+    /// <summary>
+    ///   Represents the 5-bit additional information included in a CBOR initial byte.
+    /// </summary>
     internal enum CborAdditionalInfo : byte
     {
-        SimpleValueFalse = 20,
-        SimpleValueTrue = 21,
-        SimpleValueNull = 22,
-
         Additional8BitData = 24,
         Additional16BitData = 25,
         Additional32BitData = 26,
@@ -31,15 +33,17 @@ namespace System.Formats.Cbor
         IndefiniteLength = 31,
     }
 
-    /// Represents the Cbor Data item initial byte structure
+    /// <summary>
+    ///   Represents a CBOR initial byte
+    /// </summary>
     internal readonly struct CborInitialByte
     {
         public const byte IndefiniteLengthBreakByte = 0xff;
-        private const byte AdditionalInformationMask = 0b000_11111;
+        public const byte AdditionalInformationMask = 0b000_11111;
 
         public byte InitialByte { get; }
 
-        internal CborInitialByte(CborMajorType majorType, CborAdditionalInfo additionalInfo)
+        public CborInitialByte(CborMajorType majorType, CborAdditionalInfo additionalInfo)
         {
             Debug.Assert((byte)majorType < 8, "CBOR Major Type is out of range");
             Debug.Assert((byte)additionalInfo < 32, "CBOR initial byte additional info is out of range");
@@ -47,7 +51,7 @@ namespace System.Formats.Cbor
             InitialByte = (byte)(((byte)majorType << 5) | (byte)additionalInfo);
         }
 
-        internal CborInitialByte(byte initialByte)
+        public CborInitialByte(byte initialByte)
         {
             InitialByte = initialByte;
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -16,7 +16,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -26,9 +26,9 @@ namespace System.Formats.Cbor
             else
             {
                 ReadOnlySpan<byte> buffer = GetRemainingBytes();
-                int arrayLength = DecodeDefiniteLength(header, buffer, out int additionalBytes);
+                int arrayLength = DecodeDefiniteLength(header, buffer, out int bytesRead);
 
-                AdvanceBuffer(1 + additionalBytes);
+                AdvanceBuffer(bytesRead);
                 PushDataItem(CborMajorType.Array, (int)arrayLength);
                 return (int)arrayLength;
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -26,12 +26,7 @@ namespace System.Formats.Cbor
             else
             {
                 ReadOnlySpan<byte> buffer = GetRemainingBytes();
-                ulong arrayLength = ReadUnsignedInteger(buffer, header, out int additionalBytes);
-
-                if (arrayLength > (ulong)buffer.Length)
-                {
-                    throw new FormatException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
-                }
+                int arrayLength = DecodeDefiniteLength(header, buffer, out int additionalBytes);
 
                 AdvanceBuffer(1 + additionalBytes);
                 PushDataItem(CborMajorType.Array, (int)arrayLength);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -8,6 +8,20 @@ namespace System.Formats.Cbor
 {
     public partial class CborReader
     {
+        /// <summary>
+        ///   Reads the next data item as the start of an array (major type 4)
+        /// </summary>
+        /// <returns>
+        ///   The length of the definite-length array, or <c>null</c> if the array is indefinite-length.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
         public int? ReadStartArray()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Array);
@@ -29,11 +43,22 @@ namespace System.Formats.Cbor
                 int arrayLength = DecodeDefiniteLength(header, buffer, out int bytesRead);
 
                 AdvanceBuffer(bytesRead);
-                PushDataItem(CborMajorType.Array, (int)arrayLength);
-                return (int)arrayLength;
+                PushDataItem(CborMajorType.Array, arrayLength);
+                return arrayLength;
             }
         }
 
+        /// <summary>
+        ///   Reads the end of an array (major type 4)
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///   the current context is not an array --OR--
+        ///   the reader is not at the end of the array
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data
+        /// </exception>
         public void ReadEndArray()
         {
             if (_definiteLength is null)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -16,7 +16,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items are not supported under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 AdvanceBuffer(1);
@@ -29,7 +29,7 @@ namespace System.Formats.Cbor
 
                 if (arrayLength > (ulong)_buffer.Length)
                 {
-                    throw new FormatException("Insufficient buffer size for declared definite length in CBOR data item.");
+                    throw new FormatException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
                 }
 
                 AdvanceBuffer(1 + additionalBytes);
@@ -42,13 +42,7 @@ namespace System.Formats.Cbor
         {
             if (_remainingDataItems == null)
             {
-                CborInitialByte value = PeekInitialByte();
-
-                if (value.InitialByte != CborInitialByte.IndefiniteLengthBreakByte)
-                {
-                    throw new InvalidOperationException("Not at end of indefinite-length array.");
-                }
-
+                ValidateNextByteIsBreakByte();
                 PopDataItem(expectedType: CborMajorType.Array);
                 AdvanceDataItemCounters();
                 AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -25,9 +25,10 @@ namespace System.Formats.Cbor
             }
             else
             {
-                ulong arrayLength = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
+                ReadOnlySpan<byte> buffer = GetRemainingBytes();
+                ulong arrayLength = ReadUnsignedInteger(buffer, header, out int additionalBytes);
 
-                if (arrayLength > (ulong)_buffer.Length)
+                if (arrayLength > (ulong)buffer.Length)
                 {
                     throw new FormatException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -41,7 +41,7 @@ namespace System.Formats.Cbor
 
         public void ReadEndArray()
         {
-            if (_remainingDataItems == null)
+            if (_definiteLength is null)
             {
                 ValidateNextByteIsBreakByte();
                 PopDataItem(expectedType: CborMajorType.Array);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Array.cs
@@ -9,18 +9,18 @@ namespace System.Formats.Cbor
     public partial class CborReader
     {
         /// <summary>
-        ///   Reads the next data item as the start of an array (major type 4)
+        ///   Reads the next data item as the start of an array (major type 4).
         /// </summary>
         /// <returns>
-        ///   The length of the definite-length array, or <c>null</c> if the array is indefinite-length.
+        ///   The length of the definite-length array, or <see langword="null" /> if the array is indefinite-length.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public int? ReadStartArray()
         {
@@ -49,15 +49,15 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the end of an array (major type 4)
+        ///   Reads the end of an array (major type 4).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not an array --OR--
-        ///   the reader is not at the end of the array
+        ///   the current context is not an array. -or-
+        ///   the reader is not at the end of the array.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data
         /// </exception>
         public void ReadEndArray()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -22,9 +22,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="int"/>
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the integer encoding is not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public int ReadInt32()
         {
@@ -45,9 +45,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="uint"/>
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the integer encoding is not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public uint ReadUInt32()
         {
@@ -68,9 +68,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="long"/>
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the integer encoding is not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public long ReadInt64()
         {
@@ -91,9 +91,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="ulong"/>
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the integer encoding is not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public ulong ReadUInt64()
         {
@@ -116,9 +116,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="uint"/>
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the integer encoding is not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         /// <remarks>
         ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding primitive sizes.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -68,7 +68,7 @@ namespace System.Formats.Cbor
                     throw new OverflowException();
 
                 default:
-                    throw new InvalidOperationException("Data item major type mismatch.");
+                    throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, header.MajorType));
             }
         }
 
@@ -88,7 +88,7 @@ namespace System.Formats.Cbor
                     return value;
 
                 default:
-                    throw new InvalidOperationException("Data item major type mismatch.");
+                    throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, header.MajorType));
             }
         }
 
@@ -152,14 +152,14 @@ namespace System.Formats.Cbor
                     return result;
 
                 default:
-                    throw new FormatException("initial byte contains invalid integer encoding data.");
+                    throw new FormatException(SR.Cbor_Reader_InvalidCbor_InvalidIntegerEncoding);
             }
 
             void ValidateIsNonStandardIntegerRepresentationSupported()
             {
-                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresMinimalIntegerRepresentation(ConformanceLevel))
+                if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresCanonicalIntegerRepresentation(ConformanceLevel))
                 {
-                    throw new FormatException("Non-minimal integer representations are not permitted under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_NonCanonicalIntegerRepresentation, ConformanceLevel));
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers.Binary;
-using System.Xml;
 
 namespace System.Formats.Cbor
 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -11,22 +11,21 @@ namespace System.Formats.Cbor
     {
         // Implements major type 0,1 decoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
-        public long ReadInt64()
-        {
-            long value = PeekSignedInteger(out int additionalBytes);
-            AdvanceBuffer(1 + additionalBytes);
-            AdvanceDataItemCounters();
-            return value;
-        }
-
-        public ulong ReadUInt64()
-        {
-            ulong value = PeekUnsignedInteger(out int additionalBytes);
-            AdvanceBuffer(1 + additionalBytes);
-            AdvanceDataItemCounters();
-            return value;
-        }
-
+        /// <summary>
+        ///   Reads the next data item as a signed integer (major types 0,1)
+        /// </summary>
+        /// <returns>The decoded integer value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next value does have the correct major type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        ///   the encoded integer is out of range for <see cref="int"/>
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        /// </exception>
         public int ReadInt32()
         {
             int value = checked((int)PeekSignedInteger(out int additionalBytes));
@@ -35,6 +34,21 @@ namespace System.Formats.Cbor
             return value;
         }
 
+        /// <summary>
+        ///   Reads the next data item as an usigned integer (major type 0)
+        /// </summary>
+        /// <returns>The decoded integer value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next value does have the correct major type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        ///   the encoded integer is out of range for <see cref="uint"/>
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        /// </exception>
         public uint ReadUInt32()
         {
             uint value = checked((uint)PeekUnsignedInteger(out int additionalBytes));
@@ -43,8 +57,72 @@ namespace System.Formats.Cbor
             return value;
         }
 
-        // Returns the next CBOR negative integer encoding according to
-        // https://tools.ietf.org/html/rfc7049#section-2.1
+        /// <summary>
+        ///   Reads the next data item as a signed integer (major types 0,1)
+        /// </summary>
+        /// <returns>The decoded integer value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next value does have the correct major type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        ///   the encoded integer is out of range for <see cref="long"/>
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        /// </exception>
+        public long ReadInt64()
+        {
+            long value = PeekSignedInteger(out int additionalBytes);
+            AdvanceBuffer(1 + additionalBytes);
+            AdvanceDataItemCounters();
+            return value;
+        }
+
+        /// <summary>
+        ///   Reads the next data item as an usigned integer (major type 0)
+        /// </summary>
+        /// <returns>The decoded integer value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next value does have the correct major type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        ///   the encoded integer is out of range for <see cref="ulong"/>
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        /// </exception>
+        public ulong ReadUInt64()
+        {
+            ulong value = PeekUnsignedInteger(out int additionalBytes);
+            AdvanceBuffer(1 + additionalBytes);
+            AdvanceDataItemCounters();
+            return value;
+        }
+
+        /// <summary>
+        ///   Reads the next data item as a CBOR negative integer encoding (major type 1).
+        /// </summary>
+        /// <returns>
+        ///   An unsigned integer denoting -1 minus the integer.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next value does have the correct major type.
+        /// </exception>
+        /// <exception cref="OverflowException">
+        ///   the encoded integer is out of range for <see cref="uint"/>
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        /// </exception>
+        /// <remarks>
+        ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding primitive sizes.
+        /// </remarks>
         public ulong ReadCborNegativeIntegerEncoding()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.NegativeInteger);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -48,7 +48,7 @@ namespace System.Formats.Cbor
         public ulong ReadCborNegativeIntegerEncoding()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.NegativeInteger);
-            ulong value = ReadUnsignedInteger(_buffer.Span, header, out int additionalBytes);
+            ulong value = ReadUnsignedInteger(GetRemainingBytes(), header, out int additionalBytes);
             AdvanceBuffer(1 + additionalBytes);
             AdvanceDataItemCounters();
             return value;
@@ -61,7 +61,7 @@ namespace System.Formats.Cbor
             switch (header.MajorType)
             {
                 case CborMajorType.UnsignedInteger:
-                    ulong value = ReadUnsignedInteger(_buffer.Span, header, out additionalBytes);
+                    ulong value = ReadUnsignedInteger(GetRemainingBytes(), header, out additionalBytes);
                     return value;
 
                 case CborMajorType.NegativeInteger:
@@ -80,11 +80,11 @@ namespace System.Formats.Cbor
             switch (header.MajorType)
             {
                 case CborMajorType.UnsignedInteger:
-                    value = checked((long)ReadUnsignedInteger(_buffer.Span, header, out additionalBytes));
+                    value = checked((long)ReadUnsignedInteger(GetRemainingBytes(), header, out additionalBytes));
                     return value;
 
                 case CborMajorType.NegativeInteger:
-                    value = checked(-1 - (long)ReadUnsignedInteger(_buffer.Span, header, out additionalBytes));
+                    value = checked(-1 - (long)ReadUnsignedInteger(GetRemainingBytes(), header, out additionalBytes));
                     return value;
 
                 default:
@@ -104,7 +104,7 @@ namespace System.Formats.Cbor
                     return (ulong)x;
 
                 case CborAdditionalInfo.Additional8BitData:
-                    EnsureBuffer(buffer, 2);
+                    EnsureReadCapacity(buffer, 2);
                     result = buffer[1];
 
                     if (result < (int)CborAdditionalInfo.Additional8BitData)
@@ -116,7 +116,7 @@ namespace System.Formats.Cbor
                     return result;
 
                 case CborAdditionalInfo.Additional16BitData:
-                    EnsureBuffer(buffer, 3);
+                    EnsureReadCapacity(buffer, 3);
                     result = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(1));
 
                     if (result <= byte.MaxValue)
@@ -128,7 +128,7 @@ namespace System.Formats.Cbor
                     return result;
 
                 case CborAdditionalInfo.Additional32BitData:
-                    EnsureBuffer(buffer, 5);
+                    EnsureReadCapacity(buffer, 5);
                     result = BinaryPrimitives.ReadUInt32BigEndian(buffer.Slice(1));
 
                     if (result <= ushort.MaxValue)
@@ -140,7 +140,7 @@ namespace System.Formats.Cbor
                     return result;
 
                 case CborAdditionalInfo.Additional64BitData:
-                    EnsureBuffer(buffer, 9);
+                    EnsureReadCapacity(buffer, 9);
                     result = BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(1));
 
                     if (result <= uint.MaxValue)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -159,7 +159,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresCanonicalIntegerRepresentation(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_NonCanonicalIntegerRepresentation, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_NonCanonicalIntegerRepresentation, ConformanceLevel));
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -21,9 +21,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="int"/>
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public int ReadInt32()
         {
@@ -34,7 +34,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as an usigned integer (major type 0)
+        ///   Reads the next data item as an usigned integer (major type 0).
         /// </summary>
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">
@@ -44,9 +44,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="uint"/>
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public uint ReadUInt32()
         {
@@ -67,9 +67,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="long"/>
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public long ReadInt64()
         {
@@ -80,7 +80,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as an usigned integer (major type 0)
+        ///   Reads the next data item as an usigned integer (major type 0).
         /// </summary>
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">
@@ -90,9 +90,9 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="ulong"/>
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public ulong ReadUInt64()
         {
@@ -115,12 +115,13 @@ namespace System.Formats.Cbor
         ///   the encoded integer is out of range for <see cref="uint"/>
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         /// <remarks>
-        ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding available primitive sizes.
+        ///   This method supports decoding integers between -18446744073709551616 and -1.
+        ///   Useful for handling values that do not fit in the <see cref="long"/> type.
         /// </remarks>
         public ulong ReadCborNegativeIntegerEncoding()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -120,7 +120,7 @@ namespace System.Formats.Cbor
         ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         /// <remarks>
-        ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding primitive sizes.
+        ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding available primitive sizes.
         /// </remarks>
         public ulong ReadCborNegativeIntegerEncoding()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -23,7 +23,7 @@ namespace System.Formats.Cbor
         /// </exception>
         /// <exception cref="FormatException">
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the integer encoding is not valid under the current conformance level --OR--
         ///   the data item is located in an illegal context (e.g. an indefinite-length string)
         /// </exception>
         public int ReadInt32()
@@ -46,7 +46,7 @@ namespace System.Formats.Cbor
         /// </exception>
         /// <exception cref="FormatException">
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the integer encoding is not valid under the current conformance level --OR--
         ///   the data item is located in an illegal context (e.g. an indefinite-length string)
         /// </exception>
         public uint ReadUInt32()
@@ -69,7 +69,7 @@ namespace System.Formats.Cbor
         /// </exception>
         /// <exception cref="FormatException">
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the integer encoding is not valid under the current conformance level --OR--
         ///   the data item is located in an illegal context (e.g. an indefinite-length string)
         /// </exception>
         public long ReadInt64()
@@ -92,7 +92,7 @@ namespace System.Formats.Cbor
         /// </exception>
         /// <exception cref="FormatException">
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the integer encoding is not valid under the current conformance level --OR--
         ///   the data item is located in an illegal context (e.g. an indefinite-length string)
         /// </exception>
         public ulong ReadUInt64()
@@ -117,7 +117,7 @@ namespace System.Formats.Cbor
         /// </exception>
         /// <exception cref="FormatException">
         ///   unexpected end of CBOR encoding data --OR--
-        ///   the length encoding is not valid under the current conformance level --OR--
+        ///   the integer encoding is not valid under the current conformance level --OR--
         ///   the data item is located in an illegal context (e.g. an indefinite-length string)
         /// </exception>
         /// <remarks>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -16,7 +16,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
         ///   the encoded integer is out of range for <see cref="int"/>
@@ -39,7 +39,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
         ///   the encoded integer is out of range for <see cref="uint"/>
@@ -62,7 +62,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
         ///   the encoded integer is out of range for <see cref="long"/>
@@ -85,7 +85,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded integer value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
         ///   the encoded integer is out of range for <see cref="ulong"/>
@@ -110,7 +110,7 @@ namespace System.Formats.Cbor
         ///   An unsigned integer denoting -1 minus the integer.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
         ///   the encoded integer is out of range for <see cref="uint"/>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -145,7 +145,7 @@ namespace System.Formats.Cbor
                     throw new OverflowException();
 
                 default:
-                    throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, header.MajorType));
+                    throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, (int)header.MajorType));
             }
         }
 
@@ -165,7 +165,7 @@ namespace System.Formats.Cbor
                     return value;
 
                 default:
-                    throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, header.MajorType));
+                    throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, (int)header.MajorType));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Integer.cs
@@ -18,7 +18,7 @@ namespace System.Formats.Cbor
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
-        ///   the encoded integer is out of range for <see cref="int"/>
+        ///   the encoded integer is out of range for <see cref="int"/>.
         /// </exception>
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
@@ -41,7 +41,7 @@ namespace System.Formats.Cbor
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
-        ///   the encoded integer is out of range for <see cref="uint"/>
+        ///   the encoded integer is out of range for <see cref="uint"/>.
         /// </exception>
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
@@ -64,7 +64,7 @@ namespace System.Formats.Cbor
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
-        ///   the encoded integer is out of range for <see cref="long"/>
+        ///   the encoded integer is out of range for <see cref="long"/>.
         /// </exception>
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
@@ -87,7 +87,7 @@ namespace System.Formats.Cbor
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="OverflowException">
-        ///   the encoded integer is out of range for <see cref="ulong"/>
+        ///   the encoded integer is out of range for <see cref="ulong"/>.
         /// </exception>
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -14,19 +14,28 @@ namespace System.Formats.Cbor
         private Stack<HashSet<(int Offset, int Length)>>? _pooledKeyEncodingRangeAllocations;
 
         /// <summary>
-        ///   Reads the next data item as the start of a map (major type 5)
+        ///   Reads the next data item as the start of a map (major type 5).
         /// </summary>
         /// <returns>
-        ///   The number of key-value pairs in a definite-length map, or <c>null</c> if the map is indefinite-length.
+        ///   The number of key-value pairs in a definite-length map, or <see langword="null" /> if the map is indefinite-length.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
+        /// <remarks>
+        ///   Map contents are consumed as if they were arrays twice the length of the map's declared size.
+        ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
+        ///   must be consumed by successive calls to <see cref="ReadInt32"/> and <see cref="ReadTextString"/>.
+        ///   It is up to the caller to keep track of whether the next value is a key or a value.
+        ///   
+        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
+        ///   for instance a map can contain keys that are maps themselves.
+        /// </remarks>
         public int? ReadStartMap()
         {
             int? length;
@@ -65,16 +74,16 @@ namespace System.Formats.Cbor
 
 
         /// <summary>
-        ///   Reads the end of a map (major type 5)
+        ///   Reads the end of a map (major type 5).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not a map --OR--
+        ///   the current context is not a map -or-
         ///   the reader is not at the end of the map
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public void ReadEndMap()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -24,7 +24,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_RequiresDefiniteLengthItems, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_RequiresDefiniteLengthItems, ConformanceLevel));
                 }
 
                 AdvanceBuffer(1);
@@ -121,12 +121,12 @@ namespace System.Formats.Cbor
                 if (cmp > 0)
                 {
                     ResetBuffer(currentKeyRange.Offset);
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_KeysNotInSortedOrder, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_KeysNotInSortedOrder, ConformanceLevel));
                 }
                 else if (cmp == 0 && CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
                 {
                     ResetBuffer(currentKeyRange.Offset);
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
                 }
             }
 
@@ -142,7 +142,7 @@ namespace System.Formats.Cbor
             if (!previousKeys.Add(currentKeyRange))
             {
                 ResetBuffer(currentKeyRange.Offset);
-                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
+                throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -24,7 +24,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_RequiresDefiniteLengthItems, ConformanceLevel));
                 }
 
                 AdvanceBuffer(1);
@@ -37,7 +37,7 @@ namespace System.Formats.Cbor
 
                 if (mapSize > int.MaxValue || 2 * mapSize > (ulong)_buffer.Length)
                 {
-                    throw new FormatException("Insufficient buffer size for declared definite length in CBOR data item.");
+                    throw new FormatException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
                 }
 
                 AdvanceBuffer(1 + additionalBytes);
@@ -54,16 +54,11 @@ namespace System.Formats.Cbor
         {
             if (_remainingDataItems == null)
             {
-                CborInitialByte value = PeekInitialByte();
-
-                if (value.InitialByte != CborInitialByte.IndefiniteLengthBreakByte)
-                {
-                    throw new InvalidOperationException("Not at end of indefinite-length map.");
-                }
+                ValidateNextByteIsBreakByte();
 
                 if (!_currentItemIsKey)
                 {
-                    throw new FormatException("CBOR map key is missing a value.");
+                    throw new FormatException(SR.Cbor_Reader_InvalidCbor_KeyMissingValue);
                 }
 
                 PopDataItem(expectedType: CborMajorType.Map);
@@ -126,12 +121,12 @@ namespace System.Formats.Cbor
                 if (cmp > 0)
                 {
                     ResetBuffer(currentKeyRange.Offset);
-                    throw new FormatException("CBOR map keys are not in sorted encoding order.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_KeysNotInSortedOrder, ConformanceLevel));
                 }
                 else if (cmp == 0 && CborConformanceLevelHelpers.RequiresUniqueKeys(ConformanceLevel))
                 {
                     ResetBuffer(currentKeyRange.Offset);
-                    throw new FormatException("CBOR map contains duplicate keys.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
                 }
             }
 
@@ -147,7 +142,7 @@ namespace System.Formats.Cbor
             if (!previousKeys.Add(currentKeyRange))
             {
                 ResetBuffer(currentKeyRange.Offset);
-                throw new FormatException("CBOR map contains duplicate keys.");
+                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -109,7 +109,7 @@ namespace System.Formats.Cbor
             {
                 (int Offset, int Length) previousKeyEncodingRange = _previousKeyEncodingRange.Value;
 
-                ReadOnlySpan<byte> buffer = _buffer.Span;
+                ReadOnlySpan<byte> buffer = _data.Span;
                 ReadOnlySpan<byte> previousKeyEncoding = buffer.Slice(previousKeyEncodingRange.Offset, previousKeyEncodingRange.Length);
                 ReadOnlySpan<byte> currentKeyEncoding = buffer.Slice(currentKeyEncodingRange.Offset, currentKeyEncodingRange.Length);
 
@@ -180,7 +180,7 @@ namespace System.Formats.Cbor
 
             private ReadOnlySpan<byte> GetKeyEncoding((int Offset, int Length) range)
             {
-                return _reader._buffer.Span.Slice(range.Offset, range.Length);
+                return _reader._data.Span.Slice(range.Offset, range.Length);
             }
 
             public int GetHashCode((int Offset, int Length) value)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -32,7 +32,7 @@ namespace System.Formats.Cbor
         ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
         ///   must be consumed by successive calls to <see cref="ReadInt32"/> and <see cref="ReadTextString"/>.
         ///   It is up to the caller to keep track of whether the next value is a key or a value.
-        ///   
+        ///
         ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
         ///   for instance a map can contain keys that are maps themselves.
         /// </remarks>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -33,15 +33,15 @@ namespace System.Formats.Cbor
             {
                 ReadOnlySpan<byte> buffer = GetRemainingBytes();
 
-                ulong mapSize = ReadUnsignedInteger(buffer, header, out int additionalBytes);
+                int mapSize = DecodeDefiniteLength(header, buffer, out int additionalBytes);
 
-                if (mapSize > int.MaxValue || 2 * mapSize > (ulong)buffer.Length)
+                if (2 * (ulong)mapSize > (ulong)(buffer.Length - additionalBytes))
                 {
                     throw new FormatException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
                 }
 
                 AdvanceBuffer(1 + additionalBytes);
-                PushDataItem(CborMajorType.Map, 2 * (int)mapSize);
+                PushDataItem(CborMajorType.Map, 2 * mapSize);
                 length = (int)mapSize;
             }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -33,14 +33,14 @@ namespace System.Formats.Cbor
             {
                 ReadOnlySpan<byte> buffer = GetRemainingBytes();
 
-                int mapSize = DecodeDefiniteLength(header, buffer, out int additionalBytes);
+                int mapSize = DecodeDefiniteLength(header, buffer, out int bytesRead);
 
-                if (2 * (ulong)mapSize > (ulong)(buffer.Length - additionalBytes))
+                if (2 * (ulong)mapSize > (ulong)(buffer.Length - bytesRead))
                 {
                     throw new FormatException(SR.Cbor_Reader_DefiniteLengthExceedsBufferSize);
                 }
 
-                AdvanceBuffer(1 + additionalBytes);
+                AdvanceBuffer(bytesRead);
                 PushDataItem(CborMajorType.Map, 2 * mapSize);
                 length = (int)mapSize;
             }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -17,7 +17,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as the start of a map (major type 5)
         /// </summary>
         /// <returns>
-        ///   The length of the definite-length map, or <c>null</c> if the array is indefinite-length.
+        ///   The number of key-value pairs in a definite-length map, or <c>null</c> if the map is indefinite-length.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Map.cs
@@ -77,7 +77,7 @@ namespace System.Formats.Cbor
         ///   Reads the end of a map (major type 5).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not a map -or-
+        ///   the current context is not a map. -or-
         ///   the reader is not at the end of the map
         /// </exception>
         /// <exception cref="FormatException">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Cbor
         /// <summary>
         ///   Reads the next data item as a single-precision floating point number (major type 7)
         /// </summary>
-        /// <returns>The decoded <see cref="float"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type --OR--
         ///   the next simple value is not a floating-point number encoding --OR--

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -31,10 +31,10 @@ namespace System.Formats.Cbor
                     return result;
 
                 case CborAdditionalInfo.Additional64BitData:
-                    throw new InvalidOperationException("Attempting to read double-precision floating point encoding as single-precision.");
+                    throw new InvalidOperationException(SR.Cbor_Reader_ReadingDoubleAsSingle);
 
                 default:
-                    throw new InvalidOperationException("CBOR data item does not encode a floating point number.");
+                    throw new InvalidOperationException(SR.Cbor_Reader_NotAFloatEncoding);
 
             }
         }
@@ -69,7 +69,7 @@ namespace System.Formats.Cbor
                     return result;
 
                 default:
-                    throw new InvalidOperationException("CBOR data item does not encode a floating point number.");
+                    throw new InvalidOperationException(SR.Cbor_Reader_NotAFloatEncoding);
             }
         }
 
@@ -81,7 +81,7 @@ namespace System.Formats.Cbor
             {
                 CborAdditionalInfo.SimpleValueFalse => false,
                 CborAdditionalInfo.SimpleValueTrue => true,
-                _ => throw new InvalidOperationException("CBOR data item does not encode a boolean value."),
+                _ => throw new InvalidOperationException(SR.Cbor_Reader_NotABooleanEncoding),
             };
 
             AdvanceBuffer(1);
@@ -100,7 +100,7 @@ namespace System.Formats.Cbor
                     AdvanceDataItemCounters();
                     return;
                 default:
-                    throw new InvalidOperationException("CBOR data item does not encode a null value.");
+                    throw new InvalidOperationException(SR.Cbor_Reader_NotANullEncoding);
             }
         }
 
@@ -120,14 +120,14 @@ namespace System.Formats.Cbor
 
                     if (value < 32)
                     {
-                        throw new FormatException("Two-byte CBOR simple value must be between 32 and 255.");
+                        throw new FormatException(SR.Cbor_Reader_InvalidCbor_InvalidSimpleValueEncoding);
                     }
 
                     AdvanceBuffer(2);
                     AdvanceDataItemCounters();
                     return (CborSimpleValue)value;
                 default:
-                    throw new InvalidOperationException("CBOR data item does not encode a simple value.");
+                    throw new InvalidOperationException(SR.Cbor_Reader_NotASimpleValueEncoding);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -11,20 +11,20 @@ namespace System.Formats.Cbor
         public float ReadSingle()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
-            ReadOnlySpan<byte> buffer = _buffer.Span;
+            ReadOnlySpan<byte> buffer = GetRemainingBytes();
             float result;
 
             switch (header.AdditionalInfo)
             {
                 case CborAdditionalInfo.Additional16BitData:
-                    EnsureBuffer(buffer, 3);
+                    EnsureReadCapacity(buffer, 3);
                     result = (float)ReadHalfBigEndian(buffer.Slice(1));
                     AdvanceBuffer(3);
                     AdvanceDataItemCounters();
                     return result;
 
                 case CborAdditionalInfo.Additional32BitData:
-                    EnsureBuffer(buffer, 5);
+                    EnsureReadCapacity(buffer, 5);
                     result = BinaryPrimitives.ReadSingleBigEndian(buffer.Slice(1));
                     AdvanceBuffer(5);
                     AdvanceDataItemCounters();
@@ -42,27 +42,27 @@ namespace System.Formats.Cbor
         public double ReadDouble()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
-            ReadOnlySpan<byte> buffer = _buffer.Span;
+            ReadOnlySpan<byte> buffer = GetRemainingBytes();
             double result;
 
             switch (header.AdditionalInfo)
             {
                 case CborAdditionalInfo.Additional16BitData:
-                    EnsureBuffer(buffer, 3);
+                    EnsureReadCapacity(buffer, 3);
                     result = ReadHalfBigEndian(buffer.Slice(1));
                     AdvanceBuffer(3);
                     AdvanceDataItemCounters();
                     return result;
 
                 case CborAdditionalInfo.Additional32BitData:
-                    EnsureBuffer(buffer, 5);
+                    EnsureReadCapacity(buffer, 5);
                     result = BinaryPrimitives.ReadSingleBigEndian(buffer.Slice(1));
                     AdvanceBuffer(5);
                     AdvanceDataItemCounters();
                     return result;
 
                 case CborAdditionalInfo.Additional64BitData:
-                    EnsureBuffer(buffer, 9);
+                    EnsureReadCapacity(buffer, 9);
                     result = BinaryPrimitives.ReadDoubleBigEndian(buffer.Slice(1));
                     AdvanceBuffer(9);
                     AdvanceDataItemCounters();
@@ -115,8 +115,8 @@ namespace System.Formats.Cbor
                     AdvanceDataItemCounters();
                     return (CborSimpleValue)header.AdditionalInfo;
                 case CborAdditionalInfo.Additional8BitData:
-                    EnsureBuffer(2);
-                    byte value = _buffer.Span[1];
+                    EnsureReadCapacity(2);
+                    byte value = _buffer.Span[_offset + 1];
 
                     if (value < 32)
                     {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -79,8 +79,8 @@ namespace System.Formats.Cbor
 
             bool result = header.AdditionalInfo switch
             {
-                CborAdditionalInfo.SimpleValueFalse => false,
-                CborAdditionalInfo.SimpleValueTrue => true,
+                (CborAdditionalInfo)CborSimpleValue.False => false,
+                (CborAdditionalInfo)CborSimpleValue.True => true,
                 _ => throw new InvalidOperationException(SR.Cbor_Reader_NotABooleanEncoding),
             };
 
@@ -95,7 +95,7 @@ namespace System.Formats.Cbor
 
             switch (header.AdditionalInfo)
             {
-                case CborAdditionalInfo.SimpleValueNull:
+                case (CborAdditionalInfo)CborSimpleValue.Null:
                     AdvanceBuffer(1);
                     AdvanceDataItemCounters();
                     return;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -185,9 +185,11 @@ namespace System.Formats.Cbor
                     EnsureReadCapacity(2);
                     byte value = _data.Span[_offset + 1];
 
-                    if (value <= (byte)CborAdditionalInfo.IndefiniteLength)
+                    if (value <= (byte)CborAdditionalInfo.IndefiniteLength &&
+                        _isConformanceLevelCheckEnabled &&
+                        CborConformanceLevelHelpers.RequireCanonicalSimpleValueEncodings(ConformanceLevel))
                     {
-                        throw new FormatException(SR.Cbor_Reader_InvalidCbor_InvalidSimpleValueEncoding);
+                        throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_InvalidSimpleValueEncoding, ConformanceLevel));
                     }
 
                     AdvanceBuffer(2);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -11,18 +11,18 @@ namespace System.Formats.Cbor
         private const int SizeOfHalf = 2; // the size in bytes of an IEEE 754 Half-Precision float
 
         /// <summary>
-        ///   Reads the next data item as a single-precision floating point number (major type 7)
+        ///   Reads the next data item as a single-precision floating point number (major type 7).
         /// </summary>
         /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type --OR--
-        ///   the next simple value is not a floating-point number encoding --OR--
+        ///   the next data item does not have the correct major type -or-
+        ///   the next simple value is not a floating-point number encoding -or-
         ///   the encoded value is a double-precision float
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public float ReadSingle()
         {
@@ -56,17 +56,17 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as a double-precision floating point number (major type 7)
+        ///   Reads the next data item as a double-precision floating point number (major type 7).
         /// </summary>
         /// <returns>The decoded <see cref="double"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type --OR--
+        ///   the next data item does not have the correct major type -or-
         ///   the next simple value is not a floating-point number encoding
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public double ReadDouble()
         {
@@ -103,17 +103,17 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as a boolean value (major type 7)
+        ///   Reads the next data item as a boolean value (major type 7).
         /// </summary>
         /// <returns>The decoded <see cref="bool"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type --OR--
+        ///   the next data item does not have the correct major type -or-
         ///   the next simple value is not a boolean encoding
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public bool ReadBoolean()
         {
@@ -132,16 +132,16 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as a null value (major type 7)
+        ///   Reads the next data item as a null value (major type 7).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type --OR--
+        ///   the next data item does not have the correct major type -or-
         ///   the next simple value is not a null value encoding
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public void ReadNull()
         {
@@ -159,17 +159,17 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as a CBOR simple value (major type 7)
+        ///   Reads the next data item as a CBOR simple value (major type 7).
         /// </summary>
         /// <returns>The decoded <see cref="CborSimpleValue"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type --OR--
+        ///   the next data item does not have the correct major type -or-
         ///   the next simple value is not a simple value encoding
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public CborSimpleValue ReadSimpleValue()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -211,7 +211,7 @@ namespace System.Formats.Cbor
 
             if (exp == 0)
             {
-                value = Math.ScaleB(mant, -24); 
+                value = Math.ScaleB(mant, -24);
             }
             else if (exp != 31)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -116,7 +116,7 @@ namespace System.Formats.Cbor
                     return (CborSimpleValue)header.AdditionalInfo;
                 case CborAdditionalInfo.Additional8BitData:
                     EnsureReadCapacity(2);
-                    byte value = _buffer.Span[_offset + 1];
+                    byte value = _data.Span[_offset + 1];
 
                     if (value < 32)
                     {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -8,6 +8,20 @@ namespace System.Formats.Cbor
 {
     public partial class CborReader
     {
+        /// <summary>
+        ///   Reads the next data item as a single-precision floating point number (major type 7)
+        /// </summary>
+        /// <returns>The decoded <see cref="float"/> value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type --OR--
+        ///   the next simple value is not a floating-point number encoding --OR--
+        ///   the encoded value is a double-precision float
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
         public float ReadSingle()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -39,6 +53,19 @@ namespace System.Formats.Cbor
             }
         }
 
+        /// <summary>
+        ///   Reads the next data item as a double-precision floating point number (major type 7)
+        /// </summary>
+        /// <returns>The decoded <see cref="double"/> value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type --OR--
+        ///   the next simple value is not a floating-point number encoding
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
         public double ReadDouble()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -73,6 +100,19 @@ namespace System.Formats.Cbor
             }
         }
 
+        /// <summary>
+        ///   Reads the next data item as a boolean value (major type 7)
+        /// </summary>
+        /// <returns>The decoded <see cref="bool"/> value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type --OR--
+        ///   the next simple value is not a boolean encoding
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
         public bool ReadBoolean()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -89,6 +129,18 @@ namespace System.Formats.Cbor
             return result;
         }
 
+        /// <summary>
+        ///   Reads the next data item as a null value (major type 7)
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type --OR--
+        ///   the next simple value is not a null value encoding
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
         public void ReadNull()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -104,6 +156,19 @@ namespace System.Formats.Cbor
             }
         }
 
+        /// <summary>
+        ///   Reads the next data item as a CBOR simple value (major type 7)
+        /// </summary>
+        /// <returns>The decoded <see cref="CborSimpleValue"/> value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type --OR--
+        ///   the next simple value is not a simple value encoding
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
         public CborSimpleValue ReadSimpleValue()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
@@ -142,11 +207,11 @@ namespace System.Formats.Cbor
 
             if (exp == 0)
             {
-                value = mant * 5.9604644775390625e-08 /* precomputed 2^-24 */;
+                value = Math.ScaleB(mant, -24); 
             }
             else if (exp != 31)
             {
-                value = (mant + 1024) * Math.Pow(2, exp - 25);
+                value = Math.ScaleB(mant + 1024, exp - 25);
             }
             else
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Simple.cs
@@ -15,8 +15,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type -or-
-        ///   the next simple value is not a floating-point number encoding -or-
+        ///   the next data item does not have the correct major type. -or-
+        ///   the next simple value is not a floating-point number encoding. -or-
         ///   the encoded value is a double-precision float
         /// </exception>
         /// <exception cref="FormatException">
@@ -60,7 +60,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="double"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type -or-
+        ///   the next data item does not have the correct major type. -or-
         ///   the next simple value is not a floating-point number encoding
         /// </exception>
         /// <exception cref="FormatException">
@@ -107,7 +107,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="bool"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type -or-
+        ///   the next data item does not have the correct major type. -or-
         ///   the next simple value is not a boolean encoding
         /// </exception>
         /// <exception cref="FormatException">
@@ -135,7 +135,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a null value (major type 7).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type -or-
+        ///   the next data item does not have the correct major type. -or-
         ///   the next simple value is not a null value encoding
         /// </exception>
         /// <exception cref="FormatException">
@@ -163,7 +163,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="CborSimpleValue"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type -or-
+        ///   the next data item does not have the correct major type. -or-
         ///   the next simple value is not a simple value encoding
         /// </exception>
         /// <exception cref="FormatException">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -9,22 +9,58 @@ namespace System.Formats.Cbor
 {
     public partial class CborReader
     {
-        public void SkipValue(bool validateConformance = true) => SkipToAncestor(0, validateConformance);
-        public void SkipToParent(bool validateConformance = true)
+        /// <summary>
+        ///   Reads the contents of the next value, discarding the result and advancing the reader.
+        /// </summary>
+        /// <param name="disableConformanceLevelChecks">
+        ///   Disable conformance level validation for the skipped value,
+        ///   equivalent to using <see cref="CborConformanceLevel.Lax"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   the reader is not at the start of new value.
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
+        public void SkipValue(bool disableConformanceLevelChecks = false)
+        {
+            SkipToAncestor(0, disableConformanceLevelChecks);
+        }
+
+        /// <summary>
+        ///   Reads the remaining contents of the current value context,
+        ///   discarding results and advancing the reader to the next value
+        ///   in the parent context.
+        /// </summary>
+        /// <param name="disableConformanceLevelChecks">
+        ///   Disable conformance level validation for the skipped values,
+        ///   equivalent to using <see cref="CborConformanceLevel.Lax"/>.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        ///   the reader is at the root context
+        /// </exception>
+        /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
+        ///   unexpected end of CBOR encoding data --OR--
+        ///   CBOR encoding not accepted under the current conformance level
+        /// </exception>
+        public void SkipToParent(bool disabledConformanceLevelChecks = false)
         {
             if (_currentMajorType is null)
             {
                 throw new InvalidOperationException(SR.Cbor_Reader_IsAtRootContext);
             }
 
-            SkipToAncestor(1, validateConformance);
+            SkipToAncestor(1, disabledConformanceLevelChecks);
         }
 
-        private void SkipToAncestor(int depth, bool validateConformance)
+        private void SkipToAncestor(int depth, bool disableConformanceLevelChecks)
         {
             Debug.Assert(0 <= depth && depth <= CurrentDepth);
             Checkpoint checkpoint = CreateCheckpoint();
-            _isConformanceLevelCheckEnabled = validateConformance;
+            _isConformanceLevelCheckEnabled = !disableConformanceLevelChecks;
 
             try
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -124,7 +124,7 @@ namespace System.Formats.Cbor
 
                 case CborReaderState.Null:
                 case CborReaderState.Boolean:
-                case CborReaderState.SpecialValue:
+                case CborReaderState.SimpleValue:
                     ReadSimpleValue();
                     break;
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -20,9 +20,9 @@ namespace System.Formats.Cbor
         ///   the reader is not at the start of new value.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public void SkipValue(bool disableConformanceLevelChecks = false)
         {
@@ -42,9 +42,9 @@ namespace System.Formats.Cbor
         ///   the reader is at the root context
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public void SkipToParent(bool disabledConformanceLevelChecks = false)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -46,14 +46,14 @@ namespace System.Formats.Cbor
         ///   there was an unexpected end of CBOR encoding data. -or-
         ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
-        public void SkipToParent(bool disabledConformanceLevelChecks = false)
+        public void SkipToParent(bool disableConformanceLevelChecks = false)
         {
             if (_currentMajorType is null)
             {
                 throw new InvalidOperationException(SR.Cbor_Reader_IsAtRootContext);
             }
 
-            SkipToAncestor(1, disabledConformanceLevelChecks);
+            SkipToAncestor(1, disableConformanceLevelChecks);
         }
 
         private void SkipToAncestor(int depth, bool disableConformanceLevelChecks)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -9,8 +9,8 @@ namespace System.Formats.Cbor
 {
     public partial class CborReader
     {
-        public void SkipValue(bool validateConformance = false) => SkipToAncestor(0, validateConformance);
-        public void SkipToParent(bool validateConformance = false)
+        public void SkipValue(bool validateConformance = true) => SkipToAncestor(0, validateConformance);
+        public void SkipToParent(bool validateConformance = true)
         {
             if (_currentMajorType is null)
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.SkipValue.cs
@@ -22,7 +22,7 @@ namespace System.Formats.Cbor
 
         private void SkipToAncestor(int depth, bool validateConformance)
         {
-            Debug.Assert(0 <= depth && depth <= Depth);
+            Debug.Assert(0 <= depth && depth <= CurrentDepth);
             Checkpoint checkpoint = CreateCheckpoint();
             _isConformanceLevelCheckEnabled = validateConformance;
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -19,17 +19,19 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Reads the next data item as a byte string (major type 2).
-        ///   Both definite and indefinite-length strings are supported.
         /// </summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next date item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
+        /// <remarks>
+        ///   The method accepts indefinite length strings, which it will concatenate to a single string.
+        /// </remarks>
         public byte[] ReadByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -56,24 +58,26 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Reads the next data item as a byte string (major type 2).
-        ///   Both definite and indefinite-length strings are supported.
         /// </summary>
         /// <param name="destination">The buffer in which to write.</param>
         /// <param name="bytesWritten">
         ///   On success, receives the number of bytes written to <paramref name="destination"/>.
         /// </param>
         /// <returns>
-        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
-        ///   length to receive the value, otherwise <c>false</c> and the reader does not advance.
+        ///   <see langword="true" /> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise <see langword="false" /> and the reader does not advance.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
+        /// <remarks>
+        ///   The method accepts indefinite length strings, which it will concatenate to a single string.
+        /// </remarks>
         public bool TryReadByteString(Span<byte> destination, out int bytesWritten)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
@@ -107,16 +111,16 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as the start of an indefinite-length byte string (major type 2)
+        ///   Reads the next data item as the start of an indefinite-length byte string (major type 2).
         /// </summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public void ReadStartByteString()
         {
@@ -137,14 +141,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   End reading an indefinite-length byte string (major type 2)
+        ///   End reading an indefinite-length byte string (major type 2).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not an indefinite-length string --OR--
+        ///   the current context is not an indefinite-length string -or-
         ///   the reader is not at the end of the string
         /// </exception>
         /// <exception cref="FormatException">
-        ///   unexpected end of CBOR encoding data
+        ///   there was an unexpected end of CBOR encoding data
         /// </exception>
         public void ReadEndByteString()
         {
@@ -156,17 +160,19 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Reads the next data item as a UTF-8 text string (major type 3).
-        ///   Both definite and indefinite-length strings are supported.
         /// </summary>
         /// <returns>The decoded string.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
+        /// <remarks>
+        ///   The method accepts indefinite length strings, which it will concatenate to a single string.
+        /// </remarks>
         public string ReadTextString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
@@ -204,24 +210,26 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Reads the next data item as a UTF-8 text string (major type 3).
-        ///   Both definite and indefinite-length strings are supported.
         /// </summary>
         /// <param name="destination">The buffer in which to write.</param>
         /// <param name="bytesWritten">
         ///   On success, receives the number of chars written to <paramref name="destination"/>.
         /// </param>
         /// <returns>
-        ///   <c>true</c> and advances the reader if <paramref name="destination"/> had sufficient
-        ///   length to receive the value, otherwise <c>false</c> and the reader does not advance.
+        ///   <see langword="true" /> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise <see langword="false" /> and the reader does not advance.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
+        /// <remarks>
+        ///   The method accepts indefinite length strings, which it will concatenate to a single string.
+        /// </remarks>
         public bool TryReadTextString(Span<char> destination, out int charsWritten)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
@@ -259,15 +267,15 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Reads the next data item as the start of an indefinite-length UTF-8 text string (major type 3)
+        ///   Reads the next data item as the start of an indefinite-length UTF-8 text string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public void ReadStartTextString()
         {
@@ -288,14 +296,14 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   End reading an indefinite-length UTF-8 text string (major type 3)
+        ///   End reading an indefinite-length UTF-8 text string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not an indefinite-length string --OR--
+        ///   the current context is not an indefinite-length string -or-
         ///   the reader is not at the end of the string
         /// </exception>
         /// <exception cref="FormatException">
-        ///   unexpected end of CBOR encoding data
+        ///   there was an unexpected end of CBOR encoding data
         /// </exception>
         public void ReadEndTextString()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -23,12 +23,12 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type.
+        ///   the next date item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   string encoding not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public byte[] ReadByteString()
         {
@@ -67,12 +67,12 @@ namespace System.Formats.Cbor
         ///   length to receive the value, otherwise <c>false</c> and the reader does not advance.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   string encoding not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public bool TryReadByteString(Span<byte> destination, out int bytesWritten)
         {
@@ -107,16 +107,16 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Begin reading an indefinite-length byte string (major type 2)
+        ///   Reads the next data item as the start of an indefinite-length byte string (major type 2)
         /// </summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   indefinite-length strings not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public void ReadStartByteString()
         {
@@ -140,13 +140,11 @@ namespace System.Formats.Cbor
         ///   End reading an indefinite-length byte string (major type 2)
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type --OR--
-        ///   the current context is not an indefinite-length string
+        ///   the current context is not an indefinite-length string --OR--
+        ///   the reader is not at the end of the string
         /// </exception>
         /// <exception cref="FormatException">
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   indefinite-length strings not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   unexpected end of CBOR encoding data
         /// </exception>
         public void ReadEndByteString()
         {
@@ -162,12 +160,12 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded string.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   string encoding not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public string ReadTextString()
         {
@@ -217,12 +215,12 @@ namespace System.Formats.Cbor
         ///   length to receive the value, otherwise <c>false</c> and the reader does not advance.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   string encoding not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public bool TryReadTextString(Span<char> destination, out int charsWritten)
         {
@@ -261,15 +259,15 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Begin reading an indefinite-length UTF-8 text string (major type 3)
+        ///   Reads the next data item as the start of an indefinite-length UTF-8 text string (major type 3)
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type.
+        ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
+        ///   invalid CBOR encoding data --OR--
         ///   unexpected end of CBOR encoding data --OR--
-        ///   indefinite-length strings not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   CBOR encoding not accepted under the current conformance level
         /// </exception>
         public void ReadStartTextString()
         {
@@ -293,13 +291,11 @@ namespace System.Formats.Cbor
         ///   End reading an indefinite-length UTF-8 text string (major type 3)
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the next value does not have the correct major type --OR--
-        ///   the current context is not an indefinite-length string
+        ///   the current context is not an indefinite-length string --OR--
+        ///   the reader is not at the end of the string
         /// </exception>
         /// <exception cref="FormatException">
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   indefinite-length strings not valid under the current conformance level --OR--
-        ///   the data item is located in an illegal context (e.g. an indefinite-length string)
+        ///   unexpected end of CBOR encoding data
         /// </exception>
         public void ReadEndTextString()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -113,7 +113,6 @@ namespace System.Formats.Cbor
         /// <summary>
         ///   Reads the next data item as the start of an indefinite-length byte string (major type 2).
         /// </summary>
-        /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type. -or-
         ///   the next data item is a definite-length encoded string.
@@ -213,7 +212,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a UTF-8 text string (major type 3).
         /// </summary>
         /// <param name="destination">The buffer in which to write.</param>
-        /// <param name="bytesWritten">
+        /// <param name="charsWritten">
         ///   On success, receives the number of chars written to <paramref name="destination"/>.
         /// </param>
         /// <returns>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -285,7 +285,7 @@ namespace System.Formats.Cbor
                 concatenatedStringSize += ValidateUtf8AndGetCharCount(buffer.Slice(o, l), utf8Encoding);
             }
 
-            string output = string.Create(concatenatedStringSize, (ranges, _buffer.Slice(_offset), utf8Encoding), BuildString);
+            string output = string.Create(concatenatedStringSize, (ranges, _data.Slice(_offset), utf8Encoding), BuildString);
 
             AdvanceBuffer(encodingLength);
             AdvanceDataItemCounters();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -115,7 +115,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded byte array.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type.
+        ///   the next data item does not have the correct major type. -or-
+        ///   the next data item is a definite-length encoded string.
         /// </exception>
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
@@ -270,7 +271,8 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as the start of an indefinite-length UTF-8 text string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type.
+        ///   the next data item does not have the correct major type. -or-
+        ///   the next data item is a definite-length encoded string.
         /// </exception>
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -159,7 +159,7 @@ namespace System.Formats.Cbor
             }
 
             AdvanceBuffer(1);
-            PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
+            PushDataItem(CborMajorType.TextString, definiteLength: null);
         }
 
         public void ReadEndTextString()
@@ -185,7 +185,7 @@ namespace System.Formats.Cbor
             }
 
             AdvanceBuffer(1);
-            PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
+            PushDataItem(CborMajorType.ByteString, definiteLength: null);
         }
 
         public void ReadEndByteString()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -26,7 +26,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return ReadChunkedByteStringConcatenated();
@@ -49,7 +49,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return TryReadChunkedByteStringConcatenated(destination, out bytesWritten);
@@ -81,7 +81,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return ReadChunkedTextStringConcatenated();
@@ -114,7 +114,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                    throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return TryReadChunkedTextStringConcatenated(destination, out charsWritten);
@@ -151,7 +151,7 @@ namespace System.Formats.Cbor
 
             if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
-                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
             }
 
             AdvanceBuffer(1);
@@ -177,7 +177,7 @@ namespace System.Formats.Cbor
 
             if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
-                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+                throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
             }
 
             AdvanceBuffer(1);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -26,7 +26,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return ReadChunkedByteStringConcatenated();
@@ -49,7 +49,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return TryReadChunkedByteStringConcatenated(destination, out bytesWritten);
@@ -81,7 +81,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return ReadChunkedTextStringConcatenated();
@@ -98,7 +98,7 @@ namespace System.Formats.Cbor
             }
             catch (DecoderFallbackException e)
             {
-                throw new FormatException("Text string payload is not a valid UTF8 string.", e);
+                throw new FormatException(SR.Cbor_Reader_InvalidCbor_InvalidUtf8StringEncoding, e);
             }
 
             AdvanceBuffer(1 + additionalBytes + length);
@@ -114,7 +114,7 @@ namespace System.Formats.Cbor
             {
                 if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
                 {
-                    throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
                 }
 
                 return TryReadChunkedTextStringConcatenated(destination, out charsWritten);
@@ -140,53 +140,53 @@ namespace System.Formats.Cbor
             return true;
         }
 
-        public void ReadStartTextStringIndefiniteLength()
+        public void ReadStartTextString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.TextString);
 
             if (header.AdditionalInfo != CborAdditionalInfo.IndefiniteLength)
             {
-                throw new InvalidOperationException("CBOR text string is not of indefinite length.");
+                throw new InvalidOperationException(SR.Cbor_Reader_NotIndefiniteLengthString);
             }
 
             if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
-                throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
             }
 
             AdvanceBuffer(1);
             PushDataItem(CborMajorType.TextString, expectedNestedItems: null);
         }
 
-        public void ReadEndTextStringIndefiniteLength()
+        public void ReadEndTextString()
         {
-            ReadNextIndefiniteLengthBreakByte();
+            ValidateNextByteIsBreakByte();
             PopDataItem(CborMajorType.TextString);
             AdvanceDataItemCounters();
             AdvanceBuffer(1);
         }
 
-        public void ReadStartByteStringIndefiniteLength()
+        public void ReadStartByteString()
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.ByteString);
 
             if (header.AdditionalInfo != CborAdditionalInfo.IndefiniteLength)
             {
-                throw new InvalidOperationException("CBOR text string is not of indefinite length.");
+                throw new InvalidOperationException(SR.Cbor_Reader_NotIndefiniteLengthString);
             }
 
             if (_isConformanceLevelCheckEnabled && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
             {
-                throw new FormatException("Indefinite-length items not supported under the current conformance level.");
+                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
             }
 
             AdvanceBuffer(1);
             PushDataItem(CborMajorType.ByteString, expectedNestedItems: null);
         }
 
-        public void ReadEndByteStringIndefiniteLength()
+        public void ReadEndByteString()
         {
-            ReadNextIndefiniteLengthBreakByte();
+            ValidateNextByteIsBreakByte();
             PopDataItem(CborMajorType.ByteString);
             AdvanceDataItemCounters();
             AdvanceBuffer(1);
@@ -330,14 +330,14 @@ namespace System.Formats.Cbor
             static CborInitialByte ReadNextInitialByte(ReadOnlySpan<byte> buffer, CborMajorType expectedType)
             {
                 EnsureBuffer(buffer, 1);
-                var cib = new CborInitialByte(buffer[0]);
+                var header = new CborInitialByte(buffer[0]);
 
-                if (cib.InitialByte != CborInitialByte.IndefiniteLengthBreakByte && cib.MajorType != expectedType)
+                if (header.InitialByte != CborInitialByte.IndefiniteLengthBreakByte && header.MajorType != expectedType)
                 {
-                    throw new FormatException("Indefinite-length CBOR string containing invalid data item.");
+                    throw new FormatException(SR.Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem);
                 }
 
-                return cib;
+                return header;
             }
         }
 
@@ -370,7 +370,7 @@ namespace System.Formats.Cbor
             }
             catch (DecoderFallbackException e)
             {
-                throw new FormatException("Text string payload is not a valid UTF8 string.", e);
+                throw new FormatException(SR.Cbor_Reader_InvalidCbor_InvalidUtf8StringEncoding, e);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.String.cs
@@ -144,7 +144,7 @@ namespace System.Formats.Cbor
         ///   End reading an indefinite-length byte string (major type 2).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not an indefinite-length string -or-
+        ///   the current context is not an indefinite-length string. -or-
         ///   the reader is not at the end of the string
         /// </exception>
         /// <exception cref="FormatException">
@@ -300,7 +300,7 @@ namespace System.Formats.Cbor
         ///   End reading an indefinite-length UTF-8 text string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   the current context is not an indefinite-length string -or-
+        ///   the current context is not an indefinite-length string. -or-
         ///   the reader is not at the end of the string
         /// </exception>
         /// <exception cref="FormatException">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -15,7 +15,7 @@ namespace System.Formats.Cbor
 
             if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
-                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_TagsNotSupported, ConformanceLevel));
+                throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_TagsNotSupported, ConformanceLevel));
             }
 
             AdvanceBuffer(1 + additionalBytes);
@@ -29,7 +29,7 @@ namespace System.Formats.Cbor
 
             if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
-                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_TagsNotSupported, ConformanceLevel));
+                throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_TagsNotSupported, ConformanceLevel));
             }
 
             if (expectedTag != tag)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -10,16 +10,16 @@ namespace System.Formats.Cbor
     public partial class CborReader
     {
         /// <summary>
-        ///   Reads the next data item as a semantic tag (major type 6)
+        ///   Reads the next data item as a semantic tag (major type 6).
         /// </summary>
         /// <returns>The decoded <see cref="CborTag"/> value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public CborTag ReadTag()
         {
@@ -39,9 +39,9 @@ namespace System.Formats.Cbor
         ///   the next data item does not have the correct major type.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public CborTag PeekTag() => PeekTagCore(out int _);
 
@@ -51,14 +51,14 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="DateTimeOffset"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type. --OR--
+        ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   invalid semantic date/time encoding --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   invalid semantic date/time encoding -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public DateTimeOffset ReadDateTimeOffset()
         {
@@ -102,14 +102,14 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="DateTimeOffset"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type. --OR--
+        ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   invalid semantic date/time encoding --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   invalid semantic date/time encoding -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public DateTimeOffset ReadUnixTimeSeconds()
         {
@@ -157,14 +157,14 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="BigInteger"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type. --OR--
+        ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   invalid semantic bignum encoding --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   invalid semantic bignum encoding -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public BigInteger ReadBigInteger()
         {
@@ -207,17 +207,17 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>The decoded <see cref="decimal"/> value.</returns>
         /// <exception cref="InvalidOperationException">
-        ///   the next data item does not have the correct major type. --OR--
+        ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
         /// </exception>
         /// <exception cref="OverflowException">
         ///   Decoded decimal fraction is either too large or too small for a <see cref="decimal"/> value.
         /// </exception>
         /// <exception cref="FormatException">
-        ///   invalid CBOR encoding data --OR--
-        ///   unexpected end of CBOR encoding data --OR--
-        ///   invalid semantic decimal fraction encoding --OR--
-        ///   CBOR encoding not accepted under the current conformance level
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   invalid semantic decimal fraction encoding -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public decimal ReadDecimal()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -46,7 +46,7 @@ namespace System.Formats.Cbor
         private CborTag PeekTagCore(out int additionalBytes)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Tag);
-            return (CborTag)ReadUnsignedInteger(_buffer.Span, header, out additionalBytes);
+            return (CborTag)ReadUnsignedInteger(GetRemainingBytes(), header, out additionalBytes);
         }
 
         // Additional tagged type support

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -278,7 +278,7 @@ namespace System.Formats.Cbor
 
                 ReadEndArray();
 
-                return DecimalHelpers.Reconstruct(mantissa, exponent);
+                return CborWriter.DecimalHelpers.Reconstruct(mantissa, exponent);
             }
             catch
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -11,21 +11,21 @@ namespace System.Formats.Cbor
     {
         public CborTag ReadTag()
         {
-            CborTag tag = PeekTagCore(out int additionalBytes);
+            CborTag tag = PeekTagCore(out int bytesRead);
 
             if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
                 throw new FormatException(SR.Format(SR.Cbor_ConformanceLevel_TagsNotSupported, ConformanceLevel));
             }
 
-            AdvanceBuffer(1 + additionalBytes);
+            AdvanceBuffer(bytesRead);
             _isTagContext = true;
             return tag;
         }
 
         public void ReadTag(CborTag expectedTag)
         {
-            CborTag tag = PeekTagCore(out int additionalBytes);
+            CborTag tag = PeekTagCore(out int bytesRead);
 
             if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
@@ -37,16 +37,16 @@ namespace System.Formats.Cbor
                 throw new InvalidOperationException(SR.Cbor_Reader_TagMismatch);
             }
 
-            AdvanceBuffer(1 + additionalBytes);
+            AdvanceBuffer(bytesRead);
             _isTagContext = true;
         }
 
         public CborTag PeekTag() => PeekTagCore(out int _);
 
-        private CborTag PeekTagCore(out int additionalBytes)
+        private CborTag PeekTagCore(out int bytesRead)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Tag);
-            return (CborTag)DecodeUnsignedInteger(header, GetRemainingBytes(), out additionalBytes);
+            return (CborTag)DecodeUnsignedInteger(header, GetRemainingBytes(), out bytesRead);
         }
 
         // Additional tagged type support

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -46,7 +46,7 @@ namespace System.Formats.Cbor
         private CborTag PeekTagCore(out int additionalBytes)
         {
             CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Tag);
-            return (CborTag)ReadUnsignedInteger(GetRemainingBytes(), header, out additionalBytes);
+            return (CborTag)DecodeUnsignedInteger(header, GetRemainingBytes(), out additionalBytes);
         }
 
         // Additional tagged type support

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -15,7 +15,7 @@ namespace System.Formats.Cbor
 
             if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
-                throw new FormatException("Tagged items are not permitted under the current conformance level.");
+                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_TagsNotSupported, ConformanceLevel));
             }
 
             AdvanceBuffer(1 + additionalBytes);
@@ -29,12 +29,12 @@ namespace System.Formats.Cbor
 
             if (_isConformanceLevelCheckEnabled && !CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
-                throw new FormatException("Tagged items are not permitted under the current conformance level.");
+                throw new FormatException(SR.Format(SR.Cbor_Reader_ConformanceLevel_TagsNotSupported, ConformanceLevel));
             }
 
             if (expectedTag != tag)
             {
-                throw new InvalidOperationException("CBOR tag mismatch.");
+                throw new InvalidOperationException(SR.Cbor_Reader_TagMismatch);
             }
 
             AdvanceBuffer(1 + additionalBytes);
@@ -67,7 +67,7 @@ namespace System.Formats.Cbor
                     case CborReaderState.StartTextString:
                         break;
                     default:
-                        throw new FormatException("String DateTime semantic tag should annotate string value.");
+                        throw new FormatException(SR.Cbor_Reader_InvalidDateTimeEncoding);
                 }
 
                 string dateString = ReadTextString();
@@ -75,7 +75,7 @@ namespace System.Formats.Cbor
                 // TODO determine if conformance levels should allow inexact date sting parsing
                 if (!DateTimeOffset.TryParseExact(dateString, CborWriter.Rfc3339FormatString, null, DateTimeStyles.RoundtripKind, out DateTimeOffset result))
                 {
-                    throw new FormatException("DateTime string is not valid RFC3339 format.");
+                    throw new FormatException(SR.Cbor_Reader_InvalidDateTimeEncoding);
                 }
 
                 return result;
@@ -110,14 +110,14 @@ namespace System.Formats.Cbor
 
                         if (double.IsNaN(seconds) || double.IsInfinity(seconds))
                         {
-                            throw new FormatException("Unix time representation cannot be infinity or NaN.");
+                            throw new FormatException(SR.Cbor_Reader_InvalidUnixTimeEncoding);
                         }
 
                         TimeSpan timespan = TimeSpan.FromSeconds(seconds);
                         return DateTimeOffset.UnixEpoch + timespan;
 
                     default:
-                        throw new FormatException("UnixDateTime tag should annotate a numeric value.");
+                        throw new FormatException(SR.Cbor_Reader_InvalidUnixTimeEncoding);
                 }
             }
             catch
@@ -139,7 +139,7 @@ namespace System.Formats.Cbor
                 {
                     CborTag.UnsignedBigNum => false,
                     CborTag.NegativeBigNum => true,
-                    _ => throw new InvalidOperationException("CBOR tag is not a recognized Bignum value."),
+                    _ => throw new InvalidOperationException(SR.Cbor_Reader_InvalidBigNumEncoding),
                 };
 
                 switch (PeekState())
@@ -148,7 +148,7 @@ namespace System.Formats.Cbor
                     case CborReaderState.StartByteString:
                         break;
                     default:
-                        throw new FormatException("BigNum semantic tag should annotate byte string value.");
+                        throw new FormatException(SR.Cbor_Reader_InvalidBigNumEncoding);
                 }
 
                 byte[] unsignedBigEndianEncoding = ReadByteString();
@@ -174,7 +174,7 @@ namespace System.Formats.Cbor
 
                 if (PeekState() != CborReaderState.StartArray || ReadStartArray() != 2)
                 {
-                    throw new FormatException("DecimalFraction tag should annotate a list of two numeric elements.");
+                    throw new FormatException(SR.Cbor_Reader_InvalidDecimalEncoding);
                 }
 
                 decimal mantissa; // signed integral component of the decimal value
@@ -188,7 +188,7 @@ namespace System.Formats.Cbor
                         break;
 
                     default:
-                        throw new FormatException("DecimalFraction tag should annotate a list of two numeric elements.");
+                        throw new FormatException(SR.Cbor_Reader_InvalidDecimalEncoding);
                 }
 
                 switch (PeekState())
@@ -210,13 +210,13 @@ namespace System.Formats.Cbor
                                 break;
 
                             default:
-                                throw new FormatException("DecimalFraction tag should annotate a list of two numeric elements.");
+                                throw new FormatException(SR.Cbor_Reader_InvalidDecimalEncoding);
                         }
 
                         break;
 
                     default:
-                        throw new FormatException("DecimalFraction tag should annotate a list of two numeric elements.");
+                        throw new FormatException(SR.Cbor_Reader_InvalidDecimalEncoding);
                 }
 
                 ReadEndArray();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -12,7 +12,7 @@ namespace System.Formats.Cbor
         /// <summary>
         ///   Reads the next data item as a semantic tag (major type 6).
         /// </summary>
-        /// <returns>The decoded <see cref="CborTag"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
@@ -34,7 +34,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a semantic tag (major type 6),
         ///   without advancing the reader.
         /// </summary>
-        /// <returns>The decoded <see cref="CborTag"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type.
         /// </exception>
@@ -52,7 +52,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a tagged date/time string,
         ///   as described in RFC7049 section 2.4.1.
         /// </summary>
-        /// <returns>The decoded <see cref="DateTimeOffset"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
@@ -103,7 +103,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a tagged unix time in seconds,
         ///   as described in RFC7049 section 2.4.1.
         /// </summary>
-        /// <returns>The decoded <see cref="DateTimeOffset"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
@@ -158,7 +158,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a tagged bignum encoding,
         ///   as described in RFC7049 section 2.4.2.
         /// </summary>
-        /// <returns>The decoded <see cref="BigInteger"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.
@@ -208,7 +208,7 @@ namespace System.Formats.Cbor
         ///   Reads the next data item as a tagged decimal fraction encoding,
         ///   as described in RFC7049 section 2.4.3.
         /// </summary>
-        /// <returns>The decoded <see cref="decimal"/> value.</returns>
+        /// <returns>The decoded value.</returns>
         /// <exception cref="InvalidOperationException">
         ///   the next data item does not have the correct major type. -or-
         ///   the next date item does not have the correct semantic tag.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.Tag.cs
@@ -43,6 +43,9 @@ namespace System.Formats.Cbor
         ///   there was an unexpected end of CBOR encoding data. -or-
         ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
+        /// <remarks>
+        ///   Useful in scenaria where the semantic value decoder needs to be determined at runtime.
+        /// </remarks>
         public CborTag PeekTag() => PeekTagCore(out int _);
 
         /// <summary>
@@ -57,7 +60,7 @@ namespace System.Formats.Cbor
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
         ///   there was an unexpected end of CBOR encoding data. -or-
-        ///   invalid semantic date/time encoding -or-
+        ///   invalid semantic date/time encoding. -or-
         ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public DateTimeOffset ReadDateTimeOffset()
@@ -108,7 +111,7 @@ namespace System.Formats.Cbor
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
         ///   there was an unexpected end of CBOR encoding data. -or-
-        ///   invalid semantic date/time encoding -or-
+        ///   invalid semantic date/time encoding. -or-
         ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public DateTimeOffset ReadUnixTimeSeconds()
@@ -163,7 +166,7 @@ namespace System.Formats.Cbor
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
         ///   there was an unexpected end of CBOR encoding data. -or-
-        ///   invalid semantic bignum encoding -or-
+        ///   invalid semantic bignum encoding. -or-
         ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public BigInteger ReadBigInteger()
@@ -216,7 +219,7 @@ namespace System.Formats.Cbor
         /// <exception cref="FormatException">
         ///   the next value has an invalid CBOR encoding. -or-
         ///   there was an unexpected end of CBOR encoding data. -or-
-        ///   invalid semantic decimal fraction encoding -or-
+        ///   invalid semantic decimal fraction encoding. -or-
         ///   the next value uses a CBOR encoding that is not valid under the current conformance level.
         /// </exception>
         public decimal ReadDecimal()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -281,24 +281,21 @@ namespace System.Formats.Cbor
 
             var nextByte = new CborInitialByte(_data.Span[_offset]);
 
-            if (_currentMajorType != null)
+            switch (_currentMajorType)
             {
-                switch (_currentMajorType.Value)
-                {
-                    case CborMajorType.ByteString:
-                    case CborMajorType.TextString:
-                        // Indefinite-length string contexts allow two possible data items:
-                        // 1) Definite-length string chunks of the same major type OR
-                        // 2) a break byte denoting the end of the indefinite-length string context.
-                        if (nextByte.InitialByte == CborInitialByte.IndefiniteLengthBreakByte ||
-                            nextByte.MajorType == _currentMajorType.Value &&
-                            nextByte.AdditionalInfo != CborAdditionalInfo.IndefiniteLength)
-                        {
-                            break;
-                        }
+                case CborMajorType.ByteString:
+                case CborMajorType.TextString:
+                    // Indefinite-length string contexts allow two possible data items:
+                    // 1) Definite-length string chunks of the same major type OR
+                    // 2) a break byte denoting the end of the indefinite-length string context.
+                    if (nextByte.InitialByte == CborInitialByte.IndefiniteLengthBreakByte ||
+                        nextByte.MajorType == _currentMajorType.Value &&
+                        nextByte.AdditionalInfo != CborAdditionalInfo.IndefiniteLength)
+                    {
+                        break;
+                    }
 
-                        throw new FormatException(SR.Format(SR.Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem, nextByte.MajorType));
-                }
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem, nextByte.MajorType));
             }
 
             return nextByte;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -209,10 +209,10 @@ namespace System.Formats.Cbor
 
                 switch (value)
                 {
-                    case CborAdditionalInfo.SimpleValueNull:
+                    case (CborAdditionalInfo)CborSimpleValue.Null:
                         return CborReaderState.Null;
-                    case CborAdditionalInfo.SimpleValueFalse:
-                    case CborAdditionalInfo.SimpleValueTrue:
+                    case (CborAdditionalInfo)CborSimpleValue.True:
+                    case (CborAdditionalInfo)CborSimpleValue.False:
                         return CborReaderState.Boolean;
                     case CborAdditionalInfo.Additional16BitData:
                         return CborReaderState.HalfPrecisionFloat;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -295,7 +295,7 @@ namespace System.Formats.Cbor
                         break;
                     }
 
-                    throw new FormatException(SR.Format(SR.Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem, nextByte.MajorType));
+                    throw new FormatException(SR.Format(SR.Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem, (int)nextByte.MajorType));
             }
 
             return nextByte;
@@ -307,7 +307,7 @@ namespace System.Formats.Cbor
 
             if (expectedType != result.MajorType)
             {
-                throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, result.MajorType));
+                throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypeMismatch, (int)result.MajorType));
             }
 
             return result;
@@ -360,7 +360,7 @@ namespace System.Formats.Cbor
 
             if (expectedType != _currentMajorType)
             {
-                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, _currentMajorType.Value));
+                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, (int)_currentMajorType.Value));
             }
 
             if (_definiteLength - _itemsWritten > 0)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -171,11 +171,15 @@ namespace System.Formats.Cbor
 
                 if (_definiteLength is null)
                 {
-                    // root context cannot be indefinite-length
-                    Debug.Assert(_currentMajorType != null);
-
-                    switch (_currentMajorType.Value)
+                    switch (_currentMajorType)
                     {
+                        case null:
+                            // found a break byte at the end of a root-level data item sequence
+                            Debug.Assert(AllowMultipleRootLevelValues);
+                            return throwOnFormatErrors ?
+                                throw new FormatException(SR.Cbor_Reader_InvalidCbor_UnexpectedBreakByte) :
+                                CborReaderState.FormatError;
+
                         case CborMajorType.ByteString: return CborReaderState.EndByteString;
                         case CborMajorType.TextString: return CborReaderState.EndTextString;
                         case CborMajorType.Array: return CborReaderState.EndArray;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -70,7 +70,7 @@ namespace System.Formats.Cbor
         /// </param>
         /// <param name="allowMultipleRootLevelValues">
         ///   Specify if multiple root-level values are to be supported by the reader.
-        ///   When set to <c>false</c>, the reader will throw an <see cref="InvalidOperationException"/>
+        ///   When set to <see langword="false" />, the reader will throw an <see cref="InvalidOperationException"/>
         ///   if trying to read beyond the scope of one root-level CBOR data item.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>A <see cref="ReadOnlySpan{T}"/> view of the encoded value.</returns>
         /// <exception cref="FormatException">
-        ///   The data item is not a valid CBOR data item encoding --OR--
+        ///   The data item is not a valid CBOR data item encoding -or-
         ///   The CBOR encoding is not valid under the current conformance level
         /// </exception>
         public ReadOnlySpan<byte> ReadEncodedValue()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -300,7 +300,7 @@ namespace System.Formats.Cbor
 
             if (result.InitialByte != CborInitialByte.IndefiniteLengthBreakByte)
             {
-                throw new InvalidOperationException(SR.Cbor_Reader_NotAtEndOfIndefiniteLengthDataItem);
+                throw new InvalidOperationException(SR.Cbor_NotAtEndOfIndefiniteLengthDataItem);
             }
         }
 
@@ -341,12 +341,12 @@ namespace System.Formats.Cbor
 
             if (expectedType != _currentMajorType)
             {
-                throw new InvalidOperationException(SR.Format(SR.Cbor_Reader_MajorTypePopMismatch, _currentMajorType.Value));
+                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, _currentMajorType.Value));
             }
 
             if (_remainingDataItems > 0)
             {
-                throw new InvalidOperationException(SR.Cbor_Reader_NotAtEndOfDefiniteLengthDataItem);
+                throw new InvalidOperationException(SR.Cbor_NotAtEndOfDefiniteLengthDataItem);
             }
 
             if (_isTagContext)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -233,7 +233,7 @@ namespace System.Formats.Cbor
             int initialBytesRead = _bytesRead;
 
             // call skip to read and validate the next value
-            SkipValue();
+            SkipValue(validateConformance: true);
 
             // return the slice corresponding to the consumed value
             return initialBuffer.Slice(0, _bytesRead - initialBytesRead);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -61,7 +61,7 @@ namespace System.Formats.Cbor
         public bool HasData => _offset != _data.Length;
 
         /// <summary>
-        ///   Construct a <see cref="AsnValueReader"/> instance over <paramref name="data"/> with given configuration.
+        ///   Construct a <see cref="CborReader"/> instance over <paramref name="data"/> with given configuration.
         /// </summary>
         /// <param name="data">The CBOR encoded data to read.</param>
         /// <param name="conformanceLevel">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -222,8 +222,7 @@ namespace System.Formats.Cbor
         }
 
         // TODO pass a `validateConformance` parameter
-        // TODO change return type to ReadOnSpan<byte>
-        public ReadOnlyMemory<byte> ReadEncodedValue()
+        public ReadOnlySpan<byte> ReadEncodedValue()
         {
             // keep a snapshot of the current offset
             int initialOffset = _offset;
@@ -232,7 +231,7 @@ namespace System.Formats.Cbor
             SkipValue(validateConformance: true);
 
             // return the slice corresponding to the consumed value
-            return _data.Slice(initialOffset, _offset - initialOffset);
+            return _data.Span.Slice(initialOffset, _offset - initialOffset);
         }
 
         private CborInitialByte PeekInitialByte()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -114,7 +114,7 @@ namespace System.Formats.Cbor
             int initialOffset = _offset;
 
             // call skip to read and validate the next value
-            SkipValue(validateConformance: true);
+            SkipValue(disableConformanceLevelChecks: false);
 
             // return the slice corresponding to the consumed value
             return _data.Span.Slice(initialOffset, _offset - initialOffset);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -125,7 +125,7 @@ namespace System.Formats.Cbor
             if (_definiteLength - _itemsWritten == 0)
             {
                 // is at the end of a definite-length context
-                if (_currentMajorType == null)
+                if (_currentMajorType is null)
                 {
                     return CborReaderState.Finished;
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -36,7 +36,7 @@ namespace System.Formats.Cbor
         private CborReaderState _cachedState = CborReaderState.None;
 
         /// <summary>
-        ///   The <see cref="CborConformanceLevel"/> used by this reader.
+        ///   The conformance level used by this reader.
         /// </summary>
         public CborConformanceLevel ConformanceLevel { get; }
 
@@ -61,11 +61,11 @@ namespace System.Formats.Cbor
         public bool HasData => _offset != _data.Length;
 
         /// <summary>
-        ///   Construct a <see cref="CborReader"/> instance over <paramref name="data"/> with given configuration.
+        ///   Construct a CborReader instance over <paramref name="data"/> with given configuration.
         /// </summary>
         /// <param name="data">The CBOR encoded data to read.</param>
         /// <param name="conformanceLevel">
-        ///   Specifies a <see cref="CborConformanceLevel"/> guiding the conformance checks performed on the encoded data.
+        ///   Specifies a conformance level guiding the conformance checks performed on the encoded data.
         ///   Defaults to <see cref="CborConformanceLevel.Lax" /> conformance level.
         /// </param>
         /// <param name="allowMultipleRootLevelValues">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReader.cs
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <returns>A <see cref="ReadOnlySpan{T}"/> view of the encoded value.</returns>
         /// <exception cref="FormatException">
-        ///   The data item is not a valid CBOR data item encoding -or-
+        ///   The data item is not a valid CBOR data item encoding. -or-
         ///   The CBOR encoding is not valid under the current conformance level
         /// </exception>
         public ReadOnlySpan<byte> ReadEncodedValue()

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReaderState.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReaderState.cs
@@ -1,0 +1,133 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+namespace System.Formats.Cbor
+{
+    /// <summary>
+    ///   Specifies the state of a CborReader instance.
+    /// </summary>
+    public enum CborReaderState
+    {
+        /// <summary>
+        ///   Indicates the undefined state.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is an unsigned integer (major type 0).
+        /// </summary>
+        UnsignedInteger,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is a negative integer (major type 1).
+        /// </summary>
+        NegativeInteger,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is a byte string (major type 2).
+        /// </summary>
+        ByteString,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item denotes the start of an indefinite-length byte string (major type 2).
+        /// </summary>
+        StartByteString,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> is at the end of an indefinite-length byte string (major type 2).
+        /// </summary>
+        EndByteString,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is a UTF-8 string (major type 3).
+        /// </summary>
+        TextString,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item denotes the start of an indefinite-length UTF-8 text string (major type 3).
+        /// </summary>
+        StartTextString,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> is at the end of an indefinite-length UTF-8 text string (major type 3).
+        /// </summary>
+        EndTextString,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item denotes the start of an array (major type 4).
+        /// </summary>
+        StartArray,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> is at the end of an array (major type 4).
+        /// </summary>
+        EndArray,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item denotes the start of a map (major type 5).
+        /// </summary>
+        StartMap,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> is at the end of a map (major type 5).
+        /// </summary>
+        EndMap,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is a semantic tag (major type 6).
+        /// </summary>
+        Tag,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is a simple value (major type 7).
+        /// </summary>
+        SimpleValue,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is an IEEE 754 Half-Precision float (major type 7).
+        /// </summary>
+        HalfPrecisionFloat,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is an IEEE 754 Single-Precision float (major type 7).
+        /// </summary>
+        SinglePrecisionFloat,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is an IEEE 754 Double-Precision float (major type 7).
+        /// </summary>
+        DoublePrecisionFloat,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data item is a <c>null</c> literal (major type 7).
+        /// </summary>
+        Null,
+
+        /// <summary>
+        ///   Indicates that the next CBOR data items encodes a <see cref="bool" /> value (major type 7).
+        /// </summary>
+        Boolean,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> has completed reading a full CBOR document.
+        /// </summary>
+        /// <remarks>
+        ///   If <see cref="CborReader.AllowMultipleRootLevelValues"/> is set to <c>true</c>,
+        ///   the reader will report this value even if the buffer contains trailing bytes.
+        /// </remarks>
+        Finished,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> has encountered an incomplete CBOR document.
+        /// </summary>
+        EndOfData,
+
+        /// <summary>
+        ///   Indicates that the <see cref="CborReader"/> has encountered an error in the CBOR format encoding.
+        /// </summary>
+        FormatError,
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReaderState.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborReaderState.cs
@@ -37,7 +37,7 @@ namespace System.Formats.Cbor
         StartByteString,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> is at the end of an indefinite-length byte string (major type 2).
+        ///   Indicates that the reader is at the end of an indefinite-length byte string (major type 2).
         /// </summary>
         EndByteString,
 
@@ -52,7 +52,7 @@ namespace System.Formats.Cbor
         StartTextString,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> is at the end of an indefinite-length UTF-8 text string (major type 3).
+        ///   Indicates that the reader is at the end of an indefinite-length UTF-8 text string (major type 3).
         /// </summary>
         EndTextString,
 
@@ -62,7 +62,7 @@ namespace System.Formats.Cbor
         StartArray,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> is at the end of an array (major type 4).
+        ///   Indicates that the reader is at the end of an array (major type 4).
         /// </summary>
         EndArray,
 
@@ -72,7 +72,7 @@ namespace System.Formats.Cbor
         StartMap,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> is at the end of a map (major type 5).
+        ///   Indicates that the reader is at the end of a map (major type 5).
         /// </summary>
         EndMap,
 
@@ -102,7 +102,7 @@ namespace System.Formats.Cbor
         DoublePrecisionFloat,
 
         /// <summary>
-        ///   Indicates that the next CBOR data item is a <c>null</c> literal (major type 7).
+        ///   Indicates that the next CBOR data item is a <see langword="null" /> literal (major type 7).
         /// </summary>
         Null,
 
@@ -112,21 +112,21 @@ namespace System.Formats.Cbor
         Boolean,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> has completed reading a full CBOR document.
+        ///   Indicates that the reader has completed reading a full CBOR document.
         /// </summary>
         /// <remarks>
-        ///   If <see cref="CborReader.AllowMultipleRootLevelValues"/> is set to <c>true</c>,
+        ///   If <see cref="CborReader.AllowMultipleRootLevelValues"/> is set to <see langword="true" />,
         ///   the reader will report this value even if the buffer contains trailing bytes.
         /// </remarks>
         Finished,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> has encountered an incomplete CBOR document.
+        ///   Indicates that the reader has encountered an incomplete CBOR document.
         /// </summary>
         EndOfData,
 
         /// <summary>
-        ///   Indicates that the <see cref="CborReader"/> has encountered an error in the CBOR format encoding.
+        ///   Indicates that the reader has encountered an error in the CBOR format encoding.
         /// </summary>
         FormatError,
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborTag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborTag.cs
@@ -40,17 +40,17 @@ namespace System.Formats.Cbor
         BigFloat = 5,
 
         /// <summary>
-        ///   Tag value for byte strings, meant for later encoding to a base64url string representation. 
+        ///   Tag value for byte strings, meant for later encoding to a base64url string representation.
         /// </summary>
         Base64UrlLaterEncoding = 21,
 
         /// <summary>
-        ///   Tag value for byte strings, meant for later encoding to a base64 string representation. 
+        ///   Tag value for byte strings, meant for later encoding to a base64 string representation.
         /// </summary>
         Base64StringLaterEncoding = 22,
 
         /// <summary>
-        ///   Tag value for byte strings, meant for later encoding to a base16 string representation. 
+        ///   Tag value for byte strings, meant for later encoding to a base16 string representation.
         /// </summary>
         Base16StringLaterEncoding = 23,
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborTag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborTag.cs
@@ -4,36 +4,116 @@
 
 namespace System.Formats.Cbor
 {
-    // https://tools.ietf.org/html/rfc7049#section-2.4
+    /// <summary>
+    ///   Represents a CBOR semantic tag, as described in RFC7049 section 2.4.
+    /// </summary>
     public enum CborTag : ulong
     {
+        /// <summary>
+        ///   Tag value for RFC3339 date/time strings.
+        /// </summary>
         DateTimeString = 0,
+
+        /// <summary>
+        ///   Tag value for Epoch-based date/time strings.
+        /// </summary>
         UnixTimeSeconds = 1,
+
+        /// <summary>
+        ///   Tag value for unsigned bignum encodings.
+        /// </summary>
         UnsignedBigNum = 2,
+
+        /// <summary>
+        ///   Tag value for negative bignum encodings.
+        /// </summary>
         NegativeBigNum = 3,
+
+        /// <summary>
+        ///   Tag value for decimal fraction encodings.
+        /// </summary>
         DecimalFraction = 4,
+
+        /// <summary>
+        ///   Tag value for big float encodings.
+        /// </summary>
         BigFloat = 5,
 
+        /// <summary>
+        ///   Tag value for byte strings, meant for later encoding to a base64url string representation. 
+        /// </summary>
         Base64UrlLaterEncoding = 21,
+
+        /// <summary>
+        ///   Tag value for byte strings, meant for later encoding to a base64 string representation. 
+        /// </summary>
         Base64StringLaterEncoding = 22,
+
+        /// <summary>
+        ///   Tag value for byte strings, meant for later encoding to a base16 string representation. 
+        /// </summary>
         Base16StringLaterEncoding = 23,
+
+        /// <summary>
+        ///   Tag value for byte strings containing embedded CBOR data item encodings.
+        /// </summary>
         EncodedCborDataItem = 24,
 
+        /// <summary>
+        ///   Tag value for Uri strings, as defined in RFC3986.
+        /// </summary>
         Uri = 32,
+
+        /// <summary>
+        ///   Tag value for base64url-encoded text strings, as defined in RFC4648.
+        /// </summary>
         Base64Url = 33,
+
+        /// <summary>
+        ///   Tag value for base64-encoded text strings, as defined in RFC4648.
+        /// </summary>
         Base64 = 34,
+
+        /// <summary>
+        ///   Tag value for regular expressions in Perl Compatible Regular Expressions / Javascript syntax.
+        /// </summary>
         Regex = 35,
+
+        /// <summary>
+        ///   Tag value for MIME messages (including all headers), as defined in RFC2045.
+        /// </summary>
         MimeMessage = 36,
 
-        SelfDescribingCbor = 55799,
+        /// <summary>
+        ///   Tag value for the Self-Describe CBOR header (0xd9d9f7).
+        /// </summary>
+        SelfDescribeCbor = 55799,
     }
 
-    // https://tools.ietf.org/html/rfc7049#section-2.3
+    /// <summary>
+    ///   Represents a CBOR simple value, as described in RFC7049 section 2.3.
+    /// </summary>
     public enum CborSimpleValue : byte
     {
+        /// <summary>
+        ///   Represents the value 'false'.
+        /// </summary>
         False = 20,
+
+        /// <summary>
+        ///   Represents the value 'true'.
+        /// </summary>
         True = 21,
+
+        /// <summary>
+        ///   Represents the value 'null'.
+        /// </summary>
         Null = 22,
+
+        /// <summary>
+        ///   Represents an undefined value, to be used by an encoder
+        ///   as a substitute for a data item with an encoding problem.
+        /// </summary>
         Undefined = 23,
     }
 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborTag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborTag.cs
@@ -5,7 +5,7 @@
 namespace System.Formats.Cbor
 {
     /// <summary>
-    ///   Represents a CBOR semantic tag, as described in RFC7049 section 2.4.
+    ///   Represents a CBOR semantic tag (major type 6).
     /// </summary>
     public enum CborTag : ulong
     {
@@ -91,7 +91,7 @@ namespace System.Formats.Cbor
     }
 
     /// <summary>
-    ///   Represents a CBOR simple value, as described in RFC7049 section 2.3.
+    ///   Represents a CBOR simple value (major type 7).
     /// </summary>
     public enum CborSimpleValue : byte
     {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -36,7 +36,6 @@ namespace System.Formats.Cbor
         /// <summary>
         ///   Writes the start of an indefinite-length array (major type 4).
         /// </summary>
-        /// <param name="definiteLength">The definite length of the array.</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the parent data item -or-
         ///   The major type of the encoded value is not permitted in the parent data item -or-

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -12,14 +12,14 @@ namespace System.Formats.Cbor
         // Implements major type 4 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
         /// <summary>
-        ///   Writes the start of a definite-length array (major type 4)
+        ///   Writes the start of a definite-length array (major type 4).
         /// </summary>
         /// <param name="definiteLength">The definite length of the array.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   The <paramref name="definiteLength"/> parameter cannot be negative.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
         ///   The major type of the encoded value is not permitted in the parent data item
         /// </exception>
         public void WriteStartArray(int definiteLength)
@@ -34,12 +34,12 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the start of an indefinite-length array (major type 4)
+        ///   Writes the start of an indefinite-length array (major type 4).
         /// </summary>
         /// <param name="definiteLength">The definite length of the array.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
@@ -59,7 +59,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the end of an array (major type 4)
+        ///   Writes the end of an array (major type 4).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///   The written data is not accepted under the current conformance level

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Cbor
         {
             if (definiteLength < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(definiteLength), "must be non-negative integer.");
+                throw new ArgumentOutOfRangeException(nameof(definiteLength));
             }
 
             WriteUnsignedInteger(CborMajorType.Array, (ulong)definiteLength);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -22,6 +22,11 @@ namespace System.Formats.Cbor
 
         public void WriteStartArray()
         {
+            if (!ConvertIndefiniteLengthEncodings && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new InvalidOperationException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+            }
+
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Array, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Array, definiteLength: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Array.cs
@@ -19,7 +19,7 @@ namespace System.Formats.Cbor
         ///   The <paramref name="definiteLength"/> parameter cannot be negative.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
         ///   The major type of the encoded value is not permitted in the parent data item
         /// </exception>
         public void WriteStartArray(int definiteLength)
@@ -37,8 +37,8 @@ namespace System.Formats.Cbor
         ///   Writes the start of an indefinite-length array (major type 4).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
@@ -61,7 +61,8 @@ namespace System.Formats.Cbor
         ///   Writes the end of an array (major type 4).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   The written data is not accepted under the current conformance level
+        ///   The written data is not accepted under the current conformance level. -or-
+        ///   The definite-length array anticipates more data items.
         /// </exception>
         public void WriteEndArray()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -11,22 +11,24 @@ namespace System.Formats.Cbor
         // Implements major type 0,1 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
         /// <summary>
-        ///   Writes an <see cref="int"/> value as a CBOR signed integer encoding (major types 0,1)
+        ///   Writes an <see cref="int"/> value as a signed integer encoding (major types 0,1)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context
+        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteInt32(int value) => WriteInt64(value);
 
         /// <summary>
-        ///   Writes a <see cref="long"/> value as a CBOR signed integer encoding (major types 0,1)
+        ///   Writes a <see cref="long"/> value as a signed integer encoding (major types 0,1)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context
+        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteInt64(long value)
         {
@@ -44,22 +46,24 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes an <see cref="uint"/> value as a CBOR unsigned integer encoding (major type 0)
+        ///   Writes an <see cref="uint"/> value as an unsigned integer encoding (major type 0)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context
+        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
         /// <summary>
-        ///   Writes an <see cref="ulong"/> value as a CBOR unsigned integer encoding (major type 0)
+        ///   Writes an <see cref="ulong"/> value as an unsigned integer encoding (major type 0)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context
+        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUInt64(ulong value)
         {
@@ -68,12 +72,13 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a <see cref="ulong"/> value as a CBOR negative integer encoding (major type 1).
+        ///   Writes a <see cref="ulong"/> value as a negative integer encoding (major type 1).
         /// </summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context
+        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
         ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding available primitive sizes.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -15,8 +15,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteInt32(int value) => WriteInt64(value);
@@ -26,8 +26,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteInt64(long value)
@@ -46,23 +46,23 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes an <see cref="uint"/> value as an unsigned integer encoding (major type 0)
+        ///   Writes an <see cref="uint"/> value as an unsigned integer encoding (major type 0).
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
         /// <summary>
-        ///   Writes an <see cref="ulong"/> value as an unsigned integer encoding (major type 0)
+        ///   Writes an <see cref="ulong"/> value as an unsigned integer encoding (major type 0).
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUInt64(ulong value)
@@ -76,8 +76,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -15,8 +15,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteInt32(int value) => WriteInt64(value);
@@ -26,8 +26,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteInt64(long value)
@@ -50,8 +50,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUInt32(uint value) => WriteUInt64(value);
@@ -61,8 +61,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUInt64(ulong value)
@@ -76,8 +76,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -8,14 +8,26 @@ namespace System.Formats.Cbor
 {
     public partial class CborWriter
     {
-        // Implements major type 0 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
-        public void WriteUInt64(ulong value)
-        {
-            WriteUnsignedInteger(CborMajorType.UnsignedInteger, value);
-            AdvanceDataItemCounters();
-        }
-
         // Implements major type 0,1 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
+
+        /// <summary>
+        ///   Writes an <see cref="int"/> value as a CBOR signed integer encoding (major types 0,1)
+        /// </summary>
+        /// <param name="value">The value to write</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the current data item context --OR--
+        ///   The major type of the encoded value is not permitted in the current data item context
+        /// </exception>
+        public void WriteInt32(int value) => WriteInt64(value);
+
+        /// <summary>
+        ///   Writes a <see cref="long"/> value as a CBOR signed integer encoding (major types 0,1)
+        /// </summary>
+        /// <param name="value">The value to write</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the current data item context --OR--
+        ///   The major type of the encoded value is not permitted in the current data item context
+        /// </exception>
         public void WriteInt64(long value)
         {
             if (value < 0)
@@ -31,18 +43,47 @@ namespace System.Formats.Cbor
             AdvanceDataItemCounters();
         }
 
-        public void WriteInt32(int value) => WriteInt64(value);
+        /// <summary>
+        ///   Writes an <see cref="uint"/> value as a CBOR unsigned integer encoding (major type 0)
+        /// </summary>
+        /// <param name="value">The value to write</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the current data item context --OR--
+        ///   The major type of the encoded value is not permitted in the current data item context
+        /// </exception>
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
-        // Writes a CBOR negative integer encoding according to
-        // https://tools.ietf.org/html/rfc7049#section-2.1
+        /// <summary>
+        ///   Writes an <see cref="ulong"/> value as a CBOR unsigned integer encoding (major type 0)
+        /// </summary>
+        /// <param name="value">The value to write</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the current data item context --OR--
+        ///   The major type of the encoded value is not permitted in the current data item context
+        /// </exception>
+        public void WriteUInt64(ulong value)
+        {
+            WriteUnsignedInteger(CborMajorType.UnsignedInteger, value);
+            AdvanceDataItemCounters();
+        }
+
+        /// <summary>
+        ///   Writes a <see cref="ulong"/> value as a CBOR negative integer encoding (major type 1).
+        /// </summary>
+        /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the current data item context --OR--
+        ///   The major type of the encoded value is not permitted in the current data item context
+        /// </exception>
+        /// <remarks>
+        ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding available primitive sizes.
+        /// </remarks>
         public void WriteCborNegativeIntegerEncoding(ulong value)
         {
             WriteUnsignedInteger(CborMajorType.NegativeInteger, value);
             AdvanceDataItemCounters();
         }
 
-        // Unsigned integer encoding https://tools.ietf.org/html/rfc7049#section-2.1
         private void WriteUnsignedInteger(CborMajorType type, ulong value)
         {
             if (value < (byte)CborAdditionalInfo.Additional8BitData)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -15,9 +15,9 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteInt32(int value) => WriteInt64(value);
 
@@ -26,9 +26,9 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteInt64(long value)
         {
@@ -50,9 +50,9 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
@@ -61,9 +61,9 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteUInt64(ulong value)
         {
@@ -76,9 +76,9 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         /// <remarks>
         ///   This method supports encoding integers between -18446744073709551616 and -1.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -11,7 +11,7 @@ namespace System.Formats.Cbor
         // Implements major type 0,1 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
         /// <summary>
-        ///   Writes an <see cref="int"/> value as a signed integer encoding (major types 0,1)
+        ///   Writes an value as a signed integer encoding (major types 0,1)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
@@ -22,7 +22,7 @@ namespace System.Formats.Cbor
         public void WriteInt32(int value) => WriteInt64(value);
 
         /// <summary>
-        ///   Writes a <see cref="long"/> value as a signed integer encoding (major types 0,1)
+        ///   Writes a value as a signed integer encoding (major types 0,1)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
@@ -46,7 +46,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes an <see cref="uint"/> value as an unsigned integer encoding (major type 0).
+        ///   Writes anvalue as an unsigned integer encoding (major type 0).
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
@@ -57,7 +57,7 @@ namespace System.Formats.Cbor
         public void WriteUInt32(uint value) => WriteUInt64(value);
 
         /// <summary>
-        ///   Writes an <see cref="ulong"/> value as an unsigned integer encoding (major type 0).
+        ///   Writes an value as an unsigned integer encoding (major type 0).
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
@@ -72,7 +72,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a <see cref="ulong"/> value as a negative integer encoding (major type 1).
+        ///   Writes a value as a negative integer encoding (major type 1).
         /// </summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
         /// <exception cref="InvalidOperationException">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -81,7 +81,8 @@ namespace System.Formats.Cbor
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
-        ///   Intended as an escape hatch in cases of valid CBOR negative integers exceeding available primitive sizes.
+        ///   This method supports encoding integers between -18446744073709551616 and -1.
+        ///   Useful for handling values that do not fit in the <see cref="long"/> type.
         /// </remarks>
         public void WriteCborNegativeIntegerEncoding(ulong value)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Integer.cs
@@ -22,7 +22,7 @@ namespace System.Formats.Cbor
         public void WriteInt32(int value) => WriteInt64(value);
 
         /// <summary>
-        ///   Writes a value as a signed integer encoding (major types 0,1)
+        ///   Writes the provided value as a signed integer encoding (major types 0,1)
         /// </summary>
         /// <param name="value">The value to write</param>
         /// <exception cref="InvalidOperationException">
@@ -72,7 +72,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a value as a negative integer encoding (major type 1).
+        ///   Writes the provided value as a negative integer encoding (major type 1).
         /// </summary>
         /// <param name="value">An unsigned integer denoting -1 minus the integer.</param>
         /// <exception cref="InvalidOperationException">

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -32,7 +32,7 @@ namespace System.Formats.Cbor
         ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
         ///   must be written by successive calls to <see cref="WriteInt32(int)"/> and <see cref="WriteTextString(ReadOnlySpan{char})"/>.
         ///   It is up to the caller to keep track of whether the next call is a key or a value.
-        ///   
+        ///
         ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
         ///   for instance a map can contain keys that are maps themselves.
         /// </remarks>
@@ -51,7 +51,6 @@ namespace System.Formats.Cbor
         /// <summary>
         ///   Writes the start of an indefinite-length map (major type 5).
         /// </summary>
-        /// <param name="definiteLength">The definite length of the map.</param>
         /// <exception cref="InvalidOperationException">
         ///   Writing a new value exceeds the definite length of the parent data item -or-
         ///   The major type of the encoded value is not permitted in the parent data item -or-
@@ -60,12 +59,12 @@ namespace System.Formats.Cbor
         /// <remarks>
         ///   In canonical conformance levels, the writer will reject indefinite-length writes unless
         ///   the <see cref="ConvertIndefiniteLengthEncodings"/> flag is enabled.
-        ///   
+        ///
         ///   Map contents are written as if they were arrays twice the length of the map's declared size.
         ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
         ///   must be written by successive calls to <see cref="WriteInt32(int)"/> and <see cref="WriteTextString(ReadOnlySpan{char})"/>.
         ///   It is up to the caller to keep track of whether the next call is a key or a value.
-        ///   
+        ///
         ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
         ///   for instance a map can contain keys that are maps themselves.
         /// </remarks>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -54,7 +54,7 @@ namespace System.Formats.Cbor
         // Map encoding conformance
         //
 
-        private void HandleKeyWritten()
+        private void HandleMapKeyWritten()
         {
             Debug.Assert(_currentKeyOffset != null && _currentValueOffset == null);
 
@@ -78,7 +78,7 @@ namespace System.Formats.Cbor
             _currentValueOffset = _offset;
         }
 
-        private void HandleValueWritten()
+        private void HandleMapValueWritten()
         {
             Debug.Assert(_currentKeyOffset != null && _currentValueOffset != null);
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -17,16 +17,25 @@ namespace System.Formats.Cbor
         private Stack<List<KeyValuePairEncodingRange>>? _pooledKeyValuePairEncodingRangeLists;
 
         /// <summary>
-        ///   Writes the start of a definite-length map (major type 5)
+        ///   Writes the start of a definite-length map (major type 5).
         /// </summary>
         /// <param name="definiteLength">The definite length of the map.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   The <paramref name="definiteLength"/> parameter cannot be negative.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
         ///   The major type of the encoded value is not permitted in the parent data item
         /// </exception>
+        /// <remarks>
+        ///   Map contents are written as if they were arrays twice the length of the map's declared size.
+        ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
+        ///   must be written by successive calls to <see cref="WriteInt32(int)"/> and <see cref="WriteTextString(ReadOnlySpan{char})"/>.
+        ///   It is up to the caller to keep track of whether the next call is a key or a value.
+        ///   
+        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
+        ///   for instance a map can contain keys that are maps themselves.
+        /// </remarks>
         public void WriteStartMap(int definiteLength)
         {
             if (definiteLength < 0 || definiteLength > int.MaxValue / 2)
@@ -40,17 +49,25 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the start of an indefinite-length map (major type 5)
+        ///   Writes the start of an indefinite-length map (major type 5).
         /// </summary>
         /// <param name="definiteLength">The definite length of the map.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
         ///   In canonical conformance levels, the writer will reject indefinite-length writes unless
         ///   the <see cref="ConvertIndefiniteLengthEncodings"/> flag is enabled.
+        ///   
+        ///   Map contents are written as if they were arrays twice the length of the map's declared size.
+        ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
+        ///   must be written by successive calls to <see cref="WriteInt32(int)"/> and <see cref="WriteTextString(ReadOnlySpan{char})"/>.
+        ///   It is up to the caller to keep track of whether the next call is a key or a value.
+        ///   
+        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
+        ///   for instance a map can contain keys that are maps themselves.
         /// </remarks>
         public void WriteStartMap()
         {
@@ -66,7 +83,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the end of a map (major type 5)
+        ///   Writes the end of a map (major type 5).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///   The written data is not accepted under the current conformance level

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -38,7 +38,7 @@ namespace System.Formats.Cbor
         {
             if (_itemsWritten % 2 == 1)
             {
-                throw new InvalidOperationException("CBOR Map types require an even number of key/value combinations");
+                throw new InvalidOperationException(SR.Cbor_Writer_MapIncompleteKeyValuePair);
             }
 
             PopDataItem(CborMajorType.Map);
@@ -65,7 +65,7 @@ namespace System.Formats.Cbor
                     _buffer.AsSpan(currentKey.Offset, _offset).Fill(0);
                     _offset = currentKey.Offset;
 
-                    throw new InvalidOperationException("Duplicate key encoding in CBOR map.");
+                    throw new InvalidOperationException(SR.Format(SR.Cbor_ConformanceLevel_ContainsDuplicateKeys, ConformanceLevel));
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -22,7 +22,7 @@ namespace System.Formats.Cbor
             }
 
             WriteUnsignedInteger(CborMajorType.Map, (ulong)definiteLength);
-            PushDataItem(CborMajorType.Map, definiteLength: checked(2 * definiteLength));
+            PushDataItem(CborMajorType.Map, definiteLength: 2 * definiteLength);
             _currentKeyOffset = _offset;
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -131,7 +131,7 @@ namespace System.Formats.Cbor
 
                 // now copy back to the original buffer segment & clean up
                 tmpSpan.CopyTo(source.Slice(_frameOffset, totalMapPayloadEncodingLength));
-                s_bufferPool.Return(tempBuffer, clearArray: true);
+                s_bufferPool.Return(tempBuffer);
             }
 
             ReturnKeyEncodingRangeAllocation();

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -28,6 +28,11 @@ namespace System.Formats.Cbor
 
         public void WriteStartMap()
         {
+            if (!ConvertIndefiniteLengthEncodings && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(ConformanceLevel))
+            {
+                throw new InvalidOperationException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, ConformanceLevel));
+            }
+
             EnsureWriteCapacity(1);
             WriteInitialByte(new CborInitialByte(CborMajorType.Map, CborAdditionalInfo.IndefiniteLength));
             PushDataItem(CborMajorType.Map, definiteLength: null);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Map.cs
@@ -24,16 +24,16 @@ namespace System.Formats.Cbor
         ///   The <paramref name="definiteLength"/> parameter cannot be negative.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
         ///   The major type of the encoded value is not permitted in the parent data item
         /// </exception>
         /// <remarks>
-        ///   Map contents are written as if they were arrays twice the length of the map's declared size.
+        ///   Map contents are written as if arrays twice the length of the map's declared size.
         ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
         ///   must be written by successive calls to <see cref="WriteInt32(int)"/> and <see cref="WriteTextString(ReadOnlySpan{char})"/>.
         ///   It is up to the caller to keep track of whether the next call is a key or a value.
         ///
-        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
+        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of any type,
         ///   for instance a map can contain keys that are maps themselves.
         /// </remarks>
         public void WriteStartMap(int definiteLength)
@@ -52,20 +52,20 @@ namespace System.Formats.Cbor
         ///   Writes the start of an indefinite-length map (major type 5).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
         ///   In canonical conformance levels, the writer will reject indefinite-length writes unless
         ///   the <see cref="ConvertIndefiniteLengthEncodings"/> flag is enabled.
         ///
-        ///   Map contents are written as if they were arrays twice the length of the map's declared size.
+        ///   Map contents are written as if arrays twice the length of the map's declared size.
         ///   For instance, a map of size <c>1</c> containing a key of type int with a value of type string
         ///   must be written by successive calls to <see cref="WriteInt32(int)"/> and <see cref="WriteTextString(ReadOnlySpan{char})"/>.
         ///   It is up to the caller to keep track of whether the next call is a key or a value.
         ///
-        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of arbitrary type,
+        ///   Fundamentally, this is a technical restriction stemming from the fact that CBOR allows keys of any type,
         ///   for instance a map can contain keys that are maps themselves.
         /// </remarks>
         public void WriteStartMap()
@@ -85,7 +85,9 @@ namespace System.Formats.Cbor
         ///   Writes the end of a map (major type 5).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   The written data is not accepted under the current conformance level
+        ///   The written data is not accepted under the current conformance level. -or-
+        ///   The definite-length map anticipates more data items. -or-
+        ///   The latest key/value pair is lacking a value.
         /// </exception>
         public void WriteEndMap()
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
@@ -11,12 +11,12 @@ namespace System.Formats.Cbor
         // Implements major type 7 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
         /// <summary>
-        ///   Writes a single-precision floating point number (major type 7)
+        ///   Writes a single-precision floating point number (major type 7).
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteSingle(float value)
@@ -29,12 +29,12 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a double-precision floating point number (major type 7)
+        ///   Writes a double-precision floating point number (major type 7).
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteDouble(double value)
@@ -47,12 +47,12 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a boolean value (major type 7)
+        ///   Writes a boolean value (major type 7).
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteBoolean(bool value)
@@ -61,11 +61,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a null value (major type 7)
+        ///   Writes a null value (major type 7).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteNull()
@@ -74,15 +74,15 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a simple value encoding (major type 7)
+        ///   Writes a simple value encoding (major type 7).
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   The <paramref name="value"/> parameter is in the invalid 24-31 range.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteSimpleValue(CborSimpleValue value)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
@@ -8,8 +8,17 @@ namespace System.Formats.Cbor
 {
     public partial class CborWriter
     {
-        // Implements https://tools.ietf.org/html/rfc7049#section-2.3
+        // Implements major type 7 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
+        /// <summary>
+        ///   Writes a single-precision floating point number (major type 7)
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteSingle(float value)
         {
             EnsureWriteCapacity(5);
@@ -19,6 +28,15 @@ namespace System.Formats.Cbor
             AdvanceDataItemCounters();
         }
 
+        /// <summary>
+        ///   Writes a double-precision floating point number (major type 7)
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteDouble(double value)
         {
             EnsureWriteCapacity(9);
@@ -28,22 +46,55 @@ namespace System.Formats.Cbor
             AdvanceDataItemCounters();
         }
 
+        /// <summary>
+        ///   Writes a boolean value (major type 7)
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteBoolean(bool value)
         {
             WriteSimpleValue(value ? CborSimpleValue.True : CborSimpleValue.False);
         }
 
+        /// <summary>
+        ///   Writes a null value (major type 7)
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteNull()
         {
             WriteSimpleValue(CborSimpleValue.Null);
         }
 
+        /// <summary>
+        ///   Writes a simple value encoding (major type 7)
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   The <paramref name="value"/> parameter is in the invalid 24-31 range.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteSimpleValue(CborSimpleValue value)
         {
-            if ((byte)value < 24)
+            if (value < (CborSimpleValue)CborAdditionalInfo.Additional8BitData)
             {
                 EnsureWriteCapacity(1);
                 WriteInitialByte(new CborInitialByte(CborMajorType.Simple, (CborAdditionalInfo)value));
+            }
+            else if (value <= (CborSimpleValue)CborAdditionalInfo.IndefiniteLength)
+            {
+                throw new ArgumentOutOfRangeException(SR.Cbor_Writer_InvalidSimpleValueRange);
             }
             else
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
@@ -92,9 +92,10 @@ namespace System.Formats.Cbor
                 EnsureWriteCapacity(1);
                 WriteInitialByte(new CborInitialByte(CborMajorType.Simple, (CborAdditionalInfo)value));
             }
-            else if (value <= (CborSimpleValue)CborAdditionalInfo.IndefiniteLength)
+            else if (value <= (CborSimpleValue)CborAdditionalInfo.IndefiniteLength &&
+                     CborConformanceLevelHelpers.RequireCanonicalSimpleValueEncodings(ConformanceLevel))
             {
-                throw new ArgumentOutOfRangeException(SR.Cbor_Writer_InvalidSimpleValueRange);
+                throw new ArgumentOutOfRangeException(SR.Format(SR.Cbor_ConformanceLevel_InvalidSimpleValueEncoding, ConformanceLevel));
             }
             else
             {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Simple.cs
@@ -15,8 +15,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteSingle(float value)
@@ -33,8 +33,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteDouble(double value)
@@ -51,8 +51,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteBoolean(bool value)
@@ -64,8 +64,8 @@ namespace System.Formats.Cbor
         ///   Writes a null value (major type 7).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteNull()
@@ -81,8 +81,8 @@ namespace System.Formats.Cbor
         ///   The <paramref name="value"/> parameter is in the invalid 24-31 range.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteSimpleValue(CborSimpleValue value)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -17,12 +17,12 @@ namespace System.Formats.Cbor
         private List<(int Offset, int Length)>? _currentIndefiniteLengthStringRanges = null;
 
         /// <summary>
-        ///   Writes a buffer as a byte string encoding (major type 2)
+        ///   Writes a buffer as a byte string encoding (major type 2).
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteByteString(ReadOnlySpan<byte> value)
@@ -45,11 +45,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the start of an indefinite-length byte string (major type 2)
+        ///   Writes the start of an indefinite-length byte string (major type 2).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
@@ -77,7 +77,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the end of an indefinite-length byte string (major type 2)
+        ///   Writes the end of an indefinite-length byte string (major type 2).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///   The written data is not accepted under the current conformance level
@@ -89,12 +89,12 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a buffer as a UTF-8 string encoding (major type 3)
+        ///   Writes a buffer as a UTF-8 string encoding (major type 3).
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteTextString(ReadOnlySpan<char> value)
@@ -129,11 +129,11 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the start of an indefinite-length UTF-8 string (major type 3)
+        ///   Writes the start of an indefinite-length UTF-8 string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
@@ -161,7 +161,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes the end of an indefinite-length UTF-8 string (major type 3)
+        ///   Writes the end of an indefinite-length UTF-8 string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
         ///   The written data is not accepted under the current conformance level

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 #nullable enable
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
-using System.Threading;
 
 namespace System.Formats.Cbor
 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -21,8 +21,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteByteString(ReadOnlySpan<byte> value)
@@ -48,8 +48,8 @@ namespace System.Formats.Cbor
         ///   Writes the start of an indefinite-length byte string (major type 2)
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
@@ -93,8 +93,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteTextString(ReadOnlySpan<char> value)
@@ -132,8 +132,8 @@ namespace System.Formats.Cbor
         ///   Writes the start of an indefinite-length UTF-8 string (major type 3)
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the current data item context --OR--
-        ///   The major type of the encoded value is not permitted in the current data item context --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
@@ -172,6 +172,7 @@ namespace System.Formats.Cbor
             AdvanceDataItemCounters();
         }
 
+        // perform an in-place conversion of an indefinite-length encoding into an equivalent definite-length
         private void PatchIndefiniteLengthString(CborMajorType type)
         {
             Debug.Assert(type == CborMajorType.ByteString || type == CborMajorType.TextString);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -11,8 +11,6 @@ namespace System.Formats.Cbor
 {
     public partial class CborWriter
     {
-        private static readonly System.Text.Encoding s_utf8Encoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
-
         // keeps track of chunk offsets for written indefinite-length string ranges
         private List<(int Offset, int Length)>? _currentIndefiniteLengthStringRanges = null;
 
@@ -37,10 +35,12 @@ namespace System.Formats.Cbor
         // Implements major type 3 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
         public void WriteTextString(ReadOnlySpan<char> value)
         {
+            Encoding utf8Encoding = CborConformanceLevelHelpers.GetUtf8Encoding(ConformanceLevel);
+
             int length;
             try
             {
-                length = s_utf8Encoding.GetByteCount(value);
+                length = utf8Encoding.GetByteCount(value);
             }
             catch (EncoderFallbackException e)
             {
@@ -57,7 +57,7 @@ namespace System.Formats.Cbor
                 _currentIndefiniteLengthStringRanges.Add((_offset, value.Length));
             }
 
-            s_utf8Encoding.GetBytes(value, _buffer.AsSpan(_offset, length));
+            utf8Encoding.GetBytes(value, _buffer.AsSpan(_offset, length));
             _offset += length;
             AdvanceDataItemCounters();
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -138,9 +138,8 @@ namespace System.Formats.Cbor
             tempSpan.CopyTo(_buffer.AsSpan(_offset, definiteLength));
             _offset += definiteLength;
 
-            // zero out excess bytes & other cleanups
-            _buffer.AsSpan(_offset, currentOffset - _offset).Fill(0);
-            s_bufferPool.Return(tempBuffer, clearArray: true);
+            // clean up
+            s_bufferPool.Return(tempBuffer);
             _currentIndefiniteLengthStringRanges.Clear();
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -46,7 +46,7 @@ namespace System.Formats.Cbor
             }
             catch (EncoderFallbackException e)
             {
-                throw new ArgumentException("Provided text string is not valid UTF8.", e);
+                throw new ArgumentException(SR.Cbor_Writer_InvalidUtf8String, e);
             }
 
             WriteUnsignedInteger(CborMajorType.TextString, (ulong)length);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.String.cs
@@ -21,8 +21,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteByteString(ReadOnlySpan<byte> value)
@@ -48,11 +48,12 @@ namespace System.Formats.Cbor
         ///   Writes the start of an indefinite-length byte string (major type 2).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
+        ///   Pushes a context where definite-length chunks of the same major type can be written.
         ///   In canonical conformance levels, the writer will reject indefinite-length writes unless
         ///   the <see cref="ConvertIndefiniteLengthEncodings"/> flag is enabled.
         /// </remarks>
@@ -93,8 +94,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteTextString(ReadOnlySpan<char> value)
@@ -132,11 +133,12 @@ namespace System.Formats.Cbor
         ///   Writes the start of an indefinite-length UTF-8 string (major type 3).
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         /// <remarks>
+        ///   Pushes a context where definite-length chunks of the same major type can be written.
         ///   In canonical conformance levels, the writer will reject indefinite-length writes unless
         ///   the <see cref="ConvertIndefiniteLengthEncodings"/> flag is enabled.
         /// </remarks>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -124,7 +124,6 @@ namespace System.Formats.Cbor
         /// </exception>
         public void WriteDecimal(decimal value)
         {
-            // implements https://tools.ietf.org/html/rfc7049#section-2.4.3
             DecimalHelpers.Deconstruct(value, out decimal mantissa, out byte scale);
 
             WriteTag(CborTag.DecimalFraction);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -9,6 +9,17 @@ namespace System.Formats.Cbor
 {
     public partial class CborWriter
     {
+        // Implements major type 6 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
+
+        /// <summary>
+        ///   Writes a semantic tag (major type 6)
+        /// </summary>
+        /// <param name="tag">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteTag(CborTag tag)
         {
             if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
@@ -20,10 +31,16 @@ namespace System.Formats.Cbor
             _isTagContext = true;
         }
 
-        // Additional tagged type support
-
-        internal const string Rfc3339FormatString = "yyyy-MM-ddTHH:mm:ss.FFFFFFFK";
-
+        /// <summary>
+        ///   Writes a <see cref="DateTimeOffset"/> value as a tagged date/time string,
+        ///   as described in RFC7049 section 2.4.1
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteDateTimeOffset(DateTimeOffset value)
         {
             string dateString =
@@ -35,12 +52,35 @@ namespace System.Formats.Cbor
             WriteTextString(dateString);
         }
 
+        /// <summary>
+        ///   Writes a unix time in seconds as a tagged date/time value,
+        ///   as described in RFC7049 section 2.4.1
+        /// </summary>
+        /// <param name="seconds">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteUnixTimeSeconds(long seconds)
         {
             WriteTag(CborTag.UnixTimeSeconds);
             WriteInt64(seconds);
         }
 
+        /// <summary>
+        ///   Writes a unix time in seconds as a tagged date/time value,
+        ///   as described in RFC7049 section 2.4.1
+        /// </summary>
+        /// <param name="seconds">The value to write.</param>
+        /// <exception cref="ArgumentException">
+        ///   The <paramref name="seconds"/> parameter cannot be infinite or NaN
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteUnixTimeSeconds(double seconds)
         {
             if (double.IsInfinity(seconds) || double.IsNaN(seconds))
@@ -52,6 +92,16 @@ namespace System.Formats.Cbor
             WriteDouble(seconds);
         }
 
+        /// <summary>
+        ///   Writes a <see cref="BigInteger"/> value as a tagged bignum encoding,
+        ///   as described in RFC7049 section 2.4.2
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteBigInteger(BigInteger value)
         {
             bool isUnsigned = value.Sign >= 0;
@@ -62,6 +112,16 @@ namespace System.Formats.Cbor
             WriteByteString(unsignedBigEndianEncoding);
         }
 
+        /// <summary>
+        ///   Writes a <see cref="decimal"/> value as a tagged decimal fraction encoding,
+        ///   as described in RFC7049 section 2.4.3
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        /// <exception cref="InvalidOperationException">
+        ///   Writing a new value exceeds the definite length of the parent data item --OR--
+        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   The written data is not accepted under the current conformance level
+        /// </exception>
         public void WriteDecimal(decimal value)
         {
             // implements https://tools.ietf.org/html/rfc7049#section-2.4.3
@@ -90,78 +150,80 @@ namespace System.Formats.Cbor
 
             WriteEndArray();
         }
-    }
 
-    internal static class DecimalHelpers
-    {
-        private const int SignMask = unchecked((int)0x80000000);
-        private const int ScaleMask = 0x00ff0000;
-        private const int ScaleShift = 16;
-        private const int ExponentUpperBound = 28;
+        internal const string Rfc3339FormatString = "yyyy-MM-ddTHH:mm:ss.FFFFFFFK";
 
-        /// deconstructs a decimal value into its signed integral component and negative base-10 exponent
-        public static void Deconstruct(decimal value, out decimal mantissa, out byte scale)
+        internal static class DecimalHelpers
         {
-            Span<int> buf = stackalloc int[4];
-            decimal.GetBits(value, buf);
+            private const int SignMask = unchecked((int)0x80000000);
+            private const int ScaleMask = 0x00ff0000;
+            private const int ScaleShift = 16;
+            private const int ExponentUpperBound = 28;
 
-            int flags = buf[3];
-            bool isNegative = (flags & SignMask) == SignMask;
-            mantissa = new decimal(lo: buf[0], mid: buf[1], hi: buf[2], isNegative: isNegative, scale: 0);
-            scale = (byte)((flags & ScaleMask) >> ScaleShift);
-        }
-
-        /// reconstructs a decimal value out of a signed integral component and a negative base-10 exponent
-        public static decimal Reconstruct(decimal mantissa, byte scale)
-        {
-            Span<int> buf = stackalloc int[4];
-            decimal.GetBits(mantissa, buf);
-
-            int flags = buf[3];
-            bool isNegative = (flags & SignMask) == SignMask;
-            Debug.Assert((flags & ScaleMask) == 0, "mantissa argument should be integral.");
-            return new decimal(lo: buf[0], mid: buf[1], hi: buf[2], isNegative: isNegative, scale: scale);
-        }
-
-        public static decimal Reconstruct(decimal mantissa, long exponent)
-        {
-            if (mantissa == 0)
+            /// deconstructs a decimal value into its signed integral component and negative base-10 exponent
+            public static void Deconstruct(decimal value, out decimal mantissa, out byte scale)
             {
-                return mantissa;
+                Span<int> buf = stackalloc int[4];
+                decimal.GetBits(value, buf);
+
+                int flags = buf[3];
+                bool isNegative = (flags & SignMask) == SignMask;
+                mantissa = new decimal(lo: buf[0], mid: buf[1], hi: buf[2], isNegative: isNegative, scale: 0);
+                scale = (byte)((flags & ScaleMask) >> ScaleShift);
             }
-            else if (exponent > ExponentUpperBound)
+
+            /// reconstructs a decimal value out of a signed integral component and a negative base-10 exponent
+            private static decimal ReconstructFromNegativeScale(decimal mantissa, byte scale)
             {
-                throw new OverflowException(SR.Cbor_Writer_DecimalOverflow);
+                Span<int> buf = stackalloc int[4];
+                decimal.GetBits(mantissa, buf);
+
+                int flags = buf[3];
+                bool isNegative = (flags & SignMask) == SignMask;
+                Debug.Assert((flags & ScaleMask) == 0, "mantissa argument should be integral.");
+                return new decimal(lo: buf[0], mid: buf[1], hi: buf[2], isNegative: isNegative, scale: scale);
             }
-            else if (exponent >= 0)
+
+            public static decimal Reconstruct(decimal mantissa, long exponent)
             {
-                // for positive exponents attempt to compute a decimal
-                // representation, with risk of throwing OverflowException
-                for (; exponent >= 5; exponent -= 5)
+                if (mantissa == 0)
                 {
-                    mantissa *= 100_000m;
+                    return mantissa;
                 }
-
-                switch (exponent)
+                else if (exponent > ExponentUpperBound)
                 {
-                    case 0: return mantissa;
-                    case 1: return mantissa * 10m;
-                    case 2: return mantissa * 100m;
-                    case 3: return mantissa * 1000m;
-                    case 4: return mantissa * 10000m;
-                    default:
-                        Debug.Fail("Unreachable code in decimal exponentiation logic");
-                        throw new Exception();
+                    throw new OverflowException(SR.Cbor_Writer_DecimalOverflow);
                 }
-            }
-            else if (exponent >= -ExponentUpperBound)
-            {
-                // exponent falls within range of decimal normal-form representation
-                return Reconstruct(mantissa, (byte)(-exponent));
-            }
-            else
-            {
-                throw new OverflowException(SR.Cbor_Writer_DecimalOverflow);
+                else if (exponent >= 0)
+                {
+                    // for positive exponents attempt to compute a decimal
+                    // representation, with risk of throwing OverflowException
+                    for (; exponent >= 5; exponent -= 5)
+                    {
+                        mantissa *= 100_000m;
+                    }
+
+                    switch (exponent)
+                    {
+                        case 0: return mantissa;
+                        case 1: return mantissa * 10m;
+                        case 2: return mantissa * 100m;
+                        case 3: return mantissa * 1000m;
+                        case 4: return mantissa * 10000m;
+                        default:
+                            Debug.Fail("Unreachable code in decimal exponentiation logic");
+                            throw new Exception();
+                    }
+                }
+                else if (exponent >= -ExponentUpperBound)
+                {
+                    // exponent falls within range of decimal normal-form representation
+                    return ReconstructFromNegativeScale(mantissa, (byte)(-exponent));
+                }
+                else
+                {
+                    throw new OverflowException(SR.Cbor_Writer_DecimalOverflow);
+                }
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -13,7 +13,7 @@ namespace System.Formats.Cbor
         {
             if (!CborConformanceLevelHelpers.AllowsTags(ConformanceLevel))
             {
-                throw new InvalidOperationException("Tagged items are not permitted under the current conformance level.");
+                throw new InvalidOperationException(SR.Format(SR.Cbor_ConformanceLevel_TagsNotSupported, ConformanceLevel));
             }
 
             WriteUnsignedInteger(CborMajorType.Tag, (ulong)tag);
@@ -45,7 +45,7 @@ namespace System.Formats.Cbor
         {
             if (double.IsInfinity(seconds) || double.IsNaN(seconds))
             {
-                throw new ArgumentException("Value cannot be infinite or NaN.", nameof(seconds));
+                throw new ArgumentOutOfRangeException(SR.Cbor_Writer_ValueCannotBeInfiniteOrNaN, nameof(seconds));
             }
 
             WriteTag(CborTag.UnixTimeSeconds);
@@ -131,12 +131,12 @@ namespace System.Formats.Cbor
             }
             else if (exponent > ExponentUpperBound)
             {
-                throw new OverflowException("Value was either too large or too small for a Decimal.");
+                throw new OverflowException(SR.Cbor_Writer_DecimalOverflow);
             }
             else if (exponent >= 0)
             {
-                // for positive exponents attempt to compute its decimal representation,
-                // with risk of throwing OverflowException
+                // for positive exponents attempt to compute a decimal
+                // representation, with risk of throwing OverflowException
                 for (; exponent >= 5; exponent -= 5)
                 {
                     mantissa *= 100_000m;
@@ -151,7 +151,7 @@ namespace System.Formats.Cbor
                     case 4: return mantissa * 10000m;
                     default:
                         Debug.Fail("Unreachable code in decimal exponentiation logic");
-                        throw new Exception("Unreachable code in decimal exponentiation logic");
+                        throw new Exception();
                 }
             }
             else if (exponent >= -ExponentUpperBound)
@@ -161,7 +161,7 @@ namespace System.Formats.Cbor
             }
             else
             {
-                throw new OverflowException("Value was either too large or too small for a Decimal.");
+                throw new OverflowException(SR.Cbor_Writer_DecimalOverflow);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -12,12 +12,12 @@ namespace System.Formats.Cbor
         // Implements major type 6 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
         /// <summary>
-        ///   Writes a semantic tag (major type 6)
+        ///   Writes a semantic tag (major type 6).
         /// </summary>
         /// <param name="tag">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteTag(CborTag tag)
@@ -37,8 +37,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteDateTimeOffset(DateTimeOffset value)
@@ -58,8 +58,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="seconds">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUnixTimeSeconds(long seconds)
@@ -77,8 +77,8 @@ namespace System.Formats.Cbor
         ///   The <paramref name="seconds"/> parameter cannot be infinite or NaN
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteUnixTimeSeconds(double seconds)
@@ -98,8 +98,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteBigInteger(BigInteger value)
@@ -118,8 +118,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item --OR--
-        ///   The major type of the encoded value is not permitted in the parent data item --OR--
+        ///   Writing a new value exceeds the definite length of the parent data item -or-
+        ///   The major type of the encoded value is not permitted in the parent data item -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteDecimal(decimal value)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -45,7 +45,7 @@ namespace System.Formats.Cbor
         {
             if (double.IsInfinity(seconds) || double.IsNaN(seconds))
             {
-                throw new ArgumentOutOfRangeException(SR.Cbor_Writer_ValueCannotBeInfiniteOrNaN, nameof(seconds));
+                throw new ArgumentException(SR.Cbor_Writer_ValueCannotBeInfiniteOrNaN, nameof(seconds));
             }
 
             WriteTag(CborTag.UnixTimeSeconds);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -12,13 +12,13 @@ namespace System.Formats.Cbor
         // Implements major type 6 encoding per https://tools.ietf.org/html/rfc7049#section-2.1
 
         /// <summary>
-        ///   Writes a semantic tag (major type 6).
+        ///   Assign a semantic tag (major type 6) to the next data item.
         /// </summary>
         /// <param name="tag">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteTag(CborTag tag)
         {
@@ -33,13 +33,13 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Writes a <see cref="DateTimeOffset"/> value as a tagged date/time string,
-        ///   as described in RFC7049 section 2.4.1
+        ///   as described in RFC7049 section 2.4.1.
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteDateTimeOffset(DateTimeOffset value)
         {
@@ -54,13 +54,13 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Writes a unix time in seconds as a tagged date/time value,
-        ///   as described in RFC7049 section 2.4.1
+        ///   as described in RFC7049 section 2.4.1.
         /// </summary>
         /// <param name="seconds">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteUnixTimeSeconds(long seconds)
         {
@@ -70,16 +70,16 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Writes a unix time in seconds as a tagged date/time value,
-        ///   as described in RFC7049 section 2.4.1
+        ///   as described in RFC7049 section 2.4.1.
         /// </summary>
         /// <param name="seconds">The value to write.</param>
         /// <exception cref="ArgumentException">
         ///   The <paramref name="seconds"/> parameter cannot be infinite or NaN
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteUnixTimeSeconds(double seconds)
         {
@@ -94,7 +94,7 @@ namespace System.Formats.Cbor
 
         /// <summary>
         ///   Writes a <see cref="BigInteger"/> value as a tagged bignum encoding,
-        ///   as described in RFC7049 section 2.4.2
+        ///   as described in RFC7049 section 2.4.2.
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
@@ -118,9 +118,9 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
-        ///   The written data is not accepted under the current conformance level
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
+        ///   The written data is not accepted under the current conformance level.
         /// </exception>
         public void WriteDecimal(decimal value)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -32,7 +32,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a <see cref="DateTimeOffset"/> value as a tagged date/time string,
+        ///   Writes the provided value as a tagged date/time string,
         ///   as described in RFC7049 section 2.4.1.
         /// </summary>
         /// <param name="value">The value to write.</param>
@@ -93,7 +93,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a <see cref="BigInteger"/> value as a tagged bignum encoding,
+        ///   Writes the provided value as a tagged bignum encoding,
         ///   as described in RFC7049 section 2.4.2.
         /// </summary>
         /// <param name="value">The value to write.</param>
@@ -113,7 +113,7 @@ namespace System.Formats.Cbor
         }
 
         /// <summary>
-        ///   Writes a <see cref="decimal"/> value as a tagged decimal fraction encoding,
+        ///   Writes the provided value value as a tagged decimal fraction encoding,
         ///   as described in RFC7049 section 2.4.3
         /// </summary>
         /// <param name="value">The value to write.</param>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.Tag.cs
@@ -98,8 +98,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <exception cref="InvalidOperationException">
-        ///   Writing a new value exceeds the definite length of the parent data item -or-
-        ///   The major type of the encoded value is not permitted in the parent data item -or-
+        ///   Writing a new value exceeds the definite length of the parent data item. -or-
+        ///   The major type of the encoded value is not permitted in the parent data item. -or-
         ///   The written data is not accepted under the current conformance level
         /// </exception>
         public void WriteBigInteger(BigInteger value)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -61,8 +61,6 @@ namespace System.Formats.Cbor
         /// </summary>
         public int BytesWritten => _offset;
 
-        // Returns true iff a complete CBOR document has been written to buffer
-
         /// <summary>
         ///   True if the writer has completed writing a complete root-level CBOR document,
         ///   or sequence of root-level CBOR documents.
@@ -128,8 +126,8 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="encodedValue">The encoded value to write.</param>
         /// <exception cref="ArgumentException">
-        ///   <paramref name="preEncodedValue"/> is not a well-formed CBOR encoding -or-
-        ///   <paramref name="preEncodedValue"/> is not valid under the current conformance level
+        ///   <paramref name="encodedValue"/> is not a well-formed CBOR encoding -or-
+        ///   <paramref name="encodedValue"/> is not valid under the current conformance level
         /// </exception>
         public void WriteEncodedValue(ReadOnlyMemory<byte> encodedValue)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -101,7 +101,7 @@ namespace System.Formats.Cbor
 
             static void ValidateEncoding(ReadOnlyMemory<byte> encodedValue, CborConformanceLevel conformanceLevel)
             {
-                var reader = new CborReader(encodedValue, conformanceLevel: conformanceLevel);
+                var reader = new CborReader(encodedValue, conformanceLevel: conformanceLevel, allowMultipleRootLevelValues: false);
 
                 try
                 {
@@ -112,7 +112,7 @@ namespace System.Formats.Cbor
                     throw new ArgumentException(SR.Cbor_Writer_PayloadIsNotValidCbor, e);
                 }
 
-                if (reader.BytesRemaining != 0)
+                if (reader.HasData)
                 {
                     throw new ArgumentException(SR.Cbor_Writer_PayloadIsNotValidCbor);
                 }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -56,6 +56,29 @@ namespace System.Formats.Cbor
         // Returns true iff a complete CBOR document has been written to buffer
         public bool IsWriteCompleted => _currentMajorType is null && _itemsWritten > 0;
 
+        public void Reset(bool clearBuffer = false)
+        {
+            _offset = 0;
+
+            _nestedDataItems?.Clear();
+            _currentMajorType = null;
+            _definiteLength = null;
+            _itemsWritten = 0;
+            _frameOffset = 0;
+            _isTagContext = false;
+
+            _currentKeyOffset = null;
+            _currentValueOffset = null;
+            _keysRequireSorting = false;
+            _keyValueEncodingRanges?.Clear();
+            _keyEncodingRanges?.Clear();
+
+            if (clearBuffer && _buffer != null)
+            {
+                Array.Clear(_buffer, 0, _buffer.Length);
+            }
+        }
+
         public void WriteEncodedValue(ReadOnlyMemory<byte> encodedValue)
         {
             ValidateEncoding(encodedValue, ConformanceLevel);

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -56,26 +56,25 @@ namespace System.Formats.Cbor
         // Returns true iff a complete CBOR document has been written to buffer
         public bool IsWriteCompleted => _currentMajorType is null && _itemsWritten > 0;
 
-        public void Reset(bool clearBuffer = false)
+        public void Reset()
         {
-            _offset = 0;
-
-            _nestedDataItems?.Clear();
-            _currentMajorType = null;
-            _definiteLength = null;
-            _itemsWritten = 0;
-            _frameOffset = 0;
-            _isTagContext = false;
-
-            _currentKeyOffset = null;
-            _currentValueOffset = null;
-            _keysRequireSorting = false;
-            _keyValueEncodingRanges?.Clear();
-            _keyEncodingRanges?.Clear();
-
-            if (clearBuffer && _buffer != null)
+            if (_offset > 0)
             {
-                Array.Clear(_buffer, 0, _buffer.Length);
+                Array.Clear(_buffer, 0, _offset);
+
+                _offset = 0;
+                _nestedDataItems?.Clear();
+                _currentMajorType = null;
+                _definiteLength = null;
+                _itemsWritten = 0;
+                _frameOffset = 0;
+                _isTagContext = false;
+
+                _currentKeyOffset = null;
+                _currentValueOffset = null;
+                _keysRequireSorting = false;
+                _keyValueEncodingRanges?.Clear();
+                _keyEncodingRanges?.Clear();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -39,7 +39,7 @@ namespace System.Formats.Cbor
 
             if (encodeIndefiniteLengths && CborConformanceLevelHelpers.RequiresDefiniteLengthItems(conformanceLevel))
             {
-                throw new ArgumentException($"Conformance level {conformanceLevel} does not allow indefinite length encodings.", nameof(encodeIndefiniteLengths));
+                throw new ArgumentException(SR.Format(SR.Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported, conformanceLevel), nameof(encodeIndefiniteLengths));
             }
 
             ConformanceLevel = conformanceLevel;
@@ -89,12 +89,12 @@ namespace System.Formats.Cbor
                 }
                 catch (FormatException e)
                 {
-                    throw new ArgumentException("Payload is not a valid CBOR value.", e);
+                    throw new ArgumentException(SR.Cbor_Writer_PayloadIsNotValidCbor, e);
                 }
 
                 if (reader.BytesRemaining != 0)
                 {
-                    throw new ArgumentException("Payload is not a valid CBOR value.");
+                    throw new ArgumentException(SR.Cbor_Writer_PayloadIsNotValidCbor);
                 }
             }
         }
@@ -120,7 +120,7 @@ namespace System.Formats.Cbor
         {
             if (!IsWriteCompleted)
             {
-                throw new InvalidOperationException("Buffer contains incomplete CBOR document.");
+                throw new InvalidOperationException(SR.Cbor_Writer_IncompleteCborDocument);
             }
 
             return new ReadOnlySpan<byte>(_buffer, 0, _offset);
@@ -176,19 +176,19 @@ namespace System.Formats.Cbor
 
             if (expectedType != _currentMajorType)
             {
-                throw new InvalidOperationException("Unexpected major type in nested CBOR data item.");
+                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, _currentMajorType));
             }
 
             Debug.Assert(_nestedDataItems?.Count > 0);
 
             if (_isTagContext)
             {
-                throw new InvalidOperationException("Tagged CBOR value context is incomplete.");
+                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, CborMajorType.Tag));
             }
 
             if (_definiteLength - _itemsWritten > 0)
             {
-                throw new InvalidOperationException("Definite-length nested CBOR data item is incomplete.");
+                throw new InvalidOperationException(SR.Cbor_NotAtEndOfDefiniteLengthDataItem);
             }
 
             // Perform encoding fixups that require the current context and must be done before popping
@@ -239,7 +239,7 @@ namespace System.Formats.Cbor
         {
             if (_definiteLength - _itemsWritten == 0)
             {
-                throw new InvalidOperationException("Adding a CBOR data item to the current context exceeds its definite length.");
+                throw new InvalidOperationException(SR.Cbor_Writer_DefiniteLengthExceeded);
             }
 
             if (_currentMajorType != null)
@@ -255,7 +255,7 @@ namespace System.Formats.Cbor
                             break;
                         }
 
-                        throw new InvalidOperationException("Cannot nest data items in indefinite-length CBOR string contexts.");
+                        throw new InvalidOperationException(SR.Cbor_Writer_CannotNestDataItemsInIndefiniteLengthStrings);
                 }
             }
 
@@ -290,7 +290,7 @@ namespace System.Formats.Cbor
                         break;
                     default:
                         Debug.Fail("Invalid CBOR major type pushed to stack.");
-                        throw new Exception("CborReader internal error. Invalid CBOR major type pushed to stack.");
+                        throw new Exception();
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -87,7 +87,7 @@ namespace System.Formats.Cbor
         ///   if trying to write beyond the scope of one root-level CBOR data item.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///   <paramref name="conformanceLevel"/> is not defined.
+        ///   <paramref name="conformanceLevel"/> is not a defined <see cref="CborConformanceLevel"/>.
         /// </exception>
         public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.Lax, bool convertIndefiniteLengthEncodings = false, bool allowMultipleRootLevelValues = false)
         {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -99,9 +99,9 @@ namespace System.Formats.Cbor
             }
         }
 
-        public byte[] GetEncoding() => GetSpanEncoding().ToArray();
+        public byte[] Encode() => GetSpanEncoding().ToArray();
 
-        public bool TryWriteEncoding(Span<byte> destination, out int bytesWritten)
+        public bool TryEncode(Span<byte> destination, out int bytesWritten)
         {
             ReadOnlySpan<byte> encoding = GetSpanEncoding();
 
@@ -123,7 +123,7 @@ namespace System.Formats.Cbor
                 throw new InvalidOperationException("Buffer contains incomplete CBOR document.");
             }
 
-            return (_offset == 0) ? ReadOnlySpan<byte>.Empty : new ReadOnlySpan<byte>(_buffer, 0, _offset);
+            return new ReadOnlySpan<byte>(_buffer, 0, _offset);
         }
 
         private void EnsureWriteCapacity(int pendingCount)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -24,14 +24,12 @@ namespace System.Formats.Cbor
         private int _frameOffset = 0; // buffer offset particular to the current data item context
         private bool _isTagContext = false; // true if writer is expecting a tagged value
 
-        // Map-specific conformance book-keeping
-        private int? _currentKeyOffset = null;
-        private int? _currentValueOffset = null;
-        // State required for sorting map keys
-        private bool _keysRequireSorting = false;
-        private List<KeyValueEncodingRange>? _keyValueEncodingRanges = null;
-        // State required for checking key uniqueness
-        private HashSet<(int Offset, int Length)>? _keyEncodingRanges = null;
+        // Map-specific book-keeping
+        private int? _currentKeyOffset = null; // offset for the current key encoding
+        private int? _currentValueOffset = null; // offset for the current value encoding
+        private bool _keysRequireSorting = false; // tracks whether key/value pair encodings need to be sorted
+        private List<KeyValuePairEncodingRange>? _keyValuePairEncodingRanges = null; // all key/value pair encoding ranges
+        private HashSet<(int Offset, int Length)>? _keyEncodingRanges = null; // all key encoding ranges up to encoding equality
 
         public CborWriter(CborConformanceLevel conformanceLevel = CborConformanceLevel.Lax, bool encodeIndefiniteLengths = false, bool allowMultipleRootLevelValues = false)
         {
@@ -73,7 +71,7 @@ namespace System.Formats.Cbor
                 _currentKeyOffset = null;
                 _currentValueOffset = null;
                 _keysRequireSorting = false;
-                _keyValueEncodingRanges?.Clear();
+                _keyValuePairEncodingRanges?.Clear();
                 _keyEncodingRanges?.Clear();
             }
         }
@@ -175,7 +173,7 @@ namespace System.Formats.Cbor
                 currentKeyOffset: _currentKeyOffset,
                 currentValueOffset: _currentValueOffset,
                 keysRequireSorting: _keysRequireSorting,
-                keyValueEncodingRanges: _keyValueEncodingRanges,
+                keyValuePairEncodingRanges: _keyValuePairEncodingRanges,
                 keyEncodingRanges: _keyEncodingRanges
             );
 
@@ -189,7 +187,7 @@ namespace System.Formats.Cbor
             _currentValueOffset = null;
             _keysRequireSorting = false;
             _keyEncodingRanges = null;
-            _keyValueEncodingRanges = null;
+            _keyValuePairEncodingRanges = null;
         }
 
         private void PopDataItem(CborMajorType expectedType)
@@ -235,7 +233,7 @@ namespace System.Formats.Cbor
             _currentKeyOffset = frame.CurrentKeyOffset;
             _currentValueOffset = frame.CurrentValueOffset;
             _keysRequireSorting = frame.KeysRequireSorting;
-            _keyValueEncodingRanges = frame.KeyValueEncodingRanges;
+            _keyValuePairEncodingRanges = frame.KeyValuePairEncodingRanges;
             _keyEncodingRanges = frame.KeyEncodingRanges;
         }
 
@@ -327,7 +325,7 @@ namespace System.Formats.Cbor
                 int? currentKeyOffset,
                 int? currentValueOffset,
                 bool keysRequireSorting,
-                List<KeyValueEncodingRange>? keyValueEncodingRanges,
+                List<KeyValuePairEncodingRange>? keyValuePairEncodingRanges,
                 HashSet<(int Offset, int Length)>? keyEncodingRanges)
             {
                 MajorType = type;
@@ -337,7 +335,7 @@ namespace System.Formats.Cbor
                 CurrentKeyOffset = currentKeyOffset;
                 CurrentValueOffset = currentValueOffset;
                 KeysRequireSorting = keysRequireSorting;
-                KeyValueEncodingRanges = keyValueEncodingRanges;
+                KeyValuePairEncodingRanges = keyValuePairEncodingRanges;
                 KeyEncodingRanges = keyEncodingRanges;
             }
 
@@ -349,7 +347,7 @@ namespace System.Formats.Cbor
             public int? CurrentKeyOffset { get; }
             public int? CurrentValueOffset { get; }
             public bool KeysRequireSorting { get; }
-            public List<KeyValueEncodingRange>? KeyValueEncodingRanges { get; }
+            public List<KeyValuePairEncodingRange>? KeyValuePairEncodingRanges { get; }
             public HashSet<(int Offset, int Length)>? KeyEncodingRanges { get; }
         }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -82,9 +82,8 @@ namespace System.Formats.Cbor
         ///   Defaults to <see langword="false" />.
         /// </param>
         /// <param name="allowMultipleRootLevelValues">
-        ///   Specify if multiple root-level values are to be supported by the writer.
-        ///   When set to <see langword="false" />, the reader will throw an <see cref="InvalidOperationException"/>
-        ///   if trying to write beyond the scope of one root-level CBOR data item.
+        ///   <see langword="true"/> to allow multiple root-level values to be written by the writer; otherwise, <see langword="false"/>.
+        ///   The default is <see langword="false"/>.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="conformanceLevel"/> is not a defined <see cref="CborConformanceLevel"/>.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -270,7 +270,14 @@ namespace System.Formats.Cbor
             // Validate that the pop operation can be performed
             if (typeToPop != _currentMajorType)
             {
-                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, _currentMajorType));
+                if (_currentMajorType.HasValue)
+                {
+                    throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, (int)_currentMajorType));
+                }
+                else
+                {
+                    throw new InvalidOperationException(SR.Cbor_Reader_IsAtRootContext);
+                }
             }
 
             Debug.Assert(_nestedDataItems?.Count > 0); // implied by previous check
@@ -278,7 +285,7 @@ namespace System.Formats.Cbor
             if (_isTagContext)
             {
                 // writer expecting value after a tag data item , cannot pop the current context
-                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, CborMajorType.Tag));
+                throw new InvalidOperationException(SR.Format(SR.Cbor_PopMajorTypeMismatch, (int)CborMajorType.Tag));
             }
 
             if (_definiteLength - _itemsWritten > 0)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -39,8 +39,11 @@ namespace System.Formats.Cbor
         public CborConformanceLevel ConformanceLevel { get; }
 
         /// <summary>
-        ///   True if the writer automatically converts indefinite-length encodings into definite-length equivalents.
+        ///   Gets a value that indicates whether the writer automatically converts indefinite-length encodings into definite-length equivalents.
         /// </summary>
+        /// <value>
+        ///   <see langword="true"/> if the writer automatically converts indefinite-length encodings into definite-length equivalents; otherwise, <see langword="false"/>.
+        /// </value>
         public bool ConvertIndefiniteLengthEncodings { get; }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -105,7 +105,7 @@ namespace System.Formats.Cbor
 
                 try
                 {
-                    reader.SkipValue(validateConformance: true);
+                    reader.SkipValue(disableConformanceLevelChecks: false);
                 }
                 catch (FormatException e)
                 {

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -6,7 +6,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 
 namespace System.Formats.Cbor
 {
@@ -77,11 +76,11 @@ namespace System.Formats.Cbor
         /// <param name="convertIndefiniteLengthEncodings">
         ///   Enables automatically converting indefinite-length encodings into definite-length equivalents.
         ///   Allows use of indefinite-length write APIs in conformance levels that otherwise do not permit it.
-        ///   Defaults to <c>false</c>.
+        ///   Defaults to <see langword="false" />.
         /// </param>
         /// <param name="allowMultipleRootLevelValues">
         ///   Specify if multiple root-level values are to be supported by the writer.
-        ///   When set to <c>false</c>, the reader will throw an <see cref="InvalidOperationException"/>
+        ///   When set to <see langword="false" />, the reader will throw an <see cref="InvalidOperationException"/>
         ///   if trying to write beyond the scope of one root-level CBOR data item.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
@@ -127,7 +126,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="encodedValue">The encoded value to write.</param>
         /// <exception cref="ArgumentException">
-        ///   <paramref name="preEncodedValue"/> is not a well-formed CBOR encoding --OR--
+        ///   <paramref name="preEncodedValue"/> is not a well-formed CBOR encoding -or-
         ///   <paramref name="preEncodedValue"/> is not valid under the current conformance level
         /// </exception>
         public void WriteEncodedValue(ReadOnlyMemory<byte> encodedValue)
@@ -190,8 +189,8 @@ namespace System.Formats.Cbor
         ///   On success, receives the number of bytes written to <paramref name="destination"/>.
         /// </param>
         /// <returns>
-        ///   <c>true</c> if the encode succeeded,
-        ///   <c>false</c> if <paramref name="destination"/> is too small.
+        ///   <see langword="true" /> if the encode succeeded,
+        ///   <see langword="false" /> if <paramref name="destination"/> is too small.
         /// </returns>
         /// <exception cref="InvalidOperationException">
         ///   The writer does not contain a complete CBOR value or sequence of root-level values.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -129,7 +129,7 @@ namespace System.Formats.Cbor
         /// </summary>
         /// <param name="encodedValue">The encoded value to write.</param>
         /// <exception cref="ArgumentException">
-        ///   <paramref name="encodedValue"/> is not a well-formed CBOR encoding -or-
+        ///   <paramref name="encodedValue"/> is not a well-formed CBOR encoding. -or-
         ///   <paramref name="encodedValue"/> is not valid under the current conformance level
         /// </exception>
         public void WriteEncodedValue(ReadOnlyMemory<byte> encodedValue)

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -34,7 +34,7 @@ namespace System.Formats.Cbor
         private HashSet<(int Offset, int Length)>? _keyEncodingRanges = null; // all key encoding ranges up to encoding equality
 
         /// <summary>
-        ///   The <see cref="CborConformanceLevel"/> used by this writer.
+        ///   The conformance level used by this writer.
         /// </summary>
         public CborConformanceLevel ConformanceLevel { get; }
 

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -71,7 +71,7 @@ namespace System.Formats.Cbor
         public bool IsWriteCompleted => _currentMajorType is null && _itemsWritten > 0;
 
         /// <summary>
-        ///   Create a new <see cref="CborWriter"/> instance with given configuration.
+        ///   Create a new CborWriter instance with given configuration.
         /// </summary>
         /// <param name="conformanceLevel">
         ///   Specifies a <see cref="CborConformanceLevel"/> guiding the conformance checks performed on the encoded data.

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/CborWriter.cs
@@ -49,6 +49,9 @@ namespace System.Formats.Cbor
         /// <summary>
         ///   Declares whether this writer allows multiple root-level CBOR data items.
         /// </summary>
+        /// <value>
+        ///   <see langword="true"/> if the writer allows multiple root-level CBOR data items; otherwise, <see langword="false"/>.
+        /// </value>
         public bool AllowMultipleRootLevelValues { get; }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/System.Formats.Cbor.Shared.projitems
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor/System.Formats.Cbor.Shared.projitems
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Marvin.cs" Link="Common\System\Marvin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CborReaderState.cs" Link="Common\System\Formats\Cbor\Reader\CborReaderState.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CborReader.SkipValue.cs" Link="Common\System\Formats\Cbor\Reader\CborReader.SkipValue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CborReader.Simple.cs" Link="Common\System\Formats\Cbor\Reader\CborReader.Simple.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CborReader.Tag.cs" Link="Common\System\Formats\Cbor\Reader\CborReader.Tag.cs" />

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -146,5 +206,104 @@
   </data>
   <data name="Cryptography_WriteEncodedValue_OneValueAtATime" xml:space="preserve">
     <value>The input to WriteEncodedValue must represent a single encoded value with no trailing data.</value>
+  </data>
+  <data name="Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support indefinite-length data items.</value>
+  </data>
+  <data name="Cbor_Reader_DefiniteLengthExceedsBufferSize" xml:space="preserve">
+    <value>Declared definite length of CBOR data item exceeds available buffer size.</value>
+  </data>
+  <data name="Cbor_Reader_NotAtEndOfIndefiniteLengthDataItem" xml:space="preserve">
+    <value>Not at end of the indefinite-length data item.</value>
+  </data>
+  <data name="Cbor_Reader_NoMoreDataItemsToRead" xml:space="preserve">
+    <value>No more CBOR data items to read in the current context.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_UnexpectedEndOfBuffer" xml:space="preserve">
+    <value>Invalid CBOR encoding: unexpected end of data.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem" xml:space="preserve">
+    <value>Indefinite-length CBOR string nests an invalid data item of major type {0}.</value>
+  </data>
+  <data name="Cbor_Reader_MajorTypeMismatch" xml:space="preserve">
+    <value>CBOR data item is of major type {0}, which does not match the current operation.</value>
+  </data>
+  <data name="Cbor_Reader_IsAtRootContext" xml:space="preserve">
+    <value>CBOR reader is already at the root data item context.</value>
+  </data>
+  <data name="Cbor_Reader_MajorTypePopMismatch" xml:space="preserve">
+    <value>CBOR reader is in a {0} context, which does not match the current operation.</value>
+  </data>
+  <data name="Cbor_Reader_NotAtEndOfDefiniteLengthDataItem" xml:space="preserve">
+    <value>Not at end of the definite-length data item.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_TagNotFollowedByValue" xml:space="preserve">
+    <value>A CBOR tag should always be followed by a data item.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_InvalidIntegerEncoding" xml:space="preserve">
+    <value>Initial byte contains invalid integer encoding</value>
+  </data>
+  <data name="Cbor_Reader_ConformanceLevel_NonCanonicalIntegerRepresentation" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support non-canonical integer representations.</value>
+  </data>
+  <data name="Cbor_Reader_ConformanceLevel_RequiresDefiniteLengthItems" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support indefinite-length items.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_KeyMissingValue" xml:space="preserve">
+    <value>Latest key in current CBOR map misses accompanying value.</value>
+  </data>
+  <data name="Cbor_Reader_ConformanceLevel_ContainsDuplicateKeys" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support duplicate keys.</value>
+  </data>
+  <data name="Cbor_Reader_ConformanceLevel_KeysNotInSortedOrder" xml:space="preserve">
+    <value>CBOR keys not sorted in accordance with conformance level '{0}'.</value>
+  </data>
+  <data name="Cbor_Reader_NotAFloatEncoding" xml:space="preserve">
+    <value>Data item does not encode a floating point number.</value>
+  </data>
+  <data name="Cbor_Reader_ReadingDoubleAsSingle" xml:space="preserve">
+    <value>Attempting to read double-precision floating point encoding as a single-precision value.</value>
+  </data>
+  <data name="Cbor_Reader_NotABooleanEncoding" xml:space="preserve">
+    <value>CBOR simple value does not encode a boolean value.</value>
+  </data>
+  <data name="Cbor_Reader_NotASimpleValueEncoding" xml:space="preserve">
+    <value>CBOR data item does not encode a simple value.</value>
+  </data>
+  <data name="Cbor_Reader_NotANullEncoding" xml:space="preserve">
+    <value>CBOR simple value does not encode null.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_InvalidSimpleValueEncoding" xml:space="preserve">
+    <value>Invalid CBOR simple value encoding.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_UnexpectedBreakByte" xml:space="preserve">
+    <value>CBOR definite-length data items contains unexpected break byte.</value>
+  </data>
+  <data name="Cbor_Reader_Skip_InvalidState" xml:space="preserve">
+    <value>Reader state '{0}' is not at start of a data item.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidCbor_InvalidUtf8StringEncoding" xml:space="preserve">
+    <value>CBOR text string payload is not valid UTF-8.</value>
+  </data>
+  <data name="Cbor_Reader_NotIndefiniteLengthString" xml:space="preserve">
+    <value>CBOR string is not of indefinite length.</value>
+  </data>
+  <data name="Cbor_Reader_ConformanceLevel_TagsNotSupported" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support tagged values.</value>
+  </data>
+  <data name="Cbor_Reader_TagMismatch" xml:space="preserve">
+    <value>CBOR tag does not match expected value.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidDateTimeEncoding" xml:space="preserve">
+    <value>Not a valid tagged RFC3339 DateTime encoding.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidUnixTimeEncoding" xml:space="preserve">
+    <value>Not a valid tagged unix time encoding.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidBigNumEncoding" xml:space="preserve">
+    <value>Not a valid tagged bignum encoding.</value>
+  </data>
+  <data name="Cbor_Reader_InvalidDecimalEncoding" xml:space="preserve">
+    <value>Not a valid tagged decimal fraction encoding.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -207,56 +207,59 @@
   <data name="Cryptography_WriteEncodedValue_OneValueAtATime" xml:space="preserve">
     <value>The input to WriteEncodedValue must represent a single encoded value with no trailing data.</value>
   </data>
-  <data name="Cbor_Reader_ConformanceLevel_IndefiniteLengthItemsNotSupported" xml:space="preserve">
+  <data name="Cbor_PopMajorTypeMismatch" xml:space="preserve">
+    <value>Cannot perform the requested operation, the current context is '{0}'.</value>
+  </data>
+  <data name="Cbor_NotAtEndOfDefiniteLengthDataItem" xml:space="preserve">
+    <value>Not at end of the definite-length data item.</value>
+  </data>
+  <data name="Cbor_NotAtEndOfIndefiniteLengthDataItem" xml:space="preserve">
+    <value>Not at end of the indefinite-length data item.</value>
+  </data>
+  <data name="Cbor_ConformanceLevel_IndefiniteLengthItemsNotSupported" xml:space="preserve">
     <value>CBOR Conformance level '{0}' does not support indefinite-length data items.</value>
+  </data>
+  <data name="Cbor_ConformanceLevel_NonCanonicalIntegerRepresentation" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support non-canonical integer representations.</value>
+  </data>
+  <data name="Cbor_ConformanceLevel_RequiresDefiniteLengthItems" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support indefinite-length items.</value>
+  </data>
+  <data name="Cbor_ConformanceLevel_ContainsDuplicateKeys" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support duplicate keys.</value>
+  </data>
+  <data name="Cbor_ConformanceLevel_KeysNotInSortedOrder" xml:space="preserve">
+    <value>CBOR keys not sorted in accordance with conformance level '{0}'.</value>
+  </data>
+  <data name="Cbor_ConformanceLevel_TagsNotSupported" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support tagged values.</value>
   </data>
   <data name="Cbor_Reader_DefiniteLengthExceedsBufferSize" xml:space="preserve">
     <value>Declared definite length of CBOR data item exceeds available buffer size.</value>
-  </data>
-  <data name="Cbor_Reader_NotAtEndOfIndefiniteLengthDataItem" xml:space="preserve">
-    <value>Not at end of the indefinite-length data item.</value>
   </data>
   <data name="Cbor_Reader_NoMoreDataItemsToRead" xml:space="preserve">
     <value>No more CBOR data items to read in the current context.</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_UnexpectedEndOfBuffer" xml:space="preserve">
-    <value>Invalid CBOR encoding: unexpected end of data.</value>
+    <value>Unexpected end of CBOR encoding data.</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_IndefiniteLengthStringContainsInvalidDataItem" xml:space="preserve">
     <value>Indefinite-length CBOR string nests an invalid data item of major type {0}.</value>
   </data>
   <data name="Cbor_Reader_MajorTypeMismatch" xml:space="preserve">
-    <value>CBOR data item is of major type {0}, which does not match the current operation.</value>
+    <value>Cannot perform the requested operation, the next CBOR data item is of major type '{0}'.</value>
   </data>
   <data name="Cbor_Reader_IsAtRootContext" xml:space="preserve">
     <value>CBOR reader is already at the root data item context.</value>
-  </data>
-  <data name="Cbor_Reader_MajorTypePopMismatch" xml:space="preserve">
-    <value>CBOR reader is in a {0} context, which does not match the current operation.</value>
-  </data>
-  <data name="Cbor_Reader_NotAtEndOfDefiniteLengthDataItem" xml:space="preserve">
-    <value>Not at end of the definite-length data item.</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_TagNotFollowedByValue" xml:space="preserve">
     <value>A CBOR tag should always be followed by a data item.</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_InvalidIntegerEncoding" xml:space="preserve">
-    <value>Initial byte contains invalid integer encoding</value>
-  </data>
-  <data name="Cbor_Reader_ConformanceLevel_NonCanonicalIntegerRepresentation" xml:space="preserve">
-    <value>CBOR Conformance level '{0}' does not support non-canonical integer representations.</value>
-  </data>
-  <data name="Cbor_Reader_ConformanceLevel_RequiresDefiniteLengthItems" xml:space="preserve">
-    <value>CBOR Conformance level '{0}' does not support indefinite-length items.</value>
+    <value>CBOR initial byte contains invalid integer encoding</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_KeyMissingValue" xml:space="preserve">
-    <value>Latest key in current CBOR map misses accompanying value.</value>
-  </data>
-  <data name="Cbor_Reader_ConformanceLevel_ContainsDuplicateKeys" xml:space="preserve">
-    <value>CBOR Conformance level '{0}' does not support duplicate keys.</value>
-  </data>
-  <data name="Cbor_Reader_ConformanceLevel_KeysNotInSortedOrder" xml:space="preserve">
-    <value>CBOR keys not sorted in accordance with conformance level '{0}'.</value>
+    <value>The current CBOR map contains an incomplete key/value pair.</value>
   </data>
   <data name="Cbor_Reader_NotAFloatEncoding" xml:space="preserve">
     <value>Data item does not encode a floating point number.</value>
@@ -280,16 +283,13 @@
     <value>CBOR definite-length data items contains unexpected break byte.</value>
   </data>
   <data name="Cbor_Reader_Skip_InvalidState" xml:space="preserve">
-    <value>Reader state '{0}' is not at start of a data item.</value>
+    <value>Reader state '{0}' is not at the start of a data item.</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_InvalidUtf8StringEncoding" xml:space="preserve">
-    <value>CBOR text string payload is not valid UTF-8.</value>
+    <value>CBOR text string payload is not valid a UTF-8 encoding.</value>
   </data>
   <data name="Cbor_Reader_NotIndefiniteLengthString" xml:space="preserve">
     <value>CBOR string is not of indefinite length.</value>
-  </data>
-  <data name="Cbor_Reader_ConformanceLevel_TagsNotSupported" xml:space="preserve">
-    <value>CBOR Conformance level '{0}' does not support tagged values.</value>
   </data>
   <data name="Cbor_Reader_TagMismatch" xml:space="preserve">
     <value>CBOR tag does not match expected value.</value>
@@ -304,6 +304,30 @@
     <value>Not a valid tagged bignum encoding.</value>
   </data>
   <data name="Cbor_Reader_InvalidDecimalEncoding" xml:space="preserve">
-    <value>Not a valid tagged decimal fraction encoding.</value>
+    <value>Not a valid tagged decimal encoding.</value>
+  </data>
+  <data name="Cbor_Writer_PayloadIsNotValidCbor" xml:space="preserve">
+    <value>Not a valid CBOR value encoding.</value>
+  </data>
+  <data name="Cbor_Writer_IncompleteCborDocument" xml:space="preserve">
+    <value>Writer contains an incomplete CBOR document.</value>
+  </data>
+  <data name="Cbor_Writer_DefiniteLengthExceeded" xml:space="preserve">
+    <value>Adding a CBOR data item to the current context exceeds its definite length.</value>
+  </data>
+  <data name="Cbor_Writer_CannotNestDataItemsInIndefiniteLengthStrings" xml:space="preserve">
+    <value>Cannot nest data items in indefinite-length CBOR string contexts.</value>
+  </data>
+  <data name="Cbor_Writer_MapIncompleteKeyValuePair" xml:space="preserve">
+    <value>CBOR map incomplete; each key must be followed by a corresponding value.</value>
+  </data>
+  <data name="Cbor_Writer_InvalidUtf8String" xml:space="preserve">
+    <value>Not a valid UTF-8 encoding.</value>
+  </data>
+  <data name="Cbor_Writer_ValueCannotBeInfiniteOrNaN" xml:space="preserve">
+    <value>Value cannot be infinite or NaN.</value>
+  </data>
+  <data name="Cbor_Writer_DecimalOverflow" xml:space="preserve">
+    <value>Value was either too large or too small for a Decimal.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -330,4 +330,7 @@
   <data name="Cbor_Writer_DecimalOverflow" xml:space="preserve">
     <value>Value was either too large or too small for a Decimal.</value>
   </data>
+  <data name="Cbor_Writer_InvalidSimpleValueRange" xml:space="preserve">
+    <value>Simple values in the 24-31 range are not permitted.</value>
+  </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -276,8 +276,8 @@
   <data name="Cbor_Reader_NotANullEncoding" xml:space="preserve">
     <value>CBOR simple value does not encode null.</value>
   </data>
-  <data name="Cbor_Reader_InvalidCbor_InvalidSimpleValueEncoding" xml:space="preserve">
-    <value>Invalid CBOR simple value encoding.</value>
+  <data name="Cbor_ConformanceLevel_InvalidSimpleValueEncoding" xml:space="preserve">
+    <value>CBOR Conformance level '{0}' does not support simple values in the range 24-31 and must be encoded as small as possible.</value>
   </data>
   <data name="Cbor_Reader_InvalidCbor_UnexpectedBreakByte" xml:space="preserve">
     <value>CBOR definite-length data items contains unexpected break byte.</value>
@@ -329,8 +329,5 @@
   </data>
   <data name="Cbor_Writer_DecimalOverflow" xml:space="preserve">
     <value>Value was either too large or too small for a Decimal.</value>
-  </data>
-  <data name="Cbor_Writer_InvalidSimpleValueRange" xml:space="preserve">
-    <value>Simple values in the 24-31 range are not permitted.</value>
   </data>
 </root>


### PR DESCRIPTION
Replaces #36289

Implementation Changes:

* Remove buffer pooling and IDisposable implementation from CborWriter.
* Remove `CborReader.BytesRemaining` property.
* Rename `CborWriter.GetEncoding()/TryGetEncoding()` methods to `CborWriter.Encode()/TryEncode()`.
* Implement a `CborWriter.Reset()` method.
* Refine UTF-8 validation semantics in the lax conformance level.
* Change `CborReader.SkipValue(bool validateConformance = false)` to `SkipValue(bool disableConformanceLevelChecks = false)`.
* Ensure `CborReader.SkipValue()` surfaces accurate FormatException messages.
* Ensure CborReader checkpointing implementation correctly rolls back conformance level check state.
* Fix CborReader handling of root-level break bytes when multiple root-level values are permitted.
* Disable CborWriter indefinite-to-definite length data item patching by default.
* Fix SimpleValue encoding tolerating invalid ranges.

Refinements:
* Move exception messages to resx strings.
* Add XML docs to public APIs and add more code comments.