### PR TITLE
Disable additional validation that is run post-build

### DIFF
--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -25,18 +25,13 @@ stages:
   parameters:
     validateDependsOn:
     - PrepareForPublish
-    # Symbol validation is not ready yet. https://github.com/dotnet/arcade/issues/2871
+    # The following checks are run after the build in the validation and release pipelines
+    # And thus are not enabled here. They can be enabled for dev builds for spot testing if desired
     enableSymbolValidation: false
-    # SourceLink validation doesn't work in dev builds: tries to pull from GitHub. https://github.com/dotnet/arcade/issues/3604
-    enableSourceLinkValidation: true
-    # Allow symbol publish to emit expected warnings without failing the build. Include single
-    # quotes inside the string so that it passes through to MSBuild without script interference.
-    symbolPublishingAdditionalParameters: "'-warnAsError:$false'"
-    # Publish to blob storage.
-    publishInstallersAndChecksums: true
-    # Enable SDL validation, passing through values from the 'core-setup-sdl-validation' group.
+    enableSigningValidation: false
+    enableNugetValidation: false
     SDLValidationParameters:
-      enable: false # TODO: (Consolidation) Decide who owns SDL validation errors and enable. https://github.com/dotnet/runtime/issues/1027
+      enable: false
       artifactNames:
       - PackageArtifacts
       - BlobArtifacts
@@ -51,3 +46,12 @@ stages:
         -TsaRepositoryName "$(TsaRepositoryName)"
         -TsaCodebaseName "$(TsaCodebaseName)"
         -TsaPublish $True
+    # Allow symbol publish to emit expected warnings without failing the build. Include single
+    # quotes inside the string so that it passes through to MSBuild without script interference.
+    symbolPublishingAdditionalParameters: "'-warnAsError:$false'"
+    
+    # The following checks are not available after the build and continue to be run here
+    enableSourceLinkValidation: true
+    
+    # Publish to blob storage.
+    publishInstallersAndChecksums: true

--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -46,9 +46,6 @@ stages:
         -TsaRepositoryName "$(TsaRepositoryName)"
         -TsaCodebaseName "$(TsaCodebaseName)"
         -TsaPublish $True
-    # Allow symbol publish to emit expected warnings without failing the build. Include single
-    # quotes inside the string so that it passes through to MSBuild without script interference.
-    symbolPublishingAdditionalParameters: "'-warnAsError:$false'"
     
     # The following checks are not available after the build and continue to be run here
     enableSourceLinkValidation: true


### PR DESCRIPTION
Disable more validation stages that are run post-build. The only
thing left to run during each build at this point is SourceLink validation.
Once that is available, the entire validation stage should be able to be skipped