### PR TITLE
Only pack either debug or release dotnet.js/wasm files in runtime pack

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -188,16 +188,9 @@
         Exclude="@(ExcludeNativeLibrariesRuntimeFiles)" />
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
                              Include="
-        $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.js;
-        $(LibrariesNativeArtifactsPath)wasm\runtimes\debug\dotnet.wasm;"
-        IsNative="true"
-        NativeSubDirectory="wasm/runtimes/debug/" />
-      <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'Browser'"
-                             Include="
-        $(LibrariesNativeArtifactsPath)wasm\runtimes\release\dotnet.js;
-        $(LibrariesNativeArtifactsPath)wasm\runtimes\release\dotnet.wasm"
-        IsNative="true"
-        NativeSubDirectory="wasm/runtimes/release/" />
+        $(LibrariesNativeArtifactsPath)dotnet.js;
+        $(LibrariesNativeArtifactsPath)dotnet.wasm;"
+        IsNative="true" />
     </ItemGroup>
 
     <Error Condition="'@(LibrariesRefAssemblies)' == ''" Text="The 'libs' subset must be built before building this project." />

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -20,12 +20,8 @@
       <NativeBinPlaceItem Include="$(NativeBinDir)*.dbg" />
       <NativeBinPlaceItem Include="$(NativeBinDir)*.dylib" />
       <NativeBinPlaceItem Include="$(NativeBinDir)*.dwarf" />
-      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)wasm\runtimes\debug\dotnet.js;$(NativeBinDir)wasm\runtimes\debug\dotnet.wasm">
-        <DestinationSubDirectory>wasm\runtimes\debug\</DestinationSubDirectory>
-      </NativeBinPlaceItem>
-      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)wasm\runtimes\release\dotnet.js;$(NativeBinDir)wasm\runtimes\release\dotnet.wasm">
-        <DestinationSubDirectory>wasm\runtimes\release\</DestinationSubDirectory>
-      </NativeBinPlaceItem>
+      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.js" />
+      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.wasm" />
 
       <BinPlaceItem Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="@(NativeBinPlaceItem)" />
       <FileWrites Include="@(NativeBinPlaceItem)" />

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -14,7 +14,7 @@ OBJDIR?=$(TOP)/artifacts/obj
 PINVOKE_TABLE?=$(TOP)/artifacts/obj/wasm/pinvoke-table.h
 MONO_BIN_DIR?=$(BINDIR)/mono/Browser.wasm.$(CONFIG)
 SYS_NATIVE_DIR?=$(OBJDIR)/native/net5.0-Browser-$(CONFIG)-wasm/System.Native
-BUILDS_BIN_DIR?=$(BINDIR)/native/net5.0-Browser-$(CONFIG)-wasm/wasm/runtimes
+BUILDS_BIN_DIR?=$(BINDIR)/native/net5.0-Browser-$(CONFIG)-wasm
 
 all: build-native
 
@@ -48,7 +48,7 @@ emsdk_env.sh: | provision-wasm
 
 MONO_OBJ_DIR=$(OBJDIR)/mono/Browser.wasm.$(CONFIG)
 MONO_INCLUDE_DIR=$(MONO_BIN_DIR)/include/mono-2.0
-BUILDS_OBJ_DIR=$(MONO_OBJ_DIR)/wasm/runtimes
+BUILDS_OBJ_DIR=$(MONO_OBJ_DIR)/wasm
 MONO_LIBS = \
 	$(MONO_BIN_DIR)/{libmono-ee-interp.a,libmonosgen-2.0.a,libmono-ilgen.a,libmono-icall-table.a} \
 	${SYS_NATIVE_DIR}/libSystem.Native.a
@@ -61,41 +61,40 @@ EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2 --llvm-lto 1 -DENABLE_NETCORE=1
 # Interpreter builds
 #
 
-# $(1) - name
-# $(2) - runtime dir
-# $(3) - EMCC_FLAGS
-# $(4) - libs
+# $(1) - EMCC_FLAGS
+# $(2) - libs
 define InterpBuildTemplate
 
-$(BUILDS_BIN_DIR)/$(1)/:
+$(BUILDS_BIN_DIR):
 	mkdir -p $$@
 
-$(BUILDS_OBJ_DIR)/$(1)/:
+$(BUILDS_OBJ_DIR):
 	mkdir -p $$@
 
-$(BUILDS_BIN_DIR)/$(1)/dotnet.js: $(BUILDS_OBJ_DIR)/$(1)/driver.o $(BUILDS_OBJ_DIR)/$(1)/pinvoke.o $(BUILDS_OBJ_DIR)/$(1)/corebindings.o runtime/library_mono.js runtime/binding_support.js runtime/dotnet_support.js $(5) | $(BUILDS_BIN_DIR)/$(1)/ emsdk_env.sh
-	$(EMCC) $(EMCC_FLAGS) $(3) --js-library runtime/library_mono.js --js-library runtime/binding_support.js --js-library runtime/dotnet_support.js $(BUILDS_OBJ_DIR)/$(1)/driver.o $(BUILDS_OBJ_DIR)/$(1)/pinvoke.o $(BUILDS_OBJ_DIR)/$(1)/corebindings.o $(4) -o $(BUILDS_BIN_DIR)/$(1)/dotnet.js
+$(BUILDS_BIN_DIR)/dotnet.js: $(BUILDS_OBJ_DIR)/driver.o $(BUILDS_OBJ_DIR)/pinvoke.o $(BUILDS_OBJ_DIR)/corebindings.o runtime/library_mono.js runtime/binding_support.js runtime/dotnet_support.js | $(BUILDS_BIN_DIR)/ emsdk_env.sh
+	$(EMCC) $(EMCC_FLAGS) $(1) --js-library runtime/library_mono.js --js-library runtime/binding_support.js --js-library runtime/dotnet_support.js $(BUILDS_OBJ_DIR)/driver.o $(BUILDS_OBJ_DIR)/pinvoke.o $(BUILDS_OBJ_DIR)/corebindings.o $(2) -o $(BUILDS_BIN_DIR)/dotnet.js
 
-$(BUILDS_OBJ_DIR)/$(1)/pinvoke-table.h: $(PINVOKE_TABLE) | $(BUILDS_OBJ_DIR)/$(1)/
+$(BUILDS_OBJ_DIR)/pinvoke-table.h: $(PINVOKE_TABLE) | $(BUILDS_OBJ_DIR)
 	if cmp -s $(PINVOKE_TABLE) $$@ ; then : ; else cp $(PINVOKE_TABLE) $$@ ; fi
 
-$(BUILDS_OBJ_DIR)/$(1)/driver.o: runtime/driver.c runtime/corebindings.c $(5) | $(BUILDS_OBJ_DIR)/$(1)/ emsdk_env.sh
-	$(EMCC) $(EMCC_FLAGS) $(3) -Oz -DCORE_BINDINGS -I$(BUILDS_OBJ_DIR)/$(1) -I$(MONO_INCLUDE_DIR) runtime/driver.c -c -o $$@
+$(BUILDS_OBJ_DIR)/driver.o: runtime/driver.c runtime/corebindings.c | $(BUILDS_OBJ_DIR) emsdk_env.sh
+	$(EMCC) $(EMCC_FLAGS) $(1) -Oz -DCORE_BINDINGS -I$(BUILDS_OBJ_DIR) -I$(MONO_INCLUDE_DIR) runtime/driver.c -c -o $$@
 
-$(BUILDS_OBJ_DIR)/$(1)/pinvoke.o: runtime/pinvoke.c runtime/pinvoke.h $(BUILDS_OBJ_DIR)/$(1)/pinvoke-table.h $(5) | $(BUILDS_OBJ_DIR)/$(1)/ emsdk_env.sh
-	$(EMCC) $(EMCC_FLAGS) $(3) -Oz -DGEN_PINVOKE=1 -I$(BUILDS_OBJ_DIR)/$(1) -I$(MONO_INCLUDE_DIR) runtime/pinvoke.c -c -o $$@
+$(BUILDS_OBJ_DIR)/pinvoke.o: runtime/pinvoke.c runtime/pinvoke.h $(BUILDS_OBJ_DIR)/pinvoke-table.h | $(BUILDS_OBJ_DIR) emsdk_env.sh
+	$(EMCC) $(EMCC_FLAGS) $(1) -Oz -DGEN_PINVOKE=1 -I$(BUILDS_OBJ_DIR) -I$(MONO_INCLUDE_DIR) runtime/pinvoke.c -c -o $$@
 
-$(BUILDS_OBJ_DIR)/$(1)/corebindings.o: runtime/corebindings.c | $(BUILDS_OBJ_DIR)/$(1)/ emsdk_env.sh
-	$(EMCC) $(3) -Oz -I$(MONO_INCLUDE_DIR) runtime/corebindings.c -c -o $$@
+$(BUILDS_OBJ_DIR)/corebindings.o: runtime/corebindings.c | $(BUILDS_OBJ_DIR) emsdk_env.sh
+	$(EMCC) $(1) -Oz -I$(MONO_INCLUDE_DIR) runtime/corebindings.c -c -o $$@
 
-build-native: $(BUILDS_BIN_DIR)/$(1)/dotnet.js
-
-build-interp-$(1): $(BUILDS_BIN_DIR)/$(1)/dotnet.js
+build-native: $(BUILDS_BIN_DIR)/dotnet.js
 
 endef
 
-$(eval $(call InterpBuildTemplate,debug,,$(EMCC_DEBUG_FLAGS),$(MONO_LIBS)))
-$(eval $(call InterpBuildTemplate,release,,$(EMCC_RELEASE_FLAGS),$(MONO_LIBS)))
+ifeq ($(CONFIG),Debug)
+$(eval $(call InterpBuildTemplate,$(EMCC_DEBUG_FLAGS),$(MONO_LIBS)))
+else
+$(eval $(call InterpBuildTemplate,$(EMCC_RELEASE_FLAGS),$(MONO_LIBS)))
+endif
 
 build:
 	EMSDK_PATH=$(PWD)/src/mono/wasm/emsdk $(DOTNET) build /p:TargetArchitecture=wasm /p:TargetOS=Browser /p:Configuration=$(CONFIG) $(TOP)/src/libraries/src.proj /t:NativeBinPlace

--- a/src/mono/wasm/wasm.targets
+++ b/src/mono/wasm/wasm.targets
@@ -35,7 +35,7 @@
 
   <Target Name="BuildWasmRuntimes"
           DependsOnTargets="BuildPInvokeTable">
-    <Exec Command="make -C $(MonoProjectRoot)wasm all SHELL=/bin/bash BINDIR=$(ArtifactsBinDir) MONO_BIN_DIR=$(MonoArtifactsPath) OBJDIR=$(ArtifactsObjDir) BUILDS_BIN_DIR=$(NativeBinDir)/wasm/runtimes SYS_NATIVE_DIR=$(ArtifactsObjDir)/native/$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)/System.Native CONFIG=$(Configuration) PINVOKE_TABLE=$(WasmPInvokeTablePath)" IgnoreStandardErrorWarningFormat="true"/>
+    <Exec Command="make -C $(MonoProjectRoot)wasm all SHELL=/bin/bash BINDIR=$(ArtifactsBinDir) MONO_BIN_DIR=$(MonoArtifactsPath) OBJDIR=$(ArtifactsObjDir) BUILDS_BIN_DIR=$(NativeBinDir) SYS_NATIVE_DIR=$(ArtifactsObjDir)/native/$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)/System.Native CONFIG=$(Configuration) PINVOKE_TABLE=$(WasmPInvokeTablePath)" IgnoreStandardErrorWarningFormat="true"/>
   </Target>
 
 </Project>

--- a/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -73,7 +73,7 @@ public class WasmAppBuilder : Task
         foreach (var assembly in _assemblies!.Values)
             File.Copy(assembly.Location, Path.Join(AppDir, "managed", Path.GetFileName(assembly.Location)), true);
         foreach (var f in new string[] { "dotnet.wasm", "dotnet.js" })
-            File.Copy(Path.Join (RuntimePackDir, "native", "wasm", "runtimes", "release", f), Path.Join(AppDir, f), true);
+            File.Copy(Path.Join (RuntimePackDir, "native", f), Path.Join(AppDir, f), true);
         File.Copy(MainJS!, Path.Join(AppDir, "runtime.js"),  true);
 
         if (ExtraFiles != null)


### PR DESCRIPTION
Change the runtime pack to only include either the debug or release version of dotnet.js/wasm like we do for other targets.

Fixes an issue where self-contained publish didn't work anymore because the RuntimeList.xml contained two files with the same name.