### PR TITLE
[Test] don't use process var in async readers

### DIFF
--- a/src/coreclr/tests/src/tracing/eventpipe/reverse/reverse.cs
+++ b/src/coreclr/tests/src/tracing/eventpipe/reverse/reverse.cs
@@ -60,11 +60,13 @@ namespace Tracing.Tests.ReverseValidation
 
                 Logger.logger.Log($"running sub-process: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
 
+                DateTime subprocessStartTime = DateTime.Now;
+
                 process.OutputDataReceived += new DataReceivedEventHandler((s,e) =>
                 {
                     if (!string.IsNullOrEmpty(e.Data))
                     {
-                        stdoutSb.Append($"\n\t{(DateTime.Now - process.StartTime).TotalSeconds,5:f1}s: {e.Data}");
+                        stdoutSb.Append($"\n\t{(DateTime.Now - subprocessStartTime).TotalSeconds,5:f1}s: {e.Data}");
                     }
                 });
 
@@ -72,7 +74,7 @@ namespace Tracing.Tests.ReverseValidation
                 {
                     if (!string.IsNullOrEmpty(e.Data))
                     {
-                        stderrSb.Append($"\n\t{(DateTime.Now - process.StartTime).TotalSeconds,5:f1}s: {e.Data}");
+                        stderrSb.Append($"\n\t{(DateTime.Now - subprocessStartTime).TotalSeconds,5:f1}s: {e.Data}");
                     }
                 });
 

--- a/src/coreclr/tests/src/tracing/eventpipe/reverse/reverse.cs
+++ b/src/coreclr/tests/src/tracing/eventpipe/reverse/reverse.cs
@@ -60,6 +60,8 @@ namespace Tracing.Tests.ReverseValidation
 
                 Logger.logger.Log($"running sub-process: {process.StartInfo.FileName} {process.StartInfo.Arguments}");
 
+                // use this DateTime rather than process.StartTime since the async callbacks might
+                // not happen till after the process is no longer around.
                 DateTime subprocessStartTime = DateTime.Now;
 
                 process.OutputDataReceived += new DataReceivedEventHandler((s,e) =>


### PR DESCRIPTION
should fix #37228 by not using the `process.StartTime` variable in the async callbacks.

CC @tommcdon 