### PR TITLE
Add test case for growing beyond buffer size in Utf8JsonWriter (#28409)

### DIFF
--- a/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Utf8JsonWriterTests.cs
@@ -1386,15 +1386,15 @@ namespace System.Text.Json.Tests
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public async Task GrowBeyondBufferSize(bool formatted, bool skipValidation)
+        public void GrowBeyondBufferSize(bool formatted, bool skipValidation)
         {
             const int InitialGrowthSize = 256;
-            var writer = new FixedSizedBufferWriter(InitialGrowthSize);
+            var output = new FixedSizedBufferWriter(InitialGrowthSize);
             var options = new JsonWriterOptions { Indented = formatted, SkipValidation = skipValidation };
 
             byte[] utf8String = Encoding.UTF8.GetBytes("this is a string long enough to overflow the buffer and cause an exception to be thrown.");
 
-            await using var jsonUtf8 = new Utf8JsonWriter(writer, options);
+            using var jsonUtf8 = new Utf8JsonWriter(output, options);
 
             jsonUtf8.WriteStartArray();
 


### PR DESCRIPTION
Specifically covers the case from #28409 description

> Add more tests that use FixedSizedBufferWriter to test re-try and grow logic (writing should fail if buffer too small).

This didn't have much impact on `System.Text.Json`s code coverage totals (#32341), but this particular file got an extra branch covered (Covered branches: 1130 -> 1131)

![image](https://user-images.githubusercontent.com/681706/82722468-6f413680-9d0a-11ea-9ce8-d766ab9533d8.png)