### PR TITLE
Fix wasm build when runtime configuration and configuration are different

### DIFF
--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -18,6 +18,7 @@
 
     <ProjectReference Include="$(CommonTestPath)AppleTestRunner\AppleTestRunner.csproj" Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'"/>
     <ProjectReference Include="$(CommonTestPath)AndroidTestRunner\AndroidTestRunner.csproj" Condition="'$(TargetOS)' == 'Android'" />
+    <ProjectReference Include="$(MonoProjectRoot)wasm\wasm.proj" Condition="'$(TargetOS)' == 'Browser'" />
   </ItemGroup>
 
   <Target Name="RestoreTestHost"

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -51,7 +51,7 @@
           Condition="'$(TargetOS)' == 'Browser'"
           AfterTargets="Build">
     <MSBuild Projects="$(MonoProjectRoot)\wasm\wasm.proj"
-             Properties="Configuration=$(Configuration);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture)"/>
+             Properties="Configuration=$(Configuration);MonoConfiguration=$(MonoConfiguration);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture)"/>
   </Target>
 
 </Project>

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -45,13 +45,4 @@
              Projects="@(ApiCompatProject)"
              Properties="$(TraversalGlobalProperties)" />
   </Target>
-
-  <!-- Wasm runtimes depend on the mono runtime and libs to be built, so they can only be built here -->
-  <Target Name="BuildWasmPackageDependency"
-          Condition="'$(TargetOS)' == 'Browser'"
-          AfterTargets="Build">
-    <MSBuild Projects="$(MonoProjectRoot)\wasm\wasm.proj"
-             Properties="Configuration=$(Configuration);MonoConfiguration=$(MonoConfiguration);TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture)"/>
-  </Target>
-
 </Project>

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -10,7 +10,7 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$(HostArch)</TargetArchitecture>
     <Platform>$(TargetArchitecture)</Platform>
 
-    <PlatformConfigPathPart>$(TargetOS).$(Platform).$(Configuration)</PlatformConfigPathPart>
+    <PlatformConfigPathPart>$(TargetOS).$(Platform).$(MonoConfiguration)</PlatformConfigPathPart>
   </PropertyGroup>
 
   <!-- Common properties -->

--- a/src/mono/Directory.Build.props
+++ b/src/mono/Directory.Build.props
@@ -10,7 +10,7 @@
     <TargetArchitecture Condition="'$(TargetArchitecture)' == ''">$(HostArch)</TargetArchitecture>
     <Platform>$(TargetArchitecture)</Platform>
 
-    <PlatformConfigPathPart>$(TargetOS).$(Platform).$(MonoConfiguration)</PlatformConfigPathPart>
+    <PlatformConfigPathPart>$(TargetOS).$(Platform).$(Configuration)</PlatformConfigPathPart>
   </PropertyGroup>
 
   <!-- Common properties -->

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets" DefaultTargets="BuildWasmRuntimes">
+<Project Sdk="Microsoft.Build.Traversal">
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
   </PropertyGroup>
@@ -37,7 +37,9 @@
       />
   </Target>
 
-  <Target Name="BuildWasmRuntimes" DependsOnTargets="BuildPInvokeTable">
+  <Target Name="BuildWasmRuntimes"
+          AfterTargets="Build"
+          DependsOnTargets="BuildPInvokeTable">
     <Exec Command="make -C $(MonoProjectRoot)wasm all SHELL=/bin/bash BINDIR=$(ArtifactsBinDir) MONO_BIN_DIR=$(MonoArtifactsPath) OBJDIR=$(ArtifactsObjDir) SYS_NATIVE_DIR=$(ArtifactsBinDir)/native/$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) CONFIG=$(Configuration) PINVOKE_TABLE=$(WasmPInvokeTablePath)" IgnoreStandardErrorWarningFormat="true"/>
   </Target>
 

--- a/src/mono/wasm/wasm.proj
+++ b/src/mono/wasm/wasm.proj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <UsingTask TaskName="PInvokeTableGenerator"
-    AssemblyFile="$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'WasmAppBuilder', '$(MonoConfiguration)', '$(NetCoreAppCurrent)'))publish\WasmAppBuilder.dll"/>
+    AssemblyFile="$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'WasmAppBuilder', 'Debug', '$(NetCoreAppCurrent)', 'publish', 'WasmAppBuilder.dll'))"/>
 
   <PropertyGroup>
     <WasmPInvokeTablePath>$(MonoObjDir)wasm/pinvoke-table.h</WasmPInvokeTablePath>
@@ -28,14 +28,7 @@
     <Error Condition="'$(EMSDK_PATH)' == ''" Text="The EMSDK_PATH environment variable should be set pointing to the emscripten SDK root dir."/>
   </Target>
 
-  <Target Name="BuildWasmAppBuilder">
-    <!-- Need to publish this since it references System.Reflection.MetadataLoadContext -->
-    <MSBuild Projects="$(RepoRoot)\tools-local\tasks\mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj"
-             Properties="Configuration=$(Configuration)"
-             Targets="Restore;Build;Publish"/>
-  </Target>
-
-  <Target Name="BuildPInvokeTable" DependsOnTargets="CheckEnv;BuildWasmAppBuilder">
+  <Target Name="BuildPInvokeTable" DependsOnTargets="CheckEnv">
     <MakeDir Directories="$(MonoObjDir)wasm"/>
     <PInvokeTableGenerator
       Modules="@(WasmPInvokeModules)"

--- a/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.csproj
+++ b/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.csproj
@@ -16,4 +16,8 @@
     <Compile Include="PInvokeTableGenerator.cs" />
     <Compile Include="WasmAppBuilder.cs" />
   </ItemGroup>
+
+  <Target Name="PublishBuilder"
+          AfterTargets="Build"
+          DependsOnTargets="Publish" />
 </Project>


### PR DESCRIPTION
When runtimeConfiguration and Configuration are different, the wasm.proj build fails to find the WasmAppBuilder because we were trying to load it from MonoConfiguration but publishing it with Configuration.

This also moves the Publish step to the actual build of the local-tools to avoid duplicating the build  of this task and having discrepancies on configurations as the local-tools are always built for debug and they're incrementally built based on a semaphore file.

Also, I noticed that `PlatformConfigPathPart` uses the global configuration instead of `MonoConfiguration`. 

Rolling builds are currently impacted because of this:
```
WasmAppBuilder -> /__w/1/s/artifacts/bin/WasmAppBuilder/Release/net5.0/WasmAppBuilder.dll
  WasmAppBuilder -> /__w/1/s/artifacts/bin/WasmAppBuilder/Release/net5.0/publish/
/__w/1/s/src/mono/wasm/wasm.proj(40,5): error MSB4062: The "PInvokeTableGenerator" task could not be loaded from the assembly /__w/1/s/artifacts/bin/WasmAppBuilder/Debug/net5.0/publish/WasmAppBuilder.dll. Could not load file or assembly '/__w/1/s/artifacts/bin/WasmAppBuilder/Debug/net5.0/publish/WasmAppBuilder.dll'. The system cannot find the path specified.
/__w/1/s/src/mono/wasm/wasm.proj(40,5): error MSB4062:  Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.
##[error]src/mono/wasm/wasm.proj(40,5): error MSB4062: (NETCORE_ENGINEERING_TELEMETRY=Build) The "PInvokeTableGenerator" task could not be loaded from the assembly /__w/1/s/artifacts/bin/WasmAppBuilder/Debug/net5.0/publish/WasmAppBuilder.dll. Could not load file or assembly '/__w/1/s/artifacts/bin/WasmAppBuilder/Debug/net5.0/publish/WasmAppBuilder.dll'. The system cannot find the path specified.
```
