### PR TITLE
Reduce duplication in Linux build instructions

### DIFF
--- a/docs/workflow/building/coreclr/linux-instructions.md
+++ b/docs/workflow/building/coreclr/linux-instructions.md
@@ -1,7 +1,11 @@
 Build CoreCLR on Linux
 ======================
 
-This guide will walk you through building CoreCLR on Linux.  Before building there is environment setup that needs to happen to pull in all the dependencies required by the build.  There are two suggested ways to go about doing this. First you are able to use the Docker environments provided by https://github.com/dotnet/dotnet-buildtools-prereqs-docker, or you can set up the environment yourself. The documentation will go over both ways of building. Note that using docker only allows you to leverage our existing images which have a setup environment.
+This guide will walk you through building CoreCLR on Linux.
+
+First, set up your environment to build using the instructions [here](linux-requirements.md).
+
+Choose one of the following options for building.
 
 [Build using Docker](#Build-using-Docker)
 
@@ -10,38 +14,30 @@ This guide will walk you through building CoreCLR on Linux.  Before building the
 Build using Docker
 ==================
 
-Install Docker, see https://docs.docker.com/install/
-
-Building using Docker will require that you choose the correct image for your environment. Note that the OS is strictly speaking not extremely important, for example if you are on Ubuntu 18.04 and build using the Ubuntu 16.04 x64 image there should be no issues. The target architecture is more important, as building arm32 using the x64 image will not work, there will be missing rootfs components required by the build. See [Docker Images](#Docker-Images) for more information on choosing an image to build with.
+Building using Docker will require that you choose the correct image for your environment. Note that the OS is strictly speaking not extremely important, for example if you are on Ubuntu 18.04 and build using the Ubuntu 16.04 x64 image there should be no issues. The target architecture is more important, as building arm32 using the x64 image will not work: there will be missing rootfs components required by the build. See [Docker Images](#Docker-Images), below, for more information on choosing an image to build with.
 
 Please note that when choosing an image choosing the same image as the host os you are running on you will allow you to run the product/tests outside of the docker container you built in.
 
 Once you have chosen an image the build is one command run from the root of the runtime repository:
 
 ```sh
-docker run --rm -v <RUNTIME_REPO_PATH>:/runtime -w /runtime mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20200508132555-78cbb55 ./build.sh --subset clr -clang9
+docker run --rm -v <RUNTIME_REPO_PATH>:/runtime -w /runtime mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20200508132555-78cbb55 ./build.sh -subset clr -clang9
 ```
 
 Dissecting the command:
 
-`--rm`: erase the created container after use
+- `--rm`: erase the created container after use.
+- `-v <RUNTIME_REPO_PATH>:/runtime`: mount the runtime repository under `/runtime`. Replace `<RUNTIME_REPO_PATH>` with the full path to your `runtime` repo clone, e.g., `-v /home/user/runtime:/runtime`.
+- `-w: /runtime`: set /runtime as working directory for the container.
+- `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20200508132555-78cbb55`: Docker image name.
+- `./build.sh`: command to be run in the container: run the root build command.
+- `-subset clr`: build the clr subset (excluding libraries and installers).
+- `-clang9`: argument to use clang 9 for the build (the only compiler in the build image).
 
-`-v <RUNTIME_REPO_PATH>:/runtime`: mount the runtime repository under `/runtime`
-
-`-w: /runtime`: set /runtime as working directory for the container
-
-`mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-20200508132555-78cbb55`: image name.
-
-`./build.sh`: command to be run in the container, run the build to coreclr.
-
-`--subset clr`: build the runtime subset (excluding libraries and installers)
-
-`-clang9`: argument to use clang 9 for the build, only compiler in the build image.
-
-If you are attempting to cross build for arm/arm64 then use the crossrootfs location to set the ROOTFS_DIR. The command would add `-e ROOTFS_DIR=<crossrootfs location>`. See [Docker Images](#Docker-Images) for the crossrootfs location. In addition you will need to specify `--cross`.
+If you are attempting to cross build for arm or arm64 then use the crossrootfs location to set the ROOTFS_DIR. The command would add `-e ROOTFS_DIR=<crossrootfs location>`. See [Docker Images](#Docker-Images) for the crossrootfs location. In addition you will need to specify `-cross`. For example:
 
 ```sh
-docker run --rm -v <RUNTIME_REPO_PATH>:/runtime -w /runtime -e ROOTFS_DIR=/crossrootfs/arm64 mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20200508132638-b2c2436 ./build.sh --arch arm64 --cross --subset clr
+docker run --rm -v <RUNTIME_REPO_PATH>:/runtime -w /runtime -e ROOTFS_DIR=/crossrootfs/arm64 mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20200508132638-b2c2436 ./build.sh -arch arm64 -subset clr -cross -clang9
 ```
 
 Note that instructions on building the crossrootfs location can be found at [cross-building.md](cross-building.md). These instructions are suggested only if there are plans to change the rootfs, or the Docker images for arm/arm64 are insufficient for you build.
@@ -49,29 +45,20 @@ Note that instructions on building the crossrootfs location can be found at [cro
 Docker Images
 =============
 
-These instructions might fall stale often enough as we change our images as our requirements change. The table below is just a quick reference view of the images we use in different build scenarios. The ones that we use for our our official builds can be found in [the platform matrix](../../../../eng/pipelines/common/platform-matrix.yml) of our Azure DevOps builds under the `container` key of the platform you plan to build.
+This table of images might often become stale as we change our images as our requirements change. The images used for our our official builds can be found in [the platform matrix](../../../../eng/pipelines/common/platform-matrix.yml) of our Azure DevOps builds under the `container` key of the platform you plan to build.
 
 | OS                          | Target Arch     | Image location                                                                                       | crossrootfs location | Clang Version |
 | --------------------------- | --------------- | ---------------------------------------------------------------------------------------------------- | -------------------- | ------------- |
 | Ubuntu 16.04                | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-a50a721-20191120200116`                    | -                    | -clang9       |
 | Alpine                      | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-WithNode-0fc54a3-20190918214015`             | -                    | -clang9       |
 | CentOS 6 (build for RHEL 6) | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-f39df28-20191023143802`                        | -                    | -clang9       |
-| CentOS 7 (build for RHEL 7) | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-f39df28-20191023143754`                        | -                    | -clang9       |
-| Ubuntu 16.04                | arm32(armhf)    | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20200413125008-09ec757`              | `/crossrootfs/arm`   | -clang9       |
+| CentOS 7 (build for RHEL 7) | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-359e48e-20200313130914`                        | -                    | -clang9       |
+| Ubuntu 16.04                | arm32 (armhf)   | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-20200413125008-09ec757`              | `/crossrootfs/arm`   | -clang9       |
 | Ubuntu 16.04                | arm64 (arm64v8) | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-20200413125008-cfdd435`        | `/crossrootfs/arm64` | -clang9       |
 | Alpine                      | arm64 (arm64v8) | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-20200413125008-406629a` | `/crossrootfs/arm64` | -clang5.0     |
 
 Environment
 ===========
-
-These instructions are written assuming the Ubuntu 16.04/18.04 LTS and CentOS images, since those are the distros the team and the official builds use. Pull Requests are welcome to address other environments as long as they don't break the ability to use these.
-
-Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([Issue 536](https://github.com/dotnet/coreclr/issues/536)).
-
-Toolchain Setup
----------------
-
-Follow instructions and install dependencies listed [here](https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/linux-requirements.md#toolchain-setup).
 
 Git Setup
 ---------
@@ -101,18 +88,19 @@ After the build is completed, there should some files placed in `artifacts/bin/c
 Create the Core_Root
 ===================
 
-The Core_Root folder will have the built binaries, from `build.sh` and it will also include the library packages required to run tests.
+The Core_Root folder will contain the built binaries, generated by `build.sh`, as well as the library packages required to run tests. Note that you need to build
+the libraries subset (`-subset libs`) before this command can be run.
 
 ```
 ./src/coreclr/build-test.sh generatelayoutonly
 ```
 
-After the build is complete you will be able to find the output in the `artifacts/tests/coreclr/Linux.x64.Debug/Tests/Core_Root` folder.
+After the build is complete you will find the output in the `artifacts/tests/coreclr/Linux.x64.Debug/Tests/Core_Root` folder.
 
 Running a single test
 ===================
 
-After `src/coreclr/build-test.sh` is run, corerun from the Core_Root folder is ready to be run. This can be done by using the full absolute path to corerun, or by setting an environment variable to the Core_Root folder.
+After `src/coreclr/build-test.sh` is run, `corerun` from the Core_Root folder is ready to be run. This can be done by using the full absolute path to `corerun`, or by setting an environment variable to the Core_Root folder.
 
 ```sh
 export CORE_ROOT=/runtime/artifacts/tests/coreclr/Linux.x64.Debug/Tests/Core_Root

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -1,63 +1,25 @@
 Requirements to build dotnet/runtime on Linux
 ======================
 
-This guide will walk you through the requirements to build dotnet/runtime on Linux.  Before building there is environment setup that needs to happen to pull in all the dependencies required by the build.  There are two suggested ways to go about doing this. First you are able to use the Docker environments provided by https://github.com/dotnet/dotnet-buildtools-prereqs-docker, or you can set up the environment yourself. The documentation will go over both ways of building. Note that using docker only allows you to leverage our existing images which have a setup environment.
+This guide will walk you through the requirements to build dotnet/runtime on Linux. Before building there is environment setup that needs to happen to pull in all the dependencies required by the build. There are two suggested ways to go about doing this. First you are able to use the Docker environments provided by https://github.com/dotnet/dotnet-buildtools-prereqs-docker, or you can set up the environment yourself. The documentation will go over both ways of building. Using Docker allows you to leverage our existing images which already have an environment set up.
+
+Instructions for doing the build are [here](linux-instructions.md).
+
 
 Docker
 ==================
 
-Install Docker, see https://docs.docker.com/install/
+Install Docker; see https://docs.docker.com/install/.
 
-Building using Docker will require that you choose the correct image for your environment. Note that the OS is strictly speaking not extremely important, for example if you are on Ubuntu 18.04 and build using the Ubuntu 16.04 x64 image there should be no issues. The target architecture is more important, as building arm32 using the x64 image will not work, there will be missing rootfs components required by the build. See [Docker Images](#Docker-Images) for more information on choosing an image to build with.
+All the required build tools are included in the Docker image, so no additional setup is required.
 
-Please note that when choosing an image choosing the same image as the host os you are running on you will allow you to run the product/tests outside of the docker container you built in.
-
-Once you have chosen an image the build is one command run from the root of the dotnet/runtime repository:
-
-```sh
-docker run --rm -v /home/dotnet-bot/runtime:/runtime -w /runtime mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-c103199-20180628134544 ./build.sh
-```
-
-Dissecting the command:
-
-`--rm: erase the created container after use`
-
-`-v: mount the runtime repository under /dotnet/runtime`
-
-`-w: set /runtime as working directory for the container`
-
-`mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-c103199-20180628134544: image name`
-
-`./build.sh: command to be run in the container`
-
-If you are attempting to cross build the CoreCLR runtime for arm/arm64 then use the crossrootfs location to set the ROOTFS_DIR. The command would add `-e ROOTFS_DIR=<crossrootfs location>`. See [Docker Images](#Docker-Images) for the crossrootfs location. In addition you will need to specify `cross`.
-
-```sh
-docker run --rm -v /home/dotnet-bot/runtime/src/coreclr:/coreclr -w /coreclr -e ROOTFS_DIR=/crossrootfs/arm64 mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-a3ae44b-20180315221921 ./build.sh arm64 cross
-```
-
-Note that instructions on building the crossrootfs location can be found at https://github.com/dotnet/runtime/blob/master/docs/workflow/building/coreclr/cross-building.md. These instructions are suggested only if there are plans to change the rootfs, or the Docker images for arm/arm64 are insufficient for your build.
-
-Docker Images
-=============
-
-These instructions might fall stale often enough as we change our images as our requirements change. The table below is just a quick reference view of the images we use in different build scenarios. The ones that we use for our our official builds can be found in [the platform matrix](../../../eng/pipelines/common/platform-matrix.yml) of our Azure DevOps builds under the `container` key of the platform you plan to build.
-
-| OS                             | Target Arch     | Image location                                                                                       | crossrootfs location |
-| ------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------- | -------------------- |
-| Alpine                         | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.9-WithNode-0fc54a3-20190918214015`             | -                    |
-| CentOS 6 (build for RHEL 6)    | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-6-6aaa05d-20191106231336`                        | -                    |
-| CentOS 7 (build for Linux x64) | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:centos-7-6aaa05d-20191106231356`                        | -                    |
-| Ubuntu 16.04                   | arm32(armhf)    | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross-arm-16.04-09ec757-20200324125113`        | `/crossrootfs/arm`   |
-| Ubuntu 16.04                   | arm64 (arm64v8) | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-cfdd435-20191023143847`        | `/crossrootfs/arm64` |
-| Alpine                         | arm64 (arm64v8) | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-16.04-cross-arm64-alpine-406629a-20191023143847` | `/crossrootfs/arm64` |
 
 Environment
 ===========
 
 These instructions are written assuming the Ubuntu 16.04/18.04 LTS, since that's the distro the team uses. Pull Requests are welcome to address other environments as long as they don't break the ability to use Ubuntu 16.04/18.04 LTS.
 
-Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([Issue 536](https://github.com/dotnet/coreclr/issues/536)).
+Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([dotnet/runtime#4069](https://github.com/dotnet/runtime/issues/4069)).
 
 Toolchain Setup
 ---------------
@@ -94,6 +56,6 @@ The following dependencies are needed if Mono Runtime is enabled (default behavi
 - automake
 - libtool 
 
-    ~$ sudo apt-get install cmake llvm-9 clang-9 autoconf automake libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev zlib1g-dev autoconf automake libtool
+    ~$ sudo apt-get install cmake llvm-9 clang-9 autoconf automake libtool build-essential python curl git lldb-6.0 liblldb-6.0-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libssl-dev libnuma-dev libkrb5-dev zlib1g-dev
 
 You now have all the required components.


### PR DESCRIPTION
All the Docker information was duplicated in two places; remove
that duplication.