### PR TITLE
[libraries] Add ActiveIssues for all Android test failing on helix

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -50,6 +50,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task FlushAsync_DuringReadAsync()
         {
             if (FlushNoOps)
@@ -79,6 +80,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task FlushAsync_DuringFlushAsync()
         {
             if (FlushNoOps)
@@ -155,6 +157,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task ReadAsync_DuringReadAsync()
         {
             byte[] buffer = new byte[32];
@@ -180,6 +183,7 @@ namespace System.IO.Compression
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public virtual async Task Dispose_WithUnfinishedReadAsync()
         {
             string compressedPath = CompressedTestFile(UncompressedTestFile());
@@ -198,6 +202,7 @@ namespace System.IO.Compression
 
         [Theory]
         [MemberData(nameof(UncompressedTestFiles))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task Read(string testFile)
         {
             var uncompressedStream = await LocalMemoryStream.readAppFileAsync(testFile);
@@ -233,6 +238,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task Read_EndOfStreamPosition()
         {
             var compressedStream = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile()));
@@ -252,6 +258,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task Read_BaseStreamSlowly()
         {
             string testFile = UncompressedTestFile();
@@ -436,6 +443,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task TestLeaveOpenAfterValidDecompress()
         {
             //Create the Stream
@@ -1179,6 +1187,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task BaseStream_Modify(CompressionMode mode)
         {
             using (var baseStream = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile())))
@@ -1210,6 +1219,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36845", TestPlatforms.Android)]
         public async Task BaseStream_ValidAfterDisposeWithTrueLeaveOpen(CompressionMode mode)
         {
             var ms = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile()));

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -228,6 +228,7 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task GetAsync_IPv6LinkLocalAddressUri_Success()
         {
             if (IsWinHttpHandler && UseVersion >= HttpVersion20.Value)

--- a/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpClientFactoryTest.cs
+++ b/src/libraries/Microsoft.Extensions.Http/tests/Microsoft.Extensions.Http.Tests/DefaultHttpClientFactoryTest.cs
@@ -342,6 +342,7 @@ namespace Microsoft.Extensions.Http
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported), nameof(PlatformDetection.IsPreciseGcSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37463", TestPlatforms.Android)]
         public async Task Factory_CleanupCycle_DisposesEligibleHandler()
         {
             // Arrange

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/ConversionTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/ConversionTests.cs
@@ -368,6 +368,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Hex_Single_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Hex_Float(float value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
@@ -375,6 +376,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Hex_Double_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Hex_Double(double value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
@@ -382,6 +384,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Hex_Decimal_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Hex_Decimal(decimal value, string expected)
         {
             Assert.Equal(expected, Conversion.Hex(value));
@@ -705,6 +708,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Oct_Single_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Oct_Float(float value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
@@ -712,6 +716,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Oct_Double_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Oct_Double(double value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
@@ -719,6 +724,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Oct_Decimal_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Oct_Decimal(decimal value, string expected)
         {
             Assert.Equal(expected, Conversion.Oct(value));
@@ -886,6 +892,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Val_Object_ArgumentException_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Val_ArgumentException_Object(object value)
         {
             Assert.Throws<ArgumentException>(() => Conversion.Val(value));
@@ -893,6 +900,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Val_Object_OverflowException_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Val_OverflowException_Object(object value)
         {
             Assert.Throws<OverflowException>(() => Conversion.Val(value));
@@ -921,6 +929,7 @@ namespace Microsoft.VisualBasic.Tests
 
         [Theory]
         [MemberData(nameof(Val_String_OverflowException_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Val_OverflowException_String(string value)
         {
             Assert.Throws<OverflowException>(() => Conversion.Val(value));

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/DateTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/DateTypeTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
 
         [Theory]
         [MemberData(nameof(FromObject_Invalid_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void FromObject_ThrowsInvalidCastException(object value)
         {
             Assert.Throws<InvalidCastException>(() => DateType.FromObject(value));

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/FileSystemTests.cs
@@ -27,6 +27,7 @@ namespace Microsoft.VisualBasic.Tests
         // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
         // path that followed the symlink.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void ChDir()
         {
             var savedDirectory = System.IO.Directory.GetCurrentDirectory();
@@ -83,6 +84,7 @@ namespace Microsoft.VisualBasic.Tests
 
         // Can't get current directory on OSX before setting it.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void CurDir()
         {
             Assert.Equal(FileSystem.CurDir(), System.IO.Directory.GetCurrentDirectory());

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/InteractionTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/InteractionTests.cs
@@ -103,6 +103,7 @@ namespace Microsoft.VisualBasic.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void Command()
         {
             var expected = Environment.CommandLine;

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/Microsoft/VisualBasic/FileIO/FileSystemTests.cs
@@ -296,6 +296,7 @@ namespace Microsoft.VisualBasic.FileIO.Tests
         // directory to a symlinked path will result in GetCurrentDirectory returning the absolute
         // path that followed the symlink.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotOSX))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37066", TestPlatforms.Android)]
         public void CurrentDirectorySet()
         {
             var SavedCurrentDirectory = System.IO.Directory.GetCurrentDirectory();

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayTest.cs
@@ -1984,6 +1984,7 @@ namespace System.Collections.Immutable.Tests
 
         [Theory]
         [MemberData(nameof(IStructuralEquatableGetHashCodeData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
         public void IStructuralEquatableGetHashCode(IEnumerable<int> source, IEqualityComparer comparer)
         {
             var array = source.ToImmutableArray();

--- a/src/libraries/System.Collections.NonGeneric/tests/CaseInsensitiveComparerTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/CaseInsensitiveComparerTests.cs
@@ -65,6 +65,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
         public void Ctor_CultureInfo_Compare_TurkishI()
         {
             var cultureNames = Helpers.TestCultureNames;

--- a/src/libraries/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
+++ b/src/libraries/System.Collections.NonGeneric/tests/CaseInsensitiveHashCodeProviderTests.cs
@@ -95,6 +95,7 @@ namespace System.Collections.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
         public void Ctor_CultureInfo_GetHashCodeCompare_TurkishI()
         {
             var cultureNames = Helpers.TestCultureNames;
@@ -150,6 +151,7 @@ namespace System.Collections.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37069", TestPlatforms.Android)]
         public void Default_Compare_TurkishI()
         {
             // Turkish has lower-case and upper-case version of the dotted "i", so the upper case of "i" (U+0069) isn't "I" (U+0049)

--- a/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
+++ b/src/libraries/System.ComponentModel.Composition/tests/System/Integration/DiscoveryTests.cs
@@ -786,6 +786,7 @@ namespace Tests.Integration
         public class FooWithTwoFoos : IFoo1, IFoo2 { }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37464", TestPlatforms.Android)]
         public void InheritedExport_TwoInterfaces()
         {
             var container = ContainerFactory.CreateWithAttributedCatalog(typeof(FooWithTwoFoos));

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -25,6 +25,7 @@ namespace System.ConfigurationTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37071", TestPlatforms.Android)]
         public void GetDirectoryOrRootName_GettingDirectoryFromAFilePath()
         {
             string exePath = AppDomain.CurrentDomain.BaseDirectory;

--- a/src/libraries/System.Console/tests/CancelKeyPress.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.cs
@@ -14,6 +14,7 @@ public partial class CancelKeyPressTests
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void CanAddAndRemoveHandler()
     {
         ConsoleCancelEventHandler handler = (sender, e) =>

--- a/src/libraries/System.Console/tests/Color.cs
+++ b/src/libraries/System.Console/tests/Color.cs
@@ -13,6 +13,7 @@ public class Color
 {
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void InvalidColors()
     {
         AssertExtensions.Throws<ArgumentException>(null, () => Console.BackgroundColor = (ConsoleColor)42);
@@ -21,6 +22,7 @@ public class Color
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void RoundtrippingColor()
     {
         Console.BackgroundColor = Console.BackgroundColor;
@@ -50,6 +52,7 @@ public class Color
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void RedirectedOutputDoesNotUseAnsiSequences()
     {
         // Make sure that redirecting to a memory stream causes Console not to write out the ANSI sequences

--- a/src/libraries/System.Console/tests/Color.cs
+++ b/src/libraries/System.Console/tests/Color.cs
@@ -9,11 +9,11 @@ using System.Text;
 using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
+[ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
 public class Color
 {
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void InvalidColors()
     {
         AssertExtensions.Throws<ArgumentException>(null, () => Console.BackgroundColor = (ConsoleColor)42);
@@ -22,7 +22,6 @@ public class Color
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void RoundtrippingColor()
     {
         Console.BackgroundColor = Console.BackgroundColor;
@@ -52,7 +51,6 @@ public class Color
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void RedirectedOutputDoesNotUseAnsiSequences()
     {
         // Make sure that redirecting to a memory stream causes Console not to write out the ANSI sequences

--- a/src/libraries/System.Console/tests/ConsoleEncoding.cs
+++ b/src/libraries/System.Console/tests/ConsoleEncoding.cs
@@ -23,6 +23,7 @@ public partial class ConsoleEncoding
     [Theory]
     [MemberData(nameof(InputData))]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void TestEncoding(string inputString)
     {
         TextWriter outConsoleStream = Console.Out;
@@ -80,6 +81,7 @@ public partial class ConsoleEncoding
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void TestValidEncodings()
     {
         Action<Encoding> check = encoding =>

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -259,6 +259,7 @@ public class ReadAndWrite
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static unsafe void OutputEncodingPreamble()
     {
         Encoding curEncoding = Console.OutputEncoding;
@@ -282,6 +283,7 @@ public class ReadAndWrite
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static unsafe void OutputEncoding()
     {
         Encoding curEncoding = Console.OutputEncoding;
@@ -350,6 +352,7 @@ public class ReadAndWrite
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void ReadAndReadLine()
     {
         TextWriter savedStandardOutput = Console.Out;

--- a/src/libraries/System.Console/tests/SetIn.cs
+++ b/src/libraries/System.Console/tests/SetIn.cs
@@ -8,11 +8,11 @@ using Xunit;
 //
 // System.Console BCL test cases
 //
+[ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
 public class SetIn
 {
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetInThrowsOnNull()
     {
         TextReader savedIn = Console.In;
@@ -28,7 +28,6 @@ public class SetIn
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetInReadLine()
     {
         const string TextStringFormat = "Test {0}";

--- a/src/libraries/System.Console/tests/SetIn.cs
+++ b/src/libraries/System.Console/tests/SetIn.cs
@@ -12,6 +12,7 @@ public class SetIn
 {
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetInThrowsOnNull()
     {
         TextReader savedIn = Console.In;
@@ -27,6 +28,7 @@ public class SetIn
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetInReadLine()
     {
         const string TextStringFormat = "Test {0}";

--- a/src/libraries/System.Console/tests/SyncTextReader.cs
+++ b/src/libraries/System.Console/tests/SyncTextReader.cs
@@ -79,6 +79,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadToEnd()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);
@@ -94,6 +95,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadBlock()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -113,6 +115,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void Read()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -132,6 +135,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void Peek()
     {
         const string expected = "ABC";
@@ -146,6 +150,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadToEndAsync()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);
@@ -161,6 +166,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadBlockAsync()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -186,6 +192,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadAsync()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -211,6 +218,7 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadLineAsync()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);

--- a/src/libraries/System.Console/tests/SyncTextReader.cs
+++ b/src/libraries/System.Console/tests/SyncTextReader.cs
@@ -7,6 +7,7 @@ using System.Text;
 using Xunit;
 
 
+[ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
 public class SyncTextReader
 {
     // NOTE: These tests test the underlying SyncTextReader by
@@ -79,7 +80,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadToEnd()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);
@@ -95,7 +95,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadBlock()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -115,7 +114,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void Read()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -135,7 +133,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void Peek()
     {
         const string expected = "ABC";
@@ -150,7 +147,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadToEndAsync()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);
@@ -166,7 +162,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadBlockAsync()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -192,7 +187,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadAsync()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -218,7 +212,6 @@ public class SyncTextReader
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void ReadLineAsync()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);

--- a/src/libraries/System.Console/tests/ThreadSafety.cs
+++ b/src/libraries/System.Console/tests/ThreadSafety.cs
@@ -7,13 +7,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
+[ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
 public class ThreadSafety
 {
     const int NumberOfIterations = 100;
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXXCanBeCalledConcurrently()
     {
         Parallel.For(0, NumberOfIterations, i =>
@@ -43,7 +43,6 @@ public class ThreadSafety
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetStandardXXXCanBeCalledConcurrently()
     {
         TextReader savedStandardInput = Console.In;
@@ -87,7 +86,6 @@ public class ThreadSafety
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void ReadMayBeCalledConcurrently()
     {
         const char TestChar = '+';

--- a/src/libraries/System.Console/tests/ThreadSafety.cs
+++ b/src/libraries/System.Console/tests/ThreadSafety.cs
@@ -13,6 +13,7 @@ public class ThreadSafety
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXXCanBeCalledConcurrently()
     {
         Parallel.For(0, NumberOfIterations, i =>
@@ -42,6 +43,7 @@ public class ThreadSafety
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetStandardXXXCanBeCalledConcurrently()
     {
         TextReader savedStandardInput = Console.In;
@@ -85,6 +87,7 @@ public class ThreadSafety
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void ReadMayBeCalledConcurrently()
     {
         const char TestChar = '+';

--- a/src/libraries/System.Console/tests/Timeout.cs
+++ b/src/libraries/System.Console/tests/Timeout.cs
@@ -8,11 +8,11 @@ using Xunit;
 //
 // System.Console BCL test cases
 //
+[ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
 public class TimeOut
 {
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXX_WriteTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -29,7 +29,6 @@ public class TimeOut
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXX_ReadTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -46,7 +45,6 @@ public class TimeOut
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXX_CanTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())

--- a/src/libraries/System.Console/tests/Timeout.cs
+++ b/src/libraries/System.Console/tests/Timeout.cs
@@ -12,6 +12,7 @@ public class TimeOut
 {
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXX_WriteTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -28,6 +29,7 @@ public class TimeOut
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXX_ReadTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -44,6 +46,7 @@ public class TimeOut
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void OpenStandardXXX_CanTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -338,6 +338,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void SetCursorPosition_Invoke_Success()
     {
         if (!OperatingSystem.IsWindows() || (!Console.IsInputRedirected && !Console.IsOutputRedirected))
@@ -365,6 +366,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public static void GetCursorPosition_Invoke_ReturnsExpected()
     {
         if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
@@ -392,6 +394,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void CursorLeft_Set_GetReturnsExpected()
     {
         if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
@@ -414,6 +417,7 @@ public class WindowAndCursorProps
     [InlineData(-1)]
     [InlineData(short.MaxValue + 1)]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void CursorLeft_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
     {
         if (PlatformDetection.IsWindows && Console.IsOutputRedirected)
@@ -435,6 +439,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void CursorTop_Set_GetReturnsExpected()
     {
         if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
@@ -457,6 +462,7 @@ public class WindowAndCursorProps
     [InlineData(-1)]
     [InlineData(short.MaxValue + 1)]
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37465", TestPlatforms.Android)]
     public void CursorTop_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
     {
         if (PlatformDetection.IsWindows & Console.IsOutputRedirected)

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbProviderFactoriesTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbProviderFactoriesTests.cs
@@ -60,6 +60,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void GetFactoryWithDataRowTest()
         {
             ClearRegisteredFactories();
@@ -67,6 +68,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithTypeNameTest()
         {
             ClearRegisteredFactories();
@@ -74,6 +76,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithTypeTest()
         {
             ClearRegisteredFactories();
@@ -81,6 +84,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithInstanceTest()
         {
             ClearRegisteredFactories();
@@ -104,6 +108,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithAssemblyQualifiedNameTest()
         {
             ClearRegisteredFactories();
@@ -127,6 +132,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void UnregisterFactoryTest()
         {
             ClearRegisteredFactories();
@@ -149,6 +155,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void ReplaceFactoryWithRegisterFactoryWithTypeTest()
         {
             ClearRegisteredFactories();
@@ -163,6 +170,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void GetProviderInvariantNamesTest()
         {
             ClearRegisteredFactories();

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbProviderFactoriesTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbProviderFactoriesTests.cs
@@ -16,6 +16,7 @@ namespace System.Data.Common
     }
 
     [PlatformSpecific(~TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
     public class DbProviderFactoriesTests
     {
         [Fact]
@@ -60,7 +61,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void GetFactoryWithDataRowTest()
         {
             ClearRegisteredFactories();
@@ -68,7 +68,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithTypeNameTest()
         {
             ClearRegisteredFactories();
@@ -76,7 +75,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithTypeTest()
         {
             ClearRegisteredFactories();
@@ -84,7 +82,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithInstanceTest()
         {
             ClearRegisteredFactories();
@@ -108,7 +105,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void RegisterFactoryWithAssemblyQualifiedNameTest()
         {
             ClearRegisteredFactories();
@@ -132,7 +128,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void UnregisterFactoryTest()
         {
             ClearRegisteredFactories();
@@ -155,7 +150,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void ReplaceFactoryWithRegisterFactoryWithTypeTest()
         {
             ClearRegisteredFactories();
@@ -170,7 +164,6 @@ namespace System.Data.Common
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void GetProviderInvariantNamesTest()
         {
             ClearRegisteredFactories();

--- a/src/libraries/System.Data.Common/tests/System/Data/FacadeTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/FacadeTest.cs
@@ -11,6 +11,7 @@ namespace System.Data.Tests
         [InlineData("Microsoft.SqlServer.Server.SqlMetaData")] // Type from System.Data.SqlClient
         [InlineData("System.Data.SqlTypes.SqlBytes")] // Type from System.Data.Common
         [PlatformSpecific(~TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36841", TestPlatforms.Android)]
         public void TestSystemData(string typeName)
         {
             // Verify that the type can be loaded via .NET Framework compat facade

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
@@ -67,6 +67,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
         public void Debug_WriteLineNull_IndentsEmptyStringProperly()
         {
             Debug.Indent();
@@ -208,6 +209,7 @@ namespace System.Diagnostics.Tests
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
         public void IndentLevel_Set_GetReturnsExpected(int indentLevel, int expectedIndentLevel)
         {
             Debug.IndentLevel = indentLevel;

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
@@ -196,6 +196,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
         public void Trace_ClearTraceListeners_StopsWritingToDebugger()
         {
             VerifyLogged(() => Debug.Write("pizza"), "pizza");
@@ -229,6 +230,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
         public void TraceWriteLineIf()
         {
             VerifyLogged(() => Trace.WriteLineIf(true, 5), "5" + Environment.NewLine);

--- a/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -18,6 +18,7 @@ namespace System.Diagnostics.Tests
         private const string TestNotFoundFileName = "notfound.dll";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37073", TestPlatforms.Android)]
         public void FileVersionInfo_CustomManagedAssembly()
         {
             // Assembly1.dll

--- a/src/libraries/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/CalendarTests.cs
+++ b/src/libraries/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/CalendarTests.cs
@@ -10,6 +10,7 @@ namespace System.Globalization.Tests
     public static class CalendarTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public static void TestJapaneseCalendarDateParsing()
         {
             CultureInfo ciJapanese = new CultureInfo("ja-JP") { DateTimeFormat = { Calendar = new JapaneseCalendar() } };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -280,6 +280,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Compare_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void Compare(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
             Compare_Advanced(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -174,6 +174,7 @@ namespace System.Globalization.Tests
         [MemberData(nameof(IndexOf_TestData))]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -112,6 +112,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsPrefix_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IsPrefix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected, int expectedMatchLength)
         {
             if (options == CompareOptions.None)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -112,6 +112,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsSuffix_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void IsSuffix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected, int expectedMatchLength)
         {
             if (options == CompareOptions.None)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -151,6 +151,7 @@ namespace System.Globalization.Tests
         [Theory]
         [MemberData(nameof(LastIndexOf_TestData))]
         [MemberData(nameof(LastIndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void LastIndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected, int expectedMatchLength)
         {
             if (value.Length == 1)

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -370,6 +370,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(SortKey_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void SortKeyTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expectedSign)
         {
             SortKey sk1 = compareInfo.GetSortKey(string1, options);

--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -273,6 +273,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToLower_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void ToLower(string name, string str, string expected)
         {
             TestToLower(name, str, expected);
@@ -396,6 +397,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36672", TestPlatforms.Android)]
         public void ToUpper(string name, string str, string expected)
         {
             TestToUpper(name, str, expected);

--- a/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
+++ b/src/libraries/System.IO.IsolatedStorage/tests/System/IO/IsolatedStorage/HelperTests.cs
@@ -37,6 +37,7 @@ namespace System.IO.IsolatedStorage.Tests
             InlineData(IsolatedStorageScope.Assembly | IsolatedStorageScope.Roaming),
             InlineData(IsolatedStorageScope.Machine)
             ]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36836", TestPlatforms.Android)]
         public void GetDataDirectory(IsolatedStorageScope scope)
         {
             // Machine scope is behind a policy that isn't enabled by default

--- a/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Lambda/LambdaTests.cs
@@ -222,6 +222,7 @@ namespace System.Linq.Expressions.Tests
 
         // Order this last to give IcosanaryInt32Func a chance to have been used by other tests.
         [Fact, TestOrder(1)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void ImplicitlyTyped()
         {
             LambdaExpression exp = Expression.Lambda(
@@ -792,6 +793,7 @@ namespace System.Linq.Expressions.Tests
 
 #if FEATURE_COMPILE
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void AboveByteMaxArityArgIL()
         {
             ParameterExpression[] pars = Enumerable.Range(0, 300)
@@ -884,6 +886,7 @@ namespace System.Linq.Expressions.Tests
 
 #if FEATURE_COMPILE
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void AboveByteMaxArityArgAddressIL()
         {
             ParameterExpression parToMutate = Expression.Parameter(typeof(Mutable));
@@ -967,6 +970,7 @@ namespace System.Linq.Expressions.Tests
 
         [Fact]
         [SkipOnTargetFramework(~TargetFrameworkMonikers.Netcoreapp, "Optimization in .NET Core")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public void ValidateThatInterpreterWithSimpleTypeUsesDynamicThunk()
         {
             Expression<Action<object,object,object>> complexaction = (object o1, object o2, object o3) => Console.WriteLine("");

--- a/src/libraries/System.Linq.Expressions/tests/StackSpillerTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/StackSpillerTests.cs
@@ -405,6 +405,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_IndexAssignment_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefInstance_IndexAssignment();
@@ -508,6 +509,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_Index_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefInstance_Index();
@@ -603,6 +605,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_MemberAssignment_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefInstance_MemberAssignment();
@@ -708,6 +711,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_Call_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefInstance_Call();
@@ -802,6 +806,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefArgs_Call_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefArgs_Call();
@@ -894,6 +899,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefArgs_New_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefArgs_New();
@@ -977,6 +983,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefArgs_Invoke_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefArgs_Invoke();
@@ -1088,6 +1095,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefArgs_Invoke_Inline_CodeGen()
         {
             Expression<Func<int>> e = Spill_RefArgs_Invoke_Inline();
@@ -1194,6 +1202,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_ListInit_CodeGen()
         {
             Expression<Func<ValueList>> e = Spill_RefInstance_ListInit();
@@ -1301,6 +1310,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_MemberInit_Assign_Field_CodeGen()
         {
             Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_Assign_Field();
@@ -1408,6 +1418,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_MemberInit_Assign_Property_CodeGen()
         {
             Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_Assign_Property();
@@ -1505,6 +1516,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_MemberInit_MemberBind_CodeGen()
         {
             Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_MemberBind();
@@ -1597,6 +1609,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_RefInstance_MemberInit_ListBind_CodeGen()
         {
             Expression<Func<ValueBar>> e = Spill_RefInstance_MemberInit_ListBind();
@@ -1679,6 +1692,7 @@ namespace System.Linq.Expressions.Tests
 #if FEATURE_COMPILE
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_Constant()
         {
             ParameterExpression xs = Expression.Parameter(typeof(int[]));
@@ -1737,6 +1751,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_Default()
         {
             ParameterExpression xs = Expression.Parameter(typeof(int[]));
@@ -1795,6 +1810,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_LiteralField_NotNetFramework()
         {
             Expression<Func<double>> e =
@@ -1843,6 +1859,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_StaticReadOnlyField()
         {
             Expression<Func<string>> e =
@@ -1892,6 +1909,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_RuntimeVariables1()
         {
             ParameterExpression f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
@@ -1951,6 +1969,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_RuntimeVariables2()
         {
             ParameterExpression f = Expression.Parameter(typeof(Action<IRuntimeVariables, int>));
@@ -2029,6 +2048,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_NoSpillBeyondSpillSite1()
         {
             ParameterExpression f = Expression.Parameter(typeof(Func<int, int, int, int>));
@@ -2102,6 +2122,7 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37474", TestPlatforms.Android)]
         public static void Spill_Optimizations_NoSpillBeyondSpillSite2()
         {
             ParameterExpression f = Expression.Parameter(typeof(Func<int, int, int, int>));

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -51,6 +51,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
         [MemberData(nameof(Loopbacks))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -11,6 +11,7 @@ using Xunit.Abstractions;
 
 namespace System.Net.NetworkInformation.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
     public class IPGlobalPropertiesTest
     {
         private readonly ITestOutputHelper _log;
@@ -51,7 +52,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
         [MemberData(nameof(Loopbacks))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -20,6 +20,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void BasicTest_GetNetworkInterfaces_AtLeastOne()
         {
             Assert.NotEqual<int>(0, NetworkInterface.GetAllNetworkInterfaces().Length);
@@ -132,6 +133,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void BasicTest_StaticLoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv4Support());
@@ -155,6 +157,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void BasicTest_StaticLoopbackIndex_ExceptionIfV4NotSupported()
         {
             Assert.True(Capability.IPv4Support());
@@ -164,6 +167,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void BasicTest_StaticIPv6LoopbackIndex_MatchesLoopbackNetworkInterface()
         {
             Assert.True(Capability.IPv6Support());
@@ -188,6 +192,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void BasicTest_StaticIPv6LoopbackIndex_ExceptionIfV6NotSupported()
         {
             Assert.True(Capability.IPv6Support());
@@ -268,6 +273,7 @@ namespace System.Net.NetworkInformation.Tests
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/20029 and https://github.com/Microsoft/WSL/issues/3561
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void BasicTest_GetIsNetworkAvailable_Success()
         {
             Assert.True(NetworkInterface.GetIsNetworkAvailable());

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -72,6 +72,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task ServerNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {
             using (var serverNoEncryption = new DummyTcpServer(

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -104,6 +104,7 @@ namespace System.Net.Security.Tests
 
         [Theory]
         [MemberData(nameof(Alpn_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task SslStream_StreamToStream_Alpn_Success(List<SslApplicationProtocol> clientProtocols, List<SslApplicationProtocol> serverProtocols, SslApplicationProtocol expected)
         {
             (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
@@ -130,6 +131,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public async Task SslStream_StreamToStream_Alpn_NonMatchingProtocols_Fail()
         {
             TcpListener listener = new TcpListener(IPAddress.Loopback, 0);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SocketOptionNameTest.cs
@@ -520,6 +520,7 @@ namespace System.Net.Sockets.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37087", TestPlatforms.Android)]
         public void GetSetRawSocketOption_Roundtrips(AddressFamily family)
         {
             int SOL_SOCKET;

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -44,7 +44,8 @@ namespace System.Tests
         }
 
         [Fact]
-        [PlatformSpecific(~TestPlatforms.Browser)] // throws pNSE
+        [PlatformSpecific(~TestPlatforms.Browser)] // throws PNSE
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void TargetFrameworkTest()
         {
             const int ExpectedExitCode = 0;

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -42,6 +42,7 @@ namespace System.Tests
         [InlineData(2)] // setting ExitCode both from Main and from an Unloading event handler.
         [InlineData(3)] // using Exit(exitCode)
         [PlatformSpecific(~TestPlatforms.Browser)] // throws PNSE
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void ExitCode_VoidMainAppReturnsSetValue(int mode)
         {
             int expectedExitCode = 123;

--- a/src/libraries/System.Runtime.Extensions/tests/System/StringComparer.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/StringComparer.cs
@@ -96,6 +96,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(UpperLowerCasing_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void CreateWithCulturesTest(string lowerForm, string upperForm, string cultureName)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -195,6 +196,7 @@ namespace System.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         [MemberData(nameof(CreateFromCultureAndOptionsData))]
         [MemberData(nameof(CreateFromCultureAndOptionsStringSortData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void CreateFromCultureAndOptions(string actualString, string expectedString, string cultureName, CompareOptions options, bool result)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -206,6 +208,7 @@ namespace System.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         [MemberData(nameof(CreateFromCultureAndOptionsData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public static void CreateFromCultureAndOptionsStringSort(string actualString, string expectedString, string cultureName, CompareOptions options, bool result)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class RuntimeIdentifierTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void VerifyOSRid()
         {
             Assert.NotNull(RuntimeInformation.RuntimeIdentifier);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionCodeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionCodeTests.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.InteropServices.Tests
     public class GetExceptionCodeTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionCode_NoException_ReturnsZero()
         {
             Assert.Equal(0, Marshal.GetExceptionCode());
@@ -19,6 +20,7 @@ namespace System.Runtime.InteropServices.Tests
         [Theory]
         [InlineData(-1)]
         [InlineData(10)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionCode_NormalExceptionInsideCatch_ReturnsExpected(int hresult)
         {
             try
@@ -39,6 +41,7 @@ namespace System.Runtime.InteropServices.Tests
         [Theory]
         [InlineData(-1)]
         [InlineData(10)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionCode_ComExceptionInsideCatch_ReturnsExpected(int errorCode)
         {
             try

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionCodeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionCodeTests.cs
@@ -8,10 +8,10 @@ using Xunit;
 namespace System.Runtime.InteropServices.Tests
 {
     [SkipOnMono("Marshal.GetExceptionCode will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
     public class GetExceptionCodeTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionCode_NoException_ReturnsZero()
         {
             Assert.Equal(0, Marshal.GetExceptionCode());
@@ -20,7 +20,6 @@ namespace System.Runtime.InteropServices.Tests
         [Theory]
         [InlineData(-1)]
         [InlineData(10)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionCode_NormalExceptionInsideCatch_ReturnsExpected(int hresult)
         {
             try
@@ -41,7 +40,6 @@ namespace System.Runtime.InteropServices.Tests
         [Theory]
         [InlineData(-1)]
         [InlineData(10)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionCode_ComExceptionInsideCatch_ReturnsExpected(int errorCode)
         {
             try

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionPointersTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/GetExceptionPointersTests.cs
@@ -9,6 +9,7 @@ namespace System.Runtime.InteropServices.Tests
     {
         [Fact]
         [SkipOnMono("Marshal.GetExceptionPointers will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void GetExceptionPointers_ReturnsExpected()
         {
             Assert.Equal(IntPtr.Zero, Marshal.GetExceptionPointers());

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -44,6 +44,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteByte_BlittableObject_Roundtrips()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -66,6 +67,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteByte_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -91,6 +93,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadByte_BlittableObject_ReturnsExpected()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -108,6 +111,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadByte_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -140,6 +144,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadByte_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.ReadByte(null, 2));
@@ -147,6 +152,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadByte_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
@@ -168,6 +174,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteByte_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteByte(null, 2, 0));
@@ -175,6 +182,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteByte_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -44,6 +44,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt16_BlittableObject_Roundtrips()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -66,6 +67,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt16_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -91,6 +93,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt16_BlittableObject_ReturnsExpected()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -108,6 +111,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt16_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -135,6 +139,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt16_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.ReadInt16(null, 2));
@@ -142,6 +147,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt16_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
@@ -163,6 +169,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt16_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteInt16(null, 2, 0));
@@ -170,6 +177,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt16_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
@@ -44,6 +44,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt32_BlittableObject_Roundtrips()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -66,6 +67,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt32_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -92,6 +94,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt32_BlittableObject_ReturnsExpected()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -109,6 +112,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt32_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -137,6 +141,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt32_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.ReadInt32(null, 2));
@@ -144,6 +149,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt32_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
@@ -165,6 +171,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt32_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteInt32(null, 2, 0));
@@ -172,6 +179,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt32_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
@@ -44,6 +44,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt64_BlittableObject_Roundtrips()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -66,6 +67,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt64_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -101,6 +103,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt64_BlittableObject_ReturnsExpected()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -118,6 +121,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt64_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -149,6 +153,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt64_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.ReadInt64(null, 2));
@@ -156,6 +161,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadInt64_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
@@ -177,6 +183,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt64_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteInt64(null, 2, 0));
@@ -184,6 +191,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteInt64_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
@@ -51,6 +51,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteIntPtr_BlittableObject_Roundtrips()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -73,6 +74,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteIntPtr_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -99,6 +101,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadIntPtr_BlittableObject_ReturnsExpected()
         {
             int offset1 = Marshal.OffsetOf<BlittableStruct>(nameof(BlittableStruct.value1)).ToInt32();
@@ -116,6 +119,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadIntPtr_StructWithReferenceTypes_ReturnsExpected()
         {
             int pointerOffset = Marshal.OffsetOf<StructWithReferenceTypes>(nameof(StructWithReferenceTypes.pointerValue)).ToInt32();
@@ -144,6 +148,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadIntPtr_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.ReadIntPtr(null, 2));
@@ -151,6 +156,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.ReadIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void ReadIntPtr_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);
@@ -172,6 +178,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteIntPtr_NullObject_ThrowsAccessViolationException()
         {
             Assert.Throws<AccessViolationException>(() => Marshal.WriteIntPtr(null, 2, (IntPtr)0));
@@ -179,6 +186,7 @@ namespace System.Runtime.InteropServices.Tests
 
         [Fact]
         [SkipOnMono("Marshal.WriteIntPtr will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void WriteIntPtr_NotReadable_ThrowsArgumentException()
         {
             AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("Assembly"), AssemblyBuilderAccess.RunAndCollect);

--- a/src/libraries/System.Runtime.Loader/tests/ContextualReflection.cs
+++ b/src/libraries/System.Runtime.Loader/tests/ContextualReflection.cs
@@ -597,6 +597,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void AssemblyLoadStringMultiLoadedAssemblyDefault()
         {
             string name = _fixture.defaultAlcAssembly.GetName().Name;
@@ -613,6 +614,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void AssemblyLoadStringMultiLoadedAssemblyIsolated()
         {
             string name = _fixture.defaultAlcAssembly.GetName().Name;
@@ -745,6 +747,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void TypeGetTypeStringMultiLoadedAssemblyDefault()
         {
             string typeName = typeof(ContextualReflectionTestFixture).AssemblyQualifiedName;
@@ -781,6 +784,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void TypeGetTypeStringMultiLoadedAssemblyIsolated()
         {
             string typeName = typeof(ContextualReflectionTestFixture).AssemblyQualifiedName;
@@ -879,6 +883,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void AssemblyGetTypeStringMultiLoadedAssemblyDefault()
         {
             string typeNameAGenericClass = typeof(AGenericClass<>).FullName;
@@ -902,6 +907,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void AssemblyGetTypeStringMultiLoadedAssemblyIsolated()
         {
             string typeNameAGenericClass = typeof(AGenericClass<>).FullName;
@@ -973,6 +979,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void ActivatorCreateInstanceNullGenericMultiLoadedAssemblyDefault()
         {
             string typeNameAGenericClass = typeof(AGenericClass<>).FullName;
@@ -986,6 +993,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void ActivatorCreateInstanceNullGenericMultiLoadedAssemblyIsolated()
         {
             string typeNameAGenericClass = typeof(AGenericClass<>).FullName;
@@ -999,6 +1007,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void ActivatorCreateInstanceNameGenericMultiLoadedAssemblyDefault()
         {
             string typeNameAGenericClass = typeof(AGenericClass<>).FullName;
@@ -1013,6 +1022,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         void ActivatorCreateInstanceNameGenericMultiLoadedAssemblyIsolated()
         {
             string typeNameAGenericClass = typeof(AGenericClass<>).FullName;

--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -84,6 +84,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37093", TestPlatforms.Android)]
         public void LoadInDefaultContext()
         {
             // This will attempt to load an assembly, by path, in the Default Load context via the Resolving event

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -274,6 +274,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(true, X509ChainStatusFlags.NoError, BuildChainCustomTrustStoreTestArguments.UntrustedIntermediateTrustedRoot)]
         [InlineData(true, X509ChainStatusFlags.NoError, BuildChainCustomTrustStoreTestArguments.TrustedIntermediateTrustedRoot)]
         [InlineData(true, X509ChainStatusFlags.NoError, BuildChainCustomTrustStoreTestArguments.MultipleCalls)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37094", TestPlatforms.Android)]
         public static void BuildChainCustomTrustStore(
             bool chainBuildsSuccessfully,
             X509ChainStatusFlags chainFlags,

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -426,6 +426,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37094", TestPlatforms.Android)]
         public static void MachineRootStore_NonEmpty()
         {
             // This test will fail on systems where the administrator has gone out of their

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -870,6 +870,7 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Groups_CustomCulture_TestData_Danish))]
         [MemberData(nameof(Groups_CustomCulture_TestData_Turkish))]
         [MemberData(nameof(Groups_CustomCulture_TestData_AzeriLatin))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36848", TestPlatforms.Android)]
         public void Groups(string cultureName, string pattern, string input, RegexOptions options, string[] expectedGroups)
         {
             if (cultureName is null)

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -73,6 +73,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [InlineData(2)]
         [InlineData(256)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36848", TestPlatforms.Android)]
         public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture(int length)
         {
             var turkish = new CultureInfo("tr-TR");

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -42,28 +42,11 @@
 
     <!-- Actual test failures -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests\Microsoft.Extensions.Logging.Console.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Immutable\tests\System.Collections.Immutable.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.NonGeneric\tests\System.Collections.NonGeneric.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Console\tests\System.Console.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Debug\tests\System.Diagnostics.Debug.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\CalendarTestWithConfigSwitch\System.Globalization.CalendarsWithConfigSwitch.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.IsolatedStorage\tests\System.IO.IsolatedStorage.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Pipes\tests\System.IO.Pipes.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Sockets\tests\FunctionalTests\System.Net.Sockets.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Extensions\tests\System.Runtime.Extensions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.RuntimeInformation\tests\System.Runtime.InteropServices.RuntimeInformation.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\DefaultContext\System.Runtime.Loader.DefaultContext.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Cryptography.X509Certificates\tests\System.Security.Cryptography.X509Certificates.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Encoding\tests\System.Text.Encoding.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="('$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS') and '$(RunDisablediOSTests)' != 'true'">


### PR DESCRIPTION
This PR takes the iOS tests failures logged as issues on a helix build [here](https://dev.azure.com/dnceng/public/_build/results?buildId=662483&view=results) and adds the `[ActiveIssue...]` attribute to each failing method to be ignored on helix.