### PR TITLE
#36977 - Increased test coverage for DI

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -44,12 +44,12 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         {
             Debug.Assert(!_disposed);
 
-            _captureDisposableCallback?.Invoke(service);
-
             if (ReferenceEquals(this, service) || !(service is IDisposable || service is IAsyncDisposable))
             {
                 return service;
             }
+
+            _captureDisposableCallback?.Invoke(service);
 
             lock (ResolvedServices)
             {


### PR DESCRIPTION
Issue:  https://github.com/dotnet/runtime/issues/36977

Added a test for DI. Checks that when an IDisposable service is resolved, which has an `IEnumerable<T>` injected containing other IDisposable services, all the services are disposed when the scope is disposed.