### PR TITLE
Add non-generic TaskCompletionSource

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicApi.cs
@@ -223,7 +223,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         public async ValueTask<MsQuicSecurityConfig?> CreateSecurityConfig(X509Certificate certificate, string? certFilePath, string? privateKeyFilePath)
         {
             MsQuicSecurityConfig? secConfig = null;
-            var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             uint secConfigCreateStatus = MsQuicStatusCodes.InternalError;
             uint createConfigStatus;
             IntPtr unmanagedAddr = IntPtr.Zero;
@@ -283,7 +283,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
                 {
                     secConfig = new MsQuicSecurityConfig(this, securityConfig);
                     secConfigCreateStatus = status;
-                    tcs.SetResult(null);
+                    tcs.SetResult();
                 }
 
                 await tcs.Task.ConfigureAwait(false);

--- a/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http2LoopbackConnection.cs
@@ -157,7 +157,7 @@ namespace System.Net.Test.Common
 
             if (_ignoredSettingsAckPromise != null && header.Type == FrameType.Settings && header.Flags == FrameFlags.Ack)
             {
-                _ignoredSettingsAckPromise.TrySetResult(false);
+                _ignoredSettingsAckPromise.TrySetResult(true);
                 _ignoredSettingsAckPromise = null;
                 return await ReadFrameAsync(cancellationToken).ConfigureAwait(false);
             }

--- a/src/libraries/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
+++ b/src/libraries/Common/tests/System/Net/VirtualNetwork/VirtualNetworkStream.cs
@@ -14,7 +14,7 @@ namespace System.Net.Test.Common
         private MemoryStream _readStream;
         private readonly bool _isServer;
         private SemaphoreSlim _readStreamLock = new SemaphoreSlim(1, 1);
-        private TaskCompletionSource<object> _flushTcs;
+        private TaskCompletionSource _flushTcs;
 
         public VirtualNetworkStream(VirtualNetwork network, bool isServer)
         {
@@ -44,7 +44,7 @@ namespace System.Net.Test.Common
             {
                 throw new InvalidOperationException();
             }
-            _flushTcs = new TaskCompletionSource<object>();
+            _flushTcs = new TaskCompletionSource();
 
             return _flushTcs.Task;
         }
@@ -58,7 +58,7 @@ namespace System.Net.Test.Common
                 throw new InvalidOperationException();
             }
 
-            _flushTcs.SetResult(null);
+            _flushTcs.SetResult();
             _flushTcs = null;
         }
 

--- a/src/libraries/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
+++ b/src/libraries/System.ComponentModel.EventBasedAsync/tests/BackgroundWorkerTests.cs
@@ -74,13 +74,13 @@ namespace System.ComponentModel.EventBasedAsync.Tests
         [Fact]
         public async Task RunWorkerAsync_NoOnWorkHandler_SetsResultToNull()
         {
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource();
             var backgroundWorker = new BackgroundWorker { WorkerReportsProgress = true };
             backgroundWorker.RunWorkerCompleted += (sender, e) =>
             {
                 Assert.Null(e.Result);
                 Assert.False(backgroundWorker.IsBusy);
-                tcs.SetResult(true);
+                tcs.SetResult();
             };
 
             backgroundWorker.RunWorkerAsync();

--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -36,12 +36,12 @@ public partial class CancelKeyPressTests
         RemoteExecutor.Invoke(() =>
         {
             var mre = new ManualResetEventSlim();
-            var tcs = new TaskCompletionSource<object>();
+            var tcs = new TaskCompletionSource();
 
             // CancelKeyPress is triggered by SIGINT/SIGQUIT
             Console.CancelKeyPress += (sender, e) =>
             {
-                tcs.SetResult(null);
+                tcs.SetResult();
                 // Block CancelKeyPress
                 Assert.True(mre.Wait(WaitFailTestTimeoutSeconds * 1000));
             };

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -216,19 +216,19 @@ namespace System.Diagnostics.Tests
             Process p = CreateProcessLong();
             p.EnableRaisingEvents = true;
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             if (addHandlerBeforeStart)
             {
-                p.Exited += delegate { tcs.SetResult(true); };
+                p.Exited += delegate { tcs.SetResult(); };
             }
             p.Start();
             if (!addHandlerBeforeStart)
             {
-                p.Exited += delegate { tcs.SetResult(true); };
+                p.Exited += delegate { tcs.SetResult(); };
             }
 
             p.Kill();
-            Assert.True(await tcs.Task);
+            await tcs.Task;
 
             Assert.True(p.WaitForExit(0));
             p.WaitForExit(); // wait for event handlers to complete
@@ -242,21 +242,19 @@ namespace System.Diagnostics.Tests
             Process p = CreateProcessLong();
             p.EnableRaisingEvents = true;
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             if (addHandlerBeforeStart)
             {
-                p.Exited += delegate
-                { tcs.SetResult(true); };
+                p.Exited += delegate { tcs.SetResult(); };
             }
             p.Start();
             if (!addHandlerBeforeStart)
             {
-                p.Exited += delegate
-                { tcs.SetResult(true); };
+                p.Exited += delegate { tcs.SetResult(); };
             }
 
             p.Kill();
-            Assert.True(await tcs.Task);
+            await tcs.Task;
 
             var token = new CancellationToken(canceled: true);
             await p.WaitForExitAsync(token);
@@ -274,12 +272,11 @@ namespace System.Diagnostics.Tests
         {
             using (Process p = CreateProcessPortable(RemotelyInvokable.ExitWithCode, exitCode.ToString()))
             {
-                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 p.EnableRaisingEvents = true;
-                p.Exited += delegate
-                { tcs.SetResult(true); };
+                p.Exited += delegate { tcs.SetResult(); };
                 p.Start();
-                Assert.True(await tcs.Task);
+                await tcs.Task;
                 Assert.Equal(exitCode, p.ExitCode);
             }
         }

--- a/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -267,7 +267,7 @@ namespace System.IO.Tests
     internal sealed class ManuallyReleaseAsyncOperationsStream : Stream
     {
         private readonly MemoryStream _stream = new MemoryStream();
-        private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         private bool _canSeek = true;
 
         public override bool CanSeek => _canSeek;
@@ -282,7 +282,7 @@ namespace System.IO.Tests
 
         public void SetCanSeek(bool canSeek) => _canSeek = canSeek;
 
-        public void Release() { _tcs.SetResult(true); }
+        public void Release() => _tcs.SetResult();
 
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -1705,7 +1705,7 @@ namespace System.Net.Http.Functional.Tests
         public async Task Http2_PendingReceive_SendsReset(bool doRead)
         {
             var cts = new CancellationTokenSource();
-            var doCancel = new TaskCompletionSource<bool>();
+            var doCancel = new TaskCompletionSource();
             HttpResponseMessage response = null;
 
             using (HttpClient client = CreateHttpClient())
@@ -1726,7 +1726,7 @@ namespace System.Net.Http.Functional.Tests
                             _ = await stream.ReadAsync(buffer, cts.Token);
                         }
 
-                        doCancel.SetResult(true);
+                        doCancel.SetResult();
                         _output.WriteLine($"{DateTime.Now} cancellation requested.");
 
                         // Keep reading response.
@@ -1776,7 +1776,7 @@ namespace System.Net.Http.Functional.Tests
             // test for https://github.com/dotnet/runtime/issues/30187
             var throwingContent = new ThrowingContent(() => new InvalidOperationException());
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource();
             await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 using (HttpClient client = CreateHttpClient())
@@ -1793,7 +1793,7 @@ namespace System.Net.Http.Functional.Tests
             async server =>
             {
                 await server.EstablishConnectionAsync();
-                tcs.SetResult(false);
+                tcs.SetResult();
             });
         }
 
@@ -1805,7 +1805,7 @@ namespace System.Net.Http.Functional.Tests
 
             var throwingContent = new ThrowingContent(() => new CustomException());
 
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource();
             await Http2LoopbackServer.CreateClientAndServerAsync(async url =>
             {
                 using (HttpClient client = CreateHttpClient())
@@ -1821,7 +1821,7 @@ namespace System.Net.Http.Functional.Tests
             async server =>
             {
                 await server.EstablishConnectionAsync();
-                tcs.SetResult(false);
+                tcs.SetResult();
             });
         }
 
@@ -1912,7 +1912,7 @@ namespace System.Net.Http.Functional.Tests
         class DuplexContent : HttpContent
         {
             private TaskCompletionSource<Stream> _waitForStream;
-            private TaskCompletionSource<bool> _waitForCompletion;
+            private TaskCompletionSource _waitForCompletion;
 
             public DuplexContent()
             {
@@ -1927,7 +1927,7 @@ namespace System.Net.Http.Functional.Tests
 
             protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
             {
-                _waitForCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                _waitForCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 _waitForStream.SetResult(stream);
                 await _waitForCompletion.Task;
             }
@@ -1939,7 +1939,7 @@ namespace System.Net.Http.Functional.Tests
 
             public void Complete()
             {
-                _waitForCompletion.SetResult(true);
+                _waitForCompletion.SetResult();
             }
 
             public void Fail(Exception e)
@@ -2818,8 +2818,8 @@ namespace System.Net.Http.Functional.Tests
         [OuterLoop("Waits for seconds for events that shouldn't happen")]
         public async Task SendAsync_StreamContentRequestBody_WaitsForRequestBodyToComplete()
         {
-            var waitToSendRequestBody = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            var sendAsyncCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var waitToSendRequestBody = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var sendAsyncCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // Create a content stream that will wait for a signal before it dribbles out some request content.
             int sent = 0;
@@ -2846,11 +2846,11 @@ namespace System.Net.Http.Functional.Tests
                     Assert.False(sendAsyncTask.IsCompleted);
 
                     // Now let the request content go.  The SendAsync task should complete quickly.
-                    waitToSendRequestBody.SetResult(true);
+                    waitToSendRequestBody.SetResult();
                     using (HttpResponseMessage r = await sendAsyncTask)
                     {
                         // Wake up the server.
-                        sendAsyncCompleted.SetResult(true);
+                        sendAsyncCompleted.SetResult();
                     }
                 }
             },

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -48,7 +48,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ExecutionContext_HttpConnectionLifetimeDoesntKeepContextAlive()
         {
-            var clientCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var clientCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 try
@@ -69,7 +69,7 @@ namespace System.Net.Http.Functional.Tests
                 }
                 finally
                 {
-                    clientCompleted.SetResult(true);
+                    clientCompleted.SetResult();
                 }
             }, async server =>
             {
@@ -84,7 +84,7 @@ namespace System.Net.Http.Functional.Tests
         [MethodImpl(MethodImplOptions.NoInlining)] // avoid JIT extending lifetime of the finalizable object
         private static (Task completedOnFinalized, Task getRequest) MakeHttpRequestWithTcsSetOnFinalizationInAsyncLocal(HttpClient client, Uri uri)
         {
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // Put something in ExecutionContext, start the HTTP request, then undo the EC change.
             var al = new AsyncLocal<object>() { Value = new SetOnFinalized() { _completedWhenFinalized = tcs } };
@@ -101,8 +101,8 @@ namespace System.Net.Http.Functional.Tests
 
         private sealed class SetOnFinalized
         {
-            internal TaskCompletionSource<bool> _completedWhenFinalized;
-            ~SetOnFinalized() => _completedWhenFinalized.SetResult(true);
+            internal TaskCompletionSource _completedWhenFinalized;
+            ~SetOnFinalized() => _completedWhenFinalized.SetResult();
         }
     }
 
@@ -475,7 +475,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(true)]
         public async Task DisposeTargetStream_ThrowsObjectDisposedException(bool knownLength)
         {
-            var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             await LoopbackServerFactory.CreateClientAndServerAsync(async uri =>
             {
                 try
@@ -488,7 +488,7 @@ namespace System.Net.Http.Functional.Tests
                 }
                 finally
                 {
-                    tcs.SetResult(0);
+                    tcs.SetResult();
                 }
             }, server => tcs.Task);
         }
@@ -1040,7 +1040,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task ConnectTimeout_TimesOutSSLAuth_Throws()
         {
-            var releaseServer = new TaskCompletionSource<bool>();
+            var releaseServer = new TaskCompletionSource();
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 using (var handler = new SocketsHttpHandler())
@@ -1055,7 +1055,7 @@ namespace System.Net.Http.Functional.Tests
                     sw.Stop();
 
                     Assert.InRange(sw.ElapsedMilliseconds, 500, 60_000);
-                    releaseServer.SetResult(true);
+                    releaseServer.SetResult();
                 }
             }, server => releaseServer.Task); // doesn't establish SSL connection
         }
@@ -1483,7 +1483,7 @@ namespace System.Net.Http.Functional.Tests
             {
                 await LoopbackServer.CreateServerAsync(async (server, uri) =>
                 {
-                    var releaseServer = new TaskCompletionSource<bool>();
+                    var releaseServer = new TaskCompletionSource();
 
                     // Make multiple requests iteratively.
 
@@ -1497,7 +1497,7 @@ namespace System.Net.Http.Functional.Tests
                     Task serverTask2 = server.AcceptConnectionSendCustomResponseAndCloseAsync(LoopbackServer.GetHttpResponse(connectionClose: true));
                     await new[] { client.GetStringAsync(uri), serverTask2 }.WhenAllOrAnyFailed();
 
-                    releaseServer.SetResult(true);
+                    releaseServer.SetResult();
                     await serverTask1;
                 });
             }
@@ -1629,7 +1629,7 @@ namespace System.Net.Http.Functional.Tests
         {
             RemoteExecutor.Invoke(async (secureString, useVersionString) =>
             {
-                var releaseServer = new TaskCompletionSource<bool>();
+                var releaseServer = new TaskCompletionSource();
                 await LoopbackServer.CreateClientAndServerAsync(async uri =>
                 {
                     using (var handler = new SocketsHttpHandler())
@@ -1653,7 +1653,7 @@ namespace System.Net.Http.Functional.Tests
                         // and thus could have some false negatives, but there won't be any false positives.
                         Assert.True(exceptions.Count == 0, string.Concat(exceptions));
 
-                        releaseServer.SetResult(true);
+                        releaseServer.SetResult();
                     }
                 }, server => server.AcceptConnectionAsync(async connection =>
                 {
@@ -1668,7 +1668,7 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public void HandlerDroppedWithoutDisposal_NotKeptAlive()
         {
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             HandlerDroppedWithoutDisposal_NotKeptAliveCore(tcs);
             for (int i = 0; i < 10; i++)
             {
@@ -1679,13 +1679,13 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void HandlerDroppedWithoutDisposal_NotKeptAliveCore(TaskCompletionSource<bool> setOnFinalized)
+        private void HandlerDroppedWithoutDisposal_NotKeptAliveCore(TaskCompletionSource setOnFinalized)
         {
             // This relies on knowing that in order for the connection pool to operate, it needs
             // to maintain a reference to the supplied IWebProxy.  As such, we provide a proxy
             // that when finalized will set our event, so that we can determine the state associated
             // with a handler has gone away.
-            IWebProxy p = new PassthroughProxyWithFinalizerCallback(() => setOnFinalized.TrySetResult(true));
+            IWebProxy p = new PassthroughProxyWithFinalizerCallback(() => setOnFinalized.TrySetResult());
 
             // Make a bunch of requests and drop the associated HttpClient instances after making them, without disposal.
             Task.WaitAll((from i in Enumerable.Range(0, 10)

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -27,7 +27,7 @@ namespace System.Net.WebSockets
         private WebSocketBase _webSocket;
         private HttpListenerAsyncEventArgs _writeEventArgs;
         private HttpListenerAsyncEventArgs _readEventArgs;
-        private TaskCompletionSource<object> _writeTaskCompletionSource;
+        private TaskCompletionSource _writeTaskCompletionSource;
         private TaskCompletionSource<int> _readTaskCompletionSource;
         private int _cleanedUp;
 
@@ -377,7 +377,7 @@ namespace System.Net.WebSockets
                 Debug.Assert(Interlocked.Increment(ref _outstandingOperations._writes) == 1,
                     "Only one outstanding write allowed at any given time.");
 #endif
-                _writeTaskCompletionSource = new TaskCompletionSource<object>();
+                _writeTaskCompletionSource = new TaskCompletionSource();
                 _writeEventArgs.SetBuffer(null, 0, 0);
                 _writeEventArgs.BufferList = sendBuffers;
                 if (WriteAsyncFast(_writeEventArgs))
@@ -446,7 +446,7 @@ namespace System.Net.WebSockets
                     Debug.Assert(Interlocked.Increment(ref _outstandingOperations._writes) == 1,
                         "Only one outstanding write allowed at any given time.");
 #endif
-                    _writeTaskCompletionSource = new TaskCompletionSource<object>();
+                    _writeTaskCompletionSource = new TaskCompletionSource();
                     _writeEventArgs.BufferList = null;
                     _writeEventArgs.SetBuffer(buffer, offset, count);
                     if (WriteAsyncFast(_writeEventArgs))
@@ -628,7 +628,7 @@ namespace System.Net.WebSockets
                 Debug.Assert(Interlocked.Increment(ref _outstandingOperations._writes) == 1,
                     "Only one outstanding write allowed at any given time.");
 #endif
-                _writeTaskCompletionSource = new TaskCompletionSource<object>();
+                _writeTaskCompletionSource = new TaskCompletionSource();
                 _writeEventArgs.SetShouldCloseOutput();
                 if (WriteAsyncFast(_writeEventArgs))
                 {
@@ -666,10 +666,7 @@ namespace System.Net.WebSockets
                     _readTaskCompletionSource.TrySetCanceled();
                 }
 
-                if (_writeTaskCompletionSource != null)
-                {
-                    _writeTaskCompletionSource.TrySetCanceled();
-                }
+                _writeTaskCompletionSource?.TrySetCanceled();
 
                 if (_readEventArgs != null)
                 {
@@ -722,19 +719,8 @@ namespace System.Net.WebSockets
             }
             catch { }
 
-            TaskCompletionSource<int> readTaskCompletionSourceSnapshot = thisPtr._readTaskCompletionSource;
-
-            if (readTaskCompletionSourceSnapshot != null)
-            {
-                readTaskCompletionSourceSnapshot.TrySetCanceled();
-            }
-
-            TaskCompletionSource<object> writeTaskCompletionSourceSnapshot = thisPtr._writeTaskCompletionSource;
-
-            if (writeTaskCompletionSourceSnapshot != null)
-            {
-                writeTaskCompletionSourceSnapshot.TrySetCanceled();
-            }
+            thisPtr._readTaskCompletionSource?.TrySetCanceled();
+            thisPtr._writeTaskCompletionSource?.TrySetCanceled();
 
             if (NetEventSource.IsEnabled)
             {
@@ -793,7 +779,7 @@ namespace System.Net.WebSockets
             }
             else
             {
-                thisPtr._writeTaskCompletionSource.TrySetResult(null);
+                thisPtr._writeTaskCompletionSource.TrySetResult();
             }
 
             if (NetEventSource.IsEnabled)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -800,7 +800,7 @@ namespace System.Net.Mail
             }
 
             // Create a TaskCompletionSource to represent the operation
-            var tcs = new TaskCompletionSource<object?>();
+            var tcs = new TaskCompletionSource();
 
             CancellationTokenRegistration ctr = default;
 
@@ -827,7 +827,7 @@ namespace System.Net.Mail
                     {
                         if (e.Error != null) tcs.TrySetException(e.Error);
                         else if (e.Cancelled) tcs.TrySetCanceled();
-                        else tcs.TrySetResult(null);
+                        else tcs.TrySetResult();
                     }
                 }
             };

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -328,9 +328,9 @@ namespace System.Net.NetworkInformation
         {
             using (Process p = GetPingProcess(address, buffer, timeout, options))
             {
-                var processCompletion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var processCompletion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 p.EnableRaisingEvents = true;
-                p.Exited += (s, e) => processCompletion.SetResult(true);
+                p.Exited += (s, e) => processCompletion.SetResult();
                 p.Start();
 
                 var cts = new CancellationTokenSource();

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -663,17 +663,17 @@ namespace System.Net.NetworkInformation.Tests
 
             using (Ping p = new Ping())
             {
-                TaskCompletionSource<bool> tcs = null;
+                TaskCompletionSource tcs = null;
                 PingCompletedEventArgs ea = null;
                 p.PingCompleted += (s, e) =>
                 {
                     ea = e;
-                    tcs.TrySetResult(true);
+                    tcs.TrySetResult();
                 };
                 Action reset = () =>
                 {
                     ea = null;
-                    tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
                 };
 
                 // Several normal iterations

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -439,10 +439,10 @@ namespace System.Net.Security.Tests
                 await DoHandshake(clientSslStream, serverSslStream);
 
                 var serverBuffer = new byte[1];
-                var tcs = new TaskCompletionSource<object>();
+                var tcs = new TaskCompletionSource();
                 serverStream.OnRead += (buffer, offset, count) =>
                 {
-                    tcs.TrySetResult(null);
+                    tcs.TrySetResult();
                 };
                 Task readTask = ReadAsync(serverSslStream, serverBuffer, 0, serverBuffer.Length);
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
@@ -535,7 +535,7 @@ namespace System.Net.Sockets.Tests
             {
                 var clientData = new byte[] { 42 };
                 var serverData = new byte[clientData.Length];
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource();
 
                 client.BeginWrite(clientData, 0, clientData.Length, writeIar =>
                 {
@@ -547,7 +547,7 @@ namespace System.Net.Sockets.Tests
                             try
                             {
                                 Assert.Equal(serverData.Length, server.EndRead(readIar));
-                                tcs.SetResult(true);
+                                tcs.SetResult();
                             }
                             catch (Exception e2) { tcs.SetException(e2); }
                         }, null);
@@ -1004,7 +1004,7 @@ namespace System.Net.Sockets.Tests
                 {
                     Assert.Null(SynchronizationContext.Current);
 
-                    var continuationRan = new TaskCompletionSource<bool>();
+                    var continuationRan = new TaskCompletionSource();
                     var asyncLocal = new AsyncLocal<int>();
                     bool schedulerWasFlowed = false;
                     bool executionContextWasFlowed = false;
@@ -1012,7 +1012,7 @@ namespace System.Net.Sockets.Tests
                     {
                         schedulerWasFlowed = TaskScheduler.Current is CustomTaskScheduler;
                         executionContextWasFlowed = 42 == asyncLocal.Value;
-                        continuationRan.SetResult(true);
+                        continuationRan.SetResult();
                     };
 
                     var readBuffer = new byte[1];

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1360,14 +1360,14 @@ namespace System.Net.Sockets.Tests
                 data[0] = data[499] = 2;
                 Assert.Equal(500, sender.Send(data));
 
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource();
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
 
                 var receiveBufer = new byte[600];
                 receiveBufer[0] = data[499] = 0;
 
                 args.SetBuffer(receiveBufer, 0, receiveBufer.Length);
-                args.Completed += delegate { tcs.SetResult(true); };
+                args.Completed += delegate { tcs.SetResult(); };
 
                 // First peek at the message.
                 args.SocketFlags = SocketFlags.Peek;
@@ -1381,7 +1381,7 @@ namespace System.Net.Sockets.Tests
                 receiveBufer[0] = receiveBufer[499] = 0;
 
                 // Now, we should be able to get same message again.
-                tcs = new TaskCompletionSource<bool>();
+                tcs = new TaskCompletionSource();
                 args.SocketFlags = SocketFlags.None;
                 if (receiver.ReceiveAsync(args))
                 {
@@ -1393,7 +1393,7 @@ namespace System.Net.Sockets.Tests
                 receiveBufer[0] = receiveBufer[499] = 0;
 
                 // Set buffer smaller than message.
-                tcs = new TaskCompletionSource<bool>();
+                tcs = new TaskCompletionSource();
                 args.SetBuffer(receiveBufer, 0, 100);
                 if (receiver.ReceiveAsync(args))
                 {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketAsyncEventArgsTest.cs
@@ -87,9 +87,9 @@ namespace System.Net.Sockets.Tests
                 using (Socket server = await acceptTask)
                 using (var receiveSaea = new SocketAsyncEventArgs())
                 {
-                    var tcs = new TaskCompletionSource<bool>();
+                    var tcs = new TaskCompletionSource();
                     receiveSaea.SetBuffer(new byte[1], 0, 1);
-                    receiveSaea.Completed += delegate { tcs.SetResult(true); };
+                    receiveSaea.Completed += delegate { tcs.SetResult(); };
 
                     Assert.True(client.ReceiveAsync(receiveSaea));
                     Assert.Throws<InvalidOperationException>(() => client.ReceiveAsync(receiveSaea)); // already in progress
@@ -347,16 +347,16 @@ namespace System.Net.Sockets.Tests
                 using (var receiveSaea = new SocketAsyncEventArgs())
                 {
                     receiveSaea.SetBuffer(new byte[1], 0, 1);
-                    TaskCompletionSource<bool> tcs1 = null, tcs2 = null;
+                    TaskCompletionSource tcs1 = null, tcs2 = null;
 
-                    EventHandler<SocketAsyncEventArgs> handler1 = (_, __) => tcs1.SetResult(true);
-                    EventHandler<SocketAsyncEventArgs> handler2 = (_, __) => tcs2.SetResult(true);
+                    EventHandler<SocketAsyncEventArgs> handler1 = (_, __) => tcs1.SetResult();
+                    EventHandler<SocketAsyncEventArgs> handler2 = (_, __) => tcs2.SetResult();
 
                     receiveSaea.Completed += handler2;
                     receiveSaea.Completed += handler1;
 
-                    tcs1 = new TaskCompletionSource<bool>();
-                    tcs2 = new TaskCompletionSource<bool>();
+                    tcs1 = new TaskCompletionSource();
+                    tcs2 = new TaskCompletionSource();
                     Assert.True(client.ReceiveAsync(receiveSaea));
 
                     server.Send(new byte[1]);
@@ -364,8 +364,8 @@ namespace System.Net.Sockets.Tests
 
                     receiveSaea.Completed -= handler2;
 
-                    tcs1 = new TaskCompletionSource<bool>();
-                    tcs2 = new TaskCompletionSource<bool>();
+                    tcs1 = new TaskCompletionSource();
+                    tcs2 = new TaskCompletionSource();
                     Assert.True(client.ReceiveAsync(receiveSaea));
 
                     server.Send(new byte[1]);
@@ -442,15 +442,15 @@ namespace System.Net.Sockets.Tests
 
                 using (Socket server = await acceptTask)
                 {
-                    TaskCompletionSource<bool> tcs = null;
+                    TaskCompletionSource tcs = null;
 
                     var args = new SocketAsyncEventArgs();
                     args.SetBuffer(new byte[1024], 0, 1024);
-                    args.Completed += (_, __) => tcs.SetResult(true);
+                    args.Completed += (_, __) => tcs.SetResult();
 
                     for (int i = 1; i <= 10; i++)
                     {
-                        tcs = new TaskCompletionSource<bool>();
+                        tcs = new TaskCompletionSource();
                         args.Buffer[0] = (byte)i;
                         args.SetBuffer(0, 1);
                         if (server.SendAsync(args))
@@ -459,7 +459,7 @@ namespace System.Net.Sockets.Tests
                         }
 
                         args.Buffer[0] = 0;
-                        tcs = new TaskCompletionSource<bool>();
+                        tcs = new TaskCompletionSource();
                         if (client.ReceiveAsync(args))
                         {
                             await tcs.Task;
@@ -488,25 +488,25 @@ namespace System.Net.Sockets.Tests
 
                 using (Socket server = await acceptTask)
                 {
-                    TaskCompletionSource<bool> tcs = null;
+                    TaskCompletionSource tcs = null;
 
                     var sendBuffer = new byte[64];
                     var sendBufferList = new List<ArraySegment<byte>>();
                     sendBufferList.Add(new ArraySegment<byte>(sendBuffer, 0, 1));
                     var sendArgs = new SocketAsyncEventArgs();
                     sendArgs.BufferList = sendBufferList;
-                    sendArgs.Completed += (_, __) => tcs.SetResult(true);
+                    sendArgs.Completed += (_, __) => tcs.SetResult();
 
                     var recvBuffer = new byte[64];
                     var recvBufferList = new List<ArraySegment<byte>>();
                     recvBufferList.Add(new ArraySegment<byte>(recvBuffer, 0, 1));
                     var recvArgs = new SocketAsyncEventArgs();
                     recvArgs.BufferList = recvBufferList;
-                    recvArgs.Completed += (_, __) => tcs.SetResult(true);
+                    recvArgs.Completed += (_, __) => tcs.SetResult();
 
                     for (int i = 1; i <= 10; i++)
                     {
-                        tcs = new TaskCompletionSource<bool>();
+                        tcs = new TaskCompletionSource();
 
                         sendBuffer[0] = (byte)i;
                         if (server.SendAsync(sendArgs))
@@ -515,7 +515,7 @@ namespace System.Net.Sockets.Tests
                         }
 
                         recvBuffer[0] = 0;
-                        tcs = new TaskCompletionSource<bool>();
+                        tcs = new TaskCompletionSource();
                         if (client.ReceiveAsync(recvArgs))
                         {
                             await tcs.Task;
@@ -659,8 +659,8 @@ namespace System.Net.Sockets.Tests
                 listener.Listen(1);
                 e.RemoteEndPoint = listener.LocalEndPoint;
 
-                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                e.Completed += delegate { tcs.SetResult(true); };
+                var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                e.Completed += delegate { tcs.SetResult(); };
 
                 Task<Socket> acceptTask = listener.AcceptAsync();
                 if (Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, e))

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UnixDomainSocketTest.cs
@@ -59,9 +59,9 @@ namespace System.Net.Sockets.Tests
 
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.RemoteEndPoint = endPoint;
-                args.Completed += (s, e) => ((TaskCompletionSource<bool>)e.UserToken).SetResult(true);
+                args.Completed += (s, e) => ((TaskCompletionSource)e.UserToken).SetResult();
 
-                var complete = new TaskCompletionSource<bool>();
+                var complete = new TaskCompletionSource();
                 args.UserToken = complete;
 
                 using (Socket sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))
@@ -94,9 +94,9 @@ namespace System.Net.Sockets.Tests
             {
                 SocketAsyncEventArgs args = new SocketAsyncEventArgs();
                 args.RemoteEndPoint = endPoint;
-                args.Completed += (s, e) => ((TaskCompletionSource<bool>)e.UserToken).SetResult(true);
+                args.Completed += (s, e) => ((TaskCompletionSource)e.UserToken).SetResult();
 
-                var complete = new TaskCompletionSource<bool>();
+                var complete = new TaskCompletionSource();
                 args.UserToken = complete;
 
                 using (Socket sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified))

--- a/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
@@ -536,8 +536,8 @@ namespace System.Net.Tests
             {
                 var wc = new WebClient();
 
-                var downloadProgressInvoked = new TaskCompletionSource<bool>();
-                wc.DownloadProgressChanged += (s, e) => downloadProgressInvoked.TrySetResult(true);
+                var downloadProgressInvoked = new TaskCompletionSource();
+                wc.DownloadProgressChanged += (s, e) => downloadProgressInvoked.TrySetResult();
 
                 Task<byte[]> download = DownloadDataAsync(wc, url.ToString());
                 await server.AcceptConnectionSendResponseAndCloseAsync(content: ExpectedText);
@@ -557,13 +557,13 @@ namespace System.Net.Tests
             {
                 string largeText = GetRandomText(1024 * 1024);
 
-                var downloadProgressInvokedWithContentLength = new TaskCompletionSource<bool>();
+                var downloadProgressInvokedWithContentLength = new TaskCompletionSource();
                 var wc = new WebClient();
                 wc.DownloadProgressChanged += (s, e) =>
                 {
                     if (e.TotalBytesToReceive == largeText.Length && e.BytesReceived < e.TotalBytesToReceive)
                     {
-                        downloadProgressInvokedWithContentLength.TrySetResult(true);
+                        downloadProgressInvokedWithContentLength.TrySetResult();
                     }
                 };
 
@@ -636,8 +636,8 @@ namespace System.Net.Tests
         {
             var wc = new WebClient();
 
-            var uploadProgressInvoked = new TaskCompletionSource<bool>();
-            wc.UploadProgressChanged += (s, e) => uploadProgressInvoked.TrySetResult(true); // to enable chunking of the upload
+            var uploadProgressInvoked = new TaskCompletionSource();
+            wc.UploadProgressChanged += (s, e) => uploadProgressInvoked.TrySetResult(); // to enable chunking of the upload
 
             // Server will verify uploaded data. An exception will be thrown if there is a problem.
             AddMD5Header(wc, ExpectedText);

--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -330,7 +330,7 @@ namespace System.Net.WebSockets.Client.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public async Task CloseAsync_CancelableEvenWhenPendingReceive_Throws()
         {
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
@@ -356,7 +356,7 @@ namespace System.Net.WebSockets.Client.Tests
                 }
                 finally
                 {
-                    tcs.SetResult(true);
+                    tcs.SetResult();
                 }
             }, server => server.AcceptConnectionAsync(async connection =>
             {

--- a/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/ConnectTest.cs
@@ -260,7 +260,7 @@ namespace System.Net.WebSockets.Client.Tests
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public async Task ConnectAsync_CancellationRequestedAfterConnect_ThrowsOperationCanceledException()
         {
-            var releaseServer = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseServer = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
             {
                 var clientSocket = new ClientWebSocket();
@@ -274,7 +274,7 @@ namespace System.Net.WebSockets.Client.Tests
                 }
                 finally
                 {
-                    releaseServer.SetResult(true);
+                    releaseServer.SetResult();
                     clientSocket.Dispose();
                 }
             }, server => server.AcceptConnectionAsync(async connection =>

--- a/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/SendReceiveTest.cs
@@ -396,7 +396,7 @@ namespace System.Net.WebSockets.Client.Tests
 
             Func<ClientWebSocket, LoopbackServer, Uri, Task> connectToServerThatAbortsConnection = async (clientSocket, server, url) =>
             {
-                var pendingReceiveAsyncPosted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var pendingReceiveAsyncPosted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
                 // Start listening for incoming connections on the server side.
                 Task acceptTask = server.AcceptConnectionAsync(async connection =>
@@ -420,7 +420,7 @@ namespace System.Net.WebSockets.Client.Tests
                 var recvBuffer = new byte[100];
                 var recvSegment = new ArraySegment<byte>(recvBuffer);
                 Task pendingReceiveAsync = ReceiveAsync(clientSocket, recvSegment, cts.Token);
-                pendingReceiveAsyncPosted.SetResult(true);
+                pendingReceiveAsyncPosted.SetResult();
 
                 // Wait for the server to close the underlying connection.
                 await acceptTask.WithCancellation(cts.Token);

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -944,6 +944,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskAsyncEnumerableExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCanceledException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCompletionSource.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskCompletionSource_T.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskContinuation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskExceptionHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Tasks\TaskExtensions.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -298,7 +298,9 @@ namespace System.Threading.Tasks
                 };
             }
             else
+            {
                 m_stateFlags = TASK_STATE_RAN_TO_COMPLETION | optionFlags;
+            }
         }
 
         /// <summary>Constructor for use with promise-style tasks that aren't configurable.</summary>
@@ -1373,6 +1375,18 @@ namespace System.Threading.Tasks
         /// to create this task.
         /// </summary>
         public TaskCreationOptions CreationOptions => Options & (TaskCreationOptions)(~InternalTaskOptions.InternalOptionsMask);
+
+        /// <summary>Spins until the task is completed.</summary>
+        /// <remarks>This should only be called if the task is in the process of being completed by another thread.</remarks>
+        internal void SpinUntilCompleted()
+        {
+            // Spin wait until the completion is finalized by another thread.
+            SpinWait sw = default;
+            while (!IsCompleted)
+            {
+                sw.SpinOnce();
+            }
+        }
 
         /// <summary>
         /// Gets a <see cref="System.Threading.WaitHandle"/> that can be used to wait for the task to

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCompletionSource_T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TaskCompletionSource_T.cs
@@ -7,14 +7,14 @@ using System.Collections.Generic;
 namespace System.Threading.Tasks
 {
     /// <summary>
-    /// Represents the producer side of a <see cref="Tasks.Task"/> unbound to a
-    /// delegate, providing access to the consumer side through the <see cref="Tasks.Task"/> property.
+    /// Represents the producer side of a <see cref="Task{TResult}"/> unbound to a
+    /// delegate, providing access to the consumer side through the <see cref="Task"/> property.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// It is often the case that a <see cref="Tasks.Task"/> is desired to
+    /// It is often the case that a <see cref="Task{TResult}"/> is desired to
     /// represent another asynchronous operation.
-    /// <see cref="TaskCompletionSource">TaskCompletionSource</see> is provided for this purpose. It enables
+    /// <see cref="TaskCompletionSource{TResult}">TaskCompletionSource</see> is provided for this purpose. It enables
     /// the creation of a task that can be handed out to consumers, and those consumers can use the members
     /// of the task as they would any other. However, unlike most tasks, the state of a task created by a
     /// TaskCompletionSource is controlled explicitly by the methods on TaskCompletionSource. This enables the
@@ -23,64 +23,63 @@ namespace System.Threading.Tasks
     /// corresponding TaskCompletionSource.
     /// </para>
     /// <para>
-    /// All members of <see cref="TaskCompletionSource"/> are thread-safe
+    /// All members of <see cref="TaskCompletionSource{TResult}"/> are thread-safe
     /// and may be used from multiple threads concurrently.
     /// </para>
     /// </remarks>
-    public class TaskCompletionSource
+    /// <typeparam name="TResult">The type of the result value associated with this <see
+    /// cref="TaskCompletionSource{TResult}"/>.</typeparam>
+    public class TaskCompletionSource<TResult>
     {
-        private readonly Task _task;
+        private readonly Task<TResult> _task;
 
-        /// <summary>Creates a <see cref="TaskCompletionSource"/>.</summary>
-        public TaskCompletionSource() => _task = new Task();
+        /// <summary>Creates a <see cref="TaskCompletionSource{TResult}"/>.</summary>
+        public TaskCompletionSource() => _task = new Task<TResult>();
 
-        /// <summary>Creates a <see cref="TaskCompletionSource"/> with the specified options.</summary>
+        /// <summary>Creates a <see cref="TaskCompletionSource{TResult}"/> with the specified options.</summary>
         /// <remarks>
-        /// The <see cref="Tasks.Task"/> created by this instance and accessible through its <see cref="Task"/> property
+        /// The <see cref="Task{TResult}"/> created by this instance and accessible through its <see cref="Task"/> property
         /// will be instantiated using the specified <paramref name="creationOptions"/>.
         /// </remarks>
-        /// <param name="creationOptions">The options to use when creating the underlying <see cref="Tasks.Task"/>.</param>
+        /// <param name="creationOptions">The options to use when creating the underlying <see cref="Task{TResult}"/>.</param>
         /// <exception cref="ArgumentOutOfRangeException">
         /// The <paramref name="creationOptions"/> represent options invalid for use
-        /// with a <see cref="TaskCompletionSource"/>.
+        /// with a <see cref="TaskCompletionSource{TResult}"/>.
         /// </exception>
         public TaskCompletionSource(TaskCreationOptions creationOptions) :
             this(null, creationOptions)
         {
         }
 
-        /// <summary>Creates a <see cref="TaskCompletionSource"/> with the specified state.</summary>
+        /// <summary>Creates a <see cref="TaskCompletionSource{TResult}"/> with the specified state.</summary>
         /// <param name="state">The state to use as the underlying
-        /// <see cref="Tasks.Task"/>'s AsyncState.</param>
+        /// <see cref="Task{TResult}"/>'s AsyncState.</param>
         public TaskCompletionSource(object? state) :
             this(state, TaskCreationOptions.None)
         {
         }
 
-        /// <summary>Creates a <see cref="TaskCompletionSource"/> with the specified state and options.</summary>
-        /// <param name="creationOptions">The options to use when creating the underlying <see cref="Tasks.Task"/>.</param>
-        /// <param name="state">The state to use as the underlying <see cref="Tasks.Task"/>'s AsyncState.</param>
-        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="creationOptions"/> represent options invalid for use with a <see cref="TaskCompletionSource"/>.</exception>
+        /// <summary>Creates a <see cref="TaskCompletionSource{TResult}"/> with the specified state and options.</summary>
+        /// <param name="creationOptions">The options to use when creating the underlying <see cref="Task{TResult}"/>.</param>
+        /// <param name="state">The state to use as the underlying <see cref="Task{TResult}"/>'s AsyncState.</param>
+        /// <exception cref="ArgumentOutOfRangeException">The <paramref name="creationOptions"/> represent options invalid for use with a <see cref="TaskCompletionSource{TResult}"/>.</exception>
         public TaskCompletionSource(object? state, TaskCreationOptions creationOptions) =>
-            _task = new Task(state, creationOptions, promiseStyle: true);
+            _task = new Task<TResult>(state, creationOptions);
 
-        /// <summary>
-        /// Gets the <see cref="Tasks.Task"/> created
-        /// by this <see cref="TaskCompletionSource"/>.
-        /// </summary>
+        /// <summary>Gets the <see cref="Task{TResult}"/> created by this <see cref="TaskCompletionSource{TResult}"/>.</summary>
         /// <remarks>
-        /// This property enables a consumer access to the <see cref="Task"/> that is controlled by this instance.
+        /// This property enables a consumer access to the <see cref="Task{TResult}"/> that is controlled by this instance.
         /// The <see cref="SetResult"/>, <see cref="SetException(Exception)"/>, <see cref="SetException(IEnumerable{Exception})"/>,
         /// and <see cref="SetCanceled"/> methods (and their "Try" variants) on this instance all result in the relevant state
         /// transitions on this underlying Task.
         /// </remarks>
-        public Task Task => _task;
+        public Task<TResult> Task => _task;
 
-        /// <summary>Transitions the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Faulted"/> state.</summary>
-        /// <param name="exception">The exception to bind to this <see cref="Tasks.Task"/>.</param>
+        /// <summary>Transitions the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Faulted"/> state.</summary>
+        /// <param name="exception">The exception to bind to this <see cref="Task{TResult}"/>.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="exception"/> argument is null.</exception>
         /// <exception cref="InvalidOperationException">
-        /// The underlying <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// The underlying <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -93,12 +92,12 @@ namespace System.Threading.Tasks
             }
         }
 
-        /// <summary>Transitions the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Faulted"/> state.</summary>
-        /// <param name="exceptions">The collection of exceptions to bind to this <see cref="Tasks.Task"/>.</param>
+        /// <summary>Transitions the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Faulted"/> state.</summary>
+        /// <param name="exceptions">The collection of exceptions to bind to this <see cref="Task{TResult}"/>.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="exceptions"/> argument is null.</exception>
         /// <exception cref="ArgumentException">There are one or more null elements in <paramref name="exceptions"/>.</exception>
         /// <exception cref="InvalidOperationException">
-        /// The underlying <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// The underlying <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -112,12 +111,12 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Attempts to transition the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Faulted"/> state.
+        /// Attempts to transition the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Faulted"/> state.
         /// </summary>
-        /// <param name="exception">The exception to bind to this <see cref="Tasks.Task"/>.</param>
+        /// <param name="exception">The exception to bind to this <see cref="Task{TResult}"/>.</param>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
         /// <remarks>
-        /// This operation will return false if the <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// This operation will return false if the <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -140,12 +139,12 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Attempts to transition the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Faulted"/> state.
+        /// Attempts to transition the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Faulted"/> state.
         /// </summary>
-        /// <param name="exceptions">The collection of exceptions to bind to this <see cref="Tasks.Task"/>.</param>
+        /// <param name="exceptions">The collection of exceptions to bind to this <see cref="Task{TResult}"/>.</param>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
         /// <remarks>
-        /// This operation will return false if the <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// This operation will return false if the <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -186,35 +185,37 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Transitions the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.RanToCompletion"/> state.
+        /// Transitions the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.RanToCompletion"/> state.
         /// </summary>
+        /// <param name="result">The result value to bind to this <see cref="Task{TResult}"/>.</param>
         /// <exception cref="InvalidOperationException">
-        /// The underlying <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// The underlying <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
         /// </exception>
-        public void SetResult()
+        public void SetResult(TResult result)
         {
-            if (!TrySetResult())
+            if (!TrySetResult(result))
             {
                 ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
             }
         }
 
         /// <summary>
-        /// Attempts to transition the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.RanToCompletion"/> state.
+        /// Attempts to transition the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.RanToCompletion"/> state.
         /// </summary>
+        /// <param name="result">The result value to bind to this <see cref="Task{TResult}"/>.</param>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
         /// <remarks>
-        /// This operation will return false if the <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// This operation will return false if the <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
         /// </remarks>
-        public bool TrySetResult()
+        public bool TrySetResult(TResult result)
         {
-            bool rval = _task.TrySetResult();
+            bool rval = _task.TrySetResult(result);
             if (!rval)
             {
                 _task.SpinUntilCompleted();
@@ -224,10 +225,10 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Transitions the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Canceled"/> state.
+        /// Transitions the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Canceled"/> state.
         /// </summary>
         /// <exception cref="InvalidOperationException">
-        /// The underlying <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// The underlying <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -235,12 +236,12 @@ namespace System.Threading.Tasks
         public void SetCanceled() => SetCanceled(default);
 
         /// <summary>
-        /// Transitions the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Canceled"/> state
+        /// Transitions the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Canceled"/> state
         /// using the specified token.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token with which to cancel the <see cref="Tasks.Task"/>.</param>
+        /// <param name="cancellationToken">The cancellation token with which to cancel the <see cref="Task{TResult}"/>.</param>
         /// <exception cref="InvalidOperationException">
-        /// The underlying <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// The underlying <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -254,11 +255,11 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>
-        /// Attempts to transition the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Canceled"/> state.
+        /// Attempts to transition the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Canceled"/> state.
         /// </summary>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
         /// <remarks>
-        /// This operation will return false if the <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// This operation will return false if the <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.
@@ -266,12 +267,12 @@ namespace System.Threading.Tasks
         public bool TrySetCanceled() => TrySetCanceled(default);
 
         /// <summary>
-        /// Attempts to transition the underlying <see cref="Tasks.Task"/> into the <see cref="TaskStatus.Canceled"/> state.
+        /// Attempts to transition the underlying <see cref="Task{TResult}"/> into the <see cref="TaskStatus.Canceled"/> state.
         /// </summary>
-        /// <param name="cancellationToken">The cancellation token with which to cancel the <see cref="Tasks.Task"/>.</param>
+        /// <param name="cancellationToken">The cancellation token with which to cancel the <see cref="Task{TResult}"/>.</param>
         /// <returns>True if the operation was successful; otherwise, false.</returns>
         /// <remarks>
-        /// This operation will return false if the <see cref="Tasks.Task"/> is already in one of the three final states:
+        /// This operation will return false if the <see cref="Task{TResult}"/> is already in one of the three final states:
         /// <see cref="TaskStatus.RanToCompletion"/>,
         /// <see cref="TaskStatus.Faulted"/>, or
         /// <see cref="TaskStatus.Canceled"/>.

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10725,6 +10725,24 @@ namespace System.Threading.Tasks
         public TaskCanceledException(System.Threading.Tasks.Task? task) { }
         public System.Threading.Tasks.Task? Task { get { throw null; } }
     }
+    public partial class TaskCompletionSource
+    {
+        public TaskCompletionSource() { }
+        public TaskCompletionSource(object? state) { }
+        public TaskCompletionSource(object? state, System.Threading.Tasks.TaskCreationOptions creationOptions) { }
+        public TaskCompletionSource(System.Threading.Tasks.TaskCreationOptions creationOptions) { }
+        public System.Threading.Tasks.Task Task { get { throw null; } }
+        public void SetCanceled() { }
+        public void SetCanceled(System.Threading.CancellationToken cancellationToken) { }
+        public void SetException(System.Collections.Generic.IEnumerable<System.Exception> exceptions) { }
+        public void SetException(System.Exception exception) { }
+        public void SetResult() { }
+        public bool TrySetCanceled() { throw null; }
+        public bool TrySetCanceled(System.Threading.CancellationToken cancellationToken) { throw null; }
+        public bool TrySetException(System.Collections.Generic.IEnumerable<System.Exception> exceptions) { throw null; }
+        public bool TrySetException(System.Exception exception) { throw null; }
+        public bool TrySetResult() { throw null; }
+    }
     public partial class TaskCompletionSource<TResult>
     {
         public TaskCompletionSource() { }

--- a/src/libraries/System.Threading.Tasks.Extensions/tests/ManualResetValueTaskSourceTests.cs
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/ManualResetValueTaskSourceTests.cs
@@ -93,8 +93,8 @@ namespace System.Threading.Tasks.Sources.Tests
             Assert.Equal(ValueTaskSourceStatus.Pending, mrvts.GetStatus(2));
             Assert.Throws<InvalidOperationException>(() => mrvts.GetResult(2));
 
-            var onCompletedRan = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            mrvts.OnCompleted(s => ((TaskCompletionSource<bool>)s).SetResult(true), onCompletedRan, 2, ValueTaskSourceOnCompletedFlags.None);
+            var onCompletedRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            mrvts.OnCompleted(s => ((TaskCompletionSource)s).SetResult(), onCompletedRan, 2, ValueTaskSourceOnCompletedFlags.None);
 
             Assert.False(onCompletedRan.Task.IsCompleted);
             await Task.Delay(1);
@@ -141,8 +141,8 @@ namespace System.Threading.Tasks.Sources.Tests
             Assert.Equal(ValueTaskSourceStatus.Pending, mrvts.GetStatus(2));
             Assert.Throws<InvalidOperationException>(() => mrvts.GetResult(2));
 
-            var onCompletedRan = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            mrvts.OnCompleted(s => ((TaskCompletionSource<bool>)s).SetResult(true), onCompletedRan, 2, ValueTaskSourceOnCompletedFlags.None);
+            var onCompletedRan = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            mrvts.OnCompleted(s => ((TaskCompletionSource)s).SetResult(), onCompletedRan, 2, ValueTaskSourceOnCompletedFlags.None);
 
             Assert.False(onCompletedRan.Task.IsCompleted);
             await Task.Delay(1);
@@ -312,12 +312,12 @@ namespace System.Threading.Tasks.Sources.Tests
                     mrvts.SetResult(42);
                 }
 
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource();
                 var sc = new TrackingSynchronizationContext();
                 SynchronizationContext.SetSynchronizationContext(sc);
                 Assert.Equal(0, sc.Posts);
                 mrvts.OnCompleted(
-                    _ => tcs.SetResult(true),
+                    _ => tcs.SetResult(),
                     null,
                     0,
                     captureSyncCtx ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
@@ -354,13 +354,13 @@ namespace System.Threading.Tasks.Sources.Tests
                     mrvts.SetResult(42);
                 }
 
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource();
                 var ts = new TrackingTaskScheduler();
                 Assert.Equal(0, ts.QueueTasks);
                 await Task.Factory.StartNew(() =>
                 {
                     mrvts.OnCompleted(
-                        _ => tcs.SetResult(true),
+                        _ => tcs.SetResult(),
                         null,
                         0,
                         captureTaskScheduler ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);

--- a/src/libraries/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/ValueTaskTests.cs
@@ -638,8 +638,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
                 new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.GetAwaiter().OnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.GetAwaiter().OnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -654,8 +654,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
                 new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -670,8 +670,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
                 new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.GetAwaiter().OnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.GetAwaiter().OnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -686,8 +686,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
                 new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -705,8 +705,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
                 new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -724,8 +724,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask(Task.CompletedTask) :
                 new ValueTask(ManualResetValueTaskSourceFactory.Completed(0, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -743,8 +743,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
                 new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().OnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -762,8 +762,8 @@ namespace System.Threading.Tasks.Tests
                 mode == CtorMode.Task ? new ValueTask<int>(Task.FromResult(42)) :
                 new ValueTask<int>(ManualResetValueTaskSourceFactory.Completed(42, null), 0);
 
-            var tcs = new TaskCompletionSource<bool>();
-            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult(true));
+            var tcs = new TaskCompletionSource();
+            t.ConfigureAwait(continueOnCapturedContext).GetAwaiter().UnsafeOnCompleted(() => tcs.SetResult());
             await tcs.Task;
         }
 
@@ -966,8 +966,8 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public void NonGeneric_OperatorEquals()
         {
-            var completedTcs = new TaskCompletionSource<int>();
-            completedTcs.SetResult(42);
+            var completedTcs = new TaskCompletionSource();
+            completedTcs.SetResult();
 
             var completedVts = ManualResetValueTaskSourceFactory.Completed(42, null);
 
@@ -1009,8 +1009,8 @@ namespace System.Threading.Tasks.Tests
         [Fact]
         public void NonGeneric_OperatorNotEquals()
         {
-            var completedTcs = new TaskCompletionSource<int>();
-            completedTcs.SetResult(42);
+            var completedTcs = new TaskCompletionSource();
+            completedTcs.SetResult();
 
             var completedVts = ManualResetValueTaskSourceFactory.Completed(42, null);
 

--- a/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/tests/ParallelForTests.cs
@@ -969,7 +969,7 @@ namespace System.Threading.Tasks.Tests
                     Assert.True(usedScheduler == myTaskScheduler, "TestParallelScheduler:    > FAILED.  PInvoke: Failed to run with TS.Current when null was specified.");
 
                     // Some tests for wonky behavior seen before fixes
-                    TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+                    TaskCompletionSource tcs = new TaskCompletionSource();
                     bool timeExpired = false;
                     Task continuation = tcs.Task.ContinueWith(delegate
                     {
@@ -980,7 +980,7 @@ namespace System.Threading.Tasks.Tests
                     Task delayedOperation = Task.Factory.StartNew(delegate
                     {
                         timeExpired = true;
-                        tcs.SetResult(null);
+                        tcs.SetResult();
                     });
 
                     Task.WaitAll(tcs.Task, continuation);

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -533,7 +533,7 @@ namespace System.Threading.Tasks.Tests
             // We want to make sure that holding on to the resulting Task doesn't keep
             // that finalizable object alive.
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Task t = null;
 
@@ -545,7 +545,7 @@ namespace System.Threading.Tasks.Tests
                     GC.KeepAlive(s); // keep s referenced by the state machine
                 }
 
-                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult(true) };
+                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult() };
                 var al = new AsyncLocal<object>() { Value = state }; // ensure the object is stored in ExecutionContext
                 t = YieldOnceAsync(state); // ensure the object is stored in the state machine
                 al.Value = null;
@@ -650,7 +650,7 @@ namespace System.Threading.Tasks.Tests
         {
             int local1 = 42;
             string local2 = "stored data";
-            await new TaskCompletionSource<bool>().Task; // await will never complete
+            await new TaskCompletionSource().Task; // await will never complete
             GC.KeepAlive(local1);
             GC.KeepAlive(local2);
         }

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
@@ -133,14 +133,14 @@ namespace System.Threading.Tasks.Tests
                 Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
 
                 var ctx = new ValidateCorrectContextSynchronizationContext();
-                var tcs = new TaskCompletionSource<bool>();
+                var tcs = new TaskCompletionSource();
                 var ignored = Task.Delay(1).ContinueWith(_ =>
                 {
                     SynchronizationContext orig = SynchronizationContext.Current;
                     SynchronizationContext.SetSynchronizationContext(ctx);
                     try
                     {
-                        tcs.SetResult(true);
+                        tcs.SetResult();
                     }
                     finally
                     {
@@ -162,8 +162,8 @@ namespace System.Threading.Tasks.Tests
                 Assert.Null(SynchronizationContext.Current);
                 Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
 
-                var tcs = new TaskCompletionSource<bool>();
-                var ignored = Task.Delay(1).ContinueWith(_ => tcs.SetResult(true), new QUWITaskScheduler());
+                var tcs = new TaskCompletionSource();
+                var ignored = Task.Delay(1).ContinueWith(_ => tcs.SetResult(), new QUWITaskScheduler());
                 await tcs.Task;
 
                 Assert.Null(SynchronizationContext.Current);
@@ -192,7 +192,7 @@ namespace System.Threading.Tasks.Tests
                     SynchronizationContext.SetSynchronizationContext(sc);
                 }
 
-                var tcs = runContinuationsAsynchronously ? new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously) : new TaskCompletionSource<bool>();
+                var tcs = runContinuationsAsynchronously ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) : new TaskCompletionSource();
 
                 var tl = new ThreadLocal<int>();
                 var tasks = new List<Task>();
@@ -239,7 +239,7 @@ namespace System.Threading.Tasks.Tests
                 Assert.All(tasks, t => Assert.Equal(TaskStatus.WaitingForActivation, t.Status));
 
                 tl.Value = 42;
-                tcs.SetResult(true);
+                tcs.SetResult();
                 tl.Value = 0;
 
                 SynchronizationContext.SetSynchronizationContext(null);
@@ -376,8 +376,8 @@ namespace System.Threading.Tasks.Tests
                 RunWithSchedulerAsCurrent(quwi, delegate
                 {
                     ManualResetEventSlim mres = new ManualResetEventSlim();
-                    var tcs = new TaskCompletionSource<object>();
-                    var awaiter = ((Task)tcs.Task).GetAwaiter();
+                    var tcs = new TaskCompletionSource();
+                    var awaiter = tcs.Task.GetAwaiter();
 
                     bool ranOnScheduler = false;
                     bool ranWithoutSyncCtx = false;
@@ -389,7 +389,7 @@ namespace System.Threading.Tasks.Tests
                     });
                     Assert.False(mres.IsSet, "Callback should not yet have run.");
 
-                    Task.Run(delegate { tcs.SetResult(null); });
+                    Task.Run(delegate { tcs.SetResult(); });
                     mres.Wait();
 
                     Assert.True(ranOnScheduler, "Should have run on scheduler");

--- a/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -23,6 +23,8 @@
     <Compile Include="Task\TaskPropertiesTests.cs" />
     <Compile Include="Task\TaskCreateTest.cs" />
     <Compile Include="Task\TaskWaitAllAnyTest.cs" />
+    <Compile Include="Task\TaskCompletionSourceTests.cs" />
+    <Compile Include="Task\TaskCompletionSourceTResultTests.cs" />
     <Compile Include="Task\TaskContinueWithTests.cs" />
     <Compile Include="Task\TaskContinueWithAllAnyTests.cs" />
     <Compile Include="Task\TaskContinueWith_ContFuncAndActionWithArgsTests.cs" />

--- a/src/libraries/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/ExecutionContextFlowTest.cs
@@ -39,13 +39,13 @@ namespace System.Threading.Tasks.Tests
             // We want to make sure that holding on to the resulting Task doesn't keep
             // that finalizable object alive.
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Task t = null;
 
             Thread runner = new Thread(() =>
             {
-                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult(true) };
+                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult() };
                 var al = new AsyncLocal<object>(){ Value = state }; // ensure the object is stored in ExecutionContext
                 t = Task.Run(() => { }); // run a task that'll capture EC
                 al.Value = null;
@@ -91,12 +91,12 @@ namespace System.Threading.Tasks.Tests
             // We want to make sure that holding on to the resulting TCS doesn't keep
             // that finalizable object alive.
 
-            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
             TaskCompletionSource<int> t = null;
             await Task.Run(delegate // avoid any issues with the stack keeping the object alive
             {
-                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult(true) };
+                var state = new InvokeActionOnFinalization { Action = () => tcs.SetResult() };
                 var al = new AsyncLocal<object> { Value = state }; // ensure the object is stored in ExecutionContext
                 t = tcsFactory(); // create the TCS that shouldn't capture ExecutionContext
                 al.Value = null;

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskCompletionSourceTResultTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskCompletionSourceTResultTests.cs
@@ -1,0 +1,207 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests.Status
+{
+    public sealed class TaskCompletionSourceTResultTests
+    {
+        [Fact]
+        public void Ctor_ArgumentsRoundtrip()
+        {
+            TaskCompletionSource<bool> tcs;
+            object stateObj = new object();
+
+            tcs = new TaskCompletionSource<bool>();
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Null(tcs.Task.AsyncState);
+
+            tcs = new TaskCompletionSource<bool>(stateObj);
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Same(stateObj, tcs.Task.AsyncState);
+
+            tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Equal(TaskCreationOptions.RunContinuationsAsynchronously, tcs.Task.CreationOptions);
+            Assert.Null(tcs.Task.AsyncState);
+
+            tcs = new TaskCompletionSource<bool>(stateObj, TaskCreationOptions.RunContinuationsAsynchronously);
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Equal(TaskCreationOptions.RunContinuationsAsynchronously, tcs.Task.CreationOptions);
+            Assert.Same(stateObj, tcs.Task.AsyncState);
+        }
+
+        [Fact]
+        public void Ctor_InvalidArguments_Throws()
+        {
+            // These shouldn't throw.
+            new TaskCompletionSource<bool>(TaskCreationOptions.AttachedToParent);
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            new TaskCompletionSource<bool>(TaskCreationOptions.AttachedToParent | TaskCreationOptions.RunContinuationsAsynchronously);
+            new TaskCompletionSource<bool>(new object(), TaskCreationOptions.AttachedToParent);
+            new TaskCompletionSource<bool>(new object(), TaskCreationOptions.RunContinuationsAsynchronously);
+            new TaskCompletionSource<bool>(new object(), TaskCreationOptions.AttachedToParent | TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // These should throw.
+            foreach (TaskCreationOptions options in Enum.GetValues(typeof(TaskCreationOptions)))
+            {
+                if ((options & TaskCreationOptions.AttachedToParent) != 0 &&
+                    (options & TaskCreationOptions.RunContinuationsAsynchronously) != 0)
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource<bool>(options));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource<bool>(options | TaskCreationOptions.RunContinuationsAsynchronously));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource<bool>(new object(), options));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource<bool>(new object(), options | TaskCreationOptions.RunContinuationsAsynchronously));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetResult_CompletesSuccessfully(bool tryMethod)
+        {
+            var result = new object();
+            var tcs = new TaskCompletionSource<object>();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetResult(result));
+            }
+            else
+            {
+                tcs.SetResult(result);
+            }
+            Assert.Equal(TaskStatus.RanToCompletion, tcs.Task.Status);
+            Assert.Same(result, tcs.Task.Result);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetCanceled_CompletesSuccessfully(bool tryMethod)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetCanceled());
+            }
+            else
+            {
+                tcs.SetCanceled();
+            }
+            Assert.Equal(TaskStatus.Canceled, tcs.Task.Status);
+            Assert.Null(tcs.Task.Exception);
+            TaskCanceledException tce = Assert.Throws<TaskCanceledException>(() => tcs.Task.GetAwaiter().GetResult());
+            Assert.Equal(default, tce.CancellationToken);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetCanceled_Token_CompletesSuccessfully(bool tryMethod)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            var cts = new CancellationTokenSource();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetCanceled(cts.Token));
+            }
+            else
+            {
+                tcs.SetCanceled(cts.Token);
+            }
+            Assert.Equal(TaskStatus.Canceled, tcs.Task.Status);
+            Assert.Null(tcs.Task.Exception);
+            TaskCanceledException tce = Assert.Throws<TaskCanceledException>(() => tcs.Task.GetAwaiter().GetResult());
+            Assert.Equal(cts.Token, tce.CancellationToken);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetException_Exception_CompletesSuccessfully(bool tryMethod)
+        {
+            var e = new Exception();
+            var tcs = new TaskCompletionSource<object>();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetException(e));
+            }
+            else
+            {
+                tcs.SetException(e);
+            }
+            Assert.Equal(TaskStatus.Faulted, tcs.Task.Status);
+            Assert.NotNull(tcs.Task.Exception);
+            Assert.Same(e, tcs.Task.Exception.InnerException);
+            Assert.Equal(1, tcs.Task.Exception.InnerExceptions.Count);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetException_Enumerable_CompletesSuccessfully(bool tryMethod)
+        {
+            var e = new Exception[] { new FormatException(), new InvalidOperationException(), new ArgumentException() };
+            var tcs = new TaskCompletionSource<object>();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetException(e));
+            }
+            else
+            {
+                tcs.SetException(e);
+            }
+            Assert.Equal(TaskStatus.Faulted, tcs.Task.Status);
+            Assert.NotNull(tcs.Task.Exception);
+            Assert.Equal(e, tcs.Task.Exception.InnerExceptions);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        private static void AssertCompletedTcsFailsToCompleteAgain<T>(TaskCompletionSource<T> tcs)
+        {
+            Assert.Throws<InvalidOperationException>(() => tcs.SetResult(default));
+            Assert.False(tcs.TrySetResult(default));
+
+            Assert.Throws<InvalidOperationException>(() => tcs.SetException(new Exception()));
+            Assert.Throws<InvalidOperationException>(() => tcs.SetException(Enumerable.Repeat(new Exception(), 1)));
+            Assert.False(tcs.TrySetException(new Exception()));
+            Assert.False(tcs.TrySetException(Enumerable.Repeat(new Exception(), 1)));
+
+            Assert.Throws<InvalidOperationException>(() => tcs.SetCanceled());
+            Assert.Throws<InvalidOperationException>(() => tcs.SetCanceled(default));
+            Assert.False(tcs.TrySetCanceled());
+            Assert.False(tcs.TrySetCanceled(default));
+        }
+    }
+}

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskCompletionSourceTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskCompletionSourceTests.cs
@@ -1,0 +1,205 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Xunit;
+
+namespace System.Threading.Tasks.Tests.Status
+{
+    public sealed class TaskCompletionSourceTests
+    {
+        [Fact]
+        public void Ctor_ArgumentsRoundtrip()
+        {
+            TaskCompletionSource tcs;
+            object stateObj = new object();
+
+            tcs = new TaskCompletionSource();
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Null(tcs.Task.AsyncState);
+
+            tcs = new TaskCompletionSource(stateObj);
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Same(stateObj, tcs.Task.AsyncState);
+
+            tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Equal(TaskCreationOptions.RunContinuationsAsynchronously, tcs.Task.CreationOptions);
+            Assert.Null(tcs.Task.AsyncState);
+
+            tcs = new TaskCompletionSource(stateObj, TaskCreationOptions.RunContinuationsAsynchronously);
+            Assert.NotNull(tcs.Task);
+            Assert.Same(tcs.Task, tcs.Task);
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+            Assert.Equal(TaskCreationOptions.RunContinuationsAsynchronously, tcs.Task.CreationOptions);
+            Assert.Same(stateObj, tcs.Task.AsyncState);
+        }
+
+        [Fact]
+        public void Ctor_InvalidArguments_Throws()
+        {
+            // These shouldn't throw.
+            new TaskCompletionSource(TaskCreationOptions.AttachedToParent);
+            new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            new TaskCompletionSource(TaskCreationOptions.AttachedToParent | TaskCreationOptions.RunContinuationsAsynchronously);
+            new TaskCompletionSource(new object(), TaskCreationOptions.AttachedToParent);
+            new TaskCompletionSource(new object(), TaskCreationOptions.RunContinuationsAsynchronously);
+            new TaskCompletionSource(new object(), TaskCreationOptions.AttachedToParent | TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // These should throw.
+            foreach (TaskCreationOptions options in Enum.GetValues(typeof(TaskCreationOptions)))
+            {
+                if ((options & TaskCreationOptions.AttachedToParent) != 0 &&
+                    (options & TaskCreationOptions.RunContinuationsAsynchronously) != 0)
+                {
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource(options));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource(options | TaskCreationOptions.RunContinuationsAsynchronously));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource(new object(), options));
+                    AssertExtensions.Throws<ArgumentOutOfRangeException>("creationOptions", () => new TaskCompletionSource(new object(), options | TaskCreationOptions.RunContinuationsAsynchronously));
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetResult_CompletesSuccessfully(bool tryMethod)
+        {
+            var tcs = new TaskCompletionSource();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetResult());
+            }
+            else
+            {
+                tcs.SetResult();
+            }
+            Assert.Equal(TaskStatus.RanToCompletion, tcs.Task.Status);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetCanceled_CompletesSuccessfully(bool tryMethod)
+        {
+            var tcs = new TaskCompletionSource();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetCanceled());
+            }
+            else
+            {
+                tcs.SetCanceled();
+            }
+            Assert.Equal(TaskStatus.Canceled, tcs.Task.Status);
+            Assert.Null(tcs.Task.Exception);
+            TaskCanceledException tce = Assert.Throws<TaskCanceledException>(() => tcs.Task.GetAwaiter().GetResult());
+            Assert.Equal(default, tce.CancellationToken);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetCanceled_Token_CompletesSuccessfully(bool tryMethod)
+        {
+            var tcs = new TaskCompletionSource();
+            var cts = new CancellationTokenSource();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetCanceled(cts.Token));
+            }
+            else
+            {
+                tcs.SetCanceled(cts.Token);
+            }
+            Assert.Equal(TaskStatus.Canceled, tcs.Task.Status);
+            Assert.Null(tcs.Task.Exception);
+            TaskCanceledException tce = Assert.Throws<TaskCanceledException>(() => tcs.Task.GetAwaiter().GetResult());
+            Assert.Equal(cts.Token, tce.CancellationToken);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetException_Exception_CompletesSuccessfully(bool tryMethod)
+        {
+            var e = new Exception();
+            var tcs = new TaskCompletionSource();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetException(e));
+            }
+            else
+            {
+                tcs.SetException(e);
+            }
+            Assert.Equal(TaskStatus.Faulted, tcs.Task.Status);
+            Assert.NotNull(tcs.Task.Exception);
+            Assert.Same(e, tcs.Task.Exception.InnerException);
+            Assert.Equal(1, tcs.Task.Exception.InnerExceptions.Count);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SetException_Enumerable_CompletesSuccessfully(bool tryMethod)
+        {
+            var e = new Exception[] { new FormatException(), new InvalidOperationException(), new ArgumentException() };
+            var tcs = new TaskCompletionSource();
+            Assert.Equal(TaskStatus.WaitingForActivation, tcs.Task.Status);
+
+            if (tryMethod)
+            {
+                Assert.True(tcs.TrySetException(e));
+            }
+            else
+            {
+                tcs.SetException(e);
+            }
+            Assert.Equal(TaskStatus.Faulted, tcs.Task.Status);
+            Assert.NotNull(tcs.Task.Exception);
+            Assert.Equal(e, tcs.Task.Exception.InnerExceptions);
+
+            AssertCompletedTcsFailsToCompleteAgain(tcs);
+        }
+
+        private static void AssertCompletedTcsFailsToCompleteAgain(TaskCompletionSource tcs)
+        {
+            Assert.Throws<InvalidOperationException>(() => tcs.SetResult());
+            Assert.False(tcs.TrySetResult());
+
+            Assert.Throws<InvalidOperationException>(() => tcs.SetException(new Exception()));
+            Assert.Throws<InvalidOperationException>(() => tcs.SetException(Enumerable.Repeat(new Exception(), 1)));
+            Assert.False(tcs.TrySetException(new Exception()));
+            Assert.False(tcs.TrySetException(Enumerable.Repeat(new Exception(), 1)));
+
+            Assert.Throws<InvalidOperationException>(() => tcs.SetCanceled());
+            Assert.Throws<InvalidOperationException>(() => tcs.SetCanceled(default));
+            Assert.False(tcs.TrySetCanceled());
+            Assert.False(tcs.TrySetCanceled(default));
+        }
+    }
+}

--- a/src/libraries/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -121,7 +121,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(TaskStatus.Canceled)]
         public void NonGeneric_Completed_NotCompleted(TaskStatus innerStatus)
         {
-            var innerTcs = new TaskCompletionSource<bool>();
+            var innerTcs = new TaskCompletionSource();
             Task inner = innerTcs.Task;
 
             Task<Task> outer = Task.FromResult(inner);
@@ -131,7 +131,7 @@ namespace System.Threading.Tasks.Tests
             switch (innerStatus)
             {
                 case TaskStatus.RanToCompletion:
-                    innerTcs.SetResult(true);
+                    innerTcs.SetResult();
                     break;
                 case TaskStatus.Faulted:
                     innerTcs.SetException(new InvalidProgramException());
@@ -191,7 +191,7 @@ namespace System.Threading.Tasks.Tests
         [InlineData(false, TaskStatus.Faulted)]
         public void NonGeneric_NotCompleted_NotCompleted(bool outerCompletesFirst, TaskStatus innerStatus)
         {
-            var innerTcs = new TaskCompletionSource<bool>();
+            var innerTcs = new TaskCompletionSource();
             Task inner = innerTcs.Task;
 
             var outerTcs = new TaskCompletionSource<Task>();
@@ -209,7 +209,7 @@ namespace System.Threading.Tasks.Tests
             switch (innerStatus)
             {
                 case TaskStatus.RanToCompletion:
-                    innerTcs.SetResult(true);
+                    innerTcs.SetResult();
                     break;
                 case TaskStatus.Faulted:
                     innerTcs.SetException(new InvalidOperationException());

--- a/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
+++ b/src/libraries/System.Threading.ThreadPool/tests/ThreadPoolTests.cs
@@ -497,13 +497,13 @@ namespace System.Threading.ThreadPools.Tests
         [MemberData(nameof(OneBool))]
         public async Task UnsafeQueueUserWorkItem_IThreadPoolWorkItem_ManyIndividualItems_AllInvoked(bool preferLocal)
         {
-            TaskCompletionSource<bool>[] tasks = Enumerable.Range(0, 100).Select(_ => new TaskCompletionSource<bool>()).ToArray();
+            TaskCompletionSource[] tasks = Enumerable.Range(0, 100).Select(_ => new TaskCompletionSource()).ToArray();
             for (int i = 0; i < tasks.Length; i++)
             {
                 int localI = i;
                 ThreadPool.UnsafeQueueUserWorkItem(new SimpleWorkItem(() =>
                 {
-                    tasks[localI].TrySetResult(true);
+                    tasks[localI].TrySetResult();
                 }), preferLocal);
             }
             await Task.WhenAll(tasks.Select(t => t.Task));
@@ -515,12 +515,12 @@ namespace System.Threading.ThreadPools.Tests
         {
             const int Iters = 100;
             int remaining = Iters;
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource();
             var workItem = new SimpleWorkItem(() =>
             {
                 if (Interlocked.Decrement(ref remaining) == 0)
                 {
-                    tcs.TrySetResult(true);
+                    tcs.TrySetResult();
                 }
             });
             for (int i = 0; i < Iters; i++)
@@ -536,11 +536,11 @@ namespace System.Threading.ThreadPools.Tests
         public async Task UnsafeQueueUserWorkItem_IThreadPoolWorkItem_ExecutionContextNotFlowed(bool preferLocal)
         {
             var al = new AsyncLocal<int> { Value = 42 };
-            var tcs = new TaskCompletionSource<bool>();
+            var tcs = new TaskCompletionSource();
             ThreadPool.UnsafeQueueUserWorkItem(new SimpleWorkItem(() =>
             {
                 Assert.Equal(0, al.Value);
-                tcs.TrySetResult(true);
+                tcs.TrySetResult();
             }), preferLocal);
             await tcs.Task;
             Assert.Equal(42, al.Value);

--- a/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
@@ -244,15 +244,15 @@ namespace System.Threading.Tests
         [Fact]
         public async Task Timer_LongTimersDontFirePrematurely_ShortTimersFireSuccessfully()
         {
-            var tcsShort1 = new TaskCompletionSource<bool>();
-            var tcsShort2 = new TaskCompletionSource<bool>();
-            var tcsLong1 = new TaskCompletionSource<bool>();
-            var tcsLong2 = new TaskCompletionSource<bool>();
+            var tcsShort1 = new TaskCompletionSource();
+            var tcsShort2 = new TaskCompletionSource();
+            var tcsLong1 = new TaskCompletionSource();
+            var tcsLong2 = new TaskCompletionSource();
 
-            using (var timerLong1 = new Timer(_ => tcsLong1.SetResult(true), null, TimeSpan.FromDays(30), Timeout.InfiniteTimeSpan))
-            using (var timerLong2 = new Timer(_ => tcsLong2.SetResult(true), null, TimeSpan.FromDays(40), Timeout.InfiniteTimeSpan))
-            using (var timerShort1 = new Timer(_ => tcsShort1.SetResult(true), null, 100, -1))
-            using (var timerShort2 = new Timer(_ => tcsShort2.SetResult(true), null, 200, -1))
+            using (var timerLong1 = new Timer(_ => tcsLong1.SetResult(), null, TimeSpan.FromDays(30), Timeout.InfiniteTimeSpan))
+            using (var timerLong2 = new Timer(_ => tcsLong2.SetResult(), null, TimeSpan.FromDays(40), Timeout.InfiniteTimeSpan))
+            using (var timerShort1 = new Timer(_ => tcsShort1.SetResult(), null, 100, -1))
+            using (var timerShort2 = new Timer(_ => tcsShort2.SetResult(), null, 200, -1))
             {
                 await Task.WhenAll(tcsShort1.Task, tcsShort2.Task);
                 await Task.Delay(2_000); // wait a few seconds to see if long timers complete when they shouldn't
@@ -367,16 +367,16 @@ namespace System.Threading.Tests
         {
             // We could just use Task.Delay, but it only uses Timer as an implementation detail.
             // Since these are Timer tests, we use an implementation that explicitly uses Timer.
-            var tcs = new TaskCompletionSource<bool>();
-            var t = new Timer(_ => tcs.SetResult(true)); // rely on Timer(TimerCallback) rooting itself
+            var tcs = new TaskCompletionSource();
+            var t = new Timer(_ => tcs.SetResult()); // rely on Timer(TimerCallback) rooting itself
             t.Change(dueTime, -1);
             return tcs.Task;
         }
 
         private static async Task PeriodAsync(int period, int iterations)
         {
-            var tcs = new TaskCompletionSource<bool>();
-            using (var t = new Timer(_ => { if (Interlocked.Decrement(ref iterations) == 0) tcs.SetResult(true); })) // rely on Timer(TimerCallback) rooting itself
+            var tcs = new TaskCompletionSource();
+            using (var t = new Timer(_ => { if (Interlocked.Decrement(ref iterations) == 0) tcs.SetResult(); })) // rely on Timer(TimerCallback) rooting itself
             {
                 t.Change(period, period);
                 await tcs.Task.ConfigureAwait(false);

--- a/src/libraries/System.Transactions.Local/tests/AsyncTransactionScopeTests.cs
+++ b/src/libraries/System.Transactions.Local/tests/AsyncTransactionScopeTests.cs
@@ -21,7 +21,7 @@ namespace System.Transactions.Tests
         private const int iterations = 5;
 
         // The work queue that requests will be placed in to be serviced by the background thread
-        private static BlockingCollection<Tuple<int, TaskCompletionSource<object>, Transaction>> s_workQueue = new BlockingCollection<Tuple<int, TaskCompletionSource<object>, Transaction>>();
+        private static BlockingCollection<Tuple<int, TaskCompletionSource, Transaction>> s_workQueue = new BlockingCollection<Tuple<int, TaskCompletionSource, Transaction>>();
 
         private static bool s_throwExceptionDefaultOrBeforeAwait;
         private static bool s_throwExceptionAfterAwait;
@@ -1247,7 +1247,7 @@ namespace System.Transactions.Tests
             string txId1;
             string txId2;
 
-            TaskCompletionSource<object> completionSource = new TaskCompletionSource<object>();
+            TaskCompletionSource completionSource = new TaskCompletionSource();
 
             // Start a transaction - presumably the customer would do this in our code
             using (TransactionScope ts = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
@@ -1290,7 +1290,7 @@ namespace System.Transactions.Tests
                     Debug.WriteLine("{0}: {1}", work.Item1, Transaction.Current == work.Item3);
 
                     // Tell the other thread that we completed its work
-                    work.Item2.SetResult(null);
+                    work.Item2.SetResult();
                 }
             }, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }

--- a/src/libraries/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
+++ b/src/libraries/System.Windows.Extensions/tests/System/Media/SoundPlayerTests.cs
@@ -503,8 +503,8 @@ namespace System.Media.Test
         {
             using (FileStream stream = File.OpenRead(sourceLocation.Replace("file://", "")))
             {
-                var tcs = new TaskCompletionSource<bool>();
-                AsyncCompletedEventHandler handler = (s, e) => tcs.SetResult(true);
+                var tcs = new TaskCompletionSource();
+                AsyncCompletedEventHandler handler = (s, e) => tcs.SetResult();
 
                 var player = new SoundPlayer();
                 player.LoadCompleted += handler;


### PR DESCRIPTION
- Adds the type, almost an exact copy of `TaskCompletionSource<TResult>`, but creating a `Task` instead of a `Task<TResult>`.  Primary benefits here are symmetry, smaller `Task` object, and not forcing a developer to specify an unnecessary type name.
- Adds tests for both `TCS` and `TCS<TResult>`.
- Switches a bunch of usage of the generic type over to the non-generic, both in src and tests.

Fixes https://github.com/dotnet/runtime/issues/17393