### PR TITLE
Pipeline performance tweaks (follow-up)

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -113,7 +112,7 @@ namespace System.IO.Pipelines
             // If we're using the default pool then mark it as null since we're just going to use the
             // array pool under the covers
             _pool = options.Pool == MemoryPool<byte>.Shared ? null : options.Pool;
-            _maxPooledBufferSize = _pool?.MaxBufferSize ?? 0;
+            _maxPooledBufferSize = _pool?.MaxBufferSize ?? -1;
             _minimumSegmentSize = options.MinimumSegmentSize;
             _pauseWriterThreshold = options.PauseWriterThreshold;
             _resumeWriterThreshold = options.ResumeWriterThreshold;
@@ -224,13 +223,14 @@ namespace System.IO.Pipelines
 
         private BufferSegment AllocateSegment(int sizeHint)
         {
+            Debug.Assert(sizeHint >= 0);
             BufferSegment newSegment = CreateSegmentUnsynchronized();
 
             int maxSize = _maxPooledBufferSize;
-            if (_pool != null && sizeHint <= maxSize)
+            if (sizeHint <= maxSize)
             {
-                // Use the specified pool as it fits
-                newSegment.SetOwnedMemory(_pool.Rent(GetSegmentSize(sizeHint, maxSize)));
+                // Use the specified pool as it fits. Specified pool is not null as maxSize == -1 if _pool is null.
+                newSegment.SetOwnedMemory(_pool!.Rent(GetSegmentSize(sizeHint, maxSize)));
             }
             else
             {

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -23,6 +23,7 @@ namespace System.IO.Pipelines
         private int _bytesBuffered;
 
         private readonly MemoryPool<byte>? _pool;
+        private readonly int _maxPooledBufferSize;
 
         private CancellationTokenSource? _internalTokenSource;
         private bool _isCompleted;
@@ -57,6 +58,7 @@ namespace System.IO.Pipelines
 
             _minimumBufferSize = options.MinimumBufferSize;
             _pool = options.Pool == MemoryPool<byte>.Shared ? null : options.Pool;
+            _maxPooledBufferSize = _pool?.MaxBufferSize ?? -1;
             _bufferSegmentPool = new BufferSegmentStack(InitialSegmentPoolSize);
             _leaveOpen = options.LeaveOpen;
         }
@@ -150,18 +152,20 @@ namespace System.IO.Pipelines
 
         private BufferSegment AllocateSegment(int sizeHint)
         {
+            Debug.Assert(sizeHint >= 0);
             BufferSegment newSegment = CreateSegmentUnsynchronized();
 
-            if (_pool is null || sizeHint > _pool.MaxBufferSize)
+            int maxSize = _maxPooledBufferSize;
+            if (sizeHint <= maxSize)
+            {
+                // Use the specified pool as it fits. Specified pool is not null as maxSize == -1 if _pool is null.
+                newSegment.SetOwnedMemory(_pool!.Rent(GetSegmentSize(sizeHint, maxSize)));
+            }
+            else
             {
                 // Use the array pool
                 int sizeToRequest = GetSegmentSize(sizeHint);
                 newSegment.SetOwnedMemory(ArrayPool<byte>.Shared.Rent(sizeToRequest));
-            }
-            else
-            {
-                // Use the specified pool as it fits
-                newSegment.SetOwnedMemory(_pool.Rent(GetSegmentSize(sizeHint, _pool.MaxBufferSize)));
             }
 
             _tailMemory = newSegment.AvailableMemory;


### PR DESCRIPTION
This is a follow-up to #36815 by @benaadams:

- Remove explicit null check based on the facts that `sizeHint` is guaranteed to be non-negative and `maxSize == -1` if `_pool is null`.
- Apply tweaks from Pipe to duplicated code in StreamPipeWriter