### PR TITLE
Fix signing due to subset projects rename

### DIFF
--- a/eng/SubsetValidation.targets
+++ b/eng/SubsetValidation.targets
@@ -6,7 +6,7 @@
     on a whole subset, and the dependency on the subset is disregarded automatically when Subset
     doesn't contain it.
 
-    %(InstallerProject.SignPhase): Indicates this project must be built before a certain signing
+    %(ProjectToBuild.SignPhase): Indicates this project must be built before a certain signing
       phase. Projects can depend on 'signing/stages/Sign<stage>.proj' to wait until all projects
       that are part of a stage are complete. This allows the build to perform complex container
       signing that isn't (can't be?) supported by Arcade's single pass, such as MSIs and bundles:

--- a/src/installer/signing/SignBinaries.proj
+++ b/src/installer/signing/SignBinaries.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'Binaries'))" />
+    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'Binaries'))" />
   </ItemGroup>
 
 </Project>

--- a/src/installer/signing/SignBurnBundleFiles.proj
+++ b/src/installer/signing/SignBurnBundleFiles.proj
@@ -4,7 +4,7 @@
   <Target Name="ReattachAllEnginesToBundles"
           BeforeTargets="RunArcadeSigning">
     <MSBuild
-      Projects="@(InstallerProject -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))"
+      Projects="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))"
       Targets="ReattachEngineToBundle" />
   </Target>
 

--- a/src/installer/signing/SignBurnEngineFiles.proj
+++ b/src/installer/signing/SignBurnEngineFiles.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))" />
+    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'BundleInstallerFiles'))" />
   </ItemGroup>
 
   <!-- To sign the burn engines, they need to be extracted from the bundles using WiX tools. -->

--- a/src/installer/signing/SignMsiFiles.proj
+++ b/src/installer/signing/SignMsiFiles.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'MsiFiles'))" />
+    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'MsiFiles'))" />
   </ItemGroup>
 
   <!--

--- a/src/installer/signing/SignR2RBinaries.proj
+++ b/src/installer/signing/SignR2RBinaries.proj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <StageProject Include="@(InstallerProject -> WithMetadataValue('SignPhase', 'R2RBinaries'))" />
+    <StageProject Include="@(ProjectToBuild -> WithMetadataValue('SignPhase', 'R2RBinaries'))" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This fixes the official build by fixing signing. This was a fall out from: https://github.com/dotnet/runtime/commit/f53c1565

Test build is: https://dev.azure.com/dnceng/internal/_build/results?buildId=653965&view=results

cc: @dotnet/runtime-infrastructure 