### PR TITLE
[mono] Remove unaligned apk after Sign step

### DIFF
--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/ApkBuilder.cs
@@ -218,6 +218,8 @@ public class ApkBuilder
 
         string alignedApk = Path.Combine(OutputDir, "bin", $"{ProjectName}.apk");
         Utils.RunProcess(zipalign, $"-v 4 {apkFile} {alignedApk}", workingDir: OutputDir);
+        // we don't need the unaligned one any more
+        File.Delete(apkFile);
 
         // 5. Generate key
         


### PR DESCRIPTION
We don't need two *.apk files in the output dir