### PR TITLE
Adding A log presence check before trying to delete

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -21,7 +21,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                if(EventLog.Exists(log))
+                if (EventLog.Exists(log))
                     Helpers.Retry(() => EventLog.Delete(log));
             }
 

--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -3,13 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
-using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {
     public class EventLogSourceCreationTests
     {
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckSourceExistenceAndDeletion()
         {
@@ -23,13 +21,13 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.Retry(() => EventLog.Delete(log));  // unlike other tests, throw if delete fails
+                if(EventLog.Exists(log))
+                    Helpers.Retry(() => EventLog.Delete(log));
             }
 
             Assert.False(EventLog.SourceExists(source));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void LogNameWithSame8FirstChars_NetCore()
@@ -50,13 +48,15 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                Helpers.Retry(() => EventLog.Delete(firstLog));
+                if (EventLog.Exists(firstLog))
+                    Helpers.Retry(() => EventLog.Delete(firstLog));
+
                 EventLog.DeleteEventSource(secondSource);
-                Helpers.Retry(() => EventLog.Delete(secondLog));
+                if (EventLog.Exists(secondLog))
+                   Helpers.Retry(() => EventLog.Delete(secondLog));
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void LogNameWithSame8FirstChars_NetFramework()
@@ -75,7 +75,8 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                Helpers.Retry(() => EventLog.Delete(firstLog));
+                if (EventLog.Exists(firstLog))
+                    Helpers.Retry(() => EventLog.Delete(firstLog));
             }
         }
 
@@ -145,7 +146,6 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => EventLog.CreateEventSource(null));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void SourceAlreadyExistsWhenCreatingSource()
         {
@@ -160,7 +160,8 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                Helpers.RetrySilently(() => EventLog.Delete(log));
+                if (EventLog.Exists(log))
+                    Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 


### PR DESCRIPTION
Related to https://github.com/dotnet/runtime/issues/36135

I run the tests in a loop, i am not able to repro this on the local machine

The error is we are trying to delete the non-existent log while clean up. So just adding a log check