### PR TITLE
Add OS distro info to ProcessInfo event

### DIFF
--- a/src/coreclr/src/vm/eventpipeeventsource.cpp
+++ b/src/coreclr/src/vm/eventpipeeventsource.cpp
@@ -52,7 +52,7 @@ EventPipeEventSource::EventPipeEventSource()
         1,      /* eventID */
         s_pProcessInfoEventName,
         0,      /* keywords */
-        0,      /* version */
+        1,      /* version */
         EventPipeEventLevel::LogAlways,
         params,
         numParams,

--- a/src/coreclr/src/vm/eventpipeeventsource.cpp
+++ b/src/coreclr/src/vm/eventpipeeventsource.cpp
@@ -23,7 +23,7 @@ const WCHAR* EventPipeEventSource::s_pOSInformation = W("Windows");
 const WCHAR* EventPipeEventSource::s_pOSInformation = W("OSX");
 #elif defined(__linux__)
 const WCHAR* EventPipeEventSource::s_pOSInformation = W("Linux");
-#elif
+#else
 const WCHAR* EventPipeEventSource::s_pOSInformation = W("Unknown");
 #endif
 

--- a/src/coreclr/src/vm/eventpipeeventsource.cpp
+++ b/src/coreclr/src/vm/eventpipeeventsource.cpp
@@ -20,11 +20,23 @@ const WCHAR* EventPipeEventSource::s_pProcessInfoEventName = W("ProcessInfo");
 #if defined(HOST_WINDOWS)
 const WCHAR* EventPipeEventSource::s_pOSInformation = W("Windows");
 #elif defined(__APPLE__)
-const WCHAR* EventPipeEventSource::s_pOSInformation = W("OSX");
+const WCHAR* EventPipeEventSource::s_pOSInformation = W("macOS");
 #elif defined(__linux__)
 const WCHAR* EventPipeEventSource::s_pOSInformation = W("Linux");
 #else
 const WCHAR* EventPipeEventSource::s_pOSInformation = W("Unknown");
+#endif
+
+#if defined(TARGET_X86)
+const WCHAR* EventPipeEventSource::s_pArchInformation = W("x86");
+#elif defined(TARGET_AMD64)
+const WCHAR* EventPipeEventSource::s_pArchInformation = W("x64");
+#elif defined(TARGET_ARM)
+const WCHAR* EventPipeEventSource::s_pArchInformation = W("arm32");
+#elif defined(TARGET_ARM64)
+const WCHAR* EventPipeEventSource::s_pArchInformation = W("arm64");
+#else
+const WCHAR* EventPipeEventSource::s_pArchInformation = W("Unknown");
 #endif
 
 EventPipeEventSource::EventPipeEventSource()
@@ -40,12 +52,14 @@ EventPipeEventSource::EventPipeEventSource()
     m_pProvider = EventPipe::CreateProvider(SL(s_pProviderName), NULL, NULL);
 
     // Generate metadata.
-    const unsigned int numParams = 2;
+    const unsigned int numParams = 3;
     EventPipeParameterDesc params[numParams];
     params[0].Type = EventPipeParameterType::String;
     params[0].Name = W("CommandLine");
     params[1].Type = EventPipeParameterType::String;
     params[1].Name = W("OSInformation");
+    params[2].Type = EventPipeParameterType::String;
+    params[2].Name = W("ArchInformation");
 
     size_t metadataLength = 0;
     BYTE *pMetadata = EventPipeMetadataGenerator::GenerateEventMetadata(
@@ -125,15 +139,18 @@ void EventPipeEventSource::SendProcessInfo(LPCWSTR pCommandLine)
     }
     CONTRACTL_END;
 
-    EventData data[2];
+    EventData data[3];
     data[0].Ptr = (UINT64) pCommandLine;
     data[0].Size = (unsigned int)(wcslen(pCommandLine) + 1) * 2;
     data[0].Reserved = 0;
     data[1].Ptr = (UINT64)s_pOSInformation;
     data[1].Size = (unsigned int)(wcslen(s_pOSInformation) + 1) * 2;
     data[1].Reserved = 0;
+    data[2].Ptr = (UINT64)s_pArchInformation;
+    data[2].Size = (unsigned int)(wcslen(s_pArchInformation) + 1) * 2;
+    data[2].Reserved = 0;
 
-    EventPipe::WriteEvent(*m_pProcessInfoEvent, data, 2);
+    EventPipe::WriteEvent(*m_pProcessInfoEvent, data, 3);
 }
 
 #endif // FEATURE_PERFTRACING

--- a/src/coreclr/src/vm/eventpipeeventsource.h
+++ b/src/coreclr/src/vm/eventpipeeventsource.h
@@ -21,6 +21,7 @@ private:
     EventPipeEvent *m_pProcessInfoEvent;
 
     const static WCHAR* s_pOSInformation;
+    const static WCHAR* s_pArchInformation;
 
 public:
     EventPipeEventSource();

--- a/src/coreclr/src/vm/eventpipeeventsource.h
+++ b/src/coreclr/src/vm/eventpipeeventsource.h
@@ -20,6 +20,8 @@ private:
     const static WCHAR* s_pProcessInfoEventName;
     EventPipeEvent *m_pProcessInfoEvent;
 
+    const static WCHAR* s_pOSInformation;
+
 public:
     EventPipeEventSource();
     ~EventPipeEventSource();


### PR DESCRIPTION
For https://github.com/dotnet/runtime/issues/37374.

This adds the OS distro info to EventPipeEventSource's ProcessInfo Event.