### PR TITLE
Fix incorrect devirtualization in CG2

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1301,7 +1301,7 @@ namespace Internal.JitInterface
                     //
                     // Note that it is safe to devirtualize in the following cases, since a servicing event cannot later modify it
                     //  1) Callvirt on a virtual final method of a value type - since value types are sealed types as per ECMA spec
-                    devirt = (constrainedType ?? targetMethod.OwningType).IsValueType || targetMethod.IsInternalCall;
+                    devirt = targetMethod.OwningType.IsValueType || targetMethod.IsInternalCall;
 
                     callVirtCrossingVersionBubble = true;
                 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1301,7 +1301,11 @@ namespace Internal.JitInterface
                     //
                     // Note that it is safe to devirtualize in the following cases, since a servicing event cannot later modify it
                     //  1) Callvirt on a virtual final method of a value type - since value types are sealed types as per ECMA spec
-                    devirt = targetMethod.OwningType.IsValueType || targetMethod.IsInternalCall;
+                    //  2) Delegate.Invoke() - since a Delegate is a sealed class as per ECMA spec
+                    //  3) JIT intrinsics - since they have pre-defined behavior
+                    devirt = targetMethod.OwningType.IsValueType ||
+                        (targetMethod.OwningType.IsDelegate && targetMethod.Name == "Invoke") ||
+                        (targetMethod.IsIntrinsic && getIntrinsicID(targetMethod, null) != CorInfoIntrinsics.CORINFO_INTRINSIC_Illegal);
 
                     callVirtCrossingVersionBubble = true;
                 }

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -1189,6 +1189,26 @@ internal class Program
         return true;
     }
 
+    enum TestEnum
+    {
+        A,
+        B
+    }
+
+    private static bool EnumValuesToStringTest()
+    {
+        string buffer = "";
+        foreach (TestEnum val in Enum.GetValues(typeof(TestEnum)))
+        {
+            buffer += val.ToString();
+        }
+
+        if (buffer != "AB")
+            return false;
+
+        return true;
+    }
+
     private static string EmitTextFileForTesting()
     {
         string file = Path.GetTempFileName();
@@ -1253,6 +1273,7 @@ internal class Program
         RunTest("ObjectGetTypeOnGenericParamTest", ObjectGetTypeOnGenericParamTest());
         RunTest("ObjectToStringOnGenericParamTestSByte", ObjectToStringOnGenericParamTestSByte());
         RunTest("ObjectToStringOnGenericParamTestVersionBubbleLocalStruct", ObjectToStringOnGenericParamTestVersionBubbleLocalStruct());
+        RunTest("EnumValuesToStringTest", EnumValuesToStringTest());
 
         File.Delete(TextFileName);
 


### PR DESCRIPTION
When making a constrained virtual method call on a boxed value type, CG2 devirtualizes the call incorrectly resulting in a direct call. This breaks code patterns like:

```
foreach (TestEnum val in Enum.GetValues(typeof(TestEnum)))
{
    buffer += val.ToString();
}
```

In the call to ToString(), `getCallInfo` is passed a boxed `TestEnum` and is calling `object.ToString()`. The constrained type is `TestEnum` so we end up making a direct call to `object.ToString()`. Fixed by removing the constrained type from devirtualization consideration which is how Crossgen treats this call.

cc @dotnet/crossgen-contrib 