### PR TITLE
Add build support for ILLink.Substitutions.xml files

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -54,7 +54,7 @@
   <ItemGroup>
     <None Include="$(ILLinkTrimXmlLibraryBuild)" Condition="'$(ILLinkTrimXmlLibraryBuild)' != ''" />
     <None Include="$(ILLinkSubstitutionsXml)" Condition="'$(ILLinkSubstitutionsXml)' != ''" />
-    <None Include="@(ILLinkSubstitutionsXml)" />
+    <None Include="@(ILLinkSubstitutionsXmls)" />
   </ItemGroup>
 
   <!-- Custom binplacing for pre/post-trimming and reports that is useful for analysis 
@@ -89,15 +89,14 @@
 
   <UsingTask TaskName="CombineLinkerXmlFiles" AssemblyFile="$(ILLinkTasksPath)" />
   <Target Name="_CombineILLinkSubstitutionsXmls"
-          Condition="'$(ILLinkSubstitutionsXml)' == '' and '@(ILLinkSubstitutionsXml)' != ''"
-          Inputs="@(ILLinkSubstitutionsXml)"
+          Condition="'$(ILLinkSubstitutionsXml)' == '' and '@(ILLinkSubstitutionsXmls)' != ''"
+          Inputs="@(ILLinkSubstitutionsXmls)"
           Outputs="$(ILLinkSubstitutionsXmlIntermediatePath)">
     <PropertyGroup>
       <ILLinkSubstitutionsXml>$(ILLinkSubstitutionsXmlIntermediatePath)</ILLinkSubstitutionsXml>
     </PropertyGroup>
 
-    <CombineLinkerXmlFiles Condition="'@(ILLinkSubstitutionsXml)' != ''"
-                           LinkerXmlFiles="@(ILLinkSubstitutionsXml)"
+    <CombineLinkerXmlFiles LinkerXmlFiles="@(ILLinkSubstitutionsXmls)"
                            CombinedLinkerXmlFile="$(ILLinkSubstitutionsXml)" />
 
     <ItemGroup>

--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,5 +1,12 @@
 <Project>
   <PropertyGroup>
+    <PrepareResourcesDependsOn>
+      _EmbedILLinkSubstitutionsXmls;
+      $(PrepareResourcesDependsOn)
+    </PrepareResourcesDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <TargetsTriggeredByCompilation Condition="'$(DesignTimeBuild)' != 'true'">
       $(TargetsTriggeredByCompilation);
       _SetILLinkTrimAssembly;
@@ -31,6 +38,8 @@
     <ILLinkTrimXml Condition="'$(ILLinkTrimXml)' == '' and Exists('$(MSBuildProjectDirectory)/ILLinkTrim.xml')">$(MSBuildProjectDirectory)/ILLinkTrim.xml</ILLinkTrimXml>
     <!-- ILLinkTrim_LibraryBuild.xml files are only used during building the library, not an app. They shouldn't be embedded into the assembly. -->
     <ILLinkTrimXmlLibraryBuild Condition="'$(ILLinkTrimXmlLibraryBuild)' == '' and Exists('$(MSBuildProjectDirectory)/ILLinkTrim_LibraryBuild.xml')">$(MSBuildProjectDirectory)/ILLinkTrim_LibraryBuild.xml</ILLinkTrimXmlLibraryBuild>
+    <ILLinkSubstitutionsXml Condition="'$(ILLinkSubstitutionsXml)' == '' and Exists('$(MSBuildProjectDirectory)/ILLink.Substitutions.xml')">$(MSBuildProjectDirectory)/ILLink.Substitutions.xml</ILLinkSubstitutionsXml>
+    <ILLinkSubstitutionsXmlIntermediatePath>$(IntermediateOutputPath)ILLink.Substitutions.xml</ILLinkSubstitutionsXmlIntermediatePath>
 
     <!-- if building a PDB, tell illink to rewrite the symbols file -->
     <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' and '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
@@ -42,8 +51,10 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ILLinkTrimXmlLibraryBuild)' != ''">
-    <None Include="$(ILLinkTrimXmlLibraryBuild)" />
+  <ItemGroup>
+    <None Include="$(ILLinkTrimXmlLibraryBuild)" Condition="'$(ILLinkTrimXmlLibraryBuild)' != ''" />
+    <None Include="$(ILLinkSubstitutionsXml)" Condition="'$(ILLinkSubstitutionsXml)' != ''" />
+    <None Include="@(ILLinkSubstitutionsXml)" />
   </ItemGroup>
 
   <!-- Custom binplacing for pre/post-trimming and reports that is useful for analysis 
@@ -64,6 +75,36 @@
     </BinPlaceTargetFramework>
   </ItemGroup>
 
+  <Target Name="_EmbedILLinkSubstitutionsXmls"
+          Condition="'$(ILLinkTrimAssembly)' == 'true'"
+          DependsOnTargets="_CombineILLinkSubstitutionsXmls">
+
+    <ItemGroup Condition="'$(ILLinkSubstitutionsXml)' != ''">
+      <EmbeddedResource Include="$(ILLinkSubstitutionsXml)">
+        <LogicalName>ILLink.Substitutions.xml</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
+
+  </Target>
+
+  <UsingTask TaskName="CombineLinkerXmlFiles" AssemblyFile="$(ILLinkTasksPath)" />
+  <Target Name="_CombineILLinkSubstitutionsXmls"
+          Condition="'$(ILLinkSubstitutionsXml)' == '' and '@(ILLinkSubstitutionsXml)' != ''"
+          Inputs="@(ILLinkSubstitutionsXml)"
+          Outputs="$(ILLinkSubstitutionsXmlIntermediatePath)">
+    <PropertyGroup>
+      <ILLinkSubstitutionsXml>$(ILLinkSubstitutionsXmlIntermediatePath)</ILLinkSubstitutionsXml>
+    </PropertyGroup>
+
+    <CombineLinkerXmlFiles Condition="'@(ILLinkSubstitutionsXml)' != ''"
+                           LinkerXmlFiles="@(ILLinkSubstitutionsXml)"
+                           CombinedLinkerXmlFile="$(ILLinkSubstitutionsXml)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(ILLinkSubstitutionsXml)" />
+    </ItemGroup>
+  </Target>
+  
   <Target Name="_SetILLinkTrimAssembly" 
           Condition="'$(ILLinkTrimAssembly)' == ''"
           DependsOnTargets="GetBinPlaceTargetFramework">
@@ -96,6 +137,8 @@
       <ILLinkArgs Condition="'$(ILLinkTrimXml)' != ''">$(ILLinkArgs) --strip-descriptors false</ILLinkArgs>
       <!-- pass the non-embedded root xml file on the command line -->
       <ILLinkArgs Condition="'$(ILLinkTrimXmlLibraryBuild)' != ''">$(ILLinkArgs) -x "$(ILLinkTrimXmlLibraryBuild)"</ILLinkArgs>
+      <!-- don't remove the embedded substitutions xml resource since ILLink may run again on the assembly -->
+      <ILLinkArgs Condition="'$(ILLinkSubstitutionsXml)' != ''">$(ILLinkArgs) --strip-substitutions false</ILLinkArgs>
       <!-- ignore unresolved references -->
       <ILLinkArgs>$(ILLinkArgs) --skip-unresolved true</ILLinkArgs>
       <!-- keep interface implementations -->


### PR DESCRIPTION
These files enable the ILLinker to dynamically replace method bodies at link-time.

There are two ways of embedding the file:
- By making a single `ILLink.Substitutions.xml` file next to the .csproj
- By adding one or more files to the `@(ILLinkSubstitutionsXml)` MSBuild item. This allows for libraries, like CoreLib, to have a shared substitutions file and also separate substitutions files for each RID - x64, wasm, etc - which all get combined into a single file during the build.

Here's an example of combining multiple substitution files in mono's S.P.CoreLib https://github.com/dotnet/runtime/commit/6fdb83a96bed04b277d70dbcc41f77c7c94803fd