### PR TITLE
Avoid HttpClientHandler.ServerCertificateCustomValidationCallback keeping first request message alive

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -136,7 +136,12 @@ namespace System.Net.Http
                 Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> localFromHttpClientHandler = mapper.FromHttpClientHandler;
                 HttpRequestMessage localRequest = request;
                 sslOptions.RemoteCertificateValidationCallback = (object sender, X509Certificate? certificate, X509Chain? chain, SslPolicyErrors sslPolicyErrors) =>
-                    localFromHttpClientHandler(localRequest, certificate as X509Certificate2, chain, sslPolicyErrors);
+                {
+                    Debug.Assert(localRequest != null);
+                    bool result = localFromHttpClientHandler(localRequest, certificate as X509Certificate2, chain, sslPolicyErrors);
+                    localRequest = null!; // ensure the SslOptions and this callback don't keep the first HttpRequestMessage alive indefinitely
+                    return result;
+                };
             }
 
             // Create the SslStream, authenticate, and return it.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36979
cc: @filipnavara, @wfurt, @davidsh