### PR TITLE
[browser][wasm] InteropServices.JavaScript backing code.

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -5,7 +5,7 @@
 var BindingSupportLib = {
 	$BINDING__postset: 'BINDING.export_functions (Module);',
 	$BINDING: {
-		BINDING_ASM: "[WebAssembly.Bindings]WebAssembly.Runtime",
+		BINDING_ASM: "[System.Runtime.InteropServices.JavaScript]System.Runtime.InteropServices.JavaScript.Runtime",
 		mono_wasm_object_registry: [],
 		mono_wasm_ref_counter: 0,
 		mono_wasm_free_list: [],
@@ -57,7 +57,7 @@ var BindingSupportLib = {
 
 			if (binding_fqn_class !== null && typeof binding_fqn_class !== "undefined")
 			{
-				var namespace = "WebAssembly";
+				var namespace = "System.Runtime.InteropServices.JavaScript";
 				var classname = binding_fqn_class.length > 0 ? binding_fqn_class : "Runtime";
 				if (binding_fqn_class.indexOf(".") != -1) {
 					var idx = binding_fqn_class.lastIndexOf(".");
@@ -83,7 +83,7 @@ var BindingSupportLib = {
 			this.unbind_js_obj_and_free = get_method ("UnBindJSObjectAndFree");			
 			this.unbind_raw_obj_and_free = get_method ("UnBindRawJSObjectAndFree");			
 			this.get_js_id = get_method ("GetJSObjectId");
-			this.get_raw_mono_obj = get_method ("GetMonoObject");
+			this.get_raw_mono_obj = get_method ("GetDotNetObject");
 
 			this.box_js_int = get_method ("BoxInt");
 			this.box_js_double = get_method ("BoxDouble");
@@ -103,7 +103,6 @@ var BindingSupportLib = {
 			this.create_date_time = get_method ("CreateDateTime");
 			this.create_uri = get_method ("CreateUri");
 
-			this.object_to_enum = get_method ("ObjectToEnum");
 			this.init = true;
 		},
 

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -71,23 +71,23 @@ mono_wasm_compile_function (MonoString *str, int *is_exception)
 
 void core_initialize_internals ()
 {
-	mono_add_internal_call ("WebAssembly.Runtime::InvokeJSWithArgs", mono_wasm_invoke_js_with_args);
-	mono_add_internal_call ("WebAssembly.Runtime::GetObjectProperty", mono_wasm_get_object_property);
-	mono_add_internal_call ("WebAssembly.Runtime::GetByIndex", mono_wasm_get_by_index);
-	mono_add_internal_call ("WebAssembly.Runtime::SetObjectProperty", mono_wasm_set_object_property);
-	mono_add_internal_call ("WebAssembly.Runtime::SetByIndex", mono_wasm_set_by_index);
-	mono_add_internal_call ("WebAssembly.Runtime::GetGlobalObject", mono_wasm_get_global_object);
-	mono_add_internal_call ("WebAssembly.Runtime::ReleaseHandle", mono_wasm_release_handle);
-	mono_add_internal_call ("WebAssembly.Runtime::ReleaseObject", mono_wasm_release_object);
-	mono_add_internal_call ("WebAssembly.Runtime::NewObjectJS", mono_wasm_new_object);
-	mono_add_internal_call ("WebAssembly.Runtime::BindCoreObject", mono_wasm_bind_core_object);
-	mono_add_internal_call ("WebAssembly.Runtime::BindHostObject", mono_wasm_bind_host_object);
-	mono_add_internal_call ("WebAssembly.Runtime::New", mono_wasm_new);
-	mono_add_internal_call ("WebAssembly.Runtime::TypedArrayToArray", mono_wasm_typed_array_to_array);
-	mono_add_internal_call ("WebAssembly.Runtime::TypedArrayCopyTo", mono_wasm_typed_array_copy_to);
-	mono_add_internal_call ("WebAssembly.Runtime::TypedArrayFrom", mono_wasm_typed_array_from);
-	mono_add_internal_call ("WebAssembly.Runtime::TypedArrayCopyFrom", mono_wasm_typed_array_copy_from);
-	mono_add_internal_call ("WebAssembly.Runtime::CompileFunction", mono_wasm_compile_function);
+	mono_add_internal_call ("Interop/Runtime::InvokeJSWithArgs", mono_wasm_invoke_js_with_args);
+	mono_add_internal_call ("Interop/Runtime::GetObjectProperty", mono_wasm_get_object_property);
+	mono_add_internal_call ("Interop/Runtime::GetByIndex", mono_wasm_get_by_index);
+	mono_add_internal_call ("Interop/Runtime::SetObjectProperty", mono_wasm_set_object_property);
+	mono_add_internal_call ("Interop/Runtime::SetByIndex", mono_wasm_set_by_index);
+	mono_add_internal_call ("Interop/Runtime::GetGlobalObject", mono_wasm_get_global_object);
+	mono_add_internal_call ("Interop/Runtime::ReleaseHandle", mono_wasm_release_handle);
+	mono_add_internal_call ("Interop/Runtime::ReleaseObject", mono_wasm_release_object);
+	mono_add_internal_call ("Interop/Runtime::NewObjectJS", mono_wasm_new_object);
+	mono_add_internal_call ("Interop/Runtime::BindCoreObject", mono_wasm_bind_core_object);
+	mono_add_internal_call ("Interop/Runtime::BindHostObject", mono_wasm_bind_host_object);
+	mono_add_internal_call ("Interop/Runtime::New", mono_wasm_new);
+	mono_add_internal_call ("Interop/Runtime::TypedArrayToArray", mono_wasm_typed_array_to_array);
+	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyTo", mono_wasm_typed_array_copy_to);
+	mono_add_internal_call ("Interop/Runtime::TypedArrayFrom", mono_wasm_typed_array_from);
+	mono_add_internal_call ("Interop/Runtime::TypedArrayCopyFrom", mono_wasm_typed_array_copy_from);
+	mono_add_internal_call ("Interop/Runtime::CompileFunction", mono_wasm_compile_function);
 
 }
 


### PR DESCRIPTION
Update the wasm runtime code to support new naming conventions of the bindings bridge code.

This PR does not depend on any other to be approved and merged.