### PR TITLE
Disable sourcelink validation in the build

### DIFF
--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -30,6 +30,7 @@ stages:
     enableSymbolValidation: false
     enableSigningValidation: false
     enableNugetValidation: false
+    enableSourceLinkValidation: false
     SDLValidationParameters:
       enable: false
       artifactNames:
@@ -46,9 +47,6 @@ stages:
         -TsaRepositoryName "$(TsaRepositoryName)"
         -TsaCodebaseName "$(TsaCodebaseName)"
         -TsaPublish $True
-    
-    # The following checks are not available after the build and continue to be run here
-    enableSourceLinkValidation: true
     
     # Publish to blob storage.
     publishInstallersAndChecksums: true


### PR DESCRIPTION
Now available in nightly runs and in the prep stage for releases