### PR TITLE
Clean pri1 test build

### DIFF
--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/WeakReference/WeakReferenceTest.csproj
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <!-- Test unsupported outside of windows -->
-    <TestUnsupportedOutsideWindows>true</TestUnsupportedOutsideWindows>
+    <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- Native COM interfaces left alive at the test exit -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
-    <DisableProjectBuild Condition="'$(TargetsWindows)' != 'true'">true</DisableProjectBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericClasses.csproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericClasses.csproj
@@ -4,6 +4,10 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Test stack overflows on OSX -->
+    <!-- https://github.com/dotnet/roslyn/issues/44758 -->
+    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NestedGenericClasses.cs" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericStructs.csproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericStructs.csproj
@@ -4,6 +4,10 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+
+     <!-- Test stack overflows on OSX -->
+     <!-- https://github.com/dotnet/roslyn/issues/44758 -->
+    <!--<DisableProjectBuild>true</DisableProjectBuild>-->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NestedGenericStructs.cs" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericStructs.csproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericStructs.csproj
@@ -7,7 +7,7 @@
 
      <!-- Test stack overflows on OSX -->
      <!-- https://github.com/dotnet/roslyn/issues/44758 -->
-    <!--<DisableProjectBuild>true</DisableProjectBuild>-->
+    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NestedGenericStructs.cs" />

--- a/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericTypesMix.csproj
+++ b/src/coreclr/tests/src/Loader/classloader/generics/Instantiation/Nesting/NestedGenericTypesMix.csproj
@@ -4,6 +4,10 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Test stack overflows on OSX -->
+    <!-- https://github.com/dotnet/roslyn/issues/44758 -->
+    <DisableProjectBuild>true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="NestedGenericTypesMix.cs" />


### PR DESCRIPTION
Fixes the pri1 test build by disabled three tests which do not compile on OSX.

Opened https://github.com/dotnet/roslyn/issues/44758 to track the StackOverflow.