### PR TITLE
[mono] Reduce app size for iOS

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20265.8",
+      "version": "1.0.0-prerelease.20271.3",
       "commands": [
         "xharness"
       ]

--- a/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AppleAppBuilder/AppleAppBuilder.cs
@@ -163,7 +163,7 @@ public class AppleAppBuilderTask : Task
         if (GenerateXcodeProject)
         {
             XcodeProjectPath = Xcode.GenerateXCode(ProjectName, MainLibraryFileName, assemblerFiles,
-                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, UseAotForSimulator, NativeMainSource);
+                AppDir, binDir, MonoRuntimeHeaders, !isDevice, UseConsoleUITemplate, UseAotForSimulator, Optimized, NativeMainSource);
 
             if (BuildAppBundle)
             {


### PR DESCRIPTION
We did the same mistake for Android - `libmonosgen-2.0.dylib` shouldn't be copied to bundle (we already have a mono runtime there)