### PR TITLE
Update the -vs switch and add docs for it

### DIFF
--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -71,7 +71,7 @@ While not strictly needed to build or test this repository, having the .NET SDK 
 We use this in the [Using Your Build](../testing/using-your-build.md) instructions.
 The minimum required version of the SDK is specified in the [global.json file](https://github.com/dotnet/runtime/blob/master/global.json#L3). [You can find the installers and binaries for nightly builds of .NET SDK here](https://github.com/dotnet/installer#installers-and-binaries).
 
-Alternatively to avoid modifying your machine state, you can use the repository's locally acquired SDK by passing in the solution to load via the `-vs` switch:
+Alternatively, to avoid modifying your machine state, you can use the repository's locally acquired SDK by passing in the solution to load via the `-vs` switch:
 
 ```
 build.cmd -vs System.Text.RegularExpressions

--- a/docs/workflow/requirements/windows-requirements.md
+++ b/docs/workflow/requirements/windows-requirements.md
@@ -71,6 +71,14 @@ While not strictly needed to build or test this repository, having the .NET SDK 
 We use this in the [Using Your Build](../testing/using-your-build.md) instructions.
 The minimum required version of the SDK is specified in the [global.json file](https://github.com/dotnet/runtime/blob/master/global.json#L3). [You can find the installers and binaries for nightly builds of .NET SDK here](https://github.com/dotnet/installer#installers-and-binaries).
 
+Alternatively to avoid modifying your machine state, you can use the repository's locally acquired SDK by passing in the solution to load via the `-vs` switch:
+
+```
+build.cmd -vs System.Text.RegularExpressions
+```
+
+This will set the `DOTNET_ROOT` and `PATH` environment variables to point to the locally acquired SDK under `runtime\.dotnet\` and will launch the Visual Studio instance which is registered for the `sln` extension.
+
 ## Adding to the default PATH variable
 
 The commands above need to be on your command lookup path.   Some installers will automatically add them to the path as part of the installation, but if not here is how you can do it.

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -5,6 +5,7 @@ Param(
   [ValidateSet("Debug","Release","Checked")][string[]][Alias('c')]$configuration = @("Debug"),
   [string][Alias('f')]$framework,
   [string]$vs,
+  [string][Alias('v')]$verbosity = "minimal",
   [ValidateSet("Windows_NT","Linux","OSX","Browser")][string]$os,
   [switch]$allconfigurations,
   [switch]$coverage,
@@ -65,14 +66,14 @@ if ($vs) {
   if (-Not (Test-Path $vs)) {
     $solution = $vs
     # Search for the solution in libraries
-    $vs = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "\src\libraries") $vs | Join-Path -ChildPath "$vs.sln"
+    $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\libraries" | Join-Path -ChildPath $vs | Join-Path -ChildPath "$vs.sln"
     if (-Not (Test-Path $vs)) {
       $vs = $solution
       # Search for the solution in installer
       if (-Not ($vs.endswith(".sln"))) {
         $vs = "$vs.sln"
       }
-      $vs = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "\src\installer") $vs
+      $vs = Split-Path $PSScriptRoot -Parent | Join-Path -ChildPath "src\installer" | Join-Path -ChildPath $vs
       if (-Not (Test-Path $vs)) {
         Write-Error "Passed in solution cannot be resolved."
         exit 1
@@ -125,6 +126,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "os"                     { $arguments += " /p:TargetOS=$($PSBoundParameters[$argument])" }
     "allconfigurations"      { $arguments += " /p:BuildAllConfigurations=true" }
     "properties"             { $arguments += " " + $properties }
+    "verbosity"              { $arguments += " -$argument " + $($PSBoundParameters[$argument]) }
     # configuration and arch can be specified multiple times, so they should be no-ops here
     "configuration"          {}
     "arch"                   {}

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -20,7 +20,7 @@ Param(
 function Get-Help() {
   Write-Host "Common settings:"
   Write-Host "  -subset                   Build a subset, print available subsets with -subset help (short: -s)"
-  Write-Host "  -vs                       Open the solution with VS for Test Explorer support. Path or solution name (ie -vs Microsoft.CSharp)"
+  Write-Host "  -vs                       Open the solution with VS using the locally acquired SDK. Path or solution name (ie -vs Microsoft.CSharp)"
   Write-Host "  -os                       Build operating system: Windows_NT, Linux, OSX, or Browser"
   Write-Host "  -arch                     Build platform: x86, x64, arm, arm64, or wasm (short: -a). Pass a comma-separated list to build for multiple architectures."
   Write-Host "  -configuration            Build configuration: Debug, Release or [CoreCLR]Checked (short: -c). Pass a comma-separated list to build for multiple configurations"
@@ -59,38 +59,32 @@ if ($help -or (($null -ne $properties) -and ($properties.Contains('/help') -or $
   exit 0
 }
 
-# VS Test Explorer support for libraries
 if ($vs) {
-  Write-Host "VS Test Explorer now works without needing to call build.cmd. The -vs switch will be removed eventually."
   . $PSScriptRoot\common\tools.ps1
 
-  # Microsoft.DotNet.CoreSetup.sln is special - hosting tests are currently meant to run on the
-  # bootstrapped .NET Core, not on the live-built runtime.
-  if (([System.IO.Path]::GetFileName($vs) -ieq "Microsoft.DotNet.CoreSetup.sln") -or ($vs -ieq "Microsoft.DotNet.CoreSetup")) {
+  if (-Not (Test-Path $vs)) {
+    $solution = $vs
+    # Search for the solution in libraries
+    $vs = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "\src\libraries") $vs | Join-Path -ChildPath "$vs.sln"
     if (-Not (Test-Path $vs)) {
-      if (-Not ( $vs.endswith(".sln"))) {
-          $vs = "$vs.sln"
+      $vs = $solution
+      # Search for the solution in installer
+      if (-Not ($vs.endswith(".sln"))) {
+        $vs = "$vs.sln"
       }
-      $vs = Join-Path "$PSScriptRoot\..\src\installer" $vs
+      $vs = Join-Path (Join-Path (Split-Path $PSScriptRoot -Parent) "\src\installer") $vs
+      if (-Not (Test-Path $vs)) {
+        Write-Error "Passed in solution cannot be resolved."
+        exit 1
+      }
     }
-
-    # This tells .NET Core to use the bootstrapped runtime to run the tests
-    $env:DOTNET_ROOT=InitializeDotNetCli -install:$false
   }
-  else {
-    if (-Not (Test-Path $vs)) {
-      $vs = Join-Path "$PSScriptRoot\..\src\libraries" $vs | Join-Path -ChildPath "$vs.sln"
-    }
 
-    $archTestHost = if ($arch) { $arch } else { "x64" }
-
-    # This tells .NET Core to use the same dotnet.exe that build scripts use
-    $env:DOTNET_ROOT="$PSScriptRoot\..\artifacts\bin\testhost\net5.0-Windows_NT-$configuration-$archTestHost";
-    $env:DEVPATH="$PSScriptRoot\..\artifacts\bin\testhost\net472-Windows_NT-$configuration-$archTestHost";
-  }
+  # This tells .NET Core to use the bootstrapped runtime
+  $env:DOTNET_ROOT=InitializeDotNetCli -install:$false
 
   # This tells MSBuild to load the SDK from the directory of the bootstrapped SDK
-  $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=InitializeDotNetCli -install:$false
+  $env:DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR=$env:DOTNET_ROOT
 
   # This tells .NET Core not to go looking for .NET Core in other places
   $env:DOTNET_MULTILEVEL_LOOKUP=0;


### PR DESCRIPTION
We don't need to point to the testhost folder anymore (for libraries) to support VS Test Explorer.