### PR TITLE
Revert "Adding A log presence check before trying to delete (#36779)"

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
+++ b/src/libraries/System.Diagnostics.EventLog/tests/EventLogTests/EventLogSourceCreationTests.cs
@@ -3,11 +3,13 @@
 // See the LICENSE file in the project root for more information.
 
 using Xunit;
+using Microsoft.DotNet.XUnitExtensions;
 
 namespace System.Diagnostics.Tests
 {
     public class EventLogSourceCreationTests
     {
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void CheckSourceExistenceAndDeletion()
         {
@@ -21,13 +23,13 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                if (EventLog.Exists(log))
-                    Helpers.Retry(() => EventLog.Delete(log));
+                Helpers.Retry(() => EventLog.Delete(log));  // unlike other tests, throw if delete fails
             }
 
             Assert.False(EventLog.SourceExists(source));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void LogNameWithSame8FirstChars_NetCore()
@@ -48,15 +50,13 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                if (EventLog.Exists(firstLog))
-                    Helpers.Retry(() => EventLog.Delete(firstLog));
-
+                Helpers.Retry(() => EventLog.Delete(firstLog));
                 EventLog.DeleteEventSource(secondSource);
-                if (EventLog.Exists(secondLog))
-                   Helpers.Retry(() => EventLog.Delete(secondLog));
+                Helpers.Retry(() => EventLog.Delete(secondLog));
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
         public void LogNameWithSame8FirstChars_NetFramework()
@@ -75,8 +75,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(firstSource);
-                if (EventLog.Exists(firstLog))
-                    Helpers.Retry(() => EventLog.Delete(firstLog));
+                Helpers.Retry(() => EventLog.Delete(firstLog));
             }
         }
 
@@ -146,6 +145,7 @@ namespace System.Diagnostics.Tests
             Assert.Throws<ArgumentNullException>(() => EventLog.CreateEventSource(null));
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36135")]
         [ConditionalFact(typeof(Helpers), nameof(Helpers.IsElevatedAndSupportsEventLogs))]
         public void SourceAlreadyExistsWhenCreatingSource()
         {
@@ -160,8 +160,7 @@ namespace System.Diagnostics.Tests
             finally
             {
                 EventLog.DeleteEventSource(source);
-                if (EventLog.Exists(log))
-                    Helpers.RetrySilently(() => EventLog.Delete(log));
+                Helpers.RetrySilently(() => EventLog.Delete(log));
             }
         }
 


### PR DESCRIPTION
These tests are still failing: https://github.com/dotnet/runtime/issues/36135
