### PR TITLE
[mono][metadata] Add a method custom attribute scanning function

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -3295,7 +3295,7 @@ mono_class_setup_vtable_general (MonoClass *klass, MonoMethod **overrides, int o
 						g_assert (cm->slot < max_vtsize);
 						if (!override_map)
 							override_map = g_hash_table_new (mono_aligned_addr_hash, NULL);
-						TRACE_INTERFACE_VTABLE (printf ("adding iface override from %s [%p] to %s [%p]\n",
+						TRACE_INTERFACE_VTABLE (printf ("adding base class override from %s [%p] to %s [%p]\n",
 							mono_method_full_name (m1, 1), m1,
 							mono_method_full_name (cm, 1), cm));
 						g_hash_table_insert (override_map, m1, cm);

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -787,9 +787,9 @@ class_has_isbyreflike_attribute (MonoClass *klass)
 
 
 static gboolean G_GNUC_UNUSED
-method_has_require_methodimpl_to_remain_in_effect_attribute (MonoMethod *method)
+method_has_preserve_base_overrides_attribute (MonoMethod *method)
 {
-	return method_has_wellknown_attribute (method, "System.Runtime.CompilerServices", "RequireMethodImplToRemainInEffectAttribute", TRUE);
+	return method_has_wellknown_attribute (method, "System.Runtime.CompilerServices", "PreserveBaseOverridesAttribute", TRUE);
 }
 
 static gboolean

--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -724,30 +724,73 @@ mono_generic_class_setup_parent (MonoClass *klass, MonoClass *gtd)
 	mono_loader_unlock ();
 }
 
-struct HasIsByrefLikeUD {
-	gboolean has_isbyreflike;
+struct FoundAttrUD {
+	/* inputs */
+	const char *nspace;
+	const char *name;
+	gboolean in_corlib;
+	/* output */
+	gboolean has_attr;
 };
 
 static gboolean
-has_isbyreflike_attribute_func (MonoImage *image, guint32 typeref_scope_token, const char *nspace, const char *name, guint32 method_token, gpointer user_data)
+has_wellknown_attribute_func (MonoImage *image, guint32 typeref_scope_token, const char *nspace, const char *name, guint32 method_token, gpointer user_data)
 {
-	struct HasIsByrefLikeUD *has_isbyreflike = (struct HasIsByrefLikeUD *)user_data;
-	if (!strcmp (name, "IsByRefLikeAttribute") && !strcmp (nspace, "System.Runtime.CompilerServices")) {
-		has_isbyreflike->has_isbyreflike = TRUE;
+	struct FoundAttrUD *has_attr = (struct FoundAttrUD *)user_data;
+	if (!strcmp (name, has_attr->name) && !strcmp (nspace, has_attr->nspace)) {
+		has_attr->has_attr = TRUE;
 		return TRUE;
 	}
+	/* TODO: use typeref_scope_token to check that attribute comes from
+	 * corlib if in_corlib is TRUE, without triggering an assembly load.
+	 * If we're inside corlib, expect the scope to be
+	 * MONO_RESOLUTION_SCOPE_MODULE I think, if we're outside it'll be an
+	 * MONO_RESOLUTION_SCOPE_ASSEMBLYREF and we'll need to check the
+	 * name.*/
 	return FALSE;
 }
 
 static gboolean
-class_has_isbyreflike_attribute (MonoClass *klass)
+class_has_wellknown_attribute (MonoClass *klass, const char *nspace, const char *name, gboolean in_corlib)
 {
-	struct HasIsByrefLikeUD has_isbyreflike;
-	has_isbyreflike.has_isbyreflike = FALSE;
-	mono_class_metadata_foreach_custom_attr (klass, has_isbyreflike_attribute_func, &has_isbyreflike);
-	return has_isbyreflike.has_isbyreflike;
+	struct FoundAttrUD has_attr;
+	has_attr.nspace = nspace;
+	has_attr.name = name;
+	has_attr.in_corlib = in_corlib;
+	has_attr.has_attr = FALSE;
+
+	mono_class_metadata_foreach_custom_attr (klass, has_wellknown_attribute_func, &has_attr);
+
+	return has_attr.has_attr;
 }
 
+static gboolean
+method_has_wellknown_attribute (MonoMethod *method, const char *nspace, const char *name, gboolean in_corlib)
+{
+	struct FoundAttrUD has_attr;
+	has_attr.nspace = nspace;
+	has_attr.name = name;
+	has_attr.in_corlib = in_corlib;
+	has_attr.has_attr = FALSE;
+
+	mono_method_metadata_foreach_custom_attr (method, has_wellknown_attribute_func, &has_attr);
+
+	return has_attr.has_attr;
+}
+
+
+static gboolean
+class_has_isbyreflike_attribute (MonoClass *klass)
+{
+	return class_has_wellknown_attribute (klass, "System.Runtime.CompilerServices", "IsByRefLikeAttribute", TRUE);
+}
+
+
+static gboolean G_GNUC_UNUSED
+method_has_require_methodimpl_to_remain_in_effect_attribute (MonoMethod *method)
+{
+	return method_has_wellknown_attribute (method, "System.Runtime.CompilerServices", "RequireMethodImplToRemainInEffectAttribute", TRUE);
+}
 
 static gboolean
 check_valid_generic_inst_arguments (MonoGenericInst *inst, MonoError *error)

--- a/src/mono/mono/metadata/custom-attrs-internals.h
+++ b/src/mono/mono/metadata/custom-attrs-internals.h
@@ -20,6 +20,9 @@ mono_assembly_metadata_foreach_custom_attr (MonoAssembly *assembly, MonoAssembly
 void
 mono_class_metadata_foreach_custom_attr (MonoClass *klass, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
 
+void
+mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
+
 gboolean
 mono_assembly_is_weak_field (MonoImage *image, guint32 field_idx);
 

--- a/src/mono/mono/metadata/custom-attrs.c
+++ b/src/mono/mono/metadata/custom-attrs.c
@@ -63,6 +63,9 @@ decode_blob_value_checked (const char *ptr, const char *endp, guint32 *size_out,
 static guint32
 custom_attrs_idx_from_class (MonoClass *klass);
 
+static guint32
+custom_attrs_idx_from_method (MonoMethod *method);
+
 static void
 metadata_foreach_custom_attr_from_index (MonoImage *image, guint32 idx, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data);
 
@@ -1711,9 +1714,7 @@ mono_custom_attrs_from_method_checked (MonoMethod *method, MonoError *error)
 		/* Synthetic methods */
 		return NULL;
 
-	idx = mono_method_get_index (method);
-	idx <<= MONO_CUSTOM_ATTR_BITS;
-	idx |= MONO_CUSTOM_ATTR_METHODDEF;
+	idx = custom_attrs_idx_from_method (method);
 	return mono_custom_attrs_from_index_checked (m_class_get_image (method->klass), idx, FALSE, error);
 }
 
@@ -1743,6 +1744,17 @@ custom_attrs_idx_from_class (MonoClass *klass)
 		idx <<= MONO_CUSTOM_ATTR_BITS;
 		idx |= MONO_CUSTOM_ATTR_TYPEDEF;
 	}
+	return idx;
+}
+
+guint32
+custom_attrs_idx_from_method (MonoMethod *method)
+{
+	guint32 idx;
+	g_assert (!image_is_dynamic (m_class_get_image (method->klass)));
+	idx = mono_method_get_index (method);
+	idx <<= MONO_CUSTOM_ATTR_BITS;
+	idx |= MONO_CUSTOM_ATTR_METHODDEF;
 	return idx;
 }
 
@@ -2535,6 +2547,36 @@ mono_class_metadata_foreach_custom_attr (MonoClass *klass, MonoAssemblyMetadataC
 		klass = mono_class_get_generic_class (klass)->container_class;
 
 	guint32 idx = custom_attrs_idx_from_class (klass);
+
+	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
+}
+
+/**
+ * mono_method_metadata_foreach_custom_attr:
+ * \param method - the method to iterate over
+ * \param func the funciton to call for each custom attribute
+ * \param user_data passed to \p func
+ *
+ * Calls \p func for each custom attribute type on the given class until \p func returns TRUE.
+ *
+ * Everything is done using low-level metadata APIs, so it is fafe to use
+ * during assembly loading and class initialization.
+ *
+ */
+void
+mono_method_metadata_foreach_custom_attr (MonoMethod *method, MonoAssemblyMetadataCustomAttrIterFunc func, gpointer user_data)
+{
+	if (method->is_inflated)
+		method = ((MonoMethodInflated *) method)->declaring;
+
+	MonoImage *image = m_class_get_image (method->klass);
+
+	g_assert (!image_is_dynamic (image));
+
+	if (!method->token)
+		return;
+
+	guint32 idx = custom_attrs_idx_from_method (method);
 
 	metadata_foreach_custom_attr_from_index (image, idx, func, user_data);
 }


### PR DESCRIPTION
Our normal custom attribute lookup method may trigger loading.  This is undesirable during class initialization, for example.  For this reason, we have `mono_class_metadata_foreach_custom_attr` that scans a class for custom attributes without triggering loading.

This PR adds `mono_method_metadata_foreach_custom_attr` that does the same thing - looks for custom attributes on methods without causing any loader activity.

This PR also reorganizes the code in `class-init.c` that uses these metadata custom attribute lookups to be a bit easier to use.

Finally we add a convenience method (unused so far) to look for `PreserveBaseOverridesAttribute` which is defined in #35315 and which will be necessary to implement covariant returns.