### PR TITLE
Enable calling get_runtime_delegate from app context

### DIFF
--- a/docs/design/features/host-error-codes.md
+++ b/docs/design/features/host-error-codes.md
@@ -109,3 +109,5 @@ For example if `hostfxr_get_runtime_property_value` is called with the `host_con
 * `HostPropertyNotFound` (`0x800080a4`) - property requested by `hostfxr_get_runtime_property_value` doesn't exist.
 
 * `CoreHostIncompatibleConfig` (`0x800080a5`) - Error returned by `hostfxr_initialize_for_runtime_config` if the component being initialized requires framework which is not available or incompatible with the frameworks loaded by the runtime already in the process. For example trying to load a component which requires 3.0 into a process which is already running a 2.0 runtime.
+
+* `HostApiUnsupportedScenario` (`0x800080a6`) - Error returned by `hostfxr_get_runtime_delegate` when `hostfxr` doesn't currently support requesting the given delegate type using the given context.

--- a/docs/design/features/native-hosting.md
+++ b/docs/design/features/native-hosting.md
@@ -375,7 +375,7 @@ Starts the runtime and returns a function pointer to specified functionality of 
 * `delegate` - when successful, the native function pointer to the requested runtime functionality.
 
 In .NET Core 3.0 the function only works if `hostfxr_initialize_for_runtime_config` was used to initialize the host context.
-In .NET 5 the function also works if `hostfxr_initialize_for_dotnet_command_line` was used to initialize the host context. Also for .NET 5 it will only be allowed to request `hdt_get_function_pointer` on a context initialized via `hostfxr_initialize_for_dotnet_command_line`, all other runtime delegates will not be supported in this case.
+In .NET 5 the function also works if `hostfxr_initialize_for_dotnet_command_line` was used to initialize the host context. Also for .NET 5 it will only be allowed to request `hdt_load_assembly_and_get_function_pointer` or `hdt_get_function_pointer` on a context initialized via `hostfxr_initialize_for_dotnet_command_line`, all other runtime delegates will not be supported in this case.
 
 
 ### Cleanup

--- a/src/installer/corehost/cli/corehost_context_contract.h
+++ b/src/installer/corehost/cli/corehost_context_contract.h
@@ -9,11 +9,13 @@
 #include "hostpolicy.h"
 #include <pal.h>
 
-enum intialization_options_t : int32_t
+enum initialization_options_t : uint32_t
 {
     none = 0x0,
-    wait_for_initialized = 0x1,  // Wait until initialization through a different request is completed
-    get_contract = 0x2,          // Get the contract for the initialized hostpolicy
+    wait_for_initialized = 0x1,                // Wait until initialization through a different request is completed
+    get_contract = 0x2,                        // Get the contract for the initialized hostpolicy
+    context_contract_version_set = 0x80000000, // The version field has been set in the corehost_context_contract
+                                               // on input indicating the maximum size of the buffer which can be filled
 };
 
 // Delegates for these types will have the stdcall calling convention unless otherwise specified
@@ -25,7 +27,9 @@ enum class coreclr_delegate_type
     winrt_activation,
     com_register,
     com_unregister,
-    load_assembly_and_get_function_pointer
+    load_assembly_and_get_function_pointer,
+
+    __last, // Sentinel value for determining the last known delegate type
 };
 
 #pragma pack(push, _HOST_INTERFACE_PACK)
@@ -38,6 +42,7 @@ struct corehost_initialize_request_t
 static_assert(offsetof(corehost_initialize_request_t, version) == 0 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_initialize_request_t, config_keys) == 1 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_initialize_request_t, config_values) == 3 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(sizeof(corehost_initialize_request_t) == 5 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
 
 struct corehost_context_contract
 {
@@ -59,6 +64,7 @@ struct corehost_context_contract
     int (HOSTPOLICY_CALLTYPE *get_runtime_delegate)(
         coreclr_delegate_type type,
         /*out*/ void **delegate);
+    size_t last_known_delegate_type; // Added in 5.0
 };
 static_assert(offsetof(corehost_context_contract, version) == 0 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_context_contract, get_property_value) == 1 * sizeof(size_t), "Struct offset breaks backwards compatibility");
@@ -67,6 +73,8 @@ static_assert(offsetof(corehost_context_contract, get_properties) == 3 * sizeof(
 static_assert(offsetof(corehost_context_contract, load_runtime) == 4 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_context_contract, run_app) == 5 * sizeof(size_t), "Struct offset breaks backwards compatibility");
 static_assert(offsetof(corehost_context_contract, get_runtime_delegate) == 6 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(offsetof(corehost_context_contract, last_known_delegate_type) == 7 * sizeof(size_t), "Struct offset breaks backwards compatibility");
+static_assert(sizeof(corehost_context_contract) == 8 * sizeof(size_t), "Did you add static asserts for the newly added fields?");
 #pragma pack(pop)
 
 #endif // __COREHOST_CONTEXT_CONTRACT_H__

--- a/src/installer/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/installer/corehost/cli/fxr/fx_muxer.cpp
@@ -870,8 +870,20 @@ int fx_muxer_t::run_app(host_context_t *context)
 
 int fx_muxer_t::get_runtime_delegate(host_context_t *context, coreclr_delegate_type type, void **delegate)
 {
-    if (context->is_app)
-        return StatusCode::InvalidArgFailure;
+    switch (type)
+    {
+    case coreclr_delegate_type::com_activation:
+    case coreclr_delegate_type::load_in_memory_assembly:
+    case coreclr_delegate_type::winrt_activation:
+    case coreclr_delegate_type::com_register:
+    case coreclr_delegate_type::com_unregister:
+        if (context->is_app)
+            return StatusCode::HostApiUnsupportedScenario;
+        break;
+    default:
+        // Always allowed
+        break;
+    }
 
     // last_known_delegate_type was added in 5.0, so old versions won't set it and it will be zero.
     // But when get_runtime_delegate was originally implemented in 3.0,

--- a/src/installer/corehost/cli/fxr/fx_muxer.cpp
+++ b/src/installer/corehost/cli/fxr/fx_muxer.cpp
@@ -735,7 +735,7 @@ int fx_muxer_t::initialize_for_app(
     }
 
     std::unique_ptr<host_context_t> context;
-    rc = initialize_context(hostpolicy_dir, *init, intialization_options_t::none, context);
+    rc = initialize_context(hostpolicy_dir, *init, initialization_options_t::none, context);
     if (rc != StatusCode::Success)
     {
         trace::error(_X("Failed to initialize context for app: %s. Error code: 0x%x"), host_info.app_path.c_str(), rc);
@@ -756,7 +756,7 @@ int fx_muxer_t::initialize_for_runtime_config(
     const pal::char_t *runtime_config_path,
     hostfxr_handle *host_context_handle)
 {
-    int32_t initialization_options = intialization_options_t::none;
+    uint32_t initialization_options = initialization_options_t::none;
     const host_context_t *existing_context;
     {
         std::unique_lock<std::mutex> lock{ g_context_lock };
@@ -773,7 +773,7 @@ int fx_muxer_t::initialize_for_runtime_config(
         }
         else if (existing_context->type == host_context_type::empty)
         {
-            initialization_options |= intialization_options_t::wait_for_initialized;
+            initialization_options |= initialization_options_t::wait_for_initialized;
         }
     }
 
@@ -873,6 +873,16 @@ int fx_muxer_t::get_runtime_delegate(host_context_t *context, coreclr_delegate_t
     if (context->is_app)
         return StatusCode::InvalidArgFailure;
 
+    // last_known_delegate_type was added in 5.0, so old versions won't set it and it will be zero.
+    // But when get_runtime_delegate was originally implemented in 3.0,
+    // it supported up to load_assembly_and_get_function_pointer so we check that first.
+    if (type > coreclr_delegate_type::load_assembly_and_get_function_pointer
+        && (size_t)type > context->hostpolicy_context_contract.last_known_delegate_type)
+    {
+        trace::error(_X("The requested delegate type is not available in the target framework."));
+        return StatusCode::HostApiUnsupportedVersion;
+    }
+
     const corehost_context_contract &contract = context->hostpolicy_context_contract;
     {
         propagate_error_writer_t propagate_error_writer_to_corehost(context->hostpolicy_contract.set_error_writer);
@@ -908,10 +918,12 @@ const host_context_t* fx_muxer_t::get_active_host_context()
         return nullptr;
     }
 
-    corehost_context_contract hostpolicy_context_contract;
+    corehost_context_contract hostpolicy_context_contract = {};
     {
+        hostpolicy_context_contract.version = sizeof(corehost_context_contract);
         propagate_error_writer_t propagate_error_writer_to_corehost(hostpolicy_contract.set_error_writer);
-        int rc = hostpolicy_contract.initialize(nullptr, intialization_options_t::get_contract, &hostpolicy_context_contract);
+        uint32_t options = initialization_options_t::get_contract | initialization_options_t::context_contract_version_set;
+        int rc = hostpolicy_contract.initialize(nullptr, options, &hostpolicy_context_contract);
         if (rc != StatusCode::Success)
         {
             trace::error(_X("Failed to get contract for existing initialized hostpolicy: 0x%x"), rc);

--- a/src/installer/corehost/cli/fxr/host_context.cpp
+++ b/src/installer/corehost/cli/fxr/host_context.cpp
@@ -14,7 +14,7 @@ namespace
         const hostpolicy_contract_t &hostpolicy_contract,
         const host_interface_t *host_interface,
         const corehost_initialize_request_t *init_request,
-        int32_t initialization_options,
+        uint32_t initialization_options,
         bool already_loaded,
         /*out*/ corehost_context_contract *hostpolicy_context_contract)
     {
@@ -35,6 +35,8 @@ namespace
 
             if (rc == StatusCode::Success)
             {
+                initialization_options |= initialization_options_t::context_contract_version_set;
+                hostpolicy_context_contract->version = sizeof(corehost_context_contract);
                 rc = hostpolicy_contract.initialize(init_request, initialization_options, hostpolicy_context_contract);
             }
         }
@@ -46,11 +48,11 @@ namespace
 int host_context_t::create(
     const hostpolicy_contract_t &hostpolicy_contract,
     corehost_init_t &init,
-    int32_t initialization_options,
+    uint32_t initialization_options,
     /*out*/ std::unique_ptr<host_context_t> &context)
 {
     const host_interface_t &host_interface = init.get_host_init_data();
-    corehost_context_contract hostpolicy_context_contract;
+    corehost_context_contract hostpolicy_context_contract = {};
     int rc = create_context_common(hostpolicy_contract, &host_interface, nullptr, initialization_options, /*already_loaded*/ false, &hostpolicy_context_contract);
     if (rc == StatusCode::Success)
     {
@@ -65,7 +67,7 @@ int host_context_t::create(
 int host_context_t::create_secondary(
     const hostpolicy_contract_t &hostpolicy_contract,
     std::unordered_map<pal::string_t, pal::string_t> &config_properties,
-    int32_t initialization_options,
+    uint32_t initialization_options,
     /*out*/ std::unique_ptr<host_context_t> &context)
 {
     std::vector<const pal::char_t*> config_keys;
@@ -83,7 +85,7 @@ int host_context_t::create_secondary(
     init_request.config_values.len = config_values.size();
     init_request.config_values.arr = config_values.data();
 
-    corehost_context_contract hostpolicy_context_contract;
+    corehost_context_contract hostpolicy_context_contract = {};
     int rc = create_context_common(hostpolicy_contract, nullptr, &init_request, initialization_options, /*already_loaded*/ true, &hostpolicy_context_contract);
     if (STATUS_CODE_SUCCEEDED(rc))
     {

--- a/src/installer/corehost/cli/fxr/host_context.h
+++ b/src/installer/corehost/cli/fxr/host_context.h
@@ -27,12 +27,12 @@ public: // static
     static int create(
         const hostpolicy_contract_t &hostpolicy_contract,
         corehost_init_t &init,
-        int32_t initialization_options,
+        uint32_t initialization_options,
         /*out*/ std::unique_ptr<host_context_t> &context);
     static int create_secondary(
         const hostpolicy_contract_t &hostpolicy_contract,
         std::unordered_map<pal::string_t, pal::string_t> &config_properties,
-        int32_t initialization_options,
+        uint32_t initialization_options,
         /*out*/ std::unique_ptr<host_context_t> &context);
     static host_context_t* from_handle(const hostfxr_handle handle, bool allow_invalid_type = false);
 

--- a/src/installer/corehost/cli/fxr/hostfxr.cpp
+++ b/src/installer/corehost/cli/fxr/hostfxr.cpp
@@ -636,7 +636,11 @@ namespace
 // Return value:
 //     The error code result.
 //
-// The host_context_handle must have been initialized using hostfxr_initialize_for_runtime_config.
+// If the host_context_handle was initialized using hostfxr_initialize_for_runtime_config,
+// then all delegate types are supported.
+// If the host_context_handle was initialized using hostfxr_initialize_for_dotnet_command_line,
+// then only the following delegate types are currently supported:
+//     hdt_load_assembly_and_get_function_pointer
 //
 SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_delegate(
     const hostfxr_handle host_context_handle,

--- a/src/installer/corehost/cli/fxr/hostfxr.cpp
+++ b/src/installer/corehost/cli/fxr/hostfxr.cpp
@@ -654,7 +654,11 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_get_runtime_delegate(
     if (context == nullptr)
         return StatusCode::InvalidArgFailure;
 
-    return fx_muxer_t::get_runtime_delegate(context, hostfxr_delegate_to_coreclr_delegate(type), delegate);
+    coreclr_delegate_type delegate_type = hostfxr_delegate_to_coreclr_delegate(type);
+    if (delegate_type == coreclr_delegate_type::invalid)
+        return StatusCode::InvalidArgFailure;
+
+    return fx_muxer_t::get_runtime_delegate(context, delegate_type, delegate);
 }
 
 //

--- a/src/installer/corehost/cli/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/installer/corehost/cli/fxr/standalone/hostpolicy_resolver.cpp
@@ -190,16 +190,20 @@ int hostpolicy_resolver::load(
         }
 
         // Obtain entrypoint symbols
+        g_hostpolicy_contract.corehost_main = reinterpret_cast<corehost_main_fn>(pal::get_symbol(g_hostpolicy, "corehost_main"));
         g_hostpolicy_contract.load = reinterpret_cast<corehost_load_fn>(pal::get_symbol(g_hostpolicy, "corehost_load"));
         g_hostpolicy_contract.unload = reinterpret_cast<corehost_unload_fn>(pal::get_symbol(g_hostpolicy, "corehost_unload"));
         if ((g_hostpolicy_contract.load == nullptr) || (g_hostpolicy_contract.unload == nullptr))
             return StatusCode::CoreHostEntryPointFailure;
 
+        g_hostpolicy_contract.corehost_main_with_output_buffer = reinterpret_cast<corehost_main_with_output_buffer_fn>(pal::get_symbol(g_hostpolicy, "corehost_main_with_output_buffer"));
+
+        // It's possible to not have corehost_main_with_output_buffer.
+        // This was introduced in 2.1, so 2.0 hostpolicy would not have the exports.
+        // Callers are responsible for checking that the function pointer is not null before using it.
+
         g_hostpolicy_contract.set_error_writer = reinterpret_cast<corehost_set_error_writer_fn>(pal::get_symbol(g_hostpolicy, "corehost_set_error_writer"));
         g_hostpolicy_contract.initialize = reinterpret_cast<corehost_initialize_fn>(pal::get_symbol(g_hostpolicy, "corehost_initialize"));
-
-        g_hostpolicy_contract.corehost_main = reinterpret_cast<corehost_main_fn>(pal::get_symbol(g_hostpolicy, "corehost_main"));
-        g_hostpolicy_contract.corehost_main_with_output_buffer = reinterpret_cast<corehost_main_with_output_buffer_fn>(pal::get_symbol(g_hostpolicy, "corehost_main_with_output_buffer"));
 
         // It's possible to not have corehost_set_error_writer and corehost_initialize. These were
         // introduced in 3.0, so 2.0 hostpolicy would not have the exports. In this case, we will

--- a/src/installer/corehost/cli/hostpolicy/hostpolicy_init.cpp
+++ b/src/installer/corehost/cli/hostpolicy/hostpolicy_init.cpp
@@ -26,8 +26,8 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
 
     trace::verbose(_X("Reading from host interface version: [0x%04x:%d] to initialize policy version: [0x%04x:%d]"), input->version_hi, input->version_lo, HOST_INTERFACE_LAYOUT_VERSION_HI, HOST_INTERFACE_LAYOUT_VERSION_LO);
 
-    //This check is to ensure is an old hostfxr can still load new hostpolicy.
-    //We should not read garbage due to potentially shorter struct size
+    // This check is to ensure is an old hostfxr can still load new hostpolicy.
+    // We should not read garbage due to potentially shorter struct size
 
     pal::string_t fx_requested_ver;
 
@@ -51,9 +51,9 @@ bool hostpolicy_init_t::init(host_interface_t* input, hostpolicy_init_t* init)
             offsetof(host_interface_t, host_mode) + sizeof(input->host_mode));
     }
 
-    //An old hostfxr may not provide these fields.
-    //The version_lo (sizeof) the old hostfxr saw at build time will be
-    //smaller and we should not attempt to read the fields in that case.
+    // An old hostfxr may not provide these fields.
+    // The version_lo (sizeof) the old hostfxr saw at build time will be
+    // smaller and we should not attempt to read the fields in that case.
     if (input->version_lo >= offsetof(host_interface_t, tfm) + sizeof(input->tfm))
     {
         init->tfm = input->tfm;

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.h
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.h
@@ -65,4 +65,9 @@ namespace host_context_test
         int argc,
         const pal::char_t *argv[],
         pal::stringstream_t &test_output);
+    bool app_load_assembly_and_get_function_pointer(
+        const pal::string_t &hostfxr_path,
+        int argc,
+        const pal::char_t *argv[],
+        pal::stringstream_t &test_output);
 }

--- a/src/installer/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/installer/corehost/cli/test/nativehost/nativehost.cpp
@@ -241,6 +241,31 @@ int main(const int argc, const pal::char_t *argv[])
         std::cout << tostr(test_output.str()).data() << std::endl;
         return success ? EXIT_SUCCESS : EXIT_FAILURE;
     }
+    else if (pal::strcmp(command, _X("app_load_assembly_and_get_function_pointer")) == 0)
+    {
+        // args: ... <hostfxr_path> <app_path> <assembly_path> <type_name> <method_name> [<assembly_path> <type_name> <method_name>...]
+        const int min_argc = 3;
+        if (argc < min_argc + 4)
+        {
+            std::cerr << "Invalid arguments" << std::endl;
+            return -1;
+        }
+
+        const pal::string_t hostfxr_path = argv[2];
+
+        int remaining_argc = argc - min_argc;
+        const pal::char_t **remaining_argv = nullptr;
+        if (argc > min_argc)
+            remaining_argv = &argv[min_argc];
+
+        pal::stringstream_t test_output;
+        bool success = false;
+
+        success = host_context_test::app_load_assembly_and_get_function_pointer(hostfxr_path, remaining_argc, remaining_argv, test_output);
+
+        std::cout << tostr(test_output.str()).data() << std::endl;
+        return success ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
     else if (pal::strcmp(command, _X("run_app")) == 0)
     {
         // args: ... <hostfxr_path> <dotnet_command_line>

--- a/src/installer/corehost/error_codes.h
+++ b/src/installer/corehost/error_codes.h
@@ -51,6 +51,7 @@ enum StatusCode
     HostInvalidState                    = 0x800080a3,
     HostPropertyNotFound                = 0x800080a4,
     CoreHostIncompatibleConfig          = 0x800080a5,
+    HostApiUnsupportedScenario          = 0x800080a6,
 };
 
 #define STATUS_CODE_SUCCEEDED(status_code) ((static_cast<int>(static_cast<StatusCode>(status_code))) >= 0)


### PR DESCRIPTION
This is the first part of implementing https://github.com/dotnet/runtime/issues/35465. This pull request is supposed to address all the complexities of allowing `hostfxr_get_runtime_delegate` to be called from a context from `hostfxr_initialize_for_dotnet_command_line`. As designed in https://github.com/dotnet/runtime/pull/36990, an app context may only ask for `hdt_load_assembly_and_get_function_pointer`. Implementing the new `hdt_get_function_pointer` type will be done in a subsequent pull request after this one is merged.

As part of this change, there are a couple of behavior changes that may technically be breaking changes.

### Loading the runtime when given an invalid delegate type

In 3.x, `hostfxr_get_runtime_delegate` doesn't error out when given an invalid delegate type. This means that it will load the runtime before calling into `hostpolicy`. Then the `get_delegate` call in `hostpolicy` is where it errors out. This behavior is unacceptable because the native host needs to have control over starting the runtime if there's no chance of getting a delegate from `hostfxr`.

In order to implement this change, I started making `hostpolicy` return the highest delegate type it knows about. Then `hostfxr` will check against that (or `hdt_load_assembly_and_get_function_pointer` if it's an old `hostpolicy`) before trying to load the runtime.

### ~Error code when trying to load SCD component~

~In 3.x, `hostfxr_initialize_for_runtime_config` returns the error code `InvalidConfigFile` when the config is for an SCD component. This error code is misleading since the config file is valid, just not currently supported by `hostfxr`. I made `hostfxr` return the new `HostApiUnsupportedScenario` error code in this case to give the native host better error information.~