### PR TITLE
Stop emitting weird intermediate folder artifacts/tests/artifacts

### DIFF
--- a/src/coreclr/tests/dir.common.props
+++ b/src/coreclr/tests/dir.common.props
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <OSPlatformConfig>$(TargetOS).$(TargetArchitecture).$(Configuration)</OSPlatformConfig>
 
-    <TestSrcDir>$(MSBuildThisFileDirectory)src</TestSrcDir>
+    <TestSrcDir Condition="'$(TestSrcDir)' == ''">$(MSBuildThisFileDirectory)src</TestSrcDir>
     <BuildProjectRelativeDir>$([MSBuild]::MakeRelative($(TestSrcDir), $(MSBuildProjectDirectory)))\$(MSBuildProjectName)\</BuildProjectRelativeDir>
 
     <!-- BaseIntermediateOutputPath is used by the SDK as the location

--- a/src/coreclr/tests/src/runtest.proj
+++ b/src/coreclr/tests/src/runtest.proj
@@ -354,7 +354,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
   </Target>
 
   <Target Name="CreateAllWrappers" DependsOnTargets="GetListOfTestCmds;FindCmdDirectories">
-    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateXunitWrapper;BuildXunitWrapper" Properties="_CMDDIR=%(TestDirectories.Identity)" />
+    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateXunitWrapper;BuildXunitWrapper" Properties="_CMDDIR=%(TestDirectories.Identity);TestSrcDir=$(XunitTestBinBase)" />
   </Target>
 
   <Target Name="GetListOfTestCmds">


### PR DESCRIPTION
The logic in dir.common.props for relativizing test directories
doesn't work well for the generated XUnit wrapper csproj files as
these are generated under artifacts\tests. Relativizing this
directory against src\coreclr\tests\src ended up with a weird
sequence that ended up duplicating the tests/artifacts folder
level. I have fixed this by explicitly passing the root directory
for relativization for the XUnit wrapper projects.

Thanks

Tomas

Fixes: #1655

Cc: @dotnet/runtime-infrastructure