### PR TITLE
Use friendly name in exception if OID value is null for unknown curves

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/EccSecurityTransforms.cs
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography
                     break;
                 default:
                     throw new PlatformNotSupportedException(
-                        SR.Format(SR.Cryptography_CurveNotSupported, curve.Oid.Value));
+                        SR.Format(SR.Cryptography_CurveNotSupported, curve.Oid.Value ?? curve.Oid.FriendlyName));
             }
 
             GenerateKey(keySize);

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanTests.cs
@@ -50,6 +50,14 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        public void Create_InvalidECCurveFriendlyName_ThrowsPlatformNotSupportedException()
+        {
+            ECCurve curve = ECCurve.CreateFromFriendlyName("bad potato");
+            PlatformNotSupportedException pnse = Assert.Throws<PlatformNotSupportedException>(() => ECDiffieHellman.Create(curve));
+            Assert.Contains("'bad potato'", pnse.Message);
+        }
+
+        [Fact]
         public static void Equivalence_Hash()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDsaTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDsaTests.cs
@@ -19,6 +19,14 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        public void Create_InvalidECCurveFriendlyName_ThrowsPlatformNotSupportedException()
+        {
+            ECCurve curve = ECCurve.CreateFromFriendlyName("bad potato");
+            PlatformNotSupportedException pnse = Assert.Throws<PlatformNotSupportedException>(() => ECDsa.Create(curve));
+            Assert.Contains("'bad potato'", pnse.Message);
+        }
+
+        [Fact]
         public void NotSupportedBaseMethods_Throw()
         {
             using (var ecdsa = new OverrideAbstractECDsa(ECDsaFactory.Create()))


### PR DESCRIPTION
Fixes #37106

macOS should be consistent with Windows and Linux now.