### PR TITLE
Ensure Vector3 inequality doesn't use the hidden 4th element

### DIFF
--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -707,7 +707,7 @@ void Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cmpOp)
     if ((baseType == TYP_FLOAT) && (simdSize == 12))
     {
         // For TYP_SIMD12 we don't want the upper bits to participate in the comparison. So, we will insert all ones
-        // into those bits of the result, "as if" the upper bits are equal. Then if all lower bits are equal, we get the 
+        // into those bits of the result, "as if" the upper bits are equal. Then if all lower bits are equal, we get the
         // expected all-ones result, and will get the expected 0's only where there are non-matching bits.
 
         GenTree* idxCns = comp->gtNewIconNode(3, TYP_INT);

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -706,13 +706,9 @@ void Lowering::LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cmpOp)
 
     if ((baseType == TYP_FLOAT) && (simdSize == 12))
     {
-        // For TYP_SIMD12 the value of the upper bits is unknown but shouldn't impact
-        // the comparison. So, we should always pretend the bits were equivalent to
-        // ensure that the final result is correct. In the case of equality, the unsigned
-        // min across will always treat -1 (all bits set) as higher and so it will be
-        // preserved if the other three elements were also equal. In the case of inequality
-        // it will likewise be handled and won't cause an otherwise equivalent vector from
-        // being treated as not equal.
+        // For TYP_SIMD12 we don't want the upper bits to participate in the comparison. So, we will insert all ones
+        // into those bits of the result, "as if" the upper bits are equal. Then if all lower bits are equal, we get the 
+        // expected all-ones result, and will get the expected 0's only where there are non-matching bits.
 
         GenTree* idxCns = comp->gtNewIconNode(3, TYP_INT);
         BlockRange().InsertAfter(cmp, idxCns);

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36905/GitHub_36905.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36905/GitHub_36905.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+public class GitHub_36905
+{
+    public static int Main()
+    {
+        bool success = true;
+
+        Vector3 a = new Vector3(1.0f, 2.0f, 3.0f);
+        Vector3 b = new Vector3(1.0f, 2.0f, 3.0f);
+
+        success &= ValidateResult(a == b, expected: true);
+        success &= ValidateResult(a != b, expected: false);
+
+        Vector3 c = new Vector3(1.0f, 2.0f, 3.0f);
+        Vector3 d = new Vector3(10.0f, 2.0f, 3.0f);
+
+        success &= ValidateResult(c == d, expected: false);
+        success &= ValidateResult(c != d, expected: true);
+
+        return success ? 100 : 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool ValidateResult(bool actual, bool expected)
+    {
+        return actual == expected;
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36905/GitHub_36905.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36905/GitHub_36905.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Vector3Tests.cs
@@ -967,7 +967,6 @@ namespace System.Numerics.Tests
 
         // A test for operator != (Vector3f, Vector3f)
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36905", typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))]
         public void Vector3InequalityTest()
         {
             Vector3 a = new Vector3(1.0f, 2.0f, 3.0f);


### PR DESCRIPTION
This fixes #36905 