### PR TITLE
Delegate cmake version check to cmake when possible

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -48,17 +48,9 @@ check_prereqs()
 {
     echo "Checking prerequisites..."
 
-    # Check presence of CMake on the path
-    command -v cmake 2>/dev/null || { echo >&2 "Please install cmake before running this script"; exit 1; }
-
-    function version { echo "$@" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }'; }
-
-    local cmakeRequiredMinimumVersion="3.14.5"
-    local cmakeInstalledVersion="$(cmake --version | awk '/^cmake.* version [0-9]+\.[0-9]+\.[0-9]+$/ {print $3}')"
-
-    if [[ "$(version "$cmakeInstalledVersion")" -lt "$(version "$cmakeRequiredMinimumVersion")" ]]; then
-        echo "Found cmake v$cmakeInstalledVersion in PATH. Please install v$cmakeRequiredMinimumVersion or newer from https://www.cmake.org/download/."
-        exit 1;
+    if ! cmake --help 2>&1 | grep -q \\-B; then
+        echo "Please install v3.14.5 or newer from https://www.cmake.org/download/."
+        exit 1
     fi
 
     if [[ "$__HostOS" == "OSX" ]]; then

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -49,7 +49,7 @@ check_prereqs()
     echo "Checking prerequisites..."
 
     if ! cmake --help 2>&1 | grep -q \\-B; then
-        echo "Please install v3.14.5 or newer from https://www.cmake.org/download/."
+        echo "Please install cmake v3.14.5 or newer from https://www.cmake.org/download/."
         exit 1
     fi
 


### PR DESCRIPTION
There are two kinds of old cmake versions:
* <ins>v3.13.0 onwards that support `-B` command-line option:</ins>
  cmake will print the error message based on `cmake_minimum_required`
  specified.
* <ins>< v3.13.0, which do not have `-B` option:</ins> cmake will fail
  before the version check with an obscure message, quite implicitly
  indicating that it doesn't understand `-B`. For that we have an
  up-front check just for `-B` option, covering the existence of cmake
  as well.