### PR TITLE
Remove volatile on field in ConcurrentDictionary.Tables

### DIFF
--- a/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -44,7 +44,7 @@ namespace System.Collections.Concurrent
         {
             internal readonly Node[] _buckets; // A singly-linked list for each bucket.
             internal readonly object[] _locks; // A set of locks, each guarding a section of the table.
-            internal volatile int[] _countPerLock; // The number of elements guarded by each lock.
+            internal readonly int[] _countPerLock; // The number of elements guarded by each lock.
 
             internal Tables(Node[] buckets, object[] locks, int[] countPerLock)
             {


### PR DESCRIPTION
@VSadov, do you see any reason this needs to be volatile?  It appears to always be accessed under a lock except for one fast-path that doesn't appear to rely on the volatility.