### PR TITLE
Improve test ALPN detection

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -24,6 +24,7 @@ namespace System
         public static bool IsMonoInterpreter => GetIsRunningOnMonoInterpreter();
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
+        public static bool IsIOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
 
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
@@ -109,11 +110,13 @@ namespace System
         // Windows - Schannel supports alpn from win8.1/2012 R2 and higher.
         // Linux - OpenSsl supports alpn from openssl 1.0.2 and higher.
         // OSX - SecureTransport doesn't expose alpn APIs. TODO https://github.com/dotnet/runtime/issues/27727
+        public static bool IsOpenSslSupported => IsLinux || IsFreeBSD;
+
         public static bool SupportsAlpn => (IsWindows && !IsWindows7) ||
-            ((!IsOSX && !IsWindows) &&
+            (IsOpenSslSupported &&
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
 
-        public static bool SupportsClientAlpn => SupportsAlpn || (IsOSX && Environment.OSVersion.Version > new Version(10, 12));
+        public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsIOS;
 
         // OpenSSL 1.1.1 and above.
         public static bool SupportsTls13 => GetTls13Support();
@@ -266,11 +269,13 @@ namespace System
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/1979")]
                 return false;
             }
-            else
+            else if (IsLinux)
             {
                 // Covers Linux and FreeBSD
                 return OpenSslVersion >= new Version(1,1,1);
             }
+
+            return false;
         }
 
         private static bool GetIsRunningOnMonoInterpreter()

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -269,7 +269,7 @@ namespace System
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/1979")]
                 return false;
             }
-            else if (IsLinux)
+            else if (IsOpenSslSupported)
             {
                 // Covers Linux and FreeBSD
                 return OpenSslVersion >= new Version(1,1,1);

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -24,8 +24,8 @@ namespace System
         public static bool IsMonoInterpreter => GetIsRunningOnMonoInterpreter();
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
-        public static bool IsIOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
-        public static bool IsTvOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
+        public static bool IsiOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
+        public static bool IstvOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
 
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
@@ -117,7 +117,7 @@ namespace System
             (IsOpenSslSupported &&
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
 
-        public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsIOS || IsTvOS;
+        public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsiOS || IstvOS;
 
         // OpenSSL 1.1.1 and above.
         public static bool SupportsTls13 => GetTls13Support();
@@ -265,7 +265,7 @@ namespace System
                 // assume no if key is missing or on error.
                 return false;
             }
-            else if (IsOSX || IsIOS || IsTvOS)
+            else if (IsOSX || IsiOS || IstvOS)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/1979")]
                 return false;

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -25,6 +25,7 @@ namespace System
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsIOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
+        public static bool IsTvOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
 
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
@@ -116,7 +117,7 @@ namespace System
             (IsOpenSslSupported &&
             (OpenSslVersion.Major >= 1 && (OpenSslVersion.Minor >= 1 || OpenSslVersion.Build >= 2)));
 
-        public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsIOS;
+        public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsIOS || IsTvOS;
 
         // OpenSSL 1.1.1 and above.
         public static bool SupportsTls13 => GetTls13Support();
@@ -264,7 +265,7 @@ namespace System
                 // assume no if key is missing or on error.
                 return false;
             }
-            else if (IsOSX)
+            else if (IsOSX || IsIOS || IsTvOS)
             {
                 // [ActiveIssue("https://github.com/dotnet/runtime/issues/1979")]
                 return false;


### PR DESCRIPTION
PlatformDetection made assumption that Linux = !Windowns && !OSX. That breaks runs on iOS. 
This improves TLS13 & ALPN detection. with this.

```
 Xcode: /Users/furt/github/wfurt-runtime/artifacts/bin/System.Net.WebClient.Tests/net5.0-Debug/ios-x64/AppBundle/System.Net.WebClient.Tests/System.Net.WebClient.Tests.xcodeproj
  App: /Users/furt/github/wfurt-runtime/artifacts/bin/System.Net.WebClient.Tests/net5.0-Debug/ios-x64/AppBundle/System.Net.WebClient.Tests/Release-iphonesimulator/System.Net.WebClient.Tests.app
  XHarness command issued: ios test --app=/Users/furt/github/wfurt-runtime/artifacts/bin/System.Net.WebClient.Tests/net5.0-Debug/ios-x64/AppBundle/System.Net.WebClient.Tests/Release-iphonesimulator/System.Net.WebClient.Tests.app --targets=ios-simulator-64 --output-directory=/Users/furt/github/wfurt-runtime/artifacts/bin/System.Net.WebClient.Tests/net5.0-Debug/ios-x64/AppBundle/xharness-output
  info: test[0]
        Starting test for ios-simulator-64..
  info: test[0]
        Starting application 'System.Net.WebClient.Tests' on ios-simulator-64
  info: test[0]
        Application finished the test run successfully
  info: test[0]
        Tests run: 36 Passed: 36 Inconclusive: 0 Failed: 0 Ignored: 0
  XHarness exit code: 0
  Xharness artifacts: /Users/furt/github/wfurt-runtime/artifacts/bin/System.Net.WebClient.Tests/net5.0-Debug/ios-x64/AppBundle/xharness-output

```

contributes to #36890