### PR TITLE
[browser][wasm] Use the same reference scheme for SPC as `InteropServices`.

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System.Runtime.InteropServices.JavaScript.csproj
@@ -6,15 +6,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Browser</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetsBrowser)' == 'true'">
-    <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
-    <ProjectReference Include="..\..\System.Net.Primitives\ref\System.Net.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.Collections\ref\System.Collections.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
-    <ProjectReference Include="..\..\System.Memory\ref\System.Memory.csproj" />
-    <ProjectReference Include="..\..\System.Threading\ref\System.Threading.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsBrowser)' == 'true'">
     <Compile Include="$(CommonPath)Interop\Browser\Interop.Runtime.cs" Link="Common\Interop\Browser\Interop.Runtime.cs" />
     <Compile Include="System/Runtime\InteropServices\JavaScript\Runtime.cs" />
     <Compile Include="System/Runtime\InteropServices\JavaScript\JSException.cs" />
@@ -38,5 +29,11 @@
     <Compile Include="System/Runtime\InteropServices\JavaScript\HostObject.cs" />
     <Compile Include="System/Runtime\InteropServices\JavaScript\Function.cs" />
     <Compile Include="System/Runtime\InteropServices\JavaScript\AnyRef.cs" />
-  </ItemGroup>    
+  </ItemGroup>
+  <ItemGroup>
+    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="..\..\System.Runtime.Extensions\src\System.Runtime.Extensions.csproj" />
+    <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\ref\System.Runtime.CompilerServices.Unsafe.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION


- Use `<ReferenceFromRuntime Include="System.Private.CoreLib" />`