### PR TITLE
Remove ClearInitLocalsAssemblies arg

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -150,7 +150,6 @@
             RootAssemblyNames=""
             OutputDirectory="$(ILLinkTrimOutputPath)"
             ClearInitLocals="$(ILLinkClearInitLocals)"
-            ClearInitLocalsAssemblies="$(TargetName)"
             ExtraArgs="$(ILLinkArgs)"
             ToolExe="$(_DotNetHostFileName)"
             ToolPath="$(_DotNetHostDirectory)" />


### PR DESCRIPTION
See https://github.com/mono/linker/pull/1237.
Setting the boolean ClearInitLocals is sufficient here because we are
only linking the target assembly. If in the future we need to control
it per-assembly, we can use metadata on AssemblyPaths:
https://github.com/mono/linker/blob/master/src/ILLink.Tasks/LinkTask.cs#L23