### PR TITLE
Set RollForward=Major for ILVerify dotnet tool

### DIFF
--- a/src/coreclr/src/tools/ILVerify/ILVerify.csproj
+++ b/src/coreclr/src/tools/ILVerify/ILVerify.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <Import Project="..\ILVerification\ILVerification.projitems" />


### PR DESCRIPTION
This allows it to be used by later versions of dotnet if the original one isn't available.