### PR TITLE
Remove unnecessary volatile from EventCounter

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -38,7 +38,13 @@ namespace System.Diagnostics.Tracing
             _min = double.PositiveInfinity;
             _max = double.NegativeInfinity;
 
-            InitializeBuffer();
+            var bufferedValues = new double[BufferedSize];
+            for (int i = 0; i < bufferedValues.Length; i++)
+            {
+                bufferedValues[i] = UnusedBufferSlotValue;
+            }
+            Volatile.Write(ref _bufferedValues, bufferedValues);
+
             Publish();
         }
 
@@ -136,18 +142,8 @@ namespace System.Diagnostics.Tracing
         // Values buffering
         private const int BufferedSize = 10;
         private const double UnusedBufferSlotValue = double.NegativeInfinity;
-        private volatile double[] _bufferedValues;
+        private readonly double[] _bufferedValues;
         private volatile int _bufferedValuesIndex;
-
-        [MemberNotNull(nameof(_bufferedValues))]
-        private void InitializeBuffer()
-        {
-            _bufferedValues = new double[BufferedSize];
-            for (int i = 0; i < _bufferedValues.Length; i++)
-            {
-                _bufferedValues[i] = UnusedBufferSlotValue;
-            }
-        }
 
         private void Enqueue(double value)
         {


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/36976#issuecomment-633909418

cc: @omariom, @sywhang 