### PR TITLE
Fix bad refcount management in ComWrappers WeakReference test.

### DIFF
--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.cs
@@ -65,6 +65,7 @@ namespace ComWrappersTests
 
             protected override object CreateObject(IntPtr externalComObject, CreateObjectFlags flag)
             {
+                Marshal.AddRef(externalComObject);
                 return new WeakReferencableWrapper(externalComObject);
             }
 
@@ -86,11 +87,6 @@ namespace ComWrappersTests
                 IntPtr objRaw = WeakReferenceNative.CreateWeakReferencableObject();
 
                 var obj = (WeakReferencableWrapper)cw.GetOrCreateObjectForComInstance(objRaw, CreateObjectFlags.None);
-
-                // The returned WeakReferencableWrapper from ComWrappers takes ownership
-                // of the ref returned from CreateWeakReferencableObject.
-                // Call Marshal.AddRef to ensure that objRaw owns a reference.
-                Marshal.AddRef(objRaw);
 
                 return (new WeakReference<WeakReferencableWrapper>(obj), objRaw);
             }


### PR DESCRIPTION
When the ComWrappers instance is called by the runtime, we can't assume that we take control of the reference. The contract is that we don't own the reference we are passed when called globally, which I got wrong in this test.

Fixes #36970 