### PR TITLE
Fix CoreCLR initialization on Illumos-based distros

### DIFF
--- a/src/coreclr/src/pal/src/map/virtual.cpp
+++ b/src/coreclr/src/pal/src/map/virtual.cpp
@@ -2276,6 +2276,12 @@ Function:
     at which the allocator should start allocating memory from its reserved memory range.
 
 --*/
+#ifdef __sun
+// The upper limit of the random() function on SunOS derived operating systems is not RAND_MAX, but 2^31-1.
+#define OFFSET_RAND_MAX 0x7FFFFFFF
+#else
+#define OFFSET_RAND_MAX RAND_MAX
+#endif
 int32_t ExecutableMemoryAllocator::GenerateRandomStartOffset()
 {
     int32_t pageCount;
@@ -2284,7 +2290,7 @@ int32_t ExecutableMemoryAllocator::GenerateRandomStartOffset()
     // This code is similar to what coreclr runtime does on Windows.
     // It generates a random number of pages to skip between 0...MaxStartPageOffset.
     srandom(time(NULL));
-    pageCount = (int32_t)(MaxStartPageOffset * (int64_t)random() / RAND_MAX);
+    pageCount = (int32_t)(MaxStartPageOffset * (int64_t)random() / OFFSET_RAND_MAX);
 
     return pageCount * GetVirtualPageSize();
 }

--- a/src/coreclr/src/pal/src/thread/thread.cpp
+++ b/src/coreclr/src/pal/src/thread/thread.cpp
@@ -43,6 +43,15 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <kvm.h>
+#elif defined(__sun)
+#ifndef _KERNEL
+#define _KERNEL
+#define UNDEF_KERNEL
+#endif
+#include <sys/procfs.h>
+#ifdef UNDEF_KERNEL
+#undef _KERNEL
+#endif
 #endif
 
 #include <signal.h>
@@ -1441,7 +1450,11 @@ CorUnix::GetThreadTimesInternal(
     CPalThread *pThread;
     CPalThread *pTargetThread;
     IPalObject *pobjThread = NULL;
+#ifdef __sun
+    int fd;
+#else // __sun
     clockid_t cid;
+#endif // __sun
 
     pThread = InternalGetCurrentThread();
 
@@ -1463,7 +1476,6 @@ CorUnix::GetThreadTimesInternal(
 
 #if HAVE_PTHREAD_GETCPUCLOCKID
     if (pthread_getcpuclockid(pTargetThread->GetPThreadSelf(), &cid) != 0)
-#endif
     {
         ASSERT("Unable to get clock from thread\n", hThread);
         SetLastError(ERROR_INTERNAL_ERROR);
@@ -1479,6 +1491,33 @@ CorUnix::GetThreadTimesInternal(
         pTargetThread->Unlock(pThread);
         goto SetTimesToZero;
     }
+#elif defined(__sun)
+    timestruc_t ts;
+    int readResult;
+    char statusFilename[64];
+    snprintf(statusFilename, sizeof(statusFilename), "/proc/%d/lwp/%d/lwpstatus", getpid(), pTargetThread->GetLwpId());
+    fd = open(statusFilename, O_RDONLY);
+    if (fd == -1)
+    {
+       ASSERT("open(%s) failed; errno is %d (%s)\n", statusFilename, errno, strerror(errno));
+       SetLastError(ERROR_INTERNAL_ERROR);
+       pTargetThread->Unlock(pThread);
+       goto SetTimesToZero;
+    }
+
+    lwpstatus_t status;
+    do
+    {
+        readResult = read(fd, &status, sizeof(status));
+    }
+    while ((readResult == -1) && (errno == EINTR));
+
+    close(fd);
+
+    ts = status.pr_utime;
+#else // HAVE_PTHREAD_GETCPUCLOCKID
+#error "Don't know how to obtain user cpu time on this platform."
+#endif // HAVE_PTHREAD_GETCPUCLOCKID
 
     pTargetThread->Unlock(pThread);
 

--- a/src/coreclr/src/vm/vars.hpp
+++ b/src/coreclr/src/vm/vars.hpp
@@ -690,12 +690,23 @@ struct ModuleIndex
 
 typedef DPTR(GSCookie) PTR_GSCookie;
 
+#ifdef _MSC_VER
+#define READONLY_ATTR
+#else
+#ifdef __APPLE__
+#define READONLY_ATTR_ARGS section("__TEXT,__const")
+#else
+#define READONLY_ATTR_ARGS section(".rodata")
+#endif
+#define READONLY_ATTR __attribute__((READONLY_ATTR_ARGS))
+#endif
+
 #ifndef DACCESS_COMPILE
 // const is so that it gets placed in the .text section (which is read-only)
 // volatile is so that accesses to it do not get optimized away because of the const
 //
 
-extern "C" RAW_KEYWORD(volatile) const GSCookie s_gsCookie;
+extern "C" RAW_KEYWORD(volatile) READONLY_ATTR const GSCookie s_gsCookie;
 
 inline
 GSCookie * GetProcessGSCookiePtr() { return  const_cast<GSCookie *>(&s_gsCookie); }


### PR DESCRIPTION
On SmartOS 2020 (April release), CoreCLR initialization was raising sigsegv due to `GSCookie` present in same (writable) memory page as global variables (such as `g_SpinConstants`). When protection of that page was changing to `PAGE_READONLY` in `InitGSCookie()`, writes to global variables were causing the memory violation.

The issue was agnostic of operating system but instead how GCC considers "volatile const without initial value to pack under .rodata section" as an undefined behavior, and choose to pack it under .data section instead; while Clang packs it in .rodata section.

There were also other issues such as, unimplemented `get cpu clock_id` and very low value of `RAND_MAX`.

With this PR, we:

* explicitly annotate `GSCookie` with `READONLY_ATTR`, so it lands in `.rodata` section when CoreCLR is compiled with GCC and Clang alike.
* set OFFSET_RAND_MAX for Illumos/Solaris to hardcoded 0x7FFFFFFF, which is the value of RAND_MAX on other Unices and __sun has value of 32767.
* implement the `#else` case for `#if HAVE_PTHREAD_GETCPUCLOCKID`, as illumos does not have (POSIX optional) `pthread_getcpuclockid` atm (but Oracle Solaris 11 does). 

With these changes, we get to the point where CoreCLR managed entrypoint is called. (needs cross-compilation environment to proceed further)

Fixes #36632.
Contributes to #34944.