### PR TITLE
Add additional test coverage for other digest algorithms with RSA

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -509,12 +509,13 @@ namespace System.Security.Cryptography.Rsa.Tests
         {
             get
             {
-                yield return new object[] { nameof(HashAlgorithmName.MD5), TestData.RSA1024Params };
-                yield return new object[] { nameof(HashAlgorithmName.MD5), TestData.RSA2048Params };
-                yield return new object[] { nameof(HashAlgorithmName.SHA1), TestData.RSA1024Params };
-                yield return new object[] { nameof(HashAlgorithmName.SHA1), TestData.RSA2048Params };
-                yield return new object[] { nameof(HashAlgorithmName.SHA256), TestData.RSA1024Params };
-                yield return new object[] { nameof(HashAlgorithmName.SHA256), TestData.RSA2048Params };
+                foreach (RSAParameters rsaParameters in new[] { TestData.RSA1024Params, TestData.RSA2048Params })
+                {
+                    yield return new object[] { nameof(HashAlgorithmName.MD5), rsaParameters };
+                    yield return new object[] { nameof(HashAlgorithmName.SHA1), rsaParameters };
+                    yield return new object[] { nameof(HashAlgorithmName.SHA256), rsaParameters };
+                }
+
                 yield return new object[] { nameof(HashAlgorithmName.SHA384), TestData.RSA2048Params };
                 yield return new object[] { nameof(HashAlgorithmName.SHA512), TestData.RSA2048Params };
             }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.IO;
 using Test.Cryptography;
 using Test.IO.Streams;
@@ -497,22 +498,26 @@ namespace System.Security.Cryptography.Rsa.Tests
             VerifySignature(signature, TestData.HelloBytes, "SHA256", TestData.RSA2048Params);
         }
 
-        [Fact]
-        public void SignAndVerify_SHA1_1024()
+        [Theory]
+        [MemberData(nameof(RoundTripTheories))]
+        public void SignAndVerify_Roundtrip(string hashAlgorithm, RSAParameters rsaParameters)
         {
-            SignAndVerify(TestData.HelloBytes, "SHA1", TestData.RSA1024Params);
+            SignAndVerify(TestData.HelloBytes, hashAlgorithm, rsaParameters);
         }
 
-        [Fact]
-        public void SignAndVerify_SHA1_2048()
+        public static IEnumerable<object[]> RoundTripTheories
         {
-            SignAndVerify(TestData.HelloBytes, "SHA1", TestData.RSA2048Params);
-        }
-
-        [Fact]
-        public void SignAndVerify_SHA256_1024()
-        {
-            SignAndVerify(TestData.HelloBytes, "SHA256", TestData.RSA1024Params);
+            get
+            {
+                yield return new object[] { nameof(HashAlgorithmName.MD5), TestData.RSA1024Params };
+                yield return new object[] { nameof(HashAlgorithmName.MD5), TestData.RSA2048Params };
+                yield return new object[] { nameof(HashAlgorithmName.SHA1), TestData.RSA1024Params };
+                yield return new object[] { nameof(HashAlgorithmName.SHA1), TestData.RSA2048Params };
+                yield return new object[] { nameof(HashAlgorithmName.SHA256), TestData.RSA1024Params };
+                yield return new object[] { nameof(HashAlgorithmName.SHA256), TestData.RSA2048Params };
+                yield return new object[] { nameof(HashAlgorithmName.SHA384), TestData.RSA2048Params };
+                yield return new object[] { nameof(HashAlgorithmName.SHA512), TestData.RSA2048Params };
+            }
         }
 
         [Fact]


### PR DESCRIPTION
While noodling with #36107 I completely broke RSA-MD5, but no unit tests failed in S.S.C.Algorithms.

Though I added tests in that branch, I thought it would be practical to get a little test coverage there now since I am unsure if that experiment will go anywhere.