### PR TITLE
Add linux arm/arm64 libraries checked coreclr test runs

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -919,6 +919,7 @@ jobs:
     buildConfig: Release
     platforms:
     # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
+    - Linux_arm
     - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
@@ -940,6 +941,7 @@ jobs:
     - Windows_NT_x64
     - Linux_x64
     - Linux_musl_x64
+    - Linux_arm64
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -138,6 +138,7 @@ jobs:
     - Linux_x64
     - Linux_arm
     - Linux_arm64
+    - Linux_musl_arm64
     - Linux_musl_x64
     - Windows_NT_x86
     - Windows_NT_x64
@@ -920,6 +921,7 @@ jobs:
     platforms:
     # - Windows_NT_arm return this when https://github.com/dotnet/runtime/issues/1097 is fixed.
     - Linux_arm
+    - Linux_musl_arm64
     - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -46,6 +46,7 @@ using Xunit;
 namespace MonoTests.System.Drawing
 {
 
+    [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/37082", TestPlatforms.AnyUnix, RuntimeConfiguration.Checked)]
     public class TestBitmap
     {
 


### PR DESCRIPTION
We should be running libraries tests on checked coreclr in arm/arm64 -- if we want to add these for mono as well, I'll let @naricc and @SamMonoRT to confirm... I can put up a follow up PR if needed.

This depends on: https://github.com/dotnet/runtime/pull/36909

For more details: https://github.com/dotnet/runtime/pull/36909#issuecomment-632940983

cc: @dotnet/runtime-infrastructure @sdmaclea 