### PR TITLE
Fix exception message to indicate Cofactor is required.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -199,10 +199,10 @@
     <value>Input string does not contain a valid encoding of the '{0}' '{1}' parameter.</value>
   </data>
   <data name="Cryptography_InvalidECCharacteristic2Curve" xml:space="preserve">
-    <value>The specified Characteristic2 curve parameters are not valid. Polynomial, A, B, G.X, G.Y, and Order are required. A, B, G.X, G.Y must be the same length, and the same length as Q.X, Q.Y and D if those are specified. Seed, Cofactor and Hash are optional. Other parameters are not allowed.</value>
+    <value>The specified Characteristic2 curve parameters are not valid. Polynomial, A, B, G.X, G.Y, and Order are required. A, B, G.X, G.Y must be the same length, and the same length as Q.X, Q.Y and D if those are specified. Cofactor is required. Seed and Hash are optional. Other parameters are not allowed.</value>
   </data>
   <data name="Cryptography_InvalidECPrimeCurve" xml:space="preserve">
-    <value>The specified prime curve parameters are not valid. Prime, A, B, G.X, G.Y and Order are required and must be the same length, and the same length as Q.X, Q.Y and D if those are specified. Seed, Cofactor and Hash are optional. Other parameters are not allowed.</value>
+    <value>The specified prime curve parameters are not valid. Prime, A, B, G.X, G.Y and Order are required and must be the same length, and the same length as Q.X, Q.Y and D if those are specified. Cofactor is required. Seed and Hash are optional. Other parameters are not allowed.</value>
   </data>
   <data name="Cryptography_InvalidECNamedCurve" xml:space="preserve">
     <value>The specified named curve parameters are not valid. Only the Oid parameter must be set.</value>


### PR DESCRIPTION
Fixes #21439.

Aside: I initially attempted to fix the ECCurve import to not require Cofactor since it is technically an optional parameter according to SEC1. I was able to fix this for OpenSSL (support for this seems to go back to at 1.0.2a) however CNG was not happy with an empty Cofactor specified in `BCRYPT_ECCFULLKEY_BLOB`. [Attempt is here](https://github.com/dotnet/runtime/compare/master...vcsjones:fix-21439) if anyone is curious.

At the very least we can fix the exception message to reflect that it is currently required.