### PR TITLE
Add [SuppressGCTransition] to GetSysColor

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/User32/Interop.GetSysColor.cs
+++ b/src/libraries/Common/src/Interop/Windows/User32/Interop.GetSysColor.cs
@@ -15,6 +15,7 @@ internal partial class Interop
         // the overhead in the P/Invoke. It will only fail if we try and grab a color
         // index that doesn't exist.
 
+        [SuppressGCTransition]
         [DllImport(Libraries.User32, ExactSpelling = true)]
         internal static extern uint GetSysColor(int nIndex);
     }


### PR DESCRIPTION
The API is just a bounds check & array dereference. Adding the new attribute cuts the time getting the color in half. As this value isn't cached, this can add up with multiple calls to a `Color` that is based on a system color (on Windows).

cc: @AaronRobinsonMSFT 