### PR TITLE
Stop adding NULL native code addresses in GetNativeCodeStartAddresses

### DIFF
--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -6534,9 +6534,13 @@ HRESULT ProfToEEInterfaceImpl::GetNativeCodeStartAddresses(FunctionID functionID
             NativeCodeVersionCollection nativeCodeVersions = ilCodeVersion.GetNativeCodeVersions(pMD);
             for (NativeCodeVersionIterator iter = nativeCodeVersions.Begin(); iter != nativeCodeVersions.End(); iter++)
             {
-                addresses.Append((*iter).GetNativeCode());
+                PCODE codeStart = (*iter).GetNativeCode();
 
-                ++trueLen;
+                if (codeStart != NULL)
+                {
+                    addresses.Append(codeStart);
+                    ++trueLen;
+                }
             }
         }
 

--- a/src/coreclr/tests/src/profiler/native/profiler.cpp
+++ b/src/coreclr/tests/src/profiler/native/profiler.cpp
@@ -22,7 +22,7 @@ HRESULT STDMETHODCALLTYPE Profiler::Initialize(IUnknown *pICorProfilerInfoUnk)
     printf("Profiler.dll!Profiler::Initialize\n");
     fflush(stdout);
 
-    HRESULT queryInterfaceResult = pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo8), reinterpret_cast<void **>(&this->pCorProfilerInfo));
+    HRESULT queryInterfaceResult = pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo9), reinterpret_cast<void **>(&this->pCorProfilerInfo));
     if (FAILED(queryInterfaceResult))
     {
         printf("Profiler.dll!Profiler::Initialize failed to QI for ICorProfilerInfo.\n");

--- a/src/coreclr/tests/src/profiler/native/profiler.h
+++ b/src/coreclr/tests/src/profiler/native/profiler.h
@@ -109,7 +109,7 @@ protected:
     String GetModuleIDName(ModuleID modId);
 
 public:
-    ICorProfilerInfo8* pCorProfilerInfo;
+    ICorProfilerInfo9* pCorProfilerInfo;
 
     Profiler();
     virtual ~Profiler();


### PR DESCRIPTION
Fixes #13404

If you call in to GetNativeCodeStartAddresses between when a CodeVersion is created and when NativeCodeVersion::SetNativeCodeInterlocked is called, the NativeCodeVersion will return 0 for its address.

An easy way to guarantee this sequence is to call GetNativeCodeStartAddresses from within JITCachedFunctionSearchFinished.