### PR TITLE
JIT: some small improvements to tail duplication

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5129,9 +5129,9 @@ public:
 
     bool fgOptimizeUncondBranchToSimpleCond(BasicBlock* block, BasicBlock* target);
 
-    bool fgBlockEndFavorsTailDuplication(BasicBlock* block);
+    bool fgBlockEndFavorsTailDuplication(BasicBlock* block, unsigned lclNum);
 
-    bool fgBlockIsGoodTailDuplicationCandidate(BasicBlock* block);
+    bool fgBlockIsGoodTailDuplicationCandidate(BasicBlock* block, unsigned* lclNum);
 
     bool fgOptimizeEmptyBlock(BasicBlock* block);
 

--- a/src/coreclr/src/jit/phase.cpp
+++ b/src/coreclr/src/jit/phase.cpp
@@ -158,11 +158,20 @@ void Phase::PostPhase(PhaseStatus status)
     // well as the new-style phases that have been updated to return
     // PhaseStatus from their DoPhase methods.
     //
-    static Phases s_whitelist[] =
-        {PHASE_IMPORTATION,       PHASE_INDXCALL,      PHASE_MORPH_INLINE,         PHASE_ALLOCATE_OBJECTS,
-         PHASE_EMPTY_TRY,         PHASE_EMPTY_FINALLY, PHASE_MERGE_FINALLY_CHAINS, PHASE_CLONE_FINALLY,
-         PHASE_MERGE_THROWS,      PHASE_BUILD_SSA,     PHASE_RATIONALIZE,          PHASE_LOWERING,
-         PHASE_STACK_LEVEL_SETTER};
+    static Phases s_whitelist[] = {PHASE_IMPORTATION,
+                                   PHASE_INDXCALL,
+                                   PHASE_MORPH_INLINE,
+                                   PHASE_ALLOCATE_OBJECTS,
+                                   PHASE_EMPTY_TRY,
+                                   PHASE_EMPTY_FINALLY,
+                                   PHASE_MERGE_FINALLY_CHAINS,
+                                   PHASE_CLONE_FINALLY,
+                                   PHASE_MERGE_THROWS,
+                                   PHASE_MORPH_GLOBAL,
+                                   PHASE_BUILD_SSA,
+                                   PHASE_RATIONALIZE,
+                                   PHASE_LOWERING,
+                                   PHASE_STACK_LEVEL_SETTER};
 
     if (madeChanges)
     {


### PR DESCRIPTION
1. Allow duplicating when predecessor is BBJ_NONE
2. Require that predecessor and successor reference the same local
3. Make sure that local is not address exposed
4. Check up to two statements in predecessor for local reference
5. Require successor to compare local to constant, or local to local

Changes inspired by #36649 but don't actually improve CQ for that case (yet).