### PR TITLE
ReadOnlyDictionary's IDictionary.this[object] doesn't adhere to IDictionary's contract.

### DIFF
--- a/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
+++ b/src/libraries/System.ObjectModel/src/System/Collections/ObjectModel/ReadOnlyDictionary.cs
@@ -162,7 +162,14 @@ namespace System.Collections.ObjectModel
                     return null;
                 }
 
-                return this[(TKey)key];
+                if (m_dictionary.TryGetValue((TKey)key, out TValue value))
+                {
+                    return value;
+                }
+                else
+                {
+                    return null;
+                }
             }
             set => throw new NotSupportedException(SR.NotSupported_ReadOnlyCollection);
         }

--- a/src/libraries/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
+++ b/src/libraries/System.ObjectModel/tests/ReadOnlyDictionary/ReadOnlyDictionaryTests.cs
@@ -144,6 +144,20 @@ namespace System.Collections.ObjectModel.Tests
         }
 
         /// <summary>
+        /// Tests that the explicit IDictionary.Item[] implementation returns null on a non-existing key.
+        /// </summary>
+        [Fact]
+        public static void IDictionaryItemTests()
+        {
+            KeyValuePair<int, string>[] expectedArr = new KeyValuePair<int, string>[] {
+                new KeyValuePair<int, string>(1, "one")
+            };
+            DummyDictionary<int, string> dummyExpectedDict = new DummyDictionary<int, string>(expectedArr);
+            IDictionary dictionary = new ReadOnlyDictionary<int, string>(dummyExpectedDict);
+            Assert.Null(dictionary[2]);
+        }
+
+        /// <summary>
         /// Tests that items can be retrieved by key from the Dictionary.
         /// </summary>
         [Fact]


### PR DESCRIPTION
**Quick demonstration of the bug that this PR fixes:**

``` c#
IDictionary d1 = new Dictionary<int, int>();
IDictionary d2 = new ReadOnlyDictionary<int, int>(new Dictionary<int, int>());
d1[1]; // returns null
d2[1]; // throws exception. <-- violates IDictionary's contract
```


[The contract](https://docs.microsoft.com/en-us/dotnet/api/system.collections.idictionary.item) of `IDictionary`'s indexer (i.e. `IDictionary.this[object]`) states that the property's return value is:

> The element with the specified key, _**or null if the key does not exist**_.

All (but one) of the framework's implementations of the (non-generic) `IDictionary` interface follow this behavior. This list includes:

* `System.Collections.HashTable`
* `System.Collections.SortedList`
* `System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>`
* `System.Collections.Generic.Dictionary<TKey, TValue>`
* `System.Collections.Specialized.HybridDictionary`
* `System.Collections.Specialized.ListDictionary`
* `System.Collections.Specialized.OrderedDictionary`
* `System.Collections.Generic.SortedList<TKey, TValue>`
* `System.Collections.Generic.SortedDictionary<TKey, TValue>`

The only one implementation that seems to accidentally break this contract is:

* `System.Collections.Generic.ReadOnlyDictionary<TKey, TValue>`.

Instead of returning "null if the key does not exist," `ReadOnlyDictionary<TKey, TValue>` throws a `KeyNotFoundException`. This happens because its `IDictionary.Item[]` implementation simply forwards the call to the `IDictionary<TKey, TValue>.Item[]` implementation of the wrapped dictionary. `IDictionary<TKey, TValue>.Item[]`'s [contract](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.idictionary-2.item), however, states that a `KeyNotFoundException` is thrown when the:

> key is not found.

These two contracts are incompatible and `ReadOnlyDictionary<TKey, TValue>` shouldn’t simply forward the call directly, as it currently does.

This PR fixes this bug by:

* Fixing this behavior in the class’s `IDictionary.this[object]` method.
* Adding a unit test to verify this behavior. 

After closely reviewing the [Breaking Changes](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/breaking-changes.md) document, I believe this behavioral change is justified and _not_ in violation of the code guidelines. This is because:

* The behavior of `ReadOnlyDictionary<TKey, TValue>`'s indexer is unchanged, which means that customers will not notice this change when working with the class's API.
* The change _only_ appears when casted to (non-generic) `IDictionary`, but in that case the user would actually assume the object behaves as specified by `IDictionary`.
* Although this change fits in "Bucket 2: Reasonably Grey Area," the old behavior was unpredictable, unobvious, and inconsistent, while the new behavior is now predictable, obvious, and consistent with the contract and _all_ other `IDictionary` implementations.
* It is unlikely that customers are depending on this exact bug, because in case either the `ReadOnlyDictionary<TKey, TValue>` type or `IDictionary<TKey, TValue>` type is known at compile-time, the `IDictionary.Item[]` property is not called.

On the other hand, *not fixing* this bug is problematic, because it means that the behavior of `IDictionary.Item[]` is now unreliable, because consumers typically don't know which implementation they call, and whether or not that implementation adheres to the contract or not. The introduction of `ReadOnlyDictionary<TKey, TValue>` even allowed existing code (which depends on `IDictionary`) to break, which means that, in theory, every call to `IDictionary.Item[]` now has  to be wrapped in a `try`-`catch`.