### PR TITLE
Pipelines remove lock from uncontended path

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Pipelines/src/Resources/Strings.resx
@@ -141,6 +141,9 @@
   <data name="NoReadingOperationToComplete" xml:space="preserve">
     <value>No reading operation to complete.</value>
   </data>
+  <data name="NoWritingOperationToAdvance" xml:space="preserve">
+    <value>No writing operation to advance.</value>
+  </data>
   <data name="ReadCanceledOnPipeReader" xml:space="preserve">
     <value>Read was canceled on underlying PipeReader.</value>
   </data>

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -4,70 +4,127 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.IO.Pipelines
 {
-    [DebuggerDisplay("State: {_state}")]
+    [DebuggerDisplay("State: {State}")]
+    [StructLayout(LayoutKind.Explicit)]
     internal struct PipeOperationState
     {
-        private State _state;
+        // Ensure reader and writer data not on same cache line
+        [FieldOffset(0)]
+        private WriterData _writerData;
+        [FieldOffset(128)]
+        private ReaderData _readerData;
+
+        public Memory<byte> WritingHeadMemory
+        {
+            get => _writerData._writingHeadMemory;
+            set => _writerData._writingHeadMemory = value;
+        }
+
+        public int WritingHeadBytesBuffered
+        {
+            get => _writerData._writingHeadBytesBuffered;
+            set => _writerData._writingHeadBytesBuffered = value;
+        }
+
+        public long UnflushedBytes
+        {
+            get => _writerData._unflushedBytes;
+            set => _writerData._unflushedBytes = value;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginRead()
         {
-            if ((_state & State.Reading) == State.Reading)
+            if ((_readerData._readState & ReadState.Reading) != 0)
             {
                 ThrowHelper.ThrowInvalidOperationException_AlreadyReading();
             }
 
-            _state |= State.Reading;
+            _readerData._readState |= ReadState.Reading;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginReadTentative()
         {
-            if ((_state & State.Reading) == State.Reading)
+            if ((_readerData._readState & ReadState.Reading) != 0)
             {
                 ThrowHelper.ThrowInvalidOperationException_AlreadyReading();
             }
 
-            _state |= State.ReadingTentative;
+            _readerData._readState |= ReadState.ReadingTentative;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EndRead()
         {
-            if ((_state & State.Reading) != State.Reading &&
-                (_state & State.ReadingTentative) != State.ReadingTentative)
+            if (_readerData._readState == ReadState.Inactive)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoReadToComplete();
             }
 
-            _state &= ~(State.Reading | State.ReadingTentative);
+            _readerData._readState = ReadState.Inactive;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginWrite()
         {
-            _state |= State.Writing;
+            _writerData._writeState = WriteState.Writing;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EndWrite()
         {
-            _state &= ~State.Writing;
+            _writerData._writeState = WriteState.Inactive;
         }
 
-        public bool IsWritingActive => (_state & State.Writing) == State.Writing;
+        public bool IsWritingActive
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (_writerData._writeState & WriteState.Writing) != 0;
+        }
 
-        public bool IsReadingActive => (_state & State.Reading) == State.Reading;
+        public bool IsReadingActive
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (_readerData._readState & ReadState.Reading) != 0;
+        }
+
+        private string State => $"WriteState: {_writerData._writeState}; ReadState: {_readerData._readState}";
+
+        [StructLayout(LayoutKind.Auto)]
+        private struct ReaderData
+        {
+            public volatile ReadState _readState;
+        }
+
+        [StructLayout(LayoutKind.Auto)]
+        private struct WriterData
+        {
+            public volatile WriteState _writeState;
+            // The write head which is the extent of the PipeWriter's written bytes
+            public Memory<byte> _writingHeadMemory;
+            public int _writingHeadBytesBuffered;
+            // The number of bytes written but not flushed
+            public long _unflushedBytes;
+        }
 
         [Flags]
-        internal enum State : byte
+        internal enum ReadState : int
         {
+            Inactive = 0,
             Reading = 1,
-            ReadingTentative = 2,
-            Writing = 4
+            ReadingTentative = 2
+        }
+
+        [Flags]
+        internal enum WriteState : int
+        {
+            Inactive = 0,
+            Writing = 1
         }
     }
 }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/ThrowHelper.cs
@@ -84,6 +84,11 @@ namespace System.IO.Pipelines
         public static void ThrowInvalidOperationException_InvalidZeroByteRead() => throw CreateInvalidOperationException_InvalidZeroByteRead();
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static Exception CreateInvalidOperationException_InvalidZeroByteRead() => new InvalidOperationException(SR.InvalidZeroByteRead);
+
+        [DoesNotReturn]
+        public static void ThrowInvalidOperationException_NoWriteToAdvance() => throw CreateInvalidOperationException_NoWriteToAdvance();
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static Exception CreateInvalidOperationException_NoWriteToAdvance() => new InvalidOperationException(SR.NoWritingOperationToAdvance);
     }
 
     internal enum ExceptionArgument


### PR DESCRIPTION
Simpler version of https://github.com/dotnet/runtime/pull/36934 as can achieve same effect by just removing locks from new data initialization rather than trying to remove it for all writes

Drops the lock for common path through the highlighted code paths for Json TE:

![image](https://user-images.githubusercontent.com/1142958/82759696-e64bfd00-9de6-11ea-8e05-7d089d78fb11.png)

After effect; allocation under lock call count much reduced
![image](https://user-images.githubusercontent.com/1142958/82759875-dda7f680-9de7-11ea-93ae-ff974e6aed96.png)

