### PR TITLE
Fixing tests on android that uses Icu Shim Globalization

### DIFF
--- a/src/mono/mono/metadata/native-library.c
+++ b/src/mono/mono/metadata/native-library.c
@@ -1272,7 +1272,7 @@ retry_with_libcoreclr:
 			new_scope = g_strdup ("libcoreclr.dylib");
 #else			
 #if defined(TARGET_ANDROID)
-			new_scope = g_strdup ("libmonosgen-2.0.so");
+			new_scope = g_strdup ("libruntime-android.so");
 #else
 			new_scope = g_strdup ("libcoreclr.so");
 #endif

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/CMakeLists-android.txt
@@ -13,4 +13,14 @@ target_link_libraries(
     runtime-android
     %NativeLibrariesToLink%
     libz.so
-    log)
+    log
+    "-u GlobalizationNative_LoadICU"
+    "-u GlobalizationNative_GetLatestJapaneseEra"
+    "-u GlobalizationNative_ChangeCase"
+    "-u GlobalizationNative_CloseSortHandle"
+    "-u GlobalizationNative_GetLocales"
+    "-u GlobalizationNative_GetLocaleInfoInt"
+    "-u GlobalizationNative_GetLocaleTimeFormat"
+    "-u GlobalizationNative_ToUnicode"
+    "-u GlobalizationNative_NormalizeString"
+    "-u GlobalizationNative_GetTimeZoneDisplayName")


### PR DESCRIPTION
The linker was removing the icu shim functions even exporting them. The unique solution that we found until now is to force the linking using the -u flag.
This is a temporary fix until we mplement QCalls.
Fixes https://github.com/dotnet/runtime/issues/36685