### PR TITLE
[x86/Linux] Fix SIGSEGV during evaluation abort routine.

### DIFF
--- a/src/coreclr/src/debug/ee/debugger.inl
+++ b/src/coreclr/src/debug/ee/debugger.inl
@@ -242,9 +242,24 @@ inline void FuncEvalFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->SetEcxLocation(&(pDE->m_context.Ecx));
     pRD->SetEaxLocation(&(pDE->m_context.Eax));
     pRD->SetEbpLocation(&(pDE->m_context.Ebp));
-    pRD->SP   = (DWORD)GetSP(&pDE->m_context);
     pRD->PCTAddr = GetReturnAddressPtr();
+
+#ifdef FEATURE_EH_FUNCLETS
+
+    pRD->IsCallerContextValid = FALSE;
+    pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
+
+    pRD->pCurrentContext->Eip = *PTR_PCODE(pRD->PCTAddr);
+    pRD->pCurrentContext->Esp = (DWORD)GetSP(&pDE->m_context);
+
+    SyncRegDisplayToCurrentContext(pRD);
+
+#else // FEATURE_EH_FUNCLETS
+
     pRD->ControlPC = *PTR_PCODE(pRD->PCTAddr);
+    pRD->SP = (DWORD)GetSP(&pDE->m_context);
+
+#endif // FEATURE_EH_FUNCLETS
 
 #elif defined(TARGET_AMD64)
     pRD->IsCallerContextValid = FALSE;


### PR DESCRIPTION
In case of evaluation with implicit function call aborted by ```ICorDebugEval::Abort()```, CoreCLR crash with SIGSEGV at line https://github.com/dotnet/runtime/blob/e25517ea27311297c1e3946acb3b4382d5fa7fef/src/coreclr/src/vm/jitinterface.cpp#L14293 since ```m_pJM``` is ```NULL```.
This happens because during ```EECodeInfo::Init()``` call, ```codeAddress``` parameter provide address inside native code region (this address belong to CallDescrWorkerInternal(), libcoreclr.so), but not address inside managed code, so, ```ExecutionManager::FindCodeRange()``` can't find appropriate ```RangeSection```.

During investigation I found, that at line https://github.com/dotnet/runtime/blob/e25517ea27311297c1e3946acb3b4382d5fa7fef/src/coreclr/src/vm/stackwalk.cpp#L2584 current context was not changed properly (we have wrong ```Eip``` register value).
I found, that ```FuncEvalFrame::UpdateRegDisplay()``` code https://github.com/dotnet/runtime/blob/e25517ea27311297c1e3946acb3b4382d5fa7fef/src/coreclr/src/debug/ee/debugger.inl#L238-L247 don't have x86/Linux support implemented.

I propose changes, that were already made for other ```UpdateRegDisplay()``` implementations in order to provide proper context for x86/Linux.

This changes were tested with our debugger (netcoredbg) on x86 Tizen (Linux) emulator for cases:
1. ```ICorDebugEval::Abort()``` called inside ```ICorDebugManagedCallback3::CustomNotification()``` callback.
2. ```ICorDebugEval::Abort()``` called on evaluation with implicit function call timed out.

No issues were found.

CC @alpencolt @jkotas 