### PR TITLE
Support COM objects using IEnumerator

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -61,6 +61,7 @@
     </type>
     <!-- Accessed via native code. -->
     <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
+    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerator" />
     <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
     <!-- Workaround for https://github.com/mono/linker/issues/378 -->
     <type fullname="System.Runtime.InteropServices.IDispatch" />

--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -222,6 +222,7 @@
     <Compile Include="$(BclSourcesRoot)\System\Runtime\CompilerServices\TypeDependencyAttribute.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\GCSettings.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\ComTypes\IEnumerable.cs" />
+    <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\ComTypes\IEnumerator.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\Expando\IExpando.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\GCHandle.CoreCLR.cs" />
     <Compile Include="$(BclSourcesRoot)\System\Runtime\InteropServices\Marshal.CoreCLR.cs" />

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComTypes/IEnumerator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComTypes/IEnumerator.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information
+
+namespace System.Runtime.InteropServices.ComTypes
+{
+    [Guid("496B0ABF-CDEE-11d3-88E8-00902754C43A")]
+    internal interface IEnumerator
+    {
+        bool MoveNext();
+        object Current { get; }
+        void Reset();
+    }
+}

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumVariantViewOfEnumerator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumVariantViewOfEnumerator.cs
@@ -3,11 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Runtime.InteropServices.ComTypes;
+using ComTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace System.Runtime.InteropServices.CustomMarshalers
 {
-    internal class EnumVariantViewOfEnumerator : IEnumVARIANT, ICustomAdapter
+    internal class EnumVariantViewOfEnumerator : ComTypes.IEnumVARIANT, ICustomAdapter
     {
         public EnumVariantViewOfEnumerator(IEnumerator enumerator)
         {
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices.CustomMarshalers
 
         public IEnumerator Enumerator { get; }
 
-        public IEnumVARIANT Clone()
+        public ComTypes.IEnumVARIANT Clone()
         {
             if (Enumerator is ICloneable clonable)
             {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumerableViewOfDispatch.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumerableViewOfDispatch.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Runtime.InteropServices.ComTypes;
 
 namespace System.Runtime.InteropServices.CustomMarshalers
@@ -21,7 +20,7 @@ namespace System.Runtime.InteropServices.CustomMarshalers
 
         private IDispatch Dispatch => (IDispatch)_dispatch;
 
-        public IEnumerator GetEnumerator()
+        public System.Collections.IEnumerator GetEnumerator()
         {
             Variant result;
             unsafe
@@ -50,7 +49,7 @@ namespace System.Runtime.InteropServices.CustomMarshalers
                 }
 
                 enumVariantPtr = Marshal.GetIUnknownForObject(enumVariant);
-                return (IEnumerator)EnumeratorToEnumVariantMarshaler.GetInstance(null).MarshalNativeToManaged(enumVariantPtr);
+                return (System.Collections.IEnumerator)EnumeratorToEnumVariantMarshaler.GetInstance(null).MarshalNativeToManaged(enumVariantPtr);
             }
             finally
             {

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumeratorToEnumVariantMarshaler.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumeratorToEnumVariantMarshaler.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
-using System.Runtime.InteropServices.ComTypes;
+using ComTypes = System.Runtime.InteropServices.ComTypes;
 
 namespace System.Runtime.InteropServices.CustomMarshalers
 {
@@ -41,12 +41,12 @@ namespace System.Runtime.InteropServices.CustomMarshalers
 
             if (ManagedObj is EnumeratorViewOfEnumVariant view)
             {
-                return Marshal.GetComInterfaceForObject<object, IEnumVARIANT>(view.GetUnderlyingObject());
+                return Marshal.GetComInterfaceForObject<object, ComTypes.IEnumVARIANT>(view.GetUnderlyingObject());
             }
 
             EnumVariantViewOfEnumerator nativeView = new EnumVariantViewOfEnumerator((IEnumerator)ManagedObj);
 
-            return Marshal.GetComInterfaceForObject<EnumVariantViewOfEnumerator, IEnumVARIANT>(nativeView);
+            return Marshal.GetComInterfaceForObject<EnumVariantViewOfEnumerator, ComTypes.IEnumVARIANT>(nativeView);
         }
 
         public object MarshalNativeToManaged(IntPtr pNativeData)
@@ -68,7 +68,7 @@ namespace System.Runtime.InteropServices.CustomMarshalers
                 return (comObject as IEnumerator)!;
             }
 
-            return ComDataHelpers.GetOrCreateManagedViewFromComData<IEnumVARIANT, EnumeratorViewOfEnumVariant>(comObject, var => new EnumeratorViewOfEnumVariant(var));
+            return ComDataHelpers.GetOrCreateManagedViewFromComData<ComTypes.IEnumVARIANT, EnumeratorViewOfEnumVariant>(comObject, var => new EnumeratorViewOfEnumVariant(var));
         }
     }
 }

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumeratorViewOfEnumVariant.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumeratorViewOfEnumVariant.cs
@@ -2,12 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
 using System.Runtime.InteropServices.ComTypes;
 
 namespace System.Runtime.InteropServices.CustomMarshalers
 {
-    internal class EnumeratorViewOfEnumVariant : ICustomAdapter, IEnumerator
+    internal class EnumeratorViewOfEnumVariant : ICustomAdapter, System.Collections.IEnumerator
     {
         private readonly IEnumVARIANT _enumVariantObject;
         private bool _fetchedLastObject;
@@ -56,6 +55,9 @@ namespace System.Runtime.InteropServices.CustomMarshalers
             {
                 Marshal.ThrowExceptionForHR(hr);
             }
+
+            _fetchedLastObject = false;
+            _current = null;
         }
 
         public object GetUnderlyingObject()

--- a/src/coreclr/tests/src/Interop/COM/Dynamic/CollectionTest.cs
+++ b/src/coreclr/tests/src/Interop/COM/Dynamic/CollectionTest.cs
@@ -81,6 +81,25 @@ namespace Dynamic
 
             // Enumerate collection
             List<string> list = new List<string>();
+
+            // Get and use enumerator directly
+            System.Collections.IEnumerator enumerator = obj.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                list.Add((string)enumerator.Current);
+            }
+            Assert.AreAllEqual(array, list);
+
+            list.Clear();
+            enumerator.Reset();
+            while (enumerator.MoveNext())
+            {
+                list.Add((string)enumerator.Current);
+            }
+            Assert.AreAllEqual(array, list);
+
+            // Iterate over object that handles DISPID_NEWENUM
+            list.Clear();
             foreach (string str in obj)
             {
                 list.Add(str);

--- a/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/Program.cs
@@ -168,6 +168,37 @@ namespace NetClient
             }
         }
 
+        static void Validate_Enumerator()
+        {
+            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var expected = System.Linq.Enumerable.Range(0, 10);
+
+            Console.WriteLine($"Calling {nameof(DispatchTesting.GetEnumerator)} ...");
+            var enumerator = dispatchTesting.GetEnumerator(); 
+            Assert.AreAllEqual(expected, GetEnumerable(enumerator));
+
+            enumerator.Reset();
+            Assert.AreAllEqual(expected, GetEnumerable(enumerator));
+
+            Console.WriteLine($"Calling {nameof(DispatchTesting.ExplicitGetEnumerator)} ...");
+            var enumeratorExplicit = dispatchTesting.ExplicitGetEnumerator();
+            Assert.AreAllEqual(expected, GetEnumerable(enumeratorExplicit));
+
+            enumeratorExplicit.Reset();
+            Assert.AreAllEqual(expected, GetEnumerable(enumeratorExplicit));
+
+            System.Collections.Generic.IEnumerable<int> GetEnumerable(System.Collections.IEnumerator e)
+            {
+               var list = new System.Collections.Generic.List<int>();
+               while (e.MoveNext())
+               {
+                   list.Add((int)e.Current);
+               }
+
+               return list;
+            }
+        }
+
         static int Main(string[] doNotUse)
         {
             // RegFree COM is not supported on Windows Nano
@@ -184,6 +215,7 @@ namespace NetClient
                 Validate_Exception();
                 Validate_StructNotSupported();
                 Validate_LCID_Marshaled();
+                Validate_Enumerator();
             }
             catch (Exception e)
             {

--- a/src/coreclr/tests/src/Interop/COM/NETServer/DispatchTesting.cs
+++ b/src/coreclr/tests/src/Interop/COM/NETServer/DispatchTesting.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 using Server.Contract;
@@ -75,5 +76,16 @@ public class DispatchTesting : Server.Contract.IDispatchTesting
     public int PassThroughLCID()
     {
         return CultureInfo.CurrentCulture.LCID;
+    }
+
+    public System.Collections.IEnumerator ExplicitGetEnumerator()
+    {
+        return Enumerable.Range(0, 10).ToList().GetEnumerator();
+    }
+
+    [DispId(/*DISPID_NEWENUM*/-4)]
+    public System.Collections.IEnumerator GetEnumerator()
+    {
+        return Enumerable.Range(0, 10).ToList().GetEnumerator();
     }
 }

--- a/src/coreclr/tests/src/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/coreclr/tests/src/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -249,6 +249,11 @@ namespace Server.Contract
 
         [LCIDConversion(0)]
         int PassThroughLCID();
+
+        System.Collections.IEnumerator ExplicitGetEnumerator();
+
+        [DispId(/*DISPID_NEWENUM*/-4)]
+        System.Collections.IEnumerator GetEnumerator();
     }
 
     [ComVisible(true)]

--- a/src/coreclr/tests/src/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/coreclr/tests/src/Interop/COM/ServerContracts/Server.Contracts.h
@@ -416,6 +416,9 @@ IDispatchTesting : IDispatch
     virtual HRESULT STDMETHODCALLTYPE DoubleHVAValues(
         /*[in,out]*/ HFA_4 *input,
         /*[out,retval]*/ HFA_4 *pRetVal) = 0;
+
+    virtual HRESULT STDMETHODCALLTYPE ExplicitGetEnumerator(
+        /* [retval][out] */ IUnknown** retval) = 0;
 };
 
 struct __declspec(uuid("83AFF8E4-C46A-45DB-9D91-2ADB5164545E"))


### PR DESCRIPTION
- Bring back support for COM objects with `IEnumerator` (`IEnumVARIANT`)
- Add COM tests going through `DISPID_NEWENUM` or function returning `IEnumVARIANT`

Resolves #37191

@AaronRobinsonMSFT @jkoritzinsky 