### PR TITLE
Use OrdinalIgnoreCase in IdnMapping

### DIFF
--- a/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
+++ b/src/libraries/System.Globalization.Extensions/tests/IdnMapping/IdnMappingGetAsciiTests.cs
@@ -21,19 +21,9 @@ namespace System.Globalization.Tests
                 {
                     continue;
                 }
+
                 string ascii = c.ToString();
-                if (PlatformDetection.IsIcuGlobalization) // expected platform differences, see https://github.com/dotnet/runtime/issues/17190
-                {
-                    if (c >= 'A' && c <= 'Z')
-                    {
-                        yield return new object[] { ascii, 0, 1, ascii.ToLower() };
-                    }
-                    else if (c != '-')
-                    {
-                        yield return new object[] { ascii, 0, 1, ascii };
-                    }
-                }
-                else
+                if (!PlatformDetection.IsIcuGlobalization || c != '-') // expected platform differences, see https://github.com/dotnet/runtime/issues/17190
                 {
                     yield return new object[] { ascii, 0, 1, ascii };
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/IdnMapping.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/IdnMapping.cs
@@ -152,10 +152,19 @@ namespace System.Globalization
             (_allowUnassigned ? 100 : 200) + (_useStd3AsciiRules ? 1000 : 2000);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static unsafe string GetStringForOutput(string originalString, char* input, int inputLength, char* output, int outputLength) =>
-            originalString.Length == inputLength && new ReadOnlySpan<char>(input, inputLength).SequenceEqual(new ReadOnlySpan<char>(output, outputLength)) ?
-                originalString :
-                new string(output, 0, outputLength);
+        private static unsafe string GetStringForOutput(string originalString, char* input, int inputLength, char* output, int outputLength)
+        {
+            Debug.Assert(inputLength > 0);
+
+            if (originalString.Length == inputLength &&
+                inputLength == outputLength &&
+                CompareInfo.EqualsOrdinalIgnoreCase(ref *input, ref *output, inputLength))
+            {
+                return originalString;
+            }
+
+            return new string(output, 0, outputLength);
+        }
 
         //
         // Invariant implementation


### PR DESCRIPTION
If only case has changed, we can still return the original string.  This helps avoid a string allocation when using ICU (both Unix and Windows), which lowercases ASCII inputs.

Addresses https://github.com/dotnet/runtime/issues/37229#issuecomment-637876059
cc: @tarekgh, @safern

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.Globalization;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private readonly IdnMapping _idn = new IdnMapping();

    [Benchmark] public string GetAscii_Lower() => _idn.GetAscii("lowercase");
    [Benchmark] public string GetAscii_Upper() => _idn.GetAscii("UPPERCASE");
    [Benchmark] public string GetAscii_Emoji() => _idn.GetAscii("lowerca\xD83D\xDE00");
}
```

|         Method |        Job |           Toolchain |     Mean |   Error |  StdDev | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------- |----------- |-------------------- |---------:|--------:|--------:|------:|-------:|------:|------:|----------:|
| GetAscii_Lower | Job-KLPJAZ | \master\corerun.exe | 238.9 ns | 0.92 ns | 0.77 ns |  1.00 |      - |     - |     - |         - |
| GetAscii_Lower | Job-VZDRZX |     \pr\corerun.exe | 238.1 ns | 0.67 ns | 0.59 ns |  1.00 |      - |     - |     - |         - |
|                |            |                     |          |         |         |       |        |       |       |           |
| GetAscii_Upper | Job-KLPJAZ | \master\corerun.exe | 245.6 ns | 0.91 ns | 0.86 ns |  1.00 | 0.0062 |     - |     - |      40 B |
| GetAscii_Upper | Job-VZDRZX |     \pr\corerun.exe | 234.9 ns | 1.42 ns | 1.26 ns |  0.96 |      - |     - |     - |         - |
|                |            |                     |          |         |         |       |        |       |       |           |
| GetAscii_Emoji | Job-KLPJAZ | \master\corerun.exe | 595.6 ns | 2.67 ns | 2.37 ns |  1.00 | 0.0086 |     - |     - |      56 B |
| GetAscii_Emoji | Job-VZDRZX |     \pr\corerun.exe | 589.2 ns | 1.87 ns | 1.75 ns |  0.99 | 0.0086 |     - |     - |      56 B |

