### PR TITLE
[mono] Switch to getCacheDir if getExternalFilesDir is not available

### DIFF
--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/MonoRunner.java
@@ -48,7 +48,11 @@ public class MonoRunner extends Instrumentation
         Context context = getContext();
         String filesDir = context.getFilesDir().getAbsolutePath();
         String cacheDir = context.getCacheDir().getAbsolutePath();
-        String docsDir  = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS).getAbsolutePath();
+        File docsPath  = context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS);
+        if (docsPath == null) {
+            docsPath = context.getCacheDir();
+        }
+        String docsDir = docsPath.getAbsolutePath();
 
         // unzip libs and test files to filesDir
         unzipAssets(context, filesDir, "assets.zip");


### PR DESCRIPTION
getExternalFilesDir returns null if sdcard is not mounted (e.g. emulator was configured without it).