### PR TITLE
Adding check to bypass decoding pdbs that have no sequence points.

### DIFF
--- a/src/mono/mono/metadata/debug-mono-ppdb.c
+++ b/src/mono/mono/metadata/debug-mono-ppdb.c
@@ -497,7 +497,7 @@ mono_ppdb_get_seq_points (MonoDebugMethodInfo *minfo, char **source_file, GPtrAr
 	if (source_files)
 		sindexes = g_ptr_array_new ();
 
-	if (!method->token)
+	if (!method->token || tables [MONO_TABLE_METHODBODY].rows == 0)
 		return;
 
 	method_idx = mono_metadata_token_index (method->token);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19815,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Unity has a pdb with zero sequence points somehow. If a user added a reference to the library and then attempted to set a managed breakpoint mono would hit an assert and crash when it would attempt to decode this pdb.

Call stack would look like:
```
>	mono-2.0-boehm.dll!mono_ppdb_get_seq_points(_MonoDebugMethodInfo * minfo, char * * source_file, _GPtrArray * * source_file_list, int * * source_files, MonoSymSeqPoint * * seq_points, int * n_seq_points) Line 508	C
 	mono-2.0-boehm.dll!mono_debug_get_seq_points(_MonoDebugMethodInfo * minfo, char * * source_file, _GPtrArray * * source_file_list, int * * source_files, MonoSymSeqPoint * * seq_points, int * n_seq_points) Line 1093	C
 	mono-2.0-boehm.dll!get_source_files_for_type(_MonoClass * klass) Line 6920	C
 	mono-2.0-boehm.dll!get_types_for_source_file(void * key, void * value, void * user_data) Line 7003	C
 	mono-2.0-boehm.dll!monoeg_g_hash_table_foreach(_GHashTable * hash, void(*)(void *, void *, void *) func, void * user_data) Line 364	C
 	mono-2.0-boehm.dll!mono_de_foreach_domain(void(*)(void *, void *, void *) func, void * user_data) Line 95	C
 	mono-2.0-boehm.dll!vm_commands(int command, int id, unsigned char * p, unsigned char * end, Buffer * buf) Line 7341	C
 	mono-2.0-boehm.dll!debugger_thread(void * arg) Line 10323	C
 	mono-2.0-boehm.dll!start_wrapper_internal(StartInfo * start_info, unsigned __int64 * stack_ptr) Line 1241	C
 	mono-2.0-boehm.dll!start_wrapper(void * data) Line 1315	C
 	kernel32.dll!00007ffc12017bd4()	Unknown
 	ntdll.dll!00007ffc121ece51()	Unknown
```

Adding a check to ignore pdbs like this prevents the crash and debugging can continue normally.

Related unity issue: https://issuetracker.unity3d.com/issues/macos-editor-crashes-on-mono-log-write-logfile-when-attaching-a-debugger-and-then-setting-a-breakpoint

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
