### PR TITLE
Add dotnet.js to sign exclusion list

### DIFF
--- a/eng/SignCheckExclusionsFile.txt
+++ b/eng/SignCheckExclusionsFile.txt
@@ -12,3 +12,4 @@
 *apphosttemplateapphostexe.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
 *comhosttemplatecomhostdll.dll;;Template, https://github.com/dotnet/core-setup/pull/7549
 *staticapphosttemplateapphostexe.exe;;Template, https://github.com/dotnet/core-setup/pull/7549
+*dotnet.js;;Workaround, https://github.com/dotnet/core-eng/issues/9933


### PR DESCRIPTION
Signing validation is failing despite the file being signed. We're investigating why this is happening: https://github.com/dotnet/core-eng/issues/9933

Add this to the sign exclusion list while that is figured out to unblock official builds.

Tested locally:

```
  [File] 3b943517754ea51d97ff58b02c130a7a.js, Signed: False, Excluded, Full Name: runtimes/browser-wasm/native/wasm/runtimes/release/dotnet.js [Error] HRESULT: 800b0100 (No signature was present in the subject)
  [File] 988ff77849da3dc645cfdb57f8d7fb79.wasm, Skipped (unsupported file type), Full Name: runtimes/browser-wasm/native/wasm/runtimes/release/dotnet.wasm
  [File] 08f168eb8289c6d8021113ab635d2925.xml, Skipped (unsupported file type), Full Name: [Content_Types].xml
  [File] 598ae2191e6ed455259c38d5485f2b2f.psmdcp, Skipped (unsupported file type), Full Name: package/services/metadata/core-properties/62c096d824c44e73b77fa934952039dd.psmdcp
  [File] c32380837105e3839091314b15ef5438.p7s, Skipped (unsupported file type), Full Name: .signature.p7s

No signing issues found
Total Time: 00:00:07.4048476
Total Files: 227, Signed: 167, Unsigned: 0, Skipped: 58, Excluded: 2, Skipped & Excluded: 0

Build succeeded.
    0 Warning(s)
    0 Error(s)
```

cc: @JohnTortugo @dotnet/runtime-infrastructure 