### PR TITLE
Profile driven method layout

### DIFF
--- a/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
+++ b/src/coreclr/src/tools/Common/Compiler/DependencyAnalysis/SortableDependencyNode.cs
@@ -31,6 +31,9 @@ namespace ILCompiler.DependencyAnalysis
         /// </remarks>
         public abstract int ClassCode { get; }
 
+        // Custom sort order. Used to override the default sorting mechanics.
+        public int CustomSort = int.MaxValue;
+
         // Note to implementers: the type of `other` is actually the same as the type of `this`.
         public virtual int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
@@ -162,6 +165,9 @@ namespace ILCompiler.DependencyAnalysis
 
             if (phaseX == phaseY)
             {
+                if (x.CustomSort != y.CustomSort)
+                    return x.CustomSort.CompareTo(y.CustomSort);
+
                 int codeX = x.ClassCode;
                 int codeY = y.ClassCode;
                 if (codeX == codeY)

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -114,6 +114,22 @@ namespace Internal.TypeSystem
             }
         }
 
+        public bool HasEmbeddedSignatureData
+        {
+            get
+            {
+                return _embeddedSignatureData != null;
+            }
+        }
+
+        public EmbeddedSignatureData[] GetEmbeddedSignatureData()
+        {
+            if ((_embeddedSignatureData == null) || (_embeddedSignatureData.Length == 0))
+                return null;
+
+            return (EmbeddedSignatureData[])_embeddedSignatureData.Clone();
+        }
+
         public bool Equals(MethodSignature otherSignature)
         {
             // TODO: Generics, etc.

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodWithGCInfo.cs
@@ -45,6 +45,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public List<ISymbolNode> Fixups => _fixups;
 
+        public int Size => _methodCode.Data.Length;
+
         public bool IsEmpty => _methodCode.Data.Length == 0;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly)
@@ -293,6 +295,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             Debug.Assert(_debugEHClauseInfos == null);
             _debugEHClauseInfos = debugEHClauseInfos;
         }
+
         public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
         {
             MethodWithGCInfo otherNode = (MethodWithGCInfo)other;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/SortableDependencyNodeCompilerSpecific.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/SortableDependencyNodeCompilerSpecific.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis
+{
+    partial class SortableDependencyNode
+    {
+        // Custom sort order. Used to override the default sorting mechanics.
+        public int CustomSort = int.MaxValue;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        static partial void ApplyCustomSort(SortableDependencyNode x, SortableDependencyNode y, ref int result)
+        {
+            result = x.CustomSort.CompareTo(y.CustomSort);
+        }
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -26,6 +26,9 @@ namespace ILCompiler
         private bool _generateMapFile;
         private int _parallelism;
         private InstructionSetSupport _instructionSetSupport;
+        private ProfileDataManager _profileData;
+        private ReadyToRunMethodLayoutAlgorithm _r2rMethodLayoutAlgorithm;
+        private ReadyToRunFileLayoutAlgorithm _r2rFileLayoutAlgorithm;
 
         private string _jitPath;
         private string _outputFile;
@@ -95,6 +98,19 @@ namespace ILCompiler
         public ReadyToRunCodegenCompilationBuilder UseResilience(bool resilient)
         {
             _resilient = resilient;
+            return this;
+        }
+
+        public ReadyToRunCodegenCompilationBuilder UseProfileData(ProfileDataManager profileData)
+        {
+            _profileData = profileData;
+            return this;
+        }
+
+        public ReadyToRunCodegenCompilationBuilder FileLayoutAlgorithms(ReadyToRunMethodLayoutAlgorithm r2rMethodLayoutAlgorithm, ReadyToRunFileLayoutAlgorithm r2rFileLayoutAlgorithm)
+        {
+            _r2rMethodLayoutAlgorithm = r2rMethodLayoutAlgorithm;
+            _r2rFileLayoutAlgorithm = r2rFileLayoutAlgorithm;
             return this;
         }
 
@@ -205,7 +221,10 @@ namespace ILCompiler
                 _instructionSetSupport,
                 _resilient,
                 _generateMapFile,
-                _parallelism);
+                _parallelism,
+                _profileData,
+                _r2rMethodLayoutAlgorithm,
+                _r2rFileLayoutAlgorithm);
         }
     }
 }

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunFileLayoutOptimizer.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/Compiler/ReadyToRunFileLayoutOptimizer.cs
@@ -1,0 +1,187 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using Internal.TypeSystem;
+
+using ILCompiler.DependencyAnalysis;
+using ILCompiler.DependencyAnalysis.ReadyToRun;
+using ILCompiler.DependencyAnalysisFramework;
+using System.Linq;
+using System.Collections.Immutable;
+using System.Text;
+using System.Reflection.Metadata.Ecma335;
+
+namespace ILCompiler
+{
+    public enum ReadyToRunMethodLayoutAlgorithm
+    {
+        DefaultSort,
+        ExclusiveWeight,
+        HotCold,
+        HotWarmCold
+    }
+
+    public enum ReadyToRunFileLayoutAlgorithm
+    {
+        DefaultSort,
+        MethodOrder
+    }
+
+    class ReadyToRunFileLayoutOptimizer
+    {
+        public ReadyToRunFileLayoutOptimizer (ReadyToRunMethodLayoutAlgorithm methodAlgorithm,
+                                              ReadyToRunFileLayoutAlgorithm fileAlgorithm,
+                                              ProfileDataManager profileData,
+                                              NodeFactory nodeFactory)
+        {
+            _methodLayoutAlgorithm = methodAlgorithm;
+            _fileLayoutAlgorithm = fileAlgorithm;
+            _profileData = profileData;
+            _nodeFactory = nodeFactory;
+        }
+
+        private ReadyToRunMethodLayoutAlgorithm _methodLayoutAlgorithm = ReadyToRunMethodLayoutAlgorithm.DefaultSort;
+        private ReadyToRunFileLayoutAlgorithm _fileLayoutAlgorithm = ReadyToRunFileLayoutAlgorithm.DefaultSort;
+        private ProfileDataManager _profileData;
+        private NodeFactory _nodeFactory;
+
+        private List<MethodWithGCInfo> SortByRegion(ImmutableArray<DependencyNodeCore<NodeFactory>> nodes, Func<MethodWithGCInfo, int> getRegion)
+        {
+            List<MethodWithGCInfo> methods = new List<MethodWithGCInfo>();
+            foreach (var node in nodes)
+            {
+                if (node is MethodWithGCInfo method)
+                {
+                    methods.Add(method);
+                }
+            }
+            methods.MergeSortAllowDuplicates((MethodWithGCInfo left, MethodWithGCInfo right) => getRegion(left).CompareTo(getRegion(right)));
+            return methods;
+        }
+
+        public ImmutableArray<DependencyNodeCore<NodeFactory>> ApplyProfilerGuidedMethodSort(ImmutableArray<DependencyNodeCore<NodeFactory>> nodes)
+        {
+            if (_methodLayoutAlgorithm == ReadyToRunMethodLayoutAlgorithm.DefaultSort)
+                return nodes;
+
+            Func<List<MethodWithGCInfo>> sortedMethods = null;
+
+            if (_methodLayoutAlgorithm == ReadyToRunMethodLayoutAlgorithm.ExclusiveWeight)
+            {
+                sortedMethods = () =>
+                {
+                    List<MethodWithGCInfo> methods = new List<MethodWithGCInfo>();
+                    foreach (var node in nodes)
+                    {
+                        if (node is MethodWithGCInfo method)
+                        {
+                            methods.Add(method);
+                        }
+                    }
+
+                    methods.MergeSortAllowDuplicates(sortMethodWithGCInfoByWeight);
+                    return methods;
+                };
+
+                int sortMethodWithGCInfoByWeight(MethodWithGCInfo left, MethodWithGCInfo right)
+                {
+                    return -MethodWithGCInfoToWeight(left).CompareTo(MethodWithGCInfoToWeight(right));
+                }
+                double MethodWithGCInfoToWeight(MethodWithGCInfo method)
+                {
+                    var profileData = _profileData[method.Method];
+                    double weight = 0;
+
+                    if (profileData != null)
+                    {
+                        weight = profileData.ExclusiveWeight;
+                    }
+                    return weight;
+                }
+            }
+            else if (_methodLayoutAlgorithm == ReadyToRunMethodLayoutAlgorithm.HotCold)
+            {
+                sortedMethods = () => SortByRegion(nodes, (method) =>
+                {
+                    var profileData = _profileData[method.Method];
+                    double weight = 0;
+
+                    if (profileData != null)
+                    {
+                        weight = profileData.ExclusiveWeight;
+                    }
+                    return weight > 0 ? 0 : 1;
+                });
+            }
+            else if (_methodLayoutAlgorithm == ReadyToRunMethodLayoutAlgorithm.HotWarmCold)
+            {
+                sortedMethods = () => SortByRegion(nodes, (method) =>
+                {
+                    var profileData = _profileData[method.Method];
+                    double weight = 0;
+
+                    if (profileData != null)
+                    {
+                        weight = profileData.ExclusiveWeight;
+                    }
+                    // If weight is greater than 128 its probably signicantly used at runtime
+                    if (weight > 128)
+                        return 0;
+
+                    // If weight is less than 128 but greater than 0, then its probably used at startup
+                    // or some at runtime, but is less critical than the hot code
+                    if (weight > 0)
+                        return 1;
+
+                    // Methods without weight are probably relatively rarely used
+                    return 2;
+                });
+            }
+
+            int sortOrder = 0;
+
+            List<MethodWithGCInfo> sortedMethodsList = sortedMethods();
+
+            foreach (var methodNode in sortedMethodsList)
+            {
+                methodNode.CustomSort = sortOrder;
+                sortOrder++;
+            }
+
+            if (_fileLayoutAlgorithm == ReadyToRunFileLayoutAlgorithm.MethodOrder)
+            {
+                // Sort the dependencies of methods by the method order
+                foreach (var method in sortedMethodsList)
+                {
+                    ApplySortToDependencies(method, 0);
+                }
+            }
+
+            var newNodesArray = nodes.ToArray();
+            newNodesArray.MergeSortAllowDuplicates(new SortableDependencyNode.ObjectNodeComparer(new CompilerComparer()));
+            return newNodesArray.ToImmutableArray();
+
+            void ApplySortToDependencies(DependencyNodeCore<NodeFactory> node, int depth)
+            {
+                if (depth > 5)
+                    return;
+
+                if (node is SortableDependencyNode sortableNode)
+                {
+                    if (sortableNode.CustomSort != Int32.MaxValue)
+                        return; // Node already sorted
+                    sortableNode.CustomSort += sortOrder++;
+                }
+                foreach (var dependency in node.GetStaticDependencies(_nodeFactory))
+                {
+                    ApplySortToDependencies(dependency.Node, depth + 1);
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -141,7 +141,7 @@ namespace ILCompiler.IBC
                     {
                         if (methodsFoundInData.Add(associatedMethod))
                         {
-                            methodProfileData.Add(new MethodProfileData(associatedMethod, (MethodProfilingDataFlags)entry.Flags, scenarioMask));
+                            methodProfileData.Add(new MethodProfileData(associatedMethod, (MethodProfilingDataFlags)entry.Flags, 0, null, scenarioMask));
                         }
                         else
                         {

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Compiler\ReadyToRunCompilerContext.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilation.cs" />
     <Compile Include="Compiler\ReadyToRunCodegenCompilationBuilder.cs" />
+    <Compile Include="Compiler\ReadyToRunFileLayoutOptimizer.cs" />
     <Compile Include="Compiler\ReadyToRunMetadataFieldLayoutAlgorithm.cs" />
     <Compile Include="Compiler\ReadyToRunSingleAssemblyCompilationModuleGroup.cs" />
     <Compile Include="Compiler\ReadyToRunTableManager.cs" />

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypesTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\Win32ResourcesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRunSymbolNodeFactory.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\SortableDependencyNodeCompilerSpecific.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TypeAndMethod.cs" />
     <Compile Include="Compiler\IRootingServiceProvider.cs" />
     <Compile Include="Compiler\MethodExtensions.cs" />

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -449,10 +449,44 @@ namespace ILCompiler.Reflection.ReadyToRun
                 bool[] isEntryPoint = new bool[nRuntimeFunctions];
 
                 // initialize R2RMethods
-                ParseMethodDefEntrypoints(isEntryPoint);
+                ParseMethodDefEntrypoints((section, reader) => ParseMethodDefEntrypointsSection(section, reader, isEntryPoint));
                 ParseInstanceMethodEntrypoints(isEntryPoint);
                 CountRuntimeFunctions(isEntryPoint);
             }
+        }
+
+        private Dictionary<int, ReadyToRunMethod> _runtimeFunctionToMethod = null;
+
+        private void EnsureEntrypointRuntimeFunctionToReadyToRunMethodDict()
+        {
+            EnsureMethods();
+
+            if (_runtimeFunctionToMethod == null)
+            {
+                _runtimeFunctionToMethod = new Dictionary<int, ReadyToRunMethod>();
+                foreach (var section in _methods)
+                {
+                    foreach (var method in section.Value)
+                    {
+                        if (!_runtimeFunctionToMethod.ContainsKey(method.EntryPointRuntimeFunctionId))
+                            _runtimeFunctionToMethod.Add(method.EntryPointRuntimeFunctionId, method);
+                    }
+                }
+            }
+        }
+
+        public Dictionary<TMethod, ReadyToRunMethod> GetCustomMethodToRuntimeFunctionMapping<TType, TMethod, TGenericContext>(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider)
+        {
+            EnsureEntrypointRuntimeFunctionToReadyToRunMethodDict();
+
+            Dictionary<TMethod, ReadyToRunMethod> customMethods = new Dictionary<TMethod, ReadyToRunMethod>();
+            if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.RuntimeFunctions, out ReadyToRunSection runtimeFunctionSection))
+            {
+                ParseMethodDefEntrypoints((section, reader) => ParseMethodDefEntrypointsSectionCustom<TType, TMethod, TGenericContext>(provider, customMethods, section, reader));
+                ParseInstanceMethodEntrypointsCustom<TType, TMethod, TGenericContext>(provider, customMethods);
+            }
+
+            return customMethods;
         }
 
         private bool TryLocateNativeReadyToRunHeader()
@@ -667,12 +701,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// Initialize non-generic R2RMethods with method signatures from MethodDefHandle, and runtime function indices from MethodDefEntryPoints
         /// </summary>
-        private void ParseMethodDefEntrypoints(bool[] isEntryPoint)
+        private void ParseMethodDefEntrypoints(Action<ReadyToRunSection, MetadataReader> methodDefSectionReader)
         {
             ReadyToRunSection methodEntryPointSection;
             if (ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out methodEntryPointSection))
             {
-                ParseMethodDefEntrypointsSection(methodEntryPointSection, GetGlobalMetadataReader(), isEntryPoint);
+                methodDefSectionReader(methodEntryPointSection, GetGlobalMetadataReader());
             }
             else if (ReadyToRunAssemblyHeaders != null)
             {
@@ -680,7 +714,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     if (ReadyToRunAssemblyHeaders[assemblyIndex].Sections.TryGetValue(ReadyToRunSectionType.MethodDefEntryPoints, out methodEntryPointSection))
                     {
-                        ParseMethodDefEntrypointsSection(methodEntryPointSection, OpenReferenceAssembly(assemblyIndex + 1), isEntryPoint);
+                        methodDefSectionReader(methodEntryPointSection, OpenReferenceAssembly(assemblyIndex + 1));
                     }
                 }
             }
@@ -722,6 +756,69 @@ namespace ILCompiler.Reflection.ReadyToRun
                     }
                     sectionMethods.Add(method);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Parse a single method def entrypoint section. For composite R2R images, this method is called multiple times
+        /// are method entrypoints are stored separately for each component assembly of the composite R2R executable.
+        /// </summary>
+        /// <param name="section">Method entrypoint section to parse</param>
+        /// <param name="metadataReader">ECMA metadata reader representing this method entrypoint section</param>
+        /// <param name="isEntryPoint">Set to true for each runtime function index representing a method entrypoint</param>
+        private void ParseMethodDefEntrypointsSectionCustom<TType, TMethod, TGenericContext>(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider, Dictionary<TMethod, ReadyToRunMethod> foundMethods, ReadyToRunSection section, MetadataReader metadataReader)
+        {
+            int methodDefEntryPointsOffset = GetOffset(section.RelativeVirtualAddress);
+            NativeArray methodEntryPoints = new NativeArray(Image, (uint)methodDefEntryPointsOffset);
+            uint nMethodEntryPoints = methodEntryPoints.GetCount();
+
+            for (uint rid = 1; rid <= nMethodEntryPoints; rid++)
+            {
+                int offset = 0;
+                if (methodEntryPoints.TryGetAt(Image, rid - 1, ref offset))
+                {
+                    EntityHandle methodHandle = MetadataTokens.MethodDefinitionHandle((int)rid);
+                    int runtimeFunctionId;
+                    int? fixupOffset;
+                    GetRuntimeFunctionIndexFromOffset(offset, out runtimeFunctionId, out fixupOffset);
+                    ReadyToRunMethod r2rMethod = _runtimeFunctionToMethod[runtimeFunctionId];
+                    var customMethod = provider.GetMethodFromMethodDef(metadataReader, MetadataTokens.MethodDefinitionHandle((int)rid), default(TType));
+                    
+                    if (!Object.ReferenceEquals(customMethod, null) && !foundMethods.ContainsKey(customMethod))
+                        foundMethods.Add(customMethod, r2rMethod);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Initialize generic method instances with argument types and runtime function indices from InstanceMethodEntrypoints
+        /// </summary>
+        private void ParseInstanceMethodEntrypointsCustom<TType, TMethod, TGenericContext>(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider, Dictionary<TMethod, ReadyToRunMethod> foundMethods)
+        {
+            if (!ReadyToRunHeader.Sections.TryGetValue(ReadyToRunSectionType.InstanceMethodEntryPoints, out ReadyToRunSection instMethodEntryPointSection))
+            {
+                return;
+            }
+            int instMethodEntryPointsOffset = GetOffset(instMethodEntryPointSection.RelativeVirtualAddress);
+            NativeParser parser = new NativeParser(Image, (uint)instMethodEntryPointsOffset);
+            NativeHashtable instMethodEntryPoints = new NativeHashtable(Image, parser, (uint)(instMethodEntryPointsOffset + instMethodEntryPointSection.Size));
+            NativeHashtable.AllEntriesEnumerator allEntriesEnum = instMethodEntryPoints.EnumerateAllEntries();
+            NativeParser curParser = allEntriesEnum.GetNext();
+            while (!curParser.IsNull())
+            {
+                MetadataReader mdReader = _composite ? null : _assemblyCache[0];
+                var decoder = new R2RSignatureDecoder<TType, TMethod, TGenericContext>(provider, default(TGenericContext), mdReader, this, (int)curParser.Offset);
+
+                TMethod customMethod = decoder.ParseMethod();
+
+                int runtimeFunctionId;
+                int? fixupOffset;
+                GetRuntimeFunctionIndexFromOffset((int)decoder.Offset, out runtimeFunctionId, out fixupOffset);
+                ReadyToRunMethod r2rMethod = _runtimeFunctionToMethod[runtimeFunctionId];
+                if (!Object.ReferenceEquals(customMethod, null) && !foundMethods.ContainsKey(customMethod))
+                    foundMethods.Add(customMethod, r2rMethod);
+                foundMethods.Add(customMethod, r2rMethod);
+                curParser = allEntriesEnum.GetNext();
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -475,7 +475,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
         }
 
-        public Dictionary<TMethod, ReadyToRunMethod> GetCustomMethodToRuntimeFunctionMapping<TType, TMethod, TGenericContext>(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider)
+        public IReadOnlyDictionary<TMethod, ReadyToRunMethod> GetCustomMethodToRuntimeFunctionMapping<TType, TMethod, TGenericContext>(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider)
         {
             EnsureEntrypointRuntimeFunctionToReadyToRunMethodDict();
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -825,7 +825,6 @@ namespace ILCompiler.Reflection.ReadyToRun
             Options = options;
         }
 
-        public StringBuilder CurrentBuilder;
         /// <summary>
         /// Dump options are used to specify details of signature formatting.
         /// </summary>
@@ -867,7 +866,6 @@ namespace ILCompiler.Reflection.ReadyToRun
 
             public string GetMethodFromMethodDef(MetadataReader reader, MethodDefinitionHandle handle, string owningTypeOverride)
             {
-                StringBuilder signaturePrefixBuilder = new StringBuilder();
                 uint methodDefToken = (uint)MetadataTokens.GetToken(handle);
                 return MetadataNameFormatter.FormatHandle(
                     reader,
@@ -878,7 +876,6 @@ namespace ILCompiler.Reflection.ReadyToRun
 
             public string GetMethodFromMemberRef(MetadataReader reader, MemberReferenceHandle handle, string owningTypeOverride)
             {
-                StringBuilder signaturePrefixBuilder = new StringBuilder();
                 uint methodRefToken = (uint)MetadataTokens.GetToken(handle);
                 return MetadataNameFormatter.FormatHandle(
                     reader,
@@ -921,7 +918,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     builder.Append("[INST] ");
                 }
                 builder.Append(method);
-                return method;
+                return builder.ToString();
             }
         }
 

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Text;
@@ -364,15 +366,25 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
     }
 
+    public interface IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> : ISignatureTypeProvider<TType, TGenericContext>
+    {
+        public TType GetCanonType();
+        public TMethod GetMethodFromMethodDef(MetadataReader reader, MethodDefinitionHandle handle, TType owningTypeOverride);
+        public TMethod GetMethodFromMemberRef(MetadataReader reader, MemberReferenceHandle handle, TType owningTypeOverride);
+        public TMethod GetInstantiatedMethod(TMethod uninstantiatedMethod, ImmutableArray<TType> instantiation);
+        public TMethod GetConstrainedMethod(TMethod method, TType constraint);
+        public TMethod GetMethodWithFlags(ReadyToRunMethodSigFlags flags, TMethod method);
+    }
+
     /// <summary>
     /// Helper class used as state machine for decoding a single signature.
     /// </summary>
-    public class SignatureDecoder
+    public class R2RSignatureDecoder<TType, TMethod, TGenericContext>
     {
         /// <summary>
         /// ECMA reader is used to access the embedded MSIL metadata blob in the R2R file.
         /// </summary>
-        private readonly MetadataReader _metadataReader;
+        protected readonly MetadataReader _metadataReader;
 
         /// <summary>
         /// Outer ECMA reader is used as the default context for generic parameters.
@@ -382,17 +394,12 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <summary>
         /// ECMA reader representing the reference module of the signature being decoded.
         /// </summary>
-        private readonly ReadyToRunReader _contextReader;
-
-        /// <summary>
-        /// Dump options are used to specify details of signature formatting.
-        /// </summary>
-        private readonly IAssemblyResolver _options;
+        protected readonly ReadyToRunReader _contextReader;
 
         /// <summary>
         /// Byte array representing the R2R PE file read from disk.
         /// </summary>
-        private readonly byte[] _image;
+        protected readonly byte[] _image;
 
         /// <summary>
         /// Offset within the image file.
@@ -404,17 +411,26 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public int Offset => _offset;
 
+        private IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> _provider;
+
+        protected void UpdateOffset(int offset)
+        {
+            _offset = offset;
+        }
+
+        public TGenericContext Context { get; }
+
         /// <summary>
         /// Construct the signature decoder by storing the image byte array and offset within the array.
         /// </summary>
-        /// <param name="options">Dump options and paths</param>
         /// <param name="r2rReader">R2RReader object representing the PE file containing the ECMA metadata</param>
         /// <param name="offset">Signature offset within the PE file byte array</param>
-        public SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, ReadyToRunReader r2rReader, int offset)
+        public R2RSignatureDecoder(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider, TGenericContext context, MetadataReader metadataReader, ReadyToRunReader r2rReader, int offset)
         {
             _metadataReader = metadataReader;
             _outerReader = metadataReader;
-            _options = options;
+            Context = context;
+            _provider = provider;
             _image = r2rReader.Image;
             _offset = offset;
             _contextReader = r2rReader;
@@ -429,9 +445,10 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="offset">Signature offset within the signature byte array</param>
         /// <param name="outerReader">Metadata reader representing the outer signature context</param>
         /// <param name="contextReader">Top-level signature context reader</param>
-        private SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, byte[] signature, int offset, MetadataReader outerReader, ReadyToRunReader contextReader)
+        public R2RSignatureDecoder(IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> provider, TGenericContext context, MetadataReader metadataReader, byte[] signature, int offset, MetadataReader outerReader, ReadyToRunReader contextReader)
         {
-            _options = options;
+            Context = context;
+            _provider = provider;
             _metadataReader = metadataReader;
             _image = signature;
             _offset = offset;
@@ -538,6 +555,403 @@ namespace ILCompiler.Reflection.ReadyToRun
         }
 
         /// <summary>
+        /// Decode a type from the signature stream.
+        /// </summary>
+        /// <param name="builder"></param>
+        public TType ParseType()
+        {
+            CorElementType corElemType = ReadElementType();
+            switch (corElemType)
+            {
+                case CorElementType.ELEMENT_TYPE_VOID:
+                case CorElementType.ELEMENT_TYPE_BOOLEAN:
+                case CorElementType.ELEMENT_TYPE_CHAR:
+                case CorElementType.ELEMENT_TYPE_I1:
+                case CorElementType.ELEMENT_TYPE_U1:
+                case CorElementType.ELEMENT_TYPE_I2:
+                case CorElementType.ELEMENT_TYPE_U2:
+                case CorElementType.ELEMENT_TYPE_I4:
+                case CorElementType.ELEMENT_TYPE_I8:
+                case CorElementType.ELEMENT_TYPE_U4:
+                case CorElementType.ELEMENT_TYPE_U8:
+                case CorElementType.ELEMENT_TYPE_R4:
+                case CorElementType.ELEMENT_TYPE_R8:
+                case CorElementType.ELEMENT_TYPE_STRING:
+                case CorElementType.ELEMENT_TYPE_OBJECT:
+                case CorElementType.ELEMENT_TYPE_I:
+                case CorElementType.ELEMENT_TYPE_U:
+                case CorElementType.ELEMENT_TYPE_TYPEDBYREF:
+                    return _provider.GetPrimitiveType((PrimitiveTypeCode)corElemType);
+
+                case CorElementType.ELEMENT_TYPE_PTR:
+                    return _provider.GetPointerType(ParseType());
+
+                case CorElementType.ELEMENT_TYPE_BYREF:
+                    return _provider.GetByReferenceType(ParseType());
+
+                case CorElementType.ELEMENT_TYPE_VALUETYPE:
+                case CorElementType.ELEMENT_TYPE_CLASS:
+                    return ParseTypeDefOrRef(corElemType);
+
+                case CorElementType.ELEMENT_TYPE_VAR:
+                    {
+                        uint varIndex = ReadUInt();
+                        return _provider.GetGenericTypeParameter(Context, (int)varIndex);
+                    }
+
+                case CorElementType.ELEMENT_TYPE_ARRAY:
+                    {
+                        TType elementType = ParseType();
+                        uint rank = ReadUInt();
+                        if (rank == 0)
+                            return _provider.GetSZArrayType(elementType);
+
+                        uint sizeCount = ReadUInt(); // number of sizes
+                        uint[] sizes = new uint[sizeCount];
+                        for (uint sizeIndex = 0; sizeIndex < sizeCount; sizeIndex++)
+                        {
+                            sizes[sizeIndex] = ReadUInt();
+                        }
+                        uint lowerBoundCount = ReadUInt(); // number of lower bounds
+                        int[] lowerBounds = new int[lowerBoundCount];
+                        for (uint lowerBoundIndex = 0; lowerBoundIndex < lowerBoundCount; lowerBoundIndex++)
+                        {
+                            lowerBounds[lowerBoundIndex] = ReadInt();
+                        }
+                        ArrayShape arrayShape = new ArrayShape((int)rank, ((int[])(object)sizes).ToImmutableArray(), lowerBounds.ToImmutableArray());
+                        return _provider.GetArrayType(elementType, arrayShape);
+                    }
+
+                case CorElementType.ELEMENT_TYPE_GENERICINST:
+                    {
+                        TType genericType = ParseType();
+                        uint typeArgCount = ReadUInt();
+                        var outerDecoder = new R2RSignatureDecoder<TType, TMethod, TGenericContext>(_provider, Context, _outerReader, _image, _offset, _outerReader, _contextReader);
+                        List<TType> parsedTypes = new List<TType>();
+                        for (uint paramIndex = 0; paramIndex < typeArgCount; paramIndex++)
+                        {
+                            parsedTypes.Add(outerDecoder.ParseType());
+                        }
+                        _offset = outerDecoder.Offset;
+                        return _provider.GetGenericInstantiation(genericType, parsedTypes.ToImmutableArray());
+                    }
+
+                case CorElementType.ELEMENT_TYPE_FNPTR:
+                    var sigHeader = new SignatureHeader(ReadByte());
+                    int genericParamCount = 0;
+                    if (sigHeader.IsGeneric)
+                    {
+                        genericParamCount = (int)ReadUInt();
+                    }
+                    int paramCount = (int)ReadUInt();
+                    TType returnType = ParseType();
+                    TType[] paramTypes = new TType[paramCount];
+                    int requiredParamCount = -1;
+                    for (int i = 0; i < paramCount; i++)
+                    {
+                        while (PeekElementType() == CorElementType.ELEMENT_TYPE_SENTINEL)
+                        {
+                            requiredParamCount = i;
+                            ReadElementType(); // Skip over sentinel
+                        }
+                        paramTypes[i] = ParseType();
+                    }
+                    if (requiredParamCount == -1)
+                        requiredParamCount = paramCount;
+
+                    MethodSignature<TType> methodSig = new MethodSignature<TType>(sigHeader, returnType, requiredParamCount, genericParamCount, paramTypes.ToImmutableArray());
+                    return _provider.GetFunctionPointerType(methodSig);
+
+                case CorElementType.ELEMENT_TYPE_SZARRAY:
+                    return _provider.GetSZArrayType(ParseType());
+
+                case CorElementType.ELEMENT_TYPE_MVAR:
+                    {
+                        uint varIndex = ReadUInt();
+                        return _provider.GetGenericMethodParameter(Context, (int)varIndex);
+                    }
+
+                case CorElementType.ELEMENT_TYPE_CMOD_REQD:
+                    return _provider.GetModifiedType(ParseTypeDefOrRefOrSpec(corElemType), ParseType(), true);
+
+                case CorElementType.ELEMENT_TYPE_CMOD_OPT:
+                    return _provider.GetModifiedType(ParseTypeDefOrRefOrSpec(corElemType), ParseType(), false);
+
+                case CorElementType.ELEMENT_TYPE_HANDLE:
+                    throw new BadImageFormatException("handle");
+
+                case CorElementType.ELEMENT_TYPE_SENTINEL:
+                    throw new BadImageFormatException("sentinel");
+
+                case CorElementType.ELEMENT_TYPE_PINNED:
+                    return _provider.GetPinnedType(ParseType());
+
+                case CorElementType.ELEMENT_TYPE_VAR_ZAPSIG:
+                    throw new BadImageFormatException("var_zapsig");
+
+                case CorElementType.ELEMENT_TYPE_NATIVE_VALUETYPE_ZAPSIG:
+                    throw new BadImageFormatException("native_valuetype_zapsig");
+
+                case CorElementType.ELEMENT_TYPE_CANON_ZAPSIG:
+                    return _provider.GetCanonType();
+
+                case CorElementType.ELEMENT_TYPE_MODULE_ZAPSIG:
+                    {
+                        int moduleIndex = (int)ReadUInt();
+                        MetadataReader refAsmReader = _contextReader.OpenReferenceAssembly(moduleIndex);
+                        var refAsmDecoder = new R2RSignatureDecoder<TType, TMethod, TGenericContext>(_provider, Context, refAsmReader, _image, _offset, _outerReader, _contextReader);
+                        var result = refAsmDecoder.ParseType();
+                        _offset = refAsmDecoder.Offset;
+                        return result;
+                    }
+
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+
+
+        private TType ParseTypeDefOrRef(CorElementType corElemType)
+        {
+            uint token = ReadToken();
+            var handle = MetadataTokens.Handle((int)token);
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeDefinition:
+                    return _provider.GetTypeFromDefinition(_metadataReader, (TypeDefinitionHandle)handle, (byte)corElemType);
+                case HandleKind.TypeReference:
+                    return _provider.GetTypeFromReference(_metadataReader, (TypeReferenceHandle)handle, (byte)corElemType);
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
+        private TType ParseTypeDefOrRefOrSpec(CorElementType corElemType)
+        {
+            uint token = ReadToken();
+            var handle = MetadataTokens.Handle((int)token);
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeDefinition:
+                    return _provider.GetTypeFromDefinition(_metadataReader, (TypeDefinitionHandle)handle, (byte)corElemType);
+                case HandleKind.TypeReference:
+                    return _provider.GetTypeFromReference(_metadataReader, (TypeReferenceHandle)handle, (byte)corElemType);
+                case HandleKind.TypeSpecification:
+                    return _provider.GetTypeFromSpecification(_metadataReader, Context, (TypeSpecificationHandle)handle, (byte)corElemType);
+                default:
+                    throw new BadImageFormatException();
+            }
+        }
+
+        public TMethod ParseMethod()
+        {
+            uint methodFlags = ReadUInt();
+
+            TType owningTypeOverride = default(TType);
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
+            {
+                owningTypeOverride = ParseType();
+                methodFlags &= ~(uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType;
+            }
+
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_SlotInsteadOfToken) != 0)
+            {
+                throw new NotImplementedException();
+            }
+
+            TMethod result;
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken) != 0)
+            {
+                methodFlags &= ~(uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken;
+                result = ParseMethodRefToken(owningTypeOverride: owningTypeOverride);
+            }
+            else
+            {
+                result = ParseMethodDefToken(owningTypeOverride: owningTypeOverride);
+            }
+
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation) != 0)
+            {
+                methodFlags &= ~(uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation;
+                uint typeArgCount = ReadUInt();
+                TType[] instantiationArgs = new TType[typeArgCount];
+                for (int typeArgIndex = 0; typeArgIndex < typeArgCount; typeArgIndex++)
+                {
+                    instantiationArgs[typeArgIndex] = ParseType();
+                }
+                result = _provider.GetInstantiatedMethod(result, instantiationArgs.ToImmutableArray());
+            }
+
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained) != 0)
+            {
+                methodFlags &= ~(uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained;
+                result = _provider.GetConstrainedMethod(result, ParseType());
+            }
+
+            // Any other flags should just be directly recorded
+            if (methodFlags != 0)
+                result = _provider.GetMethodWithFlags((ReadyToRunMethodSigFlags)methodFlags, result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Read a methodDef token from the signature and output the corresponding object to the builder.
+        /// </summary>
+        /// <param name="builder">Output string builder</param>
+        private TMethod ParseMethodDefToken(TType owningTypeOverride)
+        {
+            uint rid = ReadUInt();
+            return _provider.GetMethodFromMethodDef(_metadataReader, MetadataTokens.MethodDefinitionHandle((int)rid), owningTypeOverride);
+        }
+
+
+        /// <summary>
+        /// Read a memberRef token from the signature and output the corresponding object to the builder.
+        /// </summary>
+        /// <param name="builder">Output string builder</param>
+        /// <param name="owningTypeOverride">Explicit owning type override</param>
+        private TMethod ParseMethodRefToken(TType owningTypeOverride)
+        {
+            uint rid = ReadUInt();
+            return _provider.GetMethodFromMemberRef(_metadataReader, MetadataTokens.MemberReferenceHandle((int)rid), owningTypeOverride);
+        }
+
+    }
+    public class TextSignatureDecoderContext
+    {
+        public TextSignatureDecoderContext(IAssemblyResolver options)
+        {
+            Options = options;
+        }
+
+        public StringBuilder CurrentBuilder;
+        /// <summary>
+        /// Dump options are used to specify details of signature formatting.
+        /// </summary>
+        public IAssemblyResolver Options { get; }
+    }
+
+    /// <summary>
+    /// Helper class used as state machine for decoding a single signature.
+    /// </summary>
+    public class SignatureDecoder : R2RSignatureDecoder<string, string, TextSignatureDecoderContext>
+    {
+        private class TextTypeProvider : StringTypeProviderBase<TextSignatureDecoderContext>, IR2RSignatureTypeProvider<string, string, TextSignatureDecoderContext>
+        {
+            private TextTypeProvider()
+            {
+            }
+
+            public static readonly TextTypeProvider Singleton = new TextTypeProvider();
+
+            public override string GetGenericMethodParameter(TextSignatureDecoderContext genericContext, int index)
+            {
+                return $"mvar #{index}";
+            }
+
+            public override string GetGenericTypeParameter(TextSignatureDecoderContext genericContext, int index)
+            {
+                return $"var #{index}";
+            }
+
+            public override string GetTypeFromSpecification(MetadataReader reader, TextSignatureDecoderContext genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            {
+                return MetadataNameFormatter.FormatHandle(reader, handle);
+            }
+
+            public string GetCanonType()
+            {
+                return "__Canon";
+            }
+
+            public string GetMethodFromMethodDef(MetadataReader reader, MethodDefinitionHandle handle, string owningTypeOverride)
+            {
+                StringBuilder signaturePrefixBuilder = new StringBuilder();
+                uint methodDefToken = (uint)MetadataTokens.GetToken(handle);
+                return MetadataNameFormatter.FormatHandle(
+                    reader,
+                    MetadataTokens.Handle((int)methodDefToken),
+                    namespaceQualified: true,
+                    owningTypeOverride: owningTypeOverride);
+            }
+
+            public string GetMethodFromMemberRef(MetadataReader reader, MemberReferenceHandle handle, string owningTypeOverride)
+            {
+                StringBuilder signaturePrefixBuilder = new StringBuilder();
+                uint methodRefToken = (uint)MetadataTokens.GetToken(handle);
+                return MetadataNameFormatter.FormatHandle(
+                    reader,
+                    MetadataTokens.Handle((int)methodRefToken),
+                    namespaceQualified: true,
+                    owningTypeOverride: owningTypeOverride);
+            }
+
+            public string GetInstantiatedMethod(string uninstantiatedMethod, ImmutableArray<string> instantiation)
+            {
+                StringBuilder builder = new StringBuilder();
+                builder.Append(uninstantiatedMethod);
+                builder.Append("<");
+                for (int typeArgIndex = 0; typeArgIndex < instantiation.Length; typeArgIndex++)
+                {
+                    if (typeArgIndex != 0)
+                    {
+                        builder.Append(", ");
+                    }
+                    builder.Append(instantiation[typeArgIndex]);
+                }
+                builder.Append(">");
+                return builder.ToString();
+            }
+
+            public string GetConstrainedMethod(string method, string constraint)
+            {
+                return $"{method} @ {constraint}";
+            }
+
+            public string GetMethodWithFlags(ReadyToRunMethodSigFlags flags, string method)
+            {
+                StringBuilder builder = new StringBuilder();
+                if ((flags & ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
+                {
+                    builder.Append("[UNBOX] ");
+                }
+                if ((flags & ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
+                {
+                    builder.Append("[INST] ");
+                }
+                builder.Append(method);
+                return method;
+            }
+        }
+
+        /// <summary>
+        /// Construct the signature decoder by storing the image byte array and offset within the array.
+        /// </summary>
+        /// <param name="options">Dump options and paths</param>
+        /// <param name="r2rReader">R2RReader object representing the PE file containing the ECMA metadata</param>
+        /// <param name="offset">Signature offset within the PE file byte array</param>
+        public SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, ReadyToRunReader r2rReader, int offset) :
+            base(TextTypeProvider.Singleton, new TextSignatureDecoderContext(options), metadataReader, r2rReader, offset)
+        {
+        }
+
+        /// <summary>
+        /// Construct the signature decoder by storing the image byte array and offset within the array.
+        /// </summary>
+        /// <param name="options">Dump options and paths</param>
+        /// <param name="metadataReader">Metadata reader for the R2R image</param>
+        /// <param name="signature">Signature to parse</param>
+        /// <param name="offset">Signature offset within the signature byte array</param>
+        /// <param name="outerReader">Metadata reader representing the outer signature context</param>
+        /// <param name="contextReader">Top-level signature context reader</param>
+        private SignatureDecoder(IAssemblyResolver options, MetadataReader metadataReader, byte[] signature, int offset, MetadataReader outerReader, ReadyToRunReader contextReader) :
+            base(TextTypeProvider.Singleton, new TextSignatureDecoderContext(options), metadataReader, signature, offset, outerReader, contextReader)
+        {
+        }
+
+
+        /// <summary>
         /// Decode a R2R import signature. The signature starts with the fixup type followed
         /// by custom encoding per fixup type.
         /// </summary>
@@ -546,7 +960,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             result = null;
             StringBuilder builder = new StringBuilder();
-            int startOffset = _offset;
+            int startOffset = Offset;
             try
             {
                 result = ParseSignature(builder);
@@ -563,7 +977,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         public string ReadTypeSignature()
         {
             StringBuilder builder = new StringBuilder();
-            int startOffset = _offset;
+            int startOffset = Offset;
             try
             {
                 ParseType(builder);
@@ -594,12 +1008,12 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private void EmitInlineSignatureBinaryForm(StringBuilder builder, int startOffset)
         {
-            EmitInlineSignatureBinaryBytes(builder, _offset - startOffset);
+            EmitInlineSignatureBinaryBytes(builder, Offset - startOffset);
         }
 
         private void EmitInlineSignatureBinaryBytes(StringBuilder builder, int count)
         {
-            if (_options.InlineSignatureBinary)
+            if (Context.Options.InlineSignatureBinary)
             {
                 if (builder.Length > 0 && Char.IsDigit(builder[builder.Length - 1]))
                 {
@@ -612,7 +1026,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     {
                         builder.Append('-');
                     }
-                    builder.Append(_image[_offset - count + index].ToString("x2"));
+                    builder.Append(_image[Offset - count + index].ToString("x2"));
                 }
                 builder.Append("-");
             }
@@ -620,7 +1034,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private uint ReadUIntAndEmitInlineSignatureBinary(StringBuilder builder)
         {
-            int startOffset = _offset;
+            int startOffset = Offset;
             uint value = ReadUInt();
             EmitInlineSignatureBinaryForm(builder, startOffset);
             return value;
@@ -628,7 +1042,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private int ReadIntAndEmitInlineSignatureBinary(StringBuilder builder)
         {
-            int startOffset = _offset;
+            int startOffset = Offset;
             int value = ReadInt();
             EmitInlineSignatureBinaryForm(builder, startOffset);
             return value;
@@ -636,7 +1050,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private uint ReadTokenAndEmitInlineSignatureBinary(StringBuilder builder)
         {
-            int startOffset = _offset;
+            int startOffset = Offset;
             uint value = ReadToken();
             EmitInlineSignatureBinaryForm(builder, startOffset);
             return value;
@@ -644,9 +1058,9 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         private void EmitSignatureBinaryFrom(StringBuilder builder, int startOffset)
         {
-            if (_options.SignatureBinary)
+            if (Context.Options.SignatureBinary)
             {
-                for (int offset = startOffset; offset < _offset; offset++)
+                for (int offset = startOffset; offset < Offset; offset++)
                 {
                     builder.Append(offset == startOffset ? " [" : "-");
                     builder.Append(_image[offset].ToString("x2"));
@@ -672,11 +1086,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                 fixupType &= ~(uint)ReadyToRunFixupKind.ModuleOverride;
                 int moduleIndex = (int)ReadUIntAndEmitInlineSignatureBinary(builder);
                 MetadataReader refAsmEcmaReader = _contextReader.OpenReferenceAssembly(moduleIndex);
-                moduleDecoder = new SignatureDecoder(_options, refAsmEcmaReader, _image, _offset, refAsmEcmaReader, _contextReader);
+                moduleDecoder = new SignatureDecoder(Context.Options, refAsmEcmaReader, _image, Offset, refAsmEcmaReader, _contextReader);
             }
 
             ReadyToRunSignature result = moduleDecoder.ParseSignature((ReadyToRunFixupKind)fixupType, builder);
-            _offset = moduleDecoder.Offset;
+            UpdateOffset(moduleDecoder.Offset);
             return result;
         }
 
@@ -732,14 +1146,14 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case ReadyToRunFixupKind.MethodEntry_DefToken:
                     uint methodDefToken = ParseMethodDefToken(builder, owningTypeOverride: null);
                     builder.Append(" (METHOD_ENTRY");
-                    builder.Append(_options.Naked ? ")" : "_DEF_TOKEN)");
+                    builder.Append(Context.Options.Naked ? ")" : "_DEF_TOKEN)");
                     result = new MethodDefEntrySignature { MethodDefToken = methodDefToken };
                     break;
 
                 case ReadyToRunFixupKind.MethodEntry_RefToken:
                     uint methodRefToken = ParseMethodRefToken(builder, owningTypeOverride: null);
                     builder.Append(" (METHOD_ENTRY");
-                    builder.Append(_options.Naked ? ")" : "_REF_TOKEN)");
+                    builder.Append(Context.Options.Naked ? ")" : "_REF_TOKEN)");
                     result = new MethodRefEntrySignature { MethodRefToken = methodRefToken };
                     break;
 
@@ -752,13 +1166,13 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case ReadyToRunFixupKind.VirtualEntry_DefToken:
                     ParseMethodDefToken(builder, owningTypeOverride: null);
                     builder.Append(" (VIRTUAL_ENTRY");
-                    builder.Append(_options.Naked ? ")" : "_DEF_TOKEN)");
+                    builder.Append(Context.Options.Naked ? ")" : "_DEF_TOKEN)");
                     break;
 
                 case ReadyToRunFixupKind.VirtualEntry_RefToken:
                     ParseMethodRefToken(builder, owningTypeOverride: null);
                     builder.Append(" (VIRTUAL_ENTRY");
-                    builder.Append(_options.Naked ? ")" : "_REF_TOKEN)");
+                    builder.Append(Context.Options.Naked ? ")" : "_REF_TOKEN)");
                     break;
 
                 case ReadyToRunFixupKind.VirtualEntry_Slot:
@@ -948,261 +1362,24 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="builder"></param>
         private void ParseType(StringBuilder builder)
         {
-            CorElementType corElemType = ReadElementType();
-            EmitInlineSignatureBinaryBytes(builder, 1);
-            switch (corElemType)
-            {
-                case CorElementType.ELEMENT_TYPE_VOID:
-                    builder.Append("void");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_BOOLEAN:
-                    builder.Append("bool");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_CHAR:
-                    builder.Append("char");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_I1:
-                    builder.Append("sbyte");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_U1:
-                    builder.Append("byte");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_I2:
-                    builder.Append("short");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_U2:
-                    builder.Append("ushort");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_I4:
-                    builder.Append("int");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_U4:
-                    builder.Append("uint");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_I8:
-                    builder.Append("long");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_U8:
-                    builder.Append("ulong");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_R4:
-                    builder.Append("float");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_R8:
-                    builder.Append("double");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_STRING:
-                    builder.Append("string");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_PTR:
-                    ParseType(builder);
-                    builder.Append('*');
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_BYREF:
-                    builder.Append("byref");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_VALUETYPE:
-                case CorElementType.ELEMENT_TYPE_CLASS:
-                    ParseTypeToken(builder);
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_VAR:
-                    uint varIndex = ReadUIntAndEmitInlineSignatureBinary(builder);
-                    builder.Append("var #");
-                    builder.Append(varIndex);
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_ARRAY:
-                    ParseType(builder);
-                    {
-                        builder.Append('[');
-                        int startOffset = _offset;
-                        uint rank = ReadUIntAndEmitInlineSignatureBinary(builder);
-                        if (rank != 0)
-                        {
-                            uint sizeCount = ReadUIntAndEmitInlineSignatureBinary(builder); // number of sizes
-                            uint[] sizes = new uint[sizeCount];
-                            for (uint sizeIndex = 0; sizeIndex < sizeCount; sizeIndex++)
-                            {
-                                sizes[sizeIndex] = ReadUIntAndEmitInlineSignatureBinary(builder);
-                            }
-                            uint lowerBoundCount = ReadUIntAndEmitInlineSignatureBinary(builder); // number of lower bounds
-                            int[] lowerBounds = new int[lowerBoundCount];
-                            for (uint lowerBoundIndex = 0; lowerBoundIndex < lowerBoundCount; lowerBoundIndex++)
-                            {
-                                lowerBounds[lowerBoundIndex] = ReadIntAndEmitInlineSignatureBinary(builder);
-                            }
-                            for (int index = 0; index < rank; index++)
-                            {
-                                if (index > 0)
-                                {
-                                    builder.Append(',');
-                                }
-                                if (lowerBoundCount > index && lowerBounds[index] != 0)
-                                {
-                                    builder.Append(lowerBounds[index]);
-                                    builder.Append("..");
-                                    if (sizeCount > index)
-                                    {
-                                        builder.Append(lowerBounds[index] + sizes[index] - 1);
-                                    }
-                                }
-                                else if (sizeCount > index)
-                                {
-                                    builder.Append(sizes[index]);
-                                }
-                                else if (rank == 1)
-                                {
-                                    builder.Append('*');
-                                }
-                            }
-                        }
-                        builder.Append(']');
-                    }
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_GENERICINST:
-                    ParseGenericTypeInstance(builder);
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_TYPEDBYREF:
-                    builder.Append("typedbyref");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_I:
-                    builder.Append("IntPtr");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_U:
-                    builder.Append("UIntPtr");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_FNPTR:
-                    builder.Append("fnptr");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_OBJECT:
-                    builder.Append("object");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_SZARRAY:
-                    ParseType(builder);
-                    builder.Append("[]");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_MVAR:
-                    uint mvarIndex = ReadUIntAndEmitInlineSignatureBinary(builder);
-                    builder.Append("mvar #");
-                    builder.Append(mvarIndex);
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_CMOD_REQD:
-                    builder.Append("cmod_reqd");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_CMOD_OPT:
-                    builder.Append("cmod_opt");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_HANDLE:
-                    builder.Append("handle");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_SENTINEL:
-                    builder.Append("sentinel");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_PINNED:
-                    builder.Append("pinned");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_VAR_ZAPSIG:
-                    builder.Append("var_zapsig");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_NATIVE_VALUETYPE_ZAPSIG:
-                    builder.Append("native_valuetype_zapsig");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_CANON_ZAPSIG:
-                    builder.Append("__Canon");
-                    break;
-
-                case CorElementType.ELEMENT_TYPE_MODULE_ZAPSIG:
-                    {
-                        int moduleIndex = (int)ReadUIntAndEmitInlineSignatureBinary(builder);
-                        MetadataReader refAsmReader = _contextReader.OpenReferenceAssembly(moduleIndex);
-                        SignatureDecoder refAsmDecoder = new SignatureDecoder(_options, refAsmReader, _image, _offset, _outerReader, _contextReader);
-                        refAsmDecoder.ParseType(builder);
-                        _offset = refAsmDecoder.Offset;
-                    }
-                    break;
-
-                default:
-                    throw new NotImplementedException();
-            }
+            builder.Append(base.ParseType());
         }
 
         public MetadataReader GetMetadataReaderFromModuleOverride()
         {
             if (PeekElementType() == CorElementType.ELEMENT_TYPE_MODULE_ZAPSIG)
             {
-                var currentOffset = _offset;
+                var currentOffset = Offset;
 
                 ReadElementType();
                 int moduleIndex = (int)ReadUInt();
                 MetadataReader refAsmReader = _contextReader.OpenReferenceAssembly(moduleIndex);
 
-                _offset = currentOffset;
+                UpdateOffset(currentOffset);
 
                 return refAsmReader;
             }
             return null;
-        }
-
-        private void ParseGenericTypeInstance(StringBuilder builder)
-        {
-            ParseType(builder);
-            uint typeArgCount = ReadUIntAndEmitInlineSignatureBinary(builder);
-            SignatureDecoder outerDecoder = new SignatureDecoder(_options, _outerReader, _image, _offset, _outerReader, _contextReader);
-            builder.Append("<");
-            for (uint paramIndex = 0; paramIndex < typeArgCount; paramIndex++)
-            {
-                if (paramIndex > 0)
-                {
-                    builder.Append(", ");
-                }
-                outerDecoder.ParseType(builder);
-            }
-            builder.Append(">");
-            _offset = outerDecoder.Offset;
-        }
-
-        private void ParseTypeToken(StringBuilder builder)
-        {
-            StringBuilder signaturePrefixBuilder = new StringBuilder();
-            uint token = ReadTokenAndEmitInlineSignatureBinary(signaturePrefixBuilder);
-            builder.Append(MetadataNameFormatter.FormatHandle(
-                _metadataReader,
-                MetadataTokens.Handle((int)token),
-                owningTypeOverride: null,
-                signaturePrefix: signaturePrefixBuilder.ToString()));
         }
 
         /// <summary>
@@ -1211,55 +1388,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// <param name="builder">Output string builder to receive the textual signature representation</param>
         private void ParseMethod(StringBuilder builder)
         {
-            uint methodFlags = ReadUIntAndEmitInlineSignatureBinary(builder);
-
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
-            {
-                builder.Append("[UNBOX] ");
-            }
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
-            {
-                builder.Append("[INST] ");
-            }
-
-            string owningTypeOverride = null;
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
-            {
-                owningTypeOverride = ReadTypeSignatureNoEmit();
-            }
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_SlotInsteadOfToken) != 0)
-            {
-                throw new NotImplementedException();
-            }
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken) != 0)
-            {
-                ParseMethodRefToken(builder, owningTypeOverride: owningTypeOverride);
-            }
-            else
-            {
-                ParseMethodDefToken(builder, owningTypeOverride: owningTypeOverride);
-            }
-
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation) != 0)
-            {
-                uint typeArgCount = ReadUIntAndEmitInlineSignatureBinary(builder);
-                builder.Append("<");
-                for (int typeArgIndex = 0; typeArgIndex < typeArgCount; typeArgIndex++)
-                {
-                    if (typeArgIndex != 0)
-                    {
-                        builder.Append(", ");
-                    }
-                    ParseType(builder);
-                }
-                builder.Append(">");
-            }
-
-            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained) != 0)
-            {
-                builder.Append(" @ ");
-                ParseType(builder);
-            }
+            builder.Append(ParseMethod());
         }
 
         /// <summary>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -368,12 +368,12 @@ namespace ILCompiler.Reflection.ReadyToRun
 
     public interface IR2RSignatureTypeProvider<TType, TMethod, TGenericContext> : ISignatureTypeProvider<TType, TGenericContext>
     {
-        public TType GetCanonType();
-        public TMethod GetMethodFromMethodDef(MetadataReader reader, MethodDefinitionHandle handle, TType owningTypeOverride);
-        public TMethod GetMethodFromMemberRef(MetadataReader reader, MemberReferenceHandle handle, TType owningTypeOverride);
-        public TMethod GetInstantiatedMethod(TMethod uninstantiatedMethod, ImmutableArray<TType> instantiation);
-        public TMethod GetConstrainedMethod(TMethod method, TType constraint);
-        public TMethod GetMethodWithFlags(ReadyToRunMethodSigFlags flags, TMethod method);
+        TType GetCanonType();
+        TMethod GetMethodFromMethodDef(MetadataReader reader, MethodDefinitionHandle handle, TType owningTypeOverride);
+        TMethod GetMethodFromMemberRef(MetadataReader reader, MemberReferenceHandle handle, TType owningTypeOverride);
+        TMethod GetInstantiatedMethod(TMethod uninstantiatedMethod, ImmutableArray<TType> instantiation);
+        TMethod GetConstrainedMethod(TMethod method, TType constraint);
+        TMethod GetMethodWithFlags(ReadyToRunMethodSigFlags flags, TMethod method);
     }
 
     /// <summary>
@@ -1033,22 +1033,6 @@ namespace ILCompiler.Reflection.ReadyToRun
         {
             int startOffset = Offset;
             uint value = ReadUInt();
-            EmitInlineSignatureBinaryForm(builder, startOffset);
-            return value;
-        }
-
-        private int ReadIntAndEmitInlineSignatureBinary(StringBuilder builder)
-        {
-            int startOffset = Offset;
-            int value = ReadInt();
-            EmitInlineSignatureBinaryForm(builder, startOffset);
-            return value;
-        }
-
-        private uint ReadTokenAndEmitInlineSignatureBinary(StringBuilder builder)
-        {
-            int startOffset = Offset;
-            uint value = ReadToken();
             EmitInlineSignatureBinaryForm(builder, startOffset);
             return value;
         }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -38,8 +38,8 @@ namespace ILCompiler
         public bool Resilient { get; set; }
         public bool Map { get; set; }
         public int Parallelism { get; set; }
-
-
+        public ReadyToRunMethodLayoutAlgorithm MethodLayout { get; set; }
+        public ReadyToRunFileLayoutAlgorithm FileLayout { get; set; }
         public string SingleMethodTypeName { get; set; }
         public string SingleMethodName { get; set; }
         public string[] SingleMethodGenericArgs { get; set; }
@@ -177,6 +177,14 @@ namespace ILCompiler
                 new Option(new[] { "--map" }, SR.MapFileOption)
                 {
                     Argument = new Argument<bool>()
+                },
+                new Option(new[] { "--method-layout" }, "Layout file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled")
+                {
+                    Argument = new Argument<ReadyToRunMethodLayoutAlgorithm>()
+                },
+                new Option(new[] { "--file-layout" }, "Layout file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled")
+                {
+                    Argument = new Argument<ReadyToRunFileLayoutAlgorithm>()
                 },
             };
         }

--- a/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/CommandLineOptions.cs
@@ -178,11 +178,11 @@ namespace ILCompiler
                 {
                     Argument = new Argument<bool>()
                 },
-                new Option(new[] { "--method-layout" }, "Layout file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled")
+                new Option(new[] { "--method-layout" }, SR.MethodLayoutOption)
                 {
                     Argument = new Argument<ReadyToRunMethodLayoutAlgorithm>()
                 },
-                new Option(new[] { "--file-layout" }, "Layout file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled")
+                new Option(new[] { "--file-layout" }, SR.FileLayoutOption)
                 {
                     Argument = new Argument<ReadyToRunFileLayoutAlgorithm>()
                 },

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Program.cs
@@ -474,6 +474,8 @@ namespace ILCompiler
                         .UseResilience(_commandLineOptions.Resilient)
                         .UseMapFile(_commandLineOptions.Map)
                         .UseParallelism(_commandLineOptions.Parallelism)
+                        .UseProfileData(profileDataManager)
+                        .FileLayoutAlgorithms(_commandLineOptions.MethodLayout, _commandLineOptions.FileLayout)
                         .UseJitPath(_commandLineOptions.JitPath)
                         .UseInstructionSetSupport(instructionSetSupport)
                         .GenerateOutputFile(_commandLineOptions.OutputFilePath.FullName)

--- a/src/coreclr/src/tools/crossgen2/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/src/tools/crossgen2/crossgen2/Properties/Resources.resx
@@ -261,4 +261,10 @@
   <data name="ErrorMultipleInputFilesCompositeModeOnly" xml:space="preserve">
     <value>Error: multiple input files are only supported in composite build mode: {0}</value>
   </data>
+  <data name="MethodLayoutOption" xml:space="preserve">
+    <value>Layout methods in file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled</value>
+  </data>
+  <data name="FileLayoutOption" xml:space="preserve">
+    <value>Layout non-method contents of file using profile driven optimization assuming the layout algorithm specified. The default value is DefaultSort, which indicates that complex layout is disabled</value>
+  </data>
 </root>

--- a/src/coreclr/src/tools/dotnet-pgo/R2RSignatureTypeProvider.cs
+++ b/src/coreclr/src/tools/dotnet-pgo/R2RSignatureTypeProvider.cs
@@ -1,0 +1,233 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection.Metadata;
+using ILCompiler.Reflection.ReadyToRun;
+using Internal.ReadyToRunConstants;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace Microsoft.Diagnostics.Tools.Pgo
+{
+    struct R2RSigProviderContext
+    {
+
+    }
+
+    class R2RSignatureTypeProvider : IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>
+    {
+        public R2RSignatureTypeProvider(TraceTypeSystemContext tsc)
+        {
+            _tsc = tsc;
+        }
+
+        TraceTypeSystemContext _tsc;
+
+        TypeDesc IConstructedTypeProvider<TypeDesc>.GetArrayType(TypeDesc elementType, ArrayShape shape)
+        {
+            if (elementType == null)
+                return null;
+            return elementType.MakeArrayType(shape.Rank);
+        }
+
+        TypeDesc IConstructedTypeProvider<TypeDesc>.GetByReferenceType(TypeDesc elementType)
+        {
+            if (elementType == null)
+                return null;
+            return elementType.MakeByRefType();
+        }
+
+        TypeDesc IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>.GetCanonType()
+        {
+            return _tsc.CanonType;
+        }
+
+        MethodDesc IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>.GetConstrainedMethod(MethodDesc method, TypeDesc constraint)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        TypeDesc ISignatureTypeProvider<TypeDesc, R2RSigProviderContext>.GetFunctionPointerType(MethodSignature<TypeDesc> signature)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        TypeDesc IConstructedTypeProvider<TypeDesc>.GetGenericInstantiation(TypeDesc genericType, ImmutableArray<TypeDesc> typeArguments)
+        {
+            if (genericType == null)
+                return null;
+
+            foreach (var type in typeArguments)
+            {
+                if (type == null)
+                    return null;
+            }
+            return _tsc.GetInstantiatedType((MetadataType)genericType, new Instantiation(typeArguments.ToArray()));
+        }
+
+        TypeDesc ISignatureTypeProvider<TypeDesc, R2RSigProviderContext>.GetGenericMethodParameter(R2RSigProviderContext genericContext, int index)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        TypeDesc ISignatureTypeProvider<TypeDesc, R2RSigProviderContext>.GetGenericTypeParameter(R2RSigProviderContext genericContext, int index)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        MethodDesc IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>.GetInstantiatedMethod(MethodDesc uninstantiatedMethod, ImmutableArray<TypeDesc> instantiation)
+        {
+            if (uninstantiatedMethod == null)
+                return null;
+
+            foreach (var type in instantiation)
+            {
+                if (type == null)
+                    return null;
+            }
+            return uninstantiatedMethod.MakeInstantiatedMethod(instantiation.ToArray());
+        }
+
+        MethodDesc IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>.GetMethodFromMemberRef(MetadataReader reader, MemberReferenceHandle handle, TypeDesc owningTypeOverride)
+        {
+            var ecmaModule = (EcmaModule)_tsc.GetModuleForSimpleName(reader.GetString(reader.GetAssemblyDefinition().Name));
+            var method = (MethodDesc)ecmaModule.GetObject(handle);
+            if (owningTypeOverride != null)
+            {
+                return _tsc.GetMethodForInstantiatedType(method.GetTypicalMethodDefinition(), (InstantiatedType)owningTypeOverride);
+            }
+            return method;
+        }
+
+        MethodDesc IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>.GetMethodFromMethodDef(MetadataReader reader, MethodDefinitionHandle handle, TypeDesc owningTypeOverride)
+        {
+            var ecmaModule = (EcmaModule)_tsc.GetModuleForSimpleName(reader.GetString(reader.GetAssemblyDefinition().Name));
+            var method = (MethodDesc)ecmaModule.GetObject(handle);
+            if (owningTypeOverride != null)
+            {
+                return _tsc.GetMethodForInstantiatedType(method.GetTypicalMethodDefinition(), (InstantiatedType)owningTypeOverride);
+            }
+            return method;
+        }
+
+        MethodDesc IR2RSignatureTypeProvider<TypeDesc, MethodDesc, R2RSigProviderContext>.GetMethodWithFlags(ReadyToRunMethodSigFlags flags, MethodDesc method)
+        {
+            return method;
+        }
+
+        TypeDesc ISignatureTypeProvider<TypeDesc, R2RSigProviderContext>.GetModifiedType(TypeDesc modifier, TypeDesc unmodifiedType, bool isRequired)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        TypeDesc ISignatureTypeProvider<TypeDesc, R2RSigProviderContext>.GetPinnedType(TypeDesc elementType)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        TypeDesc IConstructedTypeProvider<TypeDesc>.GetPointerType(TypeDesc elementType)
+        {
+            // Cannot exist in entrypoint definition
+            throw new System.NotImplementedException();
+        }
+
+        TypeDesc ISimpleTypeProvider<TypeDesc>.GetPrimitiveType(PrimitiveTypeCode typeCode)
+        {
+            WellKnownType wkt = 0;
+            switch (typeCode)
+            {
+                case PrimitiveTypeCode.Void:
+                    wkt = WellKnownType.Void;
+                    break;
+                case PrimitiveTypeCode.Boolean:
+                    wkt = WellKnownType.Boolean;
+                    break;
+                case PrimitiveTypeCode.Char:
+                    wkt = WellKnownType.Char;
+                    break;
+                case PrimitiveTypeCode.SByte:
+                    wkt = WellKnownType.SByte;
+                    break;
+                case PrimitiveTypeCode.Byte:
+                    wkt = WellKnownType.Byte;
+                    break;
+                case PrimitiveTypeCode.Int16:
+                    wkt = WellKnownType.Int16;
+                    break;
+                case PrimitiveTypeCode.UInt16:
+                    wkt = WellKnownType.UInt16;
+                    break;
+                case PrimitiveTypeCode.Int32:
+                    wkt = WellKnownType.Int32;
+                    break;
+                case PrimitiveTypeCode.UInt32:
+                    wkt = WellKnownType.UInt32;
+                    break;
+                case PrimitiveTypeCode.Int64:
+                    wkt = WellKnownType.Int64;
+                    break;
+                case PrimitiveTypeCode.UInt64:
+                    wkt = WellKnownType.UInt64;
+                    break;
+                case PrimitiveTypeCode.Single:
+                    wkt = WellKnownType.Single;
+                    break;
+                case PrimitiveTypeCode.Double:
+                    wkt = WellKnownType.Double;
+                    break;
+                case PrimitiveTypeCode.String:
+                    wkt = WellKnownType.String;
+                    break;
+                case PrimitiveTypeCode.TypedReference:
+                    wkt = WellKnownType.TypedReference;
+                    break;
+                case PrimitiveTypeCode.IntPtr:
+                    wkt = WellKnownType.IntPtr;
+                    break;
+                case PrimitiveTypeCode.UIntPtr:
+                    wkt = WellKnownType.UIntPtr;
+                    break;
+                case PrimitiveTypeCode.Object:
+                    wkt = WellKnownType.Object;
+                    break;
+            }
+
+            return _tsc.GetWellKnownType(wkt);
+        }
+
+        TypeDesc ISZArrayTypeProvider<TypeDesc>.GetSZArrayType(TypeDesc elementType)
+        {
+            if (elementType == null)
+                return null;
+
+            return elementType.MakeArrayType();
+        }
+
+        TypeDesc ISimpleTypeProvider<TypeDesc>.GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind)
+        {
+            var ecmaModule = (EcmaModule)_tsc.GetModuleForSimpleName(reader.GetString(reader.GetAssemblyDefinition().Name));
+            return (TypeDesc)ecmaModule.GetObject(handle);
+        }
+
+        TypeDesc ISimpleTypeProvider<TypeDesc>.GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind)
+        {
+            var ecmaModule = (EcmaModule)_tsc.GetModuleForSimpleName(reader.GetString(reader.GetAssemblyDefinition().Name));
+            return (TypeDesc)ecmaModule.GetObject(handle);
+        }
+
+        TypeDesc ISignatureTypeProvider<TypeDesc, R2RSigProviderContext>.GetTypeFromSpecification(MetadataReader reader, R2RSigProviderContext genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+        {
+            var ecmaModule = (EcmaModule)_tsc.GetModuleForSimpleName(reader.GetString(reader.GetAssemblyDefinition().Name));
+            return (TypeDesc)ecmaModule.GetObject(handle);
+        }
+    }
+}

--- a/src/coreclr/src/tools/dotnet-pgo/dotnet-pgo.csproj
+++ b/src/coreclr/src/tools/dotnet-pgo/dotnet-pgo.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj" />
+    <ProjectReference Include="../crossgen2/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj" />
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.55" />
     <PackageReference Include="System.CommandLine" Version="$(SystemCommandLineVersion)" />
     <PackageReference Include="System.Reflection.Metadata" Version="1.8.1" />

--- a/src/coreclr/src/tools/dotnet-pgo/dotnet-pgo.sln
+++ b/src/coreclr/src/tools/dotnet-pgo/dotnet-pgo.sln
@@ -1,0 +1,83 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnet-pgo", "dotnet-pgo.csproj", "{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.Reflection.ReadyToRun", "..\crossgen2\ILCompiler.Reflection.ReadyToRun\ILCompiler.Reflection.ReadyToRun.csproj", "{ED3FE303-74EB-43D1-BEA1-14484A14B22E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ILCompiler.TypeSystem.ReadyToRun", "..\crossgen2\ILCompiler.TypeSystem.ReadyToRun\ILCompiler.TypeSystem.ReadyToRun.csproj", "{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Checked|Any CPU = Checked|Any CPU
+		Checked|x64 = Checked|x64
+		Checked|x86 = Checked|x86
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Checked|Any CPU.ActiveCfg = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Checked|Any CPU.Build.0 = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Checked|x64.ActiveCfg = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Checked|x64.Build.0 = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Checked|x86.ActiveCfg = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Checked|x86.Build.0 = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Debug|x64.Build.0 = Debug|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Debug|x86.Build.0 = Debug|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Release|x64.ActiveCfg = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Release|x64.Build.0 = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Release|x86.ActiveCfg = Release|Any CPU
+		{7DA4CC22-F01D-4505-845F-57C06E5C3F9F}.Release|x86.Build.0 = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Checked|Any CPU.ActiveCfg = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Checked|Any CPU.Build.0 = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Checked|x64.ActiveCfg = Release|x64
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Checked|x64.Build.0 = Release|x64
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Checked|x86.ActiveCfg = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Checked|x86.Build.0 = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Debug|x64.ActiveCfg = Debug|x64
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Debug|x64.Build.0 = Debug|x64
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Debug|x86.Build.0 = Debug|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Release|x64.ActiveCfg = Release|x64
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Release|x64.Build.0 = Release|x64
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Release|x86.ActiveCfg = Release|Any CPU
+		{ED3FE303-74EB-43D1-BEA1-14484A14B22E}.Release|x86.Build.0 = Release|Any CPU
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Checked|Any CPU.ActiveCfg = Checked|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Checked|x64.ActiveCfg = Checked|x64
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Checked|x64.Build.0 = Checked|x64
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Checked|x86.ActiveCfg = Checked|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Checked|x86.Build.0 = Checked|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Debug|x64.ActiveCfg = Debug|x64
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Debug|x64.Build.0 = Debug|x64
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Debug|x86.ActiveCfg = Debug|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Debug|x86.Build.0 = Debug|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Release|Any CPU.ActiveCfg = Release|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Release|x64.ActiveCfg = Release|x64
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Release|x64.Build.0 = Release|x64
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Release|x86.ActiveCfg = Release|x86
+		{D6BA6C4F-F7DF-4414-94BE-8E124CDDDEE6}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {EEBDF807-A078-4F0D-A7F3-A6386B6C0A68}
+	EndGlobalSection
+EndGlobal

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -6262,7 +6262,7 @@ VOID ETW::MethodLog::SendMethodDetailsEvent(MethodDesc *pMethodDesc)
             BulkTypeEventLogger typeLogger;
 
             ULONGLONG typeID = (ULONGLONG)pMethodDesc->GetMethodTable_NoLogging();
-            ETW::TypeSystemLog::LogTypeAndParametersIfNecessary(&typeLogger, typeID, ETW::TypeSystemLog::kTypeLogBehaviorTakeLockAndLogIfFirstTime);
+            ETW::TypeSystemLog::LogTypeAndParametersIfNecessary(&typeLogger, typeID, ETW::TypeSystemLog::kTypeLogBehaviorAlwaysLog);
             ULONGLONG loaderModuleID = (ULONGLONG)pMethodDesc->GetLoaderModule();
 
             StackSArray<ULONGLONG> rgTypeParameters;
@@ -6288,7 +6288,7 @@ VOID ETW::MethodLog::SendMethodDetailsEvent(MethodDesc *pMethodDesc)
             // Log any referenced parameter types
             for (COUNT_T i=0; i < cParams; i++)
             {
-                ETW::TypeSystemLog::LogTypeAndParametersIfNecessary(&typeLogger, rgTypeParameters[i], ETW::TypeSystemLog::kTypeLogBehaviorTakeLockAndLogIfFirstTime);
+                ETW::TypeSystemLog::LogTypeAndParametersIfNecessary(&typeLogger, rgTypeParameters[i], ETW::TypeSystemLog::kTypeLogBehaviorAlwaysLog);
             }
 
             typeLogger.FireBulkTypeEvent();


### PR DESCRIPTION
- Update to mpgo file format to hold weighted call graph data, and exclusive hit sample data
- Implementation of call graph data capture from both jitted and R2R code
- Add mechanism for parsing entrypoints from R2R files into arbitrary type systems insetad of just strings
- Update command line parser in dotnet-pgo to use named properties on class instead of arguments to main method
- Update dotnet-pgo to be able to use a etl.zip file
- Implement infrastructure for performing layout of PE file based on profile guided information
- Implement various profile guided method ordering routines
  - There are a variety of possible algorithms, these are simple to
  implement. More capable ones will generally use the call graph data. As this moves from an experimental feature to a product feature we should remove all but the one shown to be best
  - Sort by exclusive weight
  - Sort by Hot (known to be used) and cold (not known to be used)
  - Sort by Hot (known to be used for more than 128 sample) Warm (known
  to be used) and Cold (not known to be used)
- Since the BulkType logging lock seems to be losing some types, skip the lock for MethodDetails data