### PR TITLE
Disable GetAsync_UnicodeHostName_SuccessStatusCodeInResponse

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1625,6 +1625,7 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external server")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/29424")]
         public async Task GetAsync_UnicodeHostName_SuccessStatusCodeInResponse()
         {
             using (HttpClient client = CreateHttpClient())

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1630,7 +1630,6 @@ namespace System.Net.Http.Functional.Tests
         {
             using (HttpClient client = CreateHttpClient())
             {
-                client.Timeout = TimeSpan.FromSeconds(200);
                 // international version of the Starbucks website
                 // punycode: xn--oy2b35ckwhba574atvuzkc.com
                 string server = "http://\uc2a4\ud0c0\ubc85\uc2a4\ucf54\ub9ac\uc544.com";

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1629,6 +1629,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (HttpClient client = CreateHttpClient())
             {
+                client.Timeout = TimeSpan.FromSeconds(200);
                 // international version of the Starbucks website
                 // punycode: xn--oy2b35ckwhba574atvuzkc.com
                 string server = "http://\uc2a4\ud0c0\ubc85\uc2a4\ucf54\ub9ac\uc544.com";


### PR DESCRIPTION
SocketsHttpHandlerTest_HttpClientHandlerTest_Http2.GetAsync_UnicodeHostName_SuccessStatusCodeInResponse is periodically failing with TimeoutException. It seems to be caused by the target server unavailability, this PR disables the test until a new unicode test host is found.