### PR TITLE
Add tests for runtimepack type RuntimeLibraries

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyModel/src/RuntimeLibrary.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/src/RuntimeLibrary.cs
@@ -59,6 +59,31 @@ namespace Microsoft.Extensions.DependencyModel
          {
          }
 
+
+        /// <summary>
+        /// Initializes a new <see cref="RuntimeLibrary"/>.
+        /// </summary>
+        /// <param name="type">The library's type.</param>
+        /// <param name="name">The library's name.</param>
+        /// <param name="version">The library's version.</param>
+        /// <param name="hash">The library package's hash.</param>
+        /// <param name="runtimeAssemblyGroups">The library's runtime assemblies.</param>
+        /// <param name="nativeLibraryGroups">The library's native libraries.</param>
+        /// <param name="resourceAssemblies">The library's resource assemblies.</param>
+        /// <param name="dependencies">The library's dependencies.</param>
+        /// <param name="serviceable">Whether the library is serviceable.</param>
+        /// <param name="path">The library package's path.</param>
+        /// <param name="hashPath">The library package's hash path.</param>
+        /// <param name="runtimeStoreManifestName">The library's runtime store manifest name.</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// The <paramref name="type"/> argument is null.
+        /// The <paramref name="name"/> argument is null.
+        /// The <paramref name="version"/> argument is null.
+        /// The <paramref name="runtimeAssemblyGroups"/> argument is null.
+        /// The <paramref name="nativeLibraryGroups"/> argument is null.
+        /// The <paramref name="resourceAssemblies"/> argument is null.
+        /// The <paramref name="dependencies"/> argument is null.
+        /// </exception>
         public RuntimeLibrary(string type,
             string name,
             string version,

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonReaderTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonReaderTest.cs
@@ -667,6 +667,46 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void ReadsRuntimePackLibrary()
+        {
+            var context = Read(
+@"{
+    ""runtimeTarget"": {
+        ""name"": "".NETCoreApp,Version=v5.0/win-x86"",
+        ""signature"": """"
+    },
+    ""targets"": {
+        "".NETCoreApp,Version=v5.0/win-x86"": {
+            ""runtimepack.Microsoft.NETCore.App.Runtime.win-x86/5.0.0-preview.5.20251.1"": {
+                ""runtime"": {
+                    ""System.Private.CoreLib.dll"": {
+                        ""assemblyVersion"": ""5.0.0.0"",
+                        ""fileVersion"": ""5.0.20.25101""
+                    }
+                },
+                ""native"": {
+                    ""coreclr.dll"": {
+                        ""fileVersion"": ""5.0.20.25101""
+                    }
+                }
+            }
+        }
+    },
+    ""libraries"": {
+        ""runtimepack.Microsoft.NETCore.App.Runtime.win-x86/5.0.0-preview.5.20251.1"": {
+            ""type"": ""runtimepack"",
+            ""serviceable"": false,
+            ""sha512"": """"
+        }
+    }
+}");
+
+            var runtimeLibrary = context.RuntimeLibraries.Should().ContainSingle().Subject;
+            runtimeLibrary.Type.Should().Be("runtimepack");
+            runtimeLibrary.Serviceable.Should().Be(false);
+        }
+
+        [Fact]
         public void ReadsCompilationOptions()
         {
             var context = Read(

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonWriterTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/DependencyContextJsonWriterTests.cs
@@ -301,6 +301,68 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         [Fact]
+        public void WritesRuntimePackLibrariesWithFrameworkName()
+        {
+            var result = Save(Create(
+                "Target",
+                "win-x86",
+                false,
+                runtimeLibraries: new[]
+                {
+                    new RuntimeLibrary(
+                        "runtimepack",
+                        "RuntimePackName",
+                        "1.2.3",
+                        "HASH",
+                        new [] {
+                            new RuntimeAssetGroup(
+                                string.Empty,
+                                new []
+                                {
+                                    new RuntimeFile("System.Private.CoreLib.dll", "2.3.4", "3.4.5"),
+                                }),
+                        },
+                        new [] {
+                            new RuntimeAssetGroup(
+                                string.Empty,
+                                new []
+                                {
+                                    new RuntimeFile("coreclr.dll", "4.5.6", "5.6.7"),
+                                }),
+                        },
+                        new ResourceAssembly[0],
+                        new Dependency[0],
+                        false,
+                        "PackagePath",
+                        "PackageHashPath",
+                        "placeHolderManifest.xml"
+                    ),
+                }));
+
+            // targets
+            var targets = result.Should().HavePropertyAsObject("targets").Subject;
+            var target = targets.Should().HavePropertyAsObject("Target/win-x86").Subject;
+            var library = target.Should().HavePropertyAsObject("RuntimePackName/1.2.3").Subject;
+            library.Should().NotHaveProperty("dependencies");
+            library.Should().NotHaveProperty("resources");
+
+            library.Should().HavePropertyAsObject("runtime")
+                .Subject.Should().HaveProperty("System.Private.CoreLib.dll");
+            library.Should().HavePropertyAsObject("native")
+                .Subject.Should().HaveProperty("coreclr.dll");
+
+            //libraries
+            var libraries = result.Should().HavePropertyAsObject("libraries").Subject;
+            library = libraries.Should().HavePropertyAsObject("RuntimePackName/1.2.3").Subject;
+            library.Should().HavePropertyValue("sha512", "HASH");
+            library.Should().HavePropertyValue("type", "runtimepack");
+            library.Should().HavePropertyValue("serviceable", false);
+            library.Should().HavePropertyValue("path", "PackagePath");
+            library.Should().HavePropertyValue("hashPath", "PackageHashPath");
+            library.Should().HavePropertyValue("runtimeStoreManifestName", "placeHolderManifest.xml");
+        }
+
+        [Fact]
         public void MergesRuntimeAndCompileLibrariesForPortable()
         {
             var result = Save(Create(


### PR DESCRIPTION
Add documentation to constructor in RuntimeLibrary.

This salvages the missing tests and docs from https://github.com/dotnet/runtime/pull/35764.