### PR TITLE
Remove GenericArraySortHelper from ILLinkTrim xml

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -42,14 +42,6 @@
       <!-- Methods is used by VS Tasks Window. -->
       <method name="GetActiveTaskFromId" />
     </type>
-    <type fullname="System.Collections.Generic.GenericArraySortHelper`1">
-      <!-- Instantiated via reflection -->
-      <method name=".ctor" />
-    </type>
-    <type fullname="System.Collections.Generic.GenericArraySortHelper`2">
-      <!-- Instantiated via reflection -->
-      <method name=".ctor" />
-    </type>
     <!-- Accessed via private reflection by tracing controller. -->
     <type fullname="System.Diagnostics.Tracing.EventPipe*" />
     <!-- Accessed via private reflection and by native code. -->

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
@@ -20,6 +20,7 @@ namespace System.Collections.Generic
 
         public static IArraySortHelper<T> Default => s_defaultArraySortHelper;
 
+        [PreserveDependency(".ctor", "System.Collections.Generic.GenericArraySortHelper`1", "System.Private.CoreLib")]
         private static IArraySortHelper<T> CreateArraySortHelper()
         {
             IArraySortHelper<T> defaultArraySortHelper;
@@ -54,6 +55,7 @@ namespace System.Collections.Generic
 
         public static IArraySortHelper<TKey, TValue> Default => s_defaultArraySortHelper;
 
+        [PreserveDependency(".ctor", "System.Collections.Generic.GenericArraySortHelper`2", "System.Private.CoreLib")]
         private static IArraySortHelper<TKey, TValue> CreateArraySortHelper()
         {
             IArraySortHelper<TKey, TValue> defaultArraySortHelper;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
@@ -20,7 +20,7 @@ namespace System.Collections.Generic
 
         public static IArraySortHelper<T> Default => s_defaultArraySortHelper;
 
-        [PreserveDependency(".ctor", "System.Collections.Generic.GenericArraySortHelper`1", "System.Private.CoreLib")]
+        [PreserveDependency(".ctor", "System.Collections.Generic.GenericArraySortHelper`1")]
         private static IArraySortHelper<T> CreateArraySortHelper()
         {
             IArraySortHelper<T> defaultArraySortHelper;
@@ -55,7 +55,7 @@ namespace System.Collections.Generic
 
         public static IArraySortHelper<TKey, TValue> Default => s_defaultArraySortHelper;
 
-        [PreserveDependency(".ctor", "System.Collections.Generic.GenericArraySortHelper`2", "System.Private.CoreLib")]
+        [PreserveDependency(".ctor", "System.Collections.Generic.GenericArraySortHelper`2")]
         private static IArraySortHelper<TKey, TValue> CreateArraySortHelper()
         {
             IArraySortHelper<TKey, TValue> defaultArraySortHelper;

--- a/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/LinkerDescriptor/System.Private.CoreLib.xml
@@ -777,14 +777,6 @@
 			<!-- Methods is used by VS Tasks Window. -->
 			<method name="GetActiveTaskFromId" />
 		</type>
-		<type fullname="System.Collections.Generic.GenericArraySortHelper`1">
-			<!-- Instantiated via reflection -->
-			<method name=".ctor" />
-		</type>
-		<type fullname="System.Collections.Generic.GenericArraySortHelper`2">
-			<!-- Instantiated via reflection -->
-			<method name=".ctor" />
-		</type>
 		<!-- Accessed via private reflection by tracing controller. -->
 		<type fullname="System.Diagnostics.Tracing.EventPipe*" />
 		<!-- Accessed via private reflection and by native code. -->


### PR DESCRIPTION
Remove the GenericArraySortHelper from ILLinkTrim and instead move them into attributes where they are being used.