### PR TITLE
Remove dead Exception handling code in Uri

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/UriScheme.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriScheme.cs
@@ -104,13 +104,11 @@ namespace System
             if (!baseUri.IsAbsoluteUri)
                 throw new InvalidOperationException(SR.net_uri_NotAbsolute);
 
-
             string? newUriString = null;
             bool userEscaped = false;
-            Uri? result = Uri.ResolveHelper(baseUri, relativeUri, ref newUriString, ref userEscaped, out parsingError);
+            parsingError = null;
 
-            if (parsingError != null)
-                return null;
+            Uri? result = Uri.ResolveHelper(baseUri, relativeUri, ref newUriString, ref userEscaped);
 
             if (result != null)
                 return result.OriginalString;


### PR DESCRIPTION
`GetCombinedString` could only ever return `ParsingError.None`.
 As a result, `ResolveHelper` could never return an exception and its `out UriFormatException` parameter can be removed.
Without that parameter, more exception checks can be removed.