### PR TITLE
Update Mono CoreLib LinkerDescriptor to match CoreCLR

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -790,8 +790,6 @@
 		<!-- Accessed via private reflection and by native code. -->
 		<type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
 		<type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
-		<!-- Accessed via reflection in TraceLogging-style EventSource events. -->
-		<type fullname="*f__AnonymousType*" />
 		<type fullname="System.Diagnostics.Tracing.PropertyValue/ReferenceTypeHelper`1">
 			<!-- Instantiated via reflection -->
 			<method name=".ctor" />
@@ -799,12 +797,9 @@
 		<!-- Accessed via native code. -->
 		<type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
 		<type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
-		<!-- Accessed by the WinRT Host -->
-		<type fullname="Internal.Runtime.InteropServices.WindowsRuntime.ActivationFactoryLoader" />
 		<!-- Workaround for https://github.com/mono/linker/issues/378 -->
 		<type fullname="System.Runtime.InteropServices.IDispatch" />
 		<type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
-		<type fullname="Windows.Foundation.Diagnostics.TracingStatusChangedEventArgs" />
 		<type fullname="System.Threading.ThreadPoolBoundHandle">
 			<!-- Workaround to keep .interfaceimpl even though this type
 				is not instantiated on unix:


### PR DESCRIPTION
#36715 and #37083 modified the CoreCLR version of CoreLib's linker descriptor file, but left them in the Mono version.

#37255 will address sharing the duplicated parts of these files.