### PR TITLE
Improve Console for iOS and Android

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Android.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Android.cs
@@ -11,7 +11,7 @@ namespace System
 {
     internal sealed unsafe class LogcatStream : ConsoleStream
     {
-        private StringBuilder _buffer = new StringBuilder();
+        private readonly StringBuilder _buffer = new StringBuilder();
 
         public LogcatStream() : base(FileAccess.Write) {}
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Android.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Android.cs
@@ -21,7 +21,7 @@ namespace System
         {
             ValidateWrite(buffer, offset, count);
 
-            ReadOnlySpan<byte> bufferSpan = new ReadOnlySpan<byte>(buffer, offset, count)
+            ReadOnlySpan<byte> bufferSpan = new ReadOnlySpan<byte>(buffer, offset, count);
 
             Debug.Assert(ConsolePal.OutputEncoding == Encoding.Unicode);
             Debug.Assert(bufferSpan.Length % 2 == 0);

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -11,7 +11,7 @@ namespace System
 {
     internal sealed class NSLogStream : ConsoleStream
     {
-        private StringBuilder _buffer = new StringBuilder();
+        private readonly StringBuilder _buffer = new StringBuilder();
 
         public NSLogStream() : base(FileAccess.Write) {}
 

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -21,7 +21,7 @@ namespace System
         {
             ValidateWrite(buffer, offset, count);
 
-            ReadOnlySpan<byte> bufferSpan = new ReadOnlySpan<byte>(buffer, offset, count)
+            ReadOnlySpan<byte> bufferSpan = new ReadOnlySpan<byte>(buffer, offset, count);
 
             Debug.Assert(ConsolePal.OutputEncoding == Encoding.Unicode);
             Debug.Assert(bufferSpan.Length % 2 == 0);

--- a/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
+++ b/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
@@ -94,7 +94,7 @@ namespace System.IO
             if (!_canWrite) throw Error.GetWriteNotSupported();
         }
 
-        private static void AccumulateNewLines(StringBuilder accumulator, ReadOnlySpan<char> buffer, Action<string> printer)
+        protected static void AccumulateNewLines(StringBuilder accumulator, ReadOnlySpan<char> buffer, Action<string> printer)
         {
             int lineStartIndex = 0;
             for (int i = 0; i < buffer.Length; i++)

--- a/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
+++ b/src/libraries/System.Console/src/System/IO/ConsoleStream.cs
@@ -93,5 +93,37 @@ namespace System.IO
 
             if (!_canWrite) throw Error.GetWriteNotSupported();
         }
+
+        private static void AccumulateNewLines(StringBuilder accumulator, ReadOnlySpan<char> buffer, Action<string> printer)
+        {
+            int lineStartIndex = 0;
+            for (int i = 0; i < buffer.Length; i++)
+            {
+                if (buffer[i] == '\n')
+                {
+                    ReadOnlySpan<char> sliceWithNl = buffer.Slice(lineStartIndex, i - lineStartIndex);
+                    if (accumulator.Length > 0)
+                    {
+                        // we found a new line, append content from accumulator if it's not empty
+                        accumulator.Append(sliceWithNl);
+                        printer(accumulator.ToString());
+                        accumulator.Clear();
+                    }
+                    else
+                    {
+                        // accumulator is empty - print the line as it is
+                        printer(sliceWithNl.ToString());
+                    }
+                    lineStartIndex = i + 1;
+                }
+            }
+
+            if (buffer.Length > 0 && buffer[^1] != '\n')
+            {
+                // add a line without '\n' to accumulator
+                ReadOnlySpan<char> appendix = buffer.Slice(lineStartIndex, buffer.Length - lineStartIndex);
+                accumulator.Append(appendix);
+            }
+        }
     }
 }

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -7,8 +7,8 @@ all: runtimepack run
 
 TOOLS_DIR=../../../../../tools-local/tasks/mobile.tasks
 appbuilder:
-	$(DOTNET) build -c $(MONO_ARCH) $(TOOLS_DIR)/AotCompilerTask/MonoAOTCompiler.csproj
-	$(DOTNET) build -c $(MONO_ARCH) $(TOOLS_DIR)/AppleAppBuilder/AppleAppBuilder.csproj
+	$(DOTNET) build -c Debug $(TOOLS_DIR)/AotCompilerTask/MonoAOTCompiler.csproj
+	$(DOTNET) build -c Debug $(TOOLS_DIR)/AppleAppBuilder/AppleAppBuilder.csproj
 
 runtimepack:
 	../../../../.././build.sh Mono+Libs -os iOS -arch $(MONO_ARCH) -c $(MONO_CONFIG)

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -7,15 +7,15 @@ all: runtimepack run
 
 TOOLS_DIR=../../../../../tools-local/tasks/mobile.tasks
 appbuilder:
-	$(DOTNET) build -c Release $(TOOLS_DIR)/AotCompilerTask/MonoAOTCompiler.csproj
-	$(DOTNET) build -c Release $(TOOLS_DIR)/AppleAppBuilder/AppleAppBuilder.csproj
+	$(DOTNET) build -c $(MONO_ARCH) $(TOOLS_DIR)/AotCompilerTask/MonoAOTCompiler.csproj
+	$(DOTNET) build -c $(MONO_ARCH) $(TOOLS_DIR)/AppleAppBuilder/AppleAppBuilder.csproj
 
 runtimepack:
 	../../../../.././build.sh Mono+Libs -os iOS -arch $(MONO_ARCH) -c $(MONO_CONFIG)
 
 run: clean appbuilder
 	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH) \
-	/p:UseLLVM=$(USE_LLVM) /p:UseAotForSimulator=true
+	/p:UseLLVM=$(USE_LLVM) /p:UseAotForSimulator=false
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/iOS/Makefile
+++ b/src/mono/netcore/sample/iOS/Makefile
@@ -15,7 +15,7 @@ runtimepack:
 
 run: clean appbuilder
 	$(DOTNET) publish -c $(MONO_CONFIG) /p:TargetArchitecture=$(MONO_ARCH) \
-	/p:UseLLVM=$(USE_LLVM) /p:UseAotForSimulator=false
+	/p:UseLLVM=$(USE_LLVM) /p:UseAotForSimulator=false /p:TargetOS=iOS
 
 clean:
 	rm -rf bin

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -23,12 +23,12 @@
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
-  <Import Project="/Users/egorbo/prj/runtime/tools-local/tasks/mobile.tasks/AotCompilerTask/MonoAOTCompiler.props" />
+  <Import Project="$(RepoRoot)tools-local\tasks\mobile.tasks\AotCompilerTask\MonoAOTCompiler.props" />
   <UsingTask TaskName="AppleAppBuilderTask"
-             AssemblyFile="$(ArtifactsBinDir)AppleAppBuilder\$(Platform)\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
+             AssemblyFile="$(ArtifactsBinDir)AppleAppBuilder\Debug\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
 
   <UsingTask TaskName="MonoAOTCompiler"
-             AssemblyFile="$(ArtifactsBinDir)MonoAOTCompiler\$(Configuration)\$(NetCoreAppCurrent)\MonoAOTCompiler.dll" />
+             AssemblyFile="$(ArtifactsBinDir)MonoAOTCompiler\Debug\$(NetCoreAppCurrent)\MonoAOTCompiler.dll" />
 
   <Target Name="BuildAppBundle" AfterTargets="CopyFilesToPublishDirectory">
     <PropertyGroup>

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -4,7 +4,6 @@
     <OutputPath>bin</OutputPath>
     <DebugType>Portable</DebugType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <TargetOS>iOS</TargetOS>
     <RuntimePackDir>$(ArtifactsBinDir)lib-runtime-packs\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)\runtimes\ios-$(TargetArchitecture)</RuntimePackDir>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <RuntimeIdentifier>ios-$(TargetArchitecture)</RuntimeIdentifier>
@@ -24,11 +23,8 @@
   </Target>
 
   <Import Project="$(RepoRoot)tools-local\tasks\mobile.tasks\AotCompilerTask\MonoAOTCompiler.props" />
-  <UsingTask TaskName="AppleAppBuilderTask"
-             AssemblyFile="$(ArtifactsBinDir)AppleAppBuilder\Debug\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
-
-  <UsingTask TaskName="MonoAOTCompiler"
-             AssemblyFile="$(ArtifactsBinDir)MonoAOTCompiler\Debug\$(NetCoreAppCurrent)\MonoAOTCompiler.dll" />
+  <UsingTask TaskName="AppleAppBuilderTask" AssemblyFile="$(AppleAppBuilderTasksAssemblyPath)" />
+  <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" />
 
   <Target Name="BuildAppBundle" AfterTargets="CopyFilesToPublishDirectory">
     <PropertyGroup>

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -25,7 +25,7 @@
 
   <Import Project="/Users/egorbo/prj/runtime/tools-local/tasks/mobile.tasks/AotCompilerTask/MonoAOTCompiler.props" />
   <UsingTask TaskName="AppleAppBuilderTask"
-             AssemblyFile="$(ArtifactsBinDir)AppleAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
+             AssemblyFile="$(ArtifactsBinDir)AppleAppBuilder\$(Platform)\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
 
   <UsingTask TaskName="MonoAOTCompiler"
              AssemblyFile="$(ArtifactsBinDir)MonoAOTCompiler\$(Configuration)\$(NetCoreAppCurrent)\MonoAOTCompiler.dll" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36440 for both iOS and Android

We have to accumulate content written via Write and flush it only when `\n` is found.

Also, fix the iOS sample.