### PR TITLE
Extract shared functionality to a TryRemoveCastIfPresent method

### DIFF
--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -459,6 +459,35 @@ private:
     }
 #endif // FEATURE_HW_INTRINSICS
 
+    //----------------------------------------------------------------------------------------------
+    // TryRemoveCastIfPresent: Removes op it is a cast operation and the size of its input is at
+    //                         least the size of expectedType
+    //
+    //  Arguments:
+    //     expectedType - The expected type of the cast operation input if it is to be removed
+    //     op           - The tree to remove if it is a cast op whose input is at least the size of expectedType
+    //
+    //  Returns:
+    //     op if it was not a cast node or if its input is not at least the size of expected type;
+    //     Otherwise, it returns the underlying operation that was being casted
+    GenTree* TryRemoveCastIfPresent(var_types expectedType, GenTree* op)
+    {
+        if (!op->OperIs(GT_CAST))
+        {
+            return op;
+        }
+
+        GenTree* castOp = op->AsCast()->CastOp();
+
+        if (genTypeSize(castOp->gtType) >= genTypeSize(expectedType))
+        {
+            BlockRange().Remove(op);
+            return castOp;
+        }
+
+        return op;
+    }
+
     // Utility functions
 public:
     static bool IndirsAreEquivalent(GenTree* pTreeA, GenTree* pTreeB);

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -954,25 +954,13 @@ void Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
             assert(HWIntrinsicInfo::lookupNumArgs(node) == 3);
 
             GenTreeArgList* argList = node->gtOp1->AsArgList();
-            GenTree*        op2     = argList->Rest()->Current();
-
-            if (!op2->OperIs(GT_CAST))
-            {
-                break;
-            }
 
             // Insert takes either a 32-bit register or a memory operand.
             // In either case, only gtSIMDBaseType bits are read and so
             // widening or narrowing the operand may be unnecessary and it
             // can just be used directly.
 
-            GenTree* castOp = op2->AsCast()->CastOp();
-
-            if (genTypeSize(castOp->gtType) >= genTypeSize(node->gtSIMDBaseType))
-            {
-                BlockRange().Remove(op2);
-                argList->Rest()->gtOp1 = castOp;
-            }
+            argList->Rest()->gtOp1 = TryRemoveCastIfPresent(node->gtSIMDBaseType, argList->Rest()->gtOp1);
             break;
         }
 
@@ -980,25 +968,12 @@ void Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
         {
             assert(HWIntrinsicInfo::lookupNumArgs(node) == 2);
 
-            GenTree* op2 = node->gtOp2;
-
-            if (!op2->OperIs(GT_CAST))
-            {
-                break;
-            }
-
             // Crc32 takes either a bit register or a memory operand.
             // In either case, only gtType bits are read and so widening
             // or narrowing the operand may be unnecessary and it can
             // just be used directly.
 
-            GenTree* castOp = op2->AsCast()->CastOp();
-
-            if (genTypeSize(castOp->gtType) >= genTypeSize(node->gtType))
-            {
-                BlockRange().Remove(op2);
-                node->gtOp2 = castOp;
-            }
+            node->gtOp2 = TryRemoveCastIfPresent(node->gtType, node->gtOp2);
             break;
         }
 


### PR DESCRIPTION
This is just the minor followup requested here: https://github.com/dotnet/runtime/pull/36512#discussion_r428799789

CC. @CarolEidt, @echesakovMSFT 

As mentioned in the thread, the ARM64 path (https://github.com/dotnet/runtime/blob/master/src/coreclr/src/jit/lowerarmarch.cpp#L588-L615) can't easily share as it needs to get the underlying cast op, ensure it is constant, and then ensure that constant is in range before it can be removed.