### PR TITLE
Add RuntimeFeature.CovariantReturnsOfClasses

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -19,6 +19,11 @@ namespace System.Runtime.CompilerServices
 #endif
 
         /// <summary>
+        /// Indicates that this version of runtime supports covariant returns in overrides of methods declared in classes.
+        /// </summary>
+        public const string CovariantReturnsOfClasses = nameof(CovariantReturnsOfClasses);
+
+        /// <summary>
         /// Checks whether a certain feature is supported by the Runtime.
         /// </summary>
         public static bool IsSupported(string feature)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9098,6 +9098,7 @@ namespace System.Runtime.CompilerServices
     public static partial class RuntimeFeature
     {
         public const string DefaultImplementationsOfInterfaces = "DefaultImplementationsOfInterfaces";
+        public const string CovariantReturnsOfClasses = "CovariantReturnsOfClasses";
         public const string PortablePdb = "PortablePdb";
         public static bool IsDynamicCodeCompiled { get { throw null; } }
         public static bool IsDynamicCodeSupported { get { throw null; } }


### PR DESCRIPTION
This is needed so that C# compiler can detect that the current runtime
supports the covariant returns of methods declared on classes.

Close #37271