### PR TITLE
[mono] Fix MonoRunner.java - assets were not copied correctly

### DIFF
--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -60,7 +60,7 @@
 
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) kill-server"/>
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) start-server"/>
-    <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) logcat -c" />
+    <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) logcat -c" ContinueOnError="WarnAndContinue" />
     <Message Condition="'$(DeployAndRun)' == 'true'" Importance="High" Text="Uninstalling app if it exists (throws an error if it doesn't but it can be ignored):"/>
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) uninstall net.dot.HelloAndroid" ContinueOnError="WarnAndContinue" />
     <Exec Condition="'$(DeployAndRun)' == 'true'" Command="$(AdbTool) install $(ApkDir)/bin/HelloAndroid.apk" />

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -128,7 +128,7 @@ public class ApkBuilder
         string zip = "zip";
 
         Utils.RunProcess(zip, workingDir: Path.Combine(OutputDir, "assets-tozip"), args: "-r ../assets/assets.zip .");
-        Directory.Delete(Path.Combine(OutputDir, "assets-tozip"));
+        Directory.Delete(Path.Combine(OutputDir, "assets-tozip"), true);
         
         if (!File.Exists(androidJar))
             throw new ArgumentException($"API level={BuildApiLevel} is not downloaded in Android SDK");

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -80,6 +80,7 @@ public class ApkBuilder
         Directory.CreateDirectory(OutputDir);
         Directory.CreateDirectory(Path.Combine(OutputDir, "bin"));
         Directory.CreateDirectory(Path.Combine(OutputDir, "obj"));
+        Directory.CreateDirectory(Path.Combine(OutputDir, "assets-tozip"));
         Directory.CreateDirectory(Path.Combine(OutputDir, "assets"));
         
         var extensionsToIgnore = new List<string> { ".so", ".a", ".gz" };
@@ -90,7 +91,7 @@ public class ApkBuilder
         }
 
         // Copy AppDir to OutputDir/assets (ignore native files)
-        Utils.DirectoryCopy(sourceDir, Path.Combine(OutputDir, "assets"), file =>
+        Utils.DirectoryCopy(sourceDir, Path.Combine(OutputDir, "assets-tozip"), file =>
         {
             string fileName = Path.GetFileName(file);
             string extension = Path.GetExtension(file);
@@ -124,6 +125,10 @@ public class ApkBuilder
         string keytool = "keytool";
         string javac = "javac";
         string cmake = "cmake";
+        string zip = "zip";
+
+        Utils.RunProcess(zip, workingDir: Path.Combine(OutputDir, "assets-tozip"), args: "-r ../assets/assets.zip .");
+        Directory.Delete(Path.Combine(OutputDir, "assets-tozip"));
         
         if (!File.Exists(androidJar))
             throw new ArgumentException($"API level={BuildApiLevel} is not downloaded in Android SDK");

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -90,7 +90,8 @@ public class ApkBuilder
             extensionsToIgnore.Add(".dbg");
         }
 
-        // Copy AppDir to OutputDir/assets (ignore native files)
+        // Copy AppDir to OutputDir/assets-tozip (ignore native files)
+        // these files then will be zipped and copied to apk/assets/assets.zip
         Utils.DirectoryCopy(sourceDir, Path.Combine(OutputDir, "assets-tozip"), file =>
         {
             string fileName = Path.GetFileName(file);

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -97,11 +97,6 @@ public class ApkBuilder
             string fileName = Path.GetFileName(file);
             string extension = Path.GetExtension(file);
 
-            if (file.Any(s => s >= 128))
-            {
-                // non-ascii files/folders are not allowed
-                return false;
-            }
             if (extensionsToIgnore.Contains(extension))
             {
                 // ignore native files, those go to lib/%abi%

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -13,8 +13,8 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.app.Activity;
-import android.os.Bundle;
 import android.os.Environment;
+import android.net.Uri;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -22,6 +22,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.BufferedInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class MonoRunner extends Instrumentation
 {
@@ -43,13 +46,14 @@ public class MonoRunner extends Instrumentation
 
         MonoRunner.inst = this;
         Context context = getContext();
-        AssetManager am = context.getAssets();
         String filesDir = context.getFilesDir().getAbsolutePath();
         String cacheDir = context.getCacheDir().getAbsolutePath();
         String docsDir  = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS).getAbsolutePath();
 
-        copyAssetDir(am, "", filesDir);
+        // unzip libs and test files to filesDir
+        unzipAssets(context, filesDir, "assets.zip");
 
+        Log.i("DOTNET", "initRuntime");
         int retcode = initRuntime(filesDir, cacheDir, docsDir);
         runOnMainSync(new Runnable() {
             public void run() {
@@ -62,34 +66,38 @@ public class MonoRunner extends Instrumentation
         });
     }
 
-    static void copyAssetDir(AssetManager am, String path, String outpath) {
+    static void unzipAssets(Context context, String toPath, String zipName) {
+        AssetManager assetManager = context.getAssets();
         try {
-            String[] res = am.list(path);
-            for (int i = 0; i < res.length; ++i) {
-                String fromFile = res[i];
-                String toFile = outpath + "/" + res[i];
-                try {
-                    InputStream fromStream = am.open(fromFile);
-                    Log.w("DOTNET", "\tCOPYING " + fromFile + " to " + toFile);
-                    copy(fromStream, new FileOutputStream(toFile));
-                } catch (FileNotFoundException e) {
-                    new File(toFile).mkdirs();
-                    copyAssetDir(am, fromFile, toFile);
+            InputStream inputStream = assetManager.open(zipName);
+            ZipInputStream zipInputStream = new ZipInputStream(new BufferedInputStream(inputStream));
+            ZipEntry zipEntry;
+            byte[] buffer = new byte[4096];
+            while ((zipEntry = zipInputStream.getNextEntry()) != null) {
+                String fileOrDirectory = zipEntry.getName();
+                Uri.Builder builder = new Uri.Builder();
+                builder.scheme("file");
+                builder.appendPath(toPath);
+                builder.appendPath(fileOrDirectory);
+                String fullToPath = builder.build().getPath();
+                if (zipEntry.isDirectory()) {
+                    File directory = new File(fullToPath);
+                    directory.mkdirs();
                     continue;
                 }
+                Log.i("DOTNET", "Extracting asset to " + fullToPath);
+                int count = 0;
+                FileOutputStream fileOutputStream = new FileOutputStream(fullToPath);
+                while ((count = zipInputStream.read(buffer)) != -1) {
+                    fileOutputStream.write(buffer, 0, count);
+                }
+                fileOutputStream.close();
+                zipInputStream.closeEntry();
             }
+            zipInputStream.close();
+        } catch (IOException e) {
+            Log.e("DOTNET", e.getLocalizedMessage());
         }
-        catch (Exception e) {
-            Log.w("DOTNET", "EXCEPTION", e);
-        }
-    }
-
-    static void copy(InputStream in, OutputStream out) throws IOException {
-        byte[] buff = new byte [1024];
-        for (int len = in.read(buff); len != -1; len = in.read(buff))
-            out.write(buff, 0, len);
-        in.close();
-        out.close();
     }
 
     native int initRuntime(String libsDir, String cacheDir, String docsDir);


### PR DESCRIPTION
Turns out `copyAssetDir` was implemented incorrectly and didn't copy some files - thats why we have thousands of IO-related failures in tests.

`zip`-based solution also fixes some `aapt` issues (e.g. it refuses to bundle non-ASCI names and gz-files).


5267 test failures -> 1113 test failures (across different test suites)

half of 1113 failures are RemoteExecutor-based (PNSE)