### PR TITLE
Add multiple files compilation mode for crossgen2

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -18,6 +18,8 @@ namespace ILCompiler
 {
     public sealed class ReadyToRunCodegenCompilationBuilder : CompilationBuilder
     {
+        private static bool _isJitInitialized = false;
+
         private readonly IEnumerable<string> _inputFiles;
         private readonly string _compositeRootPath;
         private bool _ibcTuning;
@@ -233,7 +235,11 @@ namespace ILCompiler
             if (_ibcTuning)
                 corJitFlags.Add(CorJitFlag.CORJIT_FLAG_BBINSTR);
 
-            JitConfigProvider.Initialize(_context.Target, corJitFlags, _ryujitOptions, _jitPath);
+            if (!_isJitInitialized)
+            {
+                JitConfigProvider.Initialize(_context.Target, corJitFlags, _ryujitOptions, _jitPath);
+                _isJitInitialized = true;
+            }
 
             return new ReadyToRunCodegenCompilation(
                 graph,

--- a/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/tools/aot/crossgen2/CommandLineOptions.cs
@@ -32,6 +32,8 @@ namespace ILCompiler
         public bool Verbose;
         public bool Composite;
         public bool CompileNoMethods;
+        public bool OutNearInput;
+        public bool SingleFileCompilation;
 
         public string DgmlLogFileName;
         public bool GenerateFullDgmlLog;
@@ -93,6 +95,8 @@ namespace ILCompiler
                 syntax.DefineOption("inputbubble", ref InputBubble, SR.InputBubbleOption);
                 syntax.DefineOption("composite", ref Composite, SR.CompositeBuildMode);
                 syntax.DefineOption("compile-no-methods", ref CompileNoMethods, SR.CompileNoMethodsOption);
+                syntax.DefineOption("out-near-input", ref OutNearInput, SR.OutNearInputOption);
+                syntax.DefineOption("single-file-compilation", ref SingleFileCompilation, SR.SingleFileCompilationOption);
                 syntax.DefineOption("tuning", ref Tuning, SR.TuningImageOption);
                 syntax.DefineOption("partial", ref Partial, SR.PartialImageOption);
                 syntax.DefineOption("compilebubblegenerics", ref CompileBubbleGenerics, SR.BubbleGenericsOption);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -287,65 +287,101 @@ namespace ILCompiler
 
         private int Run(string[] args)
         {
+            InitializeDefaultOptions();
+
+            ProcessCommandLine(args);
+
+            if (_commandLineOptions.Help)
+            {
+                Console.WriteLine(_commandLineOptions.HelpText);
+                return 1;
+            }
+
+            if (_commandLineOptions.OutputFilePath == null && !_commandLineOptions.OutNearInput)
+                throw new CommandLineException(SR.MissingOutputFile);
+
+            ConfigureTarget();
+            InstructionSetSupport instructionSetSupport = ConfigureInstructionSetSupport();
+
+            SharedGenericsMode genericsMode = SharedGenericsMode.CanonicalReferenceTypes;
+
+            var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, instructionSetSupport.GetVectorTSimdVector());
+
+            bool versionBubbleIncludesCoreLib = false;
+            if (_commandLineOptions.InputBubble)
+            {
+                versionBubbleIncludesCoreLib = true;
+            }
+            else
+            {
+                if (!_commandLineOptions.SingleFileCompilation)
+                {
+                    foreach (var inputFile in _inputFilePaths)
+                    {
+                        if (String.Compare(inputFile.Key, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            versionBubbleIncludesCoreLib = true;
+                            break;
+                        }
+                    }
+                }
+                if (!versionBubbleIncludesCoreLib)
+                {
+                    foreach (var inputFile in _unrootedInputFilePaths)
+                    {
+                        if (String.Compare(inputFile.Key, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            versionBubbleIncludesCoreLib = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            var retcode = 0;
+
+            if (_commandLineOptions.SingleFileCompilation)
+            {
+                var singleCompilationInputFilePaths = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var inputFile in _inputFilePaths)
+                {
+                    singleCompilationInputFilePaths.Clear();
+                    singleCompilationInputFilePaths.Add(inputFile.Key, inputFile.Value);
+
+                    retcode = RunSingleCompilation(singleCompilationInputFilePaths, instructionSetSupport, targetDetails, genericsMode, versionBubbleIncludesCoreLib);
+                    if (retcode != 0)
+                    {
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                retcode = RunSingleCompilation(_inputFilePaths, instructionSetSupport, targetDetails, genericsMode, versionBubbleIncludesCoreLib);
+            }
+
+            return retcode;
+        }
+
+        private int RunSingleCompilation(Dictionary<string, string> inFilePaths, InstructionSetSupport instructionSetSupport, TargetDetails targetDetails,
+                                         SharedGenericsMode genericsMode, bool versionBubbleIncludesCoreLib)
+        {
+            //
+            // Initialize type system context
+            //
+            _typeSystemContext = new ReadyToRunCompilerContext(targetDetails, genericsMode, versionBubbleIncludesCoreLib);
+
+            //
+            // Initialize output filename
+            //
+            var outFile = _commandLineOptions.OutNearInput ? inFilePaths.First().Value.Replace(".dll", ".ni.dll") : _commandLineOptions.OutputFilePath;
+
             using (PerfEventSource.StartStopEvents.CompilationEvents())
             {
                 ICompilation compilation;
                 using (PerfEventSource.StartStopEvents.LoadingEvents())
                 {
-                    InitializeDefaultOptions();
-
-                    ProcessCommandLine(args);
-
-                    if (_commandLineOptions.Help)
-                    {
-                        Console.WriteLine(_commandLineOptions.HelpText);
-                        return 1;
-                    }
-
-                    if (_commandLineOptions.OutputFilePath == null)
-                        throw new CommandLineException(SR.MissingOutputFile);
-
-                    ConfigureTarget();
-                    InstructionSetSupport instructionSetSupport = ConfigureInstructionSetSupport();
-
-                    //
-                    // Initialize type system context
-                    //
-
-                    SharedGenericsMode genericsMode = SharedGenericsMode.CanonicalReferenceTypes;
-
-                    var targetDetails = new TargetDetails(_targetArchitecture, _targetOS, TargetAbi.CoreRT, instructionSetSupport.GetVectorTSimdVector());
-
-                    bool versionBubbleIncludesCoreLib = false;
-                    if (_commandLineOptions.InputBubble)
-                    {
-                        versionBubbleIncludesCoreLib = true;
-                    }
-                    else
-                    {
-                        foreach (var inputFile in _inputFilePaths)
-                        {
-                            if (String.Compare(inputFile.Key, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase) == 0)
-                            {
-                                versionBubbleIncludesCoreLib = true;
-                                break;
-                            }
-                        }
-                        if (!versionBubbleIncludesCoreLib)
-                        {
-                            foreach (var inputFile in _unrootedInputFilePaths)
-                            {
-                                if (String.Compare(inputFile.Key, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase) == 0)
-                                {
-                                    versionBubbleIncludesCoreLib = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    _typeSystemContext = new ReadyToRunCompilerContext(targetDetails, genericsMode, versionBubbleIncludesCoreLib);
-
                     string compositeRootPath = _commandLineOptions.CompositeRootPath;
 
                     //
@@ -355,12 +391,12 @@ namespace ILCompiler
                     // See: https://github.com/dotnet/corert/issues/2785
                     //
                     // When we undo this this hack, replace this foreach with
-                    //  typeSystemContext.InputFilePaths = _inputFilePaths;
+                    //  typeSystemContext.InputFilePaths = inFilePaths;
                     //
                     Dictionary<string, string> allInputFilePaths = new Dictionary<string, string>();
                     Dictionary<string, string> inputFilePaths = new Dictionary<string, string>();
                     List<ModuleDesc> referenceableModules = new List<ModuleDesc>();
-                    foreach (var inputFile in _inputFilePaths)
+                    foreach (var inputFile in inFilePaths)
                     {
                         try
                         {
@@ -556,7 +592,7 @@ namespace ILCompiler
                         }
                     }
                     // In single-file compilation mode, use the assembly's DebuggableAttribute to determine whether to optimize
-                    // or produce debuggable code if an explicit optimization level was not specified on the command line 
+                    // or produce debuggable code if an explicit optimization level was not specified on the command line
                     if (_optimizationMode == OptimizationMode.None && !_commandLineOptions.OptimizeDisabled && !_commandLineOptions.Composite)
                     {
                         System.Diagnostics.Debug.Assert(inputModules.Count == 1);
@@ -589,7 +625,7 @@ namespace ILCompiler
                         .UseInstructionSetSupport(instructionSetSupport)
                         .UseCustomPESectionAlignment(_commandLineOptions.CustomPESectionAlignment)
                         .UseVerifyTypeAndFieldLayout(_commandLineOptions.VerifyTypeAndFieldLayout)
-                        .GenerateOutputFile(_commandLineOptions.OutputFilePath)
+                        .GenerateOutputFile(outFile)
                         .UseILProvider(ilProvider)
                         .UseBackendOptions(_commandLineOptions.CodegenOptions)
                         .UseLogger(logger)
@@ -600,7 +636,7 @@ namespace ILCompiler
                     compilation = builder.ToCompilation();
 
                 }
-                compilation.Compile(_commandLineOptions.OutputFilePath);
+                compilation.Compile(outFile);
 
                 if (_commandLineOptions.DgmlLogFileName != null)
                     compilation.WriteDependencyLog(_commandLineOptions.DgmlLogFileName);

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -198,6 +198,9 @@
   <data name="OptimizeSpeedOption" xml:space="preserve">
     <value>Enable optimizations, favor code speed</value>
   </data>
+  <data name="OutNearInputOption" xml:space="preserve">
+    <value>Create output files near input files with ni.dll suffix</value>
+  </data>
   <data name="OutputFilePath" xml:space="preserve">
     <value>Output file path</value>
   </data>
@@ -221,6 +224,9 @@
   </data>
   <data name="SaveDetailedLogOption" xml:space="preserve">
     <value>Save detailed log of dependency analysis</value>
+  </data>
+  <data name="SingleFileCompilationOption" xml:space="preserve">
+    <value>Compile each of the input files separately</value>
   </data>
   <data name="SingleMethodGenericArgs" xml:space="preserve">
     <value>Single method compilation: generic arguments to the method</value>


### PR DESCRIPTION
By using `--out-near-input` and `--single-file-compilation` options multiple files can be compiled in one invocation of crossgen2. This allows to remove startup overhead if many files are to be compiled anyway.

x64, f95b2b2fa2d290a2a79e21677a1f326284845ecb, release build, 100 measurements for each case (for single-file compilation mode all 100 copies of file are passed in one command):
```sh
./corerun `pwd`/crossgen2/crossgen2.dll /tmp/crossgen2.dll -O -r:`pwd`/*  --out-near-input --single-file-compilation
```

### default number of threads

Basically, the result is a constant ~0.3s diff per dll:
```
before:
crossgen2.dll: 0.80555s
System.Private.CoreLib.dll: 3.15564s

after:
crossgen2.dll: 0.54847s (-31.9%, -0.26s)
System.Private.CoreLib.dll: 2.80951s (-11.0%, -0.35s) 
```

### 1 thread
```
before:
crossgen2.dll: 0.88498s
System.Private.CoreLib.dll: 8.32537s

after:
crossgen2.dll: 0.53211s (-39.9%, -0.35s)
System.Private.CoreLib.dll: 7.74492s (-7.0%, -0.58s) 
```


cc @alpencolt 