### PR TITLE
[interp] Don't save ip twice in InterpFrame

### DIFF
--- a/src/mono/mono/mini/interp/interp-internals.h
+++ b/src/mono/mono/mini/interp/interp-internals.h
@@ -213,8 +213,6 @@ struct InterpFrame {
 	InterpFrame    *next_free;
 	/* Stack fragments this frame was allocated from */
 	StackFragment *data_frag;
-	/* exception info */
-	const unsigned short  *ip;
 	/* State saved before calls */
 	/* This is valid if state.ip != NULL */
 	InterpState state;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19909,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>We had frame->ip used by EH and debugger and frame->state.ip used to save the ip of the next instruction to be executed when we return from the call. Since both represent more or less the same thing, unify them and avoid duplicate storing inside InterpFrame for each call. Because we use this ip with exception handling, we need to subtract 1 (similar to the jit) so the ip ends up being in the call instruction and not the next.