### PR TITLE
[mono] Enable parallel mode for xunit on Android by default

### DIFF
--- a/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
+++ b/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
@@ -30,7 +30,8 @@ public class SimpleAndroidTestRunner : AndroidApplicationEntryPoint, IDevice
         }
         int exitCode = 0;
         s_MainTestName = Path.GetFileNameWithoutExtension(s_testLibs[0]);
-        var simpleTestRunner = new SimpleAndroidTestRunner(true);
+        string? verbose = Environment.GetEnvironmentVariable("XUNIT_VERBOSE")?.ToLower();
+        var simpleTestRunner = new SimpleAndroidTestRunner(verbose == "true" || verbose == "1");
         simpleTestRunner.TestsCompleted += (e, result) => 
         {
             if (result.FailedTests > 0)

--- a/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
@@ -195,7 +195,7 @@ namespace System.Tests.Types
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34196", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/31713", TestRuntimes.Mono)]
         public void IsByRef_Get_ReturnsExpected()
         {
             Type t = CreateType();
@@ -532,7 +532,6 @@ namespace System.Tests.Types
         public override Type BaseType => typeof(ValueType);
     }
 
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/31713", TestRuntimes.Mono)]
     public class VoidTests : StructTypeTestBase
     {
         public override Type CreateType() => typeof(void);

--- a/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
@@ -195,6 +195,7 @@ namespace System.Tests.Types
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/34196", TestRuntimes.Mono)]
         public void IsByRef_Get_ReturnsExpected()
         {
             Type t = CreateType();

--- a/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/runtime-android.c
+++ b/tools-local/tasks/mobile.tasks/AndroidAppBuilder/Templates/runtime-android.c
@@ -139,8 +139,9 @@ mono_mobile_runtime_init (void)
 {
     // uncomment for debug output:
     //
-    // setenv ("MONO_LOG_LEVEL", "debug", TRUE);
-    // setenv ("MONO_LOG_MASK", "all", TRUE);
+    // setenv ("XUNIT_VERBOSE", "true", true);
+    // setenv ("MONO_LOG_LEVEL", "debug", true);
+    // setenv ("MONO_LOG_MASK", "all", true);
 
     bool wait_for_debugger = false;
     chdir (bundle_path);


### PR DESCRIPTION
1) Fix crash in System.Runtime.Tests - there is a test "IsByRef_Get_ReturnsExpected" - it doesn't crash on execution but somehow affects xunit report generation, we used to ignore it in mono/mono too: https://github.com/mono/mono/blob/master/netcore/CoreFX.issues.rsp#L488-L489

2) Enable parallel test execution by default