### PR TITLE
Ensure Image.Save can handle non readable / seekable Streams

### DIFF
--- a/src/libraries/System.Drawing.Common/src/System/Drawing/GdiPlusStreamHelper.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/GdiPlusStreamHelper.Unix.cs
@@ -43,10 +43,10 @@ namespace System.Drawing
     {
         private Stream _stream;
 
-        public unsafe GdiPlusStreamHelper(Stream stream, bool seekToOrigin)
+        public unsafe GdiPlusStreamHelper(Stream stream, bool seekToOrigin, bool makeSeekable = true)
         {
             // Seeking required
-            if (!stream.CanSeek)
+            if (makeSeekable && !stream.CanSeek)
             {
                 var memoryStream = new MemoryStream();
                 stream.CopyTo(memoryStream);

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Unix.cs
@@ -74,7 +74,7 @@ namespace System.Drawing
             // We use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus.  So, we wrap the stream
             // with a set of delegates.
-            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, true);
+            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, seekToOrigin: true);
 
             int st = Gdip.GdipLoadImageFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, out IntPtr imagePtr);
@@ -247,7 +247,7 @@ namespace System.Drawing
 
             try
             {
-                GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
+                GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, seekToOrigin: false, makeSeekable: false);
                 st = Gdip.GdipSaveImageToDelegate_linux(nativeImage, sh.GetBytesDelegate, sh.PutBytesDelegate,
                     sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, ref guid, nativeEncoderParams);
 

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
@@ -243,7 +243,7 @@ namespace System.Drawing
                 {
                     Gdip.CheckStatus(Gdip.GdipSaveImageToStream(
                         new HandleRef(this, nativeImage),
-                        new GPStream(stream, false),
+                        new GPStream(stream, makeSeekable: false),
                         ref g,
                         new HandleRef(encoderParams, encoderParamsMemory)));
                 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Image.Windows.cs
@@ -243,7 +243,7 @@ namespace System.Drawing
                 {
                     Gdip.CheckStatus(Gdip.GdipSaveImageToStream(
                         new HandleRef(this, nativeImage),
-                        new GPStream(stream),
+                        new GPStream(stream, false),
                         ref g,
                         new HandleRef(encoderParams, encoderParamsMemory)));
                 }

--- a/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.Unix.cs
+++ b/src/libraries/System.Drawing.Common/src/System/Drawing/Imaging/Metafile.Unix.cs
@@ -54,7 +54,7 @@ namespace System.Drawing.Imaging
 
             // With libgdiplus we use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
-            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
+            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, seekToOrigin: false);
             int status = Gdip.GdipCreateMetafileFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, out nativeImage);
 
@@ -101,7 +101,7 @@ namespace System.Drawing.Imaging
 
             // With libgdiplus we use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
-            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
+            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, seekToOrigin: false);
             int status = Gdip.GdipRecordMetafileFromDelegateI_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, referenceHdc,
                 type, ref frameRect, frameUnit, description, out nativeImage);
@@ -120,7 +120,7 @@ namespace System.Drawing.Imaging
 
             // With libgdiplus we use a custom API for this, because there's no easy way
             // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
-            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
+            GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, seekToOrigin: false);
             int status = Gdip.GdipRecordMetafileFromDelegate_linux(sh.GetHeaderDelegate, sh.GetBytesDelegate,
                 sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate, sh.SizeDelegate, referenceHdc,
                 type, ref frameRect, frameUnit, description, out nativeImage);
@@ -189,7 +189,7 @@ namespace System.Drawing.Imaging
             {
                 // With libgdiplus we use a custom API for this, because there's no easy way
                 // to get the Stream down to libgdiplus. So, we wrap the stream with a set of delegates.
-                GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, false);
+                GdiPlusStreamHelper sh = new GdiPlusStreamHelper(stream, seekToOrigin: false);
                 int status = Gdip.GdipGetMetafileHeaderFromDelegate_linux(sh.GetHeaderDelegate,
                     sh.GetBytesDelegate, sh.PutBytesDelegate, sh.SeekDelegate, sh.CloseDelegate,
                     sh.SizeDelegate, header);

--- a/src/libraries/System.Drawing.Common/tests/IconTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/IconTests.cs
@@ -276,7 +276,7 @@ namespace System.Drawing.Tests
             using (var stream = new MemoryStream())
             {
                 Exception ex = Assert.ThrowsAny<Exception>(() => icon.Save(stream));
-                Assert.True(ex is COMException || ex is ObjectDisposedException || ex is FileNotFoundException, $"{ex.GetType().ToString()} was thrown.");
+                Assert.True(ex is COMException || ex is ObjectDisposedException || ex is FileNotFoundException, $"{ex.GetType()} was thrown. Detail: {ex}");
 
                 AssertExtensions.Throws<ArgumentException>(null, () => icon.ToBitmap());
                 Assert.Equal(Size.Empty, icon.Size);

--- a/src/libraries/System.Drawing.Common/tests/IconTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/IconTests.cs
@@ -266,28 +266,6 @@ namespace System.Drawing.Tests
             AssertExtensions.Throws<ArgumentNullException, ArgumentException>("original", null, () => new Icon((Icon)null, new Size(32, 32)));
         }
 
-        // libgdiplus causes a segfault when given an invalid Icon handle.
-        [PlatformSpecific(TestPlatforms.Windows)]
-        [ConditionalFact(Helpers.IsDrawingSupported)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34591", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
-        public void Ctor_InvalidHandle_Success()
-        {
-            using (Icon icon = Icon.FromHandle((IntPtr)1))
-            using (var stream = new MemoryStream())
-            {
-                Exception ex = Assert.ThrowsAny<Exception>(() => icon.Save(stream));
-                Assert.True(ex is COMException || ex is ObjectDisposedException || ex is FileNotFoundException, $"{ex.GetType()} was thrown. Detail: {ex}");
-
-                AssertExtensions.Throws<ArgumentException>(null, () => icon.ToBitmap());
-                Assert.Equal(Size.Empty, icon.Size);
-
-                using (var newIcon = new Icon(icon, 10, 10))
-                {
-                    Assert.Throws<ObjectDisposedException>(() => newIcon.Handle);
-                }
-            }
-        }
-
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Ctor_Type_Resource()
         {


### PR DESCRIPTION
fixes #33522 