### PR TITLE
Also check shutdown state in Diagnostics Server precondition

### DIFF
--- a/src/coreclr/src/vm/diagnosticserver.cpp
+++ b/src/coreclr/src/vm/diagnosticserver.cpp
@@ -29,7 +29,7 @@ DWORD WINAPI DiagnosticServer::DiagnosticsServerThread(LPVOID)
         NOTHROW;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
-        PRECONDITION(IpcStreamFactory::HasActiveConnections());
+        PRECONDITION(s_shuttingDown || IpcStreamFactory::HasActiveConnections());
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
* there is a race that can result in the process starting shutdown before the server starts.
  The server is resilient to shutdown happening, but the precondition assumes we aren't
  in shutdown when the thread starts.  This change makes the precondition check the
  shutdown state as well.

Should fix #37203