### PR TITLE
Build test scripts whenever CopyNativeProjectBinaries builds

### DIFF
--- a/src/coreclr/tests/src/Directory.Build.targets
+++ b/src/coreclr/tests/src/Directory.Build.targets
@@ -106,11 +106,6 @@
     <SkipImportILTargets Condition="'$(CLRTestBuildAllTargets)' != '' And '$(CLRTestNeedTarget)' != '$(CLRTestBuildAllTargets)'">true</SkipImportILTargets>
   </PropertyGroup>
 
-  <Import Project="CLRTest.Execute.targets" />
-  <Target Name="CreateExecuteScript"
-          Condition="'$(GenerateRunScript)' != 'false' And ('$(_WillCLRTestProjectBuild)' == 'true')"
-          DependsOnTargets="GenerateExecutionScriptsInternal" />
-
   <Target Name="CopyNativeProjectBinaries" Condition="'$(_CopyNativeProjectBinaries)' == 'true'">
 
      <ItemGroup>
@@ -195,7 +190,14 @@
 
   </Target>
 
-  <Target Name="CopyAllNativeProjectReferenceBinaries" DependsOnTargets="ResolveCmakeNativeProjectReference;ConsolidateNativeProjectReference;CreateExecuteScript" />
+  <Target Name="CopyAllNativeProjectReferenceBinaries" DependsOnTargets="ResolveCmakeNativeProjectReference;ConsolidateNativeProjectReference" />
+
+  <!-- Build shell or command scripts whenever we copy native binaries -->
+  <Import Project="CLRTest.Execute.targets" />
+  <Target Name="CreateExecuteScript"
+          BeforeTargets="Build;CopyAllNativeProjectReferenceBinaries"
+          Condition="'$(_CopyNativeProjectBinaries)' == 'true' And '$(GenerateRunScript)' != 'false' And ('$(_WillCLRTestProjectBuild)' == 'true')"
+          DependsOnTargets="GenerateExecutionScriptsInternal" />
 
   <Target Name="UpdateReferenceItems"
           BeforeTargets="BeforeResolveReferences"


### PR DESCRIPTION
In the original PR, I had triggered `CreateExecuteScript` on  `ResolveCmakeNativeProjectReference` or something similarly esoteric.  @jkoritzinsky wisely asked me to clean up the style.

However when I did, I broke building in a normal developer workflow.

The intent of this change is to build the tests scripts during build, except when `/p:CopyNativeProjectBinaries=false` which is used in CI to split the native copying to a later stage. 
 Then we will build during `CopyAllNativeProjectReferenceBinaries`.

@trylek Has another working solution if it is preferred...

