### PR TITLE
ActivityContext Changes

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/Resources/Strings.resx
@@ -150,9 +150,6 @@
   <data name="SetParentIdOnActivityWithParent" xml:space="preserve">
     <value>"Can not set ParentId on activity which has parent"</value>
   </data>
-  <data name="SpanIdOrTraceIdInvalid" xml:space="preserve">
-    <value>"Invalid SpanId or TraceId"</value>
-  </data>
   <data name="StartTimeNotUtc" xml:space="preserve">
     <value>"StartTime is not UTC"</value>
   </data>

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
@@ -21,12 +21,6 @@ namespace System.Diagnostics
         /// <param name="traceState"> Carries system-specific configuration data.</param>
         public ActivityContext(ActivityTraceId traceId, ActivitySpanId spanId, ActivityTraceFlags traceFlags, string? traceState = null)
         {
-            // We don't allow creating context with invalid span or trace Ids.
-            if (traceId == default || spanId == default)
-            {
-                throw new ArgumentException(SR.SpanIdOrTraceIdInvalid, traceId == default ? nameof(traceId) : nameof(spanId));
-            }
-
             TraceId = traceId;
             SpanId = spanId;
             TraceFlags = traceFlags;

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -133,11 +133,12 @@ namespace System.Diagnostics
             }
             else
             {
+                ActivityContext initializedContext =  context == default && Activity.Current != null ? Activity.Current.Context : context;
                 listeners.EnumWithFunc(listener => {
                     var getRequestedDataUsingContext = listener.GetRequestedDataUsingContext;
                     if (getRequestedDataUsingContext != null)
                     {
-                        ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(this, name, context == default && Activity.Current != null ? Activity.Current.Context : context, kind, tags, links);
+                        ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(this, name, initializedContext, kind, tags, links);
                         ActivityDataRequest dr = getRequestedDataUsingContext(ref aco);
                         if (dr > dateRequest)
                         {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -137,7 +137,7 @@ namespace System.Diagnostics
                     var getRequestedDataUsingContext = listener.GetRequestedDataUsingContext;
                     if (getRequestedDataUsingContext != null)
                     {
-                        ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(this, name, context, kind, tags, links);
+                        ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(this, name, context == default && Activity.Current != null ? Activity.Current.Context : context, kind, tags, links);
                         ActivityDataRequest dr = getRequestedDataUsingContext(ref aco);
                         if (dr > dateRequest)
                         {

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -360,6 +360,40 @@ namespace System.Diagnostics.Tests
                 }
             }).Dispose();
         }
+
+        [Fact]
+        public void TestDefaultParentContext()
+        {
+            RemoteExecutor.Invoke(() => {
+                using (ActivitySource aSource = new ActivitySource("ParentContext"))
+                {
+                    using (ActivityListener listener = new ActivityListener
+                    {
+                        ShouldListenTo = (activitySource) => activitySource.Name == "ParentContext",
+                        GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) =>
+                        {
+                            Activity c = Activity.Current;
+                            if (c != null)
+                            {
+                                Assert.Equal(c.Context, activityOptions.Parent);
+                            }
+
+                            return ActivityDataRequest.AllData;
+                        }
+                    })
+                    {
+                        ActivitySource.AddActivityListener(listener);
+
+                        using (Activity a = aSource.StartActivity("a", ActivityKind.Server, new ActivityContext(ActivityTraceId.CreateRandom(), ActivitySpanId.CreateRandom(), 0)))
+                        using (Activity b = aSource.StartActivity("b"))
+                        {
+                            Assert.Equal(a.Context, b.Parent.Context);
+                        }
+                    }
+                }
+            }).Dispose();
+        }
+
         public void Dispose() => Activity.Current = null;
     }
 }


### PR DESCRIPTION
This PR has 2 changes:
- We are relaxing creating ActivityContext without throwing even when having default TraceId and SpanId. 
- We got some feedback from OpenTelemetry; when calling ActivitySource.StartActivity and not passing the activity context or passing default context, then when ActivitySoure calling the ActivityListener.GetRequestedDataUsingContext, instead of passing the default context, we'll pass the context from Activity.Current. We are doing that because this will be the context used when creating the Activity anyway. And will not require the implementers of GetRequestedDataUsingContext to manually get the Activity.Current context to during the sampling.