### PR TITLE
Add runtime detection for CovariantReturnsOfClasses

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.cs
@@ -31,6 +31,7 @@ namespace System.Runtime.CompilerServices
             switch (feature)
             {
                 case PortablePdb:
+                case CovariantReturnsOfClasses:
 #if FEATURE_DEFAULT_INTERFACES
                 case DefaultImplementationsOfInterfaces:
 #endif

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.CompilerServices.Tests
         
         [Theory]
         [MemberData(nameof(GetStaticFeatureNames))]
-        public static StaticDataMatchesDynamicProbing(string probedValue)
+        public static void StaticDataMatchesDynamicProbing(string probedValue)
         {
             Assert.True(RuntimeFeature.IsSupported(probedValue));
         }

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
@@ -38,14 +38,14 @@ namespace System.Runtime.CompilerServices.Tests
             Assert.True(RuntimeFeature.IsDynamicCodeCompiled);
         }
         
-        public static IEnumerable<string> GetStaticFeatureNames()
+        public static IEnumerable<object[]> GetStaticFeatureNames()
         {
             foreach (var field in typeof(RuntimeFeature).GetFields(BindingFlags.Public | BindingFlags.Static))
             {
                 if (!field.IsLiteral)
                     continue;
 
-                yield return field.Name;
+                yield return new object[] { field.Name };
             }
         }
         

--- a/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeFeatureTests.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using Xunit;
 
@@ -34,6 +36,24 @@ namespace System.Runtime.CompilerServices.Tests
         {
             Assert.True(RuntimeFeature.IsDynamicCodeSupported);
             Assert.True(RuntimeFeature.IsDynamicCodeCompiled);
+        }
+        
+        public static IEnumerable<string> GetStaticFeatureNames()
+        {
+            foreach (var field in typeof(RuntimeFeature).GetFields(BindingFlags.Public | BindingFlags.Static))
+            {
+                if (!field.IsLiteral)
+                    continue;
+
+                yield return field.Name;
+            }
+        }
+        
+        [Theory]
+        [MemberData(nameof(GetStaticFeatureNames))]
+        public static StaticDataMatchesDynamicProbing(string probedValue)
+        {
+            Assert.True(RuntimeFeature.IsSupported(probedValue));
         }
     }
 }


### PR DESCRIPTION
Was missed in #37276.