### PR TITLE
Run WASM tests with xharness

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20279.2",
+      "version": "1.0.0-prerelease.20303.2",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -174,9 +174,9 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>95d8c21c8d9bfc8cad107ff36fa44851f61bb28c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20301.2">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20303.2">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>bf873c70b1f983f4c9c7280ccb0481142ef64206</Sha>
+      <Sha>2de89cbfa1ad6f5003ba524d520a29d690fa04e7</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -106,7 +106,7 @@
     <SystemDataSqlClientVersion>4.8.0</SystemDataSqlClientVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.7.0-preview-20200529-01</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20301.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20303.2</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>
     <TraceEventVersion>2.0.5</TraceEventVersion>

--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -1,10 +1,20 @@
-set -ev
+#!/usr/bin/env bash
 
 EXECUTION_DIR=$(dirname $0)
 
 echo "Test: $1"
 
 cd $EXECUTION_DIR
-v8 --expose_wasm runtime.js -- --enable-gc --run WasmTestRunner.dll $*
 
-exit 0
+XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
+
+dotnet xharness wasm test --engine=v8 \
+    --js-file=runtime.js \
+    --output-directory=$XHARNESS_OUT \
+    -- --enable-gc --run WasmTestRunner.dll $*
+
+_exitCode=$?
+
+echo "Xharness artifacts: $XHARNESS_OUT"
+
+exit $_exitCode

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -120,4 +120,4 @@ app-builder:
 	$(DOTNET) build $(TOP)/tools-local/tasks/mobile.tasks/WasmAppBuilder
 
 run-tests-%:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=Release
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG)

--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -48,6 +48,15 @@ if (typeof crypto == 'undefined') {
 	}
 }
 
+if (typeof performance == 'undefined') {
+	// performance.now() is used by emscripten and doesn't work in JSC
+	var performance = {
+		now: function () {
+			return Date.now ();
+		}
+	}
+}
+
 try {
 	if (typeof arguments == "undefined")
 		arguments = WScript.Arguments;


### PR DESCRIPTION
Uses the xharness tool to drive the test execution rather than calling v8 directly.
Also includes a fix for running the tests in JavaScriptCore which doesn't provide performance.now().