### PR TITLE
Use TARGET_64BIT instead of set of TARGET_<arch> definitions.

### DIFF
--- a/src/coreclr/src/vm/profilinghelper.cpp
+++ b/src/coreclr/src/vm/profilinghelper.cpp
@@ -702,10 +702,10 @@ HRESULT ProfilingAPIUtility::AttemptLoadProfilerForStartup()
 
     IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER, &wszClsid));
 
-#if defined(TARGET_X86) || defined(TARGET_ARM)
-    IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_32, &wszProfilerDLL));
-#elif defined(TARGET_AMD64) || defined(TARGET_ARM64)
+#ifdef TARGET_64BIT
     IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_64, &wszProfilerDLL));
+#else
+    IfFailRet(CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_32, &wszProfilerDLL));
 #endif
     if(wszProfilerDLL == NULL)
     {


### PR DESCRIPTION
Use `TARGET_64BIT` instead of set of `TARGET_ARM` / `TARGET_ARM64` / `TARGET_X86` / `TARGET_ARM64` definitions for `CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_64` and `CLRConfig::EXTERNAL_CORECLR_PROFILER_PATH_32` checking.