### PR TITLE
Reduce Uri ctor overhead

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -82,7 +82,7 @@ namespace System
                 {
                     if (next + 2 < end)
                     {
-                        ch = UriHelper.EscapedAscii(pInput[next + 1], pInput[next + 2]);
+                        ch = UriHelper.DecodeHexChars(pInput[next + 1], pInput[next + 2]);
 
                         // Do not unescape a reserved char
                         if (ch == Uri.c_DummyChar || ch == '%' || CheckIsReserved(ch, component) || UriHelper.IsNotSafeForUnescape(ch))
@@ -124,7 +124,7 @@ namespace System
                                     break;
 
                                 // already made sure we have 3 characters in str
-                                ch = UriHelper.EscapedAscii(pInput[next + 1], pInput[next + 2]);
+                                ch = UriHelper.DecodeHexChars(pInput[next + 1], pInput[next + 2]);
 
                                 //invalid hex sequence ?
                                 if (ch == Uri.c_DummyChar)

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1421,7 +1421,7 @@ namespace System
             if ((pattern[index] == '%')
                 && (pattern.Length - index >= 3))
             {
-                char ret = UriHelper.EscapedAscii(pattern[index + 1], pattern[index + 2]);
+                char ret = UriHelper.DecodeHexChars(pattern[index + 1], pattern[index + 2]);
                 if (ret != c_DummyChar)
                 {
                     index += 3;
@@ -4393,7 +4393,7 @@ namespace System
                 {
                     if (!foundEscaping) foundEscaping = true;
                     //try unescape a byte hex escaping
-                    if (i + 2 < end && (c = UriHelper.EscapedAscii(str[i + 1], str[i + 2])) != c_DummyChar)
+                    if (i + 2 < end && (c = UriHelper.DecodeHexChars(str[i + 1], str[i + 2])) != c_DummyChar)
                     {
                         if (c == '.' || c == '/' || c == '\\')
                         {
@@ -4624,7 +4624,7 @@ namespace System
             if (pch >= pend) goto done;
             if (*pch++ != '%') goto over;
 
-            char ch = UriHelper.EscapedAscii(*pch++, *pch++);
+            char ch = UriHelper.DecodeHexChars(*pch++, *pch++);
             if (!(ch == ch1 || ch == ch2 || ch == ch3)) goto over;
 
             // Here we found something and now start copying the scanned chars
@@ -4636,7 +4636,7 @@ namespace System
             if (pch >= pend) goto done;
             if ((*pnew++ = *pch++) != '%') goto over_new;
 
-            ch = UriHelper.EscapedAscii((*pnew++ = *pch++), (*pnew++ = *pch++));
+            ch = UriHelper.DecodeHexChars((*pnew++ = *pch++), (*pnew++ = *pch++));
             if (!(ch == ch1 || ch == ch2 || ch == ch3))
             {
                 goto over_new;

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -223,7 +223,7 @@ namespace System
                 {
                     if ((uint)(i + 2) < (uint)data.Length)
                     {
-                        char value = UriHelper.EscapedAscii(data[i + 1], data[i + 2]);
+                        char value = UriHelper.DecodeHexChars(data[i + 1], data[i + 2]);
 
                         if (value >= UriHelper.UnreservedTable.Length || UriHelper.UnreservedTable[value])
                         {

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -84,8 +84,7 @@ namespace System
 
             bool hasUnicode = false;
 
-            if (IriParsing &&
-                (CheckForUnicode(_string) || CheckForEscapedUnreserved(_string)))
+            if (IriParsing && CheckForUnicodeOrEscapedUnreserved(_string))
             {
                 _flags |= Flags.HasUnicode;
                 hasUnicode = true;
@@ -213,49 +212,30 @@ namespace System
             }
         }
 
-        //
         // Unescapes entire string and checks if it has unicode chars
-        //
-        private bool CheckForUnicode(string data)
+        // Also checks for sequences that are 3986 Unreserved characters as these should be un-escaped
+        private static bool CheckForUnicodeOrEscapedUnreserved(string data)
         {
             for (int i = 0; i < data.Length; i++)
             {
                 char c = data[i];
                 if (c == '%')
                 {
-                    if (i + 2 < data.Length)
+                    if ((uint)(i + 2) < (uint)data.Length)
                     {
-                        if (UriHelper.EscapedAscii(data[i + 1], data[i + 2]) > 0x7F)
+                        char value = UriHelper.EscapedAscii(data[i + 1], data[i + 2]);
+
+                        if (value >= UriHelper.UnreservedTable.Length || UriHelper.UnreservedTable[value])
                         {
                             return true;
                         }
+
                         i += 2;
                     }
                 }
                 else if (c > 0x7F)
                 {
                     return true;
-                }
-            }
-            return false;
-        }
-
-        // Does this string have any %6A sequences that are 3986 Unreserved characters?  These should be un-escaped.
-        private unsafe bool CheckForEscapedUnreserved(string data)
-        {
-            fixed (char* tempPtr = data)
-            {
-                for (int i = 0; i < data.Length - 2; ++i)
-                {
-                    if (tempPtr[i] == '%' && IsHexDigit(tempPtr[i + 1]) && IsHexDigit(tempPtr[i + 2])
-                        && tempPtr[i + 1] >= '0' && tempPtr[i + 1] <= '7') // max 0x7F
-                    {
-                        char ch = UriHelper.EscapedAscii(tempPtr[i + 1], tempPtr[i + 2]);
-                        if (ch != c_DummyChar && UriHelper.IsUnreserved(ch))
-                        {
-                            return true;
-                        }
-                    }
                 }
             }
             return false;

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -376,7 +376,7 @@ namespace System
                             }
                             else if (next + 2 < end)
                             {
-                                ch = EscapedAscii(pStr[next + 1], pStr[next + 2]);
+                                ch = DecodeHexChars(pStr[next + 1], pStr[next + 2]);
                                 // Unescape a good sequence if full unescape is requested
                                 if (unescapeMode >= UnescapeMode.UnescapeAll)
                                 {
@@ -510,7 +510,7 @@ namespace System
                                 break;
 
                             // already made sure we have 3 characters in str
-                            ch = EscapedAscii(pStr[next + 1], pStr[next + 2]);
+                            ch = DecodeHexChars(pStr[next + 1], pStr[next + 2]);
 
                             //invalid hex sequence ?
                             if (ch == Uri.c_DummyChar)
@@ -668,33 +668,37 @@ namespace System
             HexConverter.ToCharsBuffer(b, to.AppendSpan(2), 0, HexConverter.Casing.Upper);
         }
 
-        internal static char EscapedAscii(uint digit, uint next)
+        /// <summary>
+        /// Converts 2 hex chars to a byte (returned in a char), e.g, "0a" becomes (char)0x0A.
+        /// <para>If either char is not hex, returns <see cref="Uri.c_DummyChar"/>.</para>
+        /// </summary>
+        internal static char DecodeHexChars(uint first, uint second)
         {
-            digit -= '0';
+            first -= '0';
 
-            if (digit <= 9)
+            if (first <= 9)
             {
-                // digit is already [0, 9]
+                // first is already [0, 9]
             }
-            else if ((uint)((digit - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
+            else if ((uint)((first - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
             {
-                digit = ((digit + '0') | 0x20) - 'a' + 10;
-            }
-            else goto Invalid;
-
-            next -= '0';
-
-            if (next <= 9)
-            {
-                // next is already [0, 9]
-            }
-            else if ((uint)((next - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
-            {
-                next = ((next + '0') | 0x20) - 'a' + 10;
+                first = ((first + '0') | 0x20) - 'a' + 10;
             }
             else goto Invalid;
 
-            return (char)((digit << 4) | next);
+            second -= '0';
+
+            if (second <= 9)
+            {
+                // second is already [0, 9]
+            }
+            else if ((uint)((second - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
+            {
+                second = ((second + '0') | 0x20) - 'a' + 10;
+            }
+            else goto Invalid;
+
+            return (char)((first << 4) | second);
 
         Invalid:
             return Uri.c_DummyChar;

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -668,35 +668,36 @@ namespace System
             HexConverter.ToCharsBuffer(b, to.AppendSpan(2), 0, HexConverter.Casing.Upper);
         }
 
-        internal static char EscapedAscii(char digit, char next)
+        internal static char EscapedAscii(uint digit, uint next)
         {
-            if (!(((digit >= '0') && (digit <= '9'))
-                || ((digit >= 'A') && (digit <= 'F'))
-                || ((digit >= 'a') && (digit <= 'f'))))
+            digit -= '0';
+
+            if (digit <= 9)
             {
-                return Uri.c_DummyChar;
+                // digit is already [0, 9]
             }
-
-            int res = (digit <= '9')
-                ? ((int)digit - (int)'0')
-                : (((digit <= 'F')
-                ? ((int)digit - (int)'A')
-                : ((int)digit - (int)'a'))
-                   + 10);
-
-            if (!(((next >= '0') && (next <= '9'))
-                || ((next >= 'A') && (next <= 'F'))
-                || ((next >= 'a') && (next <= 'f'))))
+            else if ((uint)((digit - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
             {
-                return Uri.c_DummyChar;
+                digit = ((digit + '0') | 0x20) - 'a' + 10;
             }
+            else goto Invalid;
 
-            return (char)((res << 4) + ((next <= '9')
-                    ? ((int)next - (int)'0')
-                    : (((next <= 'F')
-                        ? ((int)next - (int)'A')
-                        : ((int)next - (int)'a'))
-                       + 10)));
+            next -= '0';
+
+            if (next <= 9)
+            {
+                // next is already [0, 9]
+            }
+            else if ((uint)((next - ('A' - '0')) & ~0x20) <= ('F' - 'A'))
+            {
+                next = ((next + '0') | 0x20) - 'a' + 10;
+            }
+            else goto Invalid;
+
+            return (char)((digit << 4) | next);
+
+        Invalid:
+            return Uri.c_DummyChar;
         }
 
         internal const string RFC3986ReservedMarks = @";/?:@&=+$,#[]!'()*";

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -722,7 +722,9 @@ namespace System
                 return true;
             }
 
-            return RFC3986ReservedMarks.IndexOf(ch) >= 0 || AdditionalUnsafeToUnescape.IndexOf(ch) >= 0;
+            const string NotSafeForUnescape = RFC3986ReservedMarks + AdditionalUnsafeToUnescape;
+
+            return NotSafeForUnescape.Contains(ch);
         }
 
         // "Reserved" and "Unreserved" characters are based on RFC 3986.


### PR DESCRIPTION
Reduces the initial overhead for every Uri ctor.

```c#
public class UriInitOverhead
{
    [Benchmark]
    public Uri Ascii() => new Uri("http://foo/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

    [Benchmark]
    public Uri PercentEncoded() => new Uri("http://foo/%01%02%03%04%0F%2F%3F%7F%01%02%03%04%0F%2F%3F%7F");
}
```

|         Method |              Toolchain |     Mean |   Error |  StdDev | Ratio |
|--------------- |----------------------- |---------:|--------:|--------:|------:|
|          Ascii | \perf-base\CoreRun.exe | 226.3 ns | 0.42 ns | 0.33 ns |  1.42 |
|          Ascii |  \perf-new\CoreRun.exe | 159.6 ns | 1.63 ns | 1.53 ns |  1.00 |
|                |                        |          |         |         |       |
| PercentEncoded | \perf-base\CoreRun.exe | 499.3 ns | 1.13 ns | 1.00 ns |  2.62 |
| PercentEncoded |  \perf-new\CoreRun.exe | 190.3 ns | 0.52 ns | 0.44 ns |  1.00 |

Will also improve perf for any processing that calls into `UriHelper.EscapedAscii` - anywhere we unescape percent-encoded values.