### PR TITLE
[mono] Remove some dead code from Delegate.DynamicInvoke

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -424,15 +424,7 @@ namespace System
         {
             if (Method is null)
             {
-#nullable disable
-                // FIXME: This code cannot handle null argument values
-                Type[] mtypes = new Type[args.Length];
-                for (int i = 0; i < args.Length; ++i)
-                {
-                    mtypes[i] = args[i].GetType();
-                }
-                method_info = _target.GetType().GetMethod(data.method_name, mtypes);
-#nullable restore
+                    throw new NullReferenceException ("method_info is null");
             }
 
             object? target = _target;

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Delegate.Mono.cs
@@ -422,10 +422,7 @@ namespace System
 
         protected virtual object? DynamicInvokeImpl(object?[]? args)
         {
-            if (Method is null)
-            {
-                    throw new NullReferenceException ("method_info is null");
-            }
+            MethodInfo _method = Method ?? throw new NullReferenceException ("method_info is null");
 
             object? target = _target;
 
@@ -450,7 +447,7 @@ namespace System
                 }
             }
 
-            if (Method!.IsStatic)
+            if (_method.IsStatic)
             {
                 //
                 // The delegate is bound to _target
@@ -481,7 +478,7 @@ namespace System
                 }
             }
 
-            return Method.Invoke(target, args);
+            return _method.Invoke(target, args);
         }
 
         public override bool Equals(object? obj)


### PR DESCRIPTION
Remove some dead code from `System.Delegate.DynamicInvoke`.  It should be the case that `Method` is non-`null` when we call `DynamicInvoke` - the delegate method should be known at the time of the invoke, and it should not be picked based on the arguments.

Fixes  #37008 

