### PR TITLE
Adding extensibility point to global-build-job and some minor refactoring

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -10,6 +10,8 @@ parameters:
   timeoutInMinutes: ''
   pool: ''
   condition: true
+  extraStepsTemplate: ''
+  extraStepsParameters: {}
 
 jobs:
 - template: /eng/common/templates/job/job.yml
@@ -64,3 +66,13 @@ jobs:
         ArtifactName: Logs_Build_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
       continueOnError: true
       condition: always()
+
+      # If intended to send extra steps after regular build add them here.
+    - ${{ if ne(parameters.extraStepsTemplate, '') }}:
+      - template: ${{ parameters.extraStepsTemplate }}
+        parameters:
+          osGroup: ${{ parameters.osGroup }}
+          osSubgroup: ${{ parameters.osSubgroup }}
+          archType: ${{ parameters.archType }}
+          buildConfig: ${{ parameters.buildConfig }}
+          ${{ insert }}: ${{ parameters.extraStepsParameters }}

--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -30,17 +30,13 @@ jobs:
       - name: System.DisableZipDownload
         value: true
 
-      - ${{ if eq(parameters.jobParameters.buildConfig, 'checked') }}:
-        - name: buildConfigUpper
-          value: 'Checked'
-
-      - ${{ if eq(parameters.jobParameters.buildConfig, 'debug') }}:
-        - name: buildConfigUpper
+      - name: buildConfigUpper
+        ${{ if eq(parameters.jobParameters.buildConfig, 'debug') }}:
           value: 'Debug'
-
-      - ${{ if eq(parameters.jobParameters.buildConfig, 'release') }}:
-        - name: buildConfigUpper
+        ${{ if eq(parameters.jobParameters.buildConfig, 'release') }}:
           value: 'Release'
+        ${{ if eq(parameters.jobParameters.buildConfig, 'checked') }}:
+          value: 'Checked'
 
       - name: _BuildConfig
         value: $(buildConfigUpper)


### PR DESCRIPTION
cc: @safern 

This is part of the refactorings that have been going into https://github.com/dotnet/runtimelab/pull/2 in order to support enough extensibility so that we can start reusing existing yml for runtimelab repository. This initial port is done now because @safern needs it for his current work.