### PR TITLE
Support for overriding enum field name in JsonConverterEnum (#31081)

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -535,6 +535,12 @@ namespace System.Text.Json.Serialization
         public override bool CanConvert(System.Type typeToConvert) { throw null; }
         public override System.Text.Json.Serialization.JsonConverter CreateConverter(System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options) { throw null; }
     }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Field, AllowMultiple=false)]
+    public sealed partial class JsonStringEnumMemberAttribute : System.Text.Json.Serialization.JsonAttribute
+    {
+        public JsonStringEnumMemberAttribute(string name) { }
+        public string Name { get { throw null; } }
+    }
     public sealed partial class ReferenceHandling
     {
         internal ReferenceHandling() { }

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;netcoreapp3.0;net461;$(NetFrameworkCurrent)</TargetFrameworks>
@@ -62,6 +62,7 @@
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIgnoreAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIncludeAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Attributes\JsonStringEnumMemberAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\ClassType.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterList.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ArrayConverter.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonStringEnumMemberAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonStringEnumMemberAttribute.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Specifies the enum member that is present in the JSON when serializing and deserializing.
+    /// This overrides any naming policy specified by <see cref="JsonNamingPolicy"/>.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class JsonStringEnumMemberAttribute : JsonAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="JsonStringEnumMemberAttribute"/> with the specified enum member name.
+        /// </summary>
+        /// <param name="name">The name of the enum member.</param>
+        public JsonStringEnumMemberAttribute(string name)
+        {
+            Name = name;
+        }
+
+        /// <summary>
+        /// The name of the enum member.
+        /// </summary>
+        public string Name { get; }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/EnumConverter.cs
@@ -1,9 +1,9 @@
-﻿using System.Runtime.Serialization;
-using System.Linq;
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Runtime.Serialization;
+using System.Linq;
 using System.Collections.Concurrent;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/EnumConverterTests.cs
@@ -185,5 +185,32 @@ namespace System.Text.Json.Serialization.Tests
             obj = JsonSerializer.Deserialize<MyCustomEnum>("2");
             Assert.Equal(MyCustomEnum.Second, obj);
         }
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public enum MyCustomJsonStringEnumMemberEnum
+        {
+            [System.Text.Json.Serialization.JsonStringEnumMemberAttribute("one_")]
+            One,
+            [System.Text.Json.Serialization.JsonStringEnumMemberAttribute("two_")]
+            Two,
+            [System.Text.Json.Serialization.JsonStringEnumMemberAttribute(null)]
+            Null
+        }
+        [InlineData("One", "\"one_\"", "0")]
+        [InlineData("Two", "\"two_\"", "1")]
+        [InlineData("Null", "null", "2")]
+        [Theory]
+        public void EnumWithJsonStringEnumMemberAttribute(string enumString, string serializedString, string serializedNumber)
+        {
+            MyCustomJsonStringEnumMemberEnum e = (MyCustomJsonStringEnumMemberEnum) Enum.Parse(typeof(MyCustomJsonStringEnumMemberEnum), enumString);
+            string json = JsonSerializer.Serialize(e);
+            Assert.Equal(serializedString, json);
+
+            MyCustomJsonStringEnumMemberEnum obj = JsonSerializer.Deserialize<MyCustomJsonStringEnumMemberEnum>(serializedString);
+            Assert.Equal(e, obj);
+
+            obj = JsonSerializer.Deserialize<MyCustomJsonStringEnumMemberEnum>(serializedNumber);
+            Assert.Equal(e, obj);
+        }
     }
 }


### PR DESCRIPTION
Support for overriding enum field name in `JsonConverterEnum`.

Created a new Attribute instead of using `System.Runtime.Serialization.EnumMemberAttribute` as there seem to be some questions on if we should support attributes from that namespace or not in `JsonConverterEnum`.