### PR TITLE
Fix app local loading in Unix

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.Unix.cs
@@ -19,7 +19,7 @@ namespace System.Globalization
             {
                 if (TryGetAppLocalIcuSwitchValue(out string? icuSuffixAndVersion))
                 {
-                    LoadAppLocalIcu(icuSuffixAndVersion, suffixWithSeparator: true);
+                    LoadAppLocalIcu(icuSuffixAndVersion);
                 }
                 else if (Interop.Globalization.LoadICU() == 0)
                 {
@@ -41,15 +41,16 @@ namespace System.Globalization
             string extension = version.Length > 0 ? "so." : "so";
             bool versionAtEnd = true;
 #endif
+            ReadOnlySpan<char> suffixAndSeparator = string.Concat(suffix, ".");
 
 #if !TARGET_OSX
             // In Linux we need to load libicudata first because libicuuc and libicui18n depend on it. In order for the loader to find
             // it on the same path, we load it before loading the other two libraries.
-            LoadLibrary(CreateLibraryName("libicudata", suffix, extension, version, versionAtEnd), failOnLoadFailure: true);
+            LoadLibrary(CreateLibraryName("libicudata", suffixAndSeparator, extension, version, versionAtEnd), failOnLoadFailure: true);
 #endif
 
-            IntPtr icuucLib = LoadLibrary(CreateLibraryName("libicuuc", suffix, extension, version, versionAtEnd), failOnLoadFailure: true);
-            IntPtr icuinLib = LoadLibrary(CreateLibraryName("libicui18n", suffix, extension, version, versionAtEnd), failOnLoadFailure: true);
+            IntPtr icuucLib = LoadLibrary(CreateLibraryName("libicuuc", suffixAndSeparator, extension, version, versionAtEnd), failOnLoadFailure: true);
+            IntPtr icuinLib = LoadLibrary(CreateLibraryName("libicui18n", suffixAndSeparator, extension, version, versionAtEnd), failOnLoadFailure: true);
 
             Interop.Globalization.InitICUFunctions(icuucLib, icuinLib, version, suffix);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/GlobalizationMode.cs
@@ -44,7 +44,7 @@ namespace System.Globalization
             return true;
         }
 
-        private static void LoadAppLocalIcu(string icuSuffixAndVersion, bool suffixWithSeparator = false)
+        private static void LoadAppLocalIcu(string icuSuffixAndVersion)
         {
             ReadOnlySpan<char> version;
             ReadOnlySpan<char> icuSuffix = default;
@@ -60,11 +60,6 @@ namespace System.Globalization
             else
             {
                 version = icuSuffixAndVersion;
-            }
-
-            if (suffixWithSeparator)
-            {
-                icuSuffix = string.Concat(icuSuffix, ".");
             }
 
             LoadAppLocalIcuCore(version, icuSuffix);


### PR DESCRIPTION
While doing: https://github.com/dotnet/runtime/pull/37281 I noticed that loading app local in Unix was wrong because we were including the `.` separator on the suffix when passing it down to the native code, so exported symbols were searched wrong.

cc: @tarekgh @jkotas 