### PR TITLE
JIT: don't call back into morph from fgRemoveConditionalJump

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -10959,7 +10959,11 @@ void Compiler::fgRemoveConditionalJump(BasicBlock* block)
         {
             test->SetRootNode(sideEffList);
 
-            fgMorphBlockStmt(block, test DEBUGARG("fgRemoveConditionalJump"));
+            if (fgStmtListThreaded)
+            {
+                gtSetStmtInfo(test);
+                fgSetStmtSeq(test);
+            }
         }
     }
 }

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36468/Runtime_36468.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36468/Runtime_36468.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+class C0
+{
+    public sbyte F4;
+}
+
+#pragma warning disable 0649
+
+struct S1
+{
+    public C0 F0;
+    public bool F8;
+    public int F9;
+}
+
+public class Runtime_36468
+{
+    static S1 s_3;
+    public static int Main()
+    {
+        int result = -1;
+        try
+        {
+            M0();
+        }
+        catch (NullReferenceException)
+        {
+            result = 100;
+        }
+
+        return result;
+    }
+
+    static void M0()
+    {
+        ulong var0 = 0;
+        try
+        {
+            if (M2(ref s_3, s_3))
+            {
+                var0 -= 0;
+            }
+        }
+        finally
+        {
+            int var1 = s_3.F9;
+        }
+    }
+
+    static bool M2(ref S1 arg0, S1 arg1)
+    {
+        sbyte var0 = arg1.F0.F4--;
+        return arg0.F8;
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36468/Runtime_36468.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_36468/Runtime_36468.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This can get called before morph and run into issues where morph
specific data is not yet initialized. The remorphing wasn't going to
do much other than extract side effects and rethread the statement
ordering. So just do these latter bits.

Closes #36468.