### PR TITLE
Enum dispose signature

### DIFF
--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -440,10 +440,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         {
                             flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken;
 
-                            MemberReference memberRef = method.Token.MetadataReader.GetMemberReference((MemberReferenceHandle)method.Token.Handle);
-                            if (method.Token.Module.GetObject(memberRef.Parent) != (object)method.Method.OwningType)
+                            // Owner type is needed for type specs to instantiating stubs or generics with signature variables still present
+                            if (!method.Method.OwningType.IsDefType &&
+                                ((flags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0 || method.Method.OwningType.ContainsSignatureVariables()))
                             {
-                                // We have a memberref token for a different type - encode owning type explicitly in the signature
                                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType;
                             }
 

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -563,6 +565,25 @@ internal class Program
         using (var enumerator = listOfString.GetEnumerator())
         {
             Console.WriteLine($@"DisposeEnumeratorTest: {enumerator}");
+        }
+        return true;
+    }
+
+    private static bool DisposeEnumeratorTestWithConstrainedCall()
+    {
+        string thisAssembly = Assembly.GetExecutingAssembly().Location;
+
+        using (var fs = new FileStream(thisAssembly, FileMode.Open, FileAccess.Read))
+        {
+            using (var pereader = new PEReader(fs))
+            {
+                var reader = pereader.GetMetadataReader();
+                var methodDefinitionHandleCollection = reader.MethodDefinitions;
+                foreach (var methodDefinitionHandle in methodDefinitionHandleCollection)
+                {
+                    break;
+                }
+            }
         }
         return true;
     }
@@ -1229,6 +1250,7 @@ internal class Program
         RunTest("DisposeStructTest", DisposeStructTest());
         RunTest("DisposeClassTest", DisposeClassTest());
         RunTest("DisposeEnumeratorTest", DisposeEnumeratorTest());
+        RunTest("DisposeEnumeratorTestWithConstrainedCall", DisposeEnumeratorTestWithConstrainedCall());
         RunTest("EmptyArrayOfInt", EmptyArrayOfInt());
         RunTest("EnumerateEmptyArrayOfInt", EnumerateEmptyArrayOfInt());
         RunTest("EmptyArrayOfString", EmptyArrayOfString());


### PR DESCRIPTION
When making a constrained virtual call to `IDisposable.Dispose()` on a value type, we emit the owner type into the signature incorrectly. This causes a `MissingMethodException` at runtime as the runtime tries to resolve `System.IDisposable.Dispose()` on `IDisposable` instead of the constrained type.

Fixes CG2 compiled code which iterates over `S.R.M.MethodDefinitionHandleCollection` and its peers.

cc @dotnet/crossgen-contrib 