### PR TITLE
RyuJIT: Fold "cns_str"[cns_index] to ushort constant

### DIFF
--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -5282,13 +5282,30 @@ const int MAX_INDEX_COMPLEXITY = 4;
 GenTree* Compiler::fgMorphArrayIndex(GenTree* tree)
 {
     noway_assert(tree->gtOper == GT_INDEX);
-    GenTreeIndex* asIndex = tree->AsIndex();
-
-    var_types            elemTyp        = tree->TypeGet();
-    unsigned             elemSize       = tree->AsIndex()->gtIndElemSize;
-    CORINFO_CLASS_HANDLE elemStructType = tree->AsIndex()->gtStructElemClass;
+    GenTreeIndex*        asIndex        = tree->AsIndex();
+    var_types            elemTyp        = asIndex->TypeGet();
+    unsigned             elemSize       = asIndex->gtIndElemSize;
+    CORINFO_CLASS_HANDLE elemStructType = asIndex->gtStructElemClass;
 
     noway_assert(elemTyp != TYP_STRUCT || elemStructType != nullptr);
+
+    // Fold "cns_str"[cns_index] to ushort constant
+    if (opts.OptimizationEnabled() && asIndex->Arr()->OperIs(GT_CNS_STR) && asIndex->Index()->IsIntCnsFitsInI32())
+    {
+        const int cnsIndex = static_cast<int>(asIndex->Index()->AsIntConCommon()->IconValue());
+        if (cnsIndex >= 0)
+        {
+            int     length;
+            LPCWSTR str = info.compCompHnd->getStringLiteral(asIndex->Arr()->AsStrCon()->gtScpHnd,
+                                                             asIndex->Arr()->AsStrCon()->gtSconCPX, &length);
+            if ((cnsIndex < length) && (str != nullptr))
+            {
+                GenTree* cnsCharNode = gtNewIconNode(str[cnsIndex], elemTyp);
+                INDEBUG(cnsCharNode->gtDebugFlags |= GTF_DEBUG_NODE_MORPHED);
+                return cnsCharNode;
+            }
+        }
+    }
 
 #ifdef FEATURE_SIMD
     if (featureSIMD && varTypeIsStruct(elemTyp) && structSizeMightRepresentSIMDType(elemSize))


### PR DESCRIPTION
A small improvement to fold things like `"hello"[1] to 'e'` in RyuJIT

jit-diff (-f -pmi):
```
Total bytes of diff: -209 (-0.00% of base)
    diff is an improvement.

Top file improvements (bytes):
        -209 : System.Private.CoreLib.dasm (-0.00% of base)

1 total files with Code Size differences (1 improved, 0 regressed), 265 unchanged.

Top method improvements (bytes):
         -81 (-1.41% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:FormatCustomized(System.DateTime,System.ReadOnlySpan`1[Char],System.Globalization.DateTimeFormatInfo,System.TimeSpan,System.Text.StringBuilder):System.Text.StringBuilder
         -39 (-19.31% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:IsAllowedJapaneseTokenFollowedByNonSpaceLetter(System.String,ushort):bool:this
         -33 (-1.72% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:Tokenize(int,byref,byref,byref):bool:this
         -29 (-0.56% of base) : System.Private.CoreLib.dasm - System.DateTimeParse:ParseByFormat(byref,byref,byref,System.Globalization.DateTimeFormatInfo,byref):bool
         -27 (-15.43% of base) : System.Private.CoreLib.dasm - System.DateTimeParse:ParseJapaneseEraStart(byref,System.Globalization.DateTimeFormatInfo):bool

Top method improvements (percentages):
         -39 (-19.31% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:IsAllowedJapaneseTokenFollowedByNonSpaceLetter(System.String,ushort):bool:this
         -27 (-15.43% of base) : System.Private.CoreLib.dasm - System.DateTimeParse:ParseJapaneseEraStart(byref,System.Globalization.DateTimeFormatInfo):bool
         -33 (-1.72% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:Tokenize(int,byref,byref,byref):bool:this
         -81 (-1.41% of base) : System.Private.CoreLib.dasm - System.DateTimeFormat:FormatCustomized(System.DateTime,System.ReadOnlySpan`1[Char],System.Globalization.DateTimeFormatInfo,System.TimeSpan,System.Text.StringBuilder):System.Text.StringBuilder
         -29 (-0.56% of base) : System.Private.CoreLib.dasm - System.DateTimeParse:ParseByFormat(byref,byref,byref,System.Globalization.DateTimeFormatInfo,byref):bool

5 total methods with Code Size differences (5 improved, 0 regressed), 312722 unchanged.
```

/cc @sandreenko 