### PR TITLE
CallGetCalendarInfoEx() was being called twice even if the first call succeeded

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
@@ -218,7 +218,7 @@ namespace System.Globalization
                         localeName = "fa-IR";
 
                         // See if that works
-                        if(!CallGetCalendarInfoEx(localeName, calendar, CAL_SCALNAME, out string _))
+                        if (!CallGetCalendarInfoEx(localeName, calendar, CAL_SCALNAME, out string _))
                         {
                             // Failed again, just use en-US with the gregorian calendar
                             localeName = "en-US";

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
@@ -216,13 +216,14 @@ namespace System.Globalization
                     {
                         // Failed, set it to a locale (fa-IR) that's alway has Gregorian US available in the OS
                         localeName = "fa-IR";
-                    }
-                    // See if that works
-                    if (!CallGetCalendarInfoEx(localeName, calendar, CAL_SCALNAME, out string _))
-                    {
-                        // Failed again, just use en-US with the gregorian calendar
-                        localeName = "en-US";
-                        calendar = CalendarId.GREGORIAN;
+
+                        // See if that works
+                        if(!CallGetCalendarInfoEx(localeName, calendar, CAL_SCALNAME, out string _))
+                        {
+                            // Failed again, just use en-US with the gregorian calendar
+                            localeName = "en-US";
+                            calendar = CalendarId.GREGORIAN;
+                        }
                     }
                     break;
                 case CalendarId.TAIWAN:


### PR DESCRIPTION
In `CalendarData.CheckSpecialCalendar()` when the calendar ID is `GREGORIAN_US` `CallGetCalendarInfoEx()` was being called twice even if the first call succeeded.