### PR TITLE
ARM/ARM64: Optimize virtual call stub for R2R and JIT

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2525,7 +2525,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize), ilOffset, target->GetRegNum());
     }
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-    else if (call->IsR2RRelativeIndir() || (call->IsVirtualStubRelativeIndir() && call->gtEntryPoint.addr != NULL))
+    else if (call->IsR2RRelativeIndir() || call->IsVirtualStubRelativeIndir())
     {
         // Generate a direct call to a non-virtual user defined or helper method
         assert(callType == CT_HELPER || callType == CT_USER_FUNC);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2524,8 +2524,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     INDEBUG_LDISASM_COMMA(sigInfo) nullptr, // addr
                     retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize), ilOffset, target->GetRegNum());
     }
-#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-    else if (call->IsR2RRelativeIndir() || call->IsVirtualStubRelativeIndir())
+    else if (call->IsR2ROrVirtualStubRelativeIndir())
     {
         // Generate a direct call to a non-virtual user defined or helper method
         assert(callType == CT_HELPER || callType == CT_USER_FUNC);
@@ -2545,7 +2544,6 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     INDEBUG_LDISASM_COMMA(sigInfo) nullptr, // addr
                     retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize), ilOffset, tmpReg);
     }
-#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
     else
     {
         // Generate a direct call to a non-virtual user defined or helper method

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2326,6 +2326,10 @@ void CodeGen::genCodeForInitBlkHelper(GenTreeBlk* initBlkNode)
 //
 void CodeGen::genCallInstruction(GenTreeCall* call)
 {
+    if (this->compiler->compMethodID == 749)
+    {
+        printf("genCallInstruction : %s\n", this->compiler->info.compMethodName);
+    }
     gtCallTypes callType = (gtCallTypes)call->gtCallType;
 
     IL_OFFSETX ilOffset = BAD_IL_OFFSET;

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2521,7 +2521,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize), ilOffset, target->GetRegNum());
     }
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-    else if (call->IsR2RRelativeIndir() || call->IsVirtualStubRelativeIndir())
+    else if (call->IsR2RRelativeIndir() || (call->IsVirtualStubRelativeIndir() && call->gtEntryPoint.addr != NULL))
     {
         // Generate a direct call to a non-virtual user defined or helper method
         assert(callType == CT_HELPER || callType == CT_USER_FUNC);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2326,10 +2326,6 @@ void CodeGen::genCodeForInitBlkHelper(GenTreeBlk* initBlkNode)
 //
 void CodeGen::genCallInstruction(GenTreeCall* call)
 {
-    if (this->compiler->compMethodID == 749)
-    {
-        printf("genCallInstruction : %s\n", this->compiler->info.compMethodName);
-    }
     gtCallTypes callType = (gtCallTypes)call->gtCallType;
 
     IL_OFFSETX ilOffset = BAD_IL_OFFSET;

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2527,6 +2527,7 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
         assert(((call->IsR2RRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_PVALUE)) ||
                ((call->IsVirtualStubRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_VALUE)));
         assert(call->gtControlExpr == nullptr);
+        assert(!call->IsTailCall());
 
         regNumber tmpReg = call->GetSingleTempReg();
         GetEmitter()->emitIns_R_R(ins_Load(TYP_I_IMPL), emitActualTypeSize(TYP_I_IMPL), tmpReg, REG_R2R_INDIRECT_PARAM);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -2521,11 +2521,12 @@ void CodeGen::genCallInstruction(GenTreeCall* call)
                     retSize MULTIREG_HAS_SECOND_GC_RET_ONLY_ARG(secondRetSize), ilOffset, target->GetRegNum());
     }
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-    else if (call->IsR2RRelativeIndir())
+    else if (call->IsR2RRelativeIndir() || call->IsVirtualStubRelativeIndir())
     {
         // Generate a direct call to a non-virtual user defined or helper method
         assert(callType == CT_HELPER || callType == CT_USER_FUNC);
-        assert(call->gtEntryPoint.accessType == IAT_PVALUE);
+        assert(((call->IsR2RRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_PVALUE)) ||
+               ((call->IsVirtualStubRelativeIndir()) && (call->gtEntryPoint.accessType == IAT_VALUE)));
         assert(call->gtControlExpr == nullptr);
 
         regNumber tmpReg = call->GetSingleTempReg();

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -4202,6 +4202,16 @@ struct GenTreeCall final : public GenTree
         return (gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0;
     }
 
+    bool IsR2ROrVirtualStubRelativeIndir()
+    {
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+        return (IsR2RRelativeIndir() ||
+                ((gtFlags & GTF_CALL_VIRT_KIND_MASK) == GTF_CALL_VIRT_STUB) && (IsVirtualStubRelativeIndir()));
+#else
+        return false;
+#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
+    }
+
     bool HasNonStandardAddedArgs(Compiler* compiler) const;
     int GetNonStandardAddedArgCount(Compiler* compiler) const;
 

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -4205,8 +4205,8 @@ struct GenTreeCall final : public GenTree
     bool IsR2ROrVirtualStubRelativeIndir()
     {
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-        return (IsR2RRelativeIndir() ||
-                ((gtFlags & GTF_CALL_VIRT_KIND_MASK) == GTF_CALL_VIRT_STUB) && (IsVirtualStubRelativeIndir()));
+        bool isVirtualStub = (gtFlags & GTF_CALL_VIRT_KIND_MASK) == GTF_CALL_VIRT_STUB;
+        return ((IsR2RRelativeIndir()) || (isVirtualStub && (IsVirtualStubRelativeIndir())));
 #else
         return false;
 #endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1518,6 +1518,10 @@ GenTree* Lowering::AddrGen(void* addr)
 //
 void Lowering::LowerCall(GenTree* node)
 {
+    if (this->comp->compMethodID == 749)
+    {
+        printf("genCallInstruction : %s\n", this->comp->info.compMethodName);
+    }
     GenTreeCall* call = node->AsCall();
 
     JITDUMP("lowering call (before):\n");

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -4529,11 +4529,16 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         }
         else
         {
+
+            bool shouldOptimizeVirtualStubCall = false;
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-            result = nullptr;
-#else
-            result = Ind(addr);
-#endif // defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+            shouldOptimizeVirtualStubCall = !call->IsTailCall();
+#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
+
+            if (!shouldOptimizeVirtualStubCall)
+            {
+                result = Ind(addr);
+            }
         }
     }
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -4529,7 +4529,11 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
         }
         else
         {
+#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+            result = nullptr;
+#else
             result = Ind(addr);
+#endif // defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
         }
     }
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -1518,10 +1518,6 @@ GenTree* Lowering::AddrGen(void* addr)
 //
 void Lowering::LowerCall(GenTree* node)
 {
-    if (this->comp->compMethodID == 749)
-    {
-        printf("genCallInstruction : %s\n", this->comp->info.compMethodName);
-    }
     GenTreeCall* call = node->AsCall();
 
     JITDUMP("lowering call (before):\n");

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3489,6 +3489,9 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
         {
             bool isR2RRelativeIndir = false;
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+            // Skip inserting the indirection node to load the address that is already
+            // computed in REG_R2R_INDIRECT_PARAM as a hidden parameter. Instead during the
+            // codegen, just load the call target from REG_R2R_INDIRECT_PARAM.
             isR2RRelativeIndir = call->IsR2RRelativeIndir();
 #endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
 
@@ -4532,6 +4535,11 @@ GenTree* Lowering::LowerVirtualStubCall(GenTreeCall* call)
 
             bool shouldOptimizeVirtualStubCall = false;
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
+            // Skip inserting the indirection node to load the address that is already
+            // computed in REG_R2R_INDIRECT_PARAM as a hidden parameter. Instead during the
+            // codegen, just load the call target from REG_R2R_INDIRECT_PARAM.
+            // However, for tail calls, the call target is always computed in RBM_FASTTAILCALL_TARGET
+            // and so do not optimize virtual stub calls for such cases.
             shouldOptimizeVirtualStubCall = !call->IsTailCall();
 #endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
 

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -182,12 +182,10 @@ int LinearScan::BuildCall(GenTreeCall* call)
             ctrlExprCandidates = RBM_FASTTAILCALL_TARGET;
         }
     }
-#if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-    else if (call->IsR2RRelativeIndir() || call->IsVirtualStubRelativeIndir())
+    else if (call->IsR2ROrVirtualStubRelativeIndir())
     {
         buildInternalIntRegisterDefForNode(call);
     }
-#endif // FEATURE_READYTORUN_COMPILER && TARGET_ARMARCH
 #ifdef TARGET_ARM
     else
     {

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -183,7 +183,7 @@ int LinearScan::BuildCall(GenTreeCall* call)
         }
     }
 #if defined(FEATURE_READYTORUN_COMPILER) && defined(TARGET_ARMARCH)
-    else if (call->IsR2RRelativeIndir())
+    else if (call->IsR2RRelativeIndir() || call->IsVirtualStubRelativeIndir())
     {
         buildInternalIntRegisterDefForNode(call);
     }


### PR DESCRIPTION
Optimize the calls to virtual stub by eliminating the redundant load of address. This is similar to https://github.com/dotnet/runtime/pull/35675 but optimizes virtual call stubs which impacts both crossgen/JIT.

Fixes: https://github.com/dotnet/runtime/issues/36700

CrossGen improvements:

```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -1605632 (-3.09% of base)
    diff is an improvement.
Top file improvements (bytes):
     -207104 : System.Private.Xml.dasm (-4.30% of base)
     -169928 : System.Linq.Expressions.dasm (-3.57% of base)
     -147304 : Microsoft.CodeAnalysis.VisualBasic.dasm (-4.35% of base)
     -128872 : Microsoft.CodeAnalysis.CSharp.dasm (-4.11% of base)
      -91560 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-1.74% of base)
      -60672 : System.Data.Common.dasm (-3.52% of base)
      -49640 : Microsoft.CodeAnalysis.dasm (-4.48% of base)
      -42864 : System.Private.DataContractSerialization.dasm (-3.71% of base)
      -40648 : Newtonsoft.Json.dasm (-4.26% of base)
      -36216 : System.Management.dasm (-6.75% of base)
      -25552 : System.Configuration.ConfigurationManager.dasm (-5.17% of base)
      -25264 : System.Private.CoreLib.dasm (-0.42% of base)
      -24504 : Microsoft.VisualBasic.Core.dasm (-3.82% of base)
      -21440 : System.DirectoryServices.AccountManagement.dasm (-5.40% of base)
      -20304 : System.Linq.Parallel.dasm (-2.29% of base)
      -19408 : System.DirectoryServices.dasm (-3.21% of base)
      -19288 : System.CodeDom.dasm (-7.03% of base)
      -18808 : System.ComponentModel.TypeConverter.dasm (-5.16% of base)
      -18568 : System.Net.Http.dasm (-2.19% of base)
      -17440 : xunit.execution.dotnet.dasm (-5.89% of base)
185 total files with Code Size differences (185 improved, 0 regressed), 81 unchanged.
Top method improvements (bytes):
       -5904 (-1.96% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.CallInstruction:FastCreate(System.Reflection.MethodInfo,System.Reflection.ParameterInfo[]):System.Linq.Expressions.Interpreter.CallInstruction (241 methods)
       -2816 (-4.33% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
       -2240 (-8.91% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateMethods():this
       -2192 (-13.28% of base) : System.ComponentModel.TypeConverter.dasm - CultureInfoMapper:CreateMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
       -2056 (-10.17% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateTypeConverterClass():System.CodeDom.CodeTypeDeclaration:this
       -1816 (-9.75% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDateTimeFunction():this
       -1608 (-18.11% of base) : System.Reflection.Metadata.dasm - System.Reflection.PortableExecutable.PEHeader:.ctor(byref):this
       -1528 (-8.67% of base) : System.Data.Common.dasm - System.Data.XmlTreeGen:HandleTable(System.Data.DataTable,System.Xml.XmlDocument,System.Xml.XmlElement,bool):System.Xml.XmlElement:this
       -1496 (-10.53% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateProperties():this
       -1280 (-13.18% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Binder:FoldNeverOverflowBinaryOperators(int,Microsoft.CodeAnalysis.ConstantValue,Microsoft.CodeAnalysis.ConstantValue):System.Object
       -1176 (-10.03% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToTimeSpanFunction():this
       -1168 (-6.56% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.Utils:GetReplicaList(System.DirectoryServices.ActiveDirectory.DirectoryContext,System.String,System.String,bool,bool,bool):System.Collections.ArrayList
       -1128 (-3.83% of base) : System.Private.Xml.dasm - System.Xml.Xsl.IlGen.XmlILMethods:.cctor()
       -1096 (-7.10% of base) : System.Private.Xml.dasm - System.Xml.Schema.SchemaNames:.ctor(System.Xml.XmlNameTable):this
       -1072 (-7.81% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFDateTimeFunction():this
       -1016 (-18.39% of base) : System.Security.Cryptography.X509Certificates.dasm - System.Security.Cryptography.X509Certificates.X509Certificate2:ToString(bool):System.String:this
        -952 (-7.84% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFTimeIntervalFunction():this
        -944 (-7.88% of base) : System.Configuration.ConfigurationManager.dasm - System.Configuration.ConfigurationElement:DeserializeElement(System.Xml.XmlReader,bool):this
        -936 (-11.68% of base) : System.Private.Xml.dasm - System.Xml.Xsl.Xslt.KeywordsTable:.ctor(System.Xml.XmlNameTable):this
        -904 (-8.47% of base) : System.Data.Common.dasm - System.Data.XmlTreeGen:SchemaTree(System.Xml.XmlDocument,System.Xml.XmlWriter,System.Data.DataSet,System.Data.DataTable,bool):this
Top method improvements (percentages):
         -24 (-26.09% of base) : xunit.execution.dotnet.dasm - <>c[__Canon][System.__Canon]:<OrderTestCollections>b__40_0(System.__Canon):Xunit.Abstractions.ITestCollection:this
         -24 (-25.00% of base) : xunit.execution.dotnet.dasm - Xunit.Sdk.TestClassComparer:GetHashCode(Xunit.Abstractions.ITestClass):int:this
         -24 (-25.00% of base) : xunit.execution.dotnet.dasm - Xunit.Sdk.TestMethodComparer:GetHashCode(Xunit.Abstractions.ITestMethod):int:this
         -24 (-24.00% of base) : System.ComponentModel.Composition.dasm - System.ComponentModel.Composition.Primitives.ImportDefinition:ToString():System.String:this
         -24 (-24.00% of base) : System.Net.Mail.dasm - System.Net.Mime.ContentDisposition:GetHashCode():int:this
         -24 (-24.00% of base) : System.Net.Mail.dasm - System.Net.Mime.ContentType:GetHashCode():int:this
         -16 (-23.53% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.NamedTypeSymbol:Microsoft.Cci.ISpecializedNestedTypeReference.get_UnspecializedVersion():Microsoft.Cci.INestedTypeReference:this
         -16 (-23.53% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol:get_ISpecializedNestedTypeReferenceUnspecializedVersion():Microsoft.Cci.INestedTypeReference:this
         -16 (-23.53% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Symbols.NativeSymbolModule:get_PdbAge():int:this
         -16 (-23.53% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.Linq.JContainer:get_Count():int:this
         -16 (-23.53% of base) : xunit.execution.dotnet.dasm - <>c[__Canon][System.__Canon]:<RunTestClassesAsync>b__28_0(System.__Canon):Xunit.Abstractions.ITestClass:this
         -24 (-23.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Reader:IsIncomplete(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode):bool
        -104 (-22.81% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceModuleFile:FastSerialization.IFastSerializable.ToStream(FastSerialization.Serializer):this
        -144 (-22.78% of base) : xunit.runner.reporters.netcoreapp10.dasm - Xunit.Runner.Reporters.VstsReporterMessageHandler:HandleTestStarting(Xunit.MessageHandlerArgs`1[[Xunit.Abstractions.ITestStarting, xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c]]):this
         -88 (-22.68% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceActivity:FastSerialization.IFastSerializable.ToStream(FastSerialization.Serializer):this
        -704 (-22.62% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:GetRowCounts():System.Collections.Immutable.ImmutableArray`1[Int32]:this
         -16 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Emit.TypeMemberReference:Microsoft.Cci.INamedEntity.get_Name():System.String:this
         -16 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceTypeParameterSymbolBase:GetAttributes():System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.CSharpAttributeData, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
         -16 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceParameterSymbol:GetAttributes():System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.CSharp.Symbols.CSharpAttributeData, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
         -16 (-22.22% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.AssemblySymbol:get_Name():System.String:this
63069 total methods with Code Size differences (63069 improved, 0 regressed), 160135 unchanged.
Completed analysis in 227.23s
```

JIT improvements:

```
Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: -618928 (-1.080% of base)
    diff is an improvement.

Top file improvements (bytes):
      -84156 : System.Linq.dasm (-6.895% of base)
      -46944 : Microsoft.CodeAnalysis.dasm (-2.219% of base)
      -40752 : System.Private.CoreLib.dasm (-0.666% of base)
      -36612 : System.Private.Xml.dasm (-0.877% of base)
      -24384 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.692% of base)
      -19656 : Newtonsoft.Json.dasm (-1.932% of base)
      -19008 : System.Collections.Immutable.dasm (-1.495% of base)
      -17844 : Microsoft.CodeAnalysis.CSharp.dasm (-0.360% of base)
      -16308 : System.Linq.Expressions.dasm (-1.674% of base)
      -16140 : System.Linq.Queryable.dasm (-4.921% of base)
      -15912 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.252% of base)
      -15060 : System.Collections.dasm (-2.174% of base)
      -14592 : System.Data.Common.dasm (-0.828% of base)
      -14196 : System.ComponentModel.Composition.dasm (-3.460% of base)
      -12900 : System.Linq.Parallel.dasm (-0.716% of base)
      -12384 : System.Management.dasm (-2.939% of base)
      -12156 : System.Configuration.ConfigurationManager.dasm (-2.851% of base)
      -12008 : xunit.execution.dotnet.dasm (-4.241% of base)
      -11436 : System.Threading.Tasks.Dataflow.dasm (-1.057% of base)
      -10272 : xunit.runner.utility.netcoreapp10.dasm (-4.325% of base)

148 total files with Code Size differences (148 improved, 0 regressed), 118 unchanged.

Top method regressions (bytes):
           4 (0.980% of base) : Microsoft.Extensions.Options.dasm - Microsoft.Extensions.Options.OptionsCache`1[__Canon][System.__Canon]:TryAdd(System.String,System.__Canon):bool:this

Top method improvements (bytes):
       -1020 (-7.021% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateTypeConverterClass():System.CodeDom.CodeTypeDeclaration:this
        -756 (-7.820% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.LightCompiler:CompileIntSwitchExpression(System.Linq.Expressions.SwitchExpression):this (7 methods)
        -756 (-5.290% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDateTimeFunction():this
        -732 (-13.147% of base) : xunit.execution.dotnet.dasm - Xunit.Sdk.TheoryDiscoverer:Discover(Xunit.Abstractions.ITestFrameworkDiscoveryOptions,Xunit.Abstractions.ITestMethod,Xunit.Abstractions.IAttributeInfo):System.Collections.Generic.IEnumerable`1[[Xunit.Sdk.IXunitTestCase, xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c]]:this
        -720 (-16.791% of base) : System.Private.Xml.dasm - System.Xml.Schema.Compiler:Compile():bool:this
        -720 (-15.411% of base) : System.Private.Xml.dasm - System.Xml.Schema.SchemaCollectionCompiler:Compile():this
        -708 (-8.256% of base) : Newtonsoft.Json.dasm - <ExecuteFilter>d__4:MoveNext():bool:this (8 methods)
        -708 (-13.063% of base) : xunit.execution.dotnet.dasm - <AfterTestCaseStartingAsync>d__9:MoveNext():this
        -672 (-15.527% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.CompilerServices.ObjectType:ObjTst(System.Object,System.Object,bool):int
        -660 (-6.332% of base) : System.Configuration.ConfigurationManager.dasm - System.Configuration.ConfigurationElement:DeserializeElement(System.Xml.XmlReader,bool):this
        -624 (-12.009% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.SymbolDisplayVisitor:VisitMethod(Microsoft.CodeAnalysis.IMethodSymbol):this
        -600 (-13.514% of base) : System.Private.Xml.dasm - System.Xml.Xsl.Xslt.QilGenerator:System.Xml.Xsl.XPath.IXPathEnvironment.ResolveFunction(System.String,System.String,System.Collections.Generic.IList`1[[System.Xml.Xsl.Qil.QilNode, System.Private.Xml, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51]],System.Xml.Xsl.XPath.IFocus):System.Xml.Xsl.Qil.QilNode:this
        -588 (-11.431% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.Emit.DeltaMetadataWriter:CreateIndicesForNonTypeMembers(Microsoft.Cci.ITypeDefinition):this
        -576 (-16.533% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.JsonValidatingReader:ValidateCurrentToken():this
        -552 (-15.066% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceLog:FastSerialization.IFastSerializable.FromStream(FastSerialization.Deserializer):this
        -552 (-8.466% of base) : System.Data.Common.dasm - System.Data.XSDSchema:LoadSchema(System.Xml.Schema.XmlSchemaSet,System.Data.DataSet):this
        -528 (-5.470% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser:ParseConditionalCompilationSymbols(System.String,byref,System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]], System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]):System.Collections.Generic.IReadOnlyDictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Object, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
        -528 (-4.692% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFDateTimeFunction():this
        -516 (-3.519% of base) : System.DirectoryServices.dasm - System.DirectoryServices.ActiveDirectory.Utils:GetReplicaList(System.DirectoryServices.ActiveDirectory.DirectoryContext,System.String,System.String,bool,bool,bool):System.Collections.ArrayList
        -516 (-10.222% of base) : System.Net.Mail.dasm - System.Net.Mail.MailMessage:SetContent(bool):this

Top method regressions (percentages):
           4 (0.980% of base) : Microsoft.Extensions.Options.dasm - Microsoft.Extensions.Options.OptionsCache`1[__Canon][System.__Canon]:TryAdd(System.String,System.__Canon):bool:this

Top method improvements (percentages):
         -36 (-31.034% of base) : xunit.runner.utility.netcoreapp10.dasm - Xunit.DefaultRunnerReporterMessageHandler:GetAssemblyDisplayName(Xunit.Abstractions.ITestAssemblyMessage):System.String:this
         -36 (-31.034% of base) : xunit.runner.utility.netcoreapp10.dasm - Xunit.DefaultRunnerReporterWithTypesMessageHandler:GetAssemblyDisplayName(Xunit.Abstractions.ITestAssemblyMessage):System.String:this
         -24 (-27.273% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.SymbolDisplayVisitor:IsNullableType(Microsoft.CodeAnalysis.INamedTypeSymbol):bool
         -48 (-27.273% of base) : xunit.execution.dotnet.dasm - Xunit.Sdk.TestClassComparer:Equals(Xunit.Abstractions.ITestClass,Xunit.Abstractions.ITestClass):bool:this
         -48 (-27.273% of base) : xunit.execution.dotnet.dasm - Xunit.Sdk.TestMethodComparer:Equals(Xunit.Abstractions.ITestMethod,Xunit.Abstractions.ITestMethod):bool:this
        -132 (-26.400% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceModuleFile:FastSerialization.IFastSerializable.ToStream(FastSerialization.Serializer):this
        -144 (-25.899% of base) : xunit.runner.reporters.netcoreapp10.dasm - Xunit.Runner.Reporters.VstsReporterMessageHandler:HandleTestStarting(Xunit.MessageHandlerArgs`1[[Xunit.Abstractions.ITestStarting, xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c]]):this
        -168 (-25.767% of base) : Microsoft.Extensions.Configuration.dasm - Microsoft.Extensions.Configuration.ConfigurationRoot:Dispose():this
         -84 (-25.000% of base) : Microsoft.Extensions.Configuration.dasm - Microsoft.Extensions.Configuration.ConfigurationRoot:Reload():this
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - System.RuntimeMethodHandle:GetGenericParameterCount(System.IRuntimeMethodInfo):int
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.WindowsRuntime.ListToBindableVectorAdapter:Append(System.Object):this
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.WindowsRuntime.MapToDictionaryAdapter:Insert(System.Runtime.InteropServices.WindowsRuntime.IMap`2[Int32,Int64],int,long):bool
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.WindowsRuntime.MapToDictionaryAdapter:Insert(System.Runtime.InteropServices.WindowsRuntime.IMap`2[Double,Int64],double,long):bool
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - System.Runtime.InteropServices.WindowsRuntime.MapToDictionaryAdapter:Insert(System.Runtime.InteropServices.WindowsRuntime.IMap`2[Int64,Int64],long,long):bool
         -12 (-25.000% of base) : System.Private.CoreLib.dasm - System.Runtime.CompilerServices.ICastableHelpers:GetImplType(System.Runtime.CompilerServices.ICastable,System.RuntimeType):System.RuntimeType
         -84 (-25.000% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Helpers:AddRange(System.Collections.Generic.ICollection`1[Double],System.Collections.Generic.IEnumerable`1[Double])
         -84 (-25.000% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Helpers:AddRange(System.Collections.Generic.ICollection`1[Vector`1],System.Collections.Generic.IEnumerable`1[Vector`1])
         -84 (-24.706% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Helpers:AddRange(System.Collections.Generic.ICollection`1[Byte],System.Collections.Generic.IEnumerable`1[Byte])
         -84 (-24.706% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Helpers:AddRange(System.Collections.Generic.ICollection`1[Int16],System.Collections.Generic.IEnumerable`1[Int16])
         -84 (-24.706% of base) : System.Security.Cryptography.X509Certificates.dasm - Internal.Cryptography.Helpers:AddRange(System.Collections.Generic.ICollection`1[Int32],System.Collections.Generic.IEnumerable`1[Int32])

15477 total methods with Code Size differences (15476 improved, 1 regressed), 295936 unchanged.
```