### PR TITLE
fix test failure in crossgen2

### DIFF
--- a/src/coreclr/src/vm/inlinetracking.cpp
+++ b/src/coreclr/src/vm/inlinetracking.cpp
@@ -629,7 +629,7 @@ COUNT_T PersistentInlineTrackingMapR2R2::GetInliners(PTR_Module inlineeOwnerMod,
     CONTRACTL_END;
 
     _ASSERTE(inlineeOwnerMod);
-    _ASSERTE(inliners);
+    _ASSERTE(inliners != NULL || inlinersSize == 0);
 
     if (incompleteData)
     {

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -934,9 +934,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Loader/AssemblyDependencyResolver/AssemblyDependencyResolverTests/AssemblyDependencyResolverTests/*">
             <Issue>https://github.com/dotnet/runtime/issues/34905</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/profiler/rejit/rejit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/35639</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/SimpleSIMDProgram/*">
             <Issue>https://github.com/dotnet/runtime/issues/35724</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.h
+++ b/src/coreclr/tests/src/profiler/native/rejitprofiler/rejitprofiler.h
@@ -47,7 +47,7 @@ public:
 private:
     void AddInlining(FunctionID inliner, FunctionID inlinee);
 
-    HRESULT FunctionSeen(FunctionID func);
+    bool FunctionSeen(FunctionID func);
 
     FunctionID GetFunctionIDFromToken(ModuleID module, mdMethodDef token);
     mdMethodDef GetMethodDefForFunction(FunctionID functionId);


### PR DESCRIPTION
Fixes #35639

I was looking for a different issue and saw this test failure. The issue is an overly restrictive assert. I want to be able to call the method to get a count of inliners to allocate an array and then call back with the appropriate sized array. PersistentInlineTrackingMapR2R2::GetInliners  already does the right thing, it just had an assert that inliners != NULL. I had already fixed this issue in crossgen, I didn't realize crossgen2 had a different code path. 