### PR TITLE
fixed a bug in updating the gen0 budget for AllocateUninitializedArray

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -12321,7 +12321,14 @@ found_fit:
             assert(gen_number == 0);
             assert(allocated > acontext->alloc_ptr);
 
-            limit -= (allocated - acontext->alloc_ptr);
+            size_t extra = allocated - acontext->alloc_ptr;
+            limit -= extra;
+
+            // Since we are not consuming all the memory we already deducted from the budget,
+            // we should put the extra back.
+            dynamic_data* dd = dynamic_data_of (0);
+            dd_new_allocation (dd) += extra;
+
             // add space for an AC continuity divider
             limit += Align(min_obj_size, align_const);
         }


### PR DESCRIPTION
For AllocateUninitializedArray, we don't consume all the memory we get
from the gen0 budget but we are not putting back the part we don't consume.
This artificial consumption in budget can mean we trigger a GC way too early
when we haven't actually allocated that much.