### PR TITLE
Update covariant returns - add support for pointers

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
@@ -91,6 +91,7 @@ namespace Internal.TypeSystem
         /// </summary>
         private static bool IsMethodSignatureCompatibleWith(TypeDesc fn1Ttype, TypeDesc fn2Type)
         {
+            Debug.Assert(fn1Ttype.IsFunctionPointer && fn2Type.IsFunctionPointer);
             return fn1Ttype == fn2Type;
         }
 

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
@@ -24,7 +24,7 @@ namespace Internal.TypeSystem
         /// Get TypeFlags of the reduced type of a type.
         /// The reduced type concept is described in ECMA 335 chapter I.8.7
         /// </summary>
-        static TypeFlags GetReducedTypeElementType(TypeDesc type)
+        private static TypeFlags GetReducedTypeElementType(TypeDesc type)
         {
             TypeFlags elemType = type.GetTypeFlags(TypeFlags.CategoryMask);
             switch (elemType)
@@ -48,7 +48,7 @@ namespace Internal.TypeSystem
         /// Get CorElementType of the verification type of a type.
         /// The verification type concepts is described in ECMA 335 chapter I.8.7
         /// </summary>
-        static TypeFlags GetVerificationTypeElementType(TypeDesc type)
+        private static TypeFlags GetVerificationTypeElementType(TypeDesc type)
         {
             TypeFlags reducedTypeElementType = GetReducedTypeElementType(type);
 
@@ -66,17 +66,22 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Check if verification types of two types are equal
         /// </summary>
-        static bool AreVerificationTypesEqual(TypeDesc type1, TypeDesc type2)
+        private static bool AreVerificationTypesEqual(TypeDesc type1, TypeDesc type2)
         {
             if (type1 == type2)
             {
                 return true;
             }
 
-            TypeFlags e1 = GetVerificationTypeElementType(type1);
-            TypeFlags e2 = GetVerificationTypeElementType(type2);
+            if (type1.IsPrimitive && type2.IsPrimitive)
+            {
+                TypeFlags e1 = GetVerificationTypeElementType(type1);
+                TypeFlags e2 = GetVerificationTypeElementType(type2);
 
-            return type1.IsPrimitive && (e1 == e2);
+                return e1 == e2;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -84,7 +89,7 @@ namespace Internal.TypeSystem
         /// Note - this is a simplified version of what's described in the ECMA spec and it considers
         /// pointers to be method-signature-compatible-with only if the signatures are the same.
         /// </summary>
-        static bool IsMethodSignatureCompatibleWith(TypeDesc fn1Ttype, TypeDesc fn2Type)
+        private static bool IsMethodSignatureCompatibleWith(TypeDesc fn1Ttype, TypeDesc fn2Type)
         {
             return fn1Ttype == fn2Type;
         }

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
@@ -120,6 +120,15 @@ namespace Internal.TypeSystem
                 return IsMethodSignatureCompatibleWith(thisType, otherType);
             }
 
+            // None of the types can be a managed pointer, a pointer or a function pointer here,
+            // all the valid cases were handled above.
+            if (thisType.IsByRef || otherType.IsByRef ||
+                thisType.IsPointer || otherType.IsPointer ||
+                thisType.IsFunctionPointer || otherType.IsFunctionPointer)
+            {
+                return false;
+            }
+
             // Nullable<T> can be cast to T, but this is not compatible according to ECMA I.8.7.1
             bool isCastFromNullableOfTtoT = thisType.IsNullable && otherType.IsEquivalentTo(thisType.Instantiation[0]);
             if (isCastFromNullableOfTtoT)

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -972,6 +972,99 @@ void ClassLoader::LoadExactParents(MethodTable *pMT)
     RETURN;
 }
 
+// Get CorElementType of the reduced type of a type.
+// The reduced type concept is described in ECMA 335 chapter I.8.7
+//
+/*static*/
+CorElementType ClassLoader::GetReducedTypeElementType(TypeHandle hType)
+{
+    CorElementType elemType = hType.GetVerifierCorElementType();
+    switch (elemType)
+    {
+        case ELEMENT_TYPE_U1:
+            return ELEMENT_TYPE_I1;
+        case ELEMENT_TYPE_U2:
+            return ELEMENT_TYPE_I2;
+        case ELEMENT_TYPE_U4:
+            return ELEMENT_TYPE_I4;
+        case ELEMENT_TYPE_U8:
+            return ELEMENT_TYPE_I8;
+        case ELEMENT_TYPE_U:
+            return ELEMENT_TYPE_I;
+    }
+
+    return elemType;
+}
+
+// Get CorElementType of the verification type of a type.
+// The verification type concepts is described in ECMA 335 chapter I.8.7
+//
+/*static*/
+CorElementType ClassLoader::GetVerificationTypeElementType(TypeHandle hType)
+{
+    CorElementType reducedTypeElementType = GetReducedTypeElementType(hType);
+
+    switch (reducedTypeElementType)
+    {
+        case ELEMENT_TYPE_BOOLEAN:
+            return ELEMENT_TYPE_I1;
+        case ELEMENT_TYPE_CHAR:
+            return ELEMENT_TYPE_I2;
+    }
+
+    return reducedTypeElementType;
+}
+
+// Check if verification types of two types are equal
+//
+/*static*/
+bool ClassLoader::AreVerificationTypesEqual(TypeHandle hType1, TypeHandle hType2)
+{
+    if (hType1 == hType2)
+    {
+        return true;
+    }
+
+    CorElementType e1 = GetVerificationTypeElementType(hType1);
+    CorElementType e2 = GetVerificationTypeElementType(hType2);
+
+    return CorIsPrimitiveType(e1) && (e1 == e2);
+}
+
+// Check if signatures of two function pointers are compatible
+// Note - this is a simplified version of what's described in the ECMA spec and it considers
+// pointers to be method-signature-compatible-with only if the signatures are the same.
+//
+/*static*/
+bool ClassLoader::IsMethodSignatureCompatibleWith(FnPtrTypeDesc* fn1TD, FnPtrTypeDesc* fn2TD)
+{
+    if (fn1TD->GetCallConv() != fn1TD->GetCallConv())
+    {
+        return false;
+    }
+
+    if (fn1TD->GetNumArgs() != fn2TD->GetNumArgs())
+    {
+        return false;
+    }
+
+    TypeHandle* pFn1ArgTH = fn1TD->GetRetAndArgTypes();
+    TypeHandle* pFn2ArgTH = fn2TD->GetRetAndArgTypes();
+    for (DWORD i = 0; i < fn1TD->GetNumArgs() + 1; i++)
+    {
+#ifdef FEATURE_PREJIT
+        if (!ZapSig::CompareTaggedPointerToTypeHandle(pFn1ArgTH->GetModule(), pFn1ArgTH[i].AsTAddr(), pFn2ArgTH[i]))
+#else
+        if (pFn1ArgTH[i] != pFn2ArgTH[i])
+#endif
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // Checks if two types are compatible according to compatible-with as described in ECMA 335 I.8.7.1
 // Most of the checks are performed by the CanCastTo, but with some cases pre-filtered out.
 //
@@ -984,6 +1077,27 @@ bool ClassLoader::IsCompatibleWith(TypeHandle hType1, TypeHandle hType2)
     {
         return false;
     }
+
+    // Managed pointers are compatible only if they are pointer-element-compatible-with as described in ECMA I.8.7.2
+    if (hType1.IsByRef() && hType2.IsByRef())
+    {
+        return AreVerificationTypesEqual(hType1.GetTypeParam(), hType2.GetTypeParam());
+    }
+
+    // Unmanaged pointers are handled the same way as managed pointers
+    if (hType1.IsPointer() && hType2.IsPointer())
+    {
+        return AreVerificationTypesEqual(hType1.GetTypeParam(), hType2.GetTypeParam());
+    }
+
+    // Function pointers are compatible only if they are method-signature-compatible-with as described in ECMA I.8.7.1
+    if (hType1.IsFnPtrType() && hType2.IsFnPtrType())
+    {
+        return IsMethodSignatureCompatibleWith(hType1.AsFnPtrType(), hType2.AsFnPtrType());
+    }
+
+    _ASSERTE(hType1.GetMethodTable() != NULL);
+    _ASSERTE(hType2.GetMethodTable() != NULL);
 
     // Nullable<T> can be cast to T, but this is not compatible according to ECMA I.8.7.1
     bool isCastFromNullableOfTtoT = hType1.GetMethodTable()->IsNullable() && hType2.IsEquivalentTo(hType1.GetMethodTable()->GetInstantiation()[0]);
@@ -1083,9 +1197,6 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
         SigTypeContext context2(pMD);
         MetaSig methodSig2(pMD);
         TypeHandle hType2 = methodSig2.GetReturnProps().GetTypeHandleThrowing(pMD->GetModule(), &context2, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
-
-        _ASSERTE(hType1.GetMethodTable() != NULL);
-        _ASSERTE(hType2.GetMethodTable() != NULL);
 
         if (!IsCompatibleWith(hType1, hType2))
         {

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -991,9 +991,9 @@ CorElementType ClassLoader::GetReducedTypeElementType(TypeHandle hType)
             return ELEMENT_TYPE_I8;
         case ELEMENT_TYPE_U:
             return ELEMENT_TYPE_I;
+        default:
+            return elemType;
     }
-
-    return elemType;
 }
 
 // Get CorElementType of the verification type of a type.
@@ -1010,9 +1010,9 @@ CorElementType ClassLoader::GetVerificationTypeElementType(TypeHandle hType)
             return ELEMENT_TYPE_I1;
         case ELEMENT_TYPE_CHAR:
             return ELEMENT_TYPE_I2;
+        default:
+            return reducedTypeElementType;
     }
-
-    return reducedTypeElementType;
 }
 
 // Check if verification types of two types are equal
@@ -1026,9 +1026,14 @@ bool ClassLoader::AreVerificationTypesEqual(TypeHandle hType1, TypeHandle hType2
     }
 
     CorElementType e1 = GetVerificationTypeElementType(hType1);
+    if (!CorIsPrimitiveType(e1))
+    {
+        return false;
+    }
+
     CorElementType e2 = GetVerificationTypeElementType(hType2);
 
-    return CorIsPrimitiveType(e1) && (e1 == e2);
+    return e1 == e2;
 }
 
 // Check if signatures of two function pointers are compatible

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1096,6 +1096,15 @@ bool ClassLoader::IsCompatibleWith(TypeHandle hType1, TypeHandle hType2)
         return IsMethodSignatureCompatibleWith(hType1.AsFnPtrType(), hType2.AsFnPtrType());
     }
 
+    // None of the types can be a managed pointer, a pointer or a function pointer here,
+    // all the valid cases were handled above.
+    if (hType1.IsByRef() || hType2.IsByRef() ||
+        hType1.IsPointer() || hType2.IsPointer() ||
+        hType1.IsFnPtrType() || hType2.IsFnPtrType())
+    {
+        return false;
+    }
+
     _ASSERTE(hType1.GetMethodTable() != NULL);
     _ASSERTE(hType2.GetMethodTable() != NULL);
 

--- a/src/coreclr/src/vm/clsload.hpp
+++ b/src/coreclr/src/vm/clsload.hpp
@@ -973,6 +973,10 @@ private:
     static void ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT);
 
     static bool IsCompatibleWith(TypeHandle hType1, TypeHandle hType2);
+    static CorElementType GetReducedTypeElementType(TypeHandle hType);
+    static CorElementType GetVerificationTypeElementType(TypeHandle hType);
+    static bool AreVerificationTypesEqual(TypeHandle hType1, TypeHandle hType2);
+    static bool IsMethodSignatureCompatibleWith(FnPtrTypeDesc* fn1TD, FnPtrTypeDesc* fn2TD);
 
     // Create a non-canonical instantiation of a generic type based off the canonical instantiation
     // (For example, MethodTable for List<string> is based on the MethodTable for List<__Canon>)

--- a/src/coreclr/tests/src/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest.il
+++ b/src/coreclr/tests/src/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest.il
@@ -47,6 +47,69 @@
         ldnull
         ret
     }
+
+    .method public hidebysig newslot virtual instance class Base* M7()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance void* M8()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance method explicit instance int32 *(class Base) M9()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance int32* M10()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance native int* M11()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance uint32& M12()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance class Base& M13()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance char& M14()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
+
+    .method public hidebysig newslot virtual instance bool* M15()
+    {
+        ldc.i4.0
+        conv.u
+        ret
+    }
 }
 
 .class public auto ansi beforefieldinit C2 extends C1
@@ -158,6 +221,176 @@
     }
 }
 
+.class public auto ansi beforefieldinit C11 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance class Derived* M7()
+    {
+        .override method instance class Base* C1::M7();
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C12 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance int32* M8()
+    {
+        .override method instance void* C1::M8();
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C13 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance method explicit instance int32 *(class Derived) M9()
+    {
+        .override method instance method explicit instance int32 *(class Base) C1::M9()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C14 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance method explicit instance int32 *(class C1) M9()
+    {
+        .override method instance method explicit instance int32 *(class Base) C1::M9()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C15 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance method explicit instance int32 *(class Base) M9()
+    {
+        .override method instance method explicit instance int32 *(class Base) C1::M9()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C16 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance uint32* M10()
+    {
+        .override method instance int32* C1::M10()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C17 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance native uint* M11()
+    {
+        .override method instance native int* C1::M11()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C18 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance int32& M12()
+    {
+        .override method instance uint32& C1::M12()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C19 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance class Derived& M13()
+    {
+        .override method instance class Base& C1::M13()
+
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C20 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance uint16& M14()
+    {
+        .override method instance char& C1::M14()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C21 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance uint8* M15()
+    {
+        .override method instance bool* C1::M15()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C22 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance uint8& M14()
+    {
+        .override method instance char& C1::M14()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C23 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance uint32* M15()
+    {
+        .override method instance bool* C1::M15()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
 .class public auto ansi beforefieldinit Main extends [mscorlib]System.Object
 {
     .method public static void RunTestC1() noinlining 
@@ -254,6 +487,136 @@
     {
         newobj instance void class C10::.ctor()
         callvirt instance native int[] class C1::M6()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC11() noinlining
+    {
+        newobj instance void class C11::.ctor()
+        callvirt instance class Base* class C1::M7()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC12() noinlining
+    {
+        newobj instance void class C12::.ctor()
+        callvirt instance void* class C1::M8()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC13() noinlining
+    {
+        newobj instance void class C13::.ctor()
+        callvirt instance method explicit instance int32 *(class Base) class C1::M9()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC14() noinlining
+    {
+        newobj instance void class C14::.ctor()
+        callvirt instance method explicit instance int32 *(class Base) class C1::M9()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC15() noinlining
+    {
+        newobj instance void class C15::.ctor()
+        callvirt instance method explicit instance int32 *(class Base) class C1::M9()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC16() noinlining
+    {
+        newobj instance void class C16::.ctor()
+        callvirt instance int32* class C1::M10()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC17() noinlining
+    {
+        newobj instance void class C17::.ctor()
+        callvirt instance native int* class C1::M11()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC18() noinlining
+    {
+        newobj instance void class C18::.ctor()
+        callvirt instance uint32& class C1::M12()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC19() noinlining
+    {
+        newobj instance void class C19::.ctor()
+        callvirt instance class Base& class C1::M13()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC20() noinlining
+    {
+        newobj instance void class C20::.ctor()
+        callvirt instance char& class C1::M14()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC21() noinlining
+    {
+        newobj instance void class C21::.ctor()
+        callvirt instance bool* class C1::M15()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC22() noinlining
+    {
+        newobj instance void class C22::.ctor()
+        callvirt instance char& class C1::M14()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC23() noinlining
+    {
+        newobj instance void class C23::.ctor()
+        callvirt instance bool* class C1::M15()
         pop
         ldstr "Succeeded"
         call void [System.Console]System.Console::WriteLine(string)
@@ -379,7 +742,7 @@ CC6:
             leave.s CC7
         }  
 CC7:
-        ldstr "C7: override IList1<int32> by uint32[]"
+        ldstr "C7: override IList<int32> by uint32[]"
         call void [System.Console]System.Console::WriteLine(string)
 
         .try
@@ -433,7 +796,7 @@ CC9:
             leave.s CC10
         }  
 CC10:
-        ldstr "C10: : override native int[] by uint32[]"
+        ldstr "C10: override native int[] by uint32[]"
         call void [System.Console]System.Console::WriteLine(string)
 
         .try
@@ -441,15 +804,249 @@ CC10:
             call void Main::RunTestC10()
             ldc.i4.0
             stloc.0
-            leave.s DONE
+            leave.s CC11
         }
         catch [mscorlib]System.TypeLoadException
         {   
             ldstr "Caught expected TypeLoadException:"
             call       void [System.Console]System.Console::WriteLine(string)
             call       void [System.Console]System.Console::WriteLine(object)        
+            leave.s CC11
+        }
+CC11:
+        ldstr "C11: override Base* by Derived*"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC11()
+            ldc.i4.0
+            stloc.0
+            leave.s CC12
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC12
+        }
+CC12:
+        ldstr "C12: override void* by int32*"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC12()
+            ldc.i4.0
+            stloc.0
+            leave.s CC13
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC13
+        }
+CC13:
+        ldstr "C13: override int32 *(class Base) by int32 *(class Derived)"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC13()
+            ldc.i4.0
+            stloc.0
+            leave.s CC14
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC14
+        }
+CC14:
+        ldstr "C14: override int32 *(class Base) by int32 *(class C1)"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC14()
+            ldc.i4.0
+            stloc.0
+            leave.s CC15
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC15
+        }
+CC15:
+        ldstr "C15: override int32 *(class Base) by int32 *(class Base)"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC15()
+            leave.s CC16
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught unexpected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            ldc.i4.0
+            stloc.0
+            leave.s CC16
+        }
+CC16:
+        ldstr "C16: override int32* M10() by uint32* M10()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC16()
+            leave.s CC17
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught unexpected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            ldc.i4.0
+            stloc.0
+            leave.s CC17
+        }
+CC17:
+        ldstr "C17: override native int* M11() by native uint* M11()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC17()
+            leave.s CC18
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught unexpected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            ldc.i4.0
+            stloc.0
+            leave.s CC18
+        }
+CC18:
+        ldstr "C18: override uint32& M12() by int32& M12()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC18()
+            leave.s CC19
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught unexpected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            ldc.i4.0
+            stloc.0
+            leave.s CC19
+        }
+CC19:
+        ldstr "C19: override Base& M13() by Derived& M13()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC19()
+            ldc.i4.0
+            stloc.0
+            leave.s CC20
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC20
+        }
+CC20:
+        ldstr "C20: override char& M14() by uint16& M14()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC20()
+            leave.s CC21
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught unexpected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            ldc.i4.0
+            stloc.0
+            leave.s CC21
+        }
+CC21:
+        ldstr "C21: override bool* M15() by uint8* M15()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC21()
+            leave.s CC22
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught unexpected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            ldc.i4.0
+            stloc.0
+            leave.s CC22
+        }
+CC22:
+        ldstr "C22: override char& M14() by uint8& M14()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC22()
+            ldc.i4.0
+            stloc.0
+            leave.s CC23
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC23
+        }
+CC23:
+        ldstr "C21: override bool* M15() by uint32* M15()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC23()
+            ldc.i4.0
+            stloc.0
             leave.s DONE
-        }  
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s DONE
+        }
 DONE:
 
         ldloc.0

--- a/src/coreclr/tests/src/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest.il
+++ b/src/coreclr/tests/src/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest.il
@@ -391,6 +391,84 @@
     }
 }
 
+.class public auto ansi beforefieldinit C24 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance bool& M15()
+    {
+        .override method instance bool* C1::M15()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C25 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance method explicit instance int32 *(class Base) M15()
+    {
+        .override method instance bool* C1::M15()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C26 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance char* M14()
+    {
+        .override method instance char& C1::M14()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C27 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance method explicit instance int32 *(class Base) M14()
+    {
+        .override method instance char& C1::M14()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C28 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance int32* M9()
+    {
+        .override method instance method explicit instance int32 *(class Base) C1::M9()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
+.class public auto ansi beforefieldinit C29 extends C1
+{
+    .method public hidebysig specialname rtspecialname instance void  .ctor() cil managed { ret }
+
+    .method public hidebysig newslot virtual instance int32& M9()
+    {
+        .override method instance method explicit instance int32 *(class Base) C1::M9()
+        ldc.i4.0
+        conv.u
+        ret
+    }
+}
+
 .class public auto ansi beforefieldinit Main extends [mscorlib]System.Object
 {
     .method public static void RunTestC1() noinlining 
@@ -617,6 +695,66 @@
     {
         newobj instance void class C23::.ctor()
         callvirt instance bool* class C1::M15()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC24() noinlining
+    {
+        newobj instance void class C24::.ctor()
+        callvirt instance bool* class C1::M15()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC25() noinlining
+    {
+        newobj instance void class C25::.ctor()
+        callvirt instance bool* class C1::M15()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC26() noinlining
+    {
+        newobj instance void class C26::.ctor()
+        callvirt instance char& class C1::M14()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC27() noinlining
+    {
+        newobj instance void class C27::.ctor()
+        callvirt instance char& class C1::M14()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC28() noinlining
+    {
+        newobj instance void class C28::.ctor()
+        callvirt instance method explicit instance int32 *(class Base) class C1::M9()
+        pop
+        ldstr "Succeeded"
+        call void [System.Console]System.Console::WriteLine(string)
+        ret
+    }
+
+    .method public static void RunTestC29() noinlining
+    {
+        newobj instance void class C29::.ctor()
+        callvirt instance method explicit instance int32 *(class Base) class C1::M9()
         pop
         ldstr "Succeeded"
         call void [System.Console]System.Console::WriteLine(string)
@@ -1030,12 +1168,120 @@ CC22:
             leave.s CC23
         }
 CC23:
-        ldstr "C21: override bool* M15() by uint32* M15()"
+        ldstr "C23: override bool* M15() by uint32* M15()"
         call void [System.Console]System.Console::WriteLine(string)
 
         .try
         {
             call void Main::RunTestC23()
+            ldc.i4.0
+            stloc.0
+            leave.s CC24
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC24
+        }
+CC24:
+        ldstr "C24: override bool* M15() by bool& M15()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC24()
+            ldc.i4.0
+            stloc.0
+            leave.s CC25
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC25
+        }
+CC25:
+        ldstr "C25: override bool* M15() by int32 *(class Base) M15()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC25()
+            ldc.i4.0
+            stloc.0
+            leave.s CC26
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC26
+        }
+CC26:
+        ldstr "C26: override char& M14() by char* M14()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC26()
+            ldc.i4.0
+            stloc.0
+            leave.s CC27
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC27
+        }
+CC27:
+        ldstr "C27: override char& M14() by int32 *(class Base) M14()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC27()
+            ldc.i4.0
+            stloc.0
+            leave.s CC28
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC28
+        }
+CC28:
+        ldstr "C28: override int32 *(class Base) M9() by int32* M9()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC28()
+            ldc.i4.0
+            stloc.0
+            leave.s CC29
+        }
+        catch [mscorlib]System.TypeLoadException
+        {
+            ldstr "Caught expected TypeLoadException:"
+            call       void [System.Console]System.Console::WriteLine(string)
+            call       void [System.Console]System.Console::WriteLine(object)
+            leave.s CC29
+        }
+CC29:
+        ldstr "C29: override int32 *(class Base) M9() by int32& M9()"
+        call void [System.Console]System.Console::WriteLine(string)
+
+        .try
+        {
+            call void Main::RunTestC29()
             ldc.i4.0
             stloc.0
             leave.s DONE


### PR DESCRIPTION
This change adds support for managed, unmanaged and function pointers as
return values. It also adds related tests.