### PR TITLE
[interp] Remove saving of clause_args from interp state

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -205,7 +205,6 @@ typedef struct {
 	unsigned char *vt_sp;
 	const unsigned short  *ip;
 	GSList *finally_ips;
-	FrameClauseArgs *clause_args;
 } InterpState;
 
 struct InterpFrame {


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19857,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>clause_args can be set only from EH. This means that clause_args can be set only in the first executed frame, so there is no need to save it in the interp state. Also make sure we never check for it in the main_loop block, for normal calls and returns. Added exec_frame to the clause_args so we can detect whether a frame is the first frame invoked from EH. We can no longer use clause_args for this purpose because we no longer save it in the interp state.

Makes calls 6% faster