### PR TITLE
Add logger to cache entry to catch exception

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 catch (Exception e)
                 {
                     // This will be invoked on a background thread, don't let it throw.
-                    entry._logger.LogInformation(e, "EvictionCallback invoked failed");
+                    entry._logger.LogError(new EventId(), e, "EvictionCallback invoked failed");
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -329,7 +329,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 catch (Exception e)
                 {
                     // This will be invoked on a background thread, don't let it throw.
-                    entry._logger.LogError(new EventId(), e, "EvictionCallback invoked failed");
+                    entry._logger.LogError(e, "EvictionCallback invoked failed");
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Extensions.Caching.Memory
         private IList<IDisposable> _expirationTokenRegistrations;
         private IList<PostEvictionCallbackRegistration> _postEvictionCallbacks;
         private bool _isExpired;
+        private readonly ILogger _logger;
 
         internal IList<IChangeToken> _expirationTokens;
         internal DateTimeOffset? _absoluteExpiration;
@@ -31,7 +32,8 @@ namespace Microsoft.Extensions.Caching.Memory
         internal CacheEntry(
             object key,
             Action<CacheEntry> notifyCacheEntryDisposed,
-            Action<CacheEntry> notifyCacheOfExpiration)
+            Action<CacheEntry> notifyCacheOfExpiration,
+            ILogger logger)
         {
             if (key == null)
             {
@@ -48,11 +50,17 @@ namespace Microsoft.Extensions.Caching.Memory
                 throw new ArgumentNullException(nameof(notifyCacheOfExpiration));
             }
 
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
             Key = key;
             _notifyCacheEntryDisposed = notifyCacheEntryDisposed;
             _notifyCacheOfExpiration = notifyCacheOfExpiration;
 
             _scope = CacheEntryHelper.EnterScope(this);
+            _logger = logger;
         }
 
         /// <summary>
@@ -317,10 +325,10 @@ namespace Microsoft.Extensions.Caching.Memory
                 {
                     registration.EvictionCallback?.Invoke(entry.Key, entry.Value, entry.EvictionReason, registration.State);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
                     // This will be invoked on a background thread, don't let it throw.
-                    // TODO: LOG
+                    entry._logger.LogInformation(e, "EvictionCallback invoked failed");
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/CacheEntry.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Caching.Memory

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -103,7 +103,8 @@ namespace Microsoft.Extensions.Caching.Memory
             return new CacheEntry(
                 key,
                 _setEntry,
-                _entryExpirationNotification
+                _entryExpirationNotification,
+                _logger
             );
         }
 


### PR DESCRIPTION
As we can see, we can not know the EvictionCallback invoked failed. I want to add the logger to CacheEntry to log the exception

But I don't know if it is suitable to use LogInformation to log the exception

Thank you