### PR TITLE
SafeProcessHandle.Unix: fix missing DangerousRelease

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Win32.SafeHandles
         private readonly bool _releaseRef;
 
         internal SafeProcessHandle(int processId, SafeWaitHandle handle) :
-            this(handle.DangerousGetHandle(), ownsHandle: false)
+            this(handle.DangerousGetHandle(), ownsHandle: true)
         {
             ProcessId = processId;
             _handle = handle;


### PR DESCRIPTION
Because the SafeProcessHandle was not owned, ReleaseHandle was
not called, causing the wrapped SafeWaitHandle to never release
its resources.

Fixes https://github.com/dotnet/runtime/issues/36661

cc @stephentoub 