### PR TITLE
Optimization to remove redundant zero initializations.

### DIFF
--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -4655,6 +4655,12 @@ void CodeGen::genCheckUseBlockInit()
             continue;
         }
 
+        if (varDsc->lvHasExplicitInit)
+        {
+            varDsc->lvMustInit = 0;
+            continue;
+        }
+
         if (compiler->info.compInitMem || varDsc->HasGCPtr() || varDsc->lvMustInit)
         {
             if (varDsc->lvTracked)

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -4596,8 +4596,9 @@ void CodeGen::genCheckUseBlockInit()
         // double-counting the initialization impact of any locals.
         bool counted = false;
 
-        if (varDsc->lvIsParam)
+        if (!varDsc->lvIsInReg() && !varDsc->lvOnFrame)
         {
+            noway_assert(varDsc->lvRefCnt() == 0);
             continue;
         }
 
@@ -4608,44 +4609,10 @@ void CodeGen::genCheckUseBlockInit()
             continue;
         }
 
-        // Likewise, initialization of the GS cookie is handled specially for OSR.
-        // Could do this for non-OSR too.. (likewise for the dummy)
-        if (compiler->opts.IsOSR() && varNum == compiler->lvaGSSecurityCookie)
+        if (compiler->fgVarIsNeverZeroInitializedInProlog(varNum))
         {
             continue;
         }
-
-        if (!varDsc->lvIsInReg() && !varDsc->lvOnFrame)
-        {
-            noway_assert(varDsc->lvRefCnt() == 0);
-            continue;
-        }
-
-        if (varNum == compiler->lvaInlinedPInvokeFrameVar || varNum == compiler->lvaStubArgumentVar ||
-            varNum == compiler->lvaRetAddrVar)
-        {
-            continue;
-        }
-
-#if FEATURE_FIXED_OUT_ARGS
-        if (varNum == compiler->lvaPInvokeFrameRegSaveVar)
-        {
-            continue;
-        }
-        if (varNum == compiler->lvaOutgoingArgSpaceVar)
-        {
-            continue;
-        }
-#endif
-
-#if defined(FEATURE_EH_FUNCLETS)
-        // There's no need to force 0-initialization of the PSPSym, it will be
-        // initialized with a real value in the prolog
-        if (varNum == compiler->lvaPSPSym)
-        {
-            continue;
-        }
-#endif
 
         if (compiler->lvaIsFieldOfDependentlyPromotedStruct(varDsc))
         {

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4690,6 +4690,8 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
                 DoPhase(this, PHASE_BUILD_SSA, &Compiler::fgSsaBuild);
             }
 
+            DoPhase(this, PHASE_ZERO_INITS, &Compiler::optRemoveRedundantZeroInits);
+
             if (doEarlyProp)
             {
                 // Propagate array length and rewrite getType() method call

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -518,6 +518,10 @@ public:
 
     unsigned char lvSuppressedZeroInit : 1; // local needs zero init if we transform tail call to loop
 
+    unsigned char lvHasExplicitInit : 1; // The local is explicitly initialized and doesn't need zero initialization in
+                                         // the prolog. If the local has gc pointers, there are no gc-safe points
+                                         // between the prolog and the explicit initialization.
+
     union {
         unsigned lvFieldLclStart; // The index of the local var representing the first field in the promoted struct
                                   // local.  For implicit byref parameters, this gets hijacked between
@@ -5905,6 +5909,8 @@ public:
     void optEnsureUniqueHead(unsigned loopInd, unsigned ambientWeight);
 
     void optUnrollLoops(); // Unrolls loops (needs to have cost info)
+
+    void optRemoveRedundantZeroInits();
 
 protected:
     // This enumeration describes what is killed by a call.

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4657,8 +4657,11 @@ public:
 
     unsigned fgSsaPassesCompleted; // Number of times fgSsaBuild has been run.
 
+    // Returns "true" if this is a special variable that is never zero initialized in the prolog.
+    inline bool fgVarIsNeverZeroInitializedInProlog(unsigned varNum);
+
     // Returns "true" if the variable needs explicit zero initialization.
-    inline bool fgVarNeedsExplicitZeroInit(LclVarDsc* varDsc, bool bbInALoop, bool bbIsReturn);
+    inline bool fgVarNeedsExplicitZeroInit(unsigned varNum, bool bbInALoop, bool bbIsReturn);
 
     // The value numbers for this compilation.
     ValueNumStore* vnStore;

--- a/src/coreclr/src/jit/compmemkind.h
+++ b/src/coreclr/src/jit/compmemkind.h
@@ -58,6 +58,7 @@ CompMemKindMacro(VariableLiveRanges)
 CompMemKindMacro(ClassLayout)
 CompMemKindMacro(TailMergeThrows)
 CompMemKindMacro(EarlyProp)
+CompMemKindMacro(ZeroInit)
 //clang-format on
 
 #undef CompMemKindMacro

--- a/src/coreclr/src/jit/compphases.h
+++ b/src/coreclr/src/jit/compphases.h
@@ -55,6 +55,7 @@ CompPhaseNameMacro(PHASE_CREATE_FUNCLETS,        "Create EH funclets",          
 CompPhaseNameMacro(PHASE_MERGE_THROWS,           "Merge throw blocks",             "MRGTHROW", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_LAYOUT,        "Optimize layout",                "LAYOUT",   false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_REACHABILITY,   "Compute blocks reachability",    "BL_REACH", false, -1, false)
+CompPhaseNameMacro(PHASE_ZERO_INITS,             "Redundant zero Inits",           "ZERO-INIT", false, -1, false)
 CompPhaseNameMacro(PHASE_OPTIMIZE_LOOPS,         "Optimize loops",                 "LOOP-OPT", false, -1, false)
 CompPhaseNameMacro(PHASE_CLONE_LOOPS,            "Clone loops",                    "LP-CLONE", false, -1, false)
 CompPhaseNameMacro(PHASE_UNROLL_LOOPS,           "Unroll loops",                   "UNROLL",   false, -1, false)

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -23787,7 +23787,7 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
             if (tmpNum != BAD_VAR_NUM)
             {
                 LclVarDsc* const tmpDsc = lvaGetDesc(tmpNum);
-                if (!fgVarNeedsExplicitZeroInit(tmpDsc, bbInALoop, bbIsReturn))
+                if (!fgVarNeedsExplicitZeroInit(tmpNum, bbInALoop, bbIsReturn))
                 {
                     JITDUMP("\nSuppressing zero-init for V%02u -- expect to zero in prolog\n", tmpNum);
                     tmpDsc->lvSuppressedZeroInit = 1;

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -13883,7 +13883,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         bool bbIsReturn = (block->bbJumpKind == BBJ_RETURN) &&
                                           (!compIsForInlining() || (impInlineInfo->iciBlock->bbJumpKind == BBJ_RETURN));
                         LclVarDsc* const lclDsc = lvaGetDesc(lclNum);
-                        if (fgVarNeedsExplicitZeroInit(lclDsc, bbInALoop, bbIsReturn))
+                        if (fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn))
                         {
                             // Append a tree to zero-out the temp
                             newObjThisPtr = gtNewLclvNode(lclNum, lvaTable[lclNum].TypeGet());

--- a/src/coreclr/src/jit/objectalloc.cpp
+++ b/src/coreclr/src/jit/objectalloc.cpp
@@ -521,7 +521,7 @@ unsigned int ObjectAllocator::MorphAllocObjNodeIntoStackAlloc(GenTreeAllocObj* a
     bool             bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
     bool             bbIsReturn = block->bbJumpKind == BBJ_RETURN;
     LclVarDsc* const lclDsc     = comp->lvaGetDesc(lclNum);
-    if (comp->fgVarNeedsExplicitZeroInit(lclDsc, bbInALoop, bbIsReturn))
+    if (comp->fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn))
     {
         //------------------------------------------------------------------------
         // STMTx (IL 0x... ???)

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9189,3 +9189,132 @@ void Compiler::optOptimizeBools()
     fgDebugCheckBBlist();
 #endif
 }
+
+typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, unsigned> LclVarRefCounts;
+
+//------------------------------------------------------------------------------------------
+// optRemoveRedundantZeroInits: Remove redundant zero intializations.
+//
+// Notes:
+//    This phase iterates over basic blocks starting with the first basic block until there is no unique
+//    basic block successor or until it detects a loop. It keeps track of local nodes it encounters.
+//    When it gets to an assignment to a local variable or a local field, it checks whether the assignment
+//    is the first reference to the local (or to the parent of the local field), and, if so,
+//    it may do one of two optimizations:
+//      1. If the local is untracked, the rhs of the assignment is 0, and the local is guaranteed
+//         to be fully initialized in the prolog, the explicit zero initialization is removed.
+//      2. If the assignment is to a local (and not a field) and either the local has no gc pointers or there
+//         are no gc-safe points between the prolog and the assignment, it marks the local with lvHasExplicitInit
+//         which tells the codegen not to insert zero initialization for this local in the prolog.
+
+void Compiler::optRemoveRedundantZeroInits()
+{
+#ifdef DEBUG
+    if (verbose)
+    {
+        printf("*************** In optRemoveRedundantZeroInits()\n");
+    }
+#endif // DEBUG
+
+    CompAllocator   allocator(getAllocator(CMK_ZeroInit));
+    LclVarRefCounts refCounts(allocator);
+    bool            hasGCSafePoint = false;
+
+    assert(fgStmtListThreaded);
+
+    for (BasicBlock* block = fgFirstBB; (block != nullptr) && ((block->bbFlags & BBF_MARKED) == 0);
+         block             = block->GetUniqueSucc())
+    {
+        block->bbFlags |= BBF_MARKED;
+        for (Statement* stmt = block->FirstNonPhiDef(); stmt != nullptr;)
+        {
+            Statement* next = stmt->GetNextStmt();
+            for (GenTree* tree = stmt->GetTreeList(); tree != nullptr; tree = tree->gtNext)
+            {
+                if ((tree->gtFlags & GTF_CALL) != 0)
+                {
+                    hasGCSafePoint = true;
+                }
+
+                switch (tree->gtOper)
+                {
+                    case GT_LCL_VAR:
+                    case GT_LCL_FLD:
+                    case GT_LCL_VAR_ADDR:
+                    case GT_LCL_FLD_ADDR:
+                    {
+                        unsigned  lclNum    = tree->AsLclVarCommon()->GetLclNum();
+                        unsigned* pRefCount = refCounts.LookupPointer(lclNum);
+                        if (pRefCount != nullptr)
+                        {
+                            *pRefCount = (*pRefCount)++;
+                        }
+                        else
+                        {
+                            refCounts.Set(lclNum, 1);
+                        }
+
+                        break;
+                    }
+                    case GT_ASG:
+                    {
+                        GenTreeOp* treeOp = tree->AsOp();
+                        if (treeOp->gtOp1->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+                        {
+                            unsigned         lclNum    = treeOp->gtOp1->AsLclVarCommon()->GetLclNum();
+                            LclVarDsc* const lclDsc    = lvaGetDesc(lclNum);
+                            unsigned*        pRefCount = refCounts.LookupPointer(lclNum);
+                            assert(pRefCount != nullptr);
+                            if (*pRefCount == 1)
+                            {
+                                // The local hasn't been referenced before this assignment.
+                                bool removedExplicitZeroInit = false;
+                                if (!lclDsc->lvTracked && treeOp->gtOp2->IsIntegralConst(0))
+                                {
+                                    bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
+                                    bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
+
+                                    if (!fgVarNeedsExplicitZeroInit(lclDsc, bbInALoop, bbIsReturn))
+                                    {
+                                        // We are guaranteed to have a zero initialization in the prolog and
+                                        // the local hasn't been redefined between the prolog and this explicit
+                                        // zero initialization so the assignment can be safely removed.
+                                        if (tree == stmt->GetRootNode())
+                                        {
+                                            fgRemoveStmt(block, stmt);
+                                            removedExplicitZeroInit      = true;
+                                            *pRefCount                   = 0;
+                                            lclDsc->lvSuppressedZeroInit = 1;
+                                        }
+                                    }
+                                }
+
+                                if (!removedExplicitZeroInit && treeOp->gtOp1->OperIs(GT_LCL_VAR))
+                                {
+                                    if (!lclDsc->HasGCPtr() ||
+                                        (!GetInterruptible() && !hasGCSafePoint && !compMethodRequiresPInvokeFrame()))
+                                    {
+                                        // The local hasn't been used and won't be reported to the gc between
+                                        // the prolog and this explicit zero intialization. Therefore, it doesn't
+                                        // require zero initialization in the prolog.
+                                        lclDsc->lvHasExplicitInit = 1;
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+            stmt = next;
+        }
+    }
+
+    for (BasicBlock* block = fgFirstBB; (block != nullptr) && ((block->bbFlags & BBF_MARKED) != 0);
+         block             = block->GetUniqueSucc())
+    {
+        block->bbFlags &= ~BBF_MARKED;
+    }
+}

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9201,11 +9201,17 @@ typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, unsigned> Lc
 //    When it gets to an assignment to a local variable or a local field, it checks whether the assignment
 //    is the first reference to the local (or to the parent of the local field), and, if so,
 //    it may do one of two optimizations:
-//      1. If the local is untracked, the rhs of the assignment is 0, and the local is guaranteed
-//         to be fully initialized in the prolog, the explicit zero initialization is removed.
-//      2. If the assignment is to a local (and not a field) and either the local has no gc pointers or there
-//         are no gc-safe points between the prolog and the assignment, it marks the local with lvHasExplicitInit
-//         which tells the codegen not to insert zero initialization for this local in the prolog.
+//      1. If the following conditions are true:
+//            the local is untracked,
+//            the rhs of the assignment is 0,
+//            the local is guaranteed to be fully initialized in the prolog,
+//         then the explicit zero initialization is removed.
+//      2. If the following conditions are true:
+//            the assignment is to a local (and not a field),
+//            the local is not lvLiveInOutOfHndlr or no exceptions can be thrown between the prolog and the assignment,
+//            either the local has no gc pointers or there are no gc-safe points between the prolog and the assignment,
+//         then the local with lvHasExplicitInit which tells the codegen not to insert zero initialization for this
+//         local in the prolog.
 
 void Compiler::optRemoveRedundantZeroInits()
 {
@@ -9219,6 +9225,7 @@ void Compiler::optRemoveRedundantZeroInits()
     CompAllocator   allocator(getAllocator(CMK_ZeroInit));
     LclVarRefCounts refCounts(allocator);
     bool            hasGCSafePoint = false;
+    bool            canThrow       = false;
 
     assert(fgStmtListThreaded);
 
@@ -9231,9 +9238,14 @@ void Compiler::optRemoveRedundantZeroInits()
             Statement* next = stmt->GetNextStmt();
             for (GenTree* tree = stmt->GetTreeList(); tree != nullptr; tree = tree->gtNext)
             {
-                if ((tree->gtFlags & GTF_CALL) != 0)
+                if (((tree->gtFlags & GTF_CALL) != 0) && (!tree->IsCall() || !tree->AsCall()->IsSuppressGCTransition()))
                 {
                     hasGCSafePoint = true;
+                }
+
+                if ((tree->gtFlags & GTF_EXCEPT) != 0)
+                {
+                    canThrow = true;
                 }
 
                 switch (tree->gtOper)
@@ -9247,7 +9259,7 @@ void Compiler::optRemoveRedundantZeroInits()
                         unsigned* pRefCount = refCounts.LookupPointer(lclNum);
                         if (pRefCount != nullptr)
                         {
-                            *pRefCount = (*pRefCount)++;
+                            *pRefCount = (*pRefCount) + 1;
                         }
                         else
                         {
@@ -9274,7 +9286,7 @@ void Compiler::optRemoveRedundantZeroInits()
                                     bool bbInALoop  = (block->bbFlags & BBF_BACKWARD_JUMP) != 0;
                                     bool bbIsReturn = block->bbJumpKind == BBJ_RETURN;
 
-                                    if (!fgVarNeedsExplicitZeroInit(lclDsc, bbInALoop, bbIsReturn))
+                                    if (!fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn))
                                     {
                                         // We are guaranteed to have a zero initialization in the prolog and
                                         // the local hasn't been redefined between the prolog and this explicit
@@ -9289,13 +9301,16 @@ void Compiler::optRemoveRedundantZeroInits()
                                     }
                                 }
 
-                                if (!removedExplicitZeroInit && treeOp->gtOp1->OperIs(GT_LCL_VAR))
+                                if (!removedExplicitZeroInit && treeOp->gtOp1->OperIs(GT_LCL_VAR) &&
+                                    (!canThrow || !lclDsc->lvLiveInOutOfHndlr))
                                 {
+                                    // If compMethodRequiresPInvokeFrame() returns true, lower may later
+                                    // insert a call to CORINFO_HELP_INIT_PINVOKE_FRAME which is a gc-safe point.
                                     if (!lclDsc->HasGCPtr() ||
                                         (!GetInterruptible() && !hasGCSafePoint && !compMethodRequiresPInvokeFrame()))
                                     {
                                         // The local hasn't been used and won't be reported to the gc between
-                                        // the prolog and this explicit zero intialization. Therefore, it doesn't
+                                        // the prolog and this explicit intialization. Therefore, it doesn't
                                         // require zero initialization in the prolog.
                                         lclDsc->lvHasExplicitInit = 1;
                                     }


### PR DESCRIPTION
This change adds a phase that iterates over basic blocks starting with the first
basic block until there is no unique basic block successor or until it detects a
loop. It keeps track of local nodes it encounters. When it gets to an assignment
to a local variable or a local field, it checks whether the assignment is the
first reference to the local (or to the parent of the local field), and, if so,
it may do one of two optimizations:
1. If the local is untracked, the rhs of the assignment is 0, and the local is
   guaranteed to be fully initialized in the prolog, the explicit zero
   initialization is removed.
2. If the assignment is to a local (and not a field) and either the local has no
   gc pointers or there are no gc-safe points between the prolog and the
   assignment, it marks the local with lvHasExplicitInit which tells the codegen
   not to insert zero initialization for this local in the prolog.

This addresses one of the examples in #2325 and 5 examples in #1007.