### PR TITLE
S.S.Cryptography: Use BinaryPrimitives where possible.

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
@@ -39,21 +39,6 @@ namespace Internal.Cryptography
             return buffer;
         }
 
-        // encodes the integer i into a 4-byte array, in big endian.
-        public static void WriteInt(uint i, byte[] arr, int offset)
-        {
-            unchecked
-            {
-                Debug.Assert(arr != null);
-                Debug.Assert(arr.Length >= offset + sizeof(uint));
-
-                arr[offset] = (byte)(i >> 24);
-                arr[offset + 1] = (byte)(i >> 16);
-                arr[offset + 2] = (byte)(i >> 8);
-                arr[offset + 3] = (byte)i;
-            }
-        }
-
         public static byte[] FixupKeyParity(this byte[] key)
         {
             byte[] oddParityKey = new byte[key.Length];

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/DES.cs
@@ -4,6 +4,7 @@
 
 using Internal.Cryptography;
 using System.ComponentModel;
+using System.Buffers.Binary;
 
 namespace System.Security.Cryptography
 {
@@ -65,7 +66,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_InvalidKeySize);
 
             byte[] rgbOddParityKey = rgbKey.FixupKeyParity();
-            ulong key = QuadWordFromBigEndian(rgbOddParityKey);
+            ulong key = BinaryPrimitives.ReadUInt64BigEndian(rgbOddParityKey);
             if ((key == 0x0101010101010101) ||
                 (key == 0xfefefefefefefefe) ||
                 (key == 0x1f1f1f1f0e0e0e0e) ||
@@ -83,7 +84,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_InvalidKeySize);
 
             byte[] rgbOddParityKey = rgbKey.FixupKeyParity();
-            ulong key = QuadWordFromBigEndian(rgbOddParityKey);
+            ulong key = BinaryPrimitives.ReadUInt64BigEndian(rgbOddParityKey);
             if ((key == 0x01fe01fe01fe01fe) ||
                 (key == 0xfe01fe01fe01fe01) ||
                 (key == 0x1fe01fe00ef10ef1) ||
@@ -109,17 +110,6 @@ namespace System.Security.Cryptography
                 return true;
 
             return false;
-        }
-
-        private static ulong QuadWordFromBigEndian(byte[] block)
-        {
-            ulong x = (
-                (((ulong)block[0]) << 56) | (((ulong)block[1]) << 48) |
-                (((ulong)block[2]) << 40) | (((ulong)block[3]) << 32) |
-                (((ulong)block[4]) << 24) | (((ulong)block[5]) << 16) |
-                (((ulong)block[6]) << 8) | ((ulong)block[7])
-                );
-            return x;
         }
 
         private static readonly KeySizes[] s_legalBlockSizes =

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Text;
 using System.Diagnostics;
 
@@ -258,7 +259,7 @@ namespace System.Security.Cryptography
         // where i is the block number.
         private void Func()
         {
-            Helpers.WriteInt(_block, _salt, _salt.Length - sizeof(uint));
+            BinaryPrimitives.WriteUInt32BigEndian(_salt.AsSpan(_salt.Length - sizeof(uint)), _block);
             Debug.Assert(_blockSize == _buffer.Length);
 
             // The biggest _blockSize we have is from SHA512, which is 64 bytes.

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
@@ -750,7 +751,7 @@ namespace Internal.NativeCrypto
             // check that this is indeed an RSA/DSS key.
             byte[] algid = CapiHelper.GetKeyParameter(hKey, Constants.CLR_ALGID);
 
-            int dwAlgId = (algid[0] | (algid[1] << 8) | (algid[2] << 16) | (algid[3] << 24));
+            int dwAlgId = BinaryPrimitives.ReadInt32LittleEndian(algid);
 
             if ((keyType == CspAlgorithmType.Rsa && dwAlgId != CALG_RSA_KEYX && dwAlgId != CALG_RSA_SIGN) ||
                 (keyType == CspAlgorithmType.Dss && dwAlgId != CALG_DSS_SIGN))

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/DSACryptoServiceProvider.Windows.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Buffers.Binary;
 using System.Diagnostics;
 using System.IO;
 using Internal.NativeCrypto;
@@ -200,7 +201,7 @@ namespace System.Security.Cryptography
             get
             {
                 byte[] keySize = CapiHelper.GetKeyParameter(SafeKeyHandle, Constants.CLR_KEYLEN);
-                _keySize = (keySize[0] | (keySize[1] << 8) | (keySize[2] << 16) | (keySize[3] << 24));
+                _keySize = BinaryPrimitives.ReadInt32LittleEndian(keySize);
                 return _keySize;
             }
         }


### PR DESCRIPTION
Cleans up some places that could use BinaryPrimitives for byte/numeric packing and unpacking.