### PR TITLE
Fix incorrect filtering operation in EventPipeHelper::IsEnabled

### DIFF
--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -7612,7 +7612,7 @@ bool EventPipeHelper::IsEnabled(DOTNET_TRACE_CONTEXT Context, UCHAR Level, ULONG
     }
     CONTRACTL_END
 
-    if (Level <= Context.EventPipeProvider.Level || Context.EventPipeProvider.Level == 0)
+    if (Level <= Context.EventPipeProvider.Level)
     {
         return (Keyword == (ULONGLONG)0) || (Keyword & Context.EventPipeProvider.EnabledKeywordsBitmask) != 0;
     }


### PR DESCRIPTION
Fix #36913. 

This addresses an issue where the EventLevel does not get filtered correctly on EventPipeHelper::IsEnabled, which causes parts of the runtime that uses `ETW_CATEGORY_ENABLED` macro to check whether an event should be fired to incorrectly to incorrectly assume event is enabled when a trace session has been enabled with `EventLevel.LogAlways`, which could cause potential performance issues. 

