### PR TITLE
Fix build with FEATURE_GDBJIT enabled

### DIFF
--- a/src/coreclr/src/vm/gdbjit.cpp
+++ b/src/coreclr/src/vm/gdbjit.cpp
@@ -1792,16 +1792,6 @@ void VarDebugInfo::DumpDebugInfo(char* ptr, int& offset)
     offset += len;
 }
 
-/* static data for symbol strings */
-struct Elf_Symbol {
-    const char* m_name;
-    int m_off;
-    TADDR m_value;
-    int m_section, m_size;
-    NewArrayHolder<char> m_symbol_name;
-    Elf_Symbol() : m_name(nullptr), m_off(0), m_value(0), m_section(0), m_size(0) {}
-};
-
 template <class T>
 static int countFuncs(T &arr, int n)
 {

--- a/src/coreclr/src/vm/gdbjit.h
+++ b/src/coreclr/src/vm/gdbjit.h
@@ -334,7 +334,16 @@ public:
     uintptr_t m_high_pc;
 };
 
-struct Elf_Symbol;
+/* static data for symbol strings */
+struct Elf_Symbol {
+    const char* m_name;
+    int m_off;
+    TADDR m_value;
+    int m_section, m_size;
+    NewArrayHolder<char> m_symbol_name;
+    Elf_Symbol() : m_name(nullptr), m_off(0), m_value(0), m_section(0), m_size(0) {}
+};
+
 class Elf_Builder;
 class DebugStringsCU;
 


### PR DESCRIPTION
This commit fixes broken build in case when following arguments added to
build.sh script: --cmakeargs -DFEATURE_GDBJIT=true

@alpencolt, @jkotas 