### PR TITLE
Make Console.ReadKey() distinguish between CR and LF inputs

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(bool convertCrToNl, byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0, bool disableCrLfConversions = false);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(bool disableCrLfConversions, byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern unsafe void InitializeConsoleBeforeRead(bool convertCrToNl, byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern unsafe void InitializeConsoleBeforeRead(bool enableCrNl, byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(bool enableCrNl, byte minChars = 1, byte decisecondsTimeout = 0);
+        internal static extern unsafe void InitializeConsoleBeforeRead(bool convertCrToNl = false, byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
         internal static extern unsafe int ReadStdin(byte* buffer, int bufferSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
-        internal static extern unsafe void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0, bool disableCrLfConversions = false);
+        internal static extern unsafe void InitializeConsoleBeforeRead(bool disableCrLfConversions, byte minChars = 1, byte decisecondsTimeout = 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
         internal static extern unsafe void UninitializeConsoleAfterRead();

--- a/src/libraries/Native/Unix/System.Native/pal_console.c
+++ b/src/libraries/Native/Unix/System.Native/pal_console.c
@@ -184,6 +184,8 @@ static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minCha
         termios.c_lflag &= (uint32_t)(~(ECHO | ICANON | IEXTEN));
     }
 
+    termios.c_iflag &= (uint32_t)(~(ICRNL | INLCR | IGNCR));
+
     termios.c_cc[VMIN] = minChars;
     termios.c_cc[VTIME] = decisecondsTimeout;
 

--- a/src/libraries/Native/Unix/System.Native/pal_console.c
+++ b/src/libraries/Native/Unix/System.Native/pal_console.c
@@ -184,7 +184,6 @@ static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minCha
         termios.c_lflag &= (uint32_t)(~(ECHO | ICANON | IEXTEN));
     }
 
-
     termios.c_cc[VMIN] = minChars;
     termios.c_cc[VTIME] = decisecondsTimeout;
 
@@ -373,7 +372,7 @@ void SystemNative_GetControlCharacters(
 
 int32_t SystemNative_StdinReady()
 {
-    SystemNative_InitializeConsoleBeforeRead(false, 1);
+    SystemNative_InitializeConsoleBeforeRead(1, 0);
     struct pollfd fd = { .fd = STDIN_FILENO, .events = POLLIN };
     int rv = poll(&fd, 1, 0) > 0 ? 1 : 0;
     SystemNative_UninitializeConsoleAfterRead();

--- a/src/libraries/Native/Unix/System.Native/pal_console.c
+++ b/src/libraries/Native/Unix/System.Native/pal_console.c
@@ -186,6 +186,9 @@ static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minCha
 
     if (disableCrLfConversions)
     {
+        // Disable any CR-to-NL, NL-to-CR or Ignore-CR settings
+        // Required for scenaria where the precise input character is needed
+        // such as System.Console.ReadKey()
         termios.c_iflag &= (uint32_t)(~(ICRNL | INLCR | IGNCR));
     }
 

--- a/src/libraries/Native/Unix/System.Native/pal_console.c
+++ b/src/libraries/Native/Unix/System.Native/pal_console.c
@@ -161,7 +161,7 @@ static bool TcSetAttr(struct termios* termios, bool blockIfBackground)
     return rv;
 }
 
-static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minChars, uint8_t decisecondsTimeout, bool blockIfBackground, bool convertCrToNl)
+static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minChars, uint8_t decisecondsTimeout, bool blockIfBackground)
 {
     if (!g_hasTty)
     {
@@ -182,11 +182,6 @@ static bool ConfigureTerminal(bool signalForBreak, bool forChild, uint8_t minCha
     {
         termios.c_iflag &= (uint32_t)(~(IXON | IXOFF | ICRNL | INLCR | IGNCR));
         termios.c_lflag &= (uint32_t)(~(ECHO | ICANON | IEXTEN));
-
-        if (convertCrToNl)
-        {
-            termios.c_iflag |= (uint32_t)(ICRNL);
-        }
     }
 
 
@@ -228,15 +223,13 @@ void UninitializeTerminal()
     }
 }
 
-void SystemNative_InitializeConsoleBeforeRead(int32_t convertCrToNl, uint8_t minChars, uint8_t decisecondsTimeout)
+void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout)
 {
-    assert(convertCrToNl == 0 || convertCrToNl == 1);
-
     if (pthread_mutex_lock(&g_lock) == 0)
     {
         g_reading = true;
 
-        ConfigureTerminal(g_signalForBreak, /* forChild */ false, minChars, decisecondsTimeout, /* blockIfBackground */ true, convertCrToNl);
+        ConfigureTerminal(g_signalForBreak, /* forChild */ false, minChars, decisecondsTimeout, /* blockIfBackground */ true);
 
         pthread_mutex_unlock(&g_lock);
     }
@@ -271,7 +264,7 @@ void SystemNative_ConfigureTerminalForChildProcess(int32_t childUsesTerminal)
             g_hasCurrentTermios = false;
         }
 
-        ConfigureTerminal(g_signalForBreak, /* forChild */ childUsesTerminal, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ false, /* convertCrToNl */ true);
+        ConfigureTerminal(g_signalForBreak, /* forChild */ childUsesTerminal, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ false);
 
         // Redo "Application mode" when there are no more children using the terminal.
         if (!childUsesTerminal)
@@ -380,7 +373,7 @@ void SystemNative_GetControlCharacters(
 
 int32_t SystemNative_StdinReady()
 {
-    SystemNative_InitializeConsoleBeforeRead(false, 1, 0);
+    SystemNative_InitializeConsoleBeforeRead(false, 1);
     struct pollfd fd = { .fd = STDIN_FILENO, .events = POLLIN };
     int rv = poll(&fd, 1, 0) > 0 ? 1 : 0;
     SystemNative_UninitializeConsoleAfterRead();
@@ -416,7 +409,7 @@ int32_t SystemNative_SetSignalForBreak(int32_t signalForBreak)
 
     if (pthread_mutex_lock(&g_lock) == 0)
     {
-        if (ConfigureTerminal(signalForBreak, /* forChild */ false, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ true, /* convertCrToNl */ true))
+        if (ConfigureTerminal(signalForBreak, /* forChild */ false, /* minChars */ 1, /* decisecondsTimeout */ 0, /* blockIfBackground */ true))
         {
             g_signalForBreak = signalForBreak;
             rv = 1;

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -92,7 +92,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout, int32_t disableCrLfConversions);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -92,7 +92,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t enableCrNl, uint8_t minChars, uint8_t decisecondsTimeout);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t convertCrToNl, uint8_t minChars, uint8_t decisecondsTimeout);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -92,7 +92,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t disableCrLfConversions, uint8_t minChars, uint8_t decisecondsTimeout);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t convertCrToNl, uint8_t minChars, uint8_t decisecondsTimeout);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -92,7 +92,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t convertCrToNl, uint8_t minChars, uint8_t decisecondsTimeout);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -92,7 +92,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout, int32_t disableCrLfConversions);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t disableCrLfConversions, uint8_t minChars, uint8_t decisecondsTimeout);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/Native/Unix/System.Native/pal_console.h
+++ b/src/libraries/Native/Unix/System.Native/pal_console.h
@@ -92,7 +92,7 @@ PALEXPORT int32_t SystemNative_StdinReady(void);
 /**
  * Configures the terminal for System.Console Read.
  */
-PALEXPORT void SystemNative_InitializeConsoleBeforeRead(uint8_t minChars, uint8_t decisecondsTimeout);
+PALEXPORT void SystemNative_InitializeConsoleBeforeRead(int32_t enableCrNl, uint8_t minChars, uint8_t decisecondsTimeout);
 
 /**
  * Configures the terminal after System.Console Read.

--- a/src/libraries/System.Console/src/System/ConsoleKeyInfo.cs
+++ b/src/libraries/System.Console/src/System/ConsoleKeyInfo.cs
@@ -34,15 +34,6 @@ namespace System
                 _mods |= ConsoleModifiers.Control;
         }
 
-        internal ConsoleKeyInfo(char keyChar, ConsoleKey key, ConsoleModifiers modifiers)
-        {
-            Debug.Assert(((int)key) >= 0 && ((int)key) <= 255);
-
-            _keyChar = keyChar;
-            _key = key;
-            _mods = modifiers;
-        }
-
         public char KeyChar
         {
             get { return _keyChar; }

--- a/src/libraries/System.Console/src/System/ConsoleKeyInfo.cs
+++ b/src/libraries/System.Console/src/System/ConsoleKeyInfo.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
+
 namespace System
 {
     public readonly struct ConsoleKeyInfo
@@ -30,6 +32,15 @@ namespace System
                 _mods |= ConsoleModifiers.Alt;
             if (control)
                 _mods |= ConsoleModifiers.Control;
+        }
+
+        internal ConsoleKeyInfo(char keyChar, ConsoleKey key, ConsoleModifiers modifiers)
+        {
+            Debug.Assert(((int)key) >= 0 && ((int)key) <= 255);
+
+            _keyChar = keyChar;
+            _key = key;
+            _mods = modifiers;
         }
 
         public char KeyChar

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -44,7 +44,15 @@ namespace System
 
         public static Stream OpenStandardInput()
         {
-            return new UnixConsoleStream(SafeFileHandleHelper.Open(() => Interop.Sys.Dup(Interop.Sys.FileDescriptors.STDIN_FILENO)), FileAccess.Read);
+            Interop.Sys.InitializeConsoleBeforeRead();
+            try
+            {
+                return new UnixConsoleStream(SafeFileHandleHelper.Open(() => Interop.Sys.Dup(Interop.Sys.FileDescriptors.STDIN_FILENO)), FileAccess.Read);
+            }
+            finally
+            {
+                Interop.Sys.UninitializeConsoleAfterRead();
+            }
         }
 
         public static Stream OpenStandardOutput()

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -477,7 +477,7 @@ namespace System
                 // involved in reading/writing, such as when accessing a remote system. We also extend
                 // the timeout on the very first request to 15 seconds, to account for potential latency
                 // before we know if we will receive a response.
-                Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: false, minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
+                Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true, minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
                 try
                 {
                     // Write out the cursor position report request.
@@ -552,7 +552,7 @@ namespace System
                 {
                     if (reinitializeForRead)
                     {
-                        Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: false);
+                        Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true);
                     }
                     else
                     {

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -129,15 +129,6 @@ namespace System
             bool previouslyProcessed;
             ConsoleKeyInfo keyInfo = StdInReader.ReadKey(out previouslyProcessed);
 
-            // Replace the '\n' char for Enter by '\r' to match Windows behavior.
-            if (keyInfo.Key == ConsoleKey.Enter && keyInfo.KeyChar == '\n')
-            {
-                bool shift   = (keyInfo.Modifiers & ConsoleModifiers.Shift)   != 0;
-                bool alt     = (keyInfo.Modifiers & ConsoleModifiers.Alt)     != 0;
-                bool control = (keyInfo.Modifiers & ConsoleModifiers.Control) != 0;
-                keyInfo = new ConsoleKeyInfo('\r', keyInfo.Key, shift, alt, control);
-            }
-
             if (!intercept && !previouslyProcessed && keyInfo.KeyChar != '\0')
             {
                 Console.Write(keyInfo.KeyChar);

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -477,7 +477,7 @@ namespace System
                 // involved in reading/writing, such as when accessing a remote system. We also extend
                 // the timeout on the very first request to 15 seconds, to account for potential latency
                 // before we know if we will receive a response.
-                Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true, minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
+                Interop.Sys.InitializeConsoleBeforeRead(minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
                 try
                 {
                     // Write out the cursor position report request.
@@ -552,7 +552,7 @@ namespace System
                 {
                     if (reinitializeForRead)
                     {
-                        Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true);
+                        Interop.Sys.InitializeConsoleBeforeRead();
                     }
                     else
                     {

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -477,7 +477,7 @@ namespace System
                 // involved in reading/writing, such as when accessing a remote system. We also extend
                 // the timeout on the very first request to 15 seconds, to account for potential latency
                 // before we know if we will receive a response.
-                Interop.Sys.InitializeConsoleBeforeRead(minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
+                Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: false, minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
                 try
                 {
                     // Write out the cursor position report request.
@@ -552,7 +552,7 @@ namespace System
                 {
                     if (reinitializeForRead)
                     {
-                        Interop.Sys.InitializeConsoleBeforeRead();
+                        Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: false);
                     }
                     else
                     {

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -477,7 +477,7 @@ namespace System
                 // involved in reading/writing, such as when accessing a remote system. We also extend
                 // the timeout on the very first request to 15 seconds, to account for potential latency
                 // before we know if we will receive a response.
-                Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: false, minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
+                Interop.Sys.InitializeConsoleBeforeRead(minChars: (byte)(s_everReceivedCursorPositionResponse ? 1 : 0), decisecondsTimeout: (byte)(s_firstCursorPositionRequest ? 100 : 10));
                 try
                 {
                     // Write out the cursor position report request.
@@ -552,7 +552,7 @@ namespace System
                 {
                     if (reinitializeForRead)
                     {
-                        Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: false);
+                        Interop.Sys.InitializeConsoleBeforeRead();
                     }
                     else
                     {
@@ -1210,7 +1210,7 @@ namespace System
         /// <returns>The number of bytes read, or a negative value if there's an error.</returns>
         internal static unsafe int Read(SafeFileHandle fd, byte[] buffer, int offset, int count)
         {
-            Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: true);
+            Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true);
             try
             {
                 fixed (byte* bufPtr = buffer)

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -88,7 +88,7 @@ namespace System.IO
             Debug.Assert(_tmpKeys.Count == 0);
             string? readLineStr = null;
 
-            Interop.Sys.InitializeConsoleBeforeRead();
+            Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: false);
             try
             {
                 // Read key-by-key until we've read a line.

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -88,7 +88,7 @@ namespace System.IO
             Debug.Assert(_tmpKeys.Count == 0);
             string? readLineStr = null;
 
-            Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: false);
+            Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true);
             try
             {
                 // Read key-by-key until we've read a line.
@@ -97,7 +97,7 @@ namespace System.IO
                     // Read the next key.  This may come from previously read keys, from previously read but
                     // unprocessed data, or from an actual stdin read.
                     bool previouslyProcessed;
-                    ConsoleKeyInfo keyInfo = ReadKeyCore(disableCrLfConversions: false, out previouslyProcessed);
+                    ConsoleKeyInfo keyInfo = ReadKeyCore(convertCrToNl: true, out previouslyProcessed);
                     if (!consumeKeys && keyInfo.Key != ConsoleKey.Backspace) // backspace is the only character not written out in the below if/elses.
                     {
                         _tmpKeys.Push(keyInfo);
@@ -364,8 +364,8 @@ namespace System.IO
 
         public ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
         {
-            // Console.ReadKey() requires the precise input character
-            return ReadKeyCore(disableCrLfConversions: true, out previouslyProcessed);
+            // Disable CR to LF conversions for accurate key reporting
+            return ReadKeyCore(convertCrToNl: false, out previouslyProcessed);
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace System.IO
         /// not work, we simply return the char associated with that
         /// key with ConsoleKey set to default value.
         /// </summary>
-        private unsafe ConsoleKeyInfo ReadKeyCore(bool disableCrLfConversions, out bool previouslyProcessed)
+        private unsafe ConsoleKeyInfo ReadKeyCore(bool convertCrToNl, out bool previouslyProcessed)
         {
             // Order of reading:
             // 1. A read should first consult _availableKeys, as this contains input that has already been both read from stdin and processed into ConsoleKeyInfos.
@@ -392,7 +392,7 @@ namespace System.IO
             }
 
             previouslyProcessed = false;
-            Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: disableCrLfConversions);
+            Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: convertCrToNl);
             try
             {
                 ConsoleKey key;

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -97,7 +97,7 @@ namespace System.IO
                     // Read the next key.  This may come from previously read keys, from previously read but
                     // unprocessed data, or from an actual stdin read.
                     bool previouslyProcessed;
-                    ConsoleKeyInfo keyInfo = ReadKeyCore(convertCrToLf: true, out previouslyProcessed);
+                    ConsoleKeyInfo keyInfo = ReadKey(out previouslyProcessed);
                     if (!consumeKeys && keyInfo.Key != ConsoleKey.Backspace) // backspace is the only character not written out in the below if/elses.
                     {
                         _tmpKeys.Push(keyInfo);
@@ -362,12 +362,6 @@ namespace System.IO
             return key != default(ConsoleKey);
         }
 
-        public ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
-        {
-            // Disable CR to LF conversions for accurate key reporting
-            return ReadKeyCore(convertCrToLf: false, out previouslyProcessed);
-        }
-
         /// <summary>
         /// Try to intercept the key pressed.
         ///
@@ -378,7 +372,7 @@ namespace System.IO
         /// not work, we simply return the char associated with that
         /// key with ConsoleKey set to default value.
         /// </summary>
-        private unsafe ConsoleKeyInfo ReadKeyCore(bool convertCrToLf, out bool previouslyProcessed)
+        public unsafe ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
         {
             // Order of reading:
             // 1. A read should first consult _availableKeys, as this contains input that has already been both read from stdin and processed into ConsoleKeyInfos.
@@ -423,12 +417,6 @@ namespace System.IO
                 }
 
                 MapBufferToConsoleKey(out key, out ch, out isShift, out isAlt, out isCtrl);
-
-                // Replace the '\r' char with '\n' to match windows behaviour.
-                if (convertCrToLf && key == ConsoleKey.Enter && ch == '\r')
-                {
-                    ch = '\n';
-                }
 
                 return new ConsoleKeyInfo(ch, key, isShift, isAlt, isCtrl);
             }

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -255,6 +255,7 @@ namespace System.IO
                     return ConsoleKey.Enter;
 
                 case '\n':
+                    // Windows compatibility; LF is Ctrl+Enter
                     isCtrl = true;
                     return ConsoleKey.Enter;
 
@@ -361,8 +362,11 @@ namespace System.IO
             return key != default(ConsoleKey);
         }
 
-        public ConsoleKeyInfo ReadKey(out bool previouslyProcessed) =>
-            ReadKeyCore(disableCrLfConversions: true, out previouslyProcessed);
+        public ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
+        {
+            // Console.ReadKey() requires the precise input character
+            return ReadKeyCore(disableCrLfConversions: true, out previouslyProcessed);
+        }
 
         /// <summary>
         /// Try to intercept the key pressed.

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -88,7 +88,7 @@ namespace System.IO
             Debug.Assert(_tmpKeys.Count == 0);
             string? readLineStr = null;
 
-            Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: true);
+            Interop.Sys.InitializeConsoleBeforeRead();
             try
             {
                 // Read key-by-key until we've read a line.
@@ -97,7 +97,7 @@ namespace System.IO
                     // Read the next key.  This may come from previously read keys, from previously read but
                     // unprocessed data, or from an actual stdin read.
                     bool previouslyProcessed;
-                    ConsoleKeyInfo keyInfo = ReadKeyCore(convertCrToNl: true, out previouslyProcessed);
+                    ConsoleKeyInfo keyInfo = ReadKeyCore(convertCrToLf: true, out previouslyProcessed);
                     if (!consumeKeys && keyInfo.Key != ConsoleKey.Backspace) // backspace is the only character not written out in the below if/elses.
                     {
                         _tmpKeys.Push(keyInfo);
@@ -365,7 +365,7 @@ namespace System.IO
         public ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
         {
             // Disable CR to LF conversions for accurate key reporting
-            return ReadKeyCore(convertCrToNl: false, out previouslyProcessed);
+            return ReadKeyCore(convertCrToLf: false, out previouslyProcessed);
         }
 
         /// <summary>
@@ -378,7 +378,7 @@ namespace System.IO
         /// not work, we simply return the char associated with that
         /// key with ConsoleKey set to default value.
         /// </summary>
-        private unsafe ConsoleKeyInfo ReadKeyCore(bool convertCrToNl, out bool previouslyProcessed)
+        private unsafe ConsoleKeyInfo ReadKeyCore(bool convertCrToLf, out bool previouslyProcessed)
         {
             // Order of reading:
             // 1. A read should first consult _availableKeys, as this contains input that has already been both read from stdin and processed into ConsoleKeyInfos.
@@ -392,7 +392,7 @@ namespace System.IO
             }
 
             previouslyProcessed = false;
-            Interop.Sys.InitializeConsoleBeforeRead(convertCrToNl: convertCrToNl);
+            Interop.Sys.InitializeConsoleBeforeRead();
             try
             {
                 ConsoleKey key;
@@ -423,6 +423,13 @@ namespace System.IO
                 }
 
                 MapBufferToConsoleKey(out key, out ch, out isShift, out isAlt, out isCtrl);
+
+                // Replace the '\r' char with '\n' to match windows behaviour.
+                if (convertCrToLf && key == ConsoleKey.Enter && ch == '\r')
+                {
+                    ch = '\n';
+                }
+
                 return new ConsoleKeyInfo(ch, key, isShift, isAlt, isCtrl);
             }
             finally

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -221,9 +221,10 @@ namespace System.IO
             if (_availableKeys.Count > 0)
             {
                 ConsoleKeyInfo keyInfo = peek ? _availableKeys.Peek() : _availableKeys.Pop();
-                if (!IsEol(keyInfo.KeyChar))
+                char keyChar = (keyInfo.KeyChar == '\r') ? '\n' : keyInfo.KeyChar; // Map CR chars to LF
+                if (!IsEol(keyChar))
                 {
-                    return keyInfo.KeyChar;
+                    return keyChar;
                 }
             }
 

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -88,7 +88,7 @@ namespace System.IO
             Debug.Assert(_tmpKeys.Count == 0);
             string? readLineStr = null;
 
-            Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: false);
+            Interop.Sys.InitializeConsoleBeforeRead();
             try
             {
                 // Read key-by-key until we've read a line.
@@ -386,7 +386,7 @@ namespace System.IO
             }
 
             previouslyProcessed = false;
-            Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: false);
+            Interop.Sys.InitializeConsoleBeforeRead();
             try
             {
                 ConsoleKey key;

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -97,7 +97,7 @@ namespace System.IO
                     // Read the next key.  This may come from previously read keys, from previously read but
                     // unprocessed data, or from an actual stdin read.
                     bool previouslyProcessed;
-                    ConsoleKeyInfo keyInfo = ReadKey(out previouslyProcessed);
+                    ConsoleKeyInfo keyInfo = ReadKeyCore(disableCrLfConversions: false, out previouslyProcessed);
                     if (!consumeKeys && keyInfo.Key != ConsoleKey.Backspace) // backspace is the only character not written out in the below if/elses.
                     {
                         _tmpKeys.Push(keyInfo);
@@ -361,6 +361,9 @@ namespace System.IO
             return key != default(ConsoleKey);
         }
 
+        public ConsoleKeyInfo ReadKey(out bool previouslyProcessed) =>
+            ReadKeyCore(disableCrLfConversions: true, out previouslyProcessed);
+
         /// <summary>
         /// Try to intercept the key pressed.
         ///
@@ -371,7 +374,7 @@ namespace System.IO
         /// not work, we simply return the char associated with that
         /// key with ConsoleKey set to default value.
         /// </summary>
-        public unsafe ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
+        private unsafe ConsoleKeyInfo ReadKeyCore(bool disableCrLfConversions, out bool previouslyProcessed)
         {
             // Order of reading:
             // 1. A read should first consult _availableKeys, as this contains input that has already been both read from stdin and processed into ConsoleKeyInfos.
@@ -385,7 +388,7 @@ namespace System.IO
             }
 
             previouslyProcessed = false;
-            Interop.Sys.InitializeConsoleBeforeRead();
+            Interop.Sys.InitializeConsoleBeforeRead(disableCrLfConversions: disableCrLfConversions);
             try
             {
                 ConsoleKey key;

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -88,7 +88,7 @@ namespace System.IO
             Debug.Assert(_tmpKeys.Count == 0);
             string? readLineStr = null;
 
-            Interop.Sys.InitializeConsoleBeforeRead();
+            Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: false);
             try
             {
                 // Read key-by-key until we've read a line.
@@ -392,7 +392,7 @@ namespace System.IO
             }
 
             previouslyProcessed = false;
-            Interop.Sys.InitializeConsoleBeforeRead();
+            Interop.Sys.InitializeConsoleBeforeRead(enableCrNl: false);
             try
             {
                 ConsoleKey key;

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -251,7 +251,11 @@ namespace System.IO
                 case '\t':
                     return ConsoleKey.Tab;
 
+                case '\r':
+                    return ConsoleKey.Enter;
+
                 case '\n':
+                    isCtrl = true;
                     return ConsoleKey.Enter;
 
                 case (char)(0x1B):

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -97,7 +97,7 @@ namespace System
             }
         }
 
-        [Fact]
+        [ConditionalFact(nameof(ManualTestsEnabled))]
         public static void OpenStandardInput()
         {
             Console.WriteLine("Please type \"console\" (without the quotes). You shouldn't see it as you type:");
@@ -213,7 +213,7 @@ namespace System
             ConsoleKeyInfo info = Console.ReadKey();
             Console.WriteLine();
 
-            switch(info.Key)
+            switch (info.Key)
             {
                 case ConsoleKey.Y or ConsoleKey.N:
                     Assert.Equal(ConsoleKey.Y, info.Key);

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -97,6 +97,18 @@ namespace System
             }
         }
 
+        [Fact]
+        public static void OpenStandardInput()
+        {
+            Console.WriteLine("Please type \"console\" (without the quotes). You shouldn't see it as you type:");
+            var stream = Console.OpenStandardInput();
+            var textReader = new System.IO.StreamReader(stream);
+            var result = textReader.ReadLine();
+
+            Assert.Equal("console", result);
+            AssertUserExpectedResults("\"console\" correctly not echoed as you typed it");
+        }
+
         [ConditionalFact(nameof(ManualTestsEnabled))]
         public static void ConsoleOutWriteLine()
         {

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -38,7 +38,7 @@ namespace System
         [ConditionalFact(nameof(ManualTestsEnabled))]
         public static void InPeek()
         {
-            Console.WriteLine("Please type \"peek\" (without the quotes). You shouldn't see it as you type:");
+            Console.WriteLine("Please type \"peek\" (without the quotes). You should see it as you type:");
             foreach (char c in new[] { 'p', 'e', 'e', 'k' })
             {
                 Assert.Equal(c, Console.In.Peek());
@@ -65,6 +65,36 @@ namespace System
                 Assert.Equal(k, Console.ReadKey(intercept: true).Key);
             }
             AssertUserExpectedResults("\"console\" correctly not echoed as you typed it");
+        }
+
+        [ConditionalTheory(nameof(ManualTestsEnabled))]
+        [InlineData('\x01', ConsoleKey.A, ConsoleModifiers.Control)]
+        [InlineData('\x01', ConsoleKey.A, ConsoleModifiers.Control | ConsoleModifiers.Alt)]
+        [InlineData('\r', ConsoleKey.Enter, (ConsoleModifiers)0)]
+        [InlineData('\n', ConsoleKey.Enter, ConsoleModifiers.Control)]
+        public static void ReadKey_KeyChords(char keyChar, ConsoleKey key, ConsoleModifiers modifiers)
+        {
+            var expected = new ConsoleKeyInfo(keyChar, key, 
+                control: modifiers.HasFlag(ConsoleModifiers.Control),
+                alt: modifiers.HasFlag(ConsoleModifiers.Alt),
+                shift: modifiers.HasFlag(ConsoleModifiers.Shift));
+
+            Console.Write($"Please type key chord {RenderKeyChord(expected)}: ");
+            var actual = Console.ReadKey(intercept: true);
+            Console.WriteLine();
+
+            Assert.Equal(expected.Key, actual.Key);
+            Assert.Equal(expected.Modifiers, actual.Modifiers);
+            Assert.Equal(expected.KeyChar, actual.KeyChar);
+
+            static string RenderKeyChord(ConsoleKeyInfo key)
+            {
+                string modifiers = "";
+                if (key.Modifiers.HasFlag(ConsoleModifiers.Control)) modifiers += "Ctrl+";
+                if (key.Modifiers.HasFlag(ConsoleModifiers.Alt)) modifiers += "Alt+";
+                if (key.Modifiers.HasFlag(ConsoleModifiers.Shift)) modifiers += "Shift+";
+                return modifiers + key.Key;
+            }
         }
 
         [ConditionalFact(nameof(ManualTestsEnabled))]
@@ -168,8 +198,19 @@ namespace System
         private static void AssertUserExpectedResults(string expected)
         {
             Console.Write($"Did you see {expected}? [y/n] ");
-            Assert.Equal(ConsoleKey.Y, Console.ReadKey().Key);
+            ConsoleKeyInfo info = Console.ReadKey();
             Console.WriteLine();
+
+            switch(info.Key)
+            {
+                case ConsoleKey.Y or ConsoleKey.N:
+                    Assert.Equal(ConsoleKey.Y, info.Key);
+                    break;
+
+                default:
+                    AssertUserExpectedResults(expected);
+                    break;
+            };
         }
     }
 }

--- a/src/libraries/System.Console/tests/ManualTests/Readme.md
+++ b/src/libraries/System.Console/tests/ManualTests/Readme.md
@@ -1,0 +1,9 @@
+# System.Console manual tests
+
+For verifying console functionality that cannot be run as fully automated.
+To run the suite, follow these steps:
+
+1. Build the CLR and libraries.
+2. Using a terminal, navigate to the current folder.
+3. Enable manual testing by defining the `MANUAL_TESTS` environment variable (e.g. on bash `export MANUAL_TESTS=true`).
+4. Run `dotnet test` and follow the instructions in the command prompt.


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/802.

Fixes an issue on Unix which fails to distinguish between `^J` and `^M` inputs when calling `Console.ReadKey()`. On Windows:

```fsharp
$ dotnet fsi

> System.Console.ReadKey();; // Enter

val it : System.ConsoleKeyInfo = System.ConsoleKeyInfo {Key = Enter;
                                                        KeyChar = '\013';
                                                        Modifiers = 0;}

> System.Console.ReadKey();; // Ctrl + Enter

val it : System.ConsoleKeyInfo = System.ConsoleKeyInfo {Key = Enter;
                                                        KeyChar = '\010';
                                                        Modifiers = Control;}
```

However on Mac/Linux we have the following behaviour:

```fsharp
$ dotnet fsi

> System.Console.ReadKey();; // Enter

val it : System.ConsoleKeyInfo = System.ConsoleKeyInfo {Key = Enter;
                                                        KeyChar = '\013';
                                                        Modifiers = 0;}

> System.Console.ReadKey();; // Ctrl+Enter

val it : System.ConsoleKeyInfo = System.ConsoleKeyInfo {Key = Enter;
                                                        KeyChar = '\013';
                                                        Modifiers = 0;}
```

This PR fixes that discrepancy by introducing a change to the `pal_console` layer, where the [termios `ICRNL` flag](https://linux.die.net/man/3/termios) is disabled when `Console.ReadKey()` operations are performed. 

Note that other console read operations (e.g. `Console.Read()`) do not disable this flag, so the current behaviour of mapping CR to LF is preserved. On windows:
```fsharp
$ dotnet fsi
> while true do System.Console.WriteLine(System.Console.Read()) ;; 

// Enter
13
10
```
And on Linux:
```fsharp
$ dotnet fsi
> while true do System.Console.WriteLine(System.Console.Read()) ;;

// Enter
10

// Ctrl+Enter
10
```