### PR TITLE
RyuJIT: Don't emit null checks for constant strings

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -7319,6 +7319,10 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
     {
         return false;
     }
+    else if (addr->OperIs(GT_CNS_STR))
+    {
+        return false;
+    }
     else if (addr->gtOper == GT_LCL_VAR)
     {
         unsigned varNum = addr->AsLclVarCommon()->GetLclNum();
@@ -23758,10 +23762,13 @@ Statement* Compiler::fgInlinePrependStatements(InlineInfo* inlineInfo)
     if (call->gtFlags & GTF_CALL_NULLCHECK && !inlineInfo->thisDereferencedFirst)
     {
         // Call impInlineFetchArg to "reserve" a temp for the "this" pointer.
-        nullcheck = gtNewNullCheck(impInlineFetchArg(0, inlArgInfo, lclVarInfo), block);
-
-        // The NULL-check statement will be inserted to the statement list after those statements
-        // that assign arguments to temps and before the actual body of the inlinee method.
+        GenTree* thisOp = impInlineFetchArg(0, inlArgInfo, lclVarInfo);
+        if (fgAddrCouldBeNull(thisOp))
+        {
+            nullcheck = gtNewNullCheck(impInlineFetchArg(0, inlArgInfo, lclVarInfo), block);
+            // The NULL-check statement will be inserted to the statement list after those statements
+            // that assign arguments to temps and before the actual body of the inlinee method.
+        }
     }
 
     /* Treat arguments that had to be assigned to temps */

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -14532,10 +14532,18 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
             if (op1->OperIs(GT_CNS_STR) || op2->OperIs(GT_CNS_STR))
             {
                 // Fold "ldstr" ==/!= null
-                if (tree->OperIs(GT_EQ, GT_NE, GT_GT) && op2->IsIntegralConst(0))
+                if (op2->IsIntegralConst(0))
                 {
-                    i1 = tree->OperIs(GT_NE, GT_GT);
-                    goto FOLD_COND;
+                    if (tree->OperIs(GT_EQ))
+                    {
+                        i1 = 0;
+                        goto FOLD_COND;
+                    }
+                    if (tree->OperIs(GT_NE) || (tree->OperIs(GT_GT) && tree->IsUnsigned()))
+                    {
+                        i1 = 1;
+                        goto FOLD_COND;
+                    }
                 }
                 return tree;
             }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -14529,8 +14529,14 @@ GenTree* Compiler::gtFoldExprConst(GenTree* tree)
 
             /* String nodes are an RVA at this point */
 
-            if (op1->gtOper == GT_CNS_STR || op2->gtOper == GT_CNS_STR)
+            if (op1->OperIs(GT_CNS_STR) || op2->OperIs(GT_CNS_STR))
             {
+                // Fold "ldstr" ==/!= null
+                if (tree->OperIs(GT_EQ, GT_NE, GT_GT) && op2->IsIntegralConst(0))
+                {
+                    i1 = tree->OperIs(GT_NE, GT_GT);
+                    goto FOLD_COND;
+                }
                 return tree;
             }
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6111,7 +6111,8 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
         bool addExplicitNullCheck = false;
 
         // Implicit byref locals are never null.
-        if (fgAddrCouldBeNull(objRef) && !((objRef->gtOper == GT_LCL_VAR) && lvaIsImplicitByRefLocal(objRef->AsLclVarCommon()->GetLclNum())))
+        if (fgAddrCouldBeNull(objRef) &&
+            !((objRef->gtOper == GT_LCL_VAR) && lvaIsImplicitByRefLocal(objRef->AsLclVarCommon()->GetLclNum())))
         {
             // If the objRef is a GT_ADDR node, it, itself, never requires null checking.  The expression
             // whose address is being taken is either a local or static variable, whose address is necessarily

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6111,7 +6111,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
         bool addExplicitNullCheck = false;
 
         // Implicit byref locals are never null.
-        if (!((objRef->gtOper == GT_LCL_VAR) && lvaIsImplicitByRefLocal(objRef->AsLclVarCommon()->GetLclNum())))
+        if (fgAddrCouldBeNull(objRef) && !((objRef->gtOper == GT_LCL_VAR) && lvaIsImplicitByRefLocal(objRef->AsLclVarCommon()->GetLclNum())))
         {
             // If the objRef is a GT_ADDR node, it, itself, never requires null checking.  The expression
             // whose address is being taken is either a local or static variable, whose address is necessarily

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6110,9 +6110,8 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
 
         bool addExplicitNullCheck = false;
 
-        // Implicit byref locals are never null.
-        if (fgAddrCouldBeNull(objRef) &&
-            !((objRef->gtOper == GT_LCL_VAR) && lvaIsImplicitByRefLocal(objRef->AsLclVarCommon()->GetLclNum())))
+        // Implicit byref locals and string literals are never null.
+        if (fgAddrCouldBeNull(objRef))
         {
             // If the objRef is a GT_ADDR node, it, itself, never requires null checking.  The expression
             // whose address is being taken is either a local or static variable, whose address is necessarily


### PR DESCRIPTION
The following code converts a constant string into a `ReadOnlySpan<char>` and emits redundant nullchecks (constant strings are never null) in the codegen:
```csharp
ReadOnlySpan<char> StrToSpan() => "hey";
```
### Current codegen:
```asm
G_M46591_IG01:
G_M46591_IG02:
       mov      rax, 0xD1FFAB1E
       mov      rax, gword ptr [rax]
       test     rax, rax
       jne      SHORT G_M46591_IG04
G_M46591_IG03:
       xor      rcx, rcx
       xor      r8d, r8d
       jmp      SHORT G_M46591_IG05
G_M46591_IG04:
       cmp      dword ptr [rax], eax <-- ?? (one of them is Debug.Assert which is not removed in Checked config)
       cmp      dword ptr [rax], eax <-- ??
       add      rax, 12
       mov      rcx, rax
       mov      r8d, 3
G_M46591_IG05:
       mov      bword ptr [rdx], rcx
       mov      dword ptr [rdx+8], r8d
       mov      rax, rdx
G_M46591_IG06:
       ret      
; Total bytes of code: 53
```
### New codegen:
```asm
G_M46591_IG01:
G_M46591_IG02:
       mov      rax, 0xD1FFAB1E
       mov      rax, gword ptr [rax]
       test     rax, rax
       jne      SHORT G_M46591_IG04
G_M46591_IG03:
       xor      rcx, rcx
       xor      r8d, r8d
       jmp      SHORT G_M46591_IG05
G_M46591_IG04:
       add      rax, 12
       mov      rcx, rax
       mov      r8d, 3
G_M46591_IG05:
       mov      bword ptr [rdx], rcx
       mov      dword ptr [rdx+8], r8d
       mov      rax, rdx
G_M46591_IG06:
       ret      
; Total bytes of code: 49
```
### My PR combined with mikedn's https://github.com/dotnet/runtime/pull/1377
```asm
G_M46591_IG01:
G_M46591_IG02:
       mov      rax, 0xD1FFAB1E
       mov      rax, gword ptr [rax]
       add      rax, 12
       mov      bword ptr [rdx], rax
       mov      dword ptr [rdx+8], 3
       mov      rax, rdx
G_M46591_IG03:
       ret      
; Total bytes of code: 31
```


