### PR TITLE
Avoid extra casts in SocketAsyncContext

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -126,17 +126,12 @@ namespace System.Net.Sockets
 
             public readonly SocketAsyncContext AssociatedContext;
             public AsyncOperation Next = null!; // initialized by helper called from ctor
-            protected object? CallbackOrEvent;
             public SocketError ErrorCode;
             public byte[]? SocketAddress;
             public int SocketAddressLen;
             public CancellationTokenRegistration CancellationRegistration;
 
-            public ManualResetEventSlim? Event
-            {
-                get { return CallbackOrEvent as ManualResetEventSlim; }
-                set { CallbackOrEvent = value; }
-            }
+            public ManualResetEventSlim? Event { get; set; }
 
             public AsyncOperation(SocketAsyncContext context)
             {
@@ -147,6 +142,7 @@ namespace System.Net.Sockets
             public void Reset()
             {
                 _state = (int)State.Waiting;
+                Event = null;
                 Next = this;
 #if DEBUG
                 _callbackQueued = 0;
@@ -240,10 +236,10 @@ namespace System.Net.Sockets
                 // It's our responsibility to set the error code and queue the completion.
                 DoAbort();
 
-                var @event = CallbackOrEvent as ManualResetEventSlim;
-                if (@event != null)
+                ManualResetEventSlim? e = Event;
+                if (e != null)
                 {
-                    @event.Set();
+                    e.Set();
                 }
                 else
                 {
@@ -360,13 +356,10 @@ namespace System.Net.Sockets
 
             protected sealed override void Abort() { }
 
-            public Action<int, byte[]?, int, SocketFlags, SocketError>? Callback
-            {
-                set => CallbackOrEvent = value;
-            }
+            public Action<int, byte[]?, int, SocketFlags, SocketError>? Callback { get; set; }
 
             public override void InvokeCallback(bool allowPooling) =>
-                ((Action<int, byte[]?, int, SocketFlags, SocketError>)CallbackOrEvent!)(BytesTransferred, SocketAddress, SocketAddressLen, SocketFlags.None, ErrorCode);
+                Callback!(BytesTransferred, SocketAddress, SocketAddressLen, SocketFlags.None, ErrorCode);
         }
 
         private sealed class BufferMemorySendOperation : SendOperation
@@ -383,7 +376,7 @@ namespace System.Net.Sockets
 
             public override void InvokeCallback(bool allowPooling)
             {
-                var cb = (Action<int, byte[]?, int, SocketFlags, SocketError>)CallbackOrEvent!;
+                var cb = Callback!;
                 int bt = BytesTransferred;
                 byte[]? sa = SocketAddress;
                 int sal = SocketAddressLen;
@@ -412,7 +405,7 @@ namespace System.Net.Sockets
 
             public override void InvokeCallback(bool allowPooling)
             {
-                var cb = (Action<int, byte[]?, int, SocketFlags, SocketError>)CallbackOrEvent!;
+                var cb = Callback!;
                 int bt = BytesTransferred;
                 byte[]? sa = SocketAddress;
                 int sal = SocketAddressLen;
@@ -450,14 +443,10 @@ namespace System.Net.Sockets
 
             protected sealed override void Abort() { }
 
-            public Action<int, byte[]?, int, SocketFlags, SocketError>? Callback
-            {
-                set => CallbackOrEvent = value;
-            }
+            public Action<int, byte[]?, int, SocketFlags, SocketError>? Callback { get; set; }
 
             public override void InvokeCallback(bool allowPooling) =>
-                ((Action<int, byte[]?, int, SocketFlags, SocketError>)CallbackOrEvent!)(
-                    BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, ErrorCode);
+                Callback!(BytesTransferred, SocketAddress, SocketAddressLen, ReceivedFlags, ErrorCode);
         }
 
         private sealed class BufferMemoryReceiveOperation : ReceiveOperation
@@ -496,7 +485,7 @@ namespace System.Net.Sockets
 
             public override void InvokeCallback(bool allowPooling)
             {
-                var cb = (Action<int, byte[]?, int, SocketFlags, SocketError>)CallbackOrEvent!;
+                var cb = Callback!;
                 int bt = BytesTransferred;
                 byte[]? sa = SocketAddress;
                 int sal = SocketAddressLen;
@@ -523,7 +512,7 @@ namespace System.Net.Sockets
 
             public override void InvokeCallback(bool allowPooling)
             {
-                var cb = (Action<int, byte[]?, int, SocketFlags, SocketError>)CallbackOrEvent!;
+                var cb = Callback!;
                 int bt = BytesTransferred;
                 byte[]? sa = SocketAddress;
                 int sal = SocketAddressLen;
@@ -566,17 +555,13 @@ namespace System.Net.Sockets
 
             protected sealed override void Abort() { }
 
-            public Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError> Callback
-            {
-                set => CallbackOrEvent = value;
-            }
+            public Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError>? Callback { get; set; }
 
             protected override bool DoTryComplete(SocketAsyncContext context) =>
                 SocketPal.TryCompleteReceiveMessageFrom(context._socket, Buffer.Span, Buffers, Flags, SocketAddress!, ref SocketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
 
             public override void InvokeCallback(bool allowPooling) =>
-                ((Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError>)CallbackOrEvent!)(
-                    BytesTransferred, SocketAddress!, SocketAddressLen, ReceivedFlags, IPPacketInformation, ErrorCode);
+                Callback!(BytesTransferred, SocketAddress!, SocketAddressLen, ReceivedFlags, IPPacketInformation, ErrorCode);
         }
 
         private sealed class AcceptOperation : ReadOperation
@@ -585,10 +570,7 @@ namespace System.Net.Sockets
 
             public AcceptOperation(SocketAsyncContext context) : base(context) { }
 
-            public Action<IntPtr, byte[], int, SocketError>? Callback
-            {
-                set => CallbackOrEvent = value;
-            }
+            public Action<IntPtr, byte[], int, SocketError>? Callback { get; set; }
 
             protected override void Abort() =>
                 AcceptedFileDescriptor = (IntPtr)(-1);
@@ -602,7 +584,7 @@ namespace System.Net.Sockets
 
             public override void InvokeCallback(bool allowPooling)
             {
-                var cb = (Action<IntPtr, byte[], int, SocketError>)CallbackOrEvent!;
+                var cb = Callback!;
                 IntPtr fd = AcceptedFileDescriptor;
                 byte[] sa = SocketAddress!;
                 int sal = SocketAddressLen;
@@ -621,10 +603,7 @@ namespace System.Net.Sockets
         {
             public ConnectOperation(SocketAsyncContext context) : base(context) { }
 
-            public Action<SocketError> Callback
-            {
-                set => CallbackOrEvent = value;
-            }
+            public Action<SocketError>? Callback { get; set; }
 
             protected override void Abort() { }
 
@@ -636,7 +615,7 @@ namespace System.Net.Sockets
             }
 
             public override void InvokeCallback(bool allowPooling) =>
-                ((Action<SocketError>)CallbackOrEvent!)(ErrorCode);
+                Callback!(ErrorCode);
         }
 
         private sealed class SendFileOperation : WriteOperation
@@ -650,13 +629,10 @@ namespace System.Net.Sockets
 
             protected override void Abort() { }
 
-            public Action<long, SocketError> Callback
-            {
-                set => CallbackOrEvent = value;
-            }
+            public Action<long, SocketError>? Callback { get; set; }
 
             public override void InvokeCallback(bool allowPooling) =>
-                ((Action<long, SocketError>)CallbackOrEvent!)(BytesTransferred, ErrorCode);
+                Callback!(BytesTransferred, ErrorCode);
 
             protected override bool DoTryComplete(SocketAsyncContext context) =>
                 SocketPal.TryCompleteSendFile(context._socket, FileHandle, ref Offset, ref Count, ref BytesTransferred, out ErrorCode);


### PR DESCRIPTION
Store `ManualResetEventSlim` and `Action`s as strongly defined types.

They are pooled so isn't much advantage for saving one pointer field in exchange for 2 class casts.

Removes them from 3 such paths for Json TE

![image](https://user-images.githubusercontent.com/1142958/82857959-674fe500-9f0a-11ea-98a2-238d1b5bb157.png)


/cc @adamsitnik  @stephentoub 