### PR TITLE
Return nullptr from impSimdAsHWIntrinsic if the baseline ISA has been marked as disabled

### DIFF
--- a/src/coreclr/src/jit/simdashwintrinsic.cpp
+++ b/src/coreclr/src/jit/simdashwintrinsic.cpp
@@ -179,6 +179,22 @@ GenTree* Compiler::impSimdAsHWIntrinsic(NamedIntrinsic        intrinsic,
         return nullptr;
     }
 
+#if defined(TARGET_XARCH)
+    CORINFO_InstructionSet minimumIsa = InstructionSet_SSE2;
+#elif defined(TARGET_ARM64)
+    CORINFO_InstructionSet minimumIsa = InstructionSet_AdvSimd;
+#else
+#error Unsupported platform
+#endif // !TARGET_XARCH && !TARGET_ARM64
+
+    if (!compOpportunisticallyDependsOn(minimumIsa))
+    {
+        // The user disabled support for the baseline ISA so
+        // don't emit any SIMD intrinsics as they all require
+        // this at a minimum
+        return nullptr;
+    }
+
     CORINFO_CLASS_HANDLE argClass         = NO_CLASS_HANDLE;
     var_types            retType          = JITtype2varType(sig->retType);
     var_types            baseType         = TYP_UNKNOWN;


### PR DESCRIPTION
This resolves #37260 