### PR TITLE
Fix a typo in DropFromSingleFile list

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -17,7 +17,7 @@
     <SingleFileHostIncludeFilename Include="libSystem.IO.Compression.Native.so" />
     <SingleFileHostIncludeFilename Include="libSystem.Native.so" />
     <SingleFileHostIncludeFilename Include="libSystem.Net.Security.Native.so" />
-    <SingleFileHostIncludeFilename Include="llibSystem.Security.Cryptography.Native.OpenSsl.so" />
+    <SingleFileHostIncludeFilename Include="libSystem.Security.Cryptography.Native.OpenSsl.so" />
     <SingleFileHostIncludeFilename Include="libclrjit.so" />
     <SingleFileHostIncludeFilename Include="libcoreclr.so" />
 


### PR DESCRIPTION
On Linus, libSystem.Security.Cryptography.Native.OpenSsl.so is getting dropped from single-file apps.
This change fixes the problem.