### PR TITLE
Disable AddThresholdTest in all archs

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -79,7 +79,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/readytorun/r2rdump/R2RDumpTest/*">
             <Issue>19441;22020</Issue>
         </ExcludeList>
-
 	    <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/generics/Variance/Methods/Method002/*">
             <Issue>https://github.com/dotnet/runtime/issues/3893</Issue>
         </ExcludeList>
@@ -116,9 +115,12 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/classloader/generics/Variance/Interfaces/Interfaces001/*">
             <Issue>https://github.com/dotnet/runtime/issues/3893</Issue>
         </ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
+        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/AddThresholdTest/**">
+            <Issue>https://github.com/dotnet/runtime/issues/36850</Issue>
+        </ExcludeList>
+	    <ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
             <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
-	</ExcludeList>
+	    </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->
@@ -332,9 +334,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_26491/**/*">
             <Issue>https://github.com/dotnet/runtime/issues/13355</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/AddThresholdTest/**">
-            <Issue>https://github.com/dotnet/runtime/issues/36850</Issue>
         </ExcludeList>
     </ItemGroup>
 


### PR DESCRIPTION
Relates to: https://github.com/dotnet/runtime/issues/36939
This was disabled on arm64 but I just saw it fail in other archs.

https://dev.azure.com/dnceng/public/_build/results?buildId=660090&view=logs&j=bda9eb0b-5058-5134-e32d-3e883d28cb0d&t=88d8ef49-a1c8-51e6-e241-178b546e8b2d

cc: @jkotas @Maoni0 