### PR TITLE
Fix binplacing WASM files for in-tree runtime pack

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -138,8 +138,6 @@
         Include="$(MonoArtifactsPath)\cross\*.*" />
       <MonoIncludeFiles Condition="'$(TargetsMobile)' == 'true'"
         Include="$(MonoArtifactsPath)\include\**\*.*" />
-      <WasmDistFiles Condition="'$(TargetOS)' == 'Browser'"
-        Include="$(MonoArtifactsPath)\wasm\runtimes\**\*.*" />
     </ItemGroup>
 
     <Error Condition="'@(RuntimeFiles)' == ''" Text="The '$(RuntimeFlavor)' subset must be built before building this project." />
@@ -188,10 +186,15 @@
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
                              Include="
         $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.js;
-        $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.wasm;
+        $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.wasm;"
+        IsNative="true"
+        NativeSubDirectory="wasm/runtimes/debug/" />
+      <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
+                             Include="
         $(LibrariesNativeArtifactsPath)wasm\runtimes\release\dotnet.js;
         $(LibrariesNativeArtifactsPath)wasm\runtimes\release\dotnet.wasm"
-        IsNative="true" />
+        IsNative="true"
+        NativeSubDirectory="wasm/runtimes/release/" />
     </ItemGroup>
 
     <Error Condition="'@(LibrariesRefAssemblies)' == ''" Text="The 'libs' subset must be built before building this project." />

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -176,7 +176,7 @@
         $(LibrariesAllBinArtifactsPath)*.dll;
         $(LibrariesAllBinArtifactsPath)*.pdb"
         IsNative="" />
-      <LibrariesRuntimeFiles Condition="'$(TargetsMobile)' != 'true'" Include="
+      <LibrariesRuntimeFiles Include="
         $(LibrariesNativeArtifactsPath)*.dll;
         $(LibrariesNativeArtifactsPath)*.dylib;
         $(LibrariesNativeArtifactsPath)*.a;
@@ -185,9 +185,12 @@
         $(LibrariesNativeArtifactsPath)*.dwarf;
         $(LibrariesNativeArtifactsPath)*.pdb"
         IsNative="true" />
-      <LibrariesRuntimeFiles Condition="'$(TargetsMobile)' == 'true'"
+      <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
                              Include="
-        $(LibrariesNativeArtifactsPath)**\*.*" 
+        $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.js;
+        $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.wasm;
+        $(LibrariesNativeArtifactsPath)wasm\runtimes\release\dotnet.js;
+        $(LibrariesNativeArtifactsPath)wasm\runtimes\release\dotnet.wasm"
         IsNative="true" />
     </ItemGroup>
 

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -76,11 +76,6 @@
         <TargetPath>runtimes/$(PackageRID)/native/include/%(RecursiveDir)</TargetPath>
       </RuntimeFiles>
 
-      <RuntimeFiles Condition="'$(TargetsBrowser)' == 'true'"
-        Include="@(WasmDistFiles)">
-        <TargetPath>runtimes/$(PackageRID)/native/wasm/runtimes/%(RecursiveDir)</TargetPath>
-      </RuntimeFiles>
-
       <CoreCLRCrossTargetFiles Condition="'%(FileName)' == 'clrjit' or '%(FileName)' == 'libclrjit'">
         <TargetPath>runtimes/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
       </CoreCLRCrossTargetFiles>
@@ -105,7 +100,7 @@
 
     <ItemGroup Condition="'$(PackageRID)' != ''">
       <LibrariesRuntimeFiles Condition="'%(IsNative)' != 'true'" TargetPath="runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)" />
-      <LibrariesRuntimeFiles Condition="'%(IsNative)' == 'true'" TargetPath="runtimes/$(PackageRID)/native/%(RecursiveDir)" />
+      <LibrariesRuntimeFiles Condition="'%(IsNative)' == 'true'" TargetPath="runtimes/$(PackageRID)/native/%(LibrariesRuntimeFiles.NativeSubDirectory)%(RecursiveDir)" />
       <ReferenceCopyLocalPaths Include="@(LibrariesRuntimeFiles)" />
     </ItemGroup>
 

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -20,6 +20,12 @@
       <NativeBinPlaceItem Include="$(NativeBinDir)*.dbg" />
       <NativeBinPlaceItem Include="$(NativeBinDir)*.dylib" />
       <NativeBinPlaceItem Include="$(NativeBinDir)*.dwarf" />
+      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)wasm\runtimes\debug\dotnet.js;$(NativeBinDir)wasm\runtimes\debug\dotnet.wasm">
+        <DestinationSubDirectory>wasm\runtimes\debug\</DestinationSubDirectory>
+      </NativeBinPlaceItem>
+      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)wasm\runtimes\release\dotnet.js;$(NativeBinDir)wasm\runtimes\release\dotnet.wasm">
+        <DestinationSubDirectory>wasm\runtimes\release\</DestinationSubDirectory>
+      </NativeBinPlaceItem>
 
       <BinPlaceItem Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="@(NativeBinPlaceItem)" />
       <FileWrites Include="@(NativeBinPlaceItem)" />

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -18,7 +18,6 @@
 
     <ProjectReference Include="$(CommonTestPath)AppleTestRunner\AppleTestRunner.csproj" Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'"/>
     <ProjectReference Include="$(CommonTestPath)AndroidTestRunner\AndroidTestRunner.csproj" Condition="'$(TargetOS)' == 'Android'" />
-    <ProjectReference Include="$(MonoProjectRoot)wasm\wasm.proj" Condition="'$(TargetOS)' == 'Browser'" />
   </ItemGroup>
 
   <Target Name="RestoreTestHost"

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -88,9 +88,6 @@
       <NativeBinPlaceItem Include="@(MonoIncludeFiles)">
         <DestinationSubDirectory>include/%(RecursiveDir)</DestinationSubDirectory>
       </NativeBinPlaceItem>
-      <NativeBinPlaceItem Include="@(WasmDistFiles)">
-        <DestinationSubDirectory>wasm/%(RecursiveDir)</DestinationSubDirectory>
-      </NativeBinPlaceItem>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
       <TestHostBinPlaceItem Include="@(RuntimeFiles)" />

--- a/src/libraries/src.proj
+++ b/src/libraries/src.proj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TraversalGlobalProperties>BuildAllProjects=true</TraversalGlobalProperties>
+    <NativeBinPlaceDependsOnTargets Condition="'$(TargetOS)' == 'Browser'">BuildWasmRuntimes</NativeBinPlaceDependsOnTargets>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,8 +25,11 @@
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\src\*.vbproj" Exclude="@(ProjectExclusions)" />
   </ItemGroup>
 
+  <Import Condition="'$(TargetOS)' == 'Browser'" Project="$(MonoProjectRoot)wasm\wasm.targets" />
+
   <Target Name="NativeBinPlace"
-          BeforeTargets="Build">
+          AfterTargets="Build"
+          DependsOnTargets="$(NativeBinPlaceDependsOnTargets)">
     <MSBuild Targets="Build"
              Projects="@(NativeBinPlaceProject)"
              Properties="$(TraversalGlobalProperties)" />

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -10,7 +10,8 @@ BINDIR?=$(TOP)/artifacts/bin
 OBJDIR?=$(TOP)/artifacts/obj
 PINVOKE_TABLE?=$(TOP)/artifacts/obj/mono/Browser.wasm.$(CONFIG)/wasm/pinvoke-table.h
 MONO_BIN_DIR?=$(BINDIR)/mono/Browser.wasm.$(CONFIG)
-SYS_NATIVE_DIR?=$(BINDIR)/native/net5.0-Browser-$(CONFIG)-wasm/
+SYS_NATIVE_DIR?=$(OBJDIR)/native/net5.0-Browser-$(CONFIG)-wasm/System.Native
+BUILDS_BIN_DIR?=$(BINDIR)/native/net5.0-Browser-$(CONFIG)-wasm/wasm/runtimes
 
 all: build-native
 
@@ -44,7 +45,6 @@ emsdk_env.sh: | provision-wasm
 
 MONO_OBJ_DIR=$(OBJDIR)/mono/Browser.wasm.$(CONFIG)
 MONO_INCLUDE_DIR=$(MONO_BIN_DIR)/include/mono-2.0
-BUILDS_BIN_DIR=$(SYS_NATIVE_DIR)/wasm/runtimes
 BUILDS_OBJ_DIR=$(MONO_OBJ_DIR)/wasm/runtimes
 MONO_LIBS = \
 	$(MONO_BIN_DIR)/{libmono-ee-interp.a,libmonosgen-2.0.a,libmono-ilgen.a,libmono-icall-table.a} \

--- a/src/mono/wasm/wasm.targets
+++ b/src/mono/wasm/wasm.targets
@@ -1,14 +1,10 @@
-<Project Sdk="Microsoft.Build.Traversal">
-  <PropertyGroup>
-    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-  </PropertyGroup>
+<Project>
 
   <UsingTask TaskName="PInvokeTableGenerator"
     AssemblyFile="$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', 'WasmAppBuilder', 'Debug', '$(NetCoreAppCurrent)', 'publish', 'WasmAppBuilder.dll'))"/>
 
   <PropertyGroup>
-    <WasmPInvokeTablePath>$(MonoObjDir)wasm/pinvoke-table.h</WasmPInvokeTablePath>
-    <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\runtimes\browser-wasm\lib\$(NetCoreAppCurrent)</RuntimePackDir>
+    <WasmPInvokeTablePath>$(ArtifactsObjDir)wasm/pinvoke-table.h</WasmPInvokeTablePath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -29,7 +25,7 @@
   </Target>
 
   <Target Name="BuildPInvokeTable" DependsOnTargets="CheckEnv">
-    <MakeDir Directories="$(MonoObjDir)wasm"/>
+    <MakeDir Directories="$(ArtifactsObjDir)wasm"/>
     <PInvokeTableGenerator
       Modules="@(WasmPInvokeModules)"
       Assemblies="@(WasmPInvokeAssemblies)"
@@ -38,9 +34,8 @@
   </Target>
 
   <Target Name="BuildWasmRuntimes"
-          AfterTargets="Build"
           DependsOnTargets="BuildPInvokeTable">
-    <Exec Command="make -C $(MonoProjectRoot)wasm all SHELL=/bin/bash BINDIR=$(ArtifactsBinDir) MONO_BIN_DIR=$(MonoArtifactsPath) OBJDIR=$(ArtifactsObjDir) SYS_NATIVE_DIR=$(ArtifactsBinDir)/native/$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture) CONFIG=$(Configuration) PINVOKE_TABLE=$(WasmPInvokeTablePath)" IgnoreStandardErrorWarningFormat="true"/>
+    <Exec Command="make -C $(MonoProjectRoot)wasm all SHELL=/bin/bash BINDIR=$(ArtifactsBinDir) MONO_BIN_DIR=$(MonoArtifactsPath) OBJDIR=$(ArtifactsObjDir) BUILDS_BIN_DIR=$(NativeBinDir)/wasm/runtimes SYS_NATIVE_DIR=$(ArtifactsObjDir)/native/$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)/System.Native CONFIG=$(Configuration) PINVOKE_TABLE=$(WasmPInvokeTablePath)" IgnoreStandardErrorWarningFormat="true"/>
   </Target>
 
 </Project>

--- a/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -68,7 +68,7 @@ public class WasmAppBuilder : Task
         foreach (var assembly in Assemblies!.Values)
             File.Copy (assembly.Location, Path.Join (AppDir, "managed", Path.GetFileName (assembly.Location)), true);
         foreach (var f in new string [] { "dotnet.wasm", "dotnet.js" })
-            File.Copy (Path.Join (RuntimePackDir, "native", "wasm", "release", f), Path.Join (AppDir, f), true);
+            File.Copy (Path.Join (RuntimePackDir, "native", "wasm", "runtimes", "release", f), Path.Join (AppDir, f), true);
         File.Copy (MainJS!, Path.Join (AppDir, Path.GetFileName (MainJS!)),  true);
 
         using (var sw = File.CreateText (Path.Join (AppDir, "mono-config.js"))) {


### PR DESCRIPTION
It got broken by https://github.com/dotnet/runtime/pull/36781