### PR TITLE
Adding a case requiring RuntimeJit

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -626,6 +626,8 @@ namespace Internal.JitInterface
                 case CorInfoHelpFunc.CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPE_MAYBENULL:
                 case CorInfoHelpFunc.CORINFO_HELP_TYPEHANDLE_TO_RUNTIMETYPEHANDLE_MAYBENULL:
                 case CorInfoHelpFunc.CORINFO_HELP_GETREFANY:
+                // For Vector256.Create and similar cases
+                case CorInfoHelpFunc.CORINFO_HELP_THROW_NOT_IMPLEMENTED:
                     throw new RequiresRuntimeJitException(ftnNum.ToString());
 
                 default:


### PR DESCRIPTION
Falling back to RuntimeJIT for CORINFO_HELP_THROW_NOT_IMPLEMENTED. This resolves a recent case of failing to compile Vector256.Create.

cc @dotnet/crossgen-contrib 