### PR TITLE
Remove serializer todos and add comments

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -90,10 +90,11 @@ namespace System.Text.Json
             CancellationToken cancellationToken)
         {
             // We flush the Stream when the buffer is >=90% of capacity.
-            // With the default buffer size of 16K, if a single JSON value is >=1.6K it is possible for
-            // the buffer to max out before it can be flushed, causing the buffer to expand.
-            // So this threshold is a compromise between buffer utilization and minimizing cases where the
-            // buffer is maxed out (and expanded) before it can be flushed.
+            // This threshold is a compromise between buffer utilization and minimizing cases where the buffer
+            // needs to be expanded\doubled because it is not large enough to write the current property or element.
+            // We check for flush after each object property and array element is written to the buffer.
+            // Once the buffer is expanded to contain the largest single element\property, a 90% thresold
+            // means the buffer may be expanded a maximum of 4 times: 1-(1\(2^4))==.9375.
             const float FlushThreshold = .9f;
 
             if (options == null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -26,7 +26,11 @@ namespace System.Text.Json
         /// There is no compatible <see cref="System.Text.Json.Serialization.JsonConverter"/>
         /// for <typeparamref name="TValue"/> or its serializable members.
         /// </exception>
-        public static Task SerializeAsync<TValue>(Stream utf8Json, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static Task SerializeAsync<TValue>(
+            Stream utf8Json,
+            TValue value,
+            JsonSerializerOptions? options = null,
+            CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
                 throw new ArgumentNullException(nameof(utf8Json));
@@ -53,7 +57,12 @@ namespace System.Text.Json
         /// There is no compatible <see cref="System.Text.Json.Serialization.JsonConverter"/>
         /// for <paramref name="inputType"/>  or its serializable members.
         /// </exception>
-        public static Task SerializeAsync(Stream utf8Json, object? value, Type inputType, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static Task SerializeAsync(
+            Stream utf8Json,
+            object? value,
+            Type inputType,
+            JsonSerializerOptions? options = null,
+            CancellationToken cancellationToken = default)
         {
             if (utf8Json == null)
             {
@@ -73,8 +82,20 @@ namespace System.Text.Json
             return WriteAsyncCore<object>(utf8Json, value!, inputType, options, cancellationToken);
         }
 
-        private static async Task WriteAsyncCore<TValue>(Stream utf8Json, TValue value, Type inputType, JsonSerializerOptions? options, CancellationToken cancellationToken)
+        private static async Task WriteAsyncCore<TValue>(
+            Stream utf8Json,
+            TValue value,
+            Type inputType,
+            JsonSerializerOptions? options,
+            CancellationToken cancellationToken)
         {
+            // We flush the Stream when the buffer is >=90% of capacity.
+            // With the default buffer size of 16K, if a single JSON value is >=1.6K it is possible for
+            // the buffer to max out before it can be flushed, causing the buffer to expand.
+            // So this threshold is a compromise between buffer utilization and minimizing cases where the
+            // buffer is maxed out (and expanded) before it can be flushed.
+            const float FlushThreshold = .9f;
+
             if (options == null)
             {
                 options = JsonSerializerOptions.s_defaultOptions;
@@ -100,9 +121,7 @@ namespace System.Text.Json
 
                 do
                 {
-                    // todo: determine best value here
-                    // https://github.com/dotnet/runtime/issues/32356
-                    state.FlushThreshold = (int)(bufferWriter.Capacity * .9);
+                    state.FlushThreshold = (int)(bufferWriter.Capacity * FlushThreshold);
 
                     isFinalBlock = WriteCore(converterBase, writer, value, options, ref state);
 
@@ -111,8 +130,6 @@ namespace System.Text.Json
                     bufferWriter.Clear();
                 } while (!isFinalBlock);
             }
-
-            // todo: verify that we do want to call FlushAsync here (or above). It seems like leaving it to the caller would be best.
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -96,15 +96,12 @@ namespace System.Text.Json
         /// </summary>
         public JsonConverter InitializeReEntry(Type type, JsonSerializerOptions options, string? propertyName = null)
         {
-            JsonClassInfo newClassInfo = options.GetOrAddClass(type);
-
-            // todo: check if type==newtype and skip below?
-            // https://github.com/dotnet/runtime/issues/32358
+            JsonClassInfo classInfo = options.GetOrAddClass(type);
 
             // Set for exception handling calculation of JsonPath.
             JsonPropertyNameAsString = propertyName;
 
-            PolymorphicJsonPropertyInfo = newClassInfo.PropertyInfoForClassInfo;
+            PolymorphicJsonPropertyInfo = classInfo.PropertyInfoForClassInfo;
             return PolymorphicJsonPropertyInfo.ConverterBase;
         }
 


### PR DESCRIPTION
Non-functional changes. Remove the "todos" and add appropriate comments.

fixes https://github.com/dotnet/runtime/issues/32356
fixes https://github.com/dotnet/runtime/issues/32358

