### PR TITLE
Define Debugger.IsSupported feature switch to allow trimming of debugger only code.

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/ILLinkTrim.xml
+++ b/src/libraries/Microsoft.CSharp/src/ILLinkTrim.xml
@@ -1,10 +1,13 @@
 <linker>
   <assembly fullname="Microsoft.CSharp">
+    <!-- Required for COM event dispatch -->
+    <type fullname="System.Runtime.InteropServices.ComEventsSink"/>
+  </assembly>
+
+  <assembly fullname="Microsoft.CSharp" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="true" featuredefault="true">
     <!-- Required by the Expression Evaluator -->
     <type fullname="Microsoft.CSharp.RuntimeBinder.DynamicMetaObjectProviderDebugView"/>
     <!-- Required by the Expression Evaluator -->
     <type fullname="Microsoft.CSharp.RuntimeBinder.DynamicMetaObjectProviderDebugView/DynamicDebugViewEmptyException"/>
-    <!-- Required for COM event dispatch -->
-    <type fullname="System.Runtime.InteropServices.ComEventsSink"/>
   </assembly>
 </linker>

--- a/src/libraries/System.Linq/src/ILLinkTrim.xml
+++ b/src/libraries/System.Linq/src/ILLinkTrim.xml
@@ -1,5 +1,5 @@
 <linker>
-  <assembly fullname="System.Linq">
+  <assembly fullname="System.Linq" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="true" featuredefault="true">
     <!-- required by debugger, see comment in System/Linq/DebugView.cs -->
     <type fullname="System.Linq.SystemCore_EnumerableDebugView" />
     <type fullname="System.Linq.SystemCore_EnumerableDebugView`1" />

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -4,7 +4,16 @@
       <!-- Internal API used by tests only. -->
       <method name="GetICUVersion" />
     </type>
-    <!-- Properties and methods used by a debugger. -->
+    <type fullname="System.Threading.ThreadPoolBoundHandle">
+      <!-- Workaround to keep .interfaceimpl even though this type
+             is not instantiated on unix:
+             https://github.com/mono/linker/pull/649 -->
+      <method name=".ctor" />
+    </type>
+  </assembly>
+  
+  <!-- Properties and methods used by a debugger. -->
+  <assembly fullname="System.Private.CoreLib" feature="System.Diagnostics.Debugger.IsSupported" featurevalue="true" featuredefault="true">
     <type fullname="System.Threading.Tasks.Task">
       <property name="ParentForDebugger" />
       <property name="StateFlagsForDebugger" />
@@ -36,12 +45,6 @@
     <type fullname="System.Threading.Tasks.Task">
       <!-- Methods is used by VS Tasks Window. -->
       <method name="GetActiveTaskFromId" />
-    </type>
-    <type fullname="System.Threading.ThreadPoolBoundHandle">
-      <!-- Workaround to keep .interfaceimpl even though this type
-             is not instantiated on unix:
-             https://github.com/mono/linker/pull/649 -->
-      <method name=".ctor" />
     </type>
   </assembly>
 </linker>


### PR DESCRIPTION
This change introduces a new [feature switch](https://github.com/dotnet/designs/blob/master/accepted/2020/feature-switch.md) that enables code that is only used for debugging to be trimmed by the ILLinker.

So far, there are 2 sets of code that can be trimmed:

1. Methods and properties being rooted in System.Private.CoreLib's ILLinkTrim.xml file.
2. Types in System.Linq and Microsoft.CSharp that are required by a debugger.

In the future, once https://github.com/mono/linker/issues/1162 is implemented, we should be able to use this same feature switch to remove the `DebuggerTypeProxyAttribute` when this feature switch is enabled. That will allow us to remove the debugger proxy types as well.

With this feature switch enabled, I'm seeing a ~8KB size change in the CarChecker Blazor WASM app:

| Build          | Size     |
|----------------|----------|
| master         | 3,423,744 bytes |
| proposed change   | 3,415,552 bytes |