### PR TITLE
Bump to updated WebAssembly runner from xharness

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20271.3",
+      "version": "1.0.0-prerelease.20279.2",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -174,9 +174,9 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>9d18ed3c9b43df5d4e61810475e5b2de8e1531da</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.Tests.Runners" Version="1.0.0-prerelease.20277.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20279.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>8f6cc04f53cb6759758ffc97c9c8ca3ab4802f7f</Sha>
+      <Sha>94251a8d989891191b5dd915eec82de36d8404a1</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -107,7 +107,7 @@
     <SystemDataSqlClientVersion>4.8.0</SystemDataSqlClientVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.7.0-preview-20200521-01</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestsRunnersVersion>1.0.0-prerelease.20277.1</MicrosoftDotNetXHarnessTestsRunnersVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20279.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <CoverletCollectorVersion>1.2.1</CoverletCollectorVersion>
     <TraceEventVersion>2.0.5</TraceEventVersion>

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -1,12 +1,10 @@
 set -ev
 
 EXECUTION_DIR=$(dirname $0)
-TEST_NAME=$1
-TARGET_ARCH=$2
 
-echo "Test: $1 Arch: $2"
+echo "Test: $1"
 
 cd $EXECUTION_DIR
-v8 --expose_wasm runtime.js -- --enable-gc --run WasmTestRunner.dll $TEST_NAME.dll
+v8 --expose_wasm runtime.js -- --enable-gc --run WasmTestRunner.dll $*
 
 exit 0

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -83,6 +83,7 @@
       <RunTestsCommand>"$(RunScriptOutputPath)" --runtime-path "$(TestHostRootPath.TrimEnd('\/'))"</RunTestsCommand>
       <RunTestsCommand Condition="'$(TestRspFile)' != '' and '$(RuntimeFlavor)' != 'Mono'">$(RunTestsCommand) --rsp-file "$(TestRspFile)"</RunTestsCommand>
       <RunTestsCommand Condition="'$(TargetsMobile)' == 'true'">"$(RunScriptOutputPath)" $(AssemblyName) $(TargetArchitecture)</RunTestsCommand>
+      <RunTestsCommand Condition="'$(TargetOS)' == 'Browser'">"$(RunScriptOutputPath)" $(AssemblyName).dll $(_withoutCategories.Replace(';', ' -notrait category='))</RunTestsCommand>
     </PropertyGroup>
 
     <!-- Invoke the run script with the test host as the runtime path. -->

--- a/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
+++ b/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.cs
@@ -12,8 +12,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
-using Microsoft.DotNet.XHarness.Tests.Runners;
-using Microsoft.DotNet.XHarness.Tests.Runners.Core;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
+using Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
 public class SimpleAndroidTestRunner : AndroidApplicationEntryPoint, IDevice
 {
@@ -71,8 +71,6 @@ public class SimpleAndroidTestRunner : AndroidApplicationEntryPoint, IDevice
     protected override int? MaxParallelThreads => _maxParallelThreads;
 
     protected override IDevice Device => this;
-
-    protected override TestRunnerType TestRunner => TestRunnerType.Xunit;
 
     protected override string? IgnoreFilesDirectory => null;
 

--- a/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.csproj
+++ b/src/libraries/Common/tests/AndroidTestRunner/AndroidTestRunner.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AndroidTestRunner.cs" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Common/tests/AppleTestRunner/AppleTestRunner.cs
+++ b/src/libraries/Common/tests/AppleTestRunner/AppleTestRunner.cs
@@ -12,8 +12,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
-using Microsoft.DotNet.XHarness.Tests.Runners;
-using Microsoft.DotNet.XHarness.Tests.Runners.Core;
+using Microsoft.DotNet.XHarness.TestRunners.Common;
+using Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
 public class SimpleTestRunner : iOSApplicationEntryPoint, IDevice
 {
@@ -127,8 +127,6 @@ public class SimpleTestRunner : iOSApplicationEntryPoint, IDevice
     protected override int? MaxParallelThreads => _maxParallelThreads;
 
     protected override IDevice Device => this;
-
-    protected override TestRunnerType TestRunner => TestRunnerType.Xunit;
 
     protected override string? IgnoreFilesDirectory => null;
 

--- a/src/libraries/Common/tests/AppleTestRunner/AppleTestRunner.csproj
+++ b/src/libraries/Common/tests/AppleTestRunner/AppleTestRunner.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AppleTestRunner.cs" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.cs
+++ b/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.cs
@@ -3,27 +3,40 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Linq;
-using System.Text;
-using System.IO;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
 
-public class WasmTestRunner
+using Microsoft.DotNet.XHarness.TestRunners.Xunit;
+
+public class SimpleWasmTestRunner : WasmApplicationEntryPoint
 {
+    protected override string TestAssembly { get; set; } = "";
+    protected override IEnumerable<string> ExcludedTraits { get; set; } = new List<string>();
+
     public static int Main(string[] args)
     {
-        Console.Write("Args: ");
-        foreach (string arg in args)
-        {
-            Console.Write(arg);
-        }
-        Console.WriteLine(".");
+        var testAssembly = args[0];
+        var excludedTraits = new List<string>();
 
-        return 0;
+        for (int i = 1; i < args.Length; i++)
+        {
+            var option = args[i];
+            switch (option)
+            {
+                case "-notrait":
+                    excludedTraits.Add (args[i + 1]);
+                    i++;
+                    break;
+                default:
+                    throw new ArgumentException($"Invalid argument '{option}'.");
+            }
+        }
+
+        var runner = new SimpleWasmTestRunner()
+        {
+            TestAssembly = testAssembly,
+            ExcludedTraits = excludedTraits
+        };
+
+        return runner.Run();
     }
 }

--- a/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.csproj
+++ b/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.csproj
@@ -6,6 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="WasmTestRunner.cs" />
-    <PackageReference Include="Microsoft.DotNet.XHarness.Tests.Runners" Version="$(MicrosoftDotNetXHarnessTestsRunnersVersion)" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="$(MicrosoftDotNetXHarnessTestRunnersXunitVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Allows running unit tests on WebAssembly via the standard Test target.

The next step is to hook up the xharness CLI to drive the test instead of calling `v8` directly.