### PR TITLE
Fix evaluate paths bug when multiple include paths are specified

### DIFF
--- a/eng/pipelines/evaluate-changed-paths.sh
+++ b/eng/pipelines/evaluate-changed-paths.sh
@@ -162,7 +162,7 @@ probePaths() {
       if [[ "$include_path_string" == "" ]]; then
         include_path_string=":$_path"
       else
-        include_path_string="$exclude_path_string :$_path"
+        include_path_string="$include_path_string :$_path"
       fi
     done
 


### PR DESCRIPTION
I was appending the exclude_paths instead of the include_paths, causing it to drop the first included paths from the list 🤦 

Found in: https://github.com/dotnet/runtime/pull/36702

Tested locally by adding a change to an include path and only specifying include paths:
```script
eng/pipelines/evaluate-changed-paths.sh --azurevariable containsChange --difftarget dotnet/master --subset runtimetests --includepaths 'src/coreclr/tests/*+src/coreclr/build-test.sh'

******* Probing runtimetests include paths *******
src/coreclr/tests/*
src/coreclr/build-test.sh

+ git diff -M -C -b --ignore-cr-at-eol --ignore-space-at-eol --exit-code --quiet dotnet/master -- ':src/coreclr/tests/*' :src/coreclr/build-test.sh

----- Matching files for runtimetests -----
+ git diff -M -C -b --ignore-cr-at-eol --ignore-space-at-eol --name-only dotnet/master -- ':src/coreclr/tests/*' :src/coreclr/build-test.sh
src/coreclr/tests/build.proj

Setting pipeline variable containsChange=true
##vso[task.setvariable variable=containsChange;isSecret=false;isOutput=true]true
```

cc: @naricc @dotnet/runtime-infrastructure 