### PR TITLE
Fix fixed dictionary sizes in key generation

### DIFF
--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_ecc.c
@@ -16,7 +16,7 @@ int32_t AppleCryptoNative_EccGenerateKey(
     if (pPublicKey == NULL || pPrivateKey == NULL || pOSStatus == NULL)
         return kErrorBadInput;
 
-    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(NULL, 2, &kCFTypeDictionaryKeyCallBacks, NULL);
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(NULL, 3, &kCFTypeDictionaryKeyCallBacks, NULL);
 
     CFNumberRef cfKeySizeValue = CFNumberCreate(NULL, kCFNumberIntType, &keySizeBits);
     OSStatus status;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_rsa.c
@@ -21,7 +21,7 @@ int32_t AppleCryptoNative_RsaGenerateKey(
     if (keySizeBits < 384 || keySizeBits > 16384)
         return -2;
 
-    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(NULL, 2, &kCFTypeDictionaryKeyCallBacks, NULL);
+    CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(NULL, 3, &kCFTypeDictionaryKeyCallBacks, NULL);
 
     CFNumberRef cfKeySizeValue = CFNumberCreate(NULL, kCFNumberIntType, &keySizeBits);
     OSStatus status;


### PR DESCRIPTION
Both dictionaries had a fixed size of two, however three items were being added to it (`kSecAttrKeyType`, `kSecAttrKeySizeInBits`, `kSecUseKeychain`). This is UB in Apple's documentation.

Fixes #37164 