### PR TITLE
SafeProcessHandle.Unix: fix missing DangerousRelease (port of #37412)

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Win32.SafeHandles
         private readonly bool _releaseRef;
 
         internal SafeProcessHandle(int processId, SafeWaitHandle handle) :
-            this(handle.DangerousGetHandle(), ownsHandle: false)
+            this(handle.DangerousGetHandle(), ownsHandle: true)
         {
             ProcessId = processId;
             _handle = handle;


### PR DESCRIPTION
###  Description

Ports #37412 to preview 6. Goal is to get extra coverage in advance of potentially servicing 3.1. Original issue https://github.com/dotnet/runtime/issues/36661
Fixes regression introduced in [this PR ](https://github.com/dotnet/corefx/pull/36199) between 2.2 and 3.0 

###  Description from original PR 

Because the SafeProcessHandle was not owned, ReleaseHandle was not called, causing the wrapped SafeWaitHandle to never release its resources.

###  Customer Impact

From customer:
> This is very impactful for our embedded clients. If left out would mean skipping .Net core 3. The clients cycle a process exactly once per second which amounts to ~ 10-20 mb leak every 24 hrs. I should imagine any long running processes like asp.net core servers that spawn any child processes are also affected.

Our goal is to get coverage in 5.0 so we can confidently port to 3.1 and customer can move back to 3.1

###  Risk

Low. The change is limited to Unix; also, the lifetime was now too short, it is likely that existing tests would be crashing. Also the change is very localized and relatively straightforward. This change has not been in master long.  The impact if this change was somehow in error would likely be crashes launching processes in some cases on Unix. In such a hypothetical case we would advise impacted customers to stay on preview 5 pending preview 7, but it would have helped us avoid putting a bad change in 3.1.

