### PR TITLE
Remove HasCCWTemplate and HasGuidInfo flags

### DIFF
--- a/src/coreclr/src/debug/daccess/nidump.cpp
+++ b/src/coreclr/src/debug/daccess/nidump.cpp
@@ -5509,9 +5509,6 @@ NativeImageDumper::EnumMnemonics s_MTFlagsHigh[] =
     MTFLAG_ENTRY(HasIndirectParent),
     MTFLAG_ENTRY(ContainsPointers),
     MTFLAG_ENTRY(HasTypeEquivalence),
-#if defined(FEATURE_COMINTEROP)
-    MTFLAG_ENTRY(HasRCWPerTypeData),
-#endif
     MTFLAG_ENTRY(HasCriticalFinalizer),
     MTFLAG_ENTRY(Collectible),
     MTFLAG_ENTRY(ContainsGenericVariables),

--- a/src/coreclr/src/debug/daccess/nidump.cpp
+++ b/src/coreclr/src/debug/daccess/nidump.cpp
@@ -5503,9 +5503,6 @@ NativeImageDumper::EnumMnemonics s_MTFlagsHigh[] =
 
     MTFLAG_ENTRY(HasFinalizer),
     MTFLAG_ENTRY(IfNotInterfaceThenMarshalable),
-#if defined(FEATURE_COMINTEROP)
-    MTFLAG_ENTRY(IfInterfaceThenHasGuidInfo),
-#endif
 #if defined(FEATURE_ICASTABLE)
     MTFLAG_ENTRY(ICastable),
 #endif
@@ -5541,7 +5538,6 @@ NativeImageDumper::EnumMnemonics s_MTFlags2[] =
     MTFLAG2_ENTRY(IsIntrinsicType),
     MTFLAG2_ENTRY(RequiresDispatchTokenFat),
     MTFLAG2_ENTRY(HasCctor),
-    MTFLAG2_ENTRY(HasCCWTemplate),
 #ifdef FEATURE_64BIT_ALIGNMENT
     MTFLAG2_ENTRY(RequiresAlign8),
 #endif
@@ -7190,47 +7186,6 @@ NativeImageDumper::DumpMethodTable( PTR_MethodTable mt, const char * name,
         DisplayEndStructure( METHODTABLES );//OptionalMember_GenericsStaticsInfo
 
     }
-
-#ifdef FEATURE_COMINTEROP
-    if (haveCompleteExtents &&
-        mt->HasGuidInfo() &&
-        CHECK_OPT(METHODTABLES)
-        )
-    {
-        PTR_GuidInfo guidInfo(*mt->GetGuidInfoPtr());
-
-        if (guidInfo != NULL)
-        {
-            m_display->StartStructureWithOffset( "OptionalMember_GuidInfo",
-                                                 mt->GetOffsetOfOptionalMember(MethodTable::OptionalMember_GuidInfo),
-                                                 sizeof(void*),
-                                                 DPtrToPreferredAddr(guidInfo),
-                                                 sizeof(GuidInfo)
-                                                 );
-            TempBuffer buf;
-            GuidToString( guidInfo->m_Guid, buf );
-            DisplayWriteFieldStringW( m_Guid, (const WCHAR *)buf, GuidInfo,
-                                      ALWAYS );
-            DisplayWriteFieldFlag( m_bGeneratedFromName,
-                                   guidInfo->m_bGeneratedFromName,
-                                   GuidInfo, ALWAYS );
-            DisplayEndStructure( ALWAYS ); // OptionalMember_GuidInfo
-        }
-    }
-
-    if (haveCompleteExtents &&
-        mt->HasCCWTemplate()
-        && CHECK_OPT(METHODTABLES)
-        )
-    {
-        PTR_ComCallWrapperTemplate ccwTemplate(TO_TADDR(*mt->GetCCWTemplatePtr()));
-        m_display->WriteFieldPointer( "OptionalMember_CCWTemplate",
-                                      mt->GetOffsetOfOptionalMember(MethodTable::OptionalMember_CCWTemplate),
-                                      sizeof(void *),
-                                      DPtrToPreferredAddr(ccwTemplate)
-                                      );
-    }
-#endif // FEATURE_COMINTEROP
 
     DisplayEndStructure( METHODTABLES ); //MethodTable
 } // NativeImageDumper::DumpMethodTable

--- a/src/coreclr/src/vm/array.cpp
+++ b/src/coreclr/src/vm/array.cpp
@@ -325,8 +325,6 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     // We always have a non-virtual slot array, see assert at end
     cbMT += MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
                                                           FALSE,                           // GenericsStaticsInfo
-                                                          FALSE,                           // GuidInfo
-                                                          FALSE,                           // CCWTemplate
                                                           FALSE,                           // RCWPerTypeData
                                                           FALSE);                          // TokenOverflow
 

--- a/src/coreclr/src/vm/array.cpp
+++ b/src/coreclr/src/vm/array.cpp
@@ -325,7 +325,6 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
     // We always have a non-virtual slot array, see assert at end
     cbMT += MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
                                                           FALSE,                           // GenericsStaticsInfo
-                                                          FALSE,                           // RCWPerTypeData
                                                           FALSE);                          // TokenOverflow
 
     // This is the offset of the beginning of the interface map

--- a/src/coreclr/src/vm/ceeload.cpp
+++ b/src/coreclr/src/vm/ceeload.cpp
@@ -3089,28 +3089,6 @@ void Module::FreeClassTables()
                 if (!th.IsRestored())
                     continue;
 
-#ifdef FEATURE_COMINTEROP
-                // Some MethodTables/TypeDescs have COM interop goo attached to them which must be released
-                if (!th.IsTypeDesc())
-                {
-                    MethodTable *pMT = th.AsMethodTable();
-                    if (pMT->HasCCWTemplate() && (!pMT->IsZapped() || pMT->GetZapModule() == this))
-                    {
-                        // code:MethodTable::GetComCallWrapperTemplate() may go through canonical methodtable indirection cell.
-                        // The module load could be aborted before completing code:FILE_LOAD_EAGER_FIXUPS phase that's responsible
-                        // for resolving pre-restored indirection cells, so we have to check for it here explicitly.
-                        if (CORCOMPILE_IS_POINTER_TAGGED(pMT->GetCanonicalMethodTableFixup()))
-                            continue;
-
-                        ComCallWrapperTemplate *pTemplate = pMT->GetComCallWrapperTemplate();
-                        if (pTemplate != NULL)
-                        {
-                            pTemplate->Release();
-                        }
-                    }
-                }
-#endif // FEATURE_COMINTEROP
-
                 // We need to call destruct on instances of EEClass whose "canonical" dependent lives in this table
                 // There is nothing interesting to destruct on array EEClass
                 if (!th.IsTypeDesc())

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -2617,7 +2617,7 @@ void EEClass::Save(DataImage *image, MethodTable *pMT)
         GUID dummy;
         if (SUCCEEDED(pMT->GetGuidNoThrow(&dummy, TRUE, FALSE)))
         {
-            GuidInfo* pGuidInfo = pMT->GetGuidInfo();
+            GuidInfo* pGuidInfo = GetGuidInfo();
             _ASSERTE(pGuidInfo != NULL);
 
             image->StoreStructure(pGuidInfo, sizeof(GuidInfo),

--- a/src/coreclr/src/vm/comcallablewrapper.cpp
+++ b/src/coreclr/src/vm/comcallablewrapper.cpp
@@ -5098,7 +5098,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
 
     GCX_PREEMP();
 
-    if (!thClass.IsTypeDesc() && !thClass.AsMethodTable()->HasCCWTemplate())
+    if (!thClass.IsTypeDesc())
     {
         // Canonicalize the class type because we are going to stick the template pointer to EEClass.
         thClass = thClass.GetCanonicalMethodTable();

--- a/src/coreclr/src/vm/generics.cpp
+++ b/src/coreclr/src/vm/generics.cpp
@@ -248,9 +248,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     DWORD cbIMap = pOldMT->GetInterfaceMapSize();
     InterfaceInfo_t * pOldIMap = (InterfaceInfo_t *)pOldMT->GetInterfaceMap();
 
-    BOOL fHasGuidInfo = FALSE;
-    BOOL fHasCCWTemplate = FALSE;
-
     DWORD dwMultipurposeSlotsMask = 0;
     dwMultipurposeSlotsMask |= MethodTable::enum_flag_HasPerInstInfo;
     if (wNumInterfaces != 0)
@@ -262,8 +259,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     // We need space for the optional members.
     DWORD cbOptional = MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
                                                       fHasGenericsStaticsInfo,
-                                                      fHasGuidInfo,
-                                                      fHasCCWTemplate,
                                                       fHasRCWPerTypeData,
                                                       pOldMT->HasTokenOverflow());
 
@@ -452,14 +447,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     if (fHasGenericsStaticsInfo)
         pMT->SetDynamicStatics(TRUE);
 
-
-#ifdef FEATURE_COMINTEROP
-    if (fHasCCWTemplate)
-        pMT->SetHasCCWTemplate();
-    if (fHasGuidInfo)
-        pMT->SetHasGuidInfo();
-#endif
-
     // Since we are fabricating a new MT based on an existing one, the per-inst info should
     // be non-null
     _ASSERTE(pOldMT->HasPerInstInfo());
@@ -594,8 +581,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
 #ifdef FEATURE_COMINTEROP
     _ASSERTE(!fHasDynamicInterfaceMap == !pMT->HasDynamicInterfaceMap());
     _ASSERTE(!fHasRCWPerTypeData == !pMT->HasRCWPerTypeData());
-    _ASSERTE(!fHasCCWTemplate == !pMT->HasCCWTemplate());
-    _ASSERTE(!fHasGuidInfo == !pMT->HasGuidInfo());
 #endif
 
     LOG((LF_CLASSLOADER, LL_INFO1000, "GENERICS: Replicated methodtable to create type %s\n", pMT->GetDebugClassName()));

--- a/src/coreclr/src/vm/generics.cpp
+++ b/src/coreclr/src/vm/generics.cpp
@@ -214,10 +214,8 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
 
 #ifdef FEATURE_COMINTEROP
     BOOL fHasDynamicInterfaceMap = pOldMT->HasDynamicInterfaceMap();
-    BOOL fHasRCWPerTypeData = pOldMT->HasRCWPerTypeData();
 #else // FEATURE_COMINTEROP
     BOOL fHasDynamicInterfaceMap = FALSE;
-    BOOL fHasRCWPerTypeData = FALSE;
 #endif // FEATURE_COMINTEROP
 
     // Collectible types have some special restrictions
@@ -259,7 +257,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     // We need space for the optional members.
     DWORD cbOptional = MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
                                                       fHasGenericsStaticsInfo,
-                                                      fHasRCWPerTypeData,
                                                       pOldMT->HasTokenOverflow());
 
     // We need space for the PerInstInfo, i.e. the generic dictionary pointers...
@@ -580,7 +577,6 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     _ASSERTE(!fHasGenericsStaticsInfo == !pMT->HasGenericsStaticsInfo());
 #ifdef FEATURE_COMINTEROP
     _ASSERTE(!fHasDynamicInterfaceMap == !pMT->HasDynamicInterfaceMap());
-    _ASSERTE(!fHasRCWPerTypeData == !pMT->HasRCWPerTypeData());
 #endif
 
     LOG((LF_CLASSLOADER, LL_INFO1000, "GENERICS: Replicated methodtable to create type %s\n", pMT->GetDebugClassName()));

--- a/src/coreclr/src/vm/generics.h
+++ b/src/coreclr/src/vm/generics.h
@@ -168,13 +168,6 @@ namespace Generics
         /* in */  PTR_VOID pExactGenericArgsToken,
         /* out*/  TypeHandle *pSpecificClass,
         /* out*/  MethodDesc** pSpecificMethod);
-
-    inline void DetermineCCWTemplateAndGUIDPresenceOnNonCanonicalMethodTable(
-        // Input
-        MethodTable *pOldMT,
-        BOOL fNewMTContainsGenericVariables,
-        // Output
-        BOOL *pfHasGuidInfo, BOOL *pfHasCCWTemplate);
 };
 
 #endif

--- a/src/coreclr/src/vm/methodtable.h
+++ b/src/coreclr/src/vm/methodtable.h
@@ -284,10 +284,6 @@ struct CrossModuleGenericsStaticsInfo
 };  // struct CrossModuleGenericsStaticsInfo
 typedef DPTR(CrossModuleGenericsStaticsInfo) PTR_CrossModuleGenericsStaticsInfo;
 
-#ifdef FEATURE_COMINTEROP
-struct RCWPerTypeData;
-#endif // FEATURE_COMINTEROP
-
 //
 // This struct consolidates the writeable parts of the MethodTable
 // so that we can layout a read-only MethodTable with a pointer
@@ -2762,15 +2758,6 @@ public:
 #endif
 
     //-------------------------------------------------------------------
-    // REMOTEABLE METHOD INFO
-    //
-
-#ifdef FEATURE_COMINTEROP
-    void SetHasRCWPerTypeData();
-    BOOL HasRCWPerTypeData();
-#endif // FEATURE_COMINTEROP
-
-    //-------------------------------------------------------------------
     // DICTIONARIES FOR GENERIC INSTANTIATIONS
     //
     // The PerInstInfo pointer is a pointer to per-instantiation pointer table,
@@ -2992,14 +2979,6 @@ public:
     //   * for everything else returns the GetGuid(, TRUE)
     BOOL    GetGuidForWinRT(GUID *pGuid);
 
-private:
-    // Create RCW data associated with this type.
-    RCWPerTypeData *CreateRCWPerTypeData(bool bThrowOnOOM);
-
-public:
-    // Get the RCW data associated with this type or NULL if the type does not need such data or allocation
-    // failed (only if bThrowOnOOM is false).
-    RCWPerTypeData *GetRCWPerTypeData(bool bThrowOnOOM = true);
 #endif // FEATURE_COMINTEROP
 
     // Convenience method - determine if the interface/class has a guid specified (even if not yet cached)
@@ -3618,9 +3597,7 @@ private:
 
         enum_flag_HasTypeEquivalence          = 0x02000000, // can be equivalent to another type
 
-#ifdef FEATURE_COMINTEROP
-        enum_flag_HasRCWPerTypeData           = 0x04000000, // has optional pointer to RCWPerTypeData
-#endif // FEATURE_COMINTEROP
+        // enum_flag_unused                   = 0x04000000,
 
         enum_flag_HasCriticalFinalizer        = 0x08000000, // finalizer must be run on Appdomain Unload
         enum_flag_Collectible                 = 0x10000000,
@@ -3878,21 +3855,12 @@ private:
     /* Accessing this member efficiently is currently performance critical for static field accesses               */ \
     /* in generic classes, so place it early in the list. */                                                          \
     METHODTABLE_OPTIONAL_MEMBER(GenericsStaticsInfo,    GenericsStaticsInfo,            GetGenericsStaticsInfo      ) \
-    /* Accessed by interop, fairly frequently. */                                                                     \
-    METHODTABLE_COMINTEROP_OPTIONAL_MEMBERS()                                                                         \
     /* Accessed during x-domain transition only, so place it late in the list. */                                     \
     METHODTABLE_REMOTING_OPTIONAL_MEMBERS()                                                                           \
     /* Accessed during certain generic type load operations only, so low priority */                                  \
     METHODTABLE_OPTIONAL_MEMBER(ExtraInterfaceInfo,     TADDR,                          GetExtraInterfaceInfoPtr    ) \
     /* TypeDef token for assemblies with more than 64k types. Never happens in real world. */                         \
     METHODTABLE_OPTIONAL_MEMBER(TokenOverflow,          TADDR,                          GetTokenOverflowPtr         ) \
-
-#ifdef FEATURE_COMINTEROP
-#define METHODTABLE_COMINTEROP_OPTIONAL_MEMBERS() \
-    METHODTABLE_OPTIONAL_MEMBER(RCWPerTypeData,         RCWPerTypeData *,               GetRCWPerTypeDataPtr        )
-#else
-#define METHODTABLE_COMINTEROP_OPTIONAL_MEMBERS()
-#endif
 
 #define METHODTABLE_REMOTING_OPTIONAL_MEMBERS()
 
@@ -3941,7 +3909,6 @@ private:
     inline static DWORD GetOptionalMembersAllocationSize(
                                                   DWORD dwMultipurposeSlotsMask,
                                                   BOOL needsGenericsStaticsInfo,
-                                                  BOOL needsRCWPerTypeData,
                                                   BOOL needsTokenOverflow);
     inline DWORD GetOptionalMembersSize();
 

--- a/src/coreclr/src/vm/methodtable.h
+++ b/src/coreclr/src/vm/methodtable.h
@@ -2766,10 +2766,6 @@ public:
     //
 
 #ifdef FEATURE_COMINTEROP
-    void SetHasGuidInfo();
-    BOOL HasGuidInfo();
-    void SetHasCCWTemplate();
-    BOOL HasCCWTemplate();
     void SetHasRCWPerTypeData();
     BOOL HasRCWPerTypeData();
 #endif // FEATURE_COMINTEROP
@@ -2983,10 +2979,6 @@ public:
     //-------------------------------------------------------------------
     // The GUID Info
     // Used by COM interop to get GUIDs (IIDs and CLSIDs)
-
-    // Get/store cached GUID information
-    PTR_GuidInfo GetGuidInfo();
-    void SetGuidInfo(GuidInfo* pGuidInfo);
 
     // Get and cache the GUID for this interface/class
     HRESULT GetGuidNoThrow(GUID *pGuid, BOOL bGenerateIfNotFound, BOOL bClassic = TRUE);
@@ -3616,9 +3608,7 @@ private:
 
         enum_flag_HasFinalizer                = 0x00100000, // instances require finalization
 
-#ifdef FEATURE_COMINTEROP
-        enum_flag_IfInterfaceThenHasGuidInfo    = 0x00200000, // Does the type has optional GuidInfo
-#endif // FEATURE_COMINTEROP
+        // enum_flag_unused                   = 0x00200000,
 
         enum_flag_ICastable                   = 0x00400000, // class implements ICastable interface
 
@@ -3682,7 +3672,7 @@ private:
         enum_flag_RequiresDispatchTokenFat  = 0x0200,
 
         enum_flag_HasCctor                  = 0x0400,
-        enum_flag_HasCCWTemplate            = 0x0800, // Has an extra field pointing to a CCW template
+        // enum_flag_unused                 = 0x0800,
 
 #ifdef FEATURE_64BIT_ALIGNMENT
         enum_flag_RequiresAlign8            = 0x1000, // Type requires 8-byte alignment (only set on platforms that require this and don't get it implicitly)
@@ -3899,9 +3889,7 @@ private:
 
 #ifdef FEATURE_COMINTEROP
 #define METHODTABLE_COMINTEROP_OPTIONAL_MEMBERS() \
-    METHODTABLE_OPTIONAL_MEMBER(GuidInfo,               PTR_GuidInfo,                   GetGuidInfoPtr              ) \
-    METHODTABLE_OPTIONAL_MEMBER(RCWPerTypeData,         RCWPerTypeData *,               GetRCWPerTypeDataPtr        ) \
-    METHODTABLE_OPTIONAL_MEMBER(CCWTemplate,            ComCallWrapperTemplate *,       GetCCWTemplatePtr           )
+    METHODTABLE_OPTIONAL_MEMBER(RCWPerTypeData,         RCWPerTypeData *,               GetRCWPerTypeDataPtr        )
 #else
 #define METHODTABLE_COMINTEROP_OPTIONAL_MEMBERS()
 #endif
@@ -3953,8 +3941,6 @@ private:
     inline static DWORD GetOptionalMembersAllocationSize(
                                                   DWORD dwMultipurposeSlotsMask,
                                                   BOOL needsGenericsStaticsInfo,
-                                                  BOOL needsGuidInfo,
-                                                  BOOL needsCCWTemplate,
                                                   BOOL needsRCWPerTypeData,
                                                   BOOL needsTokenOverflow);
     inline DWORD GetOptionalMembersSize();

--- a/src/coreclr/src/vm/methodtable.inl
+++ b/src/coreclr/src/vm/methodtable.inl
@@ -363,20 +363,6 @@ inline BOOL MethodTable::HasExplicitGuid()
 }
 
 //==========================================================================================
-inline void MethodTable::SetHasRCWPerTypeData()
-{
-    LIMITED_METHOD_CONTRACT;
-    SetFlag(enum_flag_HasRCWPerTypeData);
-}
-
-//==========================================================================================
-inline BOOL MethodTable::HasRCWPerTypeData()
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-    return GetFlag(enum_flag_HasRCWPerTypeData);
-}
-
-//==========================================================================================
 // Get the GUID used for WinRT interop
 //   * if the type is not a WinRT type or a redirected interfae return FALSE
 inline BOOL MethodTable::GetGuidForWinRT(GUID *pGuid)
@@ -1230,7 +1216,6 @@ FORCEINLINE DWORD MethodTable::GetOffsetOfOptionalMember(OptionalMemberId id)
 //==========================================================================================
 inline DWORD MethodTable::GetOptionalMembersAllocationSize(DWORD dwMultipurposeSlotsMask,
                                                            BOOL needsGenericsStaticsInfo,
-                                                           BOOL needsRCWPerTypeData,
                                                            BOOL needsTokenOverflow)
 {
     LIMITED_METHOD_CONTRACT;
@@ -1239,8 +1224,6 @@ inline DWORD MethodTable::GetOptionalMembersAllocationSize(DWORD dwMultipurposeS
 
     if (needsGenericsStaticsInfo)
         size += sizeof(GenericsStaticsInfo);
-    if (needsRCWPerTypeData)
-        size += sizeof(UINT_PTR);
     if (dwMultipurposeSlotsMask & enum_flag_HasInterfaceMap)
         size += sizeof(UINT_PTR);
     if (needsTokenOverflow)

--- a/src/coreclr/src/vm/methodtable.inl
+++ b/src/coreclr/src/vm/methodtable.inl
@@ -346,30 +346,6 @@ inline BOOL MethodTable::IsAbstract()
 
 #ifdef FEATURE_COMINTEROP
 //==========================================================================================
-inline void MethodTable::SetHasGuidInfo()
-{
-    LIMITED_METHOD_CONTRACT;
-    _ASSERTE(IsInterface() || (HasCCWTemplate() && IsDelegate()));
-
-    // for delegates, having CCW template implies having GUID info
-    if (IsInterface())
-        SetFlag(enum_flag_IfInterfaceThenHasGuidInfo);
-}
-
-//==========================================================================================
-inline BOOL MethodTable::HasGuidInfo()
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-
-    if (IsInterface())
-        return GetFlag(enum_flag_IfInterfaceThenHasGuidInfo);
-
-    // HasCCWTemplate() is intentionally checked first here to avoid hitting
-    // g_pMulticastDelegateClass == NULL inside IsDelegate() during startup
-    return HasCCWTemplate() && IsDelegate();
-}
-
-//==========================================================================================
 // True IFF the type has a GUID explicitly assigned to it (including WinRT generic interfaces
 // where the GUID is computed).
 inline BOOL MethodTable::HasExplicitGuid()
@@ -384,20 +360,6 @@ inline BOOL MethodTable::HasExplicitGuid()
     GUID guid;
     GetGuid(&guid, FALSE);
     return (guid != GUID_NULL);
-}
-
-//==========================================================================================
-inline void MethodTable::SetHasCCWTemplate()
-{
-    LIMITED_METHOD_CONTRACT;
-    SetFlag(enum_flag_HasCCWTemplate);
-}
-
-//==========================================================================================
-inline BOOL MethodTable::HasCCWTemplate()
-{
-    LIMITED_METHOD_DAC_CONTRACT;
-    return GetFlag(enum_flag_HasCCWTemplate);
 }
 
 //==========================================================================================
@@ -966,10 +928,6 @@ inline MethodTable::VtableIndirectionSlotIterator MethodTable::IterateVtableIndi
 inline ComCallWrapperTemplate *MethodTable::GetComCallWrapperTemplate()
 {
     LIMITED_METHOD_CONTRACT;
-    if (HasCCWTemplate())
-    {
-        return *GetCCWTemplatePtr();
-    }
     return GetClass()->GetComCallWrapperTemplate();
 }
 
@@ -984,12 +942,6 @@ inline BOOL MethodTable::SetComCallWrapperTemplate(ComCallWrapperTemplate *pTemp
     }
     CONTRACTL_END;
 
-    if (HasCCWTemplate())
-    {
-        TypeHandle th(this);
-        g_IBCLogger.LogTypeMethodTableWriteableAccess(&th);
-        return (InterlockedCompareExchangeT(GetCCWTemplatePtr(), pTemplate, NULL) == NULL);
-    }
     g_IBCLogger.LogEEClassCOWTableAccess(this);
     return GetClass_NoLogging()->SetComCallWrapperTemplate(pTemplate);
 }
@@ -1278,8 +1230,6 @@ FORCEINLINE DWORD MethodTable::GetOffsetOfOptionalMember(OptionalMemberId id)
 //==========================================================================================
 inline DWORD MethodTable::GetOptionalMembersAllocationSize(DWORD dwMultipurposeSlotsMask,
                                                            BOOL needsGenericsStaticsInfo,
-                                                           BOOL needsGuidInfo,
-                                                           BOOL needsCCWTemplate,
                                                            BOOL needsRCWPerTypeData,
                                                            BOOL needsTokenOverflow)
 {
@@ -1289,10 +1239,6 @@ inline DWORD MethodTable::GetOptionalMembersAllocationSize(DWORD dwMultipurposeS
 
     if (needsGenericsStaticsInfo)
         size += sizeof(GenericsStaticsInfo);
-    if (needsGuidInfo)
-        size += sizeof(UINT_PTR);
-    if (needsCCWTemplate)
-        size += sizeof(UINT_PTR);
     if (needsRCWPerTypeData)
         size += sizeof(UINT_PTR);
     if (dwMultipurposeSlotsMask & enum_flag_HasInterfaceMap)

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -9666,20 +9666,20 @@ void MethodTableBuilder::CheckForSystemTypes()
 // way to allocate a new MT. Don't try calling new / ctor.
 // Called from SetupMethodTable
 // This needs to be kept consistent with MethodTable::GetSavedExtent()
-MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
-                                         DWORD dwVtableSlots,
-                                         DWORD dwVirtuals,
-                                         DWORD dwGCSize,
-                                         DWORD dwNumInterfaces,
-                                         DWORD dwNumDicts,
-                                         DWORD cbInstAndDict,
-                                         MethodTable *pMTParent,
-                                         ClassLoader *pClassLoader,
-                                         LoaderAllocator *pAllocator,
-                                         BOOL isInterface,
-                                         BOOL fDynamicStatics,
-                                         BOOL fHasGenericsStaticsInfo,
-                                         BOOL fNeedsRCWPerTypeData
+MethodTable * MethodTableBuilder::AllocateNewMT(
+    Module *pLoaderModule,
+    DWORD dwVtableSlots,
+    DWORD dwVirtuals,
+    DWORD dwGCSize,
+    DWORD dwNumInterfaces,
+    DWORD dwNumDicts,
+    DWORD cbInstAndDict,
+    MethodTable *pMTParent,
+    ClassLoader *pClassLoader,
+    LoaderAllocator *pAllocator,
+    BOOL isInterface,
+    BOOL fDynamicStatics,
+    BOOL fHasGenericsStaticsInfo
 #ifdef FEATURE_COMINTEROP
         , BOOL fHasDynamicInterfaceMap
 #endif
@@ -9709,7 +9709,6 @@ MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
     // vtable
     cbTotalSize += MethodTable::GetNumVtableIndirections(dwVirtuals) * sizeof(MethodTable::VTableIndir_t);
 
-
     DWORD dwMultipurposeSlotsMask = 0;
     if (dwNumInterfaces != 0)
         dwMultipurposeSlotsMask |= MethodTable::enum_flag_HasInterfaceMap;
@@ -9725,7 +9724,6 @@ MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
     // Add space for optional members here. Same as GetOptionalMembersSize()
     cbTotalSize += MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
                                                       fHasGenericsStaticsInfo,
-                                                      fNeedsRCWPerTypeData,
                                                       RidFromToken(GetCl()) >= METHODTABLE_TOKEN_OVERFLOW);
 
     // Interface map starts here
@@ -9961,9 +9959,6 @@ MethodTableBuilder::SetupMethodTable2(
     BOOL fHasDynamicInterfaceMap = bmtInterface->dwInterfaceMapSize > 0 &&
                                    bmtProp->fIsComObjectType &&
                                    (GetParentMethodTable() != g_pObjectClass);
-    BOOL fNeedsRCWPerTypeData = bmtProp->fNeedsRCWPerTypeData;
-#else // FEATURE_COMINTEROP
-    BOOL fNeedsRCWPerTypeData = FALSE;
 #endif // FEATURE_COMINTEROP
 
     EEClass *pClass = GetHalfBakedClass();
@@ -10011,7 +10006,6 @@ MethodTableBuilder::SetupMethodTable2(
                                    IsInterface(),
                                    bmtProp->fDynamicStatics,
                                    bmtProp->fGenericsStatics,
-                                   fNeedsRCWPerTypeData,
 #ifdef FEATURE_COMINTEROP
                                    fHasDynamicInterfaceMap,
 #endif
@@ -10027,12 +10021,6 @@ MethodTableBuilder::SetupMethodTable2(
 #ifdef _DEBUG
     pMT->SetDebugClassName(GetDebugClassName());
 #endif
-
-#ifdef FEATURE_COMINTEROP
-    if (fNeedsRCWPerTypeData)
-        pMT->SetHasRCWPerTypeData();
-#endif // FEATURE_COMINTEROP
-
 
     if (IsInterface())
         pMT->SetIsInterface();

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -9725,8 +9725,6 @@ MethodTable * MethodTableBuilder::AllocateNewMT(Module *pLoaderModule,
     // Add space for optional members here. Same as GetOptionalMembersSize()
     cbTotalSize += MethodTable::GetOptionalMembersAllocationSize(dwMultipurposeSlotsMask,
                                                       fHasGenericsStaticsInfo,
-                                                      FALSE, // no GuidInfo needed for canonical instantiations
-                                                      FALSE, // no CCW template needed for canonical instantiations
                                                       fNeedsRCWPerTypeData,
                                                       RidFromToken(GetCl()) >= METHODTABLE_TOKEN_OVERFLOW);
 

--- a/src/coreclr/src/vm/methodtablebuilder.h
+++ b/src/coreclr/src/vm/methodtablebuilder.h
@@ -1323,7 +1323,6 @@ private:
 #ifdef FEATURE_COMINTEROP
         bool fIsMngStandardItf;                 // Set to true if the interface is a manages standard interface.
         bool fComEventItfType;                  // Set to true if the class is a special COM event interface.
-        bool fNeedsRCWPerTypeData;              // Set to true if the class needs optional RCW data attached to the MethodTable
 #endif // FEATURE_COMINTEROP
 #ifdef FEATURE_TYPEEQUIVALENCE
         bool fHasTypeEquivalence;               // Set to true if the class is decorated by TypeIdentifierAttribute, or through some other technique is influenced by type equivalence
@@ -2963,8 +2962,7 @@ private:
                                 LoaderAllocator *pAllocator,
                                 BOOL isIFace,
                                 BOOL fDynamicStatics,
-                                BOOL fHasGenericsStaticsInfo,
-                                BOOL fNeedsRCWPerTypeData
+                                BOOL fHasGenericsStaticsInfo
 #ifdef FEATURE_COMINTEROP
                                 , BOOL bHasDynamicInterfaceMap
 #endif

--- a/src/coreclr/src/vm/runtimecallablewrapper.h
+++ b/src/coreclr/src/vm/runtimecallablewrapper.h
@@ -879,31 +879,6 @@ inline RCW::CreationFlags RCW::CreationFlagsFromObjForComIPFlags(ObjFromComIP::f
     return result;
 }
 
-
-// RCW data attached to MethodTable's that represent interesting types. Types without RCWPerTypeData
-// (i.e. those with MethodTable::GetRCWPerTypeData() == NULL) are not interesting and are assumed to
-// use NULL/default values for m_pVariantMT/m_pMTForQI1/m_pMTForQI2/m_pGetEnumeratorMethod.
-struct RCWPerTypeData
-{
-    // Corresponding type with variance or NULL if the type does not exhibit variant behavior.
-    MethodTable *m_pVariantMT;
-
-    // The corresponding IEnumerator<T>::GetEnumerator instantiation or NULL if the type does not
-    // act like IEnumerable.
-    MethodDesc *m_pGetEnumeratorMethod;
-
-    enum
-    {
-        VariantTypeInited       = 0x01,     // m_pVariantMT is set
-        //unused                = 0x02,
-        GetEnumeratorInited     = 0x04,     // m_pGetEnumeratorMethod is set
-        // unused               = 0x08,
-        // unused               = 0x10,
-        // unused               = 0x20,
-    };
-    DWORD m_dwFlags;
-};
-
 #ifdef FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
 
 class ComClassFactory;


### PR DESCRIPTION
Never set now that built-in WinRT support has been removed.

I plan to take over the `HasGuidInfo` slot for `ICastableObject` (#37042).

cc @jkoritzinsky @AaronRobinsonMSFT 