### PR TITLE
Add gcstress testing for Windows arm64

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -465,7 +465,7 @@ jobs:
 
 # Windows arm64
 
-- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), eq(parameters.platformGroup, 'all')) }}:
+- ${{ if or(containsValue(parameters.platforms, 'Windows_NT_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:
       jobTemplate: ${{ parameters.jobTemplate }}


### PR DESCRIPTION
This increases the platform matrix tested by:
- gcstress-extra.yml
- gcstress0x3-gcstress0xc.yml
- r2r-extra.yml

Note that these pipelines each run twice weekly: once on Saturday, once on Sunday.