### PR TITLE
Passed cancellationToken might be default.

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -540,12 +540,11 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
         public async Task PostAsync_Cancel_CancellationTokenPassedToContent(HttpContent content, CancellationTokenSource cancellationTokenSource)
         {
-#if WINHTTPHANDLER_TEST
-            if (UseVersion > HttpVersion.Version11)
+            if (IsWinHttpHandler)
             {
-                throw new SkipTestException($"Test doesn't support {UseVersion} protocol.");
+                return;
             }
-#endif
+
             await LoopbackServerFactory.CreateClientAndServerAsync(
                 async uri =>
                 {


### PR DESCRIPTION
In cases like WinHttpHandler (which is also build against .NET Framework), there is no way how to properly pass cancellationToken to content's `CopyToAsync`. The overloads accepting it are [recent addition](https://github.com/dotnet/runtime/pull/686) and not part of .NET Standard.
The tests were deadlocking waiting for `cts.Task` which is supposed to be finished from `cancellationToken.Register(...)` on the token that is **not bound** to test's `TaskCompletionSource`.

Fixes #36689

cc: @stephentoub 