### PR TITLE
Fix local build of packages on MUSL based Linux distros

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -39,7 +39,7 @@ jobs:
       
       - ${{ if and(eq(parameters.osGroup, 'Linux'), eq(parameters.osSubGroup, '_musl')) }}:
         - name: _osParameter
-          value: /p:RuntimeOS=linux-musl /p:OutputRid=linux-musl-${{ parameters.archType }}
+          value: /p:RuntimeOS=linux-musl
 
       # Do not rename as it clashes with MSBuild property in libraries/build-native.proj
       - name: _crossBuildPropertyArg

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -202,10 +202,6 @@ jobs:
       value: ${{ eq(parameters.osSubgroup, '') }}
 
     - ${{ if and(eq(parameters.osSubgroup, '_musl'), eq(parameters.osGroup, 'Linux')) }}:
-      # Set output RID manually: musl isn't properly detected. Make sure to also convert linux to
-      # lowercase for RID format. (Detection normally converts, but we're preventing it.)
-      - name: OutputRidArg
-        value: /p:OutputRid=linux-musl-${{ parameters.archType }}
       - name: _PortableBuild
         value: true
 
@@ -218,13 +214,11 @@ jobs:
         /p:SkipTests=$(SkipTests)
         $(LiveOverridePathArgs)
         $(CommonMSBuildArgs)
-        $(OutputRidArg)
 
     - name: PublishArguments
       value: >-
         /p:PortableBuild=$(_PortableBuild)
         $(CommonMSBuildArgs)
-        $(OutputRidArg)
         /bl:msbuild.publish.binlog
 
     - name: DockerRunMSBuild

--- a/src/installer/corehost/build.sh
+++ b/src/installer/corehost/build.sh
@@ -88,9 +88,10 @@ __LogsDir="$__RootBinDir/log"
 __MsbuildDebugLogsDir="$__LogsDir/MsbuildDebugLogs"
 
 # Set the remaining variables based upon the determined build configuration
+__ConfigTriplet="$(echo $__TargetOS-$__BuildArch |  tr '[:upper:]' '[:lower:]').$__BuildType"
 __DistroRidLower="$(echo $__DistroRid | tr '[:upper:]' '[:lower:]')"
-__BinDir="$__RootBinDir/bin/$__DistroRidLower.$__BuildType"
-__IntermediatesDir="$__RootBinDir/obj/$__DistroRidLower.$__BuildType"
+__BinDir="$__RootBinDir/bin/$__ConfigTriplet"
+__IntermediatesDir="$__RootBinDir/obj/$__ConfigTriplet"
 
 export __BinDir __IntermediatesDir __CoreClrArtifacts __NativeLibsArtifacts __RuntimeFlavor
 


### PR DESCRIPTION
Running the build.sh with --pack fails when compiling on or cross-compiling for MUSL based distros.
The reason is that the build of installer native parts uses a target folder name based on the RID,
but the packaging expects these artifacts to live in a folder named just by the
targetos-buildarch.BuildType. So e.g. in linux-arm.Release instead of linux-musl-arm.release.

This change fixes that. With it, the local end to end build of packages for clr, libs and installer
passes.