### PR TITLE
Publish singlefilehost on Linux, Osx, FreeBSD

### DIFF
--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.FreeBSD.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.FreeBSD.Microsoft.NETCore.DotNetAppHost.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/apphost" />
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/singlefilehost" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libnethost.so" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libnethost.a" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/nethost.h" />

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Linux.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.Linux.Microsoft.NETCore.DotNetAppHost.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/apphost" />
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/singlefilehost" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libnethost.so" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libnethost.a" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/nethost.h" />

--- a/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.OSX.Microsoft.NETCore.DotNetAppHost.props
+++ b/src/installer/pkg/projects/Microsoft.NETCore.DotNetAppHost/runtime.OSX.Microsoft.NETCore.DotNetAppHost.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/apphost" />
+    <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/singlefilehost" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libnethost.dylib" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/libnethost.a" />
     <ArchitectureSpecificNativeFile Include="$(DotNetHostBinDir)/nethost.h" />


### PR DESCRIPTION
singlefilehost is currently only published in the microsoft.netcore.app.host.win-x64
Add it to host packages for other platforms.