### PR TITLE
Pipelines remove lock from uncontended path

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -4,70 +4,104 @@
 
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace System.IO.Pipelines
 {
-    [DebuggerDisplay("State: {_state}")]
+    [DebuggerDisplay("State: {State}")]
+    [StructLayout(LayoutKind.Explicit)]
     internal struct PipeOperationState
     {
-        private State _state;
+        // Ensure reader and writer data not on same cache line
+        [FieldOffset(0)]
+        private WriterData _writerData;
+        [FieldOffset(128)]
+        private ReaderData _readerData;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginRead()
         {
-            if ((_state & State.Reading) == State.Reading)
+            if ((_readerData._readState & ReadState.Reading) != 0)
             {
                 ThrowHelper.ThrowInvalidOperationException_AlreadyReading();
             }
 
-            _state |= State.Reading;
+            _readerData._readState = ReadState.Reading;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginReadTentative()
         {
-            if ((_state & State.Reading) == State.Reading)
+            if ((_readerData._readState & ReadState.Reading) != 0)
             {
                 ThrowHelper.ThrowInvalidOperationException_AlreadyReading();
             }
 
-            _state |= State.ReadingTentative;
+            _readerData._readState = ReadState.ReadingTentative;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EndRead()
         {
-            if ((_state & State.Reading) != State.Reading &&
-                (_state & State.ReadingTentative) != State.ReadingTentative)
+            if (_readerData._readState == ReadState.Inactive)
             {
                 ThrowHelper.ThrowInvalidOperationException_NoReadToComplete();
             }
 
-            _state &= ~(State.Reading | State.ReadingTentative);
+            _readerData._readState = ReadState.Inactive;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginWrite()
         {
-            _state |= State.Writing;
+            _writerData._writeState = WriteState.Writing;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void EndWrite()
         {
-            _state &= ~State.Writing;
+            _writerData._writeState = WriteState.Inactive;
         }
 
-        public bool IsWritingActive => (_state & State.Writing) == State.Writing;
+        public bool IsWritingActive
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (_writerData._writeState & WriteState.Writing) != 0;
+        }
 
-        public bool IsReadingActive => (_state & State.Reading) == State.Reading;
+        public bool IsReadingActive
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => (_readerData._readState & (ReadState.Reading | ReadState.ReadingTentative)) != 0;
+        }
+
+        private string State => $"WriteState: {_writerData._writeState}; ReadState: {_readerData._readState}";
+
+        [StructLayout(LayoutKind.Auto)]
+        private struct ReaderData
+        {
+            public volatile ReadState _readState;
+        }
+
+        [StructLayout(LayoutKind.Auto)]
+        private struct WriterData
+        {
+            public volatile WriteState _writeState;
+        }
 
         [Flags]
-        internal enum State : byte
+        internal enum ReadState : int
         {
+            Inactive = 0,
             Reading = 1,
-            ReadingTentative = 2,
-            Writing = 4
+            ReadingTentative = 2
+        }
+
+        [Flags]
+        internal enum WriteState : int
+        {
+            Inactive = 0,
+            Writing = 1
         }
     }
 }

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -179,6 +179,14 @@ namespace System.IO.Pipelines.Tests
         [Fact]
         public void ThrowsOnAdvanceWithNoMemory()
         {
+            Memory<byte> buffer = Pipe.Writer.GetMemory(1);
+            Pipe.Writer.Advance(buffer.Length);
+            Assert.Throws<ArgumentOutOfRangeException>(() => Pipe.Writer.Advance(1));
+        }
+
+        [Fact]
+        public void ThrowsOnAdvanceWithoutWrite()
+        {
             PipeWriter buffer = Pipe.Writer;
             Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Advance(1));
         }


### PR DESCRIPTION
Simpler version of https://github.com/dotnet/runtime/pull/36955

Drops the lock for common path through the highlighted code paths for Json TE:

![image](https://user-images.githubusercontent.com/1142958/82759696-e64bfd00-9de6-11ea-8e05-7d089d78fb11.png)

Before 

![image](https://user-images.githubusercontent.com/1142958/82763321-bb6da300-9dfe-11ea-9bf3-fc9f4a8a2839.png)

After

![image](https://user-images.githubusercontent.com/1142958/82763336-d50eea80-9dfe-11ea-817c-fe515c8cd5a1.png)

Should follow up with more state out to the `PipeOperationState` to avoid cache thrashing, but should be easier to review.

/cc @halter73 @adamsitnik @stephentoub @davidfowl 