### PR TITLE
Remove additional interface cast check from ThreadPool queue

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs
@@ -942,7 +942,7 @@ namespace System.Threading
         {
             if (!(state is IAsyncStateMachineBox box))
             {
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
+                ThrowHelper.ThrowEntryPointNotFoundException();
                 return;
             }
 
@@ -1119,12 +1119,6 @@ namespace System.Threading
             // internally we call UnsafeQueueUserWorkItemInternal directly for Tasks.
             if (ReferenceEquals(callBack, ThreadPool.s_invokeAsyncStateMachineBox))
             {
-                if (!(state is IAsyncStateMachineBox))
-                {
-                    // The provided state must be the internal IAsyncStateMachineBox (Task) type
-                    ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.state);
-                }
-
                 UnsafeQueueUserWorkItemInternal((object)state!, preferLocal);
                 return true;
             }

--- a/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ThrowHelper.cs
@@ -416,6 +416,12 @@ namespace System
             throw new ArgumentOutOfRangeException("symbol", SR.Argument_BadFormatSpecifier);
         }
 
+        [DoesNotReturn]
+        internal static void ThrowEntryPointNotFoundException()
+        {
+            throw new EntryPointNotFoundException();
+        }
+
         private static Exception GetArraySegmentCtorValidationFailedException(Array? array, int offset, int count)
         {
             if (array == null)


### PR DESCRIPTION
Without the `ReferenceEquals(callBack, ThreadPool.s_invokeAsyncStateMachineBox)` check optimization it will throw an exception on the ThreadPool anyway; so change that exception to the be the same `EntryPointNotFoundException` type and remove the check on queue.

/cc @stephentoub not sure what you think about this? after https://github.com/dotnet/runtime/pull/36740 this is the remaining `IsInstanceOfInterface` calls for Json

From

![image](https://user-images.githubusercontent.com/1142958/82522411-427dfb00-9b21-11ea-9a11-31ade0dc6c41.png)

To (not called)

![image](https://user-images.githubusercontent.com/1142958/82523774-0cdb1100-9b25-11ea-85a3-31d8a9706b20.png)
