### PR TITLE
Implement ModuleBuilder.GetFieldToken

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/Emit/ModuleBuilder.Mono.cs
@@ -563,8 +563,7 @@ namespace System.Reflection.Emit
             if (field == null)
                 throw new ArgumentNullException(nameof(field));
 
-            throw new NotImplementedException();
-            //return new FieldToken (GetToken (field));
+            return new FieldToken(GetToken (field), field.GetType());
         }
 
         // FIXME:


### PR DESCRIPTION
I am not sure why this was not filled in, ModuleBuilder has support for `FieldBuilder` pseudo-tokens in the same file, and support for `RuntimeFieldInfo` in `sre.c:mono_image_create_token`.

Contributes to https://github.com/mono/mono/issues/14788