### PR TITLE
Annotate System.Security.Cryptography.ProtectedData for nullable reference types

### DIFF
--- a/src/libraries/System.Security.Cryptography.ProtectedData/ref/System.Security.Cryptography.ProtectedData.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/ref/System.Security.Cryptography.ProtectedData.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography
     }
     public static partial class ProtectedData
     {
-        public static byte[] Protect(byte[] userData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
-        public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
+        public static byte[] Protect(byte[] userData, byte[]? optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
+        public static byte[] Unprotect(byte[] encryptedData, byte[]? optionalEntropy, System.Security.Cryptography.DataProtectionScope scope) { throw null; }
     }
 }

--- a/src/libraries/System.Security.Cryptography.ProtectedData/ref/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/ref/System.Security.Cryptography.ProtectedData.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461;$(NetFrameworkCurrent)</TargetFrameworks>
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System.Security.Cryptography.ProtectedData.csproj
@@ -3,6 +3,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>netstandard2.0-Windows_NT;net461-Windows_NT;netstandard2.0;$(NetFrameworkCurrent)-Windows_NT</TargetFrameworks>
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/src/System/Security/Cryptography/ProtectedData.cs
@@ -15,7 +15,7 @@ namespace System.Security.Cryptography
     {
         private static readonly byte[] s_nonEmpty = new byte[1];
 
-        public static byte[] Protect(byte[] userData, byte[] optionalEntropy, DataProtectionScope scope)
+        public static byte[] Protect(byte[] userData, byte[]? optionalEntropy, DataProtectionScope scope)
         {
             if (userData == null)
                 throw new ArgumentNullException(nameof(userData));
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography
             return ProtectOrUnprotect(userData, optionalEntropy, scope, protect: true);
         }
 
-        public static byte[] Unprotect(byte[] encryptedData, byte[] optionalEntropy, DataProtectionScope scope)
+        public static byte[] Unprotect(byte[] encryptedData, byte[]? optionalEntropy, DataProtectionScope scope)
         {
             if (encryptedData == null)
                 throw new ArgumentNullException(nameof(encryptedData));
@@ -31,7 +31,7 @@ namespace System.Security.Cryptography
             return ProtectOrUnprotect(encryptedData, optionalEntropy, scope, protect: false);
         }
 
-        private static byte[] ProtectOrUnprotect(byte[] inputData, byte[] optionalEntropy, DataProtectionScope scope, bool protect)
+        private static byte[] ProtectOrUnprotect(byte[] inputData, byte[]? optionalEntropy, DataProtectionScope scope, bool protect)
         {
             unsafe
             {


### PR DESCRIPTION
cc: @buyaa-n, @bartonjs 
Contributes to #2339 

This is just annotating the public surface area.  We have all nullable warnings disabled when building against netfx and netstandard2.0.