### PR TITLE
Track dependently-promoted fields when struct local is no longer referenced.

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -13886,7 +13886,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                         if (fgVarNeedsExplicitZeroInit(lclNum, bbInALoop, bbIsReturn))
                         {
                             // Append a tree to zero-out the temp
-                            newObjThisPtr = gtNewLclvNode(lclNum, lvaTable[lclNum].TypeGet());
+                            newObjThisPtr = gtNewLclvNode(lclNum, lclDsc->TypeGet());
 
                             newObjThisPtr = gtNewBlkOpNode(newObjThisPtr,    // Dest
                                                            gtNewIconNode(0), // Value

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -3387,12 +3387,18 @@ void Compiler::lvaSortByRefCount()
                 lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
             }
         }
-        else if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT))
+        else if (varDsc->lvIsStructField && (lvaGetParentPromotionType(lclNum) != PROMOTION_TYPE_INDEPENDENT) &&
+                 (lvaGetDesc(varDsc->lvParentLcl)->lvRefCnt() > 1))
         {
             // SSA must exclude struct fields that are not independently promoted
             // as dependent fields could be assigned using a CopyBlock
             // resulting in a single node causing multiple SSA definitions
             // which isn't currently supported by SSA
+            //
+            // If the parent struct local ref count is less than 2, then either the struct is no longer
+            // referenced or the field is no longer referenced: we increment the struct local ref count in incRefCnts
+            // for each field use when the struct is dependently promoted. This can happen, e.g, if we've removed
+            // a block initialization for the struct. In that case we can still track the local field.
             //
             // TODO-CQ:  Consider using lvLclBlockOpAddr and only marking these LclVars
             // untracked when a blockOp is used to assign the struct.

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9210,8 +9210,8 @@ typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, unsigned> Lc
 //            the assignment is to a local (and not a field),
 //            the local is not lvLiveInOutOfHndlr or no exceptions can be thrown between the prolog and the assignment,
 //            either the local has no gc pointers or there are no gc-safe points between the prolog and the assignment,
-//         then the local with lvHasExplicitInit which tells the codegen not to insert zero initialization for this
-//         local in the prolog.
+//         then the local is marked with lvHasExplicitInit which tells the codegen not to insert zero initialization
+//         for this local in the prolog.
 
 void Compiler::optRemoveRedundantZeroInits()
 {
@@ -9276,6 +9276,9 @@ void Compiler::optRemoveRedundantZeroInits()
                             unsigned         lclNum    = treeOp->gtOp1->AsLclVarCommon()->GetLclNum();
                             LclVarDsc* const lclDsc    = lvaGetDesc(lclNum);
                             unsigned*        pRefCount = refCounts.LookupPointer(lclNum);
+
+                            // pRefCount can't be null because the local node on the lhs of the assignment
+                            // must have already been seen.
                             assert(pRefCount != nullptr);
                             if (*pRefCount == 1)
                             {
@@ -9297,6 +9300,7 @@ void Compiler::optRemoveRedundantZeroInits()
                                             removedExplicitZeroInit      = true;
                                             *pRefCount                   = 0;
                                             lclDsc->lvSuppressedZeroInit = 1;
+                                            lclDsc->setLvRefCnt(lclDsc->lvRefCnt() - 1);
                                         }
                                     }
                                 }


### PR DESCRIPTION
This is a follow-up to #36918. It addresses one of the examples in #1007
where we remove a struct zero initialization but fail to clean up a dead
field assignment.

The change is not to mark a dependently promoted field as untracked
if we know that the struct local is no longer referenced.

I also addressed a couple of late cosmetic review comments from #36918.

No diffs in framework and benchmarks.