### PR TITLE
Pipelines fast-path, return single block outside of lock

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/BufferSegment.cs
@@ -60,6 +60,31 @@ namespace System.IO.Pipelines
             AvailableMemory = arrayPoolBuffer;
         }
 
+        public IMemoryOwner<byte>? GetMemoryBlockAndResetSegment()
+        {
+            IMemoryOwner<byte>? memoryOwner = _memoryOwner;
+            if (memoryOwner != null)
+            {
+                _memoryOwner = null;
+                // We return the owner rather than disposing
+            }
+            else
+            {
+                Debug.Assert(_array != null);
+                ArrayPool<byte>.Shared.Return(_array);
+                _array = null;
+            }
+
+            Next = null;
+            RunningIndex = 0;
+            Memory = default;
+            _next = null;
+            _end = 0;
+            AvailableMemory = default;
+
+            return memoryOwner;
+        }
+
         public void ResetMemory()
         {
             IMemoryOwner<byte>? memoryOwner = _memoryOwner;

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -438,11 +438,10 @@ namespace System.IO.Pipelines
                 ThrowHelper.ThrowInvalidOperationException_InvalidExaminedOrConsumedPosition();
             }
 
-            BufferSegment? returnStart = null;
-            BufferSegment? returnEnd = null;
-
             CompletionData completionData = default;
 
+            IMemoryOwner<byte>? blockToReturn = null;
+            bool success;
             lock (_sync)
             {
                 var examinedEverything = false;
@@ -475,6 +474,8 @@ namespace System.IO.Pipelines
                     }
                 }
 
+                BufferSegment? returnStart = null;
+                BufferSegment? returnEnd = null;
                 if (consumedSegment != null)
                 {
                     if (_readHead == null)
@@ -541,18 +542,49 @@ namespace System.IO.Pipelines
                     _readerAwaitable.SetUncompleted();
                 }
 
-                while (returnStart != null && returnStart != returnEnd)
+                if (returnStart != null && returnStart != returnEnd)
                 {
                     BufferSegment? next = returnStart.NextSegment;
-                    returnStart.ResetMemory();
-                    ReturnSegmentUnsynchronized(returnStart);
-                    returnStart = next;
+                    if (next == null || next == returnEnd)
+                    {
+                        // Fast-path, single block to return; we will return the block outside of the lock.
+                        blockToReturn = returnStart.GetMemoryBlockAndResetSegment();
+                        ReturnSegmentUnsynchronized(returnStart);
+                    }
+                    else
+                    {
+                        // Multiple blocks to return; we will do it inside of lock.
+                        returnStart.ResetMemory();
+                        ReturnSegmentUnsynchronized(returnStart);
+                        returnStart = next;
+                        do
+                        {
+                            next = returnStart.NextSegment;
+                            returnStart.ResetMemory();
+                            ReturnSegmentUnsynchronized(returnStart);
+                            returnStart = next;
+                        } while (returnStart != null && returnStart != returnEnd) ;
+                    }
                 }
 
-                _operationState.EndRead();
+                success = _operationState.TryEndRead();
             }
 
-            TrySchedule(_writerScheduler, completionData);
+            if (success)
+            {
+                TrySchedule(_writerScheduler, completionData);
+            }
+
+            // Return the block before throwing the exception if there is one.
+            if (blockToReturn != null)
+            {
+                blockToReturn.Dispose();
+            }
+
+            if (!success)
+            {
+                ThrowHelper.ThrowInvalidOperationException_NoReadToComplete();
+            }
         }
 
         internal void CompleteReader(Exception? exception)

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeOperationState.cs
@@ -47,6 +47,19 @@ namespace System.IO.Pipelines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryEndRead()
+        {
+            if ((_state & State.Reading) != State.Reading &&
+                (_state & State.ReadingTentative) != State.ReadingTentative)
+            {
+                return false;
+            }
+
+            _state &= ~(State.Reading | State.ReadingTentative);
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void BeginWrite()
         {
             _state |= State.Writing;


### PR DESCRIPTION
`MemoryBlock.Dispose()` is a significant portion of `AdvanceReader`; add a fast path so when there is a single `BufferSegment` return that inside the lock and return the `MemoryBlock` outside; leaving the lock and triggering the callback early.

![image](https://user-images.githubusercontent.com/1142958/82844517-b2510480-9ed8-11ea-8f78-dea7881f1a55.png)

After for Json the majority use the new path:

![image](https://user-images.githubusercontent.com/1142958/82846505-095ad780-9ee1-11ea-92ca-c61cb0f78690.png)

