### PR TITLE
Fix output for user strings in R2RDump

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1727,7 +1727,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             uint rid = ReadUIntAndEmitInlineSignatureBinary(builder);
             UserStringHandle stringHandle = MetadataTokens.UserStringHandle((int)rid);
-            builder.AppendCSharpString(_metadataReader.GetUserString(stringHandle));
+            builder.AppendEscapedString(_metadataReader.GetUserString(stringHandle));
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Globalization;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
@@ -1728,95 +1727,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             uint rid = ReadUIntAndEmitInlineSignatureBinary(builder);
             UserStringHandle stringHandle = MetadataTokens.UserStringHandle((int)rid);
-            AppendCSharpStringLiteral(builder, _metadataReader.GetUserString(stringHandle));
-        }
-
-        /// <summary>
-        /// Appends a C# string literal with the given value to the string builder.
-        /// </summary>
-        /// <remarks>
-        /// This method closely follows the logic in <see cref="Microsoft.CodeAnalysis.CSharp.ObjectDisplay.FormatLiteral(string, ObjectDisplayOptions)"/>
-        /// method in Roslyn .NET compiler; see its
-        /// <a href="https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs">sources</a> for reference.
-        /// </remarks>
-        private static void AppendCSharpStringLiteral(StringBuilder builder, string value)
-        {
-            builder.Append('"');
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                char c = value[i];
-                UnicodeCategory category;
-
-                // Fast check for printable ASCII characters
-                if ((c <= 0x7e) && (c >= 0x20) || !NeedsEscaping(category = CharUnicodeInfo.GetUnicodeCategory(c)))
-                {
-                    if ((c == '"') || (c == '\\'))
-                    {
-                        builder.Append(@"\");
-                    }
-                    builder.Append(c);
-                }
-                else if (category == UnicodeCategory.Surrogate)
-                {
-                    // Check for a valid surrogate pair
-                    category = CharUnicodeInfo.GetUnicodeCategory(value, i);
-                    if (category == UnicodeCategory.Surrogate)
-                    {
-                        // Escape an unpaired surrogate
-                        builder.Append(@"\u" + ((int)c).ToString("x4"));
-                    }
-                    else if (NeedsEscaping(category))
-                    {
-                        // A surrogate pair that needs to be escaped
-                        int codePoint = char.ConvertToUtf32(value, i);
-                        builder.Append(@"\U" + codePoint.ToString("x8"));
-                        i++; // Skip the already-encoded second surrogate of the pair
-                    }
-                    else
-                    {
-                        // Copy a printable surrogate pair
-                        builder.Append(c);
-                        builder.Append(value[++i]);
-                    }
-                }
-                else
-                {
-                    string encoded = c switch
-                    {
-                        '\0' => @"\0",
-                        '\a' => @"\a",
-                        '\b' => @"\b",
-                        '\f' => @"\f",
-                        '\n' => @"\n",
-                        '\r' => @"\r",
-                        '\t' => @"\t",
-                        '\v' => @"\v",
-                        _ => @"\u" + ((int)c).ToString("x4")
-                    };
-                    builder.Append(encoded);
-                }
-            }
-
-            builder.Append('"');
-        }
-
-        /// <summary>
-        /// Determines whether characters of the given <see cref="UnicodeCategory"/> will be represented with escape sequences.
-        /// </summary>
-        private static bool NeedsEscaping(UnicodeCategory category)
-        {
-            switch (category)
-            {
-                case UnicodeCategory.LineSeparator:
-                case UnicodeCategory.ParagraphSeparator:
-                case UnicodeCategory.Control:
-                case UnicodeCategory.Surrogate:
-                case UnicodeCategory.OtherNotAssigned:
-                    return true;
-                default:
-                    return false;
-            }
+            builder.AppendCSharpString(_metadataReader.GetUserString(stringHandle));
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/StringExtensions.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/StringExtensions.cs
@@ -17,7 +17,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// method in Roslyn .NET compiler; see its
         /// <a href="https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs">sources</a> for reference.
         /// </remarks>
-        public static StringBuilder AppendCSharpString(this StringBuilder builder, string value)
+        public static StringBuilder AppendEscapedString(this StringBuilder builder, string value)
         {
             builder.Append('"');
 
@@ -104,9 +104,9 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Returns a C# string literal with the given value.
         /// </summary>
-        public static string ToCSharpString(this string value)
+        public static string ToEscapedString(this string value)
         {
-            return new StringBuilder(value.Length + 16).AppendCSharpString(value).ToString();
+            return new StringBuilder(value.Length + 16).AppendEscapedString(value).ToString();
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/StringExtensions.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/StringExtensions.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Globalization;
+using System.Text;
+
+namespace ILCompiler.Reflection.ReadyToRun
+{
+    public static class StringBuilderExtensions
+    {
+        /// <summary>
+        /// Appends a C# string literal with the given value to the string builder.
+        /// </summary>
+        /// <remarks>
+        /// This method closely follows the logic in <see cref="Microsoft.CodeAnalysis.CSharp.ObjectDisplay.FormatLiteral(string, ObjectDisplayOptions)"/>
+        /// method in Roslyn .NET compiler; see its
+        /// <a href="https://github.com/dotnet/roslyn/blob/master/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs">sources</a> for reference.
+        /// </remarks>
+        public static StringBuilder AppendCSharpString(this StringBuilder builder, string value)
+        {
+            builder.Append('"');
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                char c = value[i];
+                UnicodeCategory category;
+
+                // Fast check for printable ASCII characters
+                if ((c <= 0x7e) && (c >= 0x20) || !NeedsEscaping(category = CharUnicodeInfo.GetUnicodeCategory(c)))
+                {
+                    if ((c == '"') || (c == '\\'))
+                    {
+                        builder.Append(@"\");
+                    }
+                    builder.Append(c);
+                }
+                else if (category == UnicodeCategory.Surrogate)
+                {
+                    // Check for a valid surrogate pair
+                    category = CharUnicodeInfo.GetUnicodeCategory(value, i);
+                    if (category == UnicodeCategory.Surrogate)
+                    {
+                        // Escape an unpaired surrogate
+                        builder.Append(@"\u" + ((int)c).ToString("x4"));
+                    }
+                    else if (NeedsEscaping(category))
+                    {
+                        // A surrogate pair that needs to be escaped
+                        int codePoint = char.ConvertToUtf32(value, i);
+                        builder.Append(@"\U" + codePoint.ToString("x8"));
+                        i++; // Skip the already-encoded second surrogate of the pair
+                    }
+                    else
+                    {
+                        // Copy a printable surrogate pair
+                        builder.Append(c);
+                        builder.Append(value[++i]);
+                    }
+                }
+                else
+                {
+                    string escaped = c switch
+                    {
+                        '\0' => @"\0",
+                        '\a' => @"\a",
+                        '\b' => @"\b",
+                        '\f' => @"\f",
+                        '\n' => @"\n",
+                        '\r' => @"\r",
+                        '\t' => @"\t",
+                        '\v' => @"\v",
+                        _ => @"\u" + ((int)c).ToString("x4")
+                    };
+                    builder.Append(escaped);
+                }
+            }
+
+            builder.Append('"');
+            return builder;
+        }
+
+        /// <summary>
+        /// Determines whether characters of the given <see cref="UnicodeCategory"/> will be represented with escape sequences.
+        /// </summary>
+        private static bool NeedsEscaping(UnicodeCategory category)
+        {
+            switch (category)
+            {
+                case UnicodeCategory.LineSeparator:
+                case UnicodeCategory.ParagraphSeparator:
+                case UnicodeCategory.Control:
+                case UnicodeCategory.Surrogate:
+                case UnicodeCategory.OtherNotAssigned:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+
+    public static class StringExtensions
+    {
+        /// <summary>
+        /// Returns a C# string literal with the given value.
+        /// </summary>
+        public static string ToCSharpString(this string value)
+        {
+            return new StringBuilder(value.Length + 16).AppendCSharpString(value).ToString();
+        }
+    }
+}

--- a/src/coreclr/src/tools/r2rdump/R2RDump.cs
+++ b/src/coreclr/src/tools/r2rdump/R2RDump.cs
@@ -203,12 +203,14 @@ namespace R2RDump
     {
         private readonly DumpOptions _options;
         private readonly Dictionary<ReadyToRunSectionType, bool> _selectedSections = new Dictionary<ReadyToRunSectionType, bool>();
+        private readonly Encoding _encoding;
         private readonly TextWriter _writer;
         private Dumper _dumper;
 
         private R2RDump(DumpOptions options)
         {
             _options = options;
+            _encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
             if (_options.Verbose)
             {
@@ -220,7 +222,7 @@ namespace R2RDump
 
             if (_options.Out != null)
             {
-                _writer = new StreamWriter(_options.Out.FullName, append: false, encoding: new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false));
+                _writer = new StreamWriter(_options.Out.FullName, append: false, _encoding);
             }
             else
             {
@@ -569,7 +571,7 @@ namespace R2RDump
                     else
                     {
                         string perFileOutput = filename.FullName + ".common-methods.r2r";
-                        _dumper = new TextDumper(r2r, new StreamWriter(perFileOutput), disassembler, _options);
+                        _dumper = new TextDumper(r2r, new StreamWriter(perFileOutput, append: false, _encoding), disassembler, _options);
                         if (previousDumper != null)
                         {
                             new R2RDiff(previousDumper, _dumper, _writer).Run();

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -455,7 +455,7 @@ namespace R2RDump
                         R2RDump.WriteWarning("String is not zero-terminated");
                     }
                     string ownerCompositeExecutable = Encoding.UTF8.GetString(_r2r.Image, oceOffset, section.Size - 1); // exclude the zero terminator
-                    _writer.WriteLine("Composite executable: {0}", ownerCompositeExecutable.ToCSharpString());
+                    _writer.WriteLine("Composite executable: {0}", ownerCompositeExecutable.ToEscapedString());
                     break;
             }
         }

--- a/src/coreclr/src/tools/r2rdump/TextDumper.cs
+++ b/src/coreclr/src/tools/r2rdump/TextDumper.cs
@@ -450,12 +450,12 @@ namespace R2RDump
                     break;
                 case ReadyToRunSectionType.OwnerCompositeExecutable:
                     int oceOffset = _r2r.GetOffset(section.RelativeVirtualAddress);
-                    Decoder decoder = Encoding.UTF8.GetDecoder();
-                    int charLength = decoder.GetCharCount(_r2r.Image, oceOffset, section.Size - 1); // exclude the zero terminator
-                    char[] charArray = new char[charLength];
-                    decoder.GetChars(_r2r.Image, oceOffset, section.Size, charArray, 0, flush: true);
-                    string ownerCompositeExecutable = new string(charArray);
-                    _writer.WriteLine("Composite executable: {0}", ownerCompositeExecutable);
+                    if (_r2r.Image[oceOffset + section.Size - 1] != 0)
+                    {
+                        R2RDump.WriteWarning("String is not zero-terminated");
+                    }
+                    string ownerCompositeExecutable = Encoding.UTF8.GetString(_r2r.Image, oceOffset, section.Size - 1); // exclude the zero terminator
+                    _writer.WriteLine("Composite executable: {0}", ownerCompositeExecutable.ToCSharpString());
                     break;
             }
         }


### PR DESCRIPTION
R2RDump would crash dumping strings with unpaired surrogates in diff mode due to using a `UTF8Encoding` with the `throwOnInvalidBytes` flag set on.  Moreover, control characters in strings, such as `'\0'` or `'\n'`, would be output without escaping.

I am changing the code to use the same `UTF8Encoding` for both diff and non-diff modes and output user strings as C# string literals employing the same logic as in Roslyn .NET Compiler.  An example of the output:
```
    TableIndex 5, Offset 016D: "\0\0\n\0\u0002\u0004\u0005\u0003\u0001\u0006\t\u0013\0" (STRING_HANDLE)
```