### PR TITLE
Update coverlet version to fix coverage exceptions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "coverlet.console": {
-      "version": "1.7.1",
+      "version": "1.7.2",
       "commands": [
         "coverlet"
       ]

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -108,7 +108,7 @@
     <MicrosoftNETTestSdkVersion>16.7.0-preview-20200529-01</MicrosoftNETTestSdkVersion>
     <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20279.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
-    <CoverletCollectorVersion>1.2.1</CoverletCollectorVersion>
+    <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>
     <TraceEventVersion>2.0.5</TraceEventVersion>
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <MoqVersion>4.12.0</MoqVersion>


### PR DESCRIPTION
Changelog: https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/Changelog.md#release-date-2020-05-30

-Fix 'The process cannot access the file...because it is being used by another process' due to double flush for collectors driver #https://github.com/coverlet-coverage/coverlet/pull/835

cc @MarcoRossignoli 