### PR TITLE
DONT MERGE: Fix crossgen delegates to generic functions (issue #36810)

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -72,7 +72,6 @@ namespace ILCompiler.DependencyAnalysis
         public MethodWithGCInfo CompiledMethodNode(MethodDesc method)
         {
             Debug.Assert(CompilationModuleGroup.ContainsMethodBody(method, false));
-            Debug.Assert(method == method.GetCanonMethodTarget(CanonicalFormKind.Specific));
             return _localMethodCache.GetOrAdd(method);
         }
 
@@ -351,7 +350,11 @@ namespace ILCompiler.DependencyAnalysis
             bool isUnboxingStub = key.IsUnboxingStub;
             bool isInstantiatingStub = key.IsInstantiatingStub;
             bool isPrecodeImportRequired = key.IsPrecodeImportRequired;
-            MethodDesc compilableMethod = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            MethodDesc compilableMethod = method.Method;
+            if (!isInstantiatingStub)
+            {
+                compilableMethod = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            }
             if (CompilationModuleGroup.ContainsMethodBody(compilableMethod, false))
             {
                 if (isPrecodeImportRequired)


### PR DESCRIPTION
This commit fixes issue #36810, but I am sure, this is not completely
correct method to fix the issue, because with this patch applied crossgen2 generates both variants of `GenericStruct::M8` functions. Output of the crossgen2 with an option`--codegenopt 'NgenDisasm=*'`:
```
bug10.GenericStruct`1:M8([S.P.CoreLib]System.__Canon,long):long:this
bug10.GenericStruct`1:M8([bug10]bug10.EQClass`1<int64>,long):long:this
```

But crossgen1 generates only first (completely generic) variant of the function. Looks stange: practically second variant is called, second variant is used in `MethodDesc` during generation of `IL_STUB_InstantiatingStub`, but thunk (PrecodeFixupThunk) is needed as for first (completely generic with Canon) variant.