### PR TITLE
Fix ActivitySource to log the right amount of stopped

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -110,7 +110,7 @@ namespace System.Diagnostics
 
             Activity? activity = null;
 
-            ActivityDataRequest dateRequest = ActivityDataRequest.None;
+            ActivityDataRequest dataRequest = ActivityDataRequest.None;
 
             if (parentId != null)
             {
@@ -120,13 +120,13 @@ namespace System.Diagnostics
                     {
                         ActivityCreationOptions<string> aco = new ActivityCreationOptions<string>(this, name, parentId, kind, tags, links);
                         ActivityDataRequest dr = getRequestedDataUsingParentId(ref aco);
-                        if (dr > dateRequest)
+                        if (dr > dataRequest)
                         {
-                            dateRequest = dr;
+                            dataRequest = dr;
                         }
 
                         // Stop the enumeration if we get the max value RecordingAndSampling.
-                        return dateRequest != ActivityDataRequest.AllDataAndRecorded;
+                        return dataRequest != ActivityDataRequest.AllDataAndRecorded;
                     }
                     return true;
                 });
@@ -139,21 +139,21 @@ namespace System.Diagnostics
                     {
                         ActivityCreationOptions<ActivityContext> aco = new ActivityCreationOptions<ActivityContext>(this, name, context, kind, tags, links);
                         ActivityDataRequest dr = getRequestedDataUsingContext(ref aco);
-                        if (dr > dateRequest)
+                        if (dr > dataRequest)
                         {
-                            dateRequest = dr;
+                            dataRequest = dr;
                         }
 
                         // Stop the enumeration if we get the max value RecordingAndSampling.
-                        return dateRequest != ActivityDataRequest.AllDataAndRecorded;
+                        return dataRequest != ActivityDataRequest.AllDataAndRecorded;
                     }
                     return true;
                 });
             }
 
-            if (dateRequest != ActivityDataRequest.None)
+            if (dataRequest != ActivityDataRequest.None)
             {
-                activity = Activity.CreateAndStart(this, name, kind, parentId, context, tags, links, startTime, dateRequest);
+                activity = Activity.CreateAndStart(this, name, kind, parentId, context, tags, links, startTime, dataRequest);
                 listeners.EnumWithAction(listener => {
                     var activityStarted = listener.ActivityStarted;
                     if (activityStarted != null)

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -238,9 +238,7 @@ namespace System.Diagnostics
             SynchronizedList<ActivityListener>? listeners = _listeners;
             if (listeners != null &&  listeners.Count > 0)
             {
-                listeners.EnumWithAction(listener => {
-                    listeners.EnumWithAction(listener => listener.ActivityStopped?.Invoke(activity));
-                });
+                listeners.EnumWithAction(listener => listener.ActivityStopped?.Invoke(activity));
             }
         }
     }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -228,13 +228,16 @@ namespace System.Diagnostics.Tests
         {
             RemoteExecutor.Invoke(() => {
 
+                int activityStartCount = 0;
+                int activityStopCount = 0;
+
                 ActivitySource source = new ActivitySource("MultipleListenerSource");
                 ActivityListener [] listeners = new ActivityListener[4];
 
                 listeners[0] = new ActivityListener
                 {
-                    ActivityStarted = activity => Assert.NotNull(activity),
-                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ActivityStarted = (activity) => { activityStartCount++; Assert.NotNull(activity); },
+                    ActivityStopped = (activity) => { activityStopCount++; Assert.NotNull(activity); },
                     ShouldListenTo = (activitySource) => true,
                     GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.None,
                     GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.None
@@ -245,8 +248,8 @@ namespace System.Diagnostics.Tests
 
                 listeners[1] = new ActivityListener
                 {
-                    ActivityStarted = activity => Assert.NotNull(activity),
-                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ActivityStarted = (activity) => { activityStartCount++; Assert.NotNull(activity); },
+                    ActivityStopped = (activity) => { activityStopCount++; Assert.NotNull(activity); },
                     ShouldListenTo = (activitySource) => true,
                     GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.PropagationData,
                     GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.PropagationData
@@ -261,8 +264,8 @@ namespace System.Diagnostics.Tests
 
                 listeners[2] = new ActivityListener
                 {
-                    ActivityStarted = activity => Assert.NotNull(activity),
-                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ActivityStarted = (activity) => { activityStartCount++; Assert.NotNull(activity); },
+                    ActivityStopped = (activity) => { activityStopCount++; Assert.NotNull(activity); },
                     ShouldListenTo = (activitySource) => true,
                     GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
                     GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData
@@ -277,8 +280,8 @@ namespace System.Diagnostics.Tests
 
                 listeners[3] = new ActivityListener
                 {
-                    ActivityStarted = activity => Assert.NotNull(activity),
-                    ActivityStopped = activity => Assert.NotNull(activity),
+                    ActivityStarted = (activity) => { activityStartCount++; Assert.NotNull(activity); },
+                    ActivityStopped = (activity) => { activityStopCount++; Assert.NotNull(activity); },
                     ShouldListenTo = (activitySource) => true,
                     GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllDataAndRecorded,
                     GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllDataAndRecorded
@@ -289,6 +292,9 @@ namespace System.Diagnostics.Tests
                 {
                     Assert.True(a4.IsAllDataRequested);
                     Assert.True((a4.ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0, $"a4.ActivityTraceFlags failed: {a4.ActivityTraceFlags}");
+
+                    Assert.Equal(4, activityStartCount);
+                    Assert.Equal(0, activityStopCount);
                 }
 
                 foreach (IDisposable listener in listeners)
@@ -296,6 +302,8 @@ namespace System.Diagnostics.Tests
                     listener.Dispose();
                 }
 
+                Assert.Equal(activityStartCount, activityStopCount);
+                Assert.Equal(4, activityStopCount);
                 Assert.Null(source.StartActivity("a5"));
             }).Dispose();
         }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -246,6 +246,9 @@ namespace System.Diagnostics.Tests
 
                 Assert.Null(source.StartActivity("a1"));
 
+                Assert.Equal(0, activityStartCount);
+                Assert.Equal(0, activityStopCount);
+
                 listeners[1] = new ActivityListener
                 {
                     ActivityStarted = (activity) => { activityStartCount++; Assert.NotNull(activity); },
@@ -260,7 +263,13 @@ namespace System.Diagnostics.Tests
                 {
                     Assert.False(a2.IsAllDataRequested);
                     Assert.True((a2.ActivityTraceFlags & ActivityTraceFlags.Recorded) == 0);
+                    
+                    Assert.Equal(2, activityStartCount);
+                    Assert.Equal(0, activityStopCount);
                 }
+
+                Assert.Equal(activityStartCount, activityStopCount);
+                Assert.Equal(2, activityStopCount);
 
                 listeners[2] = new ActivityListener
                 {
@@ -276,7 +285,13 @@ namespace System.Diagnostics.Tests
                 {
                     Assert.True(a3.IsAllDataRequested);
                     Assert.True((a3.ActivityTraceFlags & ActivityTraceFlags.Recorded) == 0);
+                    
+                    Assert.Equal(5, activityStartCount);
+                    Assert.Equal(2, activityStopCount);
                 }
+
+                Assert.Equal(activityStartCount, activityStopCount);
+                Assert.Equal(5, activityStopCount);
 
                 listeners[3] = new ActivityListener
                 {
@@ -293,8 +308,8 @@ namespace System.Diagnostics.Tests
                     Assert.True(a4.IsAllDataRequested);
                     Assert.True((a4.ActivityTraceFlags & ActivityTraceFlags.Recorded) != 0, $"a4.ActivityTraceFlags failed: {a4.ActivityTraceFlags}");
 
-                    Assert.Equal(4, activityStartCount);
-                    Assert.Equal(0, activityStopCount);
+                    Assert.Equal(9, activityStartCount);
+                    Assert.Equal(5, activityStopCount);
                 }
 
                 foreach (IDisposable listener in listeners)
@@ -303,7 +318,7 @@ namespace System.Diagnostics.Tests
                 }
 
                 Assert.Equal(activityStartCount, activityStopCount);
-                Assert.Equal(4, activityStopCount);
+                Assert.Equal(9, activityStopCount);
                 Assert.Null(source.StartActivity("a5"));
             }).Dispose();
         }


### PR DESCRIPTION
**Issue:**
Activity stopped logged multiple times when there are multiple activity listeners

**Repro code**
```
namespace ConsoleApp
{
    class Program
    {
        static void Main(string[] args)
        {
            ActivityListener listenAll = new ActivityListener
            {
                ShouldListenTo = (d) => true,
                ActivityStarted = (o) => { Console.Write("ListenALL:"); LogStarted(o); },
                ActivityStopped = (o) => { Console.Write("ListenALL:"); LogStopped(o); },
                GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData,
                GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
            };
 
            ActivityListener listenA1 = new ActivityListener
            {
                ShouldListenTo = (d) => d.Name == "A1",
                ActivityStarted = (o) => { Console.Write("Specific:"); LogStarted(o); },
                ActivityStopped = (o) => { Console.Write("Specific:"); LogStopped(o); },
                GetRequestedDataUsingContext = (ref ActivityCreationOptions<ActivityContext> activityOptions) => ActivityDataRequest.AllData,
                GetRequestedDataUsingParentId = (ref ActivityCreationOptions<string> activityOptions) => ActivityDataRequest.AllData,
            };
 
            ActivitySource.AddActivityListener(listenAll);
            ActivitySource.AddActivityListener(listenA1);
 
            ActivitySource a1 = new ActivitySource("A1");
            using(Activity act = a1.StartActivity("Test"))
            {
                using (Activity inner = a1.StartActivity("Inner"))
                {
                    Console.WriteLine("Test");
                }
            }
        }
 
        private static void LogStopped(Activity obj)
        {
            Console.WriteLine($"Stopped {obj.OperationName}");
        }
 
        private static void LogStarted(Activity obj)
        {
            Console.WriteLine($"Started {obj.OperationName}");
        }
    }
}
```

**Output**
```
ListenALL:Started Test
Specific:Started Test
ListenALL:Started Inner
Specific:Started Inner
Test
ListenALL:Stopped Inner
Specific:Stopped Inner
ListenALL:Stopped Inner
Specific:Stopped Inner
ListenALL:Stopped Test
Specific:Stopped Test
ListenALL:Stopped Test
Specific:Stopped Test
```