### PR TITLE
[release/preview6] Fix DropFromSingleFile list

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -17,7 +17,7 @@
     <SingleFileHostIncludeFilename Include="libSystem.IO.Compression.Native.so" />
     <SingleFileHostIncludeFilename Include="libSystem.Native.so" />
     <SingleFileHostIncludeFilename Include="libSystem.Net.Security.Native.so" />
-    <SingleFileHostIncludeFilename Include="llibSystem.Security.Cryptography.Native.OpenSsl.so" />
+    <SingleFileHostIncludeFilename Include="libSystem.Security.Cryptography.Native.OpenSsl.so" />
     <SingleFileHostIncludeFilename Include="libclrjit.so" />
     <SingleFileHostIncludeFilename Include="libcoreclr.so" />
 


### PR DESCRIPTION
## Customer Scenario 

Linux SingleFile apps that use libSystem.Security.Cryptography.Native.OpenSsl.so fail.

## Problem

There was a typo in the `DropFromSingleFile` annotations added to `RuntimeList.xml` [here](https://github.com/dotnet/runtime/pull/36578). Therefore, this library was incorrectly dropped by the SDK.

## Solution

Fix a typo in the packaging properties

## Risk

Very Low.
