### PR TITLE
Remove AnonymousType ILLinkTrim entry for EventSource

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -55,8 +55,6 @@
     <!-- Accessed via private reflection and by native code. -->
     <type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
     <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
-    <!-- Accessed via reflection in TraceLogging-style EventSource events. -->
-    <type fullname="*f__AnonymousType*" />
     <type fullname="System.Diagnostics.Tracing.PropertyValue/ReferenceTypeHelper`1">
       <!-- Instantiated via reflection -->
       <method name=".ctor" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -2178,9 +2178,8 @@ namespace System.Diagnostics.Tracing
                     Keywords = (EventKeywords)unchecked(keywords),
                     Level = level
                 };
-                var msg = new { message = msgString };
-                var tlet = new TraceLoggingEventTypes(EventName, EventTags.None, new Type[] { msg.GetType() });
-                WriteMultiMergeInner(EventName, ref opt, tlet, null, null, msg);
+                var tlet = new TraceLoggingEventTypes(EventName, EventTags.None, new Type[] { typeof(string) });
+                WriteMultiMergeInner(EventName, ref opt, tlet, null, null, msgString);
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -147,7 +147,11 @@ namespace System.Diagnostics.Tracing
             string? name,
             EventFieldFormat format)
         {
-            collector.AddNullTerminatedString(name!, Statics.MakeDataType(TraceLoggingDataType.Utf16String, format));
+            // name can be null if the string was used as a top-level object in an event.
+            // In that case, use 'message' as the name of the field.
+            name ??= "message";
+
+            collector.AddNullTerminatedString(name, Statics.MakeDataType(TraceLoggingDataType.Utf16String, format));
         }
 
         public override void WriteData(TraceLoggingDataCollector collector, PropertyValue value)


### PR DESCRIPTION
Instead of using an anonymous type to do the logging, just pass the string directly.

Contributes to #35199

It seems reasonable to allow a `string` to be used as a top-level object in an event, and change `StringTypeInfo` to use `"message"` as the name of the field. Thoughts?

I tried a [different approach](https://github.com/eerhardt/runtime/commit/587833e46cea3f5ce16159565b267152b5ba68e0) to fixing this. However, that approach ran into https://github.com/mono/linker/issues/1218, which prevented it from working. If you prefer to wait for the linker to fix this and use that approach, let me know.