### PR TITLE
Enregister multireg lclVars

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1117,7 +1117,9 @@ protected:
     void genUnspillLocal(
         unsigned varNum, var_types type, GenTreeLclVar* lclNode, regNumber regNum, bool reSpill, bool isLastUse);
     void genUnspillRegIfNeeded(GenTree* tree);
+    void genUnspillRegIfNeeded(GenTree* tree, unsigned multiRegIndex);
     regNumber genConsumeReg(GenTree* tree);
+    regNumber genConsumeReg(GenTree* tree, unsigned multiRegIndex);
     void genCopyRegIfNeeded(GenTree* tree, regNumber needReg);
     void genConsumeRegAndCopy(GenTree* tree, regNumber needReg);
 
@@ -1130,6 +1132,7 @@ protected:
     }
 
     void genRegCopy(GenTree* tree);
+    regNumber genRegCopy(GenTree* tree, unsigned multiRegIndex);
     void genTransferRegGCState(regNumber dst, regNumber src);
     void genConsumeAddress(GenTree* addr);
     void genConsumeAddrMode(GenTreeAddrMode* mode);
@@ -1278,7 +1281,8 @@ protected:
     void genEHFinallyOrFilterRet(BasicBlock* block);
 #endif // !FEATURE_EH_FUNCLETS
 
-    void genMultiRegStoreToLocal(GenTree* treeNode);
+    void genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode);
+    void genMultiRegStoreToLocal(GenTreeLclVar* lclNode);
 
     // Codegen for multi-register struct returns.
     bool isStructReturn(GenTree* treeNode);

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -1048,7 +1048,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
     // var = call, where call returns a multi-reg return value
     // case is handled separately.
-    if (data->gtSkipReloadOrCopy()->IsMultiRegCall())
+    if (data->gtSkipReloadOrCopy()->IsMultiRegNode())
     {
         genMultiRegStoreToLocal(tree);
     }

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1919,21 +1919,21 @@ void CodeGen::genCodeForStoreLclFld(GenTreeLclFld* tree)
 // genCodeForStoreLclVar: Produce code for a GT_STORE_LCL_VAR node.
 //
 // Arguments:
-//    tree - the GT_STORE_LCL_VAR node
+//    lclNode - the GT_STORE_LCL_VAR node
 //
-void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
+void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* lclNode)
 {
-    GenTree* data = tree->gtOp1;
+    GenTree* data = lclNode->gtOp1;
 
-    // Multi-reg nodes are handled separately.
+    // Stores from a multi-reg source are handled separately.
     if (data->gtSkipReloadOrCopy()->IsMultiRegNode())
     {
-        genMultiRegStoreToLocal(tree);
+        genMultiRegStoreToLocal(lclNode);
         return;
     }
 
-    LclVarDsc* varDsc = compiler->lvaGetDesc(tree);
-    if (tree->IsMultiReg())
+    LclVarDsc* varDsc = compiler->lvaGetDesc(lclNode);
+    if (lclNode->IsMultiReg())
     {
         // This is the case of storing to a multi-reg HFA local from a fixed-size SIMD type.
         assert(varTypeIsSIMD(data) && varDsc->lvIsHfa() && (varDsc->GetHfaType() == TYP_FLOAT));
@@ -1941,7 +1941,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
         unsigned int regCount   = varDsc->lvFieldCnt;
         for (unsigned i = 0; i < regCount; ++i)
         {
-            regNumber varReg = tree->GetRegByIndex(i);
+            regNumber varReg = lclNode->GetRegByIndex(i);
             assert(varReg != REG_NA);
             unsigned   fieldLclNum = varDsc->lvFieldLclStart + i;
             LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(fieldLclNum);
@@ -1951,17 +1951,17 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
     }
     else
     {
-        regNumber targetReg = tree->GetRegNum();
+        regNumber targetReg = lclNode->GetRegNum();
         emitter*  emit      = GetEmitter();
 
-        unsigned  varNum     = tree->GetLclNum();
-        var_types targetType = varDsc->GetRegisterType(tree);
+        unsigned  varNum     = lclNode->GetLclNum();
+        var_types targetType = varDsc->GetRegisterType(lclNode);
 
 #ifdef FEATURE_SIMD
         // storing of TYP_SIMD12 (i.e. Vector3) field
         if (targetType == TYP_SIMD12)
         {
-            genStoreLclTypeSIMD12(tree);
+            genStoreLclTypeSIMD12(lclNode);
             return;
         }
 #endif // FEATURE_SIMD
@@ -1979,7 +1979,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
                 if (targetReg != REG_NA)
                 {
                     emit->emitIns_R_I(INS_movi, emitActualTypeSize(targetType), targetReg, 0x00, INS_OPTS_16B);
-                    genProduceReg(tree);
+                    genProduceReg(lclNode);
                 }
                 else
                 {
@@ -1992,7 +1992,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
                         assert(targetType == TYP_SIMD8);
                         GetEmitter()->emitIns_S_R(INS_str, EA_8BYTE, REG_ZR, varNum, 0);
                     }
-                    genUpdateLife(tree);
+                    genUpdateLife(lclNode);
                 }
                 return;
             }
@@ -2008,14 +2008,14 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
         if (targetReg == REG_NA) // store into stack based LclVar
         {
-            inst_set_SV_var(tree);
+            inst_set_SV_var(lclNode);
 
             instruction ins  = ins_Store(targetType);
             emitAttr    attr = emitActualTypeSize(targetType);
 
             emit->emitIns_S_R(ins, attr, dataReg, varNum, /* offset */ 0);
 
-            genUpdateLife(tree);
+            genUpdateLife(lclNode);
 
             varDsc->SetRegNum(REG_STK);
         }
@@ -2026,7 +2026,7 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
                 // Assign into targetReg when dataReg (from op1) is not the same register
                 inst_RV_RV(ins_Copy(targetType), targetReg, dataReg, targetType);
             }
-            genProduceReg(tree);
+            genProduceReg(lclNode);
         }
     }
 }

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1354,167 +1354,69 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
 }
 #endif // FEATURE_ARG_SPLIT
 
+#ifdef FEATURE_SIMD
 //----------------------------------------------------------------------------------
-// genMultiRegStoreToLocal: store multi-reg return value of a call node to a local
+// genMultiRegStoreToSIMDLocal: store multi-reg value to a single-reg SIMD local
 //
 // Arguments:
-//    treeNode  -  Gentree of GT_STORE_LCL_VAR
+//    lclNode  -  GentreeLclVar of GT_STORE_LCL_VAR
 //
 // Return Value:
 //    None
 //
-// Assumption:
-//    The child of store is a multi-reg node.
-//
-void CodeGen::genMultiRegStoreToLocal(GenTree* treeNode)
+void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
 {
-    assert(treeNode->OperGet() == GT_STORE_LCL_VAR);
-    assert(varTypeIsStruct(treeNode) || varTypeIsMultiReg(treeNode));
-    GenTree* op1       = treeNode->gtGetOp1();
-    GenTree* actualOp1 = op1->gtSkipReloadOrCopy();
+    regNumber dst       = lclNode->GetRegNum();
+    GenTree*  op1       = lclNode->gtGetOp1();
+    GenTree*  actualOp1 = op1->gtSkipReloadOrCopy();
+    unsigned  regCount =
+        actualOp1->IsMultiRegLclVar() ? actualOp1->AsLclVar()->GetFieldCount(compiler) : actualOp1->GetMultiRegCount();
     assert(op1->IsMultiRegNode());
-    unsigned regCount = actualOp1->GetMultiRegCount();
-
-    // Assumption: current implementation requires that a multi-reg
-    // var in 'var = call' is flagged as lvIsMultiRegRet to prevent it from
-    // being promoted, unless compiler->lvaEnregMultiRegVars is true.
-
-    unsigned   lclNum = treeNode->AsLclVarCommon()->GetLclNum();
-    LclVarDsc* varDsc = compiler->lvaGetDesc(lclNum);
-    if (op1->OperIs(GT_CALL))
-    {
-        assert(regCount <= MAX_RET_REG_COUNT);
-        noway_assert(varDsc->lvIsMultiRegRet);
-    }
-
     genConsumeRegs(op1);
 
-    // Check for the case of an enregistered SIMD type that's returned in multiple registers.
-    if (varDsc->lvIsRegCandidate() && treeNode->GetRegNum() != REG_NA)
+    // Treat dst register as a homogenous vector with element size equal to the src size
+    // Insert pieces in reverse order
+    for (int i = regCount - 1; i >= 0; --i)
     {
-        assert(varTypeIsSIMD(treeNode));
-        assert(regCount != 0);
-
-        regNumber dst = treeNode->GetRegNum();
-
-        // Treat dst register as a homogenous vector with element size equal to the src size
-        // Insert pieces in reverse order
-        for (int i = regCount - 1; i >= 0; --i)
+        var_types type = op1->gtSkipReloadOrCopy()->GetRegTypeByIndex(i);
+        regNumber reg  = op1->GetRegByIndex(i);
+        if (op1->IsCopyOrReload())
         {
-            var_types type = op1->gtSkipReloadOrCopy()->GetRegTypeByIndex(i);
-            regNumber reg  = op1->GetRegByIndex(i);
-            if (op1->IsCopyOrReload())
+            // GT_COPY/GT_RELOAD will have valid reg for those positions
+            // that need to be copied or reloaded.
+            regNumber reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(i);
+            if (reloadReg != REG_NA)
             {
-                // GT_COPY/GT_RELOAD will have valid reg for those positions
-                // that need to be copied or reloaded.
-                regNumber reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(i);
-                if (reloadReg != REG_NA)
-                {
-                    reg = reloadReg;
-                }
-            }
-
-            assert(reg != REG_NA);
-            if (varTypeIsFloating(type))
-            {
-                // If the register piece was passed in a floating point register
-                // Use a vector mov element instruction
-                // src is not a vector, so it is in the first element reg[0]
-                // mov dst[i], reg[0]
-                // This effectively moves from `reg[0]` to `dst[i]`, leaving other dst bits unchanged till further
-                // iterations
-                // For the case where reg == dst, if we iterate so that we write dst[0] last, we eliminate the need for
-                // a temporary
-                GetEmitter()->emitIns_R_R_I_I(INS_mov, emitTypeSize(type), dst, reg, i, 0);
-            }
-            else
-            {
-                // If the register piece was passed in an integer register
-                // Use a vector mov from general purpose register instruction
-                // mov dst[i], reg
-                // This effectively moves from `reg` to `dst[i]`
-                GetEmitter()->emitIns_R_R_I(INS_mov, emitTypeSize(type), dst, reg, i);
+                reg = reloadReg;
             }
         }
 
-        genProduceReg(treeNode);
-    }
-    else
-    {
-
-        int  offset        = 0;
-        bool isMultiRegVar = treeNode->IsMultiRegLclVar();
-        bool hasRegs       = false;
-
-        if (isMultiRegVar)
+        assert(reg != REG_NA);
+        if (varTypeIsFloating(type))
         {
-            assert(compiler->lvaEnregMultiRegVars);
-            assert(regCount == varDsc->lvFieldCnt);
-        }
-        for (unsigned i = 0; i < regCount; ++i)
-        {
-            var_types type = actualOp1->GetRegTypeByIndex(i);
-            regNumber reg  = op1->GetRegByIndex(i);
-            if (reg == REG_NA)
-            {
-                // GT_COPY/GT_RELOAD will have valid reg only for those positions
-                // that need to be copied or reloaded.
-                assert(op1->IsCopyOrReload());
-                reg = actualOp1->GetRegByIndex(i);
-            }
-
-            assert(reg != REG_NA);
-            regNumber varReg = REG_NA;
-            if (isMultiRegVar)
-            {
-                regNumber  varReg      = treeNode->GetRegByIndex(i);
-                unsigned   fieldLclNum = varDsc->lvFieldLclStart + i;
-                LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(fieldLclNum);
-                var_types  type        = fieldVarDsc->TypeGet();
-                if (varReg != REG_NA)
-                {
-                    hasRegs = true;
-                    if (varReg != reg)
-                    {
-                        inst_RV_RV(ins_Copy(type), varReg, reg, type);
-                    }
-                    fieldVarDsc->SetRegNum(varReg);
-                }
-                else
-                {
-                    if (!treeNode->AsLclVar()->IsLastUse(i))
-                    {
-                        GetEmitter()->emitIns_S_R(ins_Store(type), emitTypeSize(type), reg, fieldLclNum, 0);
-                    }
-                    fieldVarDsc->SetRegNum(REG_STK);
-                }
-            }
-            else
-            {
-                GetEmitter()->emitIns_S_R(ins_Store(type), emitTypeSize(type), reg, lclNum, offset);
-                offset += genTypeSize(type);
-            }
-        }
-
-        // Update variable liveness.
-        if (isMultiRegVar)
-        {
-            if (hasRegs)
-            {
-                genProduceReg(treeNode);
-            }
-            else
-            {
-                genUpdateLife(treeNode);
-            }
+            // If the register piece was passed in a floating point register
+            // Use a vector mov element instruction
+            // src is not a vector, so it is in the first element reg[0]
+            // mov dst[i], reg[0]
+            // This effectively moves from `reg[0]` to `dst[i]`, leaving other dst bits unchanged till further
+            // iterations
+            // For the case where reg == dst, if we iterate so that we write dst[0] last, we eliminate the need for
+            // a temporary
+            GetEmitter()->emitIns_R_R_I_I(INS_mov, emitTypeSize(type), dst, reg, i, 0);
         }
         else
         {
-            genUpdateLife(treeNode);
-            varDsc->SetRegNum(REG_STK);
+            // If the register piece was passed in an integer register
+            // Use a vector mov from general purpose register instruction
+            // mov dst[i], reg
+            // This effectively moves from `reg` to `dst[i]`
+            GetEmitter()->emitIns_R_R_I(INS_mov, emitTypeSize(type), dst, reg, i);
         }
     }
+
+    genProduceReg(lclNode);
 }
+#endif // FEATURE_SIMD
 
 //------------------------------------------------------------------------
 // genRangeCheck: generate code for GT_ARR_BOUNDS_CHECK node.

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1389,10 +1389,6 @@ void CodeGen::genMultiRegStoreToLocal(GenTree* treeNode)
 
     genConsumeRegs(op1);
 
-    int  offset        = 0;
-    bool isMultiRegVar = treeNode->IsMultiRegLclVar();
-    bool hasRegs       = false;
-
     // Check for the case of an enregistered SIMD type that's returned in multiple registers.
     if (varDsc->lvIsRegCandidate() && treeNode->GetRegNum() != REG_NA)
     {
@@ -1445,6 +1441,11 @@ void CodeGen::genMultiRegStoreToLocal(GenTree* treeNode)
     }
     else
     {
+
+        int  offset        = 0;
+        bool isMultiRegVar = treeNode->IsMultiRegLclVar();
+        bool hasRegs       = false;
+
         if (isMultiRegVar)
         {
             assert(compiler->lvaEnregMultiRegVars);

--- a/src/coreclr/src/jit/codegeninterface.h
+++ b/src/coreclr/src/jit/codegeninterface.h
@@ -129,6 +129,7 @@ public:
     // Liveness-related fields & methods
 public:
     void genUpdateRegLife(const LclVarDsc* varDsc, bool isBorn, bool isDying DEBUGARG(GenTree* tree));
+    void genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree, int regIndex);
     void genUpdateVarReg(LclVarDsc* varDsc, GenTree* tree);
 
 protected:

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1321,6 +1321,12 @@ regNumber CodeGen::genConsumeReg(GenTree* tree, unsigned multiRegIndex)
     {
         reg = genRegCopy(tree, multiRegIndex);
     }
+    else if (reg == REG_NA)
+    {
+        assert(tree->OperIs(GT_RELOAD));
+        reg = tree->gtGetOp1()->GetRegByIndex(multiRegIndex);
+        assert(reg != REG_NA);
+    }
     genUnspillRegIfNeeded(tree, multiRegIndex);
 
     // UpdateLifeFieldVar() will return true if local var should be spilled.
@@ -1340,11 +1346,6 @@ regNumber CodeGen::genConsumeReg(GenTree* tree, unsigned multiRegIndex)
         unsigned   fieldVarNum = varDsc->lvFieldLclStart + multiRegIndex;
         LclVarDsc* fldVarDsc   = compiler->lvaGetDesc(fieldVarNum);
         assert(fldVarDsc->lvLRACandidate);
-        if (reg == REG_NA)
-        {
-            assert(tree->IsCopyOrReload());
-            reg = lcl->AsLclVar()->GetRegNumByIdx(multiRegIndex);
-        }
         bool isInReg      = fldVarDsc->lvIsInReg() && reg != REG_NA;
         bool isInMemory   = !isInReg || fldVarDsc->lvLiveInOutOfHndlr;
         bool isFieldDying = lcl->IsLastUse(multiRegIndex);

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1321,7 +1321,7 @@ void CodeGen::genCheckConsumeNode(GenTree* const node)
 //
 regNumber CodeGen::genConsumeReg(GenTree* tree, unsigned multiRegIndex)
 {
-    if (tree->OperGet() == GT_COPY)
+    if (tree->OperIs(GT_COPY))
     {
         genRegCopy(tree, multiRegIndex);
     }

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1401,7 +1401,7 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
     {
         assert(compiler->lvaEnregMultiRegVars);
         GenTreeLclVar* lcl              = tree->gtSkipReloadOrCopy()->AsLclVar();
-        LclVarDsc*     varDsc           = &compiler->lvaTable[lcl->GetLclNum()];
+        LclVarDsc*     varDsc           = compiler->lvaGetDesc(lcl);
         unsigned       firstFieldVarNum = varDsc->lvFieldLclStart;
         for (unsigned i = 0; i < varDsc->lvFieldCnt; ++i)
         {
@@ -1425,7 +1425,7 @@ regNumber CodeGen::genConsumeReg(GenTree* tree)
                 // We have loaded this into a register only temporarily
                 gcInfo.gcMarkRegSetNpt(reg);
             }
-            else if (isFieldDying != 0)
+            else if (isFieldDying)
             {
                 gcInfo.gcMarkRegSetNpt(genRegMask(fldVarDsc->GetRegNum()));
             }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -1849,192 +1849,100 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
     }
 }
 
+#ifdef FEATURE_SIMD
 //----------------------------------------------------------------------------------
-// genMultiRegStoreToLocal: store multi-reg return value of a call node to a local
+// genMultiRegStoreToSIMDLocal: store multi-reg value to a single-reg SIMD local
 //
 // Arguments:
-//    treeNode  -  Gentree of GT_STORE_LCL_VAR
+//    lclNode  -  GentreeLclVar of GT_STORE_LCL_VAR
 //
 // Return Value:
 //    None
 //
-// Assumptions:
-//    The child of store is a multi-reg node.
-//
-void CodeGen::genMultiRegStoreToLocal(GenTree* treeNode)
+void CodeGen::genMultiRegStoreToSIMDLocal(GenTreeLclVar* lclNode)
 {
-    assert(treeNode->OperGet() == GT_STORE_LCL_VAR);
-    assert(varTypeIsStruct(treeNode) || varTypeIsMultiReg(treeNode));
-    GenTree* op1       = treeNode->gtGetOp1();
-    GenTree* actualOp1 = op1->gtSkipReloadOrCopy();
+#ifdef UNIX_AMD64_ABI
+    regNumber dst       = lclNode->GetRegNum();
+    GenTree*  op1       = lclNode->gtGetOp1();
+    GenTree*  actualOp1 = op1->gtSkipReloadOrCopy();
+    unsigned  regCount =
+        actualOp1->IsMultiRegLclVar() ? actualOp1->AsLclVar()->GetFieldCount(compiler) : actualOp1->GetMultiRegCount();
     assert(op1->IsMultiRegNode());
-    unsigned regCount = actualOp1->GetMultiRegCount();
-
-    // Assumption: The current implementation requires that a multi-reg
-    // var in 'var = call' is flagged as lvIsMultiRegRet to prevent it from
-    // being promoted, unless compiler->lvaEnregMultiRegVars is true.
-
-    unsigned   lclNum = treeNode->AsLclVarCommon()->GetLclNum();
-    LclVarDsc* varDsc = compiler->lvaGetDesc(lclNum);
-    if (op1->OperIs(GT_CALL))
-    {
-        assert(regCount == MAX_RET_REG_COUNT);
-        noway_assert(varDsc->lvIsMultiRegRet);
-    }
-
     genConsumeRegs(op1);
 
-#ifdef UNIX_AMD64_ABI
-    // Structs of size >=9 and <=16 are returned in two return registers on x64 Unix.
+    // Right now the only enregistrable structs supported are SIMD types.
+    // They are only returned in 1 or 2 registers - the 1 register case is
+    // handled as a regular STORE_LCL_VAR.
+    // This case is always a call (AsCall() will assert if it is not).
+    GenTreeCall*          call        = actualOp1->AsCall();
+    const ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
+    assert(retTypeDesc->GetReturnRegCount() == MAX_RET_REG_COUNT);
 
-    // Handle the case of a SIMD type returned in 2 registers.
-    if (varTypeIsSIMD(treeNode) && (treeNode->GetRegNum() != REG_NA))
+    assert(regCount == 2);
+    assert(varTypeIsFloating(retTypeDesc->GetReturnRegType(0)));
+    assert(varTypeIsFloating(retTypeDesc->GetReturnRegType(1)));
+
+    // This is a case where the two 8-bytes that comprise the operand are in
+    // two different xmm registers and need to be assembled into a single
+    // xmm register.
+    regNumber targetReg = lclNode->GetRegNum();
+    regNumber reg0      = call->GetRegNumByIdx(0);
+    regNumber reg1      = call->GetRegNumByIdx(1);
+
+    if (op1->IsCopyOrReload())
     {
-        // Right now the only enregistrable structs supported are SIMD types.
-        // They are only returned in 1 or 2 registers - the 1 register case is
-        // handled as a regular STORE_LCL_VAR.
-        // This case is always a call (AsCall() will assert if it is not).
-        GenTreeCall*          call        = actualOp1->AsCall();
-        const ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
-        assert(retTypeDesc->GetReturnRegCount() == MAX_RET_REG_COUNT);
-
-        assert(regCount == 2);
-        assert(varTypeIsFloating(retTypeDesc->GetReturnRegType(0)));
-        assert(varTypeIsFloating(retTypeDesc->GetReturnRegType(1)));
-
-        // This is a case where the two 8-bytes that comprise the operand are in
-        // two different xmm registers and need to be assembled into a single
-        // xmm register.
-        regNumber targetReg = treeNode->GetRegNum();
-        regNumber reg0      = call->GetRegNumByIdx(0);
-        regNumber reg1      = call->GetRegNumByIdx(1);
-
-        if (op1->IsCopyOrReload())
+        // GT_COPY/GT_RELOAD will have valid reg for those positions
+        // that need to be copied or reloaded.
+        regNumber reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(0);
+        if (reloadReg != REG_NA)
         {
-            // GT_COPY/GT_RELOAD will have valid reg for those positions
-            // that need to be copied or reloaded.
-            regNumber reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(0);
-            if (reloadReg != REG_NA)
-            {
-                reg0 = reloadReg;
-            }
-
-            reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(1);
-            if (reloadReg != REG_NA)
-            {
-                reg1 = reloadReg;
-            }
+            reg0 = reloadReg;
         }
 
-        if (targetReg != reg0 && targetReg != reg1)
+        reloadReg = op1->AsCopyOrReload()->GetRegNumByIdx(1);
+        if (reloadReg != REG_NA)
         {
-            // targetReg = reg0;
-            // targetReg[127:64] = reg1[127:64]
-            inst_RV_RV(ins_Copy(TYP_DOUBLE), targetReg, reg0, TYP_DOUBLE);
-            inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg1, 0x00);
+            reg1 = reloadReg;
         }
-        else if (targetReg == reg0)
-        {
-            // (elided) targetReg = reg0
-            // targetReg[127:64] = reg1[127:64]
-            inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg1, 0x00);
-        }
-        else
-        {
-            assert(targetReg == reg1);
-            // We need two shuffles to achieve this
-            // First:
-            // targetReg[63:0] = targetReg[63:0]
-            // targetReg[127:64] = reg0[63:0]
-            //
-            // Second:
-            // targetReg[63:0] = targetReg[127:64]
-            // targetReg[127:64] = targetReg[63:0]
-            //
-            // Essentially copy low 8-bytes from reg0 to high 8-bytes of targetReg
-            // and next swap low and high 8-bytes of targetReg to have them
-            // rearranged in the right order.
-            inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg0, 0x00);
-            inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, targetReg, 0x01);
-        }
+    }
+
+    if (targetReg != reg0 && targetReg != reg1)
+    {
+        // targetReg = reg0;
+        // targetReg[127:64] = reg1[127:64]
+        inst_RV_RV(ins_Copy(TYP_DOUBLE), targetReg, reg0, TYP_DOUBLE);
+        inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg1, 0x00);
+    }
+    else if (targetReg == reg0)
+    {
+        // (elided) targetReg = reg0
+        // targetReg[127:64] = reg1[127:64]
+        inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg1, 0x00);
     }
     else
-#endif // UNIX_AMD64_ABI
     {
-        // This may be:
-        // - a call returning multiple registers
-        // - a HW intrinsic producing two registers to be stored into a TYP_STRUCT
+        assert(targetReg == reg1);
+        // We need two shuffles to achieve this
+        // First:
+        // targetReg[63:0] = targetReg[63:0]
+        // targetReg[127:64] = reg0[63:0]
         //
-        int  offset        = 0;
-        bool isMultiRegVar = treeNode->IsMultiRegLclVar();
-        bool hasRegs       = false;
-        if (isMultiRegVar)
-        {
-            assert(compiler->lvaEnregMultiRegVars);
-            assert(regCount == varDsc->lvFieldCnt);
-        }
-        for (unsigned i = 0; i < regCount; ++i)
-        {
-            var_types type = actualOp1->GetRegTypeByIndex(i);
-            regNumber reg  = op1->GetRegByIndex(i);
-            if (reg == REG_NA)
-            {
-                // GT_COPY/GT_RELOAD will have valid reg only for those positions
-                // that need to be copied or reloaded.
-                assert(op1->IsCopyOrReload());
-                reg = actualOp1->GetRegByIndex(i);
-            }
-
-            assert(reg != REG_NA);
-            regNumber varReg = REG_NA;
-            if (isMultiRegVar)
-            {
-                regNumber  varReg      = treeNode->GetRegByIndex(i);
-                unsigned   fieldLclNum = varDsc->lvFieldLclStart + i;
-                LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(fieldLclNum);
-                var_types  type        = fieldVarDsc->TypeGet();
-                if (varReg != REG_NA)
-                {
-                    hasRegs = true;
-                    if (varReg != reg)
-                    {
-                        inst_RV_RV(ins_Copy(type), varReg, reg, type);
-                    }
-                    fieldVarDsc->SetRegNum(varReg);
-                }
-                else
-                {
-                    if (!treeNode->AsLclVar()->IsLastUse(i))
-                    {
-                        GetEmitter()->emitIns_S_R(ins_Store(type), emitTypeSize(type), reg, fieldLclNum, 0);
-                    }
-                    fieldVarDsc->SetRegNum(REG_STK);
-                }
-            }
-            else
-            {
-                GetEmitter()->emitIns_S_R(ins_Store(type), emitTypeSize(type), reg, lclNum, offset);
-                offset += genTypeSize(type);
-            }
-        }
-        if (isMultiRegVar)
-        {
-            if (hasRegs)
-            {
-                genProduceReg(treeNode);
-            }
-            else
-            {
-                genUpdateLife(treeNode);
-            }
-        }
-        else
-        {
-            genUpdateLife(treeNode);
-            varDsc->SetRegNum(REG_STK);
-        }
+        // Second:
+        // targetReg[63:0] = targetReg[127:64]
+        // targetReg[127:64] = targetReg[63:0]
+        //
+        // Essentially copy low 8-bytes from reg0 to high 8-bytes of targetReg
+        // and next swap low and high 8-bytes of targetReg to have them
+        // rearranged in the right order.
+        inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, reg0, 0x00);
+        inst_RV_RV_IV(INS_shufpd, EA_16BYTE, targetReg, targetReg, 0x01);
     }
+    genProduceReg(lclNode);
+#else  // !UNIX_AMD64_ABI
+    assert(!"Multireg store to SIMD reg not supported on X64 Windows");
+#endif // !UNIX_AMD64_ABI
 }
+#endif // FEATURE_SIMD
 
 //------------------------------------------------------------------------
 // genAllocLclFrame: Probe the stack and allocate the local stack frame - subtract from SP.

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4460,6 +4460,35 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
             printf(""); // flush
         }
     }
+    if (lvaEnregMultiRegVars)
+    {
+        unsigned methHash   = info.compMethodHash();
+        char*    lostr      = getenv("JitMultiRegHashLo");
+        unsigned methHashLo = 0;
+        bool     dump       = false;
+        if (lostr != nullptr)
+        {
+            sscanf_s(lostr, "%x", &methHashLo);
+            dump = true;
+        }
+        char*    histr      = getenv("JitMultiRegHashHi");
+        unsigned methHashHi = UINT32_MAX;
+        if (histr != nullptr)
+        {
+            sscanf_s(histr, "%x", &methHashHi);
+            dump = true;
+        }
+        if (methHash < methHashLo || methHash > methHashHi)
+        {
+            lvaEnregMultiRegVars = false;
+        }
+        else if (dump)
+        {
+            printf("Enregistering MultiReg Vars for method %s, hash = 0x%x.\n", info.compFullName,
+                   info.compMethodHash());
+            printf(""); // flush
+        }
+    }
 #endif
 
     // Compute bbNum, bbRefs and bbPreds

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -3108,6 +3108,7 @@ public:
     bool lvaVarDoNotEnregister(unsigned varNum);
 
     bool lvaEnregEHVars;
+    bool lvaEnregMultiRegVars;
 
 #ifdef DEBUG
     // Reasons why we can't enregister.  Some of these correspond to debug properties of local vars.
@@ -4600,7 +4601,7 @@ public:
                                       VARSET_VALARG_TP     keepAliveVars,
                                       LclVarDsc&           varDsc,
                                       GenTreeLclVarCommon* node);
-    void fgComputeLifeUntrackedLocal(VARSET_TP&           life,
+    bool fgComputeLifeUntrackedLocal(VARSET_TP&           life,
                                      VARSET_VALARG_TP     keepAliveVars,
                                      LclVarDsc&           varDsc,
                                      GenTreeLclVarCommon* lclVarNode);

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -725,9 +725,7 @@ int GenTree::GetRegisterDstCount(Compiler* compiler) const
 #endif
     if (OperIsScalarLocal())
     {
-        // temporarily cast away const-ness as AsLclVar() method is not declared const
-        GenTree* temp = const_cast<GenTree*>(this);
-        return temp->AsLclVar()->GetFieldCount(compiler);
+        return AsLclVar()->GetFieldCount(compiler);
     }
     assert(!"Unexpected multi-reg node");
     return 0;
@@ -5575,7 +5573,7 @@ bool GenTree::OperMayThrow(Compiler* comp)
 // Notes:
 //     This must be a multireg lclVar.
 //
-unsigned int GenTreeLclVar::GetFieldCount(Compiler* compiler)
+unsigned int GenTreeLclVar::GetFieldCount(Compiler* compiler) const
 {
     assert(IsMultiReg());
     LclVarDsc* varDsc = compiler->lvaGetDesc(GetLclNum());
@@ -10218,7 +10216,7 @@ void Compiler::gtDispRegVal(GenTree* tree)
     {
         // 0th reg is GetRegNum(), which is already printed above.
         // Print the remaining regs of a multi-reg call node.
-        const GenTreeCall* call     = tree->gtSkipReloadOrCopy()->AsCall();
+        const GenTreeCall* call     = tree->AsCall();
         const unsigned     regCount = call->GetReturnTypeDesc()->TryGetReturnRegCount();
         for (unsigned i = 1; i < regCount; ++i)
         {

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -10252,7 +10252,7 @@ void Compiler::gtDispRegVal(GenTree* tree)
         for (unsigned i = 1; i < regCount; i++)
         {
             regNumber reg = tree->AsCopyOrReload()->GetRegNumByIdx(i);
-            printf(",%s", (reg == REG_NA) ? ",NA" : compRegVarName(reg));
+            printf(",%s", (reg == REG_NA) ? "NA" : compRegVarName(reg));
         }
     }
 #endif

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -10849,7 +10849,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
                             fieldVarDsc->PrintVarReg();
                         }
 
-                        if (fieldVarDsc->lvTracked && fgLocalVarLivenessDone &&
+                        if (fieldVarDsc->lvTracked && fgLocalVarLivenessDone && tree->IsMultiRegLclVar() &&
                             tree->AsLclVar()->IsLastUse(i - varDsc->lvFieldLclStart))
                         {
                             printf(" (last use)");

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -3304,7 +3304,7 @@ public:
         gtSpillFlags = SetMultiRegSpillFlagsByIdx(gtSpillFlags, flags, idx);
     }
 
-    unsigned int GetFieldCount(Compiler* compiler);
+    unsigned int GetFieldCount(Compiler* compiler) const;
     var_types GetFieldTypeByIndex(Compiler* compiler, unsigned idx);
 
     //-------------------------------------------------------------------

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -621,7 +621,7 @@ public:
     void CopyReg(GenTree* from);
     bool gtHasReg() const;
 
-    int GetRegisterDstCount() const;
+    int GetRegisterDstCount(Compiler* compiler) const;
 
     regMaskTP gtGetRegMask() const;
 
@@ -798,7 +798,6 @@ public:
 
 #define GTF_VAR_ARR_INDEX   0x00000020 // The variable is part of (the index portion of) an array index expression.
                                        // Shares a value with GTF_REVERSE_OPS, which is meaningless for local var.
-
 
                                                // For additional flags for GT_CALL node see GTF_CALL_M_*
 

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1450,7 +1450,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
             }
             if (src->OperIs(GT_CALL))
             {
-                lvaGetDesc(dest->AsLclVar()->GetLclNum())->lvIsMultiRegRet = true;
+                lvaGetDesc(dest->AsLclVar())->lvIsMultiRegRet = true;
             }
         }
         dest->gtType = asgType;

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1444,7 +1444,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
     }
     if (dest->OperIs(GT_LCL_VAR) &&
         (src->IsMultiRegNode() ||
-        (src->OperIs(GT_RET_EXPR) && src->AsRetExpr()->gtInlineCandidate->AsCall()->HasMultiRegRetVal())))
+         (src->OperIs(GT_RET_EXPR) && src->AsRetExpr()->gtInlineCandidate->AsCall()->HasMultiRegRetVal())))
     {
         if (lvaEnregMultiRegVars && varTypeIsStruct(dest))
         {

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1440,20 +1440,20 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
     }
     else if (compDoOldStructRetyping())
     {
-        if (dest->OperIs(GT_LCL_VAR) &&
-            (src->IsMultiRegNode() ||
-             (src->OperIs(GT_RET_EXPR) && src->AsRetExpr()->gtInlineCandidate->AsCall()->HasMultiRegRetVal())))
-        {
-            if (lvaEnregMultiRegVars && varTypeIsStruct(dest))
-            {
-                dest->AsLclVar()->SetMultiReg();
-            }
-            if (src->OperIs(GT_CALL))
-            {
-                lvaGetDesc(dest->AsLclVar())->lvIsMultiRegRet = true;
-            }
-        }
         dest->gtType = asgType;
+    }
+    if (dest->OperIs(GT_LCL_VAR) &&
+        (src->IsMultiRegNode() ||
+        (src->OperIs(GT_RET_EXPR) && src->AsRetExpr()->gtInlineCandidate->AsCall()->HasMultiRegRetVal())))
+    {
+        if (lvaEnregMultiRegVars && varTypeIsStruct(dest))
+        {
+            dest->AsLclVar()->SetMultiReg();
+        }
+        if (src->OperIs(GT_CALL))
+        {
+            lvaGetDesc(dest->AsLclVar())->lvIsMultiRegRet = true;
+        }
     }
 
     dest->gtFlags |= destFlags;

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1440,6 +1440,19 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
     }
     else if (compDoOldStructRetyping())
     {
+        if (dest->OperIs(GT_LCL_VAR) &&
+            (src->IsMultiRegNode() ||
+             (src->OperIs(GT_RET_EXPR) && src->AsRetExpr()->gtInlineCandidate->AsCall()->HasMultiRegRetVal())))
+        {
+            if (lvaEnregMultiRegVars && varTypeIsStruct(dest))
+            {
+                dest->AsLclVar()->SetMultiReg();
+            }
+            if (src->OperIs(GT_CALL))
+            {
+                lvaGetDesc(dest->AsLclVar()->GetLclNum())->lvIsMultiRegRet = true;
+            }
+        }
         dest->gtType = asgType;
     }
 

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -246,6 +246,8 @@ CONFIG_INTEGER(EnableAVX, W("EnableAVX"), 0)
 
 CONFIG_INTEGER(EnableEHWriteThru, W("EnableEHWriteThru"), 0) // Enable the register allocator to support EH-write thru:
                                                              // partial enregistration of vars exposed on EH boundaries
+CONFIG_INTEGER(EnableMultiRegLocals, W("EnableMultiRegLocals"), 1) // Enable the enregistration of locals that are
+                                                                   // defined or used in a multireg context.
 
 // clang-format off
 

--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -1645,18 +1645,19 @@ bool Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
 
     for (unsigned i = varDsc.lvFieldLclStart; i < varDsc.lvFieldLclStart + varDsc.lvFieldCnt; ++i)
     {
+        LclVarDsc* fieldVarDsc = lvaGetDesc(i);
 #if !defined(TARGET_64BIT)
-        if (!varTypeIsLong(lvaTable[i].lvType) || !lvaTable[i].lvPromoted)
+        if (!varTypeIsLong(fieldVarDsc->lvType) || !fieldVarDsc->lvPromoted)
 #endif // !defined(TARGET_64BIT)
         {
-            noway_assert(lvaTable[i].lvIsStructField);
+            noway_assert(fieldVarDsc->lvIsStructField);
         }
-        if (lvaTable[i].lvTracked)
+        if (fieldVarDsc->lvTracked)
         {
-            const unsigned varIndex = lvaTable[i].lvVarIndex;
+            const unsigned varIndex = fieldVarDsc->lvVarIndex;
             noway_assert(varIndex < lvaTrackedCount);
             VarSetOps::AddElemD(this, fieldSet, varIndex);
-            if (isDef && !VarSetOps::IsMember(this, life, varIndex))
+            if (isDef && lclVarNode->IsMultiRegLclVar() && !VarSetOps::IsMember(this, life, varIndex))
             {
                 // Dead definition.
                 lclVarNode->AsLclVar()->SetLastUse(i - varDsc.lvFieldLclStart);

--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -1623,7 +1623,11 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP&           life,
 //    keepAliveVars - The current set of variables to keep alive regardless of their actual lifetime.
 //    varDsc        - The LclVar descriptor for the variable being used or defined.
 //    lclVarNode    - The node that corresponds to the local var def or use.
-void Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
+//
+// Returns:
+//    `true` if the node is a dead store (i.e. all fields are dead); `false` otherwise.
+//
+bool Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
                                            VARSET_VALARG_TP     keepAliveVars,
                                            LclVarDsc&           varDsc,
                                            GenTreeLclVarCommon* lclVarNode)
@@ -1632,10 +1636,12 @@ void Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
 
     if (!varTypeIsStruct(varDsc.lvType) || (lvaGetPromotionType(&varDsc) == PROMOTION_TYPE_NONE))
     {
-        return;
+        return false;
     }
 
-    VARSET_TP varBit(VarSetOps::MakeEmpty(this));
+    VARSET_TP fieldSet(VarSetOps::MakeEmpty(this));
+    bool      fieldsAreTracked = true;
+    bool      isDef            = ((lclVarNode->gtFlags & GTF_VAR_DEF) != 0);
 
     for (unsigned i = varDsc.lvFieldLclStart; i < varDsc.lvFieldLclStart + varDsc.lvFieldCnt; ++i)
     {
@@ -1649,22 +1655,46 @@ void Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
         {
             const unsigned varIndex = lvaTable[i].lvVarIndex;
             noway_assert(varIndex < lvaTrackedCount);
-            VarSetOps::AddElemD(this, varBit, varIndex);
+            VarSetOps::AddElemD(this, fieldSet, varIndex);
+            if (isDef && !VarSetOps::IsMember(this, life, varIndex))
+            {
+                // Dead definition.
+                lclVarNode->AsLclVar()->SetLastUse(i - varDsc.lvFieldLclStart);
+            }
+        }
+        else
+        {
+            fieldsAreTracked = false;
         }
     }
-    if (lclVarNode->gtFlags & GTF_VAR_DEF)
+
+    if (isDef)
     {
-        VarSetOps::DiffD(this, varBit, keepAliveVars);
-        VarSetOps::DiffD(this, life, varBit);
-        return;
+        VARSET_TP liveFields(VarSetOps::Intersection(this, life, fieldSet));
+        VarSetOps::DiffD(this, fieldSet, keepAliveVars);
+        VarSetOps::DiffD(this, life, fieldSet);
+        if (fieldsAreTracked && VarSetOps::IsEmpty(this, liveFields))
+        {
+            // None of the fields were live, so this is a dead store.
+            if (!opts.MinOpts())
+            {
+                // keepAliveVars always stay alive
+                VARSET_TP keepAliveFields(VarSetOps::Intersection(this, fieldSet, keepAliveVars));
+                noway_assert(VarSetOps::IsEmpty(this, keepAliveFields));
+
+                // Do not consider this store dead if the parent local variable is an address exposed local.
+                return !varDsc.lvAddrExposed;
+            }
+        }
+        return false;
     }
     // This is a use.
 
     // Are the variables already known to be alive?
-    if (VarSetOps::IsSubset(this, varBit, life))
+    if (VarSetOps::IsSubset(this, fieldSet, life))
     {
         lclVarNode->gtFlags &= ~GTF_VAR_DEATH; // Since we may now call this multiple times, reset if live.
-        return;
+        return false;
     }
 
     // Some variables are being used, and they are not currently live.
@@ -1674,18 +1704,19 @@ void Compiler::fgComputeLifeUntrackedLocal(VARSET_TP&           life,
     lclVarNode->gtFlags |= GTF_VAR_DEATH;
 
     // Are all the variables becoming alive (in the backwards traversal), or just a subset?
-    if (!VarSetOps::IsEmptyIntersection(this, varBit, life))
+    if (!VarSetOps::IsEmptyIntersection(this, fieldSet, life))
     {
         // Only a subset of the variables are become live; we must record that subset.
         // (Lack of an entry for "lclVarNode" will be considered to imply all become dead in the
         // forward traversal.)
         VARSET_TP* deadVarSet = new (this, CMK_bitset) VARSET_TP;
-        VarSetOps::AssignNoCopy(this, *deadVarSet, VarSetOps::Diff(this, varBit, life));
+        VarSetOps::AssignNoCopy(this, *deadVarSet, VarSetOps::Diff(this, fieldSet, life));
         GetPromotedStructDeathVars()->Set(lclVarNode, deadVarSet);
     }
 
     // In any case, all the field vars are now live (in the backwards traversal).
-    VarSetOps::UnionD(this, life, varBit);
+    VarSetOps::UnionD(this, life, fieldSet);
+    return false;
 }
 
 //------------------------------------------------------------------------
@@ -1706,12 +1737,13 @@ bool Compiler::fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVar
 
     assert(lclNum < lvaCount);
     LclVarDsc& varDsc = lvaTable[lclNum];
+    bool       isDef  = ((lclVarNode->gtFlags & GTF_VAR_DEF) != 0);
 
     // Is this a tracked variable?
     if (varDsc.lvTracked)
     {
         /* Is this a definition or use? */
-        if (lclVarNode->gtFlags & GTF_VAR_DEF)
+        if (isDef)
         {
             return fgComputeLifeTrackedLocalDef(life, keepAliveVars, varDsc, lclVarNode->AsLclVarCommon());
         }
@@ -1722,7 +1754,7 @@ bool Compiler::fgComputeLifeLocal(VARSET_TP& life, VARSET_VALARG_TP keepAliveVar
     }
     else
     {
-        fgComputeLifeUntrackedLocal(life, keepAliveVars, varDsc, lclVarNode->AsLclVarCommon());
+        return fgComputeLifeUntrackedLocal(life, keepAliveVars, varDsc, lclVarNode->AsLclVarCommon());
     }
     return false;
 }
@@ -2272,7 +2304,24 @@ bool Compiler::fgRemoveDeadStore(GenTree**        pTree,
         else
         {
             // This is an INTERIOR STATEMENT with a dead assignment - remove it
-            noway_assert(!VarSetOps::IsMember(this, life, varDsc->lvVarIndex));
+            // TODO-Cleanup: I'm not sure this assert is valuable; we've already determined this when
+            // we computed that it was dead.
+            if (varDsc->lvTracked)
+            {
+                noway_assert(!VarSetOps::IsMember(this, life, varDsc->lvVarIndex));
+            }
+            else
+            {
+                for (unsigned i = 0; i < varDsc->lvFieldCnt; ++i)
+                {
+                    unsigned fieldVarNum = varDsc->lvFieldLclStart + i;
+                    {
+                        LclVarDsc* fieldVarDsc = lvaGetDesc(fieldVarNum);
+                        noway_assert(fieldVarDsc->lvTracked &&
+                                     !VarSetOps::IsMember(this, life, fieldVarDsc->lvVarIndex));
+                    }
+                }
+            }
 
             if (sideEffList != nullptr)
             {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6009,8 +6009,9 @@ bool Lowering::NodesAreEquivalentLeaves(GenTree* tree1, GenTree* tree2)
 //                                remain a multi-reg.
 //
 // Arguments:
-//   lclNode     - the GT_LCL_VAR node
-//   retTypeDesc - a return type descriptor for the consuming node
+//   lclNode     - the GT_LCL_VAR or GT_STORE_LCL_VAR node.
+//   retTypeDesc - a return type descriptor either for a call source of a store of
+//                 the local, or for the GT_RETURN consumer of the local.
 //
 // Notes:
 //   If retTypeDesc is non-null, this method will check that the fields are compatible.

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -296,8 +296,28 @@ GenTree* Lowering::LowerNode(GenTree* node)
         }
 
         case GT_LCL_VAR:
-            WidenSIMD12IfNecessary(node->AsLclVarCommon());
+        {
+            GenTreeLclVar* lclNode = node->AsLclVar();
+            WidenSIMD12IfNecessary(lclNode);
+            LclVarDsc* varDsc = comp->lvaGetDesc(lclNode);
+
+            // The consumer of this node must check compatibility of the fields.
+            // This merely checks whether it is possible for this to be a multireg node.
+            if (lclNode->IsMultiRegLclVar())
+            {
+                if (!varDsc->lvPromoted ||
+                    (comp->lvaGetPromotionType(varDsc) != Compiler::PROMOTION_TYPE_INDEPENDENT) ||
+                    (varDsc->lvFieldCnt > MAX_MULTIREG_COUNT))
+                {
+                    lclNode->ClearMultiReg();
+                    if (lclNode->TypeIs(TYP_STRUCT))
+                    {
+                        comp->lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(Compiler::DNER_BlockOp));
+                    }
+                }
+            }
             break;
+        }
 
         case GT_STORE_LCL_VAR:
             WidenSIMD12IfNecessary(node->AsLclVarCommon());
@@ -2941,37 +2961,47 @@ void Lowering::LowerRet(GenTreeUnOp* ret)
         BlockRange().InsertBefore(ret, bitcast);
         ContainCheckBitCast(bitcast);
     }
-    else
+    else if (ret->TypeGet() != TYP_VOID)
     {
-#ifdef DEBUG
-        if (ret->TypeGet() != TYP_VOID)
+        GenTree* retVal = ret->gtGetOp1();
+#if FEATURE_MULTIREG_RET
+        if (op1->OperIs(GT_LCL_VAR) && varTypeIsStruct(op1))
         {
-            GenTree* retVal = ret->gtGetOp1();
-            if (varTypeIsStruct(ret->TypeGet()) != varTypeIsStruct(retVal->TypeGet()))
+            ReturnTypeDesc retTypeDesc;
+            LclVarDsc*     varDsc = nullptr;
+            varDsc                = comp->lvaGetDesc(op1->AsLclVar()->GetLclNum());
+            retTypeDesc.InitializeStructReturnType(comp, varDsc->lvVerTypeInfo.GetClassHandle());
+            if (retTypeDesc.GetReturnRegCount() > 1)
             {
-                if (varTypeIsStruct(ret->TypeGet()))
+                CheckMultiRegLclVar(op1->AsLclVar(), &retTypeDesc);
+            }
+        }
+#else // !FEATURE_MULTIREG_RET
+#ifdef DEBUG
+        if (varTypeIsStruct(ret->TypeGet()) != varTypeIsStruct(retVal->TypeGet()))
+        {
+            if (varTypeIsStruct(ret->TypeGet()))
+            {
+                assert(!comp->compDoOldStructRetyping());
+                bool actualTypesMatch = false;
+                if (genActualType(comp->info.compRetNativeType) == genActualType(retVal->TypeGet()))
                 {
-                    assert(!comp->compDoOldStructRetyping());
-                    bool actualTypesMatch = false;
-                    if (genActualType(comp->info.compRetNativeType) == genActualType(retVal->TypeGet()))
-                    {
-                        // This could happen if we have retyped op1 as a primitive type during struct promotion,
-                        // check `retypedFieldsMap` for details.
-                        actualTypesMatch = true;
-                    }
-                    bool constStructInit = retVal->IsConstInitVal();
-                    assert(actualTypesMatch || constStructInit);
+                    // This could happen if we have retyped op1 as a primitive type during struct promotion,
+                    // check `retypedFieldsMap` for details.
+                    actualTypesMatch = true;
                 }
-                else
-                {
+                bool constStructInit = retVal->IsConstInitVal();
+                assert(actualTypesMatch || constStructInit);
+            }
+            else
+            {
 #ifdef FEATURE_SIMD
-                    assert(comp->compDoOldStructRetyping());
-                    assert(ret->TypeIs(TYP_DOUBLE));
-                    assert(retVal->TypeIs(TYP_SIMD8));
+                assert(comp->compDoOldStructRetyping());
+                assert(ret->TypeIs(TYP_DOUBLE));
+                assert(retVal->TypeIs(TYP_SIMD8));
 #else  // !FEATURE_SIMD
-                    unreached();
+                unreached();
 #endif // !FEATURE_SIMD
-                }
             }
         }
 #endif // DEBUG
@@ -2979,6 +3009,7 @@ void Lowering::LowerRet(GenTreeUnOp* ret)
         {
             LowerRetStruct(ret);
         }
+#endif // !FEATURE_MULTIREG_RET
     }
 
     // Method doing PInvokes has exactly one return block unless it has tail calls.
@@ -3018,7 +3049,17 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
         }
     }
 
-    if ((lclStore->TypeGet() == TYP_STRUCT) && (src->OperGet() != GT_PHI))
+    bool srcIsMultiReg = src->IsMultiRegNode();
+    if (srcIsMultiReg || lclStore->IsMultiRegLclVar())
+    {
+        const ReturnTypeDesc* retTypeDesc = nullptr;
+        if (src->OperIs(GT_CALL))
+        {
+            retTypeDesc = src->AsCall()->GetReturnTypeDesc();
+        }
+        CheckMultiRegLclVar(lclStore->AsLclVar(), retTypeDesc);
+    }
+    if (!srcIsMultiReg && (lclStore->TypeGet() == TYP_STRUCT) && (src->OperGet() != GT_PHI))
     {
         if (src->OperGet() == GT_CALL)
         {
@@ -5814,6 +5855,12 @@ bool Lowering::CheckBlock(Compiler* compiler, BasicBlock* block)
 }
 #endif
 
+//------------------------------------------------------------------------
+// Lowering::LowerBlock: Lower all the nodes in a BasicBlock
+//
+// Arguments:
+//   block    - the block to lower.
+//
 void Lowering::LowerBlock(BasicBlock* block)
 {
     assert(block == comp->compCurBB); // compCurBB must already be set.
@@ -5955,6 +6002,73 @@ bool Lowering::NodesAreEquivalentLeaves(GenTree* tree1, GenTree* tree2)
         default:
             return false;
     }
+}
+
+//------------------------------------------------------------------------
+// Lowering::CheckMultiRegLclVar: Check whether a MultiReg GT_LCL_VAR node can
+//                                remain a multi-reg.
+//
+// Arguments:
+//   lclNode     - the GT_LCL_VAR node
+//   retTypeDesc - a return type descriptor for the consuming node
+//
+// Notes:
+//   If retTypeDesc is non-null, this method will check that the fields are compatible.
+//   Otherwise, it will only check that the lclVar is independently promoted
+//   (i.e. it is marked lvPromoted and not lvDoNotEnregister).
+//
+bool Lowering::CheckMultiRegLclVar(GenTreeLclVar* lclNode, const ReturnTypeDesc* retTypeDesc)
+{
+    bool canEnregister = false;
+#if FEATURE_MULTIREG_RET
+    LclVarDsc* varDsc = comp->lvaGetDesc(lclNode->GetLclNum());
+    if ((comp->lvaEnregMultiRegVars) && varDsc->lvPromoted)
+    {
+        // We can enregister if we have a promoted struct and all the fields' types match the ABI requirements.
+        // Note that we don't promote structs with explicit layout, so we don't need to check field offsets, and
+        // if we have multiple types packed into a single register, we won't have matching reg and field counts,
+        // so we can tolerate mismatches of integer size.
+        if (varDsc->lvPromoted && (comp->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_INDEPENDENT))
+        {
+            // If we have no retTypeDesc, we only care that it is independently promoted.
+            if (retTypeDesc == nullptr)
+            {
+                canEnregister = true;
+            }
+            else
+            {
+                unsigned regCount = retTypeDesc->GetReturnRegCount();
+
+                if (regCount == varDsc->lvFieldCnt)
+                {
+                    canEnregister = true;
+                }
+            }
+        }
+    }
+#ifdef TARGET_XARCH
+    // For local stores on XARCH we only handle mismatched src/dest register count for
+    // calls of SIMD type. If the source was another lclVar similarly promoted, we would
+    // have broken it into multiple stores.
+    if (lclNode->OperIs(GT_STORE_LCL_VAR) && !lclNode->gtGetOp1()->OperIs(GT_CALL))
+    {
+        canEnregister = false;
+    }
+#endif // TARGET_XARCH
+    if (canEnregister)
+    {
+        lclNode->SetMultiReg();
+    }
+    else
+    {
+        lclNode->ClearMultiReg();
+        if (varDsc->lvPromoted && !varDsc->lvDoNotEnregister)
+        {
+            comp->lvaSetVarDoNotEnregister(lclNode->GetLclNum() DEBUGARG(Compiler::DNER_BlockOp));
+        }
+    }
+#endif
+    return canEnregister;
 }
 
 //------------------------------------------------------------------------
@@ -6149,10 +6263,13 @@ void Lowering::ContainCheckRet(GenTreeUnOp* ret)
             // This must be a multi-reg return or an HFA of a single element.
             assert(varDsc->lvIsMultiRegRet || (varDsc->lvIsHfa() && varTypeIsValidHfaType(varDsc->lvType)));
 
-            // Mark var as contained if not enregistrable.
+            // Mark var as contained if not enregisterable.
             if (!varTypeIsEnregisterable(op1))
             {
-                MakeSrcContained(ret, op1);
+                if (!op1->IsMultiRegLclVar())
+                {
+                    MakeSrcContained(ret, op1);
+                }
             }
         }
     }

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -2976,9 +2976,9 @@ void Lowering::LowerRet(GenTreeUnOp* ret)
                 CheckMultiRegLclVar(op1->AsLclVar(), &retTypeDesc);
             }
         }
-#else // !FEATURE_MULTIREG_RET
+        else
 #ifdef DEBUG
-        if (varTypeIsStruct(ret->TypeGet()) != varTypeIsStruct(retVal->TypeGet()))
+            if (varTypeIsStruct(ret->TypeGet()) != varTypeIsStruct(retVal->TypeGet()))
         {
             if (varTypeIsStruct(ret->TypeGet()))
             {

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -308,6 +308,7 @@ private:
 #endif
 
     void WidenSIMD12IfNecessary(GenTreeLclVarCommon* node);
+    bool CheckMultiRegLclVar(GenTreeLclVar* lclNode, const ReturnTypeDesc* retTypeDesc);
     void LowerStoreLoc(GenTreeLclVarCommon* tree);
     GenTree* LowerArrElem(GenTree* node);
     void LowerRotate(GenTree* tree);

--- a/src/coreclr/src/jit/lsra.h
+++ b/src/coreclr/src/jit/lsra.h
@@ -1537,6 +1537,9 @@ private:
         pendingDelayFree         = false;
     }
 
+    bool isCandidateMultiRegLclVar(GenTreeLclVar* lclNode);
+    bool checkContainedOrCandidateLclVar(GenTreeLclVar* lclNode);
+
     RefPosition* BuildUse(GenTree* operand, regMaskTP candidates = RBM_NONE, int multiRegIdx = 0);
 
     void setDelayFree(RefPosition* use);
@@ -1577,6 +1580,7 @@ private:
     int BuildModDiv(GenTree* tree);
     int BuildIntrinsic(GenTree* tree);
     void BuildStoreLocDef(GenTreeLclVarCommon* storeLoc, LclVarDsc* varDsc, RefPosition* singleUseRef, int index);
+    int BuildMultiRegStoreLoc(GenTreeLclVar* storeLoc);
     int BuildStoreLoc(GenTreeLclVarCommon* tree);
     int BuildIndir(GenTreeIndir* indirTree);
     int BuildGCWriteBarrier(GenTree* tree);

--- a/src/coreclr/src/jit/lsraarm64.cpp
+++ b/src/coreclr/src/jit/lsraarm64.cpp
@@ -76,28 +76,14 @@ int LinearScan::BuildNode(GenTree* tree)
             break;
 
         case GT_LCL_VAR:
-        {
-            // We handle tracked variables differently from non-tracked ones.  If it is tracked,
-            // we will simply add a use of the tracked variable at its parent/consumer.
-            // Otherwise, for a use we need to actually add the appropriate references for loading
-            // or storing the variable.
-            //
-            // A tracked variable won't actually get used until the appropriate ancestor tree node
-            // is processed, unless this is marked "isLocalDefUse" because it is a stack-based argument
-            // to a call or an orphaned dead node.
-            //
-            bool isCandidate = compiler->lvaGetDesc(tree->AsLclVar())->lvLRACandidate;
-            if (tree->IsRegOptional() && !isCandidate)
-            {
-                tree->ClearRegOptional();
-                tree->SetContained();
-                return 0;
-            }
-            if (isCandidate)
+            // We make a final determination about whether a GT_LCL_VAR is a candidate or contained
+            // after liveness. In either case we don't build any uses or defs. Otherwise, this is a
+            // load of a stack-based local into a register and we'll fall through to the general
+            // local case below.
+            if (checkContainedOrCandidateLclVar(tree->AsLclVar()))
             {
                 return 0;
             }
-        }
             __fallthrough;
 
         case GT_LCL_FLD:
@@ -118,10 +104,14 @@ int LinearScan::BuildNode(GenTree* tree)
         }
         break;
 
-        case GT_STORE_LCL_FLD:
         case GT_STORE_LCL_VAR:
-            srcCount = 1;
-            assert(dstCount == 0);
+            if (tree->IsMultiRegLclVar() && isCandidateMultiRegLclVar(tree->AsLclVar()))
+            {
+                dstCount = compiler->lvaGetDesc(tree->AsLclVar()->GetLclNum())->lvFieldCnt;
+            }
+            __fallthrough;
+
+        case GT_STORE_LCL_FLD:
             srcCount = BuildStoreLoc(tree->AsLclVarCommon());
             break;
 
@@ -775,10 +765,10 @@ int LinearScan::BuildNode(GenTree* tree)
         isLocalDefUse = true;
     }
     // We need to be sure that we've set srcCount and dstCount appropriately
-    assert((dstCount < 2) || tree->IsMultiRegCall());
+    assert((dstCount < 2) || tree->IsMultiRegNode());
     assert(isLocalDefUse == (tree->IsValue() && tree->IsUnusedValue()));
     assert(!tree->IsUnusedValue() || (dstCount != 0));
-    assert(dstCount == tree->GetRegisterDstCount());
+    assert(dstCount == tree->GetRegisterDstCount(compiler));
     return srcCount;
 }
 

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3258,7 +3258,7 @@ int LinearScan::BuildMultiRegStoreLoc(GenTreeLclVar* storeLoc)
         LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
         assert(isCandidateVar(fieldVarDsc));
         BuildStoreLocDef(storeLoc, fieldVarDsc, nullptr, i);
-        if (isMultiRegSrc && dstCount < (dstCount - 1))
+        if (isMultiRegSrc && (i < (dstCount - 1)))
         {
             currentLoc += 2;
         }

--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -1218,6 +1218,111 @@ bool LinearScan::buildKillPositionsForNode(GenTree* tree, LsraLocation currentLo
     return insertedKills;
 }
 
+//------------------------------------------------------------------------
+// LinearScan::isCandidateMultiRegLclVar: Check whether a MultiReg node should
+//                                        remain a candidate MultiReg
+//
+// Arguments:
+//    lclNode - the GT_LCL_VAR or GT_STORE_LCL_VAR of interest
+//
+// Return Value:
+//    true iff it remains a MultiReg lclVar.
+//
+// Notes:
+//    When identifying candidates, the register allocator will only retain
+//    promoted fields of a multi-reg local as candidates if all of its fields
+//    are candidates. This is because of the added complexity of dealing with a
+//    def or use of a multi-reg lclVar when only some of the fields have liveness
+//    info.
+//    At the time we determine whether a multi-reg lclVar can still be handled
+//    as such, we've already completed Lowering, so during the build phase of
+//    LSRA we have to reset the GTF_VAR_MULTIREG flag if necessary as we visit
+//    each node.
+//
+bool LinearScan::isCandidateMultiRegLclVar(GenTreeLclVar* lclNode)
+{
+    assert(compiler->lvaEnregMultiRegVars && lclNode->IsMultiReg());
+    LclVarDsc* varDsc = compiler->lvaGetDesc(lclNode->GetLclNum());
+    assert(varDsc->lvPromoted);
+    bool isMultiReg = (compiler->lvaGetPromotionType(varDsc) == Compiler::PROMOTION_TYPE_INDEPENDENT);
+    if (!isMultiReg)
+    {
+        lclNode->ClearMultiReg();
+    }
+#ifdef DEBUG
+    for (unsigned int i = 0; i < varDsc->lvFieldCnt; i++)
+    {
+        LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
+        assert(isCandidateVar(fieldVarDsc) == isMultiReg);
+    }
+#endif // DEBUG
+    return isMultiReg;
+}
+
+//------------------------------------------------------------------------
+// checkContainedOrCandidateLclVar: Check whether a GT_LCL_VAR node is a
+//                                  candidate or contained.
+//
+// Arguments:
+//    lclNode - the GT_LCL_VAR or GT_STORE_LCL_VAR of interest
+//
+// Return Value:
+//    true if the node remains a candidate or is contained
+//    false otherwise (i.e. if it will define a register)
+//
+// Notes:
+//    We handle candidate variables differently from non-candidate ones.
+//    If it is a candidate, we will simply add a use of it at its parent/consumer.
+//    Otherwise, for a use we need to actually add the appropriate references for loading
+//    or storing the variable.
+//
+//    A candidate lclVar won't actually get used until the appropriate ancestor node
+//    is processed, unless this is marked "isLocalDefUse" because it is a stack-based argument
+//    to a call or an orphaned dead node.
+//
+//    Also, because we do containment analysis before we redo dataflow and identify register
+//    candidates, the containment analysis only uses !lvDoNotEnregister to estimate register
+//    candidates.
+//    If there is a lclVar that is estimated during Lowering to be register candidate but turns
+//    out not to be, if a use was marked regOptional it should now be marked contained instead.
+//
+bool LinearScan::checkContainedOrCandidateLclVar(GenTreeLclVar* lclNode)
+{
+    bool isCandidate;
+    bool makeContained = false;
+    // We shouldn't be calling this if this node was already contained.
+    assert(!lclNode->isContained());
+    // If we have a multireg local, verify that its fields are still register candidates.
+    if (lclNode->IsMultiReg())
+    {
+        // Multi-reg uses must support containment, but if we have an actual multi-reg local
+        // we don't want it to be RegOptional in fixed-use cases, so that we can ensure proper
+        // liveness modeling (e.g. if one field is in a register required by another field, in
+        // a RegOptional case we won't handle the conflict properly if we decide not to allocate).
+        isCandidate = isCandidateMultiRegLclVar(lclNode);
+        if (isCandidate)
+        {
+            assert(!lclNode->IsRegOptional());
+        }
+        else
+        {
+            makeContained = true;
+        }
+    }
+    else
+    {
+        isCandidate   = compiler->lvaGetDesc(lclNode)->lvLRACandidate;
+        makeContained = !isCandidate && lclNode->IsRegOptional();
+    }
+    if (makeContained)
+    {
+        lclNode->ClearRegOptional();
+        lclNode->SetContained();
+        return true;
+    }
+    return isCandidate;
+}
+
 //----------------------------------------------------------------------------
 // defineNewInternalTemp: Defines a ref position for an internal temp.
 //
@@ -1470,7 +1575,6 @@ void LinearScan::buildUpperVectorRestoreRefPosition(Interval* lclVarInterval, Ls
 // Returns:
 //    The number of registers defined by `operand`.
 //
-// static
 int LinearScan::ComputeOperandDstCount(GenTree* operand)
 {
     // GT_ARGPLACE is the only non-LIR node that is currently in the trees at this stage, though
@@ -1499,7 +1603,7 @@ int LinearScan::ComputeOperandDstCount(GenTree* operand)
     {
         // Operands that are values and are not contained consume all of their operands
         // and produce one or more registers.
-        return operand->GetRegisterDstCount();
+        return operand->GetRegisterDstCount(compiler);
     }
     else
     {
@@ -1525,7 +1629,6 @@ int LinearScan::ComputeOperandDstCount(GenTree* operand)
 // Return Value:
 //    The number of registers available as sources for `node`.
 //
-// static
 int LinearScan::ComputeAvailableSrcCount(GenTree* node)
 {
     int numSources = 0;
@@ -1603,12 +1706,6 @@ void LinearScan::buildRefPositionsForNode(GenTree* tree, BasicBlock* block, Lsra
     int newDefListCount = defList.Count();
     int produce         = newDefListCount - oldDefListCount;
     assert((consume == 0) || (ComputeAvailableSrcCount(tree) == consume));
-
-#if defined(TARGET_AMD64)
-    // Multi-reg call node is the only node that could produce multi-reg value
-    assert(produce <= 1 || (tree->IsMultiRegCall() && produce == MAX_RET_REG_COUNT));
-#endif // TARGET_AMD64
-
 #endif // DEBUG
 
 #ifdef DEBUG
@@ -2244,15 +2341,15 @@ void LinearScan::buildIntervals()
         LIR::Range& blockRange = LIR::AsRange(block);
         for (GenTree* node : blockRange.NonPhiNodes())
         {
-            // We increment the number position of each tree node by 2 to simplify the logic when there's the case of
-            // a tree that implicitly does a dual-definition of temps (the long case).  In this case it is easier to
-            // already have an idle spot to handle a dual-def instead of making some messy adjustments if we only
-            // increment the number position by one.
+            // We increment the location of each tree node by 2 so that the node definition, if any,
+            // is at a new location and doesn't interfere with the uses.
+            // For multi-reg local stores, the 'BuildMultiRegStoreLoc' method will further increment the
+            // location by 2 for each destination register beyond the first.
             CLANG_FORMAT_COMMENT_ANCHOR;
 
 #ifdef DEBUG
             node->gtSeqNum = currentLoc;
-            // In DEBUG, we want to set the gtRegTag to GT_REGTAG_REG, so that subsequent dumps will so the register
+            // In DEBUG, we want to set the gtRegTag to GT_REGTAG_REG, so that subsequent dumps will show the register
             // value.
             // Although this looks like a no-op it sets the tag.
             node->SetRegNum(node->GetRegNum());
@@ -2820,6 +2917,20 @@ RefPosition* LinearScan::BuildUse(GenTree* operand, regMaskTP candidates, int mu
         buildUpperVectorRestoreRefPosition(interval, currentLoc, operand);
 #endif
     }
+    else if (operand->IsMultiRegLclVar())
+    {
+        assert(compiler->lvaEnregMultiRegVars);
+        LclVarDsc* varDsc      = compiler->lvaGetDesc(operand->AsLclVar()->GetLclNum());
+        LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + multiRegIdx);
+        interval               = getIntervalForLocalVar(fieldVarDsc->lvVarIndex);
+        if (operand->AsLclVar()->IsLastUse(multiRegIdx))
+        {
+            VarSetOps::RemoveElemD(compiler, currentLiveVars, fieldVarDsc->lvVarIndex);
+        }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+        buildUpperVectorRestoreRefPosition(interval, currentLoc, operand);
+#endif
+    }
     else
     {
         RefInfoListNode* refInfo   = defList.removeListNode(operand, multiRegIdx);
@@ -3035,6 +3146,127 @@ int LinearScan::BuildBinaryUses(GenTreeOp* node, regMaskTP candidates)
 }
 
 //------------------------------------------------------------------------
+// BuildStoreLocDef: Build a definition RefPosition for a local store
+//
+// Arguments:
+//    storeLoc - the local store (GT_STORE_LCL_FLD or GT_STORE_LCL_VAR)
+//
+// Notes:
+//    This takes an index to enable building multiple defs for a multi-reg local.
+//
+void LinearScan::BuildStoreLocDef(GenTreeLclVarCommon* storeLoc,
+                                  LclVarDsc*           varDsc,
+                                  RefPosition*         singleUseRef,
+                                  int                  index)
+{
+    assert(varDsc->lvTracked);
+    unsigned  varIndex       = varDsc->lvVarIndex;
+    Interval* varDefInterval = getIntervalForLocalVar(varIndex);
+    if ((storeLoc->gtFlags & GTF_VAR_DEATH) == 0)
+    {
+        VarSetOps::AddElemD(compiler, currentLiveVars, varIndex);
+    }
+    if (singleUseRef != nullptr)
+    {
+        Interval* srcInterval = singleUseRef->getInterval();
+        if (srcInterval->relatedInterval == nullptr)
+        {
+            // Preference the source to the dest, unless this is a non-last-use localVar.
+            // Note that the last-use info is not correct, but it is a better approximation than preferencing
+            // the source to the dest, if the source's lifetime extends beyond the dest.
+            if (!srcInterval->isLocalVar || (singleUseRef->treeNode->gtFlags & GTF_VAR_DEATH) != 0)
+            {
+                srcInterval->assignRelatedInterval(varDefInterval);
+            }
+        }
+        else if (!srcInterval->isLocalVar)
+        {
+            // Preference the source to dest, if src is not a local var.
+            srcInterval->assignRelatedInterval(varDefInterval);
+        }
+    }
+    RefPosition* def =
+        newRefPosition(varDefInterval, currentLoc + 1, RefTypeDef, storeLoc, allRegs(varDsc->TypeGet()), index);
+    if (varDefInterval->isWriteThru)
+    {
+        // We always make write-thru defs reg-optional, as we can store them if they don't
+        // get a register.
+        def->regOptional = true;
+    }
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+    if (varTypeNeedsPartialCalleeSave(varDefInterval->registerType))
+    {
+        varDefInterval->isPartiallySpilled = false;
+    }
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+}
+
+//------------------------------------------------------------------------
+// BuildMultiRegStoreLoc: Set register requirements for a store of a lclVar
+//
+// Arguments:
+//    storeLoc - the multireg local store (GT_STORE_LCL_VAR)
+//
+// Returns:
+//    The number of source registers read.
+//
+int LinearScan::BuildMultiRegStoreLoc(GenTreeLclVar* storeLoc)
+{
+    GenTree*     op1      = storeLoc->gtGetOp1();
+    unsigned int dstCount = storeLoc->GetFieldCount(compiler);
+    unsigned int srcCount = dstCount;
+    LclVarDsc*   varDsc   = compiler->lvaGetDesc(storeLoc->GetLclNum());
+
+    assert(compiler->lvaEnregMultiRegVars);
+    assert(storeLoc->OperGet() == GT_STORE_LCL_VAR);
+    bool isMultiRegSrc = op1->IsMultiRegNode();
+    // The source must be:
+    // - a multi-reg source
+    // - an enregisterable SIMD type, or
+    // - in-memory local
+    //
+    if (isMultiRegSrc)
+    {
+        assert(op1->GetMultiRegCount() == srcCount);
+    }
+    else if (varTypeIsEnregisterable(op1))
+    {
+        // Create a delay free use, as we'll have to use it to create each field
+        RefPosition* use = BuildUse(op1, RBM_NONE);
+        setDelayFree(use);
+        srcCount = 1;
+    }
+    else
+    {
+        // Otherwise we must have an in-memory struct lclVar.
+        // We will just load directly into the register allocated for this lclVar,
+        // so we don't need to build any uses.
+        assert(op1->OperIs(GT_LCL_VAR) && op1->isContained() && op1->TypeIs(TYP_STRUCT));
+        srcCount = 0;
+    }
+    // For multi-reg local stores of multi-reg sources, the code generator will read each source
+    // register, and then move it, if needed, to the destination register. These nodes have
+    // 2*N locations where N is the number of registers, so that the liveness can
+    // be reflected accordingly.
+    //
+    for (unsigned int i = 0; i < dstCount; ++i)
+    {
+        if (isMultiRegSrc)
+        {
+            BuildUse(op1, RBM_NONE, i);
+        }
+        LclVarDsc* fieldVarDsc = compiler->lvaGetDesc(varDsc->lvFieldLclStart + i);
+        assert(isCandidateVar(fieldVarDsc));
+        BuildStoreLocDef(storeLoc, fieldVarDsc, nullptr, i);
+        if (isMultiRegSrc && dstCount < (dstCount - 1))
+        {
+            currentLoc += 2;
+        }
+    }
+    return srcCount;
+}
+
+//------------------------------------------------------------------------
 // BuildStoreLoc: Set register requirements for a store of a lclVar
 //
 // Arguments:
@@ -3042,7 +3274,7 @@ int LinearScan::BuildBinaryUses(GenTreeOp* node, regMaskTP candidates)
 //
 // Notes:
 //    This involves:
-//    - Setting the appropriate candidates for a store of a multi-reg call return value.
+//    - Setting the appropriate candidates.
 //    - Handling of contained immediates.
 //    - Requesting an internal register for SIMD12 stores.
 //
@@ -3052,6 +3284,11 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
     int          srcCount;
     RefPosition* singleUseRef = nullptr;
     LclVarDsc*   varDsc       = compiler->lvaGetDesc(storeLoc->GetLclNum());
+
+    if (storeLoc->IsMultiRegLclVar())
+    {
+        return BuildMultiRegStoreLoc(storeLoc->AsLclVar());
+    }
 
 // First, define internal registers.
 #ifdef FEATURE_SIMD
@@ -3065,17 +3302,12 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
 
     // Second, use source registers.
 
-    if (op1->IsMultiRegCall())
+    if (op1->IsMultiRegNode())
     {
-        // This is the case of var = call where call is returning
-        // a value in multiple return registers.
-        // Must be a store lclvar.
+        // This is the case where the source produces multiple registers.
+        // This must be a store lclvar.
         assert(storeLoc->OperGet() == GT_STORE_LCL_VAR);
-
-        // srcCount = number of registers in which the value is returned by call
-        const GenTreeCall*    call        = op1->AsCall();
-        const ReturnTypeDesc* retTypeDesc = call->GetReturnTypeDesc();
-        srcCount                          = retTypeDesc->GetReturnRegCount();
+        srcCount = op1->GetMultiRegCount();
 
         for (int i = 0; i < srcCount; ++i)
         {
@@ -3095,19 +3327,11 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
 #ifndef TARGET_64BIT
     else if (varTypeIsLong(op1))
     {
-        if (op1->OperIs(GT_MUL_LONG))
-        {
-            srcCount = 2;
-            BuildUse(op1, allRegs(TYP_INT), 0);
-            BuildUse(op1, allRegs(TYP_INT), 1);
-        }
-        else
-        {
-            assert(op1->OperIs(GT_LONG));
-            assert(op1->isContained() && !op1->gtGetOp1()->isContained() && !op1->gtGetOp2()->isContained());
-            srcCount = BuildBinaryUses(op1->AsOp());
-            assert(srcCount == 2);
-        }
+        // GT_MUL_LONG is handled by the IsMultiRegNode case above.
+        assert(op1->OperIs(GT_LONG));
+        assert(op1->isContained() && !op1->gtGetOp1()->isContained() && !op1->gtGetOp2()->isContained());
+        srcCount = BuildBinaryUses(op1->AsOp());
+        assert(srcCount == 2);
     }
 #endif // !TARGET_64BIT
     else if (op1->isContained())
@@ -3163,46 +3387,7 @@ int LinearScan::BuildStoreLoc(GenTreeLclVarCommon* storeLoc)
     // Add the lclVar to currentLiveVars (if it will remain live)
     if (isCandidateVar(varDsc))
     {
-        assert(varDsc->lvTracked);
-        unsigned  varIndex       = varDsc->lvVarIndex;
-        Interval* varDefInterval = getIntervalForLocalVar(varIndex);
-        if ((storeLoc->gtFlags & GTF_VAR_DEATH) == 0)
-        {
-            VarSetOps::AddElemD(compiler, currentLiveVars, varIndex);
-        }
-        if (singleUseRef != nullptr)
-        {
-            Interval* srcInterval = singleUseRef->getInterval();
-            if (srcInterval->relatedInterval == nullptr)
-            {
-                // Preference the source to the dest, unless this is a non-last-use localVar.
-                // Note that the last-use info is not correct, but it is a better approximation than preferencing
-                // the source to the dest, if the source's lifetime extends beyond the dest.
-                if (!srcInterval->isLocalVar || (singleUseRef->treeNode->gtFlags & GTF_VAR_DEATH) != 0)
-                {
-                    srcInterval->assignRelatedInterval(varDefInterval);
-                }
-            }
-            else if (!srcInterval->isLocalVar)
-            {
-                // Preference the source to dest, if src is not a local var.
-                srcInterval->assignRelatedInterval(varDefInterval);
-            }
-        }
-        RefPosition* def =
-            newRefPosition(varDefInterval, currentLoc + 1, RefTypeDef, storeLoc, allRegs(storeLoc->TypeGet()));
-        if (varDefInterval->isWriteThru)
-        {
-            // We always make write-thru defs reg-optional, as we can store them if they don't
-            // get a register.
-            def->regOptional = true;
-        }
-#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
-        if (varTypeNeedsPartialCalleeSave(varDefInterval->registerType))
-        {
-            varDefInterval->isPartiallySpilled = false;
-        }
-#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+        BuildStoreLocDef(storeLoc, varDsc, singleUseRef, 0);
     }
 
     return srcCount;
@@ -3264,7 +3449,7 @@ int LinearScan::BuildReturn(GenTree* tree)
 
 #if FEATURE_MULTIREG_RET
 #ifdef TARGET_ARM64
-        if (varTypeIsSIMD(tree))
+        if (varTypeIsSIMD(tree) && !op1->IsMultiRegLclVar())
         {
             useCandidates = allSIMDRegs();
             BuildUse(op1, useCandidates);
@@ -3274,21 +3459,45 @@ int LinearScan::BuildReturn(GenTree* tree)
 
         if (varTypeIsStruct(tree))
         {
-            // op1 has to be either an lclvar or a multi-reg returning call
-            if (op1->OperGet() == GT_LCL_VAR)
+            // op1 has to be either a lclvar or a multi-reg returning call
+            if ((op1->OperGet() == GT_LCL_VAR) && !op1->IsMultiRegLclVar())
             {
                 BuildUse(op1, useCandidates);
             }
             else
             {
-                noway_assert(op1->IsMultiRegCall());
+                noway_assert(op1->IsMultiRegCall() || op1->IsMultiRegLclVar());
 
-                const ReturnTypeDesc* retTypeDesc = op1->AsCall()->GetReturnTypeDesc();
-                const int             srcCount    = retTypeDesc->GetReturnRegCount();
-                useCandidates                     = retTypeDesc->GetABIReturnRegs();
+                int                   srcCount;
+                const ReturnTypeDesc* pRetTypeDesc;
+                if (op1->OperIs(GT_CALL))
+                {
+                    pRetTypeDesc = op1->AsCall()->GetReturnTypeDesc();
+                }
+                else
+                {
+                    assert(compiler->lvaEnregMultiRegVars);
+                    LclVarDsc*     varDsc = compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum());
+                    ReturnTypeDesc retTypeDesc;
+                    retTypeDesc.InitializeStructReturnType(compiler, varDsc->lvVerTypeInfo.GetClassHandle());
+                    pRetTypeDesc = &retTypeDesc;
+                    assert(compiler->lvaGetDesc(op1->AsLclVar()->GetLclNum())->lvFieldCnt ==
+                           retTypeDesc.GetReturnRegCount());
+                }
+                srcCount = pRetTypeDesc->GetReturnRegCount();
                 for (int i = 0; i < srcCount; i++)
                 {
-                    BuildUse(op1, useCandidates, i);
+                    // We will build uses of the type of the operand registers/fields, and the codegen
+                    // for return will move as needed.
+                    if (!op1->OperIs(GT_LCL_VAR) || (regType(op1->AsLclVar()->GetFieldTypeByIndex(compiler, i)) ==
+                                                     regType(pRetTypeDesc->GetReturnRegType(i))))
+                    {
+                        BuildUse(op1, genRegMask(pRetTypeDesc->GetABIReturnReg(i)), i);
+                    }
+                    else
+                    {
+                        BuildUse(op1, RBM_NONE, i);
+                    }
                 }
                 return srcCount;
             }

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -3672,7 +3672,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* call)
                     // actually passed in registers.
                     if (argEntry->isPassedInRegisters())
                     {
-                        assert(argEntry->structDesc.passedInRegisters);
                         if (argObj->OperIs(GT_OBJ))
                         {
                             if (passingSize != structSize)
@@ -10134,12 +10133,22 @@ GenTree* Compiler::fgMorphBlkNode(GenTree* tree, bool isDest)
     }
     GenTree* blkSrc = blkNode->Addr();
     assert(blkSrc != nullptr);
-    if (!blkNode->TypeIs(TYP_STRUCT) && blkSrc->OperIs(GT_ADDR) && blkSrc->gtGetOp1()->OperIs(GT_LCL_VAR))
+    if (blkSrc->OperIs(GT_ADDR) && blkSrc->gtGetOp1()->OperIs(GT_LCL_VAR))
     {
         GenTreeLclVarCommon* lclVarNode = blkSrc->gtGetOp1()->AsLclVarCommon();
-        if ((genTypeSize(blkNode) != genTypeSize(lclVarNode)) || (!isDest && !varTypeIsStruct(lclVarNode)))
+        if ((blkNode->TypeGet() != TYP_STRUCT) &&
+            ((genTypeSize(blkNode) != genTypeSize(lclVarNode)) || (!isDest && !varTypeIsStruct(lclVarNode))))
         {
             lvaSetVarDoNotEnregister(lclVarNode->GetLclNum() DEBUG_ARG(DNER_VMNeedsStackAddr));
+        }
+        else
+        {
+            unsigned lclSize = lclVarNode->TypeIs(TYP_STRUCT) ? lvaGetDesc(lclVarNode)->lvExactSize
+                                                              : genTypeSize(lvaGetDesc(lclVarNode));
+            if ((blkNode->Size() == lclSize) && (lclVarNode->TypeGet() == tree->TypeGet()))
+            {
+                return lclVarNode;
+            }
         }
     }
 
@@ -10730,8 +10739,18 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
         {
             if (!destLclVar->lvRegStruct || (destLclVar->lvType != dest->TypeGet()))
             {
-                // Mark it as DoNotEnregister.
-                lvaSetVarDoNotEnregister(destLclNum DEBUGARG(DNER_BlockOp));
+                if (!dest->IsMultiRegLclVar() || (blockWidth != destLclVar->lvExactSize) ||
+                    (destLclVar->lvCustomLayout && destLclVar->lvContainsHoles))
+                {
+                    // Mark it as DoNotEnregister.
+                    lvaSetVarDoNotEnregister(destLclNum DEBUGARG(DNER_BlockOp));
+                }
+                else if (dest->IsMultiRegLclVar())
+                {
+                    // Handle this as lvIsMultiRegRet; this signals to SSA that it can't consider these fields
+                    // SSA candidates (we don't have a way to represent multiple SSANums on MultiRegLclVar nodes).
+                    destLclVar->lvIsMultiRegRet = true;
+                }
             }
         }
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -10133,22 +10133,12 @@ GenTree* Compiler::fgMorphBlkNode(GenTree* tree, bool isDest)
     }
     GenTree* blkSrc = blkNode->Addr();
     assert(blkSrc != nullptr);
-    if (blkSrc->OperIs(GT_ADDR) && blkSrc->gtGetOp1()->OperIs(GT_LCL_VAR))
+    if (!blkNode->TypeIs(TYP_STRUCT) && blkSrc->OperIs(GT_ADDR) && blkSrc->gtGetOp1()->OperIs(GT_LCL_VAR))
     {
         GenTreeLclVarCommon* lclVarNode = blkSrc->gtGetOp1()->AsLclVarCommon();
-        if ((blkNode->TypeGet() != TYP_STRUCT) &&
-            ((genTypeSize(blkNode) != genTypeSize(lclVarNode)) || (!isDest && !varTypeIsStruct(lclVarNode))))
+        if ((genTypeSize(blkNode) != genTypeSize(lclVarNode)) || (!isDest && !varTypeIsStruct(lclVarNode)))
         {
             lvaSetVarDoNotEnregister(lclVarNode->GetLclNum() DEBUG_ARG(DNER_VMNeedsStackAddr));
-        }
-        else
-        {
-            unsigned lclSize = lclVarNode->TypeIs(TYP_STRUCT) ? lvaGetDesc(lclVarNode)->lvExactSize
-                                                              : genTypeSize(lvaGetDesc(lclVarNode));
-            if ((blkNode->Size() == lclSize) && (lclVarNode->TypeGet() == tree->TypeGet()))
-            {
-                return lclVarNode;
-            }
         }
     }
 

--- a/src/coreclr/src/jit/treelifeupdater.cpp
+++ b/src/coreclr/src/jit/treelifeupdater.cpp
@@ -20,6 +20,150 @@ TreeLifeUpdater<ForCodeGen>::TreeLifeUpdater(Compiler* compiler)
 }
 
 //------------------------------------------------------------------------
+// UpdateLifeFieldVar: Update live sets for only the given field of a multi-reg LclVar node.
+//
+// Arguments:
+//    lclNode - the GT_LCL_VAR node.
+//    multiRegIndex - the index of the field being updated.
+//
+// Return Value:
+//    Returns true iff the variable needs to be spilled.
+//
+// Notes:
+//    This method need only be used when the fields are dying or going live at different times,
+//    e.g. when I ready the 0th field/reg of one node and define the 0th field/reg of another
+//    before reading the subsequent fields/regs.
+//
+template <bool ForCodeGen>
+bool TreeLifeUpdater<ForCodeGen>::UpdateLifeFieldVar(GenTreeLclVar* lclNode, unsigned multiRegIndex)
+{
+    LclVarDsc* parentVarDsc = compiler->lvaGetDesc(lclNode);
+    assert(parentVarDsc->lvPromoted && (multiRegIndex < parentVarDsc->lvFieldCnt) && lclNode->IsMultiReg() &&
+           compiler->lvaEnregMultiRegVars);
+    unsigned   fieldVarNum = parentVarDsc->lvFieldLclStart + multiRegIndex;
+    LclVarDsc* fldVarDsc   = compiler->lvaGetDesc(fieldVarNum);
+    assert(fldVarDsc->lvTracked);
+    unsigned fldVarIndex = fldVarDsc->lvVarIndex;
+    assert((lclNode->gtFlags & GTF_VAR_USEASG) == 0);
+
+    VarSetOps::Assign(compiler, newLife, compiler->compCurLife);
+    bool isBorn  = ((lclNode->gtFlags & GTF_VAR_DEF) != 0);
+    bool isDying = !isBorn && lclNode->IsLastUse(multiRegIndex);
+    // GTF_SPILL will be set if any registers need to be spilled.
+    unsigned spillFlags = (lclNode->gtFlags & lclNode->GetRegSpillFlagByIdx(multiRegIndex));
+    bool     spill      = ((spillFlags & GTF_SPILL) != 0);
+    bool     isInMemory = false;
+
+    if (isBorn || isDying)
+    {
+        if (ForCodeGen)
+        {
+            regNumber reg     = lclNode->GetRegNumByIdx(multiRegIndex);
+            bool      isInReg = fldVarDsc->lvIsInReg() && reg != REG_NA;
+            isInMemory        = !isInReg || fldVarDsc->lvLiveInOutOfHndlr;
+            if (isInReg)
+            {
+                if (isBorn)
+                {
+                    compiler->codeGen->genUpdateVarReg(fldVarDsc, lclNode, multiRegIndex);
+                }
+                compiler->codeGen->genUpdateRegLife(fldVarDsc, isBorn, isDying DEBUGARG(lclNode));
+            }
+        }
+        // First, update the live set
+        if (isDying)
+        {
+            VarSetOps::RemoveElemD(compiler, newLife, fldVarIndex);
+        }
+        else
+        {
+            VarSetOps::AddElemD(compiler, newLife, fldVarIndex);
+        }
+    }
+
+    if (!VarSetOps::Equal(compiler, compiler->compCurLife, newLife))
+    {
+#ifdef DEBUG
+        if (compiler->verbose)
+        {
+            printf("\t\t\t\t\t\t\tLive vars: ");
+            dumpConvertedVarSet(compiler, compiler->compCurLife);
+            printf(" => ");
+            dumpConvertedVarSet(compiler, newLife);
+            printf("\n");
+        }
+#endif // DEBUG
+
+        VarSetOps::Assign(compiler, compiler->compCurLife, newLife);
+
+        if (ForCodeGen)
+        {
+            // Only add vars to the gcInfo.gcVarPtrSetCur if they are currently on stack, since the
+            // gcInfo.gcTrkStkPtrLcls
+            // includes all TRACKED vars that EVER live on the stack (i.e. are not always in a register).
+            VarSetOps::Assign(compiler, gcTrkStkDeltaSet, compiler->codeGen->gcInfo.gcTrkStkPtrLcls);
+            if (isInMemory && VarSetOps::IsMember(compiler, gcTrkStkDeltaSet, fldVarIndex))
+            {
+#ifdef DEBUG
+                if (compiler->verbose)
+                {
+                    printf("\t\t\t\t\t\t\tGCvars: ");
+                    dumpConvertedVarSet(compiler, compiler->codeGen->gcInfo.gcVarPtrSetCur);
+                    printf(" => ");
+                }
+#endif // DEBUG
+
+                if (isBorn)
+                {
+                    VarSetOps::AddElemD(compiler, compiler->codeGen->gcInfo.gcVarPtrSetCur, fldVarIndex);
+                }
+                else
+                {
+                    VarSetOps::RemoveElemD(compiler, compiler->codeGen->gcInfo.gcVarPtrSetCur, fldVarIndex);
+                }
+
+#ifdef DEBUG
+                if (compiler->verbose)
+                {
+                    dumpConvertedVarSet(compiler, compiler->codeGen->gcInfo.gcVarPtrSetCur);
+                    printf("\n");
+                }
+#endif // DEBUG
+            }
+
+#ifdef USING_VARIABLE_LIVE_RANGE
+            // For each of the LclVarDsc that are reporting change, variable or fields
+            compiler->codeGen->getVariableLiveKeeper()->siStartOrCloseVariableLiveRange(fldVarDsc, fieldVarNum, isBorn,
+                                                                                        isDying);
+#endif // USING_VARIABLE_LIVE_RANGE
+
+#ifdef USING_SCOPE_INFO
+            compiler->codeGen->siUpdate();
+#endif // USING_SCOPE_INFO
+        }
+    }
+
+    if (ForCodeGen && spill)
+    {
+        if (VarSetOps::IsMember(compiler, compiler->codeGen->gcInfo.gcTrkStkPtrLcls, fldVarIndex))
+        {
+            if (!VarSetOps::IsMember(compiler, compiler->codeGen->gcInfo.gcVarPtrSetCur, fldVarIndex))
+            {
+                VarSetOps::AddElemD(compiler, compiler->codeGen->gcInfo.gcVarPtrSetCur, fldVarIndex);
+#ifdef DEBUG
+                if (compiler->verbose)
+                {
+                    printf("\t\t\t\t\t\t\tVar V%02u becoming live\n", fieldVarNum);
+                }
+#endif // DEBUG
+            }
+        }
+        return true;
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
 // UpdateLifeVar: Update live sets for a given tree.
 //
 // Arguments:

--- a/src/coreclr/src/jit/treelifeupdater.h
+++ b/src/coreclr/src/jit/treelifeupdater.h
@@ -15,6 +15,7 @@ class TreeLifeUpdater
 public:
     TreeLifeUpdater(Compiler* compiler);
     void UpdateLife(GenTree* tree);
+    bool UpdateLifeFieldVar(GenTreeLclVar* lclNode, unsigned multiRegIndex);
 
 private:
     void UpdateLifeVar(GenTree* tree);


### PR DESCRIPTION
Allow struct lclVars that are returned in multiple registers to be
enregistered, as long as the fields are a match for the registers.

Fix #34105