### PR TITLE
Mono: Fix deadlock on Alpine

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -320,6 +320,11 @@ case "$host" in
                 	# available during cross-compilation
                 	mono_cv_uscore=no
                 fi
+                case "$host" in
+                *-musl)
+                        AC_DEFINE(MUSL, 1, [musl libc])
+                        ;;
+                esac
 		case "$host" in
 		*-tizen-linux-*)
 			platform_tizen=yes

--- a/src/mono/mono/utils/mono-os-mutex.h
+++ b/src/mono/mono/utils/mono-os-mutex.h
@@ -59,7 +59,7 @@ mono_os_mutex_init_type (mono_mutex_t *mutex, int type)
 	if (G_UNLIKELY (res != 0))
 		g_error ("%s: pthread_mutexattr_settype failed with \"%s\" (%d)", __func__, g_strerror (res), res);
 
-#if !defined(__HAIKU__) && defined (PTHREAD_PRIO_INHERIT) && HAVE_DECL_PTHREAD_MUTEXATTR_SETPROTOCOL
+#if !defined(__HAIKU__) && !defined(MUSL) && defined (PTHREAD_PRIO_INHERIT) && HAVE_DECL_PTHREAD_MUTEXATTR_SETPROTOCOL
 	/* use PTHREAD_PRIO_INHERIT if possible */
 	res = pthread_mutexattr_setprotocol (&attr, PTHREAD_PRIO_INHERIT);
 	if (G_UNLIKELY (res != 0 && res != ENOTSUP))


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19914,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Fixes mono/mono#7167

The PR 3e8108ea6576b07de2a64528be18674683879189 introduced a deadlock on Alpine, making it impossible to even build mono. This PR reverts the setting of PTHREAD_PRIO_INHERIT when on Alpine.
Since GCC on Alpine doesn't provide a builtin macro to detect Alpine, I also added a #define in configure.ac.

<!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->
