### PR TITLE
Rename DynamicallyAccessedMemberTypes.DefaultConstructor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/DynamicallyAccessedMemberTypes.cs
@@ -21,12 +21,12 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>
         /// Specifies the default, parameterless public constructor.
         /// </summary>
-        DefaultConstructor = 0x0001,
+        PublicParameterlessConstructor = 0x0001,
 
         /// <summary>
         /// Specifies all public constructors.
         /// </summary>
-        PublicConstructors = 0x0002 | DefaultConstructor,
+        PublicConstructors = 0x0002 | PublicParameterlessConstructor,
 
         /// <summary>
         /// Specifies all non-public constructors.

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5639,7 +5639,7 @@ namespace System.Diagnostics.CodeAnalysis
     {
         All = -1,
         None = 0,
-        DefaultConstructor = 1,
+        PublicParameterlessConstructor = 1,
         PublicConstructors = 3,
         NonPublicConstructors = 4,
         PublicMethods = 8,


### PR DESCRIPTION
API review was done over email.

Approved by @stephentoub, Immo's opinion here: https://github.com/dotnet/runtime/pull/36532#discussion_r431352102. There were no objections.