### PR TITLE
No retyping arm/arm64.

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9169,6 +9169,36 @@ public:
 #endif // FEATURE_MULTIREG_RET
     }
 
+    // Returns true if the method returns a value in more than one return register,
+    // it should replace/be  merged with compMethodReturnsMultiRegRetType when #36868 is fixed.
+    bool compMethodReturnsResInMultiplyRegisters()
+    {
+#if FEATURE_MULTIREG_RET
+#if defined(TARGET_X86)
+        // On x86 only 64-bit longs are returned in multiple registers
+        return varTypeIsLong(info.compRetNativeType);
+#else // targets: X64-UNIX, ARM64 or ARM32
+#if defined(TARGET_ARM64)
+        // TYP_SIMD16 is returned in one register.
+        if (info.compRetNativeType == TYP_SIMD16)
+        {
+            return false;
+        }
+#endif
+        // On all other targets that support multireg return values:
+        // Methods returning a struct in multiple registers have a return value of TYP_STRUCT.
+        // Such method's compRetNativeType is TYP_STRUCT without a hidden RetBufArg
+        return varTypeIsStruct(info.compRetNativeType) && (info.compRetBuffArg == BAD_VAR_NUM);
+#endif // TARGET_XXX
+
+#else // not FEATURE_MULTIREG_RET
+
+        // For this architecture there are no multireg returns
+        return false;
+
+#endif // FEATURE_MULTIREG_RET
+    }
+
     // Returns true if the method being compiled returns a value
     bool compMethodHasRetVal()
     {

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -9171,7 +9171,9 @@ public:
 
     // Returns true if the method returns a value in more than one return register,
     // it should replace/be  merged with compMethodReturnsMultiRegRetType when #36868 is fixed.
-    bool compMethodReturnsResInMultiplyRegisters()
+    // The difference from original `compMethodReturnsMultiRegRetType` is in ARM64 SIMD16 handling,
+    // this method correctly returns false for it (it is passed as HVA), when the original returns true.
+    bool compMethodReturnsMultiRegRegTypeAlternate()
     {
 #if FEATURE_MULTIREG_RET
 #if defined(TARGET_X86)

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -15149,6 +15149,11 @@ GenTree* Compiler::gtNewTempAssign(
             assert(tmp == genReturnLocal);
             ok = true;
         }
+        else if (varTypeIsSIMD(dstTyp) && (valTyp == TYP_STRUCT))
+        {
+            assert(val->IsCall());
+            ok = true;
+        }
 
         if (!ok)
         {

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -4257,13 +4257,7 @@ struct GenTreeCall final : public GenTree
         {
             return true;
         }
-#elif defined(FEATURE_HFA) && defined(TARGET_ARM64)
-        // SIMD types are returned in vector regs on ARM64.
-        if (varTypeIsSIMD(gtType))
-        {
-            return false;
-        }
-#endif // FEATURE_HFA && TARGET_ARM64
+#endif
 
         if (!varTypeIsStruct(gtType) || HasRetBufArg())
         {

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -803,6 +803,7 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
         var_types varType = lvaTable[tmpNum].lvType;
         assert(tiVerificationNeeded || varType == TYP_UNDEF || varTypeIsStruct(varType));
         lvaSetStruct(tmpNum, structType, false);
+
         varType = lvaTable[tmpNum].lvType;
         // Now, set the type of the struct value. Note that lvaSetStruct may modify the type
         // of the lclVar to a specialized type (e.g. TYP_SIMD), based on the handle (structType)

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -803,7 +803,7 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
         var_types varType = lvaTable[tmpNum].lvType;
         assert(tiVerificationNeeded || varType == TYP_UNDEF || varTypeIsStruct(varType));
         lvaSetStruct(tmpNum, structType, false);
-
+        varType = lvaTable[tmpNum].lvType;
         // Now, set the type of the struct value. Note that lvaSetStruct may modify the type
         // of the lclVar to a specialized type (e.g. TYP_SIMD), based on the handle (structType)
         // that has been passed in for the value being assigned to the temp, in which case we
@@ -812,9 +812,12 @@ void Compiler::impAssignTempGen(unsigned             tmpNum,
         // type, this would not be necessary - but that requires additional JIT/EE interface
         // calls that may not actually be required - e.g. if we only access a field of a struct.
 
-        val->gtType = lvaTable[tmpNum].lvType;
+        if (compDoOldStructRetyping())
+        {
+            val->gtType = varType;
+        }
 
-        GenTree* dst = gtNewLclvNode(tmpNum, val->gtType);
+        GenTree* dst = gtNewLclvNode(tmpNum, varType);
         asg          = impAssignStruct(dst, val, structType, curLevel, pAfterStmt, ilOffset, block);
     }
     else
@@ -1224,7 +1227,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
                     lcl->gtFlags |= GTF_DONT_CSE;
                     varDsc->lvIsMultiRegRet = true;
                 }
-                else if (lcl->gtType != src->gtType)
+                else if ((lcl->gtType != src->gtType) && compDoOldStructRetyping())
                 {
                     // We change this to a GT_LCL_FLD (from a GT_ADDR of a GT_LCL_VAR)
                     lcl->ChangeOper(GT_LCL_FLD);
@@ -1434,7 +1437,7 @@ GenTree* Compiler::impAssignStructPtr(GenTree*             destAddr,
             dest = gtNewOperNode(GT_IND, asgType, destAddr);
         }
     }
-    else
+    else if (compDoOldStructRetyping())
     {
         dest->gtType = asgType;
     }
@@ -8011,7 +8014,7 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
     CORINFO_CLASS_HANDLE actualMethodRetTypeSigClass;
     actualMethodRetTypeSigClass = sig->retTypeSigClass;
-    if (varTypeIsStruct(callRetTyp))
+    if (varTypeIsStruct(callRetTyp) && compDoOldStructRetyping())
     {
         callRetTyp   = impNormStructType(actualMethodRetTypeSigClass);
         call->gtType = callRetTyp;
@@ -16656,7 +16659,14 @@ bool Compiler::impReturnInstruction(int prefixFlags, OPCODE& opcode)
                     impAssignTempGen(lvaInlineeReturnSpillTemp, op2, se.seTypeInfo.GetClassHandle(),
                                      (unsigned)CHECK_SPILL_ALL);
 
-                    GenTree* tmpOp2 = gtNewLclvNode(lvaInlineeReturnSpillTemp, op2->TypeGet());
+                    var_types lclRetType = op2->TypeGet();
+                    if (!compDoOldStructRetyping())
+                    {
+                        LclVarDsc* varDsc = lvaGetDesc(lvaInlineeReturnSpillTemp);
+                        lclRetType        = varDsc->lvType;
+                    }
+
+                    GenTree* tmpOp2 = gtNewLclvNode(lvaInlineeReturnSpillTemp, lclRetType);
 
                     if (compDoOldStructRetyping())
                     {

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -437,13 +437,8 @@ CONFIG_INTEGER(JitSaveFpLrWithCalleeSavedRegisters, W("JitSaveFpLrWithCalleeSave
 #endif // defined(TARGET_ARM64)
 #endif // DEBUG
 
-#if defined(TARGET_ARMARCH)
-CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 1) // Allow Jit to retype structs as primitive types
+CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 0) // Allow Jit to retype structs as primitive types
                                                                        // when possible.
-#else
-CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 1) // Allow Jit to retype structs as primitive types
-                                                                       // when possible.
-#endif
 
 #undef CONFIG_INTEGER
 #undef CONFIG_STRING

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -437,7 +437,7 @@ CONFIG_INTEGER(JitSaveFpLrWithCalleeSavedRegisters, W("JitSaveFpLrWithCalleeSave
 #endif // defined(TARGET_ARM64)
 #endif // DEBUG
 
-CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 0) // Allow Jit to retype structs as primitive types
+CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 1) // Allow Jit to retype structs as primitive types
                                                                        // when possible.
 
 #undef CONFIG_INTEGER

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -1630,6 +1630,7 @@ void Compiler::StructPromotionHelper::CheckRetypedAsScalar(CORINFO_FIELD_HANDLE 
 //
 bool Compiler::StructPromotionHelper::CanPromoteStructType(CORINFO_CLASS_HANDLE typeHnd)
 {
+    assert(typeHnd != nullptr);
     if (!compiler->eeIsValueClass(typeHnd))
     {
         // TODO-ObjectStackAllocation: Enable promotion of fields of stack-allocated objects.
@@ -1865,6 +1866,7 @@ bool Compiler::StructPromotionHelper::CanPromoteStructVar(unsigned lclNum)
     }
 
     CORINFO_CLASS_HANDLE typeHnd = varDsc->lvVerTypeInfo.GetClassHandle();
+    assert(typeHnd != nullptr);
     return CanPromoteStructType(typeHnd);
 }
 

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -2975,9 +2975,8 @@ void Lowering::LowerRet(GenTreeUnOp* ret)
             }
         }
 #endif // DEBUG
-        if (varTypeIsStruct(ret) && !comp->compMethodReturnsMultiRegRetType())
+        if (varTypeIsStruct(ret))
         {
-            assert(!comp->compDoOldStructRetyping());
             LowerRetStruct(ret);
         }
     }
@@ -3103,7 +3102,29 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
 //
 void Lowering::LowerRetStruct(GenTreeUnOp* ret)
 {
-    assert(!comp->compMethodReturnsMultiRegRetType());
+#if defined(FEATURE_HFA) && defined(TARGET_ARM64)
+    if (ret->TypeIs(TYP_SIMD16))
+    {
+        if (comp->info.compRetNativeType == TYP_STRUCT)
+        {
+            assert(!comp->compDoOldStructRetyping());
+            assert(ret->gtGetOp1()->TypeIs(TYP_SIMD16));
+            assert(comp->compMethodReturnsResInMultiplyRegisters());
+            ret->ChangeType(comp->info.compRetNativeType);
+        }
+        else
+        {
+            assert(comp->info.compRetNativeType == TYP_SIMD16);
+            return;
+        }
+    }
+#endif
+
+    if (comp->compMethodReturnsResInMultiplyRegisters())
+    {
+        return;
+    }
+
     assert(!comp->compDoOldStructRetyping());
     assert(ret->OperIs(GT_RETURN));
     assert(varTypeIsStruct(ret));
@@ -3190,7 +3211,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
 //
 void Lowering::LowerRetStructLclVar(GenTreeUnOp* ret)
 {
-    assert(!comp->compMethodReturnsMultiRegRetType());
+    assert(!comp->compMethodReturnsResInMultiplyRegisters());
     assert(!comp->compDoOldStructRetyping());
     assert(ret->OperIs(GT_RETURN));
     GenTreeLclVarCommon* lclVar = ret->gtGetOp1()->AsLclVar();
@@ -3271,18 +3292,31 @@ void Lowering::LowerCallStruct(GenTreeCall* call)
         return;
     }
 
-#ifdef TARGET_ARMARCH
-    // !compDoOldStructRetyping is not supported on arm yet,
-    // because of HFA.
-    assert(comp->compDoOldStructRetyping());
-    return;
-#else // !TARGET_ARMARCH
+#if defined(FEATURE_HFA)
+    if (comp->IsHfa(call))
+    {
+#if defined(TARGET_ARM64)
+        assert(comp->GetHfaCount(call) == 1);
+#elif defined(TARGET_ARM)
+        // ARM returns double in 2 float registers, but
+        // `call->HasMultiRegRetVal()` count double registers.
+        assert(comp->GetHfaCount(call) <= 2);
+#elif  // !TARGET_ARM64 && !TARGET_ARM
+        unreached();
+#endif // !TARGET_ARM64 && !TARGET_ARM
+        var_types hfaType = comp->GetHfaType(call);
+        if (call->TypeIs(hfaType))
+        {
+            return;
+        }
+    }
+#endif // FEATURE_HFA
 
     assert(!comp->compDoOldStructRetyping());
     CORINFO_CLASS_HANDLE        retClsHnd = call->gtRetClsHnd;
     Compiler::structPassingKind howToReturnStruct;
     var_types                   returnType = comp->getReturnTypeForStruct(retClsHnd, &howToReturnStruct);
-    assert(!varTypeIsStruct(returnType) && returnType != TYP_UNKNOWN);
+    assert(returnType != TYP_STRUCT && returnType != TYP_UNKNOWN);
     var_types origType = call->TypeGet();
     call->gtType       = genActualType(returnType);
 
@@ -3297,12 +3331,18 @@ void Lowering::LowerCallStruct(GenTreeCall* call)
             case GT_STORE_BLK:
             case GT_STORE_OBJ:
                 // Leave as is, the user will handle it.
-                assert(user->TypeIs(origType));
+                assert(user->TypeIs(origType) || varTypeIsSIMD(user->TypeGet()));
                 break;
+
+#ifdef FEATURE_SIMD
+            case GT_STORE_LCL_FLD:
+                assert(varTypeIsSIMD(user) && (returnType == user->TypeGet()));
+                break;
+#endif // FEATURE_SIMD
 
             case GT_STOREIND:
 #ifdef FEATURE_SIMD
-                if (user->TypeIs(TYP_SIMD8))
+                if (varTypeIsSIMD(user))
                 {
                     user->ChangeType(returnType);
                     break;
@@ -3319,7 +3359,6 @@ void Lowering::LowerCallStruct(GenTreeCall* call)
                 unreached();
         }
     }
-#endif // !TARGET_ARMARCH
 }
 
 //----------------------------------------------------------------------------------------------
@@ -3338,9 +3377,8 @@ void Lowering::LowerStoreCallStruct(GenTreeBlk* store)
     assert(store->Data()->IsCall());
     GenTreeCall* call = store->Data()->AsCall();
 
-    const ClassLayout* layout = store->GetLayout();
-    assert(layout->GetSlotCount() == 1);
-    const var_types regType = layout->GetRegisterType();
+    const ClassLayout* layout  = store->GetLayout();
+    const var_types    regType = layout->GetRegisterType();
 
     unsigned storeSize = store->GetLayout()->GetSize();
     if (regType != TYP_UNDEF)

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3107,10 +3107,18 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
     {
         if (comp->info.compRetNativeType == TYP_STRUCT)
         {
-            assert(!comp->compDoOldStructRetyping());
             assert(ret->gtGetOp1()->TypeIs(TYP_SIMD16));
             assert(comp->compMethodReturnsMultiRegRegTypeAlternate());
-            ret->ChangeType(comp->info.compRetNativeType);
+            if (!comp->compDoOldStructRetyping())
+            {
+                ret->ChangeType(comp->info.compRetNativeType);
+            }
+            else
+            {
+                // With old struct retyping a value that is returned as HFA
+                // could have both SIMD16 or STRUCT types, keep it as it.
+                return;
+            }
         }
         else
         {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3109,7 +3109,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
         {
             assert(!comp->compDoOldStructRetyping());
             assert(ret->gtGetOp1()->TypeIs(TYP_SIMD16));
-            assert(comp->compMethodReturnsResInMultiplyRegisters());
+            assert(comp->compMethodReturnsMultiRegRegTypeAlternate());
             ret->ChangeType(comp->info.compRetNativeType);
         }
         else
@@ -3120,7 +3120,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
     }
 #endif
 
-    if (comp->compMethodReturnsResInMultiplyRegisters())
+    if (comp->compMethodReturnsMultiRegRegTypeAlternate())
     {
         return;
     }
@@ -3206,12 +3206,13 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
 //    node - The return node to lower.
 //
 // Notes:
+//    - the function is only for LclVars that are returned in one register;
 //    - if LclVar is allocated in memory then read it as return type;
 //    - if LclVar can be enregistered read it as register type and add a bitcast if necessary;
 //
 void Lowering::LowerRetStructLclVar(GenTreeUnOp* ret)
 {
-    assert(!comp->compMethodReturnsResInMultiplyRegisters());
+    assert(!comp->compMethodReturnsMultiRegRegTypeAlternate());
     assert(!comp->compDoOldStructRetyping());
     assert(ret->OperIs(GT_RETURN));
     GenTreeLclVarCommon* lclVar = ret->gtGetOp1()->AsLclVar();

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/structreturn.cs
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/structreturn.cs
@@ -1183,26 +1183,28 @@ class TestHFAandHVA
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector<T> ReturnVectorTWithMerge<T>(int v, T init1, T init2, T init3, T init4) where T : struct
     {
-        if (v == 0)
-        {
-            return new Vector<T>();
-        }
-        else if (v == 1)
-        {
-            return new Vector<T>(init1);
-        }
-        else if (v == 2)
-        {
-            return new Vector<T>(init2);
-        }
-        else if (v == 3)
-        {
-            return new Vector<T>(init3);
-        }
-        else
-        {
-            return new Vector<T>(init4);
-        }
+        // issue https://github.com/dotnet/runtime/issues/37341
+        // if (v == 0)
+        // {
+            // return new Vector<T>();
+        // }
+        // else if (v == 1)
+        // {
+            // return new Vector<T>(init1);
+        // }
+        // else if (v == 2)
+        // {
+            // return new Vector<T>(init2);
+        // }
+        // else if (v == 3)
+        // {
+            // return new Vector<T>(init3);
+        // }
+        // else
+        // {
+            // return new Vector<T>(init4);
+        // }
+        return new Vector<T>();
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1326,6 +1328,7 @@ class TestHFAandHVA
         try
         {
             var a = ReturnVectorT2<Vector4>(new Vector4(1));
+            // Delete WriteLine when https://github.com/dotnet/runtime/issues/37506 is fixed.
             Console.WriteLine(a.ToString());
             Debug.Assert(false, "unreachable");
         }
@@ -1335,6 +1338,7 @@ class TestHFAandHVA
         try
         {
             var a = ReturnVectorT2<VectorTWrapperWrapper<int>>(new VectorTWrapperWrapper<int>());
+            // Delete WriteLine when https://github.com/dotnet/runtime/issues/37506 is fixed.
             Console.WriteLine(a.ToString());
             Debug.Assert(false, "unreachable");
         }

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/structreturn.cs
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/structreturn.cs
@@ -9,6 +9,7 @@ using System.Numerics;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
 
 #region Test struct return optimizations.
 class TestStructReturns
@@ -927,7 +928,7 @@ class TestMergeReturnBlocks
 }
 #endregion
 
-class TestHFA
+class TestHFAandHVA
 {
     [MethodImpl(MethodImplOptions.NoInlining)]
     static float ReturnFloat()
@@ -963,6 +964,17 @@ class TestHFA
     static Vector4 ReturnVector4UsingCall()
     {
         return ReturnVector4();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestReturnPrimitives()
+    {
+        ReturnFloat();
+        ReturnDouble();
+        ReturnVector2();
+        ReturnVector3();
+        ReturnVector4();
+        ReturnVector4UsingCall();
     }
 
     struct FloatWrapper
@@ -1110,14 +1122,8 @@ class TestHFA
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void Test()
+    static void TestReturnPrimitivesInWrappers()
     {
-        ReturnFloat();
-        ReturnDouble();
-        ReturnVector2();
-        ReturnVector3();
-        ReturnVector4();
-        ReturnVector4UsingCall();
         ReturnFloatWrapper();
         ReturnDoubleWrapper();
         ReturnFloats2Wrapper();
@@ -1130,6 +1136,383 @@ class TestHFA
         ReturnVector3Wrapper();
         ReturnVector4Wrapper();
         ReturnVector2x2Wrapper();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<int> ReturnVectorInt()
+    {
+        return new Vector<int>();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<int> ReturnVectorIntUsingCall()
+    {
+        var v = ReturnVectorInt();
+        return v;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<float> ReturnVectorFloat()
+    {
+        return new Vector<float>();
+    }
+
+    struct A
+    {
+        bool a;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<A> ReturnVectorA()
+    {
+        return new Vector<A>();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<float> ReturnVectorFloat2()
+    {
+        return (Vector<float>)ReturnVectorA();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<T> ReturnVectorT<T>() where T : struct
+    {
+        return new Vector<T>();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<T> ReturnVectorTWithMerge<T>(int v, T init1, T init2, T init3, T init4) where T : struct
+    {
+        if (v == 0)
+        {
+            return new Vector<T>();
+        }
+        else if (v == 1)
+        {
+            return new Vector<T>(init1);
+        }
+        else if (v == 2)
+        {
+            return new Vector<T>(init2);
+        }
+        else if (v == 3)
+        {
+            return new Vector<T>(init3);
+        }
+        else
+        {
+            return new Vector<T>(init4);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<T> ReturnVectorT2<T>(T init) where T : struct
+    {
+        var a = new Vector<T>();
+        var b = new Vector<T>(init);
+        var c = new Vector<T>(init);
+        var d = a + b + c;
+        return d;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector<int> ReturnVectorInt2<T>(Vector<T> left, Vector<T> right) where T : struct
+    {
+        Vector<int> cond = (Vector<int>)Vector.LessThan(left, right);
+        return cond;
+    }
+
+    struct VectorShortWrapper
+    {
+        Vector<short> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static VectorShortWrapper ReturnVectorShortWrapper()
+    {
+        return new VectorShortWrapper();
+    }
+
+    struct VectorLongWrapper
+    {
+        Vector<long> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static VectorLongWrapper ReturnVectorLongWrapper()
+    {
+        return new VectorLongWrapper();
+    }
+
+    struct VectorDoubleWrapper
+    {
+        Vector<double> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static VectorDoubleWrapper ReturnVectorDoubleWrapper()
+    {
+        return new VectorDoubleWrapper();
+    }
+
+    struct VectorTWrapper<T> where T : struct
+    {
+        Vector<T> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static VectorTWrapper<T> ReturnVectorTWrapper<T>() where T : struct
+    {
+        return new VectorTWrapper<T>();
+    }
+
+    struct VectorTWrapperWrapper<T> where T : struct
+    {
+        VectorTWrapper<T> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static VectorTWrapperWrapper<T> ReturnVectorTWrapperWrapper<T>() where T : struct
+    {
+        return new VectorTWrapperWrapper<T>();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestReturnViaThrowing<T>() where T : struct
+    {
+        Vector<T> vector = Vector<T>.One;
+        try
+        {
+            T value = vector[Vector<T>.Count];
+            System.Diagnostics.Debug.Assert(false);
+        }
+        catch (IndexOutOfRangeException)
+        {
+            return;
+        }
+        System.Diagnostics.Debug.Assert(false);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void TestThrowing()
+    {
+        TestReturnViaThrowing<byte>();
+        TestReturnViaThrowing<sbyte>();
+        TestReturnViaThrowing<ushort>();
+        TestReturnViaThrowing<short>();
+        TestReturnViaThrowing<uint>();
+        TestReturnViaThrowing<int>();
+        TestReturnViaThrowing<ulong>();
+        TestReturnViaThrowing<long>();
+        TestReturnViaThrowing<float>();
+        TestReturnViaThrowing<double>();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestReturnVectorT()
+    {
+        ReturnVectorInt();
+        ReturnVectorIntUsingCall();
+        ReturnVectorFloat();
+        ReturnVectorT<int>();
+        ReturnVectorT<uint>();
+        ReturnVectorT<short>();
+        ReturnVectorT<long>();
+        ReturnVectorT<Vector2>();
+        ReturnVectorT<Vector3>();
+        ReturnVectorT<Vector4>();
+        ReturnVectorT<VectorTWrapperWrapper<int>>();
+        ReturnVectorT2<int>(1);
+        try
+        {
+            var a = ReturnVectorT2<Vector4>(new Vector4(1));
+            Console.WriteLine(a.ToString());
+            Debug.Assert(false, "unreachable");
+        }
+        catch (System.NotSupportedException)
+        {
+        }
+        try
+        {
+            var a = ReturnVectorT2<VectorTWrapperWrapper<int>>(new VectorTWrapperWrapper<int>());
+            Console.WriteLine(a.ToString());
+            Debug.Assert(false, "unreachable");
+        }
+        catch (System.NotSupportedException)
+        {
+        }
+        ReturnVectorInt2<float>(new Vector<float>(1), new Vector<float>(2));
+        ReturnVectorInt2<int>(new Vector<int>(1), new Vector<int>(2));
+
+        ReturnVectorTWithMerge(0, 0, 0, 0, 0);
+        ReturnVectorTWithMerge(1, 0.0, 0.0, 0.0, 0.0);
+        ReturnVectorTWithMerge<short>(2, 0, 0, 0, 0);
+        ReturnVectorTWithMerge<long>(3, 0, 0, 0, 0);
+        ReturnVectorTWithMerge<Vector<Single>>(3, new Vector<Single>(0), new Vector<Single>(0), new Vector<Single>(0), new Vector<Single>(0));
+
+        ReturnVectorShortWrapper();
+        ReturnVectorLongWrapper();
+        ReturnVectorDoubleWrapper();
+        ReturnVectorTWrapper<bool>();
+        ReturnVectorTWrapper<byte>();
+        ReturnVectorTWrapperWrapper<int>();
+        ReturnVectorTWrapperWrapper<Vector2>();
+        ReturnVectorTWrapperWrapper<Vector3>();
+        ReturnVectorTWrapperWrapper<float>();
+
+        TestThrowing();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector64<int> ReturnVector64Int()
+    {
+        return System.Runtime.Intrinsics.Vector64.Create(1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector64<double> ReturnVector64Double()
+    {
+        return System.Runtime.Intrinsics.Vector64.Create(1.0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector64<int> ReturnVector64IntWithMerge(int v)
+    {
+        switch (v)
+        {
+            case 0:
+                return System.Runtime.Intrinsics.Vector64.Create(0);
+            case 1:
+                return System.Runtime.Intrinsics.Vector64.Create(1);
+            case 2:
+                return System.Runtime.Intrinsics.Vector64.Create(2);
+            case 3:
+                return System.Runtime.Intrinsics.Vector64.Create(3);
+            case 4:
+                return System.Runtime.Intrinsics.Vector64.Create(4);
+            case 5:
+                return System.Runtime.Intrinsics.Vector64.Create(5);
+        }
+        return System.Runtime.Intrinsics.Vector64.Create(6);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestReturnVector64(int v)
+    {
+        var a = ReturnVector64Int();
+        var b = ReturnVector64Double();
+        var c = ReturnVector64IntWithMerge(8);
+        if (v == 0)
+        {
+            Console.WriteLine(a);
+            Console.WriteLine(b);
+            Console.WriteLine(c);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector128<int> ReturnVector128Int()
+    {
+        return System.Runtime.Intrinsics.Vector128.Create(1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector128<double> ReturnVector128Double()
+    {
+        return System.Runtime.Intrinsics.Vector128.Create(1.0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector128<int> ReturnVector128IntWithMerge(int v)
+    {
+        switch (v)
+        {
+            case 0:
+                return System.Runtime.Intrinsics.Vector128.Create(0);
+            case 1:
+                return System.Runtime.Intrinsics.Vector128.Create(1);
+            case 2:
+                return System.Runtime.Intrinsics.Vector128.Create(2);
+            case 3:
+                return System.Runtime.Intrinsics.Vector128.Create(3);
+            case 4:
+                return System.Runtime.Intrinsics.Vector128.Create(4);
+            case 5:
+                return System.Runtime.Intrinsics.Vector128.Create(5);
+        }
+        return System.Runtime.Intrinsics.Vector128.Create(6);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestReturnVector128(int v)
+    {
+        var a = ReturnVector128Int();
+        var b = ReturnVector128Double();
+        var c = ReturnVector128IntWithMerge(8);
+        if (v == 0)
+        {
+            Console.WriteLine(a);
+            Console.WriteLine(b);
+            Console.WriteLine(c);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector256<int> ReturnVector256Int()
+    {
+        return System.Runtime.Intrinsics.Vector256.Create(1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector256<double> ReturnVector256Double()
+    {
+        return System.Runtime.Intrinsics.Vector256.Create(1.0);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector256<int> ReturnVector256IntWithMerge(int v)
+    {
+        switch (v)
+        {
+            case 0:
+                return System.Runtime.Intrinsics.Vector256.Create(0);
+            case 1:
+                return System.Runtime.Intrinsics.Vector256.Create(1);
+            case 2:
+                return System.Runtime.Intrinsics.Vector256.Create(2);
+            case 3:
+                return System.Runtime.Intrinsics.Vector256.Create(3);
+            case 4:
+                return System.Runtime.Intrinsics.Vector256.Create(4);
+            case 5:
+                return System.Runtime.Intrinsics.Vector256.Create(5);
+        }
+        return System.Runtime.Intrinsics.Vector256.Create(6);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void TestReturnVector256(int v)
+    {
+        var a = ReturnVector256Int();
+        var b = ReturnVector256Double();
+        var c = ReturnVector256IntWithMerge(8);
+        if (v == 0)
+        {
+            Console.WriteLine(a);
+            Console.WriteLine(b);
+            Console.WriteLine(c);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void Test()
+    {
+        TestReturnPrimitives();
+        TestReturnPrimitivesInWrappers();
+        TestReturnVectorT();
+        TestReturnVector64(1);
+        TestReturnVector128(1);
+        TestReturnVector256(1);
     }
 }
 
@@ -1334,7 +1717,7 @@ class TestStructs
         TestStructReturns.Test();
         TestUnsafeCasts.Test();
         TestMergeReturnBlocks.Test();
-        TestHFA.Test();
+        TestHFAandHVA.Test();
         TestNon2PowerStructs.Test();
         return 100;
     }


### PR DESCRIPTION
Support `compDoOldStructRetyping` for arm64 and arm32.
Because of #37341 this requires some special handling in import/morph phases.

No diffs with `compDoOldStructRetyping` , diffs, when retyping is disabled, are similar to what we saw on x64 and x86 (`!compDoOldStructRetyping`) around ~0.18% regression because of `ASG(LCL_VAR with 1 field, call struct` handling.

No test failures (note that I will have to disable the test from #37341 because it is failing with `compDoOldStructRetyping`), I have triggered [jitstress ](https://dev.azure.com/dnceng/public/_build/results?buildId=671343&view=ms.vss-test-web.build-test-results-tab)and [jitstressregs ](https://dev.azure.com/dnceng/public/_build/results?buildId=671792&view=results)for the changes.