### PR TITLE
Bundler: Fix a path computation.

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -38,19 +38,20 @@ namespace Microsoft.NET.HostModel.Bundle
                        BundleOptions options = BundleOptions.None,
                        OSPlatform? targetOS = null,
                        Version targetFrameworkVersion = null,
-                       bool diagnosticOutput = false)
+                       bool diagnosticOutput = false,
+                       string appAssemblyName = null)
         {
             Tracer = new Trace(diagnosticOutput);
 
             HostName = hostName;
             OutputDir = Path.GetFullPath(string.IsNullOrEmpty(outputDir) ? Environment.CurrentDirectory : outputDir);
-
-            string baseName = Path.GetFileNameWithoutExtension(HostName);
-            DepsJson = baseName + ".deps.json";
-            RuntimeConfigJson = baseName + ".runtimeconfig.json";
-            RuntimeConfigDevJson = baseName + ".runtimeconfig.dev.json";
-
             Target = new TargetInfo(targetOS, targetFrameworkVersion);
+
+            appAssemblyName ??= Target.GetAssemblyName(hostName);
+            DepsJson = appAssemblyName + ".deps.json";
+            RuntimeConfigJson = appAssemblyName + ".runtimeconfig.json";
+            RuntimeConfigDevJson = appAssemblyName + ".runtimeconfig.dev.json";
+
             BundleManifest = new Manifest(Target.BundleVersion, netcoreapp3CompatMode: options.HasFlag(BundleOptions.BundleAllContent));
             Options = Target.DefaultOptions | options;
         }

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/TargetInfo.cs
@@ -5,6 +5,7 @@
 using Microsoft.NET.HostModel.AppHost;
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.NET.HostModel.Bundle
@@ -51,6 +52,13 @@ namespace Microsoft.NET.HostModel.Bundle
         public bool IsNativeBinary(string filePath)
         {
             return IsLinux ? ElfUtils.IsElfImage(filePath) : IsOSX ? MachOUtils.IsMachOImage(filePath) : PEUtils.IsPEImage(filePath);
+        }
+
+        public string GetAssemblyName(string hostName)
+        {
+            // This logic to calculate assembly name from hostName should be removed (and probably moved to test helpers)
+            // once the SDK in the correct assembly name.
+            return (IsWindows ? Path.GetFileNameWithoutExtension(hostName) : hostName);
         }
 
         public override string ToString()


### PR DESCRIPTION
The bundler recognizes json config files based on the input host-name as follows:

```C#
baseName = Path.GetFileNameWithoutExtension(hostName).
depsJsonName = baseName + "deps.json"
```

On Linux, since executables don't have an `.exe` extension, this logic is incorrect for apps whose name contains a `.` in their name.
For example, if `hostName` is `Some.App`, `depsJson` is incorrectly computed as `Some.deps.json` instead of `Some.App.deps.json`.

This change fixes the problem.