### PR TITLE
[libraries] Add ActiveIssues for locally failing iOS tests

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -51,6 +51,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task FlushAsync_DuringReadAsync()
         {
             if (FlushNoOps)
@@ -80,6 +81,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task FlushAsync_DuringFlushAsync()
         {
             if (FlushNoOps)
@@ -156,6 +158,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ReadAsync_DuringReadAsync()
         {
             byte[] buffer = new byte[32];
@@ -181,6 +184,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public virtual async Task Dispose_WithUnfinishedReadAsync()
         {
             string compressedPath = CompressedTestFile(UncompressedTestFile());
@@ -199,6 +203,7 @@ namespace System.IO.Compression
 
         [Theory]
         [MemberData(nameof(UncompressedTestFiles))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task Read(string testFile)
         {
             var uncompressedStream = await LocalMemoryStream.readAppFileAsync(testFile);
@@ -234,6 +239,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task Read_EndOfStreamPosition()
         {
             var compressedStream = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile()));
@@ -253,6 +259,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task Read_BaseStreamSlowly()
         {
             string testFile = UncompressedTestFile();
@@ -437,6 +444,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task TestLeaveOpenAfterValidDecompress()
         {
             //Create the Stream
@@ -1180,6 +1188,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task BaseStream_Modify(CompressionMode mode)
         {
             using (var baseStream = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile())))
@@ -1211,6 +1220,7 @@ namespace System.IO.Compression
         [Theory]
         [InlineData(CompressionMode.Compress)]
         [InlineData(CompressionMode.Decompress)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task BaseStream_ValidAfterDisposeWithTrueLeaveOpen(CompressionMode mode)
         {
             var ms = await LocalMemoryStream.readAppFileAsync(CompressedTestFile(UncompressedTestFile()));

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAImportExport.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         public static bool SupportsKeyGeneration => DSAFactory.SupportsKeyGeneration;
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAutoKey()
         {
             DSAParameters privateParams;
@@ -41,6 +42,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Import_512()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -52,6 +54,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Import_576()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -63,6 +66,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Import_1024()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -74,6 +78,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Import_2048()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -85,6 +90,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void MultiExport()
         {
             DSAParameters imported = DSATestData.GetDSA1024Params();
@@ -115,6 +121,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportRoundTrip(bool includePrivate)
         {
             DSAParameters imported = DSATestData.GetDSA1024Params();
@@ -135,6 +142,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAfterDispose(bool importKey)
         {
             DSA key = importKey ? DSAFactory.Create(DSATestData.GetDSA1024Params()) : DSAFactory.Create(512);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyFileTests.cs
@@ -13,12 +13,14 @@ namespace System.Security.Cryptography.Dsa.Tests
         public static bool SupportsFips186_3 => DSAFactory.SupportsFips186_3;
 
         [ConditionalFact(typeof(DSAFactory), nameof(DSAFactory.SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void UseAfterDispose_NewKey()
         {
             UseAfterDispose(false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void UseAfterDispose_ImportedKey()
         {
             UseAfterDispose(true);
@@ -72,6 +74,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa512Pkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -85,6 +88,7 @@ fve77OGaTv4qbZwinTYAg86p9yHzmwW6+XBS3vxnpYorBBYCFC49eoTIW2Z4Xh9v
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa2048DeficientXPkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -106,6 +110,7 @@ hpTvzzEtnljU3dHAHig4M/TxSeX5vUVJMEQxthvg2tcXtTjFzVL94ajmYZPonQnB
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa512EncryptedPkcs8()
         {
             // pbeWithSHA1And40BitRC2-CBC (PKCS12-PBE)
@@ -126,6 +131,7 @@ UCouQg==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa576EncryptedPkcs8()
         {
             // pbeWithSHA1And128BitRC2-CBC (PKCS12-PBE)
@@ -146,6 +152,7 @@ itsfZ16jNKxoJbAx3psVTGdzxnw8",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa1024EncryptedPkcs8()
         {
             // pbeWithSHA1AndDES-CBC (PBES1)
@@ -168,6 +175,7 @@ CU+l4wPQR0rRmYHIJJIvFh5OXk84pV0crsOrekw7tHeNU6DMzw==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa1024EncryptedPkcs8_PasswordBytes()
         {
             // pbeWithSHA1AndDES-CBC (PBES1)
@@ -190,6 +198,7 @@ CU+l4wPQR0rRmYHIJJIvFh5OXk84pV0crsOrekw7tHeNU6DMzw==",
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa2048EncryptedPkcs8()
         {
             ReadBase64EncryptedPkcs8(
@@ -217,6 +226,7 @@ EDVKgNkAxxCnPVjTUalttxCxTv7FC/vxfN7ulB2uKzicegsf6t/nS6i2dpJjUYDF
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa2048DeficientXEncryptedPkcs8()
         {
             ReadBase64EncryptedPkcs8(
@@ -244,6 +254,7 @@ dOwrkyNhKY+C3S3Hrg+1jGkxn95eJRPX7giU2GBUdc535JhKZH4=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa576SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -258,6 +269,7 @@ ZfDP+UTj7VaoW3WVPrFpASSJhbtfiROY6rXjlkXn",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa1024SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -276,6 +288,7 @@ pfTBO6zjtLRN4Q==",
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDsa2048SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -302,6 +315,7 @@ vAB5Wz646GeWztKawSR/9xIqHq8IECV1FXI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoFuzzySubjectPublicKeyInfo()
         {
             using (DSA key = DSAFactory.Create())
@@ -333,6 +347,7 @@ vAB5Wz646GeWztKawSR/9xIqHq8IECV1FXI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoFuzzyPkcs8()
         {
             using (DSA key = DSAFactory.Create())
@@ -364,6 +379,7 @@ vAB5Wz646GeWztKawSR/9xIqHq8IECV1FXI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoFuzzyEncryptedPkcs8()
         {
             using (DSA key = DSAFactory.Create())
@@ -389,6 +405,7 @@ vAB5Wz646GeWztKawSR/9xIqHq8IECV1FXI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoPrivKeyFromPublicOnly()
         {
             using (DSA key = DSAFactory.Create())
@@ -418,6 +435,7 @@ vAB5Wz646GeWztKawSR/9xIqHq8IECV1FXI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BadPbeParameters()
         {
             using (DSA key = DSAFactory.Create())
@@ -542,6 +560,7 @@ vAB5Wz646GeWztKawSR/9xIqHq8IECV1FXI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecryptPkcs12WithBytes()
         {
             using (DSA key = DSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyGeneration.cs
@@ -23,18 +23,21 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void GenerateMinKey()
         {
             GenerateKey(dsa => GetMin(dsa.LegalKeySizes));
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void GenerateSecondMinKey()
         {
             GenerateKey(dsa => GetSecondMin(dsa.LegalKeySizes));
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void GenerateKey_1024()
         {
             GenerateKey(1024);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyPemTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAKeyPemTests.cs
@@ -26,6 +26,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_Pkcs8UnEncrypted_Simple()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -46,6 +47,7 @@ fve77OGaTv4qbZwinTYAg86p9yHzmwW6+XBS3vxnpYorBBYCFC49eoTIW2Z4Xh9v
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_Pkcs8UnEncrypted_IgnoresUnrelatedAlgorithm()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -71,6 +73,7 @@ fve77OGaTv4qbZwinTYAg86p9yHzmwW6+XBS3vxnpYorBBYCFC49eoTIW2Z4Xh9v
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_Pkcs8_UnrelatedPrecedingPem()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -94,6 +97,7 @@ fve77OGaTv4qbZwinTYAg86p9yHzmwW6+XBS3vxnpYorBBYCFC49eoTIW2Z4Xh9v
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_Pkcs8_PrecedingMalformedPem()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -117,6 +121,7 @@ fve77OGaTv4qbZwinTYAg86p9yHzmwW6+XBS3vxnpYorBBYCFC49eoTIW2Z4Xh9v
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_SubjectPublicKeyInfo_Simple()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -251,6 +256,7 @@ m5NTLEHDwUd7idstLzPXuah0WEjgao5oO1BEUR4byjYlJ+F89Cs4BhUCAwEAAQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromEncryptedPem_Pkcs8_Encrypted_Char_Simple()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -273,6 +279,7 @@ v8pi3w==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromEncryptedPem_Pkcs8_Encrypted_Byte_Simple()
         {
             using (DSA dsa = DSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.NistValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.NistValidation.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Dsa.Tests
     public abstract partial class DSASignVerify
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_2_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-2dsatestvectors.zip
@@ -49,6 +50,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L1024_N160_SHA256_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -89,6 +91,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L1024_N160_SHA384_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -129,6 +132,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L1024_N160_SHA384_4()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -169,6 +173,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L1024_N160_SHA512_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -209,6 +214,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L1024_N160_SHA512_4()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -249,6 +255,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L2048_N256_SHA256_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -306,6 +313,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L2048_N256_SHA384_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -363,6 +371,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L2048_N256_SHA1_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -420,6 +429,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L2048_N256_SHA384_3()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -477,6 +487,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L3072_N256_SHA256_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -546,6 +557,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L3072_N256_SHA384_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -615,6 +627,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L3072_N256_SHA512_1()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip
@@ -684,6 +697,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Fips186_3_L3072_N256_SHA512_12()
         {
             // http://csrc.nist.gov/groups/STM/cavp/documents/dss/186-3dsatestvectors.zip

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignVerify.cs
@@ -113,6 +113,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         public abstract bool VerifyData(DSA dsa, byte[] data, byte[] signature, HashAlgorithmName hashAlgorithm);
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void InvalidKeySize_DoesNotInvalidateKey()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -175,6 +176,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignAndVerifyDataNew1024()
         {
             using (DSA dsa = DSAFactory.Create(1024))
@@ -186,6 +188,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyKnown_512()
         {
             byte[] signature = (
@@ -202,6 +205,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyKnown_576()
         {
             byte[] signature = (
@@ -218,6 +222,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PublicKey_CannotSign()
         {
             DSAParameters keyParameters = DSATestData.GetDSA1024Params();
@@ -233,18 +238,21 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignAndVerifyDataExplicit1024()
         {
             SignAndVerify(DSATestData.HelloBytes, "SHA1", DSATestData.GetDSA1024Params(), 40);
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignAndVerifyDataExplicit2048()
         {
             SignAndVerify(DSATestData.HelloBytes, "SHA256", DSATestData.GetDSA2048Params(), 64);
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyKnown_2048_SHA256()
         {
             byte[] signature =
@@ -269,6 +277,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyKnown_2048_SHA384()
         {
             byte[] signature =
@@ -293,6 +302,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyKnown_2048_SHA512()
         {
             byte[] signature =
@@ -317,6 +327,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyKnownSignature()
         {
             using (DSA dsa = DSAFactory.Create())
@@ -336,6 +347,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Sign2048WithSha1()
         {
             byte[] data = { 1, 2, 3, 4 };
@@ -351,6 +363,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Verify2048WithSha1()
         {
             byte[] data = { 1, 2, 3, 4 };

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSASignatureFormatTests.cs
@@ -180,6 +180,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OffsetAndCountOutOfRange()
         {
             KeyDescription keyDescription = GetKey();
@@ -330,6 +331,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Rfc23279TrySignHashUnderMax()
         {
             KeyDescription keyDescription = GetKey();
@@ -358,6 +360,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Rfc23279TrySignDataUnderMax()
         {
             KeyDescription keyDescription = GetKey();

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DSAXml.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Dsa.Tests
     public static class DSAXml
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead512Parameters_Public()
         {
             DSAParameters expectedParameters = DSATestData.Dsa512Parameters;
@@ -29,6 +30,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead512Parameters_Private()
         {
             TestReadXml(
@@ -47,6 +49,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead576Parameters_Public()
         {
             DSAParameters expectedParameters = DSATestData.Dsa576Parameters;
@@ -77,6 +80,7 @@ gVpUm2/QztrwRLALfP4TUZAtdyfW1/tzYAOk4cTNjfv0MeT/RzPz+pLHZfDP+UTj7VaoW3WVPrFpASSJ
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead576Parameters_Private()
         {
             TestReadXml(
@@ -107,6 +111,7 @@ rDJpPhzXKtY+GgtugVfrvKZx09s=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead1024Parameters_Public()
         {
             DSAParameters expectedParameters = DSATestData.GetDSA1024Params();
@@ -142,6 +147,7 @@ wTus47S0TeE=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead1024Parameters_Private()
         {
             TestReadXml(
@@ -183,6 +189,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [ConditionalFact(typeof(DSAFactory), nameof(DSAFactory.SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead2048Parameters_Public()
         {
             DSAParameters expectedParameters = DSATestData.Dsa2048DeficientXParameters;
@@ -223,6 +230,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [ConditionalFact(typeof(DSAFactory), nameof(DSAFactory.SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead2048Parameters_Private_CryptoBinary()
         {
             TestReadXml(
@@ -261,6 +269,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [ConditionalFact(typeof(DSAFactory), nameof(DSAFactory.SupportsFips186_3))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead2048Parameters_Private_Base64Binary()
         {
             TestReadXml(
@@ -301,6 +310,7 @@ S      9      R      /       j       6       9        C        v        C
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWrite512Parameters(bool includePrivateParameters)
         {
             TestWriteXml(
@@ -325,6 +335,7 @@ S      9      R      /       j       6       9        C        v        C
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWrite576Parameters(bool includePrivateParameters)
         {
             TestWriteXml(
@@ -349,6 +360,7 @@ S      9      R      /       j       6       9        C        v        C
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWrite1024Parameters(bool includePrivateParameters)
         {
             TestWriteXml(
@@ -376,6 +388,7 @@ S      9      R      /       j       6       9        C        v        C
         [ConditionalTheory(typeof(DSAFactory), nameof(DSAFactory.SupportsFips186_3))]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWriteDeficientXParameters(bool includePrivateParameters)
         {
             TestWriteXml(
@@ -581,6 +594,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FromXmlWithSeedAndCounterAndJ()
         {
             // This key comes from FIPS-186-2, Appendix 5, Example of the DSA.
@@ -615,6 +629,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FromXmlWrongJ_OK()
         {
             // No one really reads the J value on import, but xmldsig defined it,
@@ -688,6 +703,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FromXmlWrongCounter_SometimesOK()
         {
             // DSACryptoServiceProvider doesn't check this error state, DSACng does.
@@ -740,6 +756,7 @@ S      9      R      /       j       6       9        C        v        C
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FromXml_CounterOverflow_Succeeds()
         {
             // The counter value should be 105 (0x69).

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DsaFamilySignatureFormatTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DSA/DsaFamilySignatureFormatTests.cs
@@ -131,6 +131,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(SignatureFormats))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignHashVerifyHash(DSASignatureFormat signatureFormat)
         {
             KeyDescription key = GetKey();
@@ -142,6 +143,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(SignatureFormats))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignDataVerifyData_SHA1(DSASignatureFormat signatureFormat)
         {
             HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA1;
@@ -154,6 +156,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(SignatureFormats))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignDataVerifyHash_SHA1(DSASignatureFormat signatureFormat)
         {
             HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA1;
@@ -171,6 +174,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(SignatureFormats))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignDataVerifyData_SHA256(DSASignatureFormat signatureFormat)
         {
             if (!SupportsSha2)
@@ -186,6 +190,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(SignatureFormats))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignDataVerifyHash_SHA256(DSASignatureFormat signatureFormat)
         {
             if (!SupportsSha2)
@@ -205,6 +210,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyInvalidRfc3279Signature()
         {
             KeyDescription key = GetKey();
@@ -233,6 +239,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Rfc3279SignatureValidatesLength()
         {
             KeyDescription key = GetKey();
@@ -266,6 +273,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         [Theory]
         [InlineData(DSASignatureFormat.IeeeP1363FixedFieldConcatenation, DSASignatureFormat.Rfc3279DerSequence)]
         [InlineData(DSASignatureFormat.Rfc3279DerSequence, DSASignatureFormat.IeeeP1363FixedFieldConcatenation)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignatureFormatsAreNotCompatible(DSASignatureFormat signFormat, DSASignatureFormat verifyFormat)
         {
             if (!SupportsSha2)
@@ -305,6 +313,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void BadSignatureFormat()
         {
             KeyDescription key = GetKey();
@@ -330,6 +339,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EmptyHashAlgorithm()
         {
             KeyDescription key = GetKey();
@@ -348,6 +358,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void UnknownHashAlgorithm()
         {
             KeyDescription key = GetKey();
@@ -365,6 +376,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void NullInputs()
         {
             if (IsNotArrayBased)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.LimitedPrivate.cs
@@ -41,6 +41,7 @@ AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP521Pkcs8_LimitedPrivate()
         {
             const string base64 = @"
@@ -52,6 +53,7 @@ FmY=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_LimitedPrivateKey()
         {
             const string base64 = @"
@@ -72,6 +74,7 @@ PFzVQfJ396S+yx4IIC4=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_LimitedPrivateKey_PasswordBytes()
         {
             const string base64 = @"
@@ -92,6 +95,7 @@ PFzVQfJ396S+yx4IIC4=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ECPrivateKey_LimitedPrivateKey()
         {
             const string base64 = @"
@@ -104,6 +108,7 @@ AwEH";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -120,6 +125,7 @@ YyVRAgEB",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitPkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -136,6 +142,7 @@ AAAA//////////+85vqtpxeehPO5ysL8YyVRAgEBBCcwJQIBAQQgcKEsLbFoRe1W
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitEncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -159,6 +166,7 @@ hjy6jYfLa1BCJhvq+WbNc7zEb2MfXVhnImaG+XTqXI0c",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1ECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -168,6 +176,7 @@ hjy6jYfLa1BCJhvq+WbNc7zEb2MfXVhnImaG+XTqXI0c",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1Pkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -179,6 +188,7 @@ MDYCAQAwFAYHKoZIzj0CAQYJKyQDAwIIAQEBBBswGQIBAQQUxdlEVH3hFdsliNxv
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1EncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -197,6 +207,7 @@ heDtThcoFBJUsNhEHrc=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -206,6 +217,7 @@ heDtThcoFBJUsNhEHrc=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1Pkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -217,6 +229,7 @@ EBfmpBI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -231,6 +244,7 @@ XlyU7ugCiQcPsF04/1gyHy6ABTbVOMzao9kCFQQAAAAAAAAAAAACAQii4MwNmfil
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitPkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -245,6 +259,7 @@ wZla366MBRjcE9/mMEuwEBfmpBI=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1EncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -263,6 +278,7 @@ DAYIKoZIhvcNAgkFADAdBglghkgBZQMEAQIEENKfCUCiZgnSk3NJ1fYNsfsEQEiv
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitEncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -284,6 +300,7 @@ RVA9DXUNz5+yUlfGzgErHYGwRLaLCACU6+WAC34Kkyk=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1ECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -295,6 +312,7 @@ gQQAEA==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -309,6 +327,7 @@ nwIVBAAAAAAAAAAAAAHmD8iCHMdNrq/BAgEC",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitPkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -323,6 +342,7 @@ PXkyn8w9dIgPM7voA8sB7CMhG1lmreodP4f36lhIrvC3yp8CFQQAAAAAAAAAAAAB
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitEncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -344,6 +364,7 @@ AerBJbccwFJfDAXP+eW3qWtaMgulL0gUYZQ7FcXH+z5CAWwdarLOCDZGqvQFtZ16",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1Pkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -355,6 +376,7 @@ UrJiMebAFnD8xsPqLF0/7UDt8Dc=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1EncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -373,6 +395,7 @@ vW82QOEXDhi1gO24nhx2gUeqVTHjhFq14blAu5l5",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ECPrivateKey_LimitedPrivate()
         {
             ReadWriteBase64ECPrivateKey(
@@ -382,6 +405,7 @@ vW82QOEXDhi1gO24nhx2gUeqVTHjhFq14blAu5l5",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1Pkcs8_LimitedPrivate()
         {
             ReadWriteBase64Pkcs8(
@@ -393,6 +417,7 @@ k8AJOmU2eYY=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1EncryptedPkcs8_LimitedPrivate()
         {
             ReadWriteBase64EncryptedPkcs8(

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyFileTests.cs
@@ -93,6 +93,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP521Pkcs8()
         {
             const string base64 = @"
@@ -107,6 +108,7 @@ oA==";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP521Pkcs8_ECDH()
         {
             const string base64 = @"
@@ -123,6 +125,7 @@ kdJEBnF/hv3v3ghuCblUpX3A9elFl1bWDCqubeABqN27PwLIwjUkcp9Ui34jMlIz
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP521SubjectPublicKeyInfo()
         {
             const string base64 = @"
@@ -135,6 +138,7 @@ GOHeQPlen/5PV7eRU6A=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP521SubjectPublicKeyInfo_ECDH()
         {
             const string base64 = @"
@@ -150,6 +154,7 @@ yMI1JHKfVIt+IzJSM+9n3TB1K5JPKXRZ48LhKujY9P5EVOOEfBiyVcrO9Zc3uRjh
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_Sha384()
         {
             // PBES2, PBKDF2 (SHA384), AES128
@@ -174,6 +179,7 @@ qtlbnispri1a/EghiaPQ0po=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadNistP521EncryptedPkcs8_Pbes2_Aes128_Sha384_PasswordBytes()
         {
             // PBES2, PBKDF2 (SHA384), AES128
@@ -198,6 +204,7 @@ qtlbnispri1a/EghiaPQ0po=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadNistP256EncryptedPkcs8_Pbes1_RC2_MD5()
         {
             const string base64 = @"
@@ -217,6 +224,7 @@ m8STNpW+zSpHWlpHpWHgXGq4wrUKJifxOv6Rm5KTYcvUT38=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ECPrivateKey()
         {
             const string base64 = @"
@@ -230,6 +238,7 @@ NfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -247,6 +256,7 @@ HVmSNfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitPkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -264,6 +274,7 @@ Ji0iy6T3Y16v8maAqNihK6YdWZI19n2ctNWPF4PTykPnjwpauqYkB5k2wMOp",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitEncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -287,6 +298,7 @@ eWDIWFuFRj58uAQ65/viFausHWt1BdywcwcyVRb2eLI5MR7DWA==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteNistP256ExplicitSubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -303,6 +315,7 @@ kaMmLSLLpPdjXq/yZoCo2KErph1ZkjX2fZy01Y8Xg9PKQ+ePClq6piQHmTbAw6k=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1ECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -314,6 +327,7 @@ jwk5x2KSdsrb/pnAHDZQk1TictLI7vH2zDIF0AV+ud5sqeMQUJY=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1Pkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -326,6 +340,7 @@ bKnjEFCW",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1EncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -343,6 +358,7 @@ HiDaMtpw7yT5+32Vkxv5C2jvqNPpicmEFpf2wJ8yVLQtMOKAF2sOwxN/",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteBrainpoolKey1SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -354,6 +370,7 @@ ctLI7vH2zDIF0AV+ud5sqeMQUJY=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -365,6 +382,7 @@ zIElQ1/mRYnV/KbcGIdVHQeI/rti/8kkjYs5iv4+C1w8ArP+Nw==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1Pkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -377,6 +395,7 @@ PAKz/jc=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1EncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -394,6 +413,7 @@ f+ESRyxDnBgKz6H2RKeenyrwVhxF98SyJzAdP637vR3QmDNAWWAgoUhg",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -405,6 +425,7 @@ u2L/ySSNizmK/j4LXDwCs/43",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -419,6 +440,7 @@ iv4+C1w8ArP+Nw==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitPkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -433,6 +455,7 @@ ptwYh1UdB4j+u2L/ySSNizmK/j4LXDwCs/43",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitEncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -453,6 +476,7 @@ z2NFvWcpK0Fh9fCVGuXV9sjJ5qE=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect163k1Key1ExplicitSubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -466,6 +490,7 @@ njcZzIElQ1/mRYnV/KbcGIdVHQeI/rti/8kkjYs5iv4+C1w8ArP+Nw==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1ECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -478,6 +503,7 @@ fbmZXDVgPF5rL4zf8Otx03rjQxughJ66sTpMkAPHlp9VzZA=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1Pkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -491,6 +517,7 @@ Vc2Q",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1EncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -509,6 +536,7 @@ nTvuaAMG/xvXzKoigakX+1D60cmftPsC7t23SF+xMdzfZNlJGrxXFYX1Gg==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteSect283k1Key1SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -520,6 +548,7 @@ V9r2k5CdhAcW7qeqBH25mVw1YDxeay+M3/DrcdN640MboISeurE6TJADx5afVc2Q",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -531,6 +560,7 @@ Jy8cVYJCaIjpG9aSV3SUIyJIqgQnCDD3oQCa1nCojekr1ZJIzIE7RQ==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1Pkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -543,6 +573,7 @@ K9WSSMyBO0U=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1EncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -561,6 +592,7 @@ wiA=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1SubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -572,6 +604,7 @@ BCcIMPehAJrWcKiN6SvVkkjMgTtF",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitECPrivateKey()
         {
             ReadWriteBase64ECPrivateKey(
@@ -587,6 +620,7 @@ dJQjIkiqBCcIMPehAJrWcKiN6SvVkkjMgTtF",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitPkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -602,6 +636,7 @@ BAIRJy8cVYJCaIjpG9aSV3SUIyJIqgQnCDD3oQCa1nCojekr1ZJIzIE7RQ==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitEncryptedPkcs8()
         {
             ReadWriteBase64EncryptedPkcs8(
@@ -623,6 +658,7 @@ wxcZ+wOsnebIwy4ftKL+klh5EXv/9S5sCjC8g8J2cA6GmcZbiQ==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ReadWriteC2pnb163v1ExplicitSubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -674,6 +710,7 @@ HMdNrq/BAgECAywABAIRJy8cVYJCaIjpG9aSV3SUIyJIqgQnCDD3oQCa1nCojekr
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void NoFuzzyECPrivateKey()
         {
             using (T key = CreateKey())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyPemTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/EC/ECKeyPemTests.cs
@@ -28,6 +28,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_ECPrivateKey_Simple()
         {
             using (TAlg key = CreateKey())
@@ -45,6 +46,7 @@ NfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_ECPrivateKey_IgnoresUnrelatedAlgorithm()
         {
             using (TAlg key = CreateKey())
@@ -71,6 +73,7 @@ NfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_Pkcs8_Simple()
         {
             using (TAlg key = CreateKey())
@@ -88,6 +91,7 @@ y6T3Y16v8maAqNihK6YdWZI19n2ctNWPF4PTykPnjwpauqYkB5k2wMOp
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_Pkcs8_IgnoresUnrelatedAlgorithm()
         {
             using (TAlg key = CreateKey())
@@ -114,6 +118,7 @@ y6T3Y16v8maAqNihK6YdWZI19n2ctNWPF4PTykPnjwpauqYkB5k2wMOp
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_Spki_Simple()
         {
             using (TAlg key = CreateKey())
@@ -130,6 +135,7 @@ Isuk92Ner/JmgKjYoSumHVmSNfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_Spki_PrecedingUnrelatedPemIsIgnored()
         {
             using (TAlg key = CreateKey())
@@ -161,6 +167,7 @@ Isuk92Ner/JmgKjYoSumHVmSNfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_Spki_IgnoresUnrelatedAlgorithms()
         {
             using (TAlg key = CreateKey())
@@ -186,6 +193,7 @@ Isuk92Ner/JmgKjYoSumHVmSNfZ9nLTVjxeD08pD548KWrqmJAeZNsDDqQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromPem_Spki_PrecedingMalformedPem()
         {
             using (TAlg key = CreateKey())
@@ -311,6 +319,7 @@ Qh0fqdrNovgFLubbJFMQN/MwwIAfIuf0Mn0WFYYeQiBJ3kg=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromEncryptedPem_Pkcs8_Char_Simple()
         {
             using (TAlg key = CreateKey())
@@ -331,6 +340,7 @@ Qh0fqdrNovgFLubbJFMQN/MwwIAfIuf0Mn0WFYYeQiBJ3kg=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportFromEncryptedPem_Pkcs8_Byte_Simple()
         {
             using (TAlg key = CreateKey())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.Hash.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.Hash.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(MismatchedKeysizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivation_SameSizeOtherKeyRequired(int aliceSize, int bobSize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(aliceSize))
@@ -34,6 +35,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivation_AlgorithmRequired()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -46,6 +48,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivation(int keySize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(keySize))
@@ -61,6 +64,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivationVariesOnPublicKey()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -78,6 +82,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivationVariesOnAlgorithm()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -94,6 +99,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_HashPrepend(int keySize)
         {
             byte[] prefix = new byte[10];
@@ -111,6 +117,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivationVariesOnPrepend()
         {
             byte[] alicePrefix = new byte[10];
@@ -131,6 +138,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_HashAppend(int keySize)
         {
             byte[] suffix = new byte[10];
@@ -148,6 +156,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivationVariesOnAppend()
         {
             byte[] aliceSuffix = new byte[10];
@@ -167,6 +176,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivationIsStable()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -181,6 +191,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SimpleHashMethodForwardsNull()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -194,6 +205,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DeriveKeyMaterialEquivalentToDeriveKeyFromHash()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -263,6 +275,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 #if NETCOREAPP
         [Theory]
         [MemberData(nameof(HashDerivationTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HashDerivation_KnownResults(
             HashAlgorithmName hashAlgorithm,
             string prependBytes,

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.Hmac.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.Hmac.cs
@@ -26,6 +26,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(MismatchedKeysizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivation_SameSizeOtherKeyRequired(int aliceSize, int bobSize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(aliceSize))
@@ -39,6 +40,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_Hmac(int keySize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(keySize))
@@ -54,6 +56,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivationVariesOnPublicKey()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -71,6 +74,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivationVariesOnAlgorithm()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -86,6 +90,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivationVariesOnKey()
         {
             byte[] hmacKeyAlice = { 0, 1, 2, 3, 4, 5 };
@@ -105,6 +110,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_HmacPrepend(int keySize)
         {
             byte[] prefix = new byte[10];
@@ -122,6 +128,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivationVariesOnPrepend()
         {
             byte[] alicePrefix = new byte[10];
@@ -142,6 +149,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_HmacAppend(int keySize)
         {
             byte[] suffix = new byte[10];
@@ -159,6 +167,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivationVariesOnAppend()
         {
             byte[] aliceSuffix = new byte[10];
@@ -178,6 +187,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivationIsStable()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -193,6 +203,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_HmacNullKey(int keySize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(keySize))
@@ -208,6 +219,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacNullKeyDerivationIsStable()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -222,6 +234,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SimpleHmacMethodForwardsNull()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -235,6 +248,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SimpleHmacNullKeyForwardsNull()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -319,6 +333,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 #if NETCOREAPP
         [Theory]
         [MemberData(nameof(HmacDerivationTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void HmacDerivation_KnownResults(
             HashAlgorithmName hashAlgorithm,
             string hmacKeyBytes,

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.ImportExport.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
             ECDiffieHellmanFactory.IsCurveValid(new Oid(ECDSA_P224_OID_VALUE));
 
         [Theory, MemberData(nameof(TestCurvesFull))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestNamedCurves(CurveDef curveDef)
         {
             if (!curveDef.Curve.IsNamed)
@@ -39,6 +40,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Theory, MemberData(nameof(TestInvalidCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestNamedCurvesNegative(CurveDef curveDef)
         {
             if (!curveDef.Curve.IsNamed)
@@ -50,6 +52,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Theory, MemberData(nameof(TestCurvesFull))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestExplicitCurves(CurveDef curveDef)
         {
             if (!ECDiffieHellmanFactory.ExplicitCurvesSupported)
@@ -74,6 +77,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Theory, MemberData(nameof(TestCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestExplicitCurvesKeyAgree(CurveDef curveDef)
         {
             if (!ECDiffieHellmanFactory.ExplicitCurvesSupported)
@@ -135,6 +139,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeySizeCreateKey()
         {
             using (ECDiffieHellman ec = ECDiffieHellmanFactory.Create(ECCurve.NamedCurves.nistP256))
@@ -152,6 +157,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestExplicitImportValidationNegative()
         {
             if (!ECDiffieHellmanFactory.ExplicitCurvesSupported)
@@ -205,6 +211,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportExplicitWithSeedButNoHash()
         {
             if (!ECDiffieHellmanFactory.ExplicitCurvesSupported)
@@ -287,6 +294,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGeneralExportWithExplicitParameters()
         {
             if (!ECDiffieHellmanFactory.ExplicitCurvesSupported)
@@ -353,6 +361,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportIncludingPrivateOnPublicOnlyKey()
         {
             ECParameters iutParameters = new ECParameters
@@ -387,6 +396,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPrivateOnlyKey()
         {
             byte[] expectedX = "00d45615ed5d37fde699610a62cd43ba76bedd8f85ed31005fe00d6450fbbd101291abd96d4945a8b57bc73b3fe9f4671105309ec9b6879d0551d930dac8ba45d255".HexToByteArray();

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.NistValidation.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.NistValidation.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
     public partial class ECDiffieHellmanTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidateNistP256_0()
         {
             Verify(
@@ -31,6 +32,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidateNistP256_1()
         {
             Verify(
@@ -45,6 +47,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidateNistP384_0()
         {
             Verify(
@@ -59,6 +62,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidateNistP384_1()
         {
             Verify(
@@ -73,6 +77,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidateNistP521_0()
         {
             Verify(
@@ -87,6 +92,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidateNistP521_1()
         {
             Verify(

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.Tls.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.Tls.cs
@@ -26,6 +26,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(MismatchedKeysizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsDerivation_SameSizeOtherKeyRequired(int aliceSize, int bobSize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(aliceSize))
@@ -38,6 +39,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsRequiresLabel()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -49,6 +51,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsRequiresSeed()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -63,6 +66,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         [InlineData(0)]
         [InlineData(63)]
         [InlineData(65)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsRequiresSeed64(int seedSize)
         {
             byte[] seed = new byte[seedSize];
@@ -77,6 +81,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SymmetricDerivation_TlsPrf(int keySize)
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create(keySize))
@@ -92,6 +97,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsPrfDerivationIsStable()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -107,6 +113,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsPrfOutputIs48Bytes(int keySize)
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create(keySize))
@@ -119,6 +126,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsPrfVariesOnOtherKey()
         {
             using (ECDiffieHellman alice = ECDiffieHellmanFactory.Create())
@@ -136,6 +144,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsPrfVariesOnLabel()
         {
             byte[] aliceLabel = s_fourByteLabel;
@@ -154,6 +163,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsPrfVariesOnSeed()
         {
             byte[] aliceSeed = s_emptySeed;
@@ -193,6 +203,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 #if NETCOREAPP
         [Theory]
         [MemberData(nameof(TlsDerivationTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TlsDerivation_KnownResults(string labelText, string answerHex)
         {
             byte[] label = Encoding.ASCII.GetBytes(labelText);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDiffieHellman/ECDiffieHellmanTests.cs
@@ -91,6 +91,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
 
         [Theory]
         [MemberData(nameof(EveryKeysize))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PublicKey_NotNull(int keySize)
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create(keySize))
@@ -101,6 +102,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PublicKeyIsFactory()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())
@@ -114,6 +116,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void UseAfterDispose(bool importKey)
         {
             ECDiffieHellman key = ECDiffieHellmanFactory.Create();

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaImportExport.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     {
 #if NETCOREAPP
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DiminishedCoordsRoundtrip()
         {
             ECParameters toImport = EccTestData.GetNistP521DiminishedCoordsParameters();
@@ -108,6 +109,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [ConditionalTheory(nameof(ECExplicitCurvesSupported)), MemberData(nameof(TestCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestExplicitCurvesSignVerify(CurveDef curveDef)
         {
             using (ECDsa ec1 = ECDsaFactory.Create(curveDef.Curve))

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.cs
@@ -143,6 +143,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(RealImplementations))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void UseAfterDispose_Import(ECDsa ecdsa)
         {
             ecdsa.ImportParameters(EccTestData.GetNistP256ReferenceKey());
@@ -199,6 +200,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(RealImplementations))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignData_MaxOffset_ZeroLength_NoThrow(ECDsa ecdsa)
         {
             // Explicitly larger than Array.Empty
@@ -210,6 +212,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(RealImplementations))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyData_MaxOffset_ZeroLength_NoThrow(ECDsa ecdsa)
         {
             // Explicitly larger than Array.Empty
@@ -221,6 +224,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(RealImplementations))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Roundtrip_WithOffset(ECDsa ecdsa)
         {
             byte[] data = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -240,6 +244,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         [InlineData(256)]
         [InlineData(384)]
         [InlineData(521)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void CreateKey(int keySize)
         {
             using (ECDsa ecdsa = ECDsaFactory.Create())
@@ -269,6 +274,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(InteroperableSignatureConfigurations))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignVerify_InteroperableSameKeys_RoundTripsUnlessTampered(ECDsa ecdsa, HashAlgorithmName hashAlgorithm)
         {
             byte[] data = Encoding.UTF8.GetBytes("something to repeat and sign");

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/ECDsa/ECDsaTests.netcoreapp.cs
@@ -58,6 +58,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     public abstract partial class ECDsaTests : ECDsaTestsBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void KeySizeProp()
         {
             using (ECDsa e = ECDsaFactory.Create())
@@ -80,6 +81,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Theory, MemberData(nameof(TestNewCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TestRegenKeyExplicit(CurveDef curveDef)
         {
             ECParameters param, param2;
@@ -182,6 +184,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(TestCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TestRegenKeyNamed(CurveDef curveDef)
         {
             ECParameters param, param2;
@@ -205,6 +208,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [ConditionalFact(nameof(ECExplicitCurvesSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TestRegenKeyNistP256()
         {
             ECParameters param, param2;
@@ -227,6 +231,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
 
         [Theory]
         [MemberData(nameof(TestCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TestChangeFromNamedCurveToKeySize(CurveDef curveDef)
         {
             if (!curveDef.Curve.IsNamed)
@@ -253,6 +258,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [ConditionalFact(nameof(ECExplicitCurvesSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TestPositive256WithExplicitParameters()
         {
             using (ECDsa ecdsa = ECDsaFactory.Create())
@@ -263,6 +269,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TestNegative256WithRandomKey()
         {
             using (ECDsa ecdsa = ECDsaFactory.Create(ECCurve.NamedCurves.nistP256))

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -61,6 +61,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptSavedAnswer()
         {
             byte[] cipherBytes =
@@ -95,6 +96,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptWithPublicKey_Fails()
         {
             byte[] cipherBytes =
@@ -134,6 +136,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptSavedAnswer_OaepSHA256()
         {
             byte[] cipherBytes = (
@@ -169,6 +172,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptSavedAnswer_OaepSHA384()
         {
             byte[] cipherBytes =
@@ -230,6 +234,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptSavedAnswer_OaepSHA512()
         {
             byte[] cipherBytes = (
@@ -265,6 +270,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptSavedAnswerUnusualExponent()
         {
             byte[] cipherBytes =
@@ -299,17 +305,21 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaCryptRoundtrip_OaepSHA1() => RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA1);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaCryptRoundtrip_OaepSHA256() =>
             RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA256, RSAFactory.SupportsSha2Oaep);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaCryptRoundtrip_OaepSHA384() =>
             RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA384, RSAFactory.SupportsSha2Oaep);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaCryptRoundtrip_OaepSHA512() =>
             RsaCryptRoundtrip(RSAEncryptionPadding.OaepSHA512, RSAFactory.SupportsSha2Oaep);
 
@@ -338,6 +348,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RoundtripEmptyArray()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
@@ -363,6 +374,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaPkcsEncryptMaxSize()
         {
             RSAParameters rsaParameters = TestData.RSA2048Params;
@@ -389,6 +401,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaOaepMaxSize()
         {
             RSAParameters rsaParameters = TestData.RSA2048Params;
@@ -426,6 +439,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptOaep_ExpectFailure()
         {
             // This particular byte pattern, when decrypting under OAEP-SHA-2-384 has
@@ -448,6 +462,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsSha2Oaep))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptOaepWrongAlgorithm()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
@@ -461,6 +476,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptOaepWrongData()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
@@ -484,6 +500,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptPkcs1LeadingZero()
         {
             // The first search for an encrypted value with a leading 0x00 turned up one with
@@ -506,6 +523,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptPkcs1Deficient()
         {
             // This value is gibberish, but it happens to be true that if it is preceded
@@ -537,6 +555,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptPkcs1WrongDataLength()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
@@ -562,6 +581,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptOaepWrongDataLength()
         {
             using (RSA rsa = RSAFactory.Create(TestData.RSA2048Params))
@@ -602,6 +622,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryptAfterExport()
         {
             byte[] output;
@@ -619,6 +640,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void LargeKeyCryptRoundtrip()
         {
             byte[] output;
@@ -646,6 +668,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void UnusualExponentCryptRoundtrip()
         {
             byte[] crypt;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.netcoreapp.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.netcoreapp.cs
@@ -30,6 +30,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Decrypt_VariousSizeSpans_Success()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -62,6 +63,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Encrypt_VariousSizeSpans_Success()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -89,18 +91,21 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Decrypt_WrongKey_Pkcs7()
         {
             Decrypt_WrongKey(RSAEncryptionPadding.Pkcs1);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Decrypt_WrongKey_OAEP_SHA1()
         {
             Decrypt_WrongKey(RSAEncryptionPadding.OaepSHA1);
         }
 
         [ConditionalFact(nameof(SupportsSha2Oaep))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Decrypt_WrongKey_OAEP_SHA256()
         {
             Decrypt_WrongKey(RSAEncryptionPadding.OaepSHA256);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -43,6 +43,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PaddedExport()
         {
             // OpenSSL's numeric type for the storage of RSA key parts disregards zero-valued
@@ -70,6 +71,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void LargeKeyImportExport()
         {
             RSAParameters imported = TestData.RSA16384Params;
@@ -99,6 +101,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void UnusualExponentImportExport()
         {
             // Most choices for the Exponent value in an RSA key use a Fermat prime.
@@ -123,6 +126,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportExport1032()
         {
             RSAParameters imported = TestData.RSA1032Parameters;
@@ -144,6 +148,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportReset()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -174,6 +179,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPrivateExportPublic()
         {
             RSAParameters imported = TestData.RSA1024Params;
@@ -223,6 +229,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PublicOnlyPrivateExport()
         {
             RSAParameters imported = new RSAParameters
@@ -239,6 +246,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportNoExponent()
         {
             RSAParameters imported = new RSAParameters
@@ -256,6 +264,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportNoModulus()
         {
             RSAParameters imported = new RSAParameters
@@ -276,6 +285,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 #if TESTING_CNG_IMPLEMENTATION
         [ActiveIssue("https://github.com/dotnet/runtime/issues/21341", TargetFrameworkMonikers.NetFramework)]
 #endif
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportNoDP()
         {
             // Because RSAParameters is a struct, this is a copy,

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/KeyGeneration.cs
@@ -27,12 +27,14 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void GenerateKey_2048()
         {
             GenerateKey(2048);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void GenerateKey_4096()
         {
             GenerateKey(4096);

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyExchangeFormatter.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public partial class RSAKeyExchangeFormatterTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyDecryptKeyExchangeOaep()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -24,6 +25,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyDecryptKeyExchangePkcs1()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -37,6 +39,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKnownValueOaep()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -54,6 +57,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKnownValuePkcs1()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyFileTests.cs
@@ -73,6 +73,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsLargeExponent))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteBigExponentPrivatePkcs1()
         {
             ReadWriteBase64PrivatePkcs1(
@@ -106,6 +107,7 @@ CE5b4bVi7nbp+SyaseWurZ0pGmM35N6FveZ6DXK05Vrc8gf3paUiXhU=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDiminishedDPPrivatePkcs1()
         {
             ReadWriteBase64PrivatePkcs1(
@@ -172,6 +174,7 @@ t4Ru7LOzqUULk+Y3+gSNHX34/+Jw+VCq5hHlolNkpw+thqvba8lMvzMCAwEAAQ==",
         }
 
         [ConditionalFact(nameof(SupportsLargeExponent))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteSubjectPublicKeyInfo()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -187,6 +190,7 @@ RwIFAgAABEE=",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteSubjectPublicKeyInfo_DiminishedDPKey()
         {
             ReadWriteBase64SubjectPublicKeyInfo(
@@ -451,6 +455,7 @@ xBdaeIJFmTymL1LOru69mA9gwhuFFQ==",
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWriteDiminishedDPPkcs8()
         {
             ReadWriteBase64Pkcs8(
@@ -467,6 +472,7 @@ acPiMCuFTnRSFYAhozpmsqoLyTREqwIhAMLJlZTGjEB2N+sEazH5ToEczQzKqp7t
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadEncryptedDiminishedDP()
         {
             // PBES1: PbeWithMD5AndDESCBC
@@ -492,6 +498,7 @@ YMSYHxE=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadEncryptedRsa1032()
         {
             // PBES2: PBKDF2 + aes192
@@ -735,6 +742,7 @@ pgCJTk846cb+AizgZMeOsYpTOgu2UL6cQiLtsYNz7WpDK3iS7Agj9EoL2ao7QxA=";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadPbes2Rc2EncryptedDiminishedDP()
         {
             // PBES2: PBKDF2 + RC2-128
@@ -761,6 +769,7 @@ RdMKfFP3he4C+CFyGGslffbxCaJhKebeuOil5xxlvP8aBPVNDtQfSS1HXHd1/Ikq
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadPbes2Rc2EncryptedDiminishedDP_PasswordBytes()
         {
             // PBES2: PBKDF2 + RC2-128
@@ -787,6 +796,7 @@ RdMKfFP3he4C+CFyGGslffbxCaJhKebeuOil5xxlvP8aBPVNDtQfSS1HXHd1/Ikq
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadEncryptedDiminishedDP_EmptyPassword()
         {
             const string base64 = @"
@@ -811,6 +821,7 @@ Dmw2pL/LzHORugcg9BxRkur91lenPNcLAvnke76tMGvSGkA82I9NpBDcGRK4cPie
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadEncryptedDiminishedDP_EmptyPasswordBytes()
         {
             const string base64 = @"
@@ -835,6 +846,7 @@ Dmw2pL/LzHORugcg9BxRkur91lenPNcLAvnke76tMGvSGkA82I9NpBDcGRK4cPie
         }
 
         [ConditionalFact(nameof(Supports384BitPrivateKey))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadPbes1Rc2EncryptedRsa384()
         {
             // PbeWithSha1AndRC2CBC
@@ -858,6 +870,7 @@ pWre7nAO4O6sP1JzXvVmwrS5C/hw";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoFuzzyRSAPublicKey()
         {
             using (RSA key = RSAFactory.Create())
@@ -944,6 +957,7 @@ pWre7nAO4O6sP1JzXvVmwrS5C/hw";
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoFuzzyRSAPrivateKey()
         {
             using (RSA key = RSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyPemTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAKeyPemTests.cs
@@ -26,6 +26,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_RSAPrivateKey_Simple()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -73,6 +74,7 @@ acPiMCuFTnRSFYAhozpmsqoLyTREqwIhAMLJlZTGjEB2N+sEazH5ToEczQzKqp7t
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_Pkcs8UnEncrypted_UnrelatedAlgorithmIsIgnored()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -119,6 +121,7 @@ m5NTLEHDwUd7idstLzPXuah0WEjgao5oO1BEUR4byjYlJ+F89Cs4BhUCAwEAAQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_SubjectPublicKeyInfo_IgnoresUnrelatedAlgorithm()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -141,6 +144,7 @@ m5NTLEHDwUd7idstLzPXuah0WEjgao5oO1BEUR4byjYlJ+F89Cs4BhUCAwEAAQ==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_RSAPublicKey_Simple()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -159,6 +163,7 @@ MEgCQQC3P1n17ovVXiS3/wKa0WqFQ8ltJT5UMZuTUyxBw8FHe4nbLS8z17modFhI
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_RSAPrivateKey_PrecedingUnrelatedPem()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -196,6 +201,7 @@ yZWUxoxAdjfrBGsx+U6BHM0Myqqe7fY7hjWzj4aBCw==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_RSAPrivateKey_PrecedingMalformedPem()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -221,6 +227,7 @@ yZWUxoxAdjfrBGsx+U6BHM0Myqqe7fY7hjWzj4aBCw==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromPem_RSAPrivateKey_IgnoresOtherAlgorithms()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -383,6 +390,7 @@ eDr38gQ/Hk0CgW3/RFrNWdbIpfMifs80vqCUNqDggcQixEmDVZ0gwq4+wz8EVyYG
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromEncryptedPem_Pkcs8Encrypted_Char_Simple()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -408,6 +416,7 @@ CA7ffFk=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromEncryptedPem_Pkcs8Encrypted_Byte_Simple()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSASignatureFormatter.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSASignatureFormatter.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public partial class RSASignatureFormatterTests : AsymmetricSignatureFormatterTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifySignature_SHA1()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -29,6 +30,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifySignature_SHA256()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/RSAXml.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public static class RSAXml
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead1032Parameters_Public()
         {
             RSAParameters expectedParameters = ImportExport.MakePublic(TestData.RSA1032Parameters);
@@ -33,6 +34,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRead1032Parameters_Private()
         {
             // Bonus trait of this XML: the root element name is wrong
@@ -383,6 +385,7 @@ zM=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestReadDiminishedDPParameters_Public()
         {
             RSAParameters expectedParameters =
@@ -404,6 +407,7 @@ zM=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestReadDiminishedDPParameters_Private_Base64Binary()
         {
             // This test uses the base64Binary version of the DP value, where the 0x00
@@ -446,6 +450,7 @@ zM=
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestReadDiminishedDPParameters_Private_CryptoBinary()
         {
             // This test writes the DP value as a CryptoBinary, meaning the leading
@@ -538,6 +543,7 @@ zM=
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWrite1032Parameters(bool includePrivateParameters)
         {
             TestWriteXml(
@@ -585,6 +591,7 @@ zM=
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWrite2048Parameters(bool includePrivateParameters)
         {
             TestWriteXml(
@@ -904,6 +911,7 @@ zM=
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWriteDiminishedDPParameters(bool includePrivateParameters)
         {
             // This test checks for the base64Binary version of DP (leading 0x00 written),
@@ -935,6 +943,7 @@ zM=
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestWriteUnusualExponentParameters(bool includePrivateParameters)
         {
             // This test ensures we pay attention to the Exponent value, instead of assuming
@@ -982,6 +991,7 @@ zM=
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FromToXml()
         {
             using (RSA rsa = RSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -132,6 +132,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignEmptyHash()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -142,6 +143,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedSignature_SHA1_384()
         {
             byte[] expectedSignature =
@@ -173,6 +175,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedSignature_SHA1_1032()
         {
             byte[] expectedSignature =
@@ -200,6 +203,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedSignature_SHA1_2048()
         {
             byte[] expectedSignature = new byte[]
@@ -242,6 +246,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedSignature_SHA256_1024()
         {
             byte[] expectedSignature = new byte[]
@@ -268,6 +273,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedSignature_SHA256_2048()
         {
             byte[] expectedSignature = new byte[]
@@ -310,6 +316,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectSignature_SHA256_1024_Stream()
         {
             byte[] expectedSignature = new byte[]
@@ -345,6 +352,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifySignature_SHA1_384()
         {
             byte[] signature =
@@ -361,6 +369,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifySignature_SHA1_1032()
         {
             byte[] signature =
@@ -388,6 +397,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifySignature_SHA1_2048()
         {
             byte[] signature = new byte[]
@@ -430,6 +440,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifySignature_SHA256_1024()
         {
             byte[] signature = new byte[]
@@ -456,6 +467,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifySignature_SHA256_2048()
         {
             byte[] signature = new byte[]
@@ -498,24 +510,28 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignAndVerify_SHA1_1024()
         {
             SignAndVerify(TestData.HelloBytes, "SHA1", TestData.RSA1024Params);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignAndVerify_SHA1_2048()
         {
             SignAndVerify(TestData.HelloBytes, "SHA1", TestData.RSA2048Params);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignAndVerify_SHA256_1024()
         {
             SignAndVerify(TestData.HelloBytes, "SHA256", TestData.RSA1024Params);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void NegativeVerify_WrongAlgorithm()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -529,6 +545,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void NegativeVerify_WrongSignature()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -545,6 +562,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void NegativeVerify_TamperedData()
         {
             using (RSA rsa = RSAFactory.Create())
@@ -557,6 +575,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void NegativeVerify_BadKeysize()
         {
             byte[] signature;
@@ -577,6 +596,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PkcsSignHash_MismatchedHashSize()
         {
             RSASignaturePadding padding = RSASignaturePadding.Pkcs1;
@@ -600,6 +620,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedHashSignature_SHA1_2048()
         {
             byte[] expectedHashSignature = new byte[]
@@ -649,6 +670,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedHashSignature_SHA256_1024()
         {
             byte[] expectedHashSignature = new byte[]
@@ -682,6 +704,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ExpectedHashSignature_SHA256_2048()
         {
             byte[] expectedHashSignature = new byte[]
@@ -731,6 +754,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyHashSignature_SHA1_2048()
         {
             byte[] hashSignature = new byte[]
@@ -780,6 +804,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyHashSignature_SHA256_1024()
         {
             byte[] hashSignature = new byte[]
@@ -813,6 +838,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyHashSignature_SHA256_2048()
         {
             byte[] hashSignature = new byte[]
@@ -867,6 +893,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         [InlineData("SHA512")]
         [InlineData("MD5")]
         [InlineData("SHA1")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PssRoundtrip(string hashAlgorithmName)
         {
             RSAParameters privateParameters = TestData.RSA2048Params;
@@ -909,6 +936,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyExpectedSignature_PssSha256_RSA2048()
         {
             byte[] modulus2048Signature = (
@@ -929,6 +957,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyExpectedSignature_PssSha256_RSA16384()
         {
             byte[] modulus2048Signature = (
@@ -1005,6 +1034,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyExpectedSignature_PssSha384()
         {
             byte[] bigModulusSignature = (
@@ -1022,6 +1052,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyExpectedSignature_PssSha512()
         {
             byte[] helloSignature = (
@@ -1100,6 +1131,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsPss))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PssSignature_WrongHashAlgorithm()
         {
             RSASignaturePadding padding = RSASignaturePadding.Pss;
@@ -1114,6 +1146,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         [ConditionalFact(nameof(SupportsPss))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PssVerifyHash_MismatchedHashSize()
         {
             // This is a legal SHA-1 value, which we're going to use with SHA-2-256 instead.
@@ -1137,6 +1170,7 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         [ConditionalFact(nameof(SupportsPss))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PssSignHash_MismatchedHashSize()
         {
             RSASignaturePadding padding = RSASignaturePadding.Pss;
@@ -1160,6 +1194,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsPss))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PssSignature_WrongData()
         {
             RSASignaturePadding padding = RSASignaturePadding.Pss;
@@ -1175,6 +1210,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [ConditionalFact(nameof(SupportsPss))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void PssSignature_WrongLength()
         {
             RSASignaturePadding padding = RSASignaturePadding.Pss;

--- a/src/libraries/Common/tests/Tests/System/StringTests.cs
+++ b/src/libraries/Common/tests/Tests/System/StringTests.cs
@@ -621,6 +621,7 @@ namespace System.Tests
         [InlineData(null, 0, null, 0, 0, StringComparison.OrdinalIgnoreCase, 0)]
         [InlineData("Hello", 0, null, 0, 5, StringComparison.OrdinalIgnoreCase, 1)]
         [InlineData(null, 0, "Hello", 0, 5, StringComparison.OrdinalIgnoreCase, -1)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Compare(string strA, int indexA, string strB, int indexB, int length, StringComparison comparisonType, int expected)
         {
             bool hasNullInputs = (strA == null || strB == null);
@@ -1667,6 +1668,7 @@ namespace System.Tests
         [InlineData("Hello", "llo" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", "a", StringComparison.OrdinalIgnoreCase, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void EndsWith_StringComparison(string s, string value, StringComparison comparisonType, bool expected)
         {
             if (comparisonType == StringComparison.CurrentCulture)
@@ -2157,6 +2159,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void EndsWithMatchNonOrdinal_StringComparison()
         {
             string s = "dabc";
@@ -2541,6 +2544,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Equals_EncyclopaediaData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void Equals_Encyclopaedia_ReturnsExpected(StringComparison comparison, bool expected)
         {
             string source = "encyclop\u00e6dia";
@@ -2861,6 +2865,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_TurkishI_TurkishCulture()
         {
             using (new ThreadCultureChange("tr-TR"))
@@ -2944,6 +2949,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_HungarianDoubleCompression_HungarianCulture()
         {
             using (new ThreadCultureChange("hu-HU"))
@@ -2994,6 +3000,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_EquivalentDiacritics_EnglishUSCulture()
         {
             using (new ThreadCultureChange("en-US"))
@@ -3028,6 +3035,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_EquivalentDiacritics_InvariantCulture()
         {
             using (new ThreadCultureChange(CultureInfo.InvariantCulture))
@@ -4657,6 +4665,7 @@ namespace System.Tests
         [InlineData("Hello", SoftHyphen + "Hel", StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("", "hello", StringComparison.OrdinalIgnoreCase, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void StartsWith_StringComparison(string s, string value, StringComparison comparisonType, bool expected)
         {
             if (comparisonType == StringComparison.CurrentCulture)
@@ -5074,6 +5083,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Test_ToLower_Culture()
         {
             foreach (object[] testdata in ToLower_Culture_TestData())
@@ -5551,6 +5561,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_Culture_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Test_ToUpper_Culture(string actual, string expected, CultureInfo culture)
         {
             Assert.Equal(expected, actual.ToUpper(culture));
@@ -5609,6 +5620,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_TurkishI_TurkishCulture_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToUpper_TurkishI_TurkishCulture(string s, string expected)
         {
             using (new ThreadCultureChange("tr-TR"))
@@ -5629,6 +5641,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_TurkishI_EnglishUSCulture_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToUpper_TurkishI_EnglishUSCulture(string s, string expected)
         {
             using (new ThreadCultureChange("en-US"))
@@ -6735,6 +6748,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Compare_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void CompareTest(string s1, string s2, string cultureName, bool ignoreCase, int expected)
         {
             CultureInfo ci = cultureName != null ? CultureInfo.GetCultureInfo(cultureName) : null;
@@ -6780,6 +6794,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(StartEndWith_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void StartEndWithTest(string source, string start, string end, string cultureName, bool ignoreCase, bool expected)
         {
              CultureInfo ci = cultureName != null ? CultureInfo.GetCultureInfo(cultureName) : null;
@@ -6792,6 +6807,7 @@ namespace System.Tests
         [InlineData("", StringComparison.Ordinal, true)]
         [InlineData(ZeroWidthJoiner, StringComparison.InvariantCulture, true)]
         [InlineData(ZeroWidthJoiner, StringComparison.Ordinal, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void StartEndWith_ZeroWeightValue(string value, StringComparison comparison, bool expectedStartsAndEndsWithResult)
         {
             Assert.Equal(expectedStartsAndEndsWithResult, string.Empty.StartsWith(value, comparison));
@@ -6972,6 +6988,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void StartsWithMatchNonOrdinal_StringComparison()
         {
             string s1 = "abcd";

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DbProviderFactoriesTests.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DbProviderFactoriesTests.cs
@@ -37,6 +37,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void GetFactoryWithInvariantNameTest()
         {
             ClearRegisteredFactories();
@@ -48,6 +49,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void GetFactoryWithDbConnectionTest()
         {
             ClearRegisteredFactories();
@@ -59,6 +61,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void GetFactoryWithDataRowTest()
         {
             ClearRegisteredFactories();
@@ -66,6 +69,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithTypeNameTest()
         {
             ClearRegisteredFactories();
@@ -73,6 +77,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithTypeTest()
         {
             ClearRegisteredFactories();
@@ -80,6 +85,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithInstanceTest()
         {
             ClearRegisteredFactories();
@@ -87,6 +93,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithWrongTypeTest()
         {
             ClearRegisteredFactories();
@@ -95,6 +102,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithBadInvariantNameTest()
         {
             ClearRegisteredFactories();
@@ -103,6 +111,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithAssemblyQualifiedNameTest()
         {
             ClearRegisteredFactories();
@@ -110,6 +119,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void RegisterFactoryWithWrongAssemblyQualifiedNameTest()
         {
             ClearRegisteredFactories();
@@ -126,6 +136,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void UnregisterFactoryTest()
         {
             ClearRegisteredFactories();
@@ -136,6 +147,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TryGetFactoryTest()
         {
             ClearRegisteredFactories();
@@ -148,6 +160,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReplaceFactoryWithRegisterFactoryWithTypeTest()
         {
             ClearRegisteredFactories();
@@ -162,6 +175,7 @@ namespace System.Data.Common
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void GetProviderInvariantNamesTest()
         {
             ClearRegisteredFactories();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataRowTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataRowTest2.cs
@@ -1895,6 +1895,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void IsNull_ByName()
         {
             DataTable dt = new DataTable();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetInferXmlSchemaTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetInferXmlSchemaTest.cs
@@ -247,6 +247,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void SimpleDataSet()
         {
             DataSet ds = GetDataSet(_xml8, null);
@@ -338,6 +339,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TwoElementTable()
         {
             // FIXME: Also test ReadXml (, XmlReadMode.InferSchema) and
@@ -357,6 +359,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ConflictSimpleComplexColumns()
         {
             DataSet ds = GetDataSet(_xml18, null);
@@ -378,6 +381,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ConflictColumnTable()
         {
             DataSet ds = GetDataSet(_xml19, null);
@@ -399,6 +403,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ConflictColumnTableAttribute()
         {
             // Conflicts between a column and a table, additionally an attribute.
@@ -422,6 +427,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ConflictAttributeDataTable()
         {
             Assert.Throws<DataException>(() =>
@@ -434,6 +440,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ConflictExistingPrimaryKey()
         {
             Assert.Throws<ConstraintException>(() =>

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetReadXmlSchemaTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetReadXmlSchemaTest.cs
@@ -53,6 +53,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void SingleElementTreatmentDifference()
         {
             // This is one of the most complicated case. When the content
@@ -324,6 +325,7 @@ namespace System.Data.Tests
 
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ElementHasIdentityConstraint()
         {
             string constraints = @"
@@ -682,6 +684,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TestAnnotatedRelation1()
         {
             var ds = new DataSet();
@@ -733,6 +736,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TestAnnotatedRelation2()
         {
             var ds = new DataSet();
@@ -905,6 +909,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadAnnotatedRelations_MultipleColumns()
         {
             var ds = new DataSet();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetReadXmlTest.cs
@@ -66,6 +66,7 @@ namespace System.Data.Tests
         private const string schema2 = schema1 + xml8;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadSimpleAuto()
         {
             DataSet ds;
@@ -286,6 +287,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadSimpleInferSchema()
         {
             DataSet ds;
@@ -607,6 +609,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadComplexElementDocument()
         {
             var ds = new DataSet();
@@ -640,6 +643,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void NameConflictDSAndTable()
         {
             string xml = @"<PriceListDetails>
@@ -658,6 +662,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ColumnOrder()
         {
             string xml = "<?xml version=\"1.0\" standalone=\"yes\"?>" +
@@ -691,6 +696,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void XmlSpace()
         {
             string xml = "<?xml version=\"1.0\" standalone=\"yes\"?>" +

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetTest.cs
@@ -368,6 +368,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadWriteXml()
         {
             var ds = new DataSet();
@@ -425,6 +426,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadWriteXmlDiffGram()
         {
             var ds = new DataSet();
@@ -508,6 +510,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void WriteXmlSchema()
         {
             using (new ThreadCultureChange("fi-FI"))
@@ -990,6 +993,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void WriteXmlToStream()
         {
             string xml = "<set><table1><col1>sample text</col1><col2/></table1><table2 attr='value'><col3>sample text 2</col3></table2></set>";
@@ -1029,6 +1033,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadWriteXml2()
         {
             string xml = "<FullTextResponse><Domains><AvailResponse info='y' name='novell-ximian-group' /><AvailResponse info='n' name='ximian' /></Domains></FullTextResponse>";
@@ -1047,6 +1052,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadWriteXml3()
         {
             string input = @"<FullTextResponse>
@@ -1560,6 +1566,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void WriteXmlModeSchema1()
         {
             // Keeping the brackets as the test otherwise starts to fail.

--- a/src/libraries/System.Data.Common/tests/System/Data/DataSetTest2.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataSetTest2.cs
@@ -541,6 +541,7 @@ namespace System.Data.Tests
         #region test namespaces
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_BasicXml()
         {
             StringBuilder sb = new StringBuilder();
@@ -573,6 +574,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_WithoutIgnoreNameSpaces()
         {
             StringBuilder sb = new StringBuilder();
@@ -598,6 +600,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_IgnoreNameSpace()
         {
             StringBuilder sb = new StringBuilder();
@@ -638,6 +641,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_IgnoreNameSpaces() //Ignoring 2 namespaces
         {
             StringBuilder sb = new StringBuilder();
@@ -668,6 +672,7 @@ namespace System.Data.Tests
 
         #region inferringTables
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringTables1()
         {
             //According to the msdn documantaion :
@@ -692,6 +697,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringTables2()
         {
             //According to the msdn documantaion :
@@ -742,6 +748,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringTables4()
         {
             //According to the msdn documantaion :
@@ -767,6 +774,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringTables5()
         {
             //According to the msdn documantaion :
@@ -792,6 +800,7 @@ namespace System.Data.Tests
 
         #region inferringColumns
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringColumns1()
         {
             //ms-help://MS.MSDNQTR.2003FEB.1033/cpguide/html/cpconinferringcolumns.htm
@@ -816,6 +825,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringColumns2()
         {
             //ms-help://MS.MSDNQTR.2003FEB.1033/cpguide/html/cpconinferringcolumns.htm
@@ -851,6 +861,7 @@ namespace System.Data.Tests
         #region Inferring Relationships
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_inferringRelationships1()
         {
             //ms-help://MS.MSDNQTR.2003FEB.1033/cpguide/html/cpconinferringrelationships.htm
@@ -915,6 +926,7 @@ namespace System.Data.Tests
         #region Inferring Element Text
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_elementText1()
         {
             //ms-help://MS.MSDNQTR.2003FEB.1033/cpguide/html/cpconinferringelementtext.htm
@@ -943,6 +955,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void InferXmlSchema_elementText2()
         {
             //ms-help://MS.MSDNQTR.2003FEB.1033/cpguide/html/cpconinferringelementtext.htm
@@ -989,6 +1002,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void DataSetSpecificCulture()
         {
             using (new ThreadCultureChange("cs-CZ"))
@@ -2236,6 +2250,7 @@ namespace System.Data.Tests
             Assert.Equal("Stock_Price", ds.Tables[2].ParentRelations[0].RelationName);
         }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadXml_Strm3()
         {
             DataSet ds = new DataSet("TestDataSet");
@@ -2265,6 +2280,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadXml_Strm4()
         {
             _ds = new DataSet("Stocks");
@@ -2366,6 +2382,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadXml_Strm5()
         {
             string xmlData;
@@ -2590,6 +2607,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadXml_Strm6()
         {
             // TC1
@@ -3071,6 +3089,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void WriteXml_Stream()
         {
             {

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableReadXmlSchemaTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableReadXmlSchemaTest.cs
@@ -54,6 +54,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void SuspiciousDataSetElement()
         {
             string schema = @"<?xml version='1.0'?>
@@ -109,6 +110,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void IsDataSetAndTypeIgnored()
         {
             string xsbase = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:msdata='urn:schemas-microsoft-com:xml-msdata'>
@@ -141,6 +143,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void NestedReferenceNotAllowed()
         {
             string xs = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:msdata='urn:schemas-microsoft-com:xml-msdata'>
@@ -195,6 +198,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void PrefixedTargetNS()
         {
             string xs = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema' xmlns:msdata='urn:schemas-microsoft-com:xml-msdata' xmlns:x='urn:foo' targetNamespace='urn:foo' elementFormDefault='qualified'>
@@ -309,6 +313,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TestSampleFileComplexTables3()
         {
             var ds = new DataSet();
@@ -339,6 +344,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TestSampleFileXPath()
         {
             var ds = new DataSet();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest.cs
@@ -2888,6 +2888,7 @@ Assert.False(true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ReadXmlSchema_2()
         {
             DataTable dt = new DataTable();

--- a/src/libraries/System.Data.Common/tests/System/Data/DataTableTest4.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/DataTableTest4.cs
@@ -871,6 +871,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void XmlTest8()
         {
             MakeParentTable1();
@@ -911,6 +912,7 @@ namespace System.Data.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void XmlTest9()
         {
             MakeParentTable1();

--- a/src/libraries/System.Data.Common/tests/System/Data/FacadeTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/FacadeTest.cs
@@ -10,6 +10,7 @@ namespace System.Data.Tests
         [Theory]
         [InlineData("Microsoft.SqlServer.Server.SqlMetaData")] // Type from System.Data.SqlClient
         [InlineData("System.Data.SqlTypes.SqlBytes")] // Type from System.Data.Common
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void TestSystemData(string typeName)
         {
             // Verify that the type can be loaded via .NET Framework compat facade

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlStringSortingTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlStringSortingTest.cs
@@ -51,6 +51,7 @@ namespace System.Data.SqlTypes.Tests
         [InlineData("cs-CZ", 0x0405)] // Czech - Czech Republic
         [InlineData("fr-CH", 0x100c)] // French - Switzerland
         [InlineData("en-US", 0x0409)] // English - United States
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public static void SqlStringValidComparisonTest(string cultureName, int localeId)
         {
             if (PlatformDetection.IsIcuGlobalization && cultureName == "ja-JP" && localeId == 0x0411)

--- a/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/SqlTypes/SqlStringTest.cs
@@ -65,6 +65,7 @@ namespace System.Data.Tests.SqlTypes
         [Theory]
         [InlineData(1033, "en-US")]
         [InlineData(1036, "fr-FR")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void Constructor_ValueLcid_Success(int lcid, string name)
         {
             const string value = "foo";
@@ -91,6 +92,7 @@ namespace System.Data.Tests.SqlTypes
 
         // Test constructor
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void Create()
         {
             // SqlString (String)
@@ -171,6 +173,7 @@ namespace System.Data.Tests.SqlTypes
 
         // Test properties
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void Properties()
         {
             using (new ThreadCultureChange("en-AU"))

--- a/src/libraries/System.Data.DataSetExtensions/tests/Mono/DataTableExtensionsTest.cs
+++ b/src/libraries/System.Data.DataSetExtensions/tests/Mono/DataTableExtensionsTest.cs
@@ -76,6 +76,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void AsEnumerable()
         {
             DataSet ds = new DataSet();

--- a/src/libraries/System.Data.DataSetExtensions/tests/Mono/EnumerableRowCollectionTest.cs
+++ b/src/libraries/System.Data.DataSetExtensions/tests/Mono/EnumerableRowCollectionTest.cs
@@ -42,6 +42,7 @@ namespace MonoTests.System.Data
         private string _testDataSet = "Mono/testdataset1.xml";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void QueryWhere()
         {
             var ds = new DataSet();
@@ -69,6 +70,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void QueryWhereSelect ()
         {
             var ds = new DataSet ();
@@ -90,6 +92,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void QueryWhereSelectOrderBy ()
         {
             var ds = new DataSet ();
@@ -120,6 +123,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void QueryWhereSelectOrderByDescending ()
         {
             var ds = new DataSet ();
@@ -150,6 +154,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ThenBy ()
         {
             var ds = new DataSet ();
@@ -180,6 +185,7 @@ namespace MonoTests.System.Data
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36879", TestPlatforms.iOS)]
         public void ThenByDescending ()
         {
             var ds = new DataSet ();

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsNoListeners.cs
@@ -68,6 +68,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Debug_WriteLineNull_IndentsEmptyStringProperly()
         {
             Debug.Indent();
@@ -209,6 +210,7 @@ namespace System.Diagnostics.Tests
         [InlineData(-1, 0)]
         [InlineData(0, 0)]
         [InlineData(1, 1)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void IndentLevel_Set_GetReturnsExpected(int indentLevel, int expectedIndentLevel)
         {
             Debug.IndentLevel = indentLevel;

--- a/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
+++ b/src/libraries/System.Diagnostics.Debug/tests/DebugTestsUsingListeners.cs
@@ -197,6 +197,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Trace_ClearTraceListeners_StopsWritingToDebugger()
         {
             VerifyLogged(() => Debug.Write("pizza"), "pizza");
@@ -230,6 +231,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void TraceWriteLineIf()
         {
             VerifyLogged(() => Trace.WriteLineIf(true, 5), "5" + Environment.NewLine);

--- a/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -21,6 +21,7 @@ namespace System.Diagnostics.Tests
         private const string TestNotFoundFileName = "notfound.dll";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void FileVersionInfo_CustomManagedAssembly()
         {
             // Assembly1.dll

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsManifestNegative.cs
@@ -60,6 +60,7 @@ namespace BasicEventSourceTests
         /// </summary>
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/runtime/issues/21421")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_GenerateManifest_InvalidEventSources()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsTraits.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsTraits.cs
@@ -30,6 +30,7 @@ namespace BasicEventSourceTests
         /// Tests EventSource Traits.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_EventSource_Traits_Contract()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");
@@ -46,6 +47,7 @@ namespace BasicEventSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_EventSource_Traits_Dynamic()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.cs
@@ -206,6 +206,7 @@ namespace BasicEventSourceTests
         static partial void Test_WriteEvent_ArgsCornerCases_TestEtw(EventSourceTest log);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_WriteEvent_InvalidCalls()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");
@@ -228,6 +229,7 @@ namespace BasicEventSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_WriteEvent_ToChannel_Coverage()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");
@@ -278,6 +280,7 @@ namespace BasicEventSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_EventSourceCreatedEvents_BeforeListener()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");
@@ -341,6 +344,7 @@ namespace BasicEventSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36882", TestPlatforms.iOS)]
         public void Test_EventSourceCreatedEvents_AfterListener()
         {
             TestUtilities.CheckNoEventSourcesRunning("Start");

--- a/src/libraries/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/CalendarTests.cs
+++ b/src/libraries/System.Globalization.Calendars/tests/CalendarTestWithConfigSwitch/CalendarTests.cs
@@ -11,6 +11,7 @@ namespace System.Globalization.Tests
     public static class CalendarTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public static void TestJapaneseCalendarDateParsing()
         {
             CultureInfo ciJapanese = new CultureInfo("ja-JP") { DateTimeFormat = { Calendar = new JapaneseCalendar() } };

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.Compare.cs
@@ -265,6 +265,7 @@ namespace System.Globalization.Tests
                                                               s_invariantCompare.Compare("\u3060", "\uFF80\uFF9E", CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase) == 0;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CompareWithUnassignedChars()
         {
             int result = PlatformDetection.IsNlsGlobalization ? 0 : -1;
@@ -274,6 +275,7 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(nameof(IsNotWindowsKanaRegressedVersion))]
         [MemberData(nameof(Compare_Kana_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CompareWithKana(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
             Compare_Advanced(compareInfo, string1, 0, string1?.Length ?? 0, string2, 0, string2?.Length ?? 0, options, expected);

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IndexOf.cs
@@ -159,6 +159,7 @@ namespace System.Globalization.Tests
         [MemberData(nameof(IndexOf_TestData))]
         [MemberData(nameof(IndexOf_Aesc_Ligature_TestData))]
         [MemberData(nameof(IndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected)
         {
             if (value.Length == 1)
@@ -249,6 +250,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IndexOf_UnassignedUnicode()
         {
             bool useNls = PlatformDetection.IsNlsGlobalization;

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsPrefix.cs
@@ -92,6 +92,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsPrefix_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsPrefix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected)
         {
             if (options == CompareOptions.None)
@@ -119,6 +120,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsPrefix_UnassignedUnicode()
         {
             bool result = PlatformDetection.IsNlsGlobalization ? true : false;

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.IsSuffix.cs
@@ -94,6 +94,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsSuffix_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsSuffix(CompareInfo compareInfo, string source, string value, CompareOptions options, bool expected)
         {
             if (options == CompareOptions.None)
@@ -121,6 +122,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsSuffix_UnassignedUnicode()
         {
             bool result = PlatformDetection.IsIcuGlobalization ? false : true;

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.LastIndexOf.cs
@@ -137,6 +137,7 @@ namespace System.Globalization.Tests
         [Theory]
         [MemberData(nameof(LastIndexOf_TestData))]
         [MemberData(nameof(LastIndexOf_U_WithDiaeresis_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void LastIndexOf_String(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected)
         {
             if (value.Length == 1)
@@ -256,12 +257,14 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(LastIndexOf_Aesc_Ligature_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void LastIndexOf_Aesc_Ligature(CompareInfo compareInfo, string source, string value, int startIndex, int count, CompareOptions options, int expected)
         {
             LastIndexOf_String(compareInfo, source, value, startIndex, count, options, expected);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void LastIndexOf_UnassignedUnicode()
         {
             bool useNls = PlatformDetection.IsNlsGlobalization;

--- a/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/CompareInfo/CompareInfoTests.cs
@@ -19,6 +19,7 @@ namespace System.Globalization.Tests
         [InlineData("en")]
         [InlineData("zh-Hans")]
         [InlineData("zh-Hant")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetCompareInfo(string name)
         {
             CompareInfo compare = CompareInfo.GetCompareInfo(name);
@@ -62,6 +63,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCodeTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetHashCodeTest(string source1, CompareOptions options1, string source2, CompareOptions options2, bool expected)
         {
             CompareInfo invariantCompare = CultureInfo.InvariantCulture.CompareInfo;
@@ -355,6 +357,7 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(typeof(CompareInfoCompareTests), nameof(CompareInfoCompareTests.IsNotWindowsKanaRegressedVersion))]
         [MemberData(nameof(SortKey_Kana_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void SortKeyKanaTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expected)
         {
             SortKeyTest(compareInfo, string1, string2, options, expected);
@@ -362,6 +365,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(SortKey_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void SortKeyTest(CompareInfo compareInfo, string string1, string string2, CompareOptions options, int expectedSign)
         {
             SortKey sk1 = compareInfo.GetSortKey(string1, options);
@@ -406,6 +410,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void SortKeyMiscTest()
         {
             CompareInfo ci = new CultureInfo("en-US").CompareInfo;
@@ -461,6 +466,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(IsSortable_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsSortableTest(object sourceObj, bool expected)
         {
             string source = sourceObj as string ?? new string((char[])sourceObj);
@@ -480,6 +486,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void VersionTest()
         {
             SortVersion sv1 = CultureInfo.GetCultureInfo("en-US").CompareInfo.Version;
@@ -492,6 +499,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCodeTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetHashCode_Span(string source1, CompareOptions options1, string source2, CompareOptions options2, bool expectSameHashCode)
         {
             CompareInfo invariantCompare = CultureInfo.InvariantCulture.CompareInfo;

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -538,6 +538,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(CultureInfo_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void LcidTest(string cultureName, int lcid, string specificCultureName, string threeLetterISOLanguageName, string threeLetterWindowsLanguageName, string alternativeCultureName, string consoleUICultureName)
         {
             _ = alternativeCultureName;
@@ -606,6 +607,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(CultureInfo_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetCulturesTest(string cultureName, int lcid, string specificCultureName, string threeLetterISOLanguageName, string threeLetterWindowsLanguageName, string alternativeCultureName, string consoleUICultureName)
         {
             _ = lcid;

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCtor.cs
@@ -26,6 +26,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_String_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Ctor_String(string name, string[] expectedNames)
         {
             CultureInfo culture = new CultureInfo(name);
@@ -34,6 +35,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Ctor_String_Invalid()
         {
             AssertExtensions.Throws<ArgumentNullException>("name", () => new CultureInfo(null)); // Name is null

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoCurrentCulture.cs
@@ -15,6 +15,7 @@ namespace System.Globalization.Tests
     public class CurrentCultureTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrentCulture()
         {
             var newCulture = new CultureInfo(CultureInfo.CurrentCulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");
@@ -38,6 +39,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrentUICulture()
         {
             var newUICulture = new CultureInfo(CultureInfo.CurrentUICulture.Name.Equals("ja-JP", StringComparison.OrdinalIgnoreCase) ? "ar-SA" : "ja-JP");

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEnglishName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoEnglishName.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(EnglishName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void EnglishName(string name, string expected)
         {
             CultureInfo myTestCulture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNativeName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoNativeName.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(NativeName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void NativeName(string name, string expected)
         {
             CultureInfo myTestCulture = new CultureInfo(name);

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoParent.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoParent.cs
@@ -12,6 +12,7 @@ namespace System.Globalization.Tests
         [InlineData("en-US", "en")]
         [InlineData("en", "")]
         [InlineData("", "")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Parent(string name, string expectedParentName)
         {
             CultureInfo culture = new CultureInfo(name);
@@ -19,6 +20,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Parent_ParentChain()
         {
             CultureInfo myExpectParentCulture = new CultureInfo("uz-Cyrl-UZ");

--- a/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoTwoLetterISOLanguageName.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/CultureInfoTwoLetterISOLanguageName.cs
@@ -12,6 +12,7 @@ namespace System.Globalization.Tests
         [InlineData("de-DE", "de")]
         [InlineData("en", "en")]
         [InlineData("", "iv")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void TwoLetterISOLanguageName(string name, string expected)
         {
             Assert.Equal(expected, new CultureInfo(name).TwoLetterISOLanguageName);

--- a/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
+++ b/src/libraries/System.Globalization/tests/CultureInfo/GetCultureInfo.cs
@@ -26,6 +26,7 @@ namespace System.Globalization.Tests
         [ConditionalTheory(nameof(PlatformSupportsFakeCulture))]
         [InlineData("en@US")]
         [InlineData("\uFFFF")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void TestInvalidCultureNames(string name)
         {
             Assert.Throws<CultureNotFoundException>(() => CultureInfo.GetCultureInfo(name));
@@ -37,6 +38,7 @@ namespace System.Globalization.Tests
         [InlineData("xx")]
         [InlineData("xx-XX")]
         [InlineData("xx-YY")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void TestFakeCultureNames(string name)
         {
             Assert.Equal(name, CultureInfo.GetCultureInfo(name).Name);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(CalendarWeekRule_Get_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CalendarWeekRuleTest(DateTimeFormatInfo format, CalendarWeekRule expected)
         {
             Assert.Equal(expected, format.CalendarWeekRule);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoFirstDayOfWeek.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(FirstDayOfWeek_Get_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void FirstDayOfWeek(DateTimeFormatInfo format, DayOfWeek expected)
         {
             Assert.Equal(expected, format.FirstDayOfWeek);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
@@ -24,6 +24,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetAbbreviatedDayName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetAbbreviatedDayName_Invoke_ReturnsExpected(DateTimeFormatInfo info, string[] expected)
         {
             DayOfWeek[] values = new DayOfWeek[]

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedEraName.cs
@@ -20,6 +20,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetAbbreviatedEraName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetAbbreviatedEraName_Invoke_ReturnsExpected(DateTimeFormatInfo format, int era, string expected)
         {
             Assert.Equal(expected, format.GetAbbreviatedEraName(era));

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
@@ -27,6 +27,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetAbbreviatedMonthName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetAbbreviatedMonthName_Invoke_ReturnsExpected(DateTimeFormatInfo info, string[] expected)
         {
             for (int i = MinMonth; i <= MaxMonth; ++i)

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
@@ -25,6 +25,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetDayName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetDayName_Invoke_ReturnsExpected(DateTimeFormatInfo format, string[] expected)
         {
             DayOfWeek[] values = new DayOfWeek[]

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEra.cs
@@ -52,6 +52,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetEra_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetEra_Invoke_RetrunsExpected(DateTimeFormatInfo format, string eraName, int expected)
         {
             Assert.Equal(expected, format.GetEra(eraName));

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetEraName.cs
@@ -25,6 +25,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetEraName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetEraName_Invoke_ReturnsExpected(DateTimeFormatInfo format, int era, string expected)
         {
             Assert.Equal(expected, format.GetEraName(era));

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
@@ -27,6 +27,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(GetMonthName_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void GetMonthName_Invoke_ReturnsExpected(DateTimeFormatInfo format, string[] expected)
         {
             for (int i = MinMonth; i <= MaxMonth; ++i)

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthGenitiveNames.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoMonthGenitiveNames.cs
@@ -36,6 +36,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(MonthGenitiveNames_Get_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void MonthGenitiveNames_Get_ReturnsExpected(DateTimeFormatInfo format, string[] expected)
         {
             Assert.Equal(expected, format.MonthGenitiveNames);

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoTests.cs
@@ -62,6 +62,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(DateTimeFormatInfo_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void NativeCalendarName_Get_ReturnsExpected(DateTimeFormatInfo dtfi, Calendar calendar, string nativeCalendarName)
         {
             try
@@ -135,6 +136,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Months_GetHebrew_ReturnsExpected()
         {
             CultureInfo ci = new CultureInfo("he-IL");
@@ -163,6 +165,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void TestFirstYearOfJapaneseEra()
         {
             DateTimeFormatInfo jpnFormat = new CultureInfo("ja-JP").DateTimeFormat;

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoYearMonthPattern.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoYearMonthPattern.cs
@@ -17,6 +17,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(YearMonthPattern_Get_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void YearMonthPattern(DateTimeFormatInfo format, string expected)
         {
             Assert.Equal(expected, format.YearMonthPattern);

--- a/src/libraries/System.Globalization/tests/IcuTests.cs
+++ b/src/libraries/System.Globalization/tests/IcuTests.cs
@@ -31,6 +31,7 @@ namespace System.Globalization.Tests
         }
 
         [ConditionalFact(nameof(IsIcuCompatiblePlatform))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public static void IcuShouldBeLoaded()
         {
             Assert.True(PlatformDetection.IsIcuGlobalization);

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyDecimalDigits.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyDecimalDigits.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(CurrencyDecimalDigits_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrencyDecimalDigits_Get_ReturnsExpected(NumberFormatInfo format, int expectedNls, int expectedIcu)
         {
             int expected = PlatformDetection.IsNlsGlobalization ? expectedNls : expectedIcu;

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyGroupSizes.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyGroupSizes.cs
@@ -22,6 +22,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(CurrencyGroupSizes_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrencyGroupSizes_Get_ReturnsExpected(NumberFormatInfo format, int[] expected)
         {
             Assert.Equal(expected, format.CurrencyGroupSizes);

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -31,6 +31,7 @@ namespace System.Globalization.Tests
         [InlineData("as")]
         [InlineData("es-BO")]
         [InlineData("fr-CA")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrencyNegativePattern_Get_ReturnsExpected_ByLocale(string locale)
         {
             CultureInfo culture;

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyPositivePattern.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyPositivePattern.cs
@@ -18,6 +18,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(CurrencyPositivePattern_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrencyPositivePattern_Get_ReturnsExpected(NumberFormatInfo format, int expected)
         {
             Assert.Equal(expected, format.CurrencyPositivePattern);

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencySymbol.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencySymbol.cs
@@ -12,6 +12,7 @@ namespace System.Globalization.Tests
         [InlineData("en-US", "$")]
         [InlineData("en-GB", "\x00a3")] // pound
         [InlineData("", "\x00a4")] // international
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrencySymbol_Get_ReturnsExpected(string name, string expected)
         {
             Assert.Equal(expected, CultureInfo.GetCultureInfo(name).NumberFormat.CurrencySymbol);

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -23,6 +23,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(NumberGroupSizes_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void NumberGroupSizes_Get_ReturnsExpected(NumberFormatInfo format, int[] expected)
         {
             Assert.Equal(expected, format.NumberGroupSizes);

--- a/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoTests.cs
@@ -103,6 +103,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(DigitSubstitution_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void DigitSubstitutionListTest(string cultureName, DigitShapes shape)
         {
             try

--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -25,6 +25,7 @@ namespace System.Globalization.Tests
         [InlineData("en-IE", "IE", "en-IE")]
         [InlineData("en-US", "US", "en-US")]
         [InlineData("zh-CN", "CN", "zh-CN")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Ctor(string name, string expectedName, string windowsDesktopName)
         {
             var regionInfo = new RegionInfo(name);
@@ -47,6 +48,7 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("no-such-culture")]
         [InlineData("en")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void Ctor_InvalidName_ThrowsArgumentException(string name)
         {
             AssertExtensions.Throws<ArgumentException>("name", () => new RegionInfo(name));
@@ -114,6 +116,7 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("en-US", false)]
         [InlineData("zh-CN", true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsMetric(string name, bool expected)
         {
             Assert.Equal(expected, new RegionInfo(name).IsMetric);
@@ -124,6 +127,7 @@ namespace System.Globalization.Tests
         [InlineData("zh-CN", "CNY")]
         [InlineData("de-DE", "EUR")]
         [InlineData("it-IT", "EUR")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void ISOCurrencySymbol(string name, string expected)
         {
             Assert.Equal(expected, new RegionInfo(name).ISOCurrencySymbol);
@@ -132,6 +136,7 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("en-US", new string[] { "$" })]
         [InlineData("zh-CN", new string[] { "\u00A5", "\uffe5" })] // \u00A5 is Latin-1 Supplement(Windows), \uffe5 is Halfwidth and Fullwidth Forms(ICU)
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void CurrencySymbol(string name, string[] expected)
         {
             string result = new RegionInfo(name).CurrencySymbol;
@@ -143,6 +148,7 @@ namespace System.Globalization.Tests
         [InlineData("zh-CN", "CN")]
         [InlineData("de-DE", "DE")]
         [InlineData("it-IT", "IT")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void TwoLetterISORegionName(string name, string expected)
         {
             Assert.Equal(expected, new RegionInfo(name).TwoLetterISORegionName);
@@ -186,6 +192,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(Equals_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void EqualsTest(RegionInfo regionInfo1, object obj, bool expected)
         {
             Assert.Equal(expected, regionInfo1.Equals(obj));

--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -23,6 +23,7 @@ namespace System.Globalization.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))] // OS changes
         [MemberData(nameof(TextInfo_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void MiscTest(string cultureName, int lcid, int ansiCodePage, int ebcdiCCodePage, int macCodePage, int oemCodePage, bool isRightToLeft)
         {
             TextInfo ti = CultureInfo.GetCultureInfo(cultureName).TextInfo;
@@ -116,6 +117,7 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("en-US", false)]
         [InlineData("ar", true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void IsRightToLeft(string name, bool expected)
         {
             Assert.Equal(expected, new CultureInfo(name).TextInfo.IsRightToLeft);
@@ -263,6 +265,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToLower_TestData_netcore))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void ToLower_Netcore(string name, string str, string expected)
         {
             TestToLower(name, str, expected);
@@ -386,6 +389,7 @@ namespace System.Globalization.Tests
 
         [Theory]
         [MemberData(nameof(ToUpper_TestData_netcore))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]
         public void ToUpper_netcore(string name, string str, string expected)
         {
             TestToUpper(name, str, expected);

--- a/src/libraries/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
+++ b/src/libraries/System.IO.Compression.Brotli/tests/BrotliEncoderTests.cs
@@ -43,6 +43,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void GetMaxCompressedSize()
         {
             string uncompressedFile = UncompressedTestFile();
@@ -56,6 +57,7 @@ namespace System.IO.Compression.Tests
         /// Test to ensure that when given an empty Destination span, the decoder will consume no input and write no output.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void Decompress_WithEmptyDestination()
         {
             string testFile = UncompressedTestFile();
@@ -100,6 +102,7 @@ namespace System.IO.Compression.Tests
         /// Test to ensure that when given an empty Destination span, the encoder consume no input and write no output
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void Compress_WithEmptyDestination()
         {
             string testFile = UncompressedTestFile();

--- a/src/libraries/System.IO.Compression.Brotli/tests/BrotliGoogleTestData.cs
+++ b/src/libraries/System.IO.Compression.Brotli/tests/BrotliGoogleTestData.cs
@@ -33,6 +33,7 @@ namespace System.IO.Compression.Tests
 
         [Theory]
         [MemberData(nameof(GoogleTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void DecompressFile(string fileName)
         {
             byte[] bytes = File.ReadAllBytes(CompressedTestFile(fileName));
@@ -43,6 +44,7 @@ namespace System.IO.Compression.Tests
 
         [Theory]
         [MemberData(nameof(GoogleTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void RoundtripCompressDecompressFile(string fileName)
         {
             byte[] bytes = File.ReadAllBytes(fileName);

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
@@ -13,6 +13,7 @@ namespace System.IO.Compression.Tests
     public class ZipFile_Create : ZipFileTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task CreateFromDirectoryNormal()
         {
             string folderName = zfolder("normal");
@@ -23,6 +24,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void CreateFromDirectory_IncludeBaseDirectory()
         {
             string folderName = zfolder("normal");
@@ -47,6 +49,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void CreateFromDirectoryUnicode()
         {
             string folderName = zfolder("unicode");
@@ -149,6 +152,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void InvalidFiles()
         {
             Assert.Throws<InvalidDataException>(() => ZipFile.OpenRead(bad("EOCDmissing.zip")));
@@ -228,6 +232,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("LZMA.zip", true)]
         [InlineData("invalidDeflate.zip", false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void UnsupportedCompressionRoutine(string zipName, bool throwsOnOpen)
         {
             string filename = bad(zipName);
@@ -276,6 +281,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void InvalidDates()
         {
             using (ZipArchive archive = ZipFile.OpenRead(bad("invaliddate.zip")))
@@ -375,6 +381,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task UpdateAddFile()
         {
             //add file

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -17,6 +17,7 @@ namespace System.IO.Compression.Tests
         [InlineData("appended.zip", "small")]
         [InlineData("prepended.zip", "small")]
         [InlineData("noexplicitdir.zip", "explicitdir")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryNormal(string file, string folder)
         {
             string zipFileName = zfile(file);
@@ -35,6 +36,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryUnicode()
         {
             string zipFileName = zfile("unicode.zip");
@@ -120,6 +122,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryOverwrite()
         {
             string zipFileName = zfile("normal.zip");
@@ -137,6 +140,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryOverwriteEncoding()
         {
             string zipFileName = zfile("normal.zip");
@@ -154,6 +158,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryZipArchiveOverwrite()
         {
             string zipFileName = zfile("normal.zip");

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Create.cs
@@ -13,6 +13,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task CreateEntryFromFileExtension(bool withCompressionLevel)
         {
             //add file

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchive.Extract.cs
@@ -9,6 +9,7 @@ namespace System.IO.Compression.Tests
     public class ZipFile_ZipArchive_Extract : ZipFileTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryExtension()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("normal.zip"), ZipArchiveMode.Read))
@@ -23,6 +24,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToDirectoryExtension_Unicode()
         {
             using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -9,6 +9,7 @@ namespace System.IO.Compression.Tests
     public class ZipFile_ZipArchiveEntry_Extract : ZipFileTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ExtractToFileExtension()
         {
             using (ZipArchive archive = ZipFile.Open(zfile("normal.zip"), ZipArchiveMode.Read))

--- a/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
+++ b/src/libraries/System.IO.Compression/tests/CompressionStreamUnitTests.Deflate.cs
@@ -22,6 +22,7 @@ namespace System.IO.Compression
         /// </summary>
         [Theory]
         [MemberData(nameof(UncompressedTestFiles))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task DecompressFailsWithRealGzStream(string uncompressedPath)
         {
             string fileName = Path.Combine("GZipTestData", Path.GetFileName(uncompressedPath) + ".gz");

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_CreateTests.cs
@@ -61,6 +61,7 @@ namespace System.IO.Compression.Tests
         [InlineData("normal", true, false)]
         [InlineData("small", false, true)]
         [InlineData("normal", false, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task CreateNormal_Seekable(string folder, bool useSpansForWriting, bool writeInChunks)
         {
             using (var s = new MemoryStream())
@@ -77,6 +78,7 @@ namespace System.IO.Compression.Tests
         [InlineData("normal")]
         [InlineData("empty")]
         [InlineData("emptydir")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task CreateNormal_Unseekable(string folder)
         {
             using (var s = new MemoryStream())
@@ -89,6 +91,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task CreateNormal_Unicode_Seekable()
         {
             using (var s = new MemoryStream())
@@ -101,6 +104,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task CreateNormal_Unicode_Unseekable()
         {
             using (var s = new MemoryStream())

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_InvalidParametersAndStrangeFiles.cs
@@ -30,6 +30,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task InvalidInstanceMethods()
         {
             Stream zipFile = await StreamHelpers.CreateTempCopyStream(zfile("normal.zip"));
@@ -99,6 +100,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("LZMA.zip")]
         [InlineData("invalidDeflate.zip")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchiveEntry_InvalidUpdate(string zipname)
         {
             string filename = bad(zipname);
@@ -129,6 +131,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task LargeArchive_DataDescriptor_Read_NonZip64_FileLengthGreaterThanIntMax()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(strange("fileLengthGreaterIntLessUInt.zip"));
@@ -159,6 +162,7 @@ namespace System.IO.Compression.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix not shipped for .NET Framework.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchiveEntry_CorruptedStream_ReadMode_CopyTo_UpToUncompressedSize()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(zfile("normal.zip"));
@@ -188,6 +192,7 @@ namespace System.IO.Compression.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix not shipped for .NET Framework.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchiveEntry_CorruptedStream_ReadMode_Read_UpToUncompressedSize()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(zfile("normal.zip"));
@@ -219,6 +224,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static void ZipArchiveEntry_CorruptedStream_EnsureNoExtraBytesReadOrOverWritten()
         {
             MemoryStream stream = populateStream().Result;
@@ -257,6 +263,7 @@ namespace System.IO.Compression.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Deflate64 zip support is not available on .NET Framework.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task Zip64ArchiveEntry_CorruptedStream_CopyTo_UpToUncompressedSize()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(compat("deflate64.zip"));
@@ -284,6 +291,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchiveEntry_CorruptedStream_UnCompressedSizeBiggerThanExpected_NothingShouldBreak()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(zfile("normal.zip"));
@@ -306,6 +314,7 @@ namespace System.IO.Compression.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Deflate64 zip support is not available on .NET Framework.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task Zip64ArchiveEntry_CorruptedFile_Read_UpToUncompressedSize()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(compat("deflate64.zip"));
@@ -333,6 +342,7 @@ namespace System.IO.Compression.Tests
 
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UnseekableVeryLargeArchive_DataDescriptor_Read_Zip64()
         {
             MemoryStream stream = await LocalMemoryStream.readAppFileAsync(strange("veryLarge.zip"));
@@ -355,6 +365,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateZipArchive_AppendTo_CorruptedFileEntry()
         {
             MemoryStream stream = await StreamHelpers.CreateTempCopyStream(zfile("normal.zip"));
@@ -397,6 +408,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateZipArchive_OverwriteCorruptedEntry()
         {
             MemoryStream stream = await StreamHelpers.CreateTempCopyStream(zfile("normal.zip"));
@@ -437,6 +449,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateZipArchive_AddFileTo_ZipWithCorruptedFile()
         {
             string addingFile = "added.txt";
@@ -535,6 +548,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("CDoffsetOutOfBounds.zip")]
         [InlineData("EOCDmissing.zip")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchive_InvalidStream(string zipname)
         {
             string filename = bad(zipname);
@@ -545,6 +559,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData("CDoffsetInBoundsWrong.zip")]
         [InlineData("numberOfEntriesDifferent.zip")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchive_InvalidEntryTable(string zipname)
         {
             string filename = bad(zipname);
@@ -558,6 +573,7 @@ namespace System.IO.Compression.Tests
         [InlineData("localFileOffsetOutOfBounds.zip", true)]
         [InlineData("LZMA.zip", true)]
         [InlineData("invalidDeflate.zip", false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchive_InvalidEntry(string zipname, bool throwsOnOpen)
         {
             string filename = bad(zipname);
@@ -579,6 +595,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipArchiveEntry_InvalidLastWriteTime_Read()
         {
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(
@@ -613,6 +630,7 @@ namespace System.IO.Compression.Tests
         [InlineData("extradata/zip64ThenExtraData.zip", "verysmall", true)]
         [InlineData("dataDescriptor.zip", "normalWithoutBinary", false)]
         [InlineData("filenameTimeAndSizesDifferentInLH.zip", "verysmall", false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task StrangeFiles(string zipFile, string zipFolder, bool requireExplicit)
         {
             IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(strange(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, requireExplicit, checkTimes: true);
@@ -623,6 +641,7 @@ namespace System.IO.Compression.Tests
         /// cause any bytes to be left in ZLib's buffer.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static void ZipWithLargeSparseFile()
         {
             string zipname = strange("largetrailingwhitespacedeflation.zip");
@@ -727,6 +746,7 @@ namespace System.IO.Compression.Tests
         /// Prepends 64KB of garbage at the beginning of the file. Verifies we throw.
         /// </summary>
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static void ReadArchive_WithEOCDComment_TrailingPrecedingGarbage()
         {
             void InsertEntry(ZipArchive archive, string name, string contents)

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ManualAndCompatibilityTests.cs
@@ -17,12 +17,14 @@ namespace System.IO.Compression.Tests
         [InlineData("dotnetzipstreaming.zip", "normal", false, false)]
         [InlineData("sharpziplib.zip", "normalWithoutEmptyDir", false, false)]
         [InlineData("xceedstreaming.zip", "normal", false, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task CompatibilityTests(string zipFile, string zipFolder, bool requireExplicit, bool checkTimes)
         {
             IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, requireExplicit, checkTimes);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task Deflate64Zip()
         {
             IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat("deflate64.zip")), zfolder("normal"), ZipArchiveMode.Update, requireExplicit: true, checkTimes: true);
@@ -34,6 +36,7 @@ namespace System.IO.Compression.Tests
         [InlineData("word.docx", "word", false, false)]
         [InlineData("silverlight.xap", "silverlight", false, false)]
         [InlineData("packaging.package", "packaging", false, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task CompatibilityTestsMsFiles(string withTrailing, string withoutTrailing, bool requireExplicit, bool checkTimes)
         {
             IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(compat(withTrailing)), compat(withoutTrailing), ZipArchiveMode.Update, requireExplicit, checkTimes);
@@ -53,6 +56,7 @@ namespace System.IO.Compression.Tests
         [InlineData("WindowsInvalid_FromWindows.zip", "aa<b>d")]
         [InlineData("NullCharFileName_FromWindows.zip", "a\06b6d")]
         [InlineData("NullCharFileName_FromUnix.zip", "a\06b6d")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipWithInvalidFileNames_ParsedBasedOnSourceOS(string zipName, string fileName)
         {
             using (Stream stream = await StreamHelpers.CreateTempCopyStream(compat(zipName)))
@@ -93,6 +97,7 @@ namespace System.IO.Compression.Tests
         [InlineData("net46_unicode.zip", "unicode")]
         [InlineData("net45_normal.zip", "normal")]
         [InlineData("net46_normal.zip", "normal")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipBinaryCompat_LocalFileHeaders(string zipFile, string zipFolder)
         {
             using (MemoryStream actualArchiveStream = new MemoryStream())
@@ -158,6 +163,7 @@ namespace System.IO.Compression.Tests
         [InlineData("net46_unicode.zip", "unicode")]
         [InlineData("net45_normal.zip", "normal")]
         [InlineData("net46_normal.zip", "normal")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ZipBinaryCompat_CentralDirectoryHeaders(string zipFile, string zipFolder)
         {
             using (MemoryStream actualArchiveStream = new MemoryStream())

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -18,6 +18,7 @@ namespace System.IO.Compression.Tests
         [InlineData("emptydir.zip", "emptydir")]
         [InlineData("small.zip", "small")]
         [InlineData("unicode.zip", "unicode")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ReadNormal(string zipFile, string zipFolder)
         {
             await IsZipSameAsDirAsync(zfile(zipFile), zfolder(zipFolder), ZipArchiveMode.Read);
@@ -32,6 +33,7 @@ namespace System.IO.Compression.Tests
         [InlineData("emptydir.zip", "emptydir")]
         [InlineData("small.zip", "small")]
         [InlineData("unicode.zip", "unicode")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task TestStreamingRead(string zipFile, string zipFolder)
         {
             using (var stream = await StreamHelpers.CreateTempCopyStream(zfile(zipFile)))
@@ -43,6 +45,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ReadStreamOps()
         {
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Read))
@@ -61,6 +64,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ReadInterleaved()
         {
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip"))))
@@ -147,6 +151,7 @@ namespace System.IO.Compression.Tests
             }
         }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task ReadModeInvalidOpsTest()
         {
             ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")), ZipArchiveMode.Read);

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -20,12 +20,14 @@ namespace System.IO.Compression.Tests
         [InlineData("emptydir.zip", "emptydir")]
         [InlineData("small.zip", "small")]
         [InlineData("unicode.zip", "unicode")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateReadNormal(string zipFile, string zipFolder)
         {
             IsZipSameAsDir(await StreamHelpers.CreateTempCopyStream(zfile(zipFile)), zfolder(zipFolder), ZipArchiveMode.Update, requireExplicit: true, checkTimes: true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateReadTwice()
         {
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(zfile("small.zip")), ZipArchiveMode.Update))
@@ -48,6 +50,7 @@ namespace System.IO.Compression.Tests
         [InlineData("normal")]
         [InlineData("empty")]
         [InlineData("unicode")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateCreate(string zipFolder)
         {
             var zs = new LocalMemoryStream();
@@ -113,6 +116,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task DeleteAndMoveEntries()
         {
             //delete and move
@@ -139,6 +143,7 @@ namespace System.IO.Compression.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task AppendToEntry(bool writeWithSpans)
         {
             //append
@@ -170,6 +175,7 @@ namespace System.IO.Compression.Tests
 
         }
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task OverwriteEntry()
         {
             //Overwrite file
@@ -197,6 +203,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task AddFileToArchive()
         {
             //add file
@@ -211,6 +218,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task AddFileToArchive_AfterReading()
         {
             //add file and read entries before
@@ -227,6 +235,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task AddFileToArchive_ThenReadEntries()
         {
             //add file and read entries after
@@ -261,6 +270,7 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task UpdateModeInvalidOperations()
         {
             using (LocalMemoryStream ms = await LocalMemoryStream.readAppFileAsync(zfile("normal.zip")))

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_netcoreappTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_netcoreappTests.cs
@@ -15,6 +15,7 @@ namespace System.IO.Compression.Tests
         [InlineData("Linux_RW_RW_R__.zip", 0x8000 + 0x0100 + 0x0080 + 0x0020 + 0x0010 + 0x0004)]
         [InlineData("Linux_RWXRW_R__.zip", 0x8000 + 0x01C0 + 0x0020 + 0x0010 + 0x0004)]
         [InlineData("OSX_RWXRW_R__.zip", 0x8000 + 0x01C0 + 0x0020 + 0x0010 + 0x0004)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task Read_UnixFilePermissions(string zipName, uint expectedAttr)
         {
             using (ZipArchive archive = new ZipArchive(await StreamHelpers.CreateTempCopyStream(compat(zipName)), ZipArchiveMode.Read))
@@ -31,6 +32,7 @@ namespace System.IO.Compression.Tests
         [InlineData(int.MinValue)]
         [InlineData(0)]
         [InlineData((0x8000 + 0x01C0 + 0x0020 + 0x0010 + 0x0004) << 16)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static async Task RoundTrips_UnixFilePermissions(int expectedAttr)
         {
             using (var stream = await StreamHelpers.CreateTempCopyStream(zfile("normal.zip")))

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateServer.cs
@@ -56,12 +56,14 @@ namespace System.IO.Pipes.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("pipeName", () => new NamedPipeServerStream(reservedName, direction, 1, PipeTransmissionMode.Byte, PipeOptions.None, 0, 0));}
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static void Create_PipeName()
         {
             new NamedPipeServerStream(GetUniquePipeName()).Dispose();
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public static void Create_PipeName_Direction_MaxInstances()
         {
             new NamedPipeServerStream(GetUniquePipeName(), PipeDirection.Out, 1).Dispose();

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CrossProcess.cs
@@ -15,6 +15,7 @@ namespace System.IO.Pipes.Tests
     public sealed class NamedPipeTest_CrossProcess
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void InheritHandles_AvailableInChildProcess()
         {
             string pipeName = GetUniquePipeName();
@@ -46,6 +47,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void PingPong_Sync()
         {
             // Create names for two pipes
@@ -72,6 +74,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task PingPong_Async()
         {
             // Create names for two pipes

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Simple.cs
@@ -34,6 +34,7 @@ namespace System.IO.Pipes.Tests
 
         [Theory]
         [MemberData(nameof(OneWayReadWritesMemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task OneWayReadWrites(PipeOptions serverOptions, PipeOptions clientOptions, bool asyncServerOps, bool asyncClientOps)
         {
             using (NamedPipePair pair = CreateNamedPipePair(serverOptions, clientOptions))
@@ -102,6 +103,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ClonedServer_ActsAsOriginalServer()
         {
             byte[] msg1 = new byte[] { 5, 7, 9, 10 };
@@ -143,6 +145,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ClonedClient_ActsAsOriginalClient()
         {
             byte[] msg1 = new byte[] { 5, 7, 9, 10 };
@@ -182,6 +185,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ConnectOnAlreadyConnectedClient_Throws_InvalidOperationException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -200,6 +204,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WaitForConnectionOnAlreadyConnectedServer_Throws_InvalidOperationException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -218,6 +223,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task CancelTokenOn_ServerWaitForConnectionAsync_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -268,6 +274,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task OperationsOnDisconnectedServer()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -305,6 +312,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public virtual async Task OperationsOnDisconnectedClient()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -383,6 +391,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void OperationsOnUnconnectedServer()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -417,6 +426,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void OperationsOnUnconnectedClient()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -448,6 +458,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task DisposedServerPipe_Throws_ObjectDisposedException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -464,6 +475,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task DisposedClientPipe_Throws_ObjectDisposedException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -480,6 +492,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ReadAsync_DisconnectDuringRead_Returns0()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -523,6 +536,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task Server_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -621,6 +635,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task Client_ReadWriteCancelledToken_Throws_OperationCanceledException()
         {
             using (NamedPipePair pair = CreateNamedPipePair())
@@ -717,6 +732,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ManyConcurrentOperations(bool cancelable)
         {
             using (NamedPipePair pair = CreateNamedPipePair(PipeOptions.Asynchronous, PipeOptions.Asynchronous))

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -29,6 +29,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ConnectToNonExistentServer_Throws_TimeoutException()
         {
             using (NamedPipeClientStream client = new NamedPipeClientStream(".", "notthere"))
@@ -80,6 +81,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(1)]
         [InlineData(3)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task MultipleWaitingClients_ServerServesOneAtATime(int numClients)
         {
             string name = GetUniquePipeName();
@@ -115,6 +117,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void MaxNumberOfServerInstances_TooManyServers_Throws()
         {
             string name = GetUniquePipeName();
@@ -152,6 +155,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(1)]
         [InlineData(4)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task MultipleServers_ServeMultipleClientsConcurrently(int numServers)
         {
             string name = GetUniquePipeName();
@@ -441,6 +445,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void PipeTransmissionMode_Returns_Byte()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -533,6 +538,7 @@ namespace System.IO.Pipes.Tests
         [Theory]
         [InlineData(PipeDirection.Out, PipeDirection.In)]
         [InlineData(PipeDirection.In, PipeDirection.Out)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void InvalidReadMode_Throws_ArgumentOutOfRangeException(PipeDirection serverDirection, PipeDirection clientDirection)
         {
             string pipeName = GetUniquePipeName();
@@ -594,6 +600,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ClientConnect_Throws_Timeout_When_Pipe_Not_Found()
         {
             string pipeName = GetUniquePipeName();
@@ -605,6 +612,7 @@ namespace System.IO.Pipes.Tests
 
         [Theory]
         [MemberData(nameof(GetCancellationTokens))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ClientConnectAsync_Throws_Timeout_When_Pipe_Not_Found(CancellationToken cancellationToken)
         {
             string pipeName = GetUniquePipeName();

--- a/src/libraries/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -19,6 +19,7 @@ namespace System.IO.Pipes.Tests
         public virtual bool SupportsBidirectionalReadingWriting => false;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadWithNullBuffer_Throws_ArgumentNullException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -42,6 +43,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadWithNegativeOffset_Throws_ArgumentOutOfRangeException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -57,6 +59,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadWithNegativeCount_Throws_ArgumentOutOfRangeException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -72,6 +75,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadWithOutOfBoundsArray_Throws_ArgumentException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -119,6 +123,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteToReadOnlyPipe_Throws_NotSupportedException()
         {
             if (SupportsBidirectionalReadingWriting)
@@ -148,6 +153,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ReadWithZeroLengthBuffer_Nop()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -162,6 +168,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadPipeUnsupportedMembers_Throws_NotSupportedException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -182,6 +189,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadOnDisposedReadablePipe_Throws_ObjectDisposedException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -200,6 +208,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void CopyToAsync_InvalidArgs_Throws()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -215,6 +224,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public virtual async Task ReadFromPipeWithClosedPartner_ReadNoBytes()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -234,6 +244,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ValidWriteAsync_ValidReadAsync()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -252,6 +263,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ValidWrite_ValidRead()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -271,6 +283,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ValidWriteByte_ValidReadByte()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -357,6 +370,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ValidWriteAsync_ValidReadAsync_APM()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -413,6 +427,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteToReadOnlyPipe_Span_Throws_NotSupportedException()
         {
             if (SupportsBidirectionalReadingWriting)
@@ -433,6 +448,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ReadWithZeroLengthBuffer_Span_Nop()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -447,6 +463,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadOnDisposedReadablePipe_Span_Throws_ObjectDisposedException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -461,6 +478,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public virtual async Task ReadFromPipeWithClosedPartner_Span_ReadNoBytes()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -479,6 +497,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ValidWriteAsync_Span_ValidReadAsync()
         {
             using (ServerClientPair pair = CreateServerClientPair())

--- a/src/libraries/System.IO.Pipes/tests/PipeTest.Write.cs
+++ b/src/libraries/System.IO.Pipes/tests/PipeTest.Write.cs
@@ -17,6 +17,7 @@ namespace System.IO.Pipes.Tests
         public virtual bool SupportsBidirectionalReadingWriting => false;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteWithNullBuffer_Throws_ArgumentNullException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -41,6 +42,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteWithNegativeOffset_Throws_ArgumentOutOfRangeException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -57,6 +59,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteWithNegativeCount_Throws_ArgumentOutOfRangeException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -72,6 +75,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteWithOutOfBoundsArray_Throws_ArgumentException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -119,6 +123,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadOnWriteOnlyPipe_Throws_NotSupportedException()
         {
             if (SupportsBidirectionalReadingWriting)
@@ -143,6 +148,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task WriteZeroLengthBuffer_Nop()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -158,6 +164,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WritePipeUnsupportedMembers_Throws_NotSupportedException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -178,6 +185,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteToDisposedWriteablePipe_Throws_ObjectDisposedException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -196,6 +204,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public virtual void WriteToPipeWithClosedPartner_Throws_IOException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -219,6 +228,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task ValidFlush_DoesntThrow()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -232,6 +242,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void ReadOnWriteOnlyPipe_Span_Throws_NotSupportedException()
         {
             if (SupportsBidirectionalReadingWriting)
@@ -251,6 +262,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public async Task WriteZeroLengthBuffer_Span_Nop()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -264,6 +276,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void WriteToDisposedWriteablePipe_Span_Throws_ObjectDisposedException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -278,6 +291,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public virtual void WriteToPipeWithClosedPartner_Span_Throws_IOException()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -299,6 +313,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36884", TestPlatforms.iOS)]
         public void DisposeAsync_NothingWrittenNeedsToBeFlushed_CompletesSynchronously()
         {
             ServerClientPair pair = CreateServerClientPair();

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpClientJsonExtensionsTests.cs
@@ -22,6 +22,7 @@ namespace System.Net.Http.Json.Functional.Tests
             };
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestGetFromJsonAsync()
         {
             const string json = @"{""Name"":""David"",""Age"":24}";
@@ -57,6 +58,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestGetFromJsonAsyncUnsuccessfulResponseAsync()
         {
             const int NumRequests = 2;
@@ -79,6 +81,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestPostAsJsonAsync()
         {
             const int NumRequests = 4;
@@ -114,6 +117,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestPutAsJsonAsync()
         {
             const int NumRequests = 4;
@@ -175,6 +179,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task AllowNullRequesturlAsync()
         {
             const int NumRequests = 4;

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpContentJsonExtensionsTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/HttpContentJsonExtensionsTests.cs
@@ -26,6 +26,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task HttpContentGetThenReadFromJsonAsync()
         {
             const int NumRequests = 2;
@@ -55,6 +56,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task HttpContentReturnValueIsNull()
         {
             const int NumRequests = 2;
@@ -83,6 +85,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestReadFromJsonNoMessageBodyAsync()
         {
             await LoopbackServer.CreateClientAndServerAsync(
@@ -102,6 +105,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestReadFromJsonNoContentTypeAsync()
         {
             await LoopbackServer.CreateClientAndServerAsync(
@@ -119,6 +123,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestGetFromJsonQuotedCharSetAsync()
         {
             List<HttpHeaderData> customHeaders = new List<HttpHeaderData>
@@ -142,6 +147,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestGetFromJsonThrowOnInvalidCharSetAsync()
         {
             List<HttpHeaderData> customHeaders = new List<HttpHeaderData>
@@ -165,6 +171,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestGetFromJsonAsyncTextPlainUtf16Async()
         {
             const string json = @"{""Name"":""David"",""Age"":24}";
@@ -210,6 +217,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task EnsureDefaultJsonSerializerOptionsAsync()
         {
             await LoopbackServer.CreateClientAndServerAsync(
@@ -231,6 +239,7 @@ namespace System.Net.Http.Json.Functional.Tests
         [InlineData("application/foo+json")] // Structured Syntax Json Suffix
         [InlineData("application/foo+Json")]
         [InlineData("appLiCaTiOn/a+JsOn")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestValidMediaTypes(string mediaType)
         {
             List<HttpHeaderData> customHeaders = new List<HttpHeaderData>
@@ -261,6 +270,7 @@ namespace System.Net.Http.Json.Functional.Tests
         [InlineData("application/+json")] // empty subtype before suffix is invalid.
         [InlineData("application/problem+")] // no suffix after '+'.
         [InlineData("application/problem+foo+json")] // more than one '+' not allowed.
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestInvalidMediaTypeAsync(string mediaType)
         {
             List<HttpHeaderData> customHeaders = new List<HttpHeaderData>

--- a/src/libraries/System.Net.Http.Json/tests/FunctionalTests/JsonContentTests.cs
+++ b/src/libraries/System.Net.Http.Json/tests/FunctionalTests/JsonContentTests.cs
@@ -69,6 +69,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendQuotedCharsetAsync()
         {
 
@@ -104,6 +105,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task JsonContentMediaTypeValidateOnServerAsync()
         {
             await LoopbackServer.CreateClientAndServerAsync(
@@ -161,6 +163,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static async Task ValidateUtf16IsTranscodedAsync()
         {
             await LoopbackServer.CreateClientAndServerAsync(
@@ -202,6 +205,7 @@ namespace System.Net.Http.Json.Functional.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task TestJsonContentNullContentTypeAsync()
         {
             await LoopbackServer.CreateClientAndServerAsync(

--- a/src/libraries/System.Net.Mail/tests/Unit/MailAddressTests/MailAddressParserTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/MailAddressTests/MailAddressParserTest.cs
@@ -461,6 +461,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void MailAddress_NeedsUnicodeNormalization_ShouldParseAndNormalize()
         {
             string needsNormalization = "\u0063\u0301\u0327\u00BE";
@@ -474,6 +475,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void MailAddress_NeedsUnicodeNormalizationWithDisplayName_ShouldParseAndNormalize()
         {
             string needsNormalization = "\u0063\u0301\u0327\u00BE";

--- a/src/libraries/System.Net.Mail/tests/Unit/MailAddressTests/MailAddressParsingTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/MailAddressTests/MailAddressParsingTest.cs
@@ -162,6 +162,7 @@ namespace System.Net.Mail.Tests
 
         [Theory]
         [MemberData(nameof(GetInvalidEmailTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void TestInvalidEmailAddresses(string address)
         {
             Assert.Throws<FormatException>(() => { new MailAddress(address); });

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
@@ -25,6 +25,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void IPv4GatewayAddressParsing()
         {
             string fileName = GetTestFilePath();
@@ -39,6 +40,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void IPv6GatewayAddressParsing()
         {
             string fileName = GetTestFilePath();
@@ -66,6 +68,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void DhcpServerAddressParsing()
         {
             string fileName = GetTestFilePath();
@@ -76,6 +79,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void WinsServerAddressParsing()
         {
             string fileName = GetTestFilePath();

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/ConnectionsParsingTests.cs
@@ -10,6 +10,7 @@ namespace System.Net.NetworkInformation.Tests
     public class ConnectionsParsingTests : FileCleanupTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void NumSocketConnectionsParsing()
         {
             string sockstatFile = GetTestFilePath();
@@ -31,6 +32,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void ActiveTcpConnectionsParsing()
         {
             string tcpFile = GetTestFilePath();
@@ -84,6 +86,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void TcpListenersParsing()
         {
             string tcpFile = GetTestFilePath();
@@ -99,6 +102,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void UdpListenersParsing()
         {
             string udpFile = GetTestFilePath();

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/DnsParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/DnsParsingTests.cs
@@ -13,6 +13,7 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData("NetworkFiles/resolv.conf")]
         [InlineData("NetworkFiles/resolv_nonewline.conf")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void DnsSuffixParsing(string file)
         {
             string fileName = GetTestFilePath();
@@ -25,6 +26,7 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData("NetworkFiles/resolv.conf")]
         [InlineData("NetworkFiles/resolv_nonewline.conf")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void DnsAddressesParsing(string file)
         {
             string fileName = GetTestFilePath();

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/IPGlobalPropertiesTest.cs
@@ -53,6 +53,7 @@ namespace System.Net.NetworkInformation.Tests
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/18258")]
         [MemberData(nameof(Loopbacks))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void IPGlobalProperties_TcpListeners_Succeed(IPAddress address)
         {
             using (var server = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp))

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
@@ -10,6 +10,7 @@ namespace System.Net.NetworkInformation.Tests
     public class MiscParsingTests : FileCleanupTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void NumRoutesParsing()
         {
             string fileName = GetTestFilePath();
@@ -19,6 +20,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void DefaultTtlParsing()
         {
             string fileName = GetTestFilePath();
@@ -28,6 +30,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static void RawIntFileParsing()
         {
             int val = StringParsingHelpers.ParseRawIntFile("NetworkFiles/rawint");
@@ -38,6 +41,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static void RawLongFileParsing()
         {
             long val = StringParsingHelpers.ParseRawLongFile("NetworkFiles/rawlong");
@@ -48,6 +52,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static void RawHexIntParsing()
         {
             int val = StringParsingHelpers.ParseRawHexFileAsInt("NetworkFiles/rawhexint");

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -254,6 +254,7 @@ namespace System.Net.NetworkInformation.Tests
 
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsSubsystemForLinux))] // https://github.com/dotnet/runtime/issues/20029 and https://github.com/Microsoft/WSL/issues/3561
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void BasicTest_GetIsNetworkAvailable_Success()
         {
             Assert.True(NetworkInterface.GetIsNetworkAvailable());

--- a/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/libraries/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -10,6 +10,7 @@ namespace System.Net.NetworkInformation.Tests
     public class StatisticsParsingTests : FileCleanupTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void Icmpv4Parsing()
         {
             string fileName = GetTestFilePath();
@@ -45,6 +46,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void Icmpv6Parsing()
         {
             string fileName = GetTestFilePath();
@@ -85,6 +87,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void TcpGlobalStatisticsParsing()
         {
             string fileName = GetTestFilePath();
@@ -108,6 +111,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void Udpv4GlobalStatisticsParsing()
         {
             string fileName = GetTestFilePath();
@@ -123,6 +127,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void Udpv6GlobalStatisticsParsing()
         {
             string fileName = GetTestFilePath();
@@ -138,6 +143,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void Ipv4GlobalStatisticsParsing()
         {
             string fileName = GetTestFilePath();
@@ -166,6 +172,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void Ipv6GlobalStatisticsParsing()
         {
             string fileName = GetTestFilePath();
@@ -192,6 +199,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void IpInterfaceStatisticsParsingFirst()
         {
             string fileName = GetTestFilePath();
@@ -218,6 +226,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void IpInterfaceStatisticsParsingLast()
         {
             string fileName = GetTestFilePath();

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -130,6 +130,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void SendPingWithIPAddress(AddressFamily addressFamily)
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress(addressFamily);
@@ -150,6 +151,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPingAsyncWithIPAddress(AddressFamily addressFamily)
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync(addressFamily);
@@ -170,6 +172,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void SendPingWithIPAddress_AddressAsString(AddressFamily addressFamily)
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress(addressFamily);
@@ -188,6 +191,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPingAsyncWithIPAddress_AddressAsString()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
@@ -201,6 +205,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void SendPingWithIPAddressAndTimeout()
         {
             IPAddress localIpAddress = TestSettings.GetLocalIPAddress();
@@ -214,6 +219,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPingAsyncWithIPAddressAndTimeout()
         {
             IPAddress localIpAddress = await TestSettings.GetLocalIPAddressAsync();
@@ -409,6 +415,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void SendPingWithHost()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
@@ -422,6 +429,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPingAsyncWithHost()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
@@ -435,6 +443,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public void SendPingWithHostAndTimeout()
         {
             IPAddress[] localIpAddresses = TestSettings.GetLocalIPAddresses();
@@ -448,6 +457,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPingAsyncWithHostAndTimeout()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
@@ -627,6 +637,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPings_ReuseInstance_Hostname()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
@@ -642,6 +653,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Sends_ReuseInstance_Hostname()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
@@ -657,6 +669,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendAsyncs_ReuseInstance_Hostname()
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();
@@ -707,6 +720,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static void Ping_DisposeAfterSend_Success()
         {
             Ping p = new Ping();
@@ -715,6 +729,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static async Task PingAsync_DisposeAfterSend_Success()
         {
             Ping p = new Ping();
@@ -791,6 +806,7 @@ namespace System.Net.NetworkInformation.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SendPingAsyncWithHostAndTtlAndFragmentPingOptions(bool fragment)
         {
             IPAddress[] localIpAddresses = await TestSettings.GetLocalIPAddressesAsync();

--- a/src/libraries/System.Net.Primitives/src/System/Net/NetworkInformation/IPAddressCollection.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/NetworkInformation/IPAddressCollection.cs
@@ -33,6 +33,7 @@ namespace System.Net.NetworkInformation
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public virtual void Add(IPAddress address)
         {
             throw new NotSupportedException(SR.net_collection_readonly);
@@ -61,6 +62,7 @@ namespace System.Net.NetworkInformation
             }
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public virtual bool Remove(IPAddress address)
         {
             throw new NotSupportedException(SR.net_collection_readonly);

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -308,6 +308,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task ContentLength_Get_ExpectSameAsGetResponseStream(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -361,6 +362,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Headers_SetAfterRequestSubmitted_ThrowsInvalidOperationException()
         {
             await LoopbackServer.CreateServerAsync(async (server, uri) =>
@@ -383,6 +385,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task HttpWebRequest_SetHostHeader_ContainsPortNumber()
         {
             await LoopbackServer.CreateServerAsync(async (server, uri) =>
@@ -498,6 +501,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Timeout_SetTenMillisecondsOnLoopback_ThrowsWebException()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>
@@ -648,6 +652,7 @@ namespace System.Net.Tests
         [InlineData(null)]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task KeepAlive_CorrectConnectionHeaderSent(bool? keepAlive)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -1159,6 +1164,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginGetRequestStream_CreateRequestThenBeginGetResponsePrior_ThrowsProtocolViolationException()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>
@@ -1176,6 +1182,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginGetResponse_CreateRequestThenCallTwice_ThrowsInvalidOperationException()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>
@@ -1198,6 +1205,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_AllowAutoRedirectTrueWithTooManyRedirects_ThrowsWebException()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -1211,6 +1219,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_AllowAutoRedirectFalseWithRedirect_ReturnsRedirectResponse()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -1226,6 +1235,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_AllowAutoRedirectFalseWithBadRequest_ThrowsWebException()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -1238,6 +1248,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetRequestStreamAsync_WriteAndDisposeRequestStreamThenOpenRequestStream_ThrowsArgumentException()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -1253,6 +1264,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetRequestStreamAsync_SetPOSTThenGet_ExpectNotNull()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -1267,6 +1279,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_GetResponseStream_ExpectNotNull()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -1283,6 +1296,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_GetResponseStream_ContainsHost(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1330,6 +1344,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_PostRequestStream_ContainsData(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1375,6 +1390,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_UseDefaultCredentials_ExpectSuccess(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1400,6 +1416,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task GetResponseAsync_ResourceNotFound_ThrowsWebException()
         {
             await LoopbackServer.CreateClientAndServerAsync(async uri =>
@@ -1414,6 +1431,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task HaveResponse_GetResponseAsync_ExpectTrue(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1432,6 +1450,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Headers_GetResponseHeaders_ContainsExpectedValue(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1532,6 +1551,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task ResponseUri_GetResponseAsync_ExpectSameUri(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1555,6 +1575,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SimpleScenario_UseGETVerb_Success(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1571,6 +1592,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task SimpleScenario_UsePOSTVerb_Success(bool useSsl)
         {
             var options = new LoopbackServer.Options { UseSsl = useSsl };
@@ -1593,6 +1615,7 @@ namespace System.Net.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task ContentType_AddHeaderWithNoContent_SendRequest_HeaderGetsSent(bool useSsl)
         {
             const string ContentType = "text/plain; charset=utf-8";
@@ -1734,6 +1757,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task HttpWebRequest_EndGetRequestStreamContext_ExpectedValue()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>
@@ -1774,6 +1798,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Abort_BeginGetResponseThenAbort_ResponseCallbackCalledBeforeAbortReturns()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>
@@ -1813,6 +1838,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Abort_BeginGetResponseUsingNoCallbackThenAbort_Success()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -86,6 +86,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task LastModified_ValidDate_Success()
         {
             DateTime expected = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2018, 4, 10, 3, 4, 5, DateTimeKind.Utc), TimeZoneInfo.Local);
@@ -103,6 +104,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task LastModified_InvalidDate_Throws()
         {
             DateTime expected = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2018, 4, 10, 3, 4, 5, DateTimeKind.Utc), TimeZoneInfo.Local);
@@ -120,6 +122,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task HttpWebResponse_Serialize_ExpectedResult()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -123,6 +123,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(Dates_ReadValue_Data))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task LastModified_ReadValue(string raw, DateTime expected)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -143,6 +144,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(Dates_Always_Invalid_Data))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Date_AlwaysInvalidValue(string invalid)
         {
             await LastModified_InvalidValue(invalid);
@@ -150,6 +152,7 @@ namespace System.Net.Tests
 
         [Theory]
         [MemberData(nameof(Dates_Now_Invalid_Data))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task LastModified_InvalidValue(string invalid)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -169,6 +172,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task LastModified_NotPresent()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -199,6 +203,7 @@ namespace System.Net.Tests
         [InlineData("text/html")]
         [InlineData("text/html; charset=utf-8")]
         [InlineData("TypeAndNoSubType")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task ContentType_ServerResponseHasContentTypeHeader_ContentTypeReceivedCorrectly(string expectedContentType)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -216,6 +221,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task ContentType_ServerResponseMissingContentTypeHeader_ContentTypeIsEmptyString()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/libraries/System.Net.Requests/tests/RequestStreamTest.cs
@@ -18,6 +18,7 @@ namespace System.Net.Tests
         #region Write
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Write_BufferIsNull_ThrowsArgumentNullException()
         {
             await GetRequestStream((stream) =>
@@ -27,6 +28,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Write_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
         {
             await GetRequestStream((stream) =>
@@ -36,6 +38,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Write_CountIsNegative_ThrowsArgumentOutOfRangeException()
         {
             await GetRequestStream((stream) =>
@@ -45,6 +48,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Write_OffsetPlusCountExceedsBufferLength_ThrowsArgumentException()
         {
             await GetRequestStream((stream) =>
@@ -54,6 +58,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task Write_OffsetPlusCountMaxValueExceedsBufferLength_Throws()
         {
             await GetRequestStream((stream) =>
@@ -67,6 +72,7 @@ namespace System.Net.Tests
         #region WriteAsync
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_BufferIsNull_ThrowsArgumentNullException()
         {
             await GetRequestStream((stream) =>
@@ -76,6 +82,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
         {
             await GetRequestStream((stream) =>
@@ -85,6 +92,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_CountIsNegative_ThrowsArgumentOutOfRangeException()
         {
             await GetRequestStream((stream) =>
@@ -94,6 +102,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_OffsetPlusCountExceedsBufferLength_ThrowsArgumentException()
         {
             await GetRequestStream((stream) =>
@@ -103,6 +112,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_OffsetPlusCountMaxValueExceedsBufferLength_Throws()
         {
             await GetRequestStream((stream) =>
@@ -112,6 +122,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_ValidParameters_TaskRanToCompletion()
         {
             await GetRequestStream((stream) =>
@@ -122,6 +133,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task WriteAsync_TokenIsCanceled_TaskIsCanceled()
         {
             await GetRequestStream((stream) =>
@@ -138,6 +150,7 @@ namespace System.Net.Tests
         #region BeginWrite
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginWriteAsync_BufferIsNull_ThrowsArgumentNullException()
         {
             await GetRequestStream((stream) =>
@@ -147,6 +160,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginWriteAsync_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
         {
             await GetRequestStream((stream) =>
@@ -156,6 +170,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginWriteAsync_CountIsNegative_ThrowsArgumentOutOfRangeException()
         {
             await GetRequestStream((stream) =>
@@ -165,6 +180,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginWriteAsync_OffsetPlusCountExceedsBufferLength_ThrowsArgumentException()
         {
             await GetRequestStream((stream) =>
@@ -174,6 +190,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginWriteAsync_OffsetPlusCountMaxValueExceedsBufferLength_Throws()
         {
             await GetRequestStream((stream) =>
@@ -183,6 +200,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task BeginWriteAsync_ValidParameters_TaskRanToCompletion()
         {
             await GetRequestStream((stream) =>
@@ -197,6 +215,7 @@ namespace System.Net.Tests
         #endregion
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task FlushAsync_TaskRanToCompletion()
         {
             await GetRequestStream((stream) =>
@@ -207,6 +226,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task FlushAsync_TokenIsCanceled_TaskIsCanceled()
         {
             await GetRequestStream((stream) =>

--- a/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
@@ -369,6 +369,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static async Task ResponseHeaders_ContainsHeadersAfterOperation()
         {
             var wc = new DerivedWebClient(); // verify we can use a derived type as well
@@ -421,6 +422,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static async Task RequestHeaders_SpecialHeaders_RequestSucceeds()
         {
             var wc = new WebClient();
@@ -440,6 +442,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public static async Task ConcurrentOperations_Throw()
         {
             await LoopbackServer.CreateServerAsync((server, url) =>
@@ -513,6 +516,7 @@ namespace System.Net.Tests
         [InlineData(null)]
         [InlineData("text/html; charset=utf-8")]
         [InlineData("text/html; charset=us-ascii")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task DownloadString_Success(string contentType)
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -530,6 +534,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task DownloadData_Success()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -551,6 +556,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task DownloadData_LargeData_Success()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -579,6 +585,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task DownloadFile_Success()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>
@@ -601,6 +608,7 @@ namespace System.Net.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36890", TestPlatforms.iOS)]
         public async Task OpenRead_Success()
         {
             await LoopbackServer.CreateServerAsync(async (server, url) =>

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -538,6 +538,7 @@ namespace System.PrivateUri.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36891", TestPlatforms.iOS)]
         public static void TestCompare()
         {
             Uri uri1 = new Uri("http://www.contoso.com/path?name#frag");

--- a/src/libraries/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/XmlResolver/XmlSystemPathResolverTests.cs
@@ -100,6 +100,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public static void TestResolveDTD_Default()
         {
             XmlReaderSettings settings = new XmlReaderSettings();
@@ -108,6 +109,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public static void TestResolveDTD_AllowDTDProcessing()
         {
             XmlReaderSettings settings = new XmlReaderSettings();

--- a/src/libraries/System.Private.Xml/tests/XmlResolver/System.Xml.XmlResolver.Tests/XmlPreloadedResolverGetEntity.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlResolver/System.Xml.XmlResolver.Tests/XmlPreloadedResolverGetEntity.cs
@@ -66,6 +66,7 @@ namespace System.Xml.XmlResolver.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XmlResolverGetKnownEntity()
         {
             var xmlResolver = new XmlPreloadedResolver(XmlKnownDtds.All);
@@ -120,6 +121,7 @@ namespace System.Xml.XmlResolver.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public async Task XmlResolverGetKnownEntityAsync()
         {
             var xmlResolver = new XmlPreloadedResolver(XmlKnownDtds.All);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Reader.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Reader.cs
@@ -29,6 +29,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void NullNamespaceValidReader()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -40,6 +41,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidNamespaceValidReader()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -51,6 +53,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidNamespaceReaderPositionedOnElementButNoXsdSchemaTag()
         {
             Assert.ThrowsAny<XmlSchemaException>(() =>
@@ -65,6 +68,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void NamespaceUnmatchingReaderValid()
         {
             Assert.ThrowsAny<XmlSchemaException>(() =>
@@ -76,6 +80,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Adding2ReadersOnSchemaWithNoNamespacesAddWithDiffNamespace()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -90,6 +95,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddingSameReaderForNullNamespace()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -105,6 +111,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddingReaderOnXDRSchema()
         {
             Assert.ThrowsAny<XmlSchemaException>(() =>
@@ -116,6 +123,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidNamespaceReaderPositionedOnANonElementNode()
         {
             Assert.ThrowsAny<XmlSchemaException>(() =>
@@ -131,6 +139,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidNamespaceValidReaderWithResolverSetToNull()
         {
             XmlSchemaSet sc = new XmlSchemaSet();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_Schema.cs
@@ -398,6 +398,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "649967a.XmlSchemaSet.Reprocess() fix is changing a collection where schemas are stored")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v12a()
         {
             using (XmlReader r = XmlReader.Create(Path.Combine(TestData._Root, @"bug264908_v1.xsd")))

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Add_URL.cs
@@ -84,6 +84,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v5 - ns = unmatching, URL = valid")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v5()
         {
             try
@@ -102,6 +103,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v6 - adding same chameleon for diff NS")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v6()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -119,6 +121,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v7 - adding same URL for null ns")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v7()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -137,6 +140,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v8 - adding a schema with NS and one without, to a NS.")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v8()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -152,6 +156,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v9 - adding URL to XSD schema")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v9()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -172,6 +177,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v10 - Adding schema with top level element collision")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v10()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -197,6 +203,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v11 - Adding schema with top level element collision to Compiled Schemaset")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v11()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -223,6 +230,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "v12 - Adding schema with no tagetNS with element already existing in NS")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v12()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -244,6 +252,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         [Fact]
         //[Variation(Desc = "435368 - schema validation error")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v13()
         {
             string xsdPath = Path.Combine(TestData._Root, @"bug435368.xsd");

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Count.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Count.cs
@@ -49,6 +49,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v3 - Add two schemas for diff ns with imports/includes and Count")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v3()
         {
             XmlSchemaSet sc = new XmlSchemaSet();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Imports.cs
@@ -336,6 +336,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v13 - Import: B(ns-b) added, A(ns-a) imports B with bogus url", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v16()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -356,6 +357,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v14 - Import: A(ns-a) includes B(ns-a) which imports C(ns-c)", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v17()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -379,6 +381,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v15 - Import: A(ns-a) includes A(ns-a) of v17", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v18()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -402,6 +405,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v16 - Import: A(ns-b) imports A(ns-a) of v17", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v19()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -471,6 +475,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v25- Import: Bug 114549 , A imports only B's NS, and B also improts A's NS AND refers to A's type, D refers to A's type (WARNING)", Priority = 1, Params = new object[] { "import_v24_b.xsd", "import_v21_c.xsd", "import_v25_d.xsd", "import_v22_a.xsd" })]
         [InlineData("import_v24_b.xsd", "import_v21_c.xsd", "import_v25_d.xsd", "import_v22_a.xsd")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v24(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -491,6 +496,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v100 - Import: Bug 105897", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v100()
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -598,6 +604,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v102.2 - Import: Add B(no ns) with ns-b , then A(ns-a) which imports B (no ns)", Priority = 1, Params = new object[] { "import_v5_a.xsd", "import_v4_b.xsd", 3, "ns-b", null })]
         [InlineData("import_v5_a.xsd", "import_v4_b.xsd", "ns-b")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v102a(object param0, object param1, object param3)
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -865,6 +872,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v108 - Import: A(ns-a) imports B(ns-b) imports C (ns-a)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v108()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -888,6 +896,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v109 - Import: A(ns-a) imports B(ns-b) and C (ns-b)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v109()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -911,6 +920,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v110 - Import: A imports B and B and C, B imports C and D, C imports D and A", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v110()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -932,6 +942,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v111 - Import: A(ns-a) imports B(ns-b) and C (ns-b), B and C include each other", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v111()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -954,6 +965,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v112 - Import: A(ns-a) imports B(BOGUS) and C (ns-c)", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v112()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -975,6 +987,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v113 - Import: B(ns-b) added, A(ns-a) imports B with bogus url", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v113()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -999,6 +1012,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v114 - Import: A(ns-a) includes B(ns-a) which imports C(ns-c)", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v114()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1026,6 +1040,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v115 - Import: A(ns-a) includes A(ns-a) of v17", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v115()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1053,6 +1068,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v116 - Import: A(ns-b) imports A(ns-a) of v17", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v116()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1076,6 +1092,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v117 - Import: A,B,C,D all import and reference each other for types", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v117()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1122,6 +1139,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v123- Import: Bug 114549 , A imports only B's NS, and B also improts A's NS AND refers to A's types", Priority = 1, Params = new object[] { "import_v24_b.xsd", "import_v21_c.xsd", "import_v21_d.xsd", "import_v22_a.xsd" })]
         [InlineData("import_v24_b.xsd", "import_v21_c.xsd", "import_v21_d.xsd", "import_v22_a.xsd")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v118(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -1153,6 +1171,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v125- Import: Bug 114549 , A imports only B's NS, and B also improts A's NS AND refers to A's type, D refers to A's type (WARNING)", Priority = 1, Params = new object[] { "import_v24_b.xsd", "import_v21_c.xsd", "import_v25_d.xsd", "import_v22_a.xsd" })]
         [InlineData("import_v24_b.xsd", "import_v21_c.xsd", "import_v25_d.xsd", "import_v22_a.xsd")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v119(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -1183,6 +1202,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v120 - Import: Bug 105897", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v120()
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -1294,6 +1314,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v202.2 - Import: Add B(no ns) with ns-b , then A(ns-a) which imports B (no ns)", Priority = 1, Params = new object[] { "import_v5_a.xsd", "import_v4_b.xsd", 3, "ns-b", null })]
         [InlineData("import_v5_a.xsd", "import_v4_b.xsd", "ns-b")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v202a(object param0, object param1, object param3)
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1564,6 +1585,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v208 - Import: A(ns-a) imports B(ns-b) imports C (ns-a)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v208()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1586,6 +1608,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v209 - Import: A(ns-a) imports B(ns-b) and C (ns-b)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v209()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1608,6 +1631,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v210 - Import: A imports B and B and C, B imports C and D, C imports D and A", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v210()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1629,6 +1653,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v211 - Import: A(ns-a) imports B(ns-b) and C (ns-b), B and C include each other", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v211()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1651,6 +1676,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v212 - Import: A(ns-a) imports B(BOGUS) and C (ns-c)", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v212()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1672,6 +1698,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v213 - Import: B(ns-b) added, A(ns-a) imports B with bogus url", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v213()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1696,6 +1723,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v214 - Import: A(ns-a) includes B(ns-a) which imports C(ns-c)", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v214()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1722,6 +1750,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v215 - Import: A(ns-a) includes A(ns-a) of v17", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v215()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1748,6 +1777,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v216 - Import: A(ns-b) imports A(ns-a) of v17", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v216()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1770,6 +1800,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v217 - Import: A,B,C,D all import and reference each other for types", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v217()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -1816,6 +1847,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v223- Import: Bug 114549 , A imports only B's NS, and B also improts A's NS AND refers to A's types", Priority = 1, Params = new object[] { "import_v24_b.xsd", "import_v21_c.xsd", "import_v21_d.xsd", "import_v22_a.xsd" })]
         [InlineData("import_v24_b.xsd", "import_v21_c.xsd", "import_v21_d.xsd", "import_v22_a.xsd")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v218(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -1847,6 +1879,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v225- Import: Bug 114549 , A imports only B's NS, and B also improts A's NS AND refers to A's type, D refers to A's type (WARNING)", Priority = 1, Params = new object[] { "import_v24_b.xsd", "import_v21_c.xsd", "import_v25_d.xsd", "import_v22_a.xsd" })]
         [InlineData("import_v24_b.xsd", "import_v21_c.xsd", "import_v25_d.xsd", "import_v22_a.xsd")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v219(object param0, object param1, object param2, object param3)
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -1877,6 +1910,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v220 - Import: Bug 105897", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v220()
         {
             XmlSchemaSet ss = new XmlSchemaSet();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Includes.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Includes.cs
@@ -258,6 +258,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v101.1 - Include: A with NS includes B with no NS", Priority = 0, Params = new object[] { "include_v1_a.xsd", 1, "ns-a:e2" })]
         [InlineData("include_v1_a.xsd", 1, "ns-a:e2")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v101(object param0, object param1, object param2)
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -284,6 +285,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v102 - Include: A with NS includes B with a diff NS (INVALID)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v102()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -332,6 +334,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v103 - Include: A(ns-a) which includes B(ns-a) twice", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v103()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -362,6 +365,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v104 - Include: A(ns-a) which includes B(No NS) twice", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v104()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -393,6 +397,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v105 - Include: A,B,C all include each other, all with no ns and refer each others' types", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v105()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -429,6 +434,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v106 - Include: A,B,C all include each other, all with same ns and refer each others' types", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v106()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -475,6 +481,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v112 - 20008213 SOM: SourceUri property on a chameleon include is not set", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v107()
         {
             bool succeeded = false;
@@ -522,6 +529,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v201.1 - Include: A with NS includes B with no NS", Priority = 0, Params = new object[] { "include_v1_a.xsd", 1, "ns-a:e2" })]
         [InlineData("include_v1_a.xsd", 1, "ns-a:e2")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v201(object param0, object param1, object param2)
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -549,6 +557,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v202 - Include: A with NS includes B with a diff NS (INVALID)", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v202()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -597,6 +606,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v203 - Include: A(ns-a) which includes B(ns-a) twice", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v203()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -627,6 +637,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v204 - Include: A(ns-a) which includes B(No NS) twice", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v204()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -658,6 +669,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v205 - Include: A,B,C all include each other, all with no ns and refer each others' types", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v205()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -694,6 +706,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v206 - Include: A,B,C all include each other, all with same ns and refer each others' types", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v206()
         {
             XmlSchemaSet sc = new XmlSchemaSet();
@@ -740,6 +753,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v212 - 20008213 SOM: SourceUri property on a chameleon include is not set", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v207()
         {
             bool succeeded = false;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Misc.cs
@@ -273,6 +273,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v25 - Bug 338038 - Conflicting definitions for xml attributes in two schemas", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v25()
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -298,6 +299,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v26 - Bug 338038 - Change type of xml:lang to decimal and xml:base to short in two steps", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v26()
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -327,6 +329,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v27 - Bug 338038 - Add new attributes to the already present xml namespace System.Xml.Tests", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v27()
         {
             XmlSchemaSet ss = new XmlSchemaSet();
@@ -351,6 +354,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v28 - Bug 338038 - Add new attributes to the already present xml namespace System.Xml.Tests, remove default ns schema", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v28()
         {
             string xmlns = @"http://www.w3.org/XML/1998/namespace";
@@ -912,6 +916,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v120a.XmlDocument.Load non-validating reader.Expect IOE.")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v120a()
         {
             XmlReaderSettings readerSettings = new XmlReaderSettings();
@@ -1008,6 +1013,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "Dev10_40561 Redefine Chameleon: Unexpected qualified name on local particle")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Dev10_40561()
         {
             Initialize();
@@ -1061,6 +1067,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "Dev10_40509 Assert and NRE when validate the XML against the XSD")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Dev10_40509()
         {
             Initialize();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_ProhibitDTD.cs
@@ -409,6 +409,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v14 - SchemaSet.Add(XmlReader) with pDTD False ,then a SchemaSet.Add(URL) for schema with DTD", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v14()
         {
             Initialize();
@@ -434,6 +435,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v15 - SchemaSet.Add(XmlReader) with pDTD True ,then a SchemaSet.Add(XmlReader) with pDTD False with DTD", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v15()
         {
             Initialize();
@@ -498,6 +500,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v21- Underlying XmlReader with ProhibitDTD=False and Create new Reader with ProhibitDTD=True", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v21()
         {
             Initialize();
@@ -532,6 +535,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v22.4- Test Default value of ProhibitDTD for XML containing Inline schema containing xs:import of a schema which has a xs:import of schema with DTD", Priority = 1, Params = new object[] { "bug356711_4.xml" })]
         [InlineData("bug356711_4.xml")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v22(object param0)
         {
             Initialize();
@@ -555,6 +559,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v23- Underlying XmlReader with ProhibitDTD=True and Create new Reader with ProhibitDTD=False", Priority = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v23()
         {
             Initialize();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Remove.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Remove.cs
@@ -357,6 +357,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "v20 - 358206 : Removing the last schema from the set should clear the global tables", Priority = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v20()
         {
             XmlSchemaSet sc = new XmlSchemaSet();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Reprocess.cs
@@ -533,6 +533,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "v51 Regression bug 382119 - XmlEditor:  Changes within an include is not getting picked up as expected - redefine", Priority = 1, Params = new object[] { "bug382119_c.xsd", "bug382119_red.xsd", "bug382119_red1.xsd", false })]
         [InlineData("bug382119_c.xsd", "bug382119_red.xsd", "bug382119_red1.xsd", false)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v51(object param0, object param1, object param2, object param3)
         {
             bWarningCallback = false;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Schemas.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaSet/TC_SchemaSet_Schemas.cs
@@ -76,6 +76,7 @@ namespace System.Xml.Tests
         //-----------------------------------------------------------------------------------
         //[Variation(Desc = "v4 - Schemas on non empty collection,call Schemas,Edit check all members of ICollection")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v4()
         {
             XmlSchemaSet sc = new XmlSchemaSet();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Constructor_AddSchema.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Constructor_AddSchema.cs
@@ -89,6 +89,7 @@ namespace System.Xml.Tests
         [InlineData("empty")]
         [InlineData("notcompiled")]
         [InlineData("compiled")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SetSchemaSetTo_Empty_NotCompiled_Compiled(string schemaSetStatus)
         {
             XmlSchemaValidator val;
@@ -334,6 +335,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ImportAnotherSchemaThat_Is_IsNot_InSchemaSet(bool importTwice)
         {
             XmlSchemaValidator val;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/GetExpectedAttributes.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/GetExpectedAttributes.cs
@@ -50,6 +50,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallOnElementWithNoAttributesAfterValidateElement()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_ATTRIBUTES);
@@ -69,6 +70,7 @@ namespace System.Xml.Tests
         [InlineData("Default")]
         [InlineData("Fixed")]
         [InlineData("FixedRequired")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallOnElementWith_Required_Optional_Default_Fixed_FixedRequired_AttributesAfterValidateElement(string attrType)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_ATTRIBUTES);
@@ -91,6 +93,7 @@ namespace System.Xml.Tests
         [InlineData("Fixed", "after")]
         [InlineData("FixedRequired", "before")]
         [InlineData("FixedRequired", "after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Call_Before_After_GetUnspecifiedDefaultAttributeWhenJust_Required_Optional_Fixed_FixedRequired_AttributesAreLeft(string attrType, string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_ATTRIBUTES);
@@ -113,6 +116,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Call_Before_After_GetUnspecifiedDefaultAttributesWhenJustDefaultAttributesAreLeft(string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_ATTRIBUTES);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/GetExpectedParticles.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/GetExpectedParticles.cs
@@ -23,6 +23,7 @@ namespace System.Xml.Tests
         [InlineData("ctor")]
         [InlineData("init")]
         [InlineData("end")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfter_Constructor_Initialize_EndValidation(string after)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -48,6 +49,7 @@ namespace System.Xml.Tests
         [InlineData("elem")]
         [InlineData("attrib")]
         [InlineData("endof")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfterValidate_Element_Attribute_EndOfAttributes_ForSequence(string after)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -74,6 +76,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("inside")]
         [InlineData("end")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForSequence_Between_After_ValidationAllSeqElements(string callOn)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -111,6 +114,7 @@ namespace System.Xml.Tests
         [InlineData("elem")]
         [InlineData("attrib")]
         [InlineData("endof")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfterValidate_Element_Attribute_EndOfAttributes_ForChoice(string after)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -137,6 +141,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("elem1")]
         [InlineData("elem2")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForChoiceAfterValidating_1_2_ChoiceElement(string elemAfter)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -162,6 +167,7 @@ namespace System.Xml.Tests
         [InlineData("elem")]
         [InlineData("attrib")]
         [InlineData("endof")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfterValidate_Element_Attribute_EndOfAttributes_ForAll(string after)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -188,6 +194,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("elem1")]
         [InlineData("elem2")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForAllAfterValidating_1_2_element(string elemAfter)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -211,6 +218,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForAllAfterValidatingBothElements()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -234,6 +242,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForElementWithReferenceToGlobalElement()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -261,6 +270,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForElementWithZeroMinOccurs()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -276,6 +286,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForElementWithZeroMaxOccurs()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -293,6 +304,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForSequence_Before_After_ValidatingWildcard(string callOrder)
         {
             XmlSchemaValidator val;
@@ -330,6 +342,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForChoice_Before_After_ValidatingWildcard(string callOrder)
         {
             XmlSchemaValidator val;
@@ -383,6 +396,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForSequenceWithChoiceGroup_Before_After_ValidatingGroupMembers(string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -413,6 +427,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForChoiceWithSequenceGroup_Before_After_ValidatingGroupMembers(string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -443,6 +458,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForExtendedSequence_Before_After_ValidatingSeqOrAllBaseElements(string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -476,6 +492,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("before")]
         [InlineData("after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForExtendedChoice_Before_After_ValidatingBaseChoiceElement(string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -511,6 +528,7 @@ namespace System.Xml.Tests
         [InlineData("Choice", "after" )]
         [InlineData("All", "before")]
         [InlineData("All", "after")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForRestricted_Sequence_Choice_All__Before_After_ValidatingSeqElements(string restrType, string callOrder)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_GET_EXPECTED_PARTICLES);
@@ -540,6 +558,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForChoiceWithElementsFromDifferentNamespaces()
         {
             XmlSchemaValidator val;
@@ -573,6 +592,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallForElementWithoutTypeDefined()
         {
             XmlSchemaValidator val;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Initialize_EndValidation.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/Initialize_EndValidation.cs
@@ -23,6 +23,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeShouldResetIDConstraints()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_IDENTITY_CONSTRAINS);
@@ -171,6 +172,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithElementValidateSameElement()
         {
             XmlSchemaValidator val;
@@ -198,6 +200,7 @@ namespace System.Xml.Tests
         [InlineData("other")]
         [InlineData("type")]
         [InlineData("attribute")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithElementValidate_OtherElement_Type_Attribute(string typeToValidate)
         {
             XmlSchemaValidator val;
@@ -255,6 +258,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithTypeValidateSameType()
         {
             XmlSchemaValidator val;
@@ -280,6 +284,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("other")]
         [InlineData("attribute")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithTypeValidate_OtherType_Attribute(string typeToValidate)
         {
             XmlSchemaValidator val;
@@ -330,6 +335,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithTypeValidateElement()
         {
             XmlSchemaValidator val;
@@ -355,6 +361,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithAttributeValidateSameAttribute()
         {
             XmlSchemaValidator val;
@@ -379,6 +386,7 @@ namespace System.Xml.Tests
         [InlineData("other")]
         [InlineData("element")]
         [InlineData("type")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InitializeWithAttributeValidate_OtherAttribute_Element_Type(string typeToValidate)
         {
             XmlSchemaValidator val;
@@ -478,6 +486,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("text")]
         [InlineData("whitespace")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SetPartiaValidationAndCallValidate_Text_WhiteSpace_Valid(string typeToValidate)
         {
             XmlSchemaValidator val;
@@ -527,6 +536,7 @@ namespace System.Xml.Tests
         [InlineData("valid")]
         [InlineData("missing")]
         [InlineData("ignore")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TestForRootLevelIdentityConstraints_Valid_IDREFMissingInvalid_IgnoreIdentityConstraintsIsSetInvalid(string validity)
         {
             XmlSchemaValidator val;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/PropertiesTests.cs
@@ -25,6 +25,7 @@ namespace System.Xml.Tests
 
         //BUG #304124
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void DefaultValueForXmlResolver_XmlUrlResolver()
         {
             XmlNamespaceManager manager = new XmlNamespaceManager(new NameTable());
@@ -89,6 +90,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InternalSchemaSetShouldUseSeparateXmlResolver()
         {
             CXmlTestResolver res = new CXmlTestResolver();
@@ -151,6 +153,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SetResolverToCustomValidateSomethingSetResolverToNullThenVerify()
         {
             CXmlTestResolver res = new CXmlTestResolver();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute.cs
@@ -26,6 +26,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(null, "")]
         [InlineData("attr", null)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNull_LocalName_NameSpace__Invalid(string localName, string nameSpace)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -46,6 +47,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNullValueGetter__Invalid()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -66,6 +68,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNullXmlSchemaInfo__Valid()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -84,6 +87,7 @@ namespace System.Xml.Tests
         [InlineData("DefaultAttribute")]
         [InlineData("FixedAttribute")]
         [InlineData("FixedRequiredAttribute")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Validate_Required_Optional_Default_Fixed_FixedRequired_Attribute(string attrType)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -101,6 +105,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidateAttributeWithNamespace()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -118,6 +123,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidateAnyAttribute()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -133,6 +139,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AskForDefaultAttributesAndValidateThem()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_200_DEF_ATTRIBUTES);
@@ -157,6 +164,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidateTopLevelAttribute()
         {
             XmlSchemaValidator val;
@@ -176,6 +184,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidateSameAttributeTwice()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -210,6 +219,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNull__Invalid()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -230,6 +240,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallTwice()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -249,6 +260,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void NestBetweenValidateAttributeCalls()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -276,6 +288,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfterGetExpectedAttributes()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -294,6 +307,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfterValidatingSomeDefaultAttributes()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -317,6 +331,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallOnElementWithFixedAttribute()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -332,6 +347,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v6a()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -378,6 +394,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallOnELementWithNoAttributes()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -390,6 +407,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallAfterValidationOfAllAttributes()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -406,6 +424,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("OptionalAttribute")]
         [InlineData("FixedAttribute")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallWithoutValidationOf_Optional_Fixed_Attributes(string attrType)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -420,6 +439,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallWithoutValidationOfDefaultAttributesGetUnspecifiedDefault_Called_NotCalled(bool call)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);
@@ -437,6 +457,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallWithoutValidationOfRequiredAttribute()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute_String.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateAttribute_String.cs
@@ -26,6 +26,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(null, "")]
         [InlineData("attr", null)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNull_LocalName_Namespace__Invalid(string localName, string nameSpace)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_ATTRIBUTE);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateElement.cs
@@ -106,6 +106,7 @@ namespace System.Xml.Tests
         [InlineData("ElementOnlyElement", XmlSchemaContentType.ElementOnly, "second")]
         [InlineData("EmptyElement", XmlSchemaContentType.Empty, "second")]
         [InlineData("MixedElement", XmlSchemaContentType.Mixed, "second")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallValidateElementAndCHeckXmlSchemaInfoFOr_Simple_Complex_Empty_Mixed_Element_First_Second_Overload(string elemType, XmlSchemaContentType schemaContentType, string overload)
         {
             XmlSchemaValidator val;
@@ -137,6 +138,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SanityTestsForNestedElements()
         {
             XmlSchemaValidator val;
@@ -171,6 +173,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(XmlSchemaValidationFlags.ReportValidationWarnings | XmlSchemaValidationFlags.ProcessIdentityConstraints | XmlSchemaValidationFlags.ProcessInlineSchema | XmlSchemaValidationFlags.ProcessSchemaLocation)]
         [InlineData(XmlSchemaValidationFlags.ReportValidationWarnings | XmlSchemaValidationFlags.ProcessIdentityConstraints | XmlSchemaValidationFlags.ProcessInlineSchema)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CheckSchemaLocationIs_UsedWhenSpecified_NotUsedWhenFlagIsNotSet(XmlSchemaValidationFlags allFlags)
         {
             XmlSchemaValidator val;
@@ -208,6 +211,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(XmlSchemaValidationFlags.ReportValidationWarnings | XmlSchemaValidationFlags.ProcessIdentityConstraints | XmlSchemaValidationFlags.ProcessInlineSchema | XmlSchemaValidationFlags.ProcessSchemaLocation)]
         [InlineData(XmlSchemaValidationFlags.ReportValidationWarnings | XmlSchemaValidationFlags.ProcessIdentityConstraints | XmlSchemaValidationFlags.ProcessInlineSchema)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CheckNoNamespaceSchemaLocationIs_UsedWhenSpecified_NotUsedWhenFlagIsSet(XmlSchemaValidationFlags allFlags)
         {
             XmlSchemaValidator val;
@@ -243,6 +247,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("false")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallWith_Null_False_XsiNil(string xsiNil)
         {
             XmlSchemaValidator val;
@@ -270,6 +275,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallWithXsiNilTrue()
         {
             XmlSchemaValidator val;
@@ -288,6 +294,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ProvideValidXsiType()
         {
             XmlSchemaValidator val;
@@ -306,6 +313,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ProvideInvalidXsiType()
         {
             XmlSchemaValidator val;
@@ -391,6 +399,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CheckThatWarningOccursWhenUndefinedElementIsValidatedWithLaxValidation()
         {
             XmlSchemaValidator val;
@@ -412,6 +421,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CheckThatWarningsDontOccurWhenIgnoreValidationWarningsIsSet()
         {
             XmlSchemaValidator val;
@@ -432,6 +442,7 @@ namespace System.Xml.Tests
 
         //342447
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void VerifyThatSubstitutionGroupMembersAreResolvedAndAddedToTheList()
         {
             XmlSchemaValidator val;

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateMisc.cs
@@ -35,6 +35,7 @@ namespace System.Xml.Tests
         [InlineData("simpleType", "stE064.xsd", 1, 1, 1, 0)]
         [InlineData("Wildcards", "wildG007.xsd", 1, 1, 2, 0)]
         [InlineData("Wildcards", "wildG010.xsd", 3, 1, 5, 0)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v1(string testDir, string testFile, int expCount, int expCountGT, int expCountGE, int expCountGA)
         {
             Initialize();
@@ -89,6 +90,7 @@ namespace System.Xml.Tests
         [InlineData("simpleType", "stE064", 1, 1, 1, 0)]
         [InlineData("Wildcards", "wildG007", 1, 1, 2, 0)]
         [InlineData("Wildcards", "wildG010", 3, 1, 5, 0)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void v2(string testDir, string testFile, int expCount, int expCountGT, int expCountGE, int expCountGA)
         {
             Initialize();
@@ -423,6 +425,7 @@ namespace System.Xml.Tests
         [InlineData("SCHEMA", "schB1_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schM2_a.xsd", 1, 3, 3)]
         [InlineData("SCHEMA", "schH2_a.xsd", 1, 3, 3)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddValid_Import_Include_Redefine(string testDir, string testFile, int expCount, int expCountGT, int expCountGE)
         {
             string xsd = Path.Combine(path, testDir, testFile);
@@ -450,6 +453,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("SCHEMA", "schE9.xsd", 1, 1)]
         [InlineData("SCHEMA", "schA7_a.xsd", 2, 2)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddEditInvalidImport(string testDir, string testFile, int expCountGT, int expCountGE)
         {
             string xsd = Path.Combine(path, testDir, testFile);
@@ -504,6 +508,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("include_v7_a.xsd", 4, 7)]
         [InlineData("include_v1_a.xsd", 3, 3)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddEditInvalidIncludeSchema(string testFile, int expCountGT, int expCountGE)
         {
             string xsd = Path.Combine(testData, testFile);
@@ -561,6 +566,7 @@ namespace System.Xml.Tests
         [InlineData("SCHEMA", "schE1i.xsd")]
         [InlineData("SCHEMA", "schB4_a.xsd")]
         [InlineData("SCHEMA", "schB1i.xsd")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddInvalid_Import_Include(string testDir, string testFile)
         {
             Initialize();

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateText_EndElement.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateText_EndElement.cs
@@ -22,6 +22,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNull()
         {
             XmlSchemaValidator val = CreateValidator(new XmlSchemaSet());
@@ -40,6 +41,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TopLevelText()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -59,6 +61,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("single")]
         [InlineData("multiple")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SanityTestForSimpleType_MultipleCallInOneContext(string param)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -91,6 +94,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void MixedContent()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -122,6 +126,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ElementOnlyContent()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -147,6 +152,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void EmptyContent()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -202,6 +208,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TopLevelWhitespace()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -219,6 +226,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void WhitespaceInsideElement_Single()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -250,6 +258,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void WhitespaceInEmptyContent__Invalid()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -273,6 +282,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNonWhitespaceContent()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -325,6 +335,7 @@ namespace System.Xml.Tests
 
         // BUG 305258
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SanityTestForComplexTypes()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -355,6 +366,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void IncompleteContet__Valid()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -382,6 +394,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void IncompleteContent__Invalid()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -411,6 +424,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TextNodeWithoutValidateTextCall()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -431,6 +445,7 @@ namespace System.Xml.Tests
         // 2nd overload
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Typed_NullXmlSchemaInfo()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -446,6 +461,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Typed_NullTypedValue()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -467,6 +483,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallValidateTextThenValidateEndElementWithTypedValue()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -492,6 +509,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CheckSchemaInfoAfterCallingValidateEndElementWithTypedValue()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -514,6 +532,7 @@ namespace System.Xml.Tests
 
         //bug #305258
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SanityTestForEmptyTypes()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -538,6 +557,7 @@ namespace System.Xml.Tests
         [InlineData("duplicate")]
         [InlineData("missing")]
         [InlineData("ignore")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TestForIdentityConstraints_Valid_InvalidDuplicateKey_InvalidKeyRefMissing_InvalidIdentitiConstraintIsSet(string constrType)
         {
             XmlSchemaValidator val;
@@ -649,6 +669,7 @@ namespace System.Xml.Tests
 
         //Bug #305376
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AllXmlSchemaInfoArgsCanBeNull()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -674,6 +695,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("first")]
         [InlineData("second")] //(BUG #307549)
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TestXmlSchemaInfoValuesAfterUnionValidation_Without_With_ValidationEndElementOverload(string overload)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -699,6 +721,7 @@ namespace System.Xml.Tests
 
         //BUG #308578
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CallValidateEndElementWithTypedValueForComplexContent()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -761,6 +784,7 @@ namespace System.Xml.Tests
         [Theory]
         [InlineData("valid")]
         [InlineData("invalid")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void SkipAfterValidating_ValidContent_IncompleteContent(string validity)
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -792,6 +816,7 @@ namespace System.Xml.Tests
 
         //bug #306869
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidateTextAndSkip()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -810,6 +835,7 @@ namespace System.Xml.Tests
 
         //bug #306869
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidateAttributesAndSkip()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);
@@ -826,6 +852,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void CheckThatSkipToEndElementJumpsIntoRightContext()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_END_ELEMENT);

--- a/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateWhitespace_String.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSchema/XmlSchemaValidatorApi/ValidateWhitespace_String.cs
@@ -57,6 +57,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void WhitespaceInsideElement()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);
@@ -111,6 +112,7 @@ namespace System.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void PassNonWhitespaceContent__ShouldNotWork()
         {
             XmlSchemaValidator val = CreateValidator(XSDFILE_VALIDATE_TEXT);

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.RuntimeOnly.cs
@@ -1318,6 +1318,7 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
     public static void XmlSchemaTest()
     {
         var schemas = new XmlSchemas();

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/Errata4.cs
@@ -286,6 +286,7 @@ namespace System.Xml.Tests
         //[Variation(Priority = 0, Desc = "Valid name CharType.NameSurrogateHighChar", Params = new object[] { true, CharType.NameSurrogateHighChar })]
         //[Variation(Priority = 0, Desc = "Valid name CharType.NameSurrogateLowChar", Params = new object[] { true, CharType.NameSurrogateLowChar })]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TestXslTransform(object param0, object param1)
         {
             int numOfRepeat = 300; // from the test case

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/OutputSettings.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/OutputSettings.cs
@@ -50,6 +50,7 @@ namespace System.Xml.Tests
 
         //[Variation(id = 1, Desc = "Verify the default value of the OutputSettings, expected null", Pri = 0)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS1()
         {
             XslCompiledTransform xslt = new XslCompiledTransform();
@@ -74,6 +75,7 @@ namespace System.Xml.Tests
         //[Variation(id = 9, Desc = "Verify the OutputMethod when multiple output methods (Text,Xml,Html) are defined, expected Html", Pri = 1, Params = new object[] { "books.xml", "OutputMethod_Multiple3.xsl" })]
         [InlineData("books.xml", "OutputMethod_Multiple3.xsl", 9)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS2(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
@@ -125,6 +127,7 @@ namespace System.Xml.Tests
         //[Variation(id = 12, Desc = "Verify OmitXmlDeclaration when omit-xml-declared is no in XSLT, expected false", Pri = 1, Params = new object[] { "books.xml", "OmitXmlDecl_No.xsl", false, "OmitXmlDeclaration must be 'no'" })]
         [InlineData("books.xml", "OmitXmlDecl_No.xsl", false)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS3(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
@@ -137,6 +140,7 @@ namespace System.Xml.Tests
         //[Variation(id = 13, Desc = "Verify OutputSettings when omit-xml-declaration has an invalid value, expected null", Pri = 2, Params = new object[] { "books.xml", "OmitXmlDecl_Invalid1.xsl" })]
         [InlineData("books.xml", "OmitXmlDecl_Invalid1.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS4(object param0, object param1)
         {
             Init(param0.ToString(), param1.ToString());
@@ -158,6 +162,7 @@ namespace System.Xml.Tests
         //[Variation(id = 14, Desc = "Verify OutputSettings on non well-formed XSLT, expected null", Pri = 2, Params = new object[] { "books.xml", "OmitXmlDecl_Invalid2.xsl" })]
         [InlineData("books.xml", "OmitXmlDecl_Invalid2.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS5(object param0, object param1)
         {
             Init(param0.ToString(), param1.ToString());
@@ -179,6 +184,7 @@ namespace System.Xml.Tests
         //[Variation(id = 18, Desc = "Verify Encoding set to windows-1252 explicitly, expected windows-1252", Pri = 1, Params = new object[] { "books.xml", "Encoding4.xsl", "windows-1252", "Encoding must be windows-1252" })]
         [InlineData("books.xml", "Encoding4.xsl", "windows-1252")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS6_Windows1252Encoding(object param0, object param1, object param2)
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
@@ -194,6 +200,7 @@ namespace System.Xml.Tests
         //[Variation(id = 19, Desc = "Verify Encoding when multiple xsl:output tags are present, expected the last set (iso-8859-1)", Pri = 1, Params = new object[] { "books.xml", "Encoding5.xsl", "iso-8859-1", "Encoding must be iso-8859-1" })]
         [InlineData("books.xml", "Encoding5.xsl", "iso-8859-1")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS6(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
@@ -211,6 +218,7 @@ namespace System.Xml.Tests
         //[Variation(id = 22, Desc = "Verify Indent when indent is no in XSLT, expected false", Pri = 1, Params = new object[] { "books.xml", "Indent_No.xsl", false, "Indent must be 'no'" })]
         [InlineData("books.xml", "Indent_No.xsl", false)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS7(object param0, object param1, object param2)
         {
             Init(param0.ToString(), param1.ToString());
@@ -223,6 +231,7 @@ namespace System.Xml.Tests
         //[Variation(id = 23, Desc = "Verify OutputSettings when Indent has an invalid value, expected null", Pri = 2, Params = new object[] { "books.xml", "Indent_Invalid1.xsl" })]
         [InlineData("books.xml", "Indent_Invalid1.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS8(object param0, object param1)
         {
             Init(param0.ToString(), param1.ToString());
@@ -244,6 +253,7 @@ namespace System.Xml.Tests
         //[Variation(id = 24, Desc = "Verify OutputSettings on non well-formed XSLT, expected null", Pri = 2, Params = new object[] { "books.xml", "Indent_Invalid2.xsl" })]
         [InlineData("books.xml", "Indent_Invalid2.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS9(object param0, object param1)
         {
             Init(param0.ToString(), param1.ToString());
@@ -265,6 +275,7 @@ namespace System.Xml.Tests
         //[Variation(id = 25, Desc = "Verify OutputSettings with all attributes on xsl:output", Pri = 0, Params = new object[] { "books.xml", "OutputSettings.xsl" })]
         [InlineData("books.xml", "OutputSettings.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS10(object param0, object param1)
         {
             Init(param0.ToString(), param1.ToString());
@@ -285,6 +296,7 @@ namespace System.Xml.Tests
         //[Variation(id = 26, Desc = "Compare Stream Output with XmlWriter over Stream with OutputSettings", Pri = 0, Params = new object[] { "books.xml", "OutputSettings1.xsl" })]
         [InlineData("books.xml", "OutputSettings1.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void OS11(object param0, object param1)
         {
             Init(param0.ToString(), param1.ToString());

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/TempFiles.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/TempFiles.cs
@@ -22,6 +22,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "Load File from a drive c:", Pri = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TempFiles1()
         {
             string childFile = Path.Combine(Directory.GetCurrentDirectory(), "child.xsl");
@@ -85,6 +86,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "Bug 469775 - XSLT V2 : Exception thrown if xsl:preserve-space/xsl:strip-space is used and input document contains entities", Pri = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TempFiles2()
         {
             try
@@ -104,6 +106,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "Bug 469770 - XslCompiledTransform failed to load embedded stylesheets when prefixes are defined outside of xsl:stylesheet element", Pri = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TempFiles3()
         {
             try
@@ -141,6 +144,7 @@ namespace System.Xml.Tests
 
         //[Variation(Desc = "Bug 482971 - XslCompiledTransform cannot output numeric character reference after long output", Pri = 2)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TempFiles4()
         {
             try

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslCompiledTransform.cs
@@ -90,6 +90,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(MethodInfo = null, ByteArray, TypeArray)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var1()
         {
             XslCompiledTransform xslt = new XslCompiledTransform();
@@ -111,6 +112,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(MethodInfo, ByteArray = null, TypeArray)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var2()
         {
             XslCompiledTransform xslt = new XslCompiledTransform();
@@ -142,6 +144,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(string = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var0()
         {
             try
@@ -202,6 +205,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(IXPathNavigable = null, XmlResolver = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var3()
         {
             try
@@ -222,6 +226,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(XmlReader = null, XmlResolver = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var4()
         {
             try
@@ -242,6 +247,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(IXPathNavigable = null, XmlResolver = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var5()
         {
             try
@@ -262,6 +268,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load(XmlReader = null, XmlResolver = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var6()
         {
             try
@@ -282,6 +289,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var7()
         {
             try
@@ -305,6 +313,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var8()
         {
             try
@@ -328,6 +337,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null, TextWriter = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var9()
         {
             try
@@ -350,6 +360,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null, TextWriter = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var10()
         {
             try
@@ -372,6 +383,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null, Stream = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var11()
         {
             try
@@ -394,6 +406,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null, Stream = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var12()
         {
             try
@@ -416,6 +429,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null, XmlWriter = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var13()
         {
             try
@@ -438,6 +452,7 @@ namespace System.Xml.Tests
 
         //[Variation("Transform(IXPathNavigable = null, XsltArgumentList = null, XmlWriter = null)", Pri = 1)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Var14()
         {
             try
@@ -487,6 +502,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XmlResolver1(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -517,6 +533,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XmlResolver2(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -554,6 +571,7 @@ namespace System.Xml.Tests
         [InlineData("DefaultResolver.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("DefaultResolver.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XmlResolver3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -587,6 +605,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XmlResolver7(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -667,6 +686,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric1(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -692,6 +712,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric2(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             if (LoadXSL("showParam.xsl", xslInputType, readerType) == 1)
@@ -732,6 +753,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -762,6 +784,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric4(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -804,6 +827,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric5(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -829,6 +853,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric6(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -854,6 +879,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric7(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             FileStream s2;
@@ -886,6 +912,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric9(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             FileStream s2;
@@ -918,6 +945,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric11(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             if (navType.ToString() == "DataDocument")
@@ -948,6 +976,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric12(XslInputType xslInputType, ReaderType readerType)
         {
             Stream strmTemp;
@@ -1296,6 +1325,7 @@ namespace System.Xml.Tests
         [InlineData("XmlResolverTestMain.txt", XslInputType.Reader, ReaderType.XmlValidatingReader)]
         [InlineData("XmlResolverTestMain.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric8(object param, XslInputType xslInputType, ReaderType readerType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1436,6 +1466,7 @@ namespace System.Xml.Tests
         [InlineData("XmlResolverTestMain.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("XmlResolverTestMain.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrlResolver1(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             // XsltResolverTestMain.xsl is placed in IIS virtual directory
@@ -1454,6 +1485,7 @@ namespace System.Xml.Tests
         //[Variation("Load XSL that needs cred. with null resolver, should fail", Param = "XmlResolverTestMain.txt")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrlResolver2(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -1472,6 +1504,7 @@ namespace System.Xml.Tests
         //[Variation("Call Load with null source value")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrlResolver3(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -1504,6 +1537,7 @@ namespace System.Xml.Tests
         //[Variation("Call Load with an invalid uri")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrl1(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -1539,6 +1573,7 @@ namespace System.Xml.Tests
         //[Variation("Load file with empty string")]
         [InlineData(ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrl2(ReaderType readerType)
         {
             try
@@ -1556,6 +1591,7 @@ namespace System.Xml.Tests
         //[Variation("Load with \".\"")]
         [InlineData(ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrl3(ReaderType readerType)
         {
             try
@@ -1573,6 +1609,7 @@ namespace System.Xml.Tests
         //[Variation("Load with \"..\"")]
         [InlineData(ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadUrl(ReaderType readerType)
         {
             try
@@ -1622,6 +1659,7 @@ namespace System.Xml.Tests
         //[Variation("Basic Verification Test", Param = "showParam.txt")]
         [InlineData("showParam.txt", OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadNavigator1(object param, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1647,6 +1685,7 @@ namespace System.Xml.Tests
         //[Variation("Create Navigator and navigate away from root", Param = "showParam.txt")]
         [InlineData("showParam.txt", OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadNavigator2(object param, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1670,6 +1709,7 @@ namespace System.Xml.Tests
         //[Variation("Basic check for usage of credentials on resolver, load XSL that needs cred. with correct resolver", Param = "XmlResolverTestMain.txt")]
         [InlineData("XmlResolverTestMain.txt", OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadNavigator3(object param, OutputType outputType, NavType navType)
         {
             xslt = new XslCompiledTransform();
@@ -1690,6 +1730,7 @@ namespace System.Xml.Tests
 
         //[Variation("Regression case for bug 80768")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadNavigator4()
         {
             var e = Assert.ThrowsAny<XsltException>(() =>
@@ -1730,6 +1771,7 @@ namespace System.Xml.Tests
         //[Variation("Basic Verification Test", Param = "showParam.txt")]
         [InlineData("showParam.txt", OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader1(object param, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1767,6 +1809,7 @@ namespace System.Xml.Tests
 
         //[Variation("Calling with a closed reader, should throw exception")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader2()
         {
             xslt = new XslCompiledTransform();
@@ -1793,6 +1836,7 @@ namespace System.Xml.Tests
 
         //[Variation("Verify Reader isn't closed after Load")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader3()
         {
             bool fTEST_FAIL = false;
@@ -1829,6 +1873,7 @@ namespace System.Xml.Tests
 
         //[Variation("Verify position of node in Reader is at EOF after Load")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader4()
         {
             bool fTEST_FAIL = false;
@@ -1864,6 +1909,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load with reader position at EOF, should throw exception")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader5()
         {
             bool fTEST_FAIL = false;
@@ -1895,6 +1941,7 @@ namespace System.Xml.Tests
 
         //[Variation("Load with NULL reader, should throw System.ArgumentNullException")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader6()
         {
             xslt = new XslCompiledTransform();
@@ -1916,6 +1963,7 @@ namespace System.Xml.Tests
         //[Variation("Basic check for usage of credentials on resolver, load XSL that needs cred. with correct resolver", Param = "XmlResolverTestMain.txt")]
         [InlineData("XmlResolverTestMain.txt", OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadXmlReader7(object param, OutputType outputType, NavType navType)
         {
             xslt = new XslCompiledTransform();
@@ -1935,6 +1983,7 @@ namespace System.Xml.Tests
 
         //[Variation("bug 380138 NRE during XSLT compilation")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Bug380138()
         {
             string xsl = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -2127,6 +2176,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric1(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2150,6 +2200,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric2(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2174,6 +2225,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2198,6 +2250,7 @@ namespace System.Xml.Tests
         [InlineData(OutputType.Writer, NavType.XPathDocument)]
         [InlineData(OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric4(OutputType outputType, NavType navType)
         {
             xslt = new XslCompiledTransform();
@@ -2225,6 +2278,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric5(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             FileStream s2;
@@ -2254,6 +2308,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric7(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             try
@@ -2272,6 +2327,7 @@ namespace System.Xml.Tests
 
         //[Variation("Bug382506 - Loading stylesheet from custom navigator with enableDebug = true causes ArgumentOutOfRangeException")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric8()
         {
             xslt = new XslCompiledTransform();
@@ -2291,6 +2347,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric9(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             try
@@ -2309,6 +2366,7 @@ namespace System.Xml.Tests
 
         //[Variation("Bug349757 - document() function does not work when stylesheet was loaded from a stream or reader or constructed DOM")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric10()
         {
             xslt = new XslCompiledTransform();
@@ -2330,6 +2388,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformGeneric11(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             try
@@ -2487,6 +2546,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XmlResolver5(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -2576,6 +2636,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr1(object param, XslInputType xslInputType, ReaderType readerType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2595,6 +2656,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr2(XslInputType xslInputType, ReaderType readerType)
         {
             if (LoadXSL("showParam.xsl", xslInputType, readerType) == 1)
@@ -2615,6 +2677,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr3(XslInputType xslInputType, ReaderType readerType)
         {
             string szFullFilename = FullFilePath("fruits.xml");
@@ -2639,6 +2702,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr4(XslInputType xslInputType, ReaderType readerType)
         {
             if (LoadXSL("showParam.xsl", xslInputType, readerType) == 1)
@@ -2686,6 +2750,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr6(XslInputType xslInputType, ReaderType readerType)
         {
             if (LoadXSL("showParam.xsl", xslInputType, readerType) == 1)
@@ -2708,6 +2773,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr7(XslInputType xslInputType, ReaderType readerType)
         {
             string szFullFilename = FullFilePath("fruits.xml");
@@ -2732,6 +2798,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr8(object param, XslInputType xslInputType, ReaderType readerType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2751,6 +2818,7 @@ namespace System.Xml.Tests
 
         //[Variation("Call without loading")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr9()
         {
             xslt = new XslCompiledTransform();
@@ -2773,6 +2841,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr10(XslInputType xslInputType, ReaderType readerType)
         {
             if (LoadXSL("showParam.xsl", xslInputType, readerType) == 1)
@@ -2796,6 +2865,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr11(XslInputType xslInputType, ReaderType readerType)
         {
             int iCount = 0;
@@ -2842,6 +2912,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr12(XslInputType xslInputType, ReaderType readerType)
         {
             string szFullFilename = FullFilePath("fruits.xml");
@@ -2898,6 +2969,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStr13(XslInputType xslInputType, ReaderType readerType)
         {
             string szFullFilename = FullFilePath("fruits.xml");
@@ -2948,6 +3020,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStrResolver1(XslInputType xslInputType, ReaderType readerType)
         {
             string szFullFilename = FullFilePath("fruits.xml");
@@ -2974,6 +3047,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStrResolver2(XslInputType xslInputType, ReaderType readerType)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -3002,6 +3076,7 @@ namespace System.Xml.Tests
         [InlineData("xmlResolver_document_function.txt", XslInputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData("xmlResolver_document_function.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TransformStrStrResolver3(object param, XslInputType xslInputType, ReaderType readerType)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -3061,6 +3136,7 @@ namespace System.Xml.Tests
         [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false, "IXPathNavigable")]
         [InlineData("XmlResolver_Main.xsl", "fruits.xml", "xmlResolver_main.txt", "NullResolver", false, "XmlReader")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidCases_ExternalURI(object param0, object param1, object param2, object param3, object param4, object param5)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -3090,6 +3166,7 @@ namespace System.Xml.Tests
         [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "NullResolver", true, "IXPathNavigable")]
         [InlineData("Bug382198.xsl", "fruits.xml", "bug382198.txt", "NullResolver", true, "XmlReader")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void ValidCases(object param0, object param1, object param2, object param3, object param4, object param5)
         {
             string xslFile = FullFilePath(param0 as string);
@@ -3185,6 +3262,7 @@ namespace System.Xml.Tests
         [InlineData(4, true, "IXPathNavigable")]
         [InlineData(4, true, "XmlReader")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void InValidCases(object param0, object param1, object param2)
         {
             int argumentNumber = (int)param0;
@@ -3243,6 +3321,7 @@ namespace System.Xml.Tests
         //[Variation("Local parameter gets overwritten with global param value", Pri = 1)]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void var1(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>
@@ -3264,6 +3343,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
         //[Variation("Local parameter gets overwritten with global variable value", Pri = 1)]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void var2(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><out>
@@ -3285,6 +3365,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
         //[Variation("Subclassed XPathNodeIterator returned from an extension object or XsltFunction is not accepted by XPath", Pri = 1)]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void var3(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><distinct-countries>France, Spain, Austria, Germany</distinct-countries>";
@@ -3304,6 +3385,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
         //[Variation("Iterator using for-each over a variable is not reset correctly while using msxsl:node-set()", Pri = 1)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void var4(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -3334,6 +3416,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
         //[Variation("Bug398968 - Globalization is broken for document() function")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RegressionTest1(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             // <SQL BU Defect Tracking 410060>
@@ -3356,6 +3439,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
         //[Variation("Bug412703 - Off-by-one errors for XSLT loading error column")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RegressionTest3(XslInputType xslInputType, ReaderType readerType)
         {
             try
@@ -3375,6 +3459,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
 
         //[Variation("Bug423641 - XslCompiledTransform.Load() [retail] throws a NullReferenceException when scripts are prohibited")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RegressionTest4()
         {
             XslCompiledTransform xslt = new XslCompiledTransform();
@@ -3385,6 +3470,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
 
         //[Variation("Bug423641 - XslCompiledTransform.Load() [debug] throws a NullReferenceException when scripts are prohibited")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RegressionTest5()
         {
             XslCompiledTransform xslt = new XslCompiledTransform(true);
@@ -3395,6 +3481,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
 
         //[Variation("Bug469781 - Replace shouldn't relax original type 'assertion failure'")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RegressionTest7()
         {
             string xslString = "<xsl:stylesheet version=\"1.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\" xmlns:user=\"urn:user\">"
@@ -3423,6 +3510,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
 
         //[Variation("Bug737816 - Dynamic method will have declaring type == null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RegressionTest8()
         {
             try

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XslTransformMultith.cs
@@ -119,6 +119,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - AVTs")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc3()
         {
             Load("xslt_multith_AVTs.xsl", "xslt_multith_AVTs.xml");
@@ -139,6 +140,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - xsl:key")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc4()
         {
             Load("xslt_multith_keytest.xsl", "xslt_multith_keytest.xml");
@@ -159,6 +161,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - xsl:sort")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc5()
         {
             Load("xslt_multith_sorting.xsl", "xslt_multith_sorting.xml");
@@ -179,6 +182,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - Attribute Sets")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc6()
         {
             Load("xslt_mutith_attribute_sets.xsl", "xslt_mutith_attribute_sets.xml");
@@ -199,6 +203,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - Boolean Expression AND")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc7()
         {
             Load("xslt_mutith_boolean_expr_and.xsl", "xslt_mutith_boolean_expr_and.xml");
@@ -219,6 +224,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - Boolean Expression OR")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc8()
         {
             Load("xslt_mutith_boolean_expr_or.xsl", "xslt_mutith_boolean_expr_or.xml");
@@ -239,6 +245,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - FormatNubmer function")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc9()
         {
             Load("xslt_mutith_format_number.xsl", "xslt_mutith_format_number.xml");
@@ -259,6 +266,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - Position() function")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc10()
         {
             Load("xslt_mutith_position_func.xsl", "xslt_mutith_position_func.xml");
@@ -279,6 +287,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - preserve space")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc11()
         {
             Load("xslt_mutith_preserve_space.xsl", "xslt_mutith_preserve_space.xml");
@@ -299,6 +308,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Transform(): Reader - Variable nodeset")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc12()
         {
             Load("xslt_mutith_variable_nodeset.xsl", "xslt_mutith_variable_nodeset.xml");

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentList.cs
@@ -76,6 +76,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "Dictionary.XsltArgumentList.AddParam/AddExtensionObject", Param = 4)]
         [InlineData(4)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam_Tuple(object param)
         {
             WriteXmlAndXslFiles();
@@ -135,6 +136,7 @@ namespace System.Xml.Tests
 
         //[Variation("Param name is empty string")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam3()
         {
             m_xsltArg = new XsltArgumentList();
@@ -150,6 +152,7 @@ namespace System.Xml.Tests
 
         //[Variation("Param name is non existent")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam4()
         {
             m_xsltArg = new XsltArgumentList();
@@ -165,6 +168,7 @@ namespace System.Xml.Tests
 
         //[Variation("Invalid Param name")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam5()
         {
             m_xsltArg = new XsltArgumentList();
@@ -180,6 +184,7 @@ namespace System.Xml.Tests
 
         //[Variation("Very Long Param")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam6()
         {
             m_xsltArg = new XsltArgumentList();
@@ -194,6 +199,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI = null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam7()
         {
             m_xsltArg = new XsltArgumentList();
@@ -209,6 +215,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI is empty string")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam8()
         {
             m_xsltArg = new XsltArgumentList();
@@ -223,6 +230,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI non-existent")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam9()
         {
             m_xsltArg = new XsltArgumentList();
@@ -254,6 +262,7 @@ namespace System.Xml.Tests
 
         //[Variation("Very long namespace System.Xml.Tests")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam10()
         {
             m_xsltArg = new XsltArgumentList();
@@ -268,6 +277,7 @@ namespace System.Xml.Tests
 
         //[Variation("Invalid Namespace URI")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam11()
         {
             m_xsltArg = new XsltArgumentList();
@@ -280,6 +290,7 @@ namespace System.Xml.Tests
 
         //[Variation("Different Data Types")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam12()
         {
             m_xsltArg = new XsltArgumentList();
@@ -341,6 +352,7 @@ namespace System.Xml.Tests
 
         //[Variation("Case Sensitivity")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam13()
         {
             m_xsltArg = new XsltArgumentList();
@@ -361,6 +373,7 @@ namespace System.Xml.Tests
 
         //[Variation("Whitespace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam14()
         {
             int i = 1;
@@ -394,6 +407,7 @@ namespace System.Xml.Tests
 
         //[Variation("Call After Param has been removed")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam15()
         {
             m_xsltArg = new XsltArgumentList();
@@ -409,6 +423,7 @@ namespace System.Xml.Tests
 
         //[Variation("Call multiple Times")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam16()
         {
             m_xsltArg = new XsltArgumentList();
@@ -432,6 +447,7 @@ namespace System.Xml.Tests
 
         //[Variation("Using XSL namespace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam17()
         {
             m_xsltArg = new XsltArgumentList();
@@ -449,6 +465,7 @@ namespace System.Xml.Tests
 
         //[Variation("Resolving conflicts with variables with different namespaces")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam18()
         {
             m_xsltArg = new XsltArgumentList();
@@ -474,6 +491,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace AND param = null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam19()
         {
             m_xsltArg = new XsltArgumentList();
@@ -489,6 +507,7 @@ namespace System.Xml.Tests
 
         //[Variation("Data Types - Of type Double ")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParamDoubles()
         {
             double d1 = double.PositiveInfinity;
@@ -576,6 +595,7 @@ namespace System.Xml.Tests
         //DCR : 298350 - XsltArgumentList no longer reports the same type on the GetParam methods
         //[Variation(id = 20, Desc = "Add Parameter other than XSLT Data Type and verify the type, expected same as added", Pri = 0)]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetParam20()
         {
             m_xsltArg = new XsltArgumentList();
@@ -611,6 +631,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "Basic Verification Test", Pri = 1)]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject1(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(1, _output);
@@ -638,6 +659,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI = null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject2()
         {
             m_xsltArg = new XsltArgumentList();
@@ -657,6 +679,7 @@ namespace System.Xml.Tests
         //[Variation("Namespace URI is empty string", Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -684,6 +707,7 @@ namespace System.Xml.Tests
         //[Variation("Namespace URI non-existent")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject4(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             m_xsltArg = new XsltArgumentList();
@@ -711,6 +735,7 @@ namespace System.Xml.Tests
         //[Variation("Very long namespace System.Xml.Tests")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject5(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             m_xsltArg = new XsltArgumentList();
@@ -737,6 +762,7 @@ namespace System.Xml.Tests
 
         //[Variation("Invalid namespace System.Xml.Tests")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject6()
         {
             m_xsltArg = new XsltArgumentList();
@@ -750,6 +776,7 @@ namespace System.Xml.Tests
 
         //[Variation("Different Data Types")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject7()
         {
             m_xsltArg = new XsltArgumentList();
@@ -811,6 +838,7 @@ namespace System.Xml.Tests
         //[Variation("Case sensitivity")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject8(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(8, _output);
@@ -859,6 +887,7 @@ namespace System.Xml.Tests
         //[Variation("Whitespace")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject9(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             int i = 1;
@@ -894,6 +923,7 @@ namespace System.Xml.Tests
         //[Variation("Call after object has been removed")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject10(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(10, _output);
@@ -925,6 +955,7 @@ namespace System.Xml.Tests
         //[Variation("Call multiple times")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject11(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(11, _output);
@@ -953,6 +984,7 @@ namespace System.Xml.Tests
 
         //[Variation("Using XSL Namespace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void GetExtObject12()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1002,6 +1034,7 @@ namespace System.Xml.Tests
         [InlineData("showParam1.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam1.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam1(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1024,6 +1057,7 @@ namespace System.Xml.Tests
 
         //[Variation("Param  = null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam2()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1042,6 +1076,7 @@ namespace System.Xml.Tests
 
         //[Variation("Param name is empty string")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam3()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1069,6 +1104,7 @@ namespace System.Xml.Tests
         [InlineData("LongParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("LongParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam4(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1091,6 +1127,7 @@ namespace System.Xml.Tests
 
         //[Variation("Invalid Param name")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam5()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1109,6 +1146,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI = null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam6()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1136,6 +1174,7 @@ namespace System.Xml.Tests
         [InlineData("showParam7.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam7.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam7(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1168,6 +1207,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam8(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1190,6 +1230,7 @@ namespace System.Xml.Tests
 
         //[Variation("Invalid Namespace URI")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam9()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1200,6 +1241,7 @@ namespace System.Xml.Tests
 
         //[Variation("Setting a param that already exists")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam11()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1228,6 +1270,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam12.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam12.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam12(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1273,6 +1316,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam13.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam13.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam13(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1317,6 +1361,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam14.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam14.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam14(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1357,6 +1402,7 @@ namespace System.Xml.Tests
 
         //[Variation("Object is null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam15()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1384,6 +1430,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam16.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam16.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam16(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1443,6 +1490,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam17.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam17.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam17(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1506,6 +1554,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam18.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam18.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam18(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1540,6 +1589,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam19.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam19.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam19(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1582,6 +1632,7 @@ namespace System.Xml.Tests
         [InlineData("AddParam20.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("AddParam20.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam20(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -1623,6 +1674,7 @@ namespace System.Xml.Tests
 
         //[Variation("Using Default XSLT namespace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam21()
         {
             m_xsltArg = new XsltArgumentList();
@@ -1643,6 +1695,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject32(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected1 = @"<?xml version=""1.0"" encoding=""utf-8""?><out>Param: first</out>";
@@ -2433,6 +2486,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject1(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(1, _output);
@@ -2452,6 +2506,7 @@ namespace System.Xml.Tests
 
         //[Variation("namespace System.Xml.Tests = null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject2()
         {
             MyObject obj = new MyObject(2, _output);
@@ -2471,6 +2526,7 @@ namespace System.Xml.Tests
 
         //[Variation("namespace System.Xml.Tests is empty string")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject3()
         {
             MyObject obj = new MyObject(3, _output);
@@ -2492,6 +2548,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectLongNS.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("myObjectLongNS.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject4(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             m_xsltArg = new XsltArgumentList();
@@ -2511,6 +2568,7 @@ namespace System.Xml.Tests
 
         //[Variation("Invalid namespace System.Xml.Tests")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject5()
         {
             MyObject obj = new MyObject(5, _output);
@@ -2522,6 +2580,7 @@ namespace System.Xml.Tests
 
         //[Variation("Same Namespace different objects")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject7()
         {
             MyObject obj1 = new MyObject(1, _output);
@@ -2552,6 +2611,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject8(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(1, _output);
@@ -2581,6 +2641,7 @@ namespace System.Xml.Tests
 
         //[Variation("Set a null object")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject9()
         {
             MyObject obj = new MyObject(9, _output);
@@ -2609,6 +2670,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject10(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
@@ -2641,6 +2703,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject11(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2676,6 +2739,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject12(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             int i = 1;
@@ -2703,6 +2767,7 @@ namespace System.Xml.Tests
 
         //[Variation("Add object many times")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject13()
         {
             MyObject obj = new MyObject(13, _output);
@@ -2732,6 +2797,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject14(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2765,6 +2831,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject15(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(15, _output);
@@ -2796,6 +2863,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject16(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(1, _output);
@@ -2842,6 +2910,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject17(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
@@ -2873,6 +2942,7 @@ namespace System.Xml.Tests
         [InlineData("MyObject_Recursion.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("MyObject_Recursion.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject18(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(18, _output);
@@ -2901,6 +2971,7 @@ namespace System.Xml.Tests
         [InlineData("MyObject_FnExists.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("MyObject_FnExists.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject20(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2929,6 +3000,7 @@ namespace System.Xml.Tests
         [InlineData("MyObject_Arguments.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("MyObject_Arguments.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject21(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -2948,6 +3020,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple Objects in same NameSpace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject24()
         {
             m_xsltArg = new XsltArgumentList();
@@ -2979,6 +3052,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TC_ExtensionObj_Function_Mismatch_IncorrectCasing(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(25, _output);
@@ -3002,6 +3076,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject26(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(26, _output);
@@ -3035,6 +3110,7 @@ namespace System.Xml.Tests
         [InlineData("MyObject_KeepingState.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("MyObject_KeepingState.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject27(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(27, _output);
@@ -3063,6 +3139,7 @@ namespace System.Xml.Tests
         [InlineData("MyObject_KillerStrings.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("MyObject_KillerStrings.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject28(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(28, _output);
@@ -3094,6 +3171,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject29(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(29, _output);
@@ -3118,6 +3196,7 @@ namespace System.Xml.Tests
 
         //[Variation("Using Default XSLT namespace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject31()
         {
             MyObject obj = new MyObject(31, _output);
@@ -3252,6 +3331,7 @@ namespace System.Xml.Tests
         [InlineData("sort.xsl", "sort.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject33(object param0, object param1, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             ExObj obj = new ExObj(0, _output);
@@ -3331,6 +3411,7 @@ namespace System.Xml.Tests
         [InlineData("param4.xsl", "param4.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("param4.xsl", "param4.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject41(object param0, object param1, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             /*
@@ -3406,6 +3487,7 @@ namespace System.Xml.Tests
         [InlineData("RemoveParam1.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("RemoveParam1.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam1(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             m_xsltArg = new XsltArgumentList();
@@ -3440,6 +3522,7 @@ namespace System.Xml.Tests
 
         //[Variation(id = 2, Desc = "Param name is null", Pri = 1, Param = "RemoveParam2.txt")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam2()
         {
             m_xsltArg = new XsltArgumentList();
@@ -3458,6 +3541,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3479,6 +3563,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam4(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3500,6 +3585,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam5(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3521,6 +3607,7 @@ namespace System.Xml.Tests
         [InlineData("showParamLongName.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParamLongName.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam6(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3540,6 +3627,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI is null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam7()
         {
             m_xsltArg = new XsltArgumentList();
@@ -3559,6 +3647,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam8(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3582,6 +3671,7 @@ namespace System.Xml.Tests
         [InlineData("RemoveParam9.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("RemoveParam9.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam9(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3605,6 +3695,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam10(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3628,6 +3719,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam11(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3836,6 +3928,7 @@ namespace System.Xml.Tests
         [InlineData("RemoveParam12.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("RemoveParam12.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam12(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3862,6 +3955,7 @@ namespace System.Xml.Tests
         [InlineData("RemoveParam13.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("RemoveParam13.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam13(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3911,6 +4005,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Writer, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.TextWriter, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam14(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -3932,6 +4027,7 @@ namespace System.Xml.Tests
 
         //[Variation("Using Default XSLT Namespace")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveParam15()
         {
             m_xsltArg = new XsltArgumentList();
@@ -3963,6 +4059,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj1(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(1, _output);
@@ -3986,6 +4083,7 @@ namespace System.Xml.Tests
 
         //[Variation("Namespace URI is null")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj2()
         {
             MyObject obj = new MyObject(2, _output);
@@ -4009,6 +4107,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4034,6 +4133,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectDef.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj4(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4058,6 +4158,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj5(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             m_xsltArg = new XsltArgumentList();
@@ -4085,6 +4186,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj6(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4124,6 +4226,7 @@ namespace System.Xml.Tests
         [InlineData("myObjectDef.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData("myObjectDef.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj7(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(7, _output);
@@ -4152,6 +4255,7 @@ namespace System.Xml.Tests
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData(XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj8(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             int i = 1;
@@ -4191,6 +4295,7 @@ namespace System.Xml.Tests
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [InlineData("showParam.txt", XslInputType.Navigator, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void RemoveExtObj9(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4226,6 +4331,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "Basic Verification Test", Pri = 1, Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear1(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4253,6 +4359,7 @@ namespace System.Xml.Tests
         //[Variation("Clear with nothing loaded", Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear2(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4271,6 +4378,7 @@ namespace System.Xml.Tests
         //[Variation("Clear Params", Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear3(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4298,6 +4406,7 @@ namespace System.Xml.Tests
         //[Variation("Clear Extension Objects")]
         [InlineData(XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear4(XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             MyObject obj = new MyObject(26, _output);
@@ -4330,6 +4439,7 @@ namespace System.Xml.Tests
         //[Variation("Clear Many Objects", Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear5(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4375,6 +4485,7 @@ namespace System.Xml.Tests
         //[Variation("Clear Multiple Times", Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear6(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4403,6 +4514,7 @@ namespace System.Xml.Tests
         //[Variation("Loading one object, but clearing another", Param = "ClearParam7.txt")]
         [InlineData("ClearParam7.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear7(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4428,6 +4540,7 @@ namespace System.Xml.Tests
         //[Variation("Clear after objects have been \"Removed\"", Param = "showParam.txt")]
         [InlineData("showParam.txt", XslInputType.URI, ReaderType.XmlValidatingReader, OutputType.Stream, NavType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Clear8(object param, XslInputType xslInputType, ReaderType readerType, OutputType outputType, NavType navType)
         {
             string Baseline = Path.Combine("baseline", (string)param);
@@ -4515,6 +4628,7 @@ namespace System.Xml.Tests
         //[Variation(id = 10, Desc = "OnQueryEvent Exists - xsl:message with template content and  terminate='yes'", Priority = 1, Params = new object[] { "Message10.xsl", "yes", "yes", "Message10.txt" })]
         [InlineData("Message10.xsl", "yes", "yes", "Message10.txt")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void EventsTests(object param0, object param1, object param2, object param3)
         {
             XslCompiledTransform xslt = new XslCompiledTransform();
@@ -4602,6 +4716,7 @@ namespace System.Xml.Tests
 
         //[Variation(id = 1, Desc = "Call Current without MoveNext")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void NodeIter1()
         {
             var e = Assert.ThrowsAny<XsltException>(() =>
@@ -4621,6 +4736,7 @@ namespace System.Xml.Tests
 
         //[Variation(id = 2, Desc = "Call Current after MoveNext")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void NodeIter2()
         {
             var e = Assert.ThrowsAny<XsltException>(() =>

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltArgumentListMultith.cs
@@ -67,6 +67,7 @@ namespace System.Xml.Tests
         // Same instance testing:
         // Multiple GetParam() over same ArgumentList
         ////////////////////////////////////////////////////////////////
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public int GetParam1(object args)
         {
             object retObj;
@@ -84,6 +85,7 @@ namespace System.Xml.Tests
             return 1;
         }
 
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public int GetParam2(object args)
         {
             object retObj;
@@ -104,6 +106,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple GetParam for same parameter name")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc1()
         {
             CThreads rThreads = new CThreads(_output);
@@ -122,6 +125,7 @@ namespace System.Xml.Tests
 
         //[Variation("Multiple GetParam for different parameter name")]
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void proc2()
         {
             CThreads rThreads = new CThreads(_output);

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltSettings.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/XsltSettings.cs
@@ -57,6 +57,7 @@ namespace System.Xml.Tests
         //[Variation(id = 11, Desc = "Test the combination of script and document function with EnableScript, only script should work", Pri = 2, Params = new object[] { "XsltSettings.xml", "XsltSettings3.xsl", false, true })]
         [InlineData(11, "XsltSettings.xml", "XsltSettings3.xsl", false, true)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings1_1_ContainsScript(object param0, object param1, object param2, object param3, object param4)
         {
             var e = Assert.ThrowsAny<XsltException>(() => XsltSettings1_1(param0, param1, param2, param3, param4));
@@ -72,6 +73,7 @@ namespace System.Xml.Tests
         //[Variation(id = 20, Desc = "Test 10 with TrustedXslt override, should work", Pri = 1, Params = new object[] { "XsltSettings.xml", "XsltSettings3.xsl", false, false, true, true })]
         [InlineData(20, "XsltSettings.xml", "XsltSettings3.xsl", false, false, true, true)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings1_2_ContainsScript(object param0, object param1, object param2, object param3, object param4, object param5, object param6)
         {
             var e = Assert.ThrowsAny<XsltException>(() => XsltSettings1_2(param0, param1, param2, param3, param4, param5, param6));
@@ -83,6 +85,7 @@ namespace System.Xml.Tests
         //[Variation(id = 8, Desc = "Test the document function with TrustedXslt, should work", Pri = 1, Params = new object[] { "XsltSettings.xml", "XsltSettings2.xsl", true, true })]
         [InlineData(8, "XsltSettings.xml", "XsltSettings2.xsl", true, true)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings1_1_ExternalURI(object param0, object param1, object param2, object param3, object param4)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -93,6 +96,7 @@ namespace System.Xml.Tests
         //[Variation(id = 18, Desc = "Test 6 with EnableDocumentFunction override, should work", Pri = 1, Params = new object[] { "XsltSettings.xml", "XsltSettings2.xsl", false, false, true, false })]
         [InlineData(18, "XsltSettings.xml", "XsltSettings2.xsl", false, false, true, false)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings1_2_ExternalURI(object param0, object param1, object param2, object param3, object param4, object param5, object param6)
         {
             AppContext.SetSwitch("Switch.System.Xml.AllowDefaultResolver", true);
@@ -124,6 +128,7 @@ namespace System.Xml.Tests
 
          */
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings1_1(object param0, object param1, object param2, object param3, object param4)
         {
             Init(param1.ToString(), param2.ToString());
@@ -197,6 +202,7 @@ namespace System.Xml.Tests
 
          */
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings1_2(object param0, object param1, object param2, object param3, object param4, object param5, object param6)
         {
             Init(param1.ToString(), param2.ToString());
@@ -258,6 +264,7 @@ namespace System.Xml.Tests
         //[Variation(id = 24, Desc = "Disable Scripting and load a stylesheet with multiple script blocks with different languages", Pri = 1, Params = new object[] { "XsltSettings.xml", "XsltSettings8.xsl", false, false })]
         [InlineData("XsltSettings.xml", "XsltSettings8.xsl", false, false)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings2(object param0, object param1, object param2, object param3)
         {
             Init(param0.ToString(), param1.ToString());
@@ -294,6 +301,7 @@ namespace System.Xml.Tests
         //[Variation(id = 31, Desc = "Disable DocumentFunction and Stylesheet has an entity reference to doc(), ENTITY s document('foo.xml')", Pri = 1, Params = new object[] { "XsltSettings.xml", "XsltSettings15.xsl", false, false })]
         [InlineData("XsltSettings.xml", "XsltSettings15.xsl", false, false)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void XsltSettings3(object param0, object param1, object param2, object param3)
         {
             Init(param0.ToString(), param1.ToString());

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTArgumentList.cs
@@ -81,6 +81,7 @@ namespace System.Xml.Tests
         //[Variation(Desc = "Dictionary.XsltArgumentList.AddParam/AddExtensionObject", Param = 4)]
         [InlineData(4)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void var_types(int param)
         {
             WriteXmlAndXslFiles();
@@ -843,6 +844,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddParam10(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
@@ -2279,6 +2281,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject6(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
@@ -2786,6 +2789,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject19(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">
@@ -2897,6 +2901,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void AddExtObject22(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result xmlns:myObj=""urn:my-object"">

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransform.cs
@@ -449,6 +449,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TC_Xslt_Document_Function_Use_XmlUrlResolver(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             // "xmlResolver_document_function.xsl" contains
@@ -1014,6 +1015,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TC_Resolver_Null_Should_Not_Break_Transform(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
@@ -1043,6 +1045,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TC_CustomNullResover_Then_XmlUrlResolver(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             CustomNullResolver myResolver = new CustomNullResolver(_output);
@@ -1072,6 +1075,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.URI, ReaderType.XmlValidatingReader)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TC_No_Explicit_Resolver_Prohibits_External_Url(InputType inputType, ReaderType readerType)
         {
             AppContext.TryGetSwitch("Switch.System.Xml.AllowDefaultResolver", out bool isEnabled);
@@ -1132,6 +1136,7 @@ namespace System.Xml.Tests
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void LoadGeneric10(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             string expected = @"<?xml version=""1.0"" encoding=""utf-8""?><result>
@@ -2649,6 +2654,7 @@ param2 (correct answer is 'local-param2-arg'): local-param2-arg
         [InlineData(InputType.URI, ReaderType.XmlValidatingReader, TransformType.Stream, DocType.XPathDocument)]
         [InlineData(InputType.Navigator, ReaderType.XmlValidatingReader, TransformType.TextWriter, DocType.XPathDocument)]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void TC_XPathNodeIterator_From_ExtensionObject(InputType inputType, ReaderType readerType, TransformType transformType, DocType docType)
         {
             m_xsltArg = new XsltArgumentList();

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransformMultith.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/CXslTransformMultith.cs
@@ -77,6 +77,7 @@ namespace System.Xml.Tests
         //[Variation("Local and global variables", Params = new object[] { "xslt_mutith_variable_local_and_global.xsl", "xslt_mutith_variable_local_and_global.xsl" })]
         [InlineData("xslt_mutith_variable_local_and_global.xsl", "xslt_mutith_variable_local_and_global.xsl")]
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36903", TestPlatforms.iOS)]
         public void Variations(object param0, object param1)
         {
             string xslFile = (string)param0;

--- a/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
+++ b/src/libraries/System.Reflection.Emit/ref/System.Reflection.Emit.cs
@@ -335,8 +335,10 @@ namespace System.Reflection.Emit
         public override System.Type[] GetTypes() { throw null; }
         public override bool IsDefined(System.Type attributeType, bool inherit) { throw null; }
         public override bool IsResource() { throw null; }
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36892", TestPlatforms.iOS)]
         public override System.Reflection.FieldInfo? ResolveField(int metadataToken, System.Type[]? genericTypeArguments, System.Type[]? genericMethodArguments) { throw null; }
         public override System.Reflection.MemberInfo? ResolveMember(int metadataToken, System.Type[]? genericTypeArguments, System.Type[]? genericMethodArguments) { throw null; }
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36892", TestPlatforms.iOS)]
         public override System.Reflection.MethodBase? ResolveMethod(int metadataToken, System.Type[]? genericTypeArguments, System.Type[]? genericMethodArguments) { throw null; }
         public override byte[] ResolveSignature(int metadataToken) { throw null; }
         public override string ResolveString(int metadataToken) { throw null; }

--- a/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/PortableExecutable/PEBuilderTests.cs
@@ -135,6 +135,7 @@ namespace System.Reflection.PortableExecutable.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36892", TestPlatforms.iOS)]
         public void BasicValidationSigned()
         {
             using (var peStream = new MemoryStream())
@@ -655,6 +656,7 @@ namespace System.Reflection.PortableExecutable.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36892", TestPlatforms.iOS)]
         public void Checksum()
         {
             Assert.True(TestChecksumAndAuthenticodeSignature(new MemoryStream(Misc.Signed), Misc.KeyPair));

--- a/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyNameTests.cs
@@ -154,6 +154,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36892", TestPlatforms.iOS)]
         public void CultureName_Set_Invalid_ThrowsCultureNotFoundException()
         {
             var assemblyName = new AssemblyName("Test");

--- a/src/libraries/System.Reflection/tests/AssemblyTests.cs
+++ b/src/libraries/System.Reflection/tests/AssemblyTests.cs
@@ -143,6 +143,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36892", TestPlatforms.iOS)]
         public void GetEntryAssembly()
         {
             Assert.NotNull(Assembly.GetEntryAssembly());

--- a/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -81,6 +81,7 @@ namespace System.Resources.Tests
 
         [Theory]
         [MemberData(nameof(CultureResourceData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36893", TestPlatforms.iOS)]
         public static void GetString_CultureFallback(string key, string cultureName, string expectedValue)
         {
             Type resourceType = typeof(Resources.TestResx);
@@ -91,6 +92,7 @@ namespace System.Resources.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36893", TestPlatforms.iOS)]
         public static void GetString_FromTestClassWithoutNeutralResources()
         {
             // This test is designed to complement the GetString_FromCulutureAndResourceType "fr" & "fr-CA" cases

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -45,6 +45,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void TargetFrameworkTest()
         {
             const int ExpectedExitCode = 0;

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.Exit.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.Exit.cs
@@ -42,6 +42,7 @@ namespace System.Tests
         [InlineData(1)] // setting ExitCode and exiting Main
         [InlineData(2)] // setting ExitCode both from Main and from an Unloading event handler.
         [InlineData(3)] // using Exit(exitCode)
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ExitCode_VoidMainAppReturnsSetValue(int mode)
         {
             int expectedExitCode = 123;

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.UserName.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.UserName.cs
@@ -23,6 +23,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void UserName_Valid()
         {
             string name = Environment.UserName;

--- a/src/libraries/System.Runtime.Extensions/tests/System/StringComparer.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/StringComparer.cs
@@ -93,6 +93,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(UpperLowerCasing_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void CreateWithCulturesTest(string lowerForm, string upperForm, string cultureName)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -191,6 +192,7 @@ namespace System.Tests
         [Theory]
         [MemberData(nameof(CreateFromCultureAndOptionsData))]
         [MemberData(nameof(CreateFromCultureAndOptionsStringSortData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void CreateFromCultureAndOptions(string actualString, string expectedString, string cultureName, CompareOptions options, bool result)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);
@@ -202,6 +204,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(CreateFromCultureAndOptionsData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void CreateFromCultureAndOptionsStringSort(string actualString, string expectedString, string cultureName, CompareOptions options, bool result)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class RuntimeIdentifierTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void VerifyOSRid()
         {
             Assert.NotNull(RuntimeInformation.RuntimeIdentifier);

--- a/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -84,6 +84,7 @@ namespace System.Runtime.Loader.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void LoadInDefaultContext()
         {
             // This will attempt to load an assembly, by path, in the Default Load context via the Resolving event

--- a/src/libraries/System.Runtime.Loader/tests/SatelliteAssemblies.cs
+++ b/src/libraries/System.Runtime.Loader/tests/SatelliteAssemblies.cs
@@ -64,6 +64,7 @@ namespace System.Runtime.Loader.Tests
         [InlineData("es-MX", "Spanish (Mexico) language Main description 1.0.0")]
         [InlineData("fr", "Neutral language Main description 1.0.0")]
         [InlineData("fr-FR", "Neutral language Main description 1.0.0")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void mainResources(string lang, string expected)
         {
             Assert.Equal(expected, Describe(lang));
@@ -116,6 +117,7 @@ namespace System.Runtime.Loader.Tests
         [InlineData("ReferencedClassLibNeutralIsSatellite", "ReferencedClassLibNeutralIsSatellite.Program, ReferencedClassLibNeutralIsSatellite", "en",      "English language ReferencedClassLibNeutralIsSatellite description 1.0.0")]
         [InlineData("ReferencedClassLibNeutralIsSatellite", "ReferencedClassLibNeutralIsSatellite.Program, ReferencedClassLibNeutralIsSatellite", "en-US",   "English language ReferencedClassLibNeutralIsSatellite description 1.0.0")]
         [InlineData("ReferencedClassLibNeutralIsSatellite", "ReferencedClassLibNeutralIsSatellite.Program, ReferencedClassLibNeutralIsSatellite", "es",      "Neutral (es) language ReferencedClassLibNeutralIsSatellite description 1.0.0")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void describeLib(string alc, string type, string culture, string expected)
         {
             string result = "Oops";
@@ -167,6 +169,7 @@ namespace System.Runtime.Loader.Tests
         [InlineData("ReferencedClassLib", "ReferencedClassLib", "en")]
         [InlineData("ReferencedClassLibNeutralIsSatellite", "ReferencedClassLibNeutralIsSatellite", "en")]
         [InlineData("ReferencedClassLibNeutralIsSatellite", "ReferencedClassLibNeutralIsSatellite", "es")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void SatelliteLoadsCorrectly(string alc, string assemblyName, string culture)
         {
             AssemblyName satelliteAssemblyName = new AssemblyName(assemblyName + ".resources");

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -72,6 +72,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         [Theory]
         [SkipOnCoreClr("Takes too long on Checked", RuntimeConfiguration.Checked)]
         [MemberData(nameof(SerializableEqualityComparers_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void ValidateEqualityComparersAgainstBlobs(object obj, TypeSerializableValue[] blobs)
             => ValidateAndRoundtrip(obj, blobs, true);
 

--- a/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -2561,6 +2561,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
     public static void DCJS_VerifyDateTimeForFormatStringDCJsonSerSettings()
     {
         var jsonTypes = new JsonTypes();
@@ -2621,6 +2622,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
     public static void DCJS_VerifyDateTimeForDateTimeFormat()
     {
         var jsonTypes = new JsonTypes();

--- a/src/libraries/System.Runtime/tests/System/CharTests.cs
+++ b/src/libraries/System.Runtime/tests/System/CharTests.cs
@@ -782,6 +782,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToLower()
         {
             Assert.Equal('a', char.ToLower('A'));
@@ -803,6 +804,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToLowerInvariant()
         {
             Assert.Equal('a', char.ToLowerInvariant('A'));
@@ -833,6 +835,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToUpper()
         {
             Assert.Equal('A', char.ToUpper('A'));
@@ -854,6 +857,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToUpperInvariant()
         {
             Assert.Equal('A', char.ToUpperInvariant('A'));
@@ -1102,6 +1106,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(UpperLowerCasing_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void CasingTest(char lowerForm, char upperForm, string cultureName)
         {
             CultureInfo ci = CultureInfo.GetCultureInfo(cultureName);

--- a/src/libraries/System.Runtime/tests/System/DateTimeOffsetTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeOffsetTests.cs
@@ -1253,6 +1253,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_MatchesExpected_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToString_MatchesExpected(DateTimeOffset dateTimeOffset, string format, IFormatProvider provider, string expected)
         {
             if (provider == null)
@@ -1271,6 +1272,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_WithCulture_MatchesExpected_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToString_WithCulture_MatchesExpected(DateTimeOffset dateTimeOffset, string format, CultureInfo culture, string expected)
         {
             Assert.Equal(expected, dateTimeOffset.ToString(format, culture));
@@ -1352,6 +1354,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_MatchesExpected_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void TryFormat_MatchesExpected(DateTimeOffset dateTimeOffset, string format, IFormatProvider provider, string expected)
         {
             var destination = new char[expected.Length];

--- a/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DateTimeTests.cs
@@ -1723,6 +1723,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidInput_Succeeds_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Parse_ValidInput_Succeeds(string input, CultureInfo culture, DateTime? expected)
         {
             Assert.Equal(expected, DateTime.Parse(input, culture));
@@ -1844,6 +1845,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ParseExact_ValidInput_Succeeds_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ParseExact_ValidInput_Succeeds(string input, string format, CultureInfo culture, DateTimeStyles style, DateTime? expected)
         {
             DateTime result1 = DateTime.ParseExact(input, format, culture, style);
@@ -2019,6 +2021,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_MatchesExpected_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void ToString_Invoke_ReturnsExpected(DateTime dateTime, string format, IFormatProvider provider, string expected)
         {
             if (provider == null)
@@ -2315,6 +2318,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidInput_Succeeds_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Parse_Span_ValidInput_Succeeds(string input, CultureInfo culture, DateTime? expected)
         {
             Assert.Equal(expected, DateTime.Parse(input.AsSpan(), culture));
@@ -2322,6 +2326,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ParseExact_ValidInput_Succeeds_MemberData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ParseExact_Span_ValidInput_Succeeds(string input, string format, CultureInfo culture, DateTimeStyles style, DateTime? expected)
         {
             DateTime result1 = DateTime.ParseExact(input.AsSpan(), format, culture, style);

--- a/src/libraries/System.Runtime/tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/StringTests.cs
@@ -272,6 +272,7 @@ namespace System.Tests
         [InlineData("Hello", "", StringComparison.OrdinalIgnoreCase, true)]
         [InlineData("Hello", "ell" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
         [InlineData("Hello", "Ell" + SoftHyphen, StringComparison.OrdinalIgnoreCase, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Contains_String_StringComparison(string s, string value, StringComparison comparisonType, bool expected)
         {
             Assert.Equal(expected, s.Contains(value, comparisonType));
@@ -279,6 +280,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Contains_StringComparison_TurkishI()
         {
             const string Source = "\u0069\u0130";
@@ -651,12 +653,14 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Replace_StringComparison_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void Replace_StringComparison_ReturnsExpected(string original, string oldValue, string newValue, StringComparison comparisonType, string expected)
         {
             Assert.Equal(expected, original.Replace(oldValue, newValue, comparisonType));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void Replace_StringComparison_TurkishI()
         {
             const string Source = "\u0069\u0130";
@@ -707,6 +711,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Replace_StringComparisonCulture_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void Replace_StringComparisonCulture_ReturnsExpected(string original, string oldValue, string newValue, bool ignoreCase, CultureInfo culture, string expected)
         {
             Assert.Equal(expected, original.Replace(oldValue, newValue, ignoreCase, culture));
@@ -739,6 +744,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void Replace_StringComparison_WeightlessOldValue_WithLinguisticComparison_TerminatesReplacement()
         {
             Assert.Equal("abc" + ZeroWidthJoiner + "def", ("abc" + ZeroWidthJoiner + "def").Replace(ZeroWidthJoiner, "xyz", StringComparison.CurrentCulture));
@@ -973,6 +979,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_TurkishI_TurkishCulture_Char()
         {
             using (new ThreadCultureChange("tr-TR"))
@@ -1041,6 +1048,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_EquivalentDiacritics_EnglishUSCulture_Char()
         {
             string s = "Exhibit a\u0300\u00C0";
@@ -1057,6 +1065,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void IndexOf_EquivalentDiacritics_InvariantCulture_Char()
         {
             string s = "Exhibit a\u0300\u00C0";

--- a/src/libraries/System.Runtime/tests/System/TimeSpanTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeSpanTests.cs
@@ -616,6 +616,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Parse(string input, IFormatProvider provider, TimeSpan expected)
         {
             TimeSpan result;
@@ -678,6 +679,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_Invalid_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Parse_Invalid(string input, IFormatProvider provider, Type exceptionType)
         {
             TimeSpan result;
@@ -1035,6 +1037,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void ToString_Valid(TimeSpan input, string format, CultureInfo info, string expected)
         {
             Assert.Equal(expected, input.ToString(format, info));
@@ -1224,6 +1227,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Parse_Span(string inputString, int offset, int count, IFormatProvider provider, TimeSpan expected)
         {
             ReadOnlySpan<char> input = inputString.AsSpan(offset, count);
@@ -1254,6 +1258,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_Invalid_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void Parse_Span_Invalid(string inputString, IFormatProvider provider, Type exceptionType)
         {
             if (inputString != null)
@@ -1356,6 +1361,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(ToString_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public static void TryFormat_Valid(TimeSpan input, string format, CultureInfo info, string expected)
         {
             int charsWritten;

--- a/src/libraries/System.Runtime/tests/System/TupleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TupleTests.cs
@@ -231,6 +231,7 @@ namespace System.Tests
                 Assert.Throws<NullReferenceException>(() => equatable.GetHashCode(null));
             }
 
+            [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
             public void CompareTo(TupleTestDriver<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other, int expectedResult, int expectedStructuralResult)
             {
                 Assert.Equal(expectedResult, ((IComparable)Tuple).CompareTo(other.Tuple));

--- a/src/libraries/System.Runtime/tests/System/Uri.CreateStringTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Uri.CreateStringTests.cs
@@ -1242,6 +1242,7 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Create_String_Invalid_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36896", TestPlatforms.iOS)]
         public void Create_String_Invalid(string uriString, UriKind uriKind)
         {
             if (uriKind == UriKind.Absolute)

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/AesCcmTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/AesCcmTests.cs
@@ -23,6 +23,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         [InlineData(41, 25)]
         [InlineData(48, 22)]
         [InlineData(50, 5)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptTamperAADDecrypt(int dataLength, int additionalDataLength)
         {
             byte[] additionalData = new byte[additionalDataLength];
@@ -82,6 +83,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetValidNonceSizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidNonceSize(int nonceSize)
         {
             const int dataLength = 35;
@@ -124,6 +126,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetValidTagSizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ValidTagSize(int tagSize)
         {
             const int dataLength = 35;
@@ -146,6 +149,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TwoEncryptionsAndDecryptionsUsingOneInstance()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -278,6 +282,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InplaceEncryptDecrypt()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -298,6 +303,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InplaceEncryptTamperTagDecrypt()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -322,6 +328,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetNistCcmTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AesCcmNistTests(AEADTest testCase)
         {
             using (var aesCcm = new AesCcm(testCase.Key))
@@ -340,6 +347,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetNistCcmTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AesCcmNistTestsTamperTag(AEADTest testCase)
         {
             using (var aesCcm = new AesCcm(testCase.Key))
@@ -362,6 +370,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetNistCcmTestCasesWithNonEmptyPT))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AesCcmNistTestsTamperCiphertext(AEADTest testCase)
         {
             using (var aesCcm = new AesCcm(testCase.Key))

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/AesGcmTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/AesGcmTests.cs
@@ -63,6 +63,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetInvalidNonceSizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InvalidNonceSize(int nonceSize)
         {
             int dataLength = 30;
@@ -105,6 +106,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetInvalidTagSizes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InvalidTagSize(int tagSize)
         {
             int dataLength = 30;
@@ -196,6 +198,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         [InlineData(4, 3)]
         [InlineData(20, 120)]
         [InlineData(120, 20)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PlaintextAndCiphertextSizeDiffer(int ptLen, int ctLen)
         {
             byte[] key = new byte[16];
@@ -218,6 +221,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptDecryptNullNonce()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -233,6 +237,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptDecryptNullPlaintext()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -248,6 +253,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptDecryptNullCiphertext()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -263,6 +269,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptDecryptNullTag()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -278,6 +285,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InplaceEncrypDecrypt()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -298,6 +306,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InplaceEncrypTamperTagDecrypt()
         {
             byte[] key = "d5a194ed90cfe08abecd4691997ceb2c".HexToByteArray();
@@ -322,6 +331,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetNistGcmTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AesGcmNistTests(AEADTest testCase)
         {
             using (var aesGcm = new AesGcm(testCase.Key))
@@ -340,6 +350,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetNistGcmTestCases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AesGcmNistTestsTamperTag(AEADTest testCase)
         {
             using (var aesGcm = new AesGcm(testCase.Key))
@@ -362,6 +373,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [Theory]
         [MemberData(nameof(GetNistGcmTestCasesWithNonEmptyPT))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AesGcmNistTestsTamperCiphertext(AEADTest testCase)
         {
             using (var aesGcm = new AesGcm(testCase.Key))

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DSACreateTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DSACreateTests.cs
@@ -30,6 +30,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
 
         [ConditionalTheory(nameof(SupportsKeyGeneration), nameof(SupportsFips186_3))]
         [InlineData(1088)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithKeysize_BigKeys(int keySizeInBits)
         {
             using (DSA dsa = DSA.Create(keySizeInBits))
@@ -52,12 +53,14 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithParameters_512()
         {
             CreateWithParameters(DSATestData.Dsa512Parameters);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithParameters_1024()
         {
             CreateWithParameters(DSATestData.GetDSA1024Params());

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DSATests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DSATests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TryCreateSignature_UsesCreateSignature()
         {
             var input = new byte[1024];
@@ -63,6 +64,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TrySignData_UsesTryHashDataAndTryCreateSignature()
         {
             var input = new byte[1024];
@@ -88,6 +90,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyData_Array_UsesHashDataAndVerifySignature()
         {
             var input = new byte[1024];
@@ -112,6 +115,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyData_Stream_UsesHashDataAndVerifySignature()
         {
             var input = new byte[1024];
@@ -131,6 +135,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void VerifyData_Span_UsesTryHashDataAndVerifySignature()
         {
             var input = new byte[1024];

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDiffieHellmanTests.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
     public partial class ECDiffieHellmanTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ECCurve_ctor()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create(ECCurve.NamedCurves.nistP256))
@@ -39,6 +40,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         [InlineData("1.3.132.0.35", 521)] //secp521r1
         [InlineData("1.3.132.0.34", 384)] //secp384r1
         [InlineData("1.2.840.10045.3.1.7", 256)] //secp256v1
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ECCurve_ctor_SEC2_OID_From_Value(string oidValue, int expectedKeySize)
         {
             ECCurve ecCurve = ECCurve.CreateFromValue(oidValue);
@@ -50,6 +52,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Equivalence_Hash()
         {
             using (ECDiffieHellman ecdh = ECDiffieHellmanFactory.Create())

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDsaTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/ECDsaTests.cs
@@ -46,6 +46,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Array_SignData_VerifyData_UsesHashDataAndSignHashAndVerifyHash()
         {
             using (var ecdsa = new OverrideAbstractECDsa(ECDsaFactory.Create()))
@@ -82,6 +83,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Stream_SignData_VerifyData_UsesHashDataAndSignHashAndVerifyHash()
         {
             using (var ecdsa = new OverrideAbstractECDsa(ECDsaFactory.Create()))
@@ -108,6 +110,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Span_TrySignData_VerifyData_UsesTryHashDataAndTrySignHashAndTryVerifyHash()
         {
             using (var ecdsa = new OverrideAbstractECDsa(ECDsaFactory.Create()))

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/RSACreateTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/RSACreateTests.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.Algorithms.Tests
         [InlineData(1088)]
         [InlineData(1152)]
         [InlineData(2048)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithKeysize(int keySizeInBits)
         {
             using (RSA rsa = RSA.Create(keySizeInBits))
@@ -40,18 +41,21 @@ namespace System.Security.Cryptography.Algorithms.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithParameters_1032()
         {
             CreateWithParameters(TestData.RSA1032Parameters);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithParameters_UnusualExponent()
         {
             CreateWithParameters(TestData.UnusualExponentParameters);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateWithParameters_2048()
         {
             CreateWithParameters(TestData.RSA2048Params);

--- a/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderTests.cs
@@ -34,6 +34,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PublicOnly_WithPrivateKey()
         {
             using (var dsa = new DSACryptoServiceProvider())
@@ -247,6 +248,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyHash_InvalidHashAlgorithm_Throws()
         {
             byte[] hashVal;
@@ -263,6 +265,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignHash_DefaultAlgorithm_Success()
         {
             byte[] hashVal;
@@ -294,6 +297,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyHash_DefaultAlgorithm_Success()
         {
             byte[] hashVal;
@@ -310,6 +314,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyHash_CaseInsensitive_Success()
         {
             byte[] hashVal;
@@ -349,6 +354,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [ConditionalFact(nameof(SupportsKeyGeneration))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyData_InvalidHashAlgorithm_Throws()
         {
             using (var dsa = new DSACryptoServiceProvider())

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography.Csp.Tests
 
         [Theory]
         [MemberData(nameof(AlgorithmIdentifiers))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AlgorithmLookups(string primaryId, object halg)
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -29,6 +30,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ApiInterop_OldToNew()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -39,6 +41,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ApiInterop_OldToNew_Positional()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -49,6 +52,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ApiInterop_OldToNew_Stream()
         {
             const int TotalCount = 10;
@@ -63,6 +67,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ApiInterop_NewToOld()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -91,6 +96,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignHash_WrongSizeHash()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -100,6 +106,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignHash_PublicKey()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -121,6 +128,7 @@ namespace System.Security.Cryptography.Csp.Tests
         [InlineData(true, false)]
         [InlineData(false, true)]
         // (false, false) is not required, that would be equivalent to the RSA AlgorithmImplementation suite.
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyLegacySignVerifyHash(bool useLegacySign, bool useLegacyVerify)
         {
             byte[] dataHash, signature;

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderTests.cs
@@ -44,6 +44,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PublicOnly_WithNoPrivate()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -366,6 +367,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Verify_InvalidPaddingMode_Throws()
         {
             using (var rsa = new RSACryptoServiceProvider())
@@ -385,6 +387,7 @@ namespace System.Security.Cryptography.Csp.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignData_VerifyHash_CaseInsensitive_Success()
         {
             byte[] hashVal;

--- a/src/libraries/System.Security.Cryptography.Csp/tests/RSAImportExportCspBlobTests.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/RSAImportExportCspBlobTests.cs
@@ -10,6 +10,7 @@ namespace System.Security.Cryptography.Rsa.Tests
     public class RSAImportExportCspBlobTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportImportPublicOnly()
         {
             byte[] expectedExport = ByteUtils.HexToByteArray(
@@ -42,6 +43,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportImportPublicPrivate()
         {
             // This blob contains the private key of TestData.CspTestKey. The guidelines for the TestData class
@@ -82,6 +84,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RSAParametersToBlob_PublicOnly()
         {
             byte[] blob;
@@ -113,6 +116,7 @@ namespace System.Security.Cryptography.Rsa.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RSAParametersToBlob_PublicPrivate()
         {
             byte[] blob;

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborReaderTests.cs
@@ -201,6 +201,7 @@ namespace System.Formats.Cbor.Tests
                     "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
                     "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
                     null, "ECDSA_P256")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CoseKeyHelpers_ECDsaParseCosePublicKey_HappyPath(string hexEncoding, string hexExpectedQx, string hexExpectedQy, string? expectedHashAlgorithmName, string curveFriendlyName)
         {
             ECPoint q = new ECPoint() { X = hexExpectedQx.HexToByteArray(), Y = hexExpectedQy.HexToByteArray() };

--- a/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/tests/Cbor.Tests/CborWriterTests.cs
@@ -272,6 +272,7 @@ namespace System.Formats.Cbor.Tests
                     "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d",
                     "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c",
                     null, "ECDSA_P256")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CoseKeyHelpers_ECDsaExportCosePublicKey_HappyPath(string expectedHexEncoding, string hexQx, string hexQy, string? hashAlgorithmName, string curveFriendlyName)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/CmsRecipientCollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/CmsRecipientCollectionTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
     public static class CmsRecipientCollectionTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Nullary()
         {
             CmsRecipientCollection c = new CmsRecipientCollection();
@@ -29,6 +30,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Oneary()
         {
             CmsRecipient a0 = s_cr0;
@@ -37,6 +39,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Twoary()
         {
             CmsRecipient a0 = s_cr0;
@@ -48,6 +51,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Twoary_Ski()
         {
             CmsRecipient a0 = s_cr0;
@@ -59,6 +63,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Twoary_Negative()
         {
             object ignore;
@@ -106,6 +111,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddNegative()
         {
             CmsRecipientCollection c = new CmsRecipientCollection();
@@ -113,6 +119,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveNegative()
         {
             CmsRecipientCollection c = new CmsRecipientCollection();
@@ -120,6 +127,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveNonExistent()
         {
             CmsRecipientCollection c = new CmsRecipientCollection();
@@ -128,6 +136,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void IndexOutOfBounds()
         {
             CmsRecipient a0 = s_cr0;
@@ -145,6 +154,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CopyExceptions()
         {
             CmsRecipient a0 = s_cr0;

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/CertificateTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/CertificateTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class CertificateTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeCertificates0_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -37,6 +38,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeCertificates0_FixedValue()
         {
             byte[] encodedMessage =
@@ -59,6 +61,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeCertificates3_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -80,6 +83,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeCertificates3_FixedValue()
         {
             byte[] encodedMessage =

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/ContentEncryptionAlgorithmTests.cs
@@ -16,6 +16,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static bool DoesNotSupportRc4 => !SupportsRc4;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptionAlgorithmRc2_InvalidKeyLength()
         {
             // For .NET Framework compat, variable key length ciphers throw an error if the key length provided
@@ -31,6 +32,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAlgorithmRc2_128_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Rc2));
@@ -155,6 +157,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAlgorithmDes_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Des));
@@ -193,6 +196,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAlgorithm3Des_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.TripleDesCbc));
@@ -288,6 +292,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptionAlgorithmAes128_IgnoresKeyLength()
         {
             // For .NET Framework compat, static key length ciphers ignore the key lengths supplied
@@ -308,6 +313,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAlgorithmAes128_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes128));
@@ -346,6 +352,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAlgorithmAes192_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes192));
@@ -384,6 +391,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAlgorithmAes256_RoundTrip()
         {
             AlgorithmIdentifier algorithm = new AlgorithmIdentifier(new Oid(Oids.Aes256));

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTests.cs
@@ -195,6 +195,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EncryptToNegativeSerialNumber()
         {
             CertLoader negativeSerial = Certificates.NegativeSerialNumber;
@@ -691,6 +692,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedOctetStringWithDefiniteLength()
         {
             // enveloped content consists of 5 bytes: <id: 1 byte><length: 1 byte><content: 3 bytes>
@@ -710,6 +712,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedOctetStringWithInefficientlyEncodedLength()
         {
             // enveloped content consists of 5 or 6 bytes: <id: 1 byte><length: 1 or 2 bytes><content: 3 bytes>
@@ -731,6 +734,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "netfx does not allow it")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedEmptyArray()
         {
             byte[] content = Array.Empty<byte>();
@@ -743,6 +747,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedEmptyOctetString()
         {
             byte[] content = "0400".HexToByteArray();
@@ -755,6 +760,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedOctetStringWithExtraData()
         {
             byte[] content = "04010203".HexToByteArray();
@@ -767,6 +773,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedDataWithNonPkcs7Oid()
         {
             byte[] content = "3003010203".HexToByteArray();
@@ -778,6 +785,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [ConditionalFact(nameof(SupportsIndefiniteLengthEncoding))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedEmptyOctetStringWithIndefiniteLength()
         {
             byte[] content = "30800000".HexToByteArray();
@@ -790,6 +798,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [ConditionalFact(nameof(SupportsIndefiniteLengthEncoding))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DecryptEnvelopedOctetStringWithIndefiniteLength()
         {
             byte[] content = "308004000000".HexToByteArray();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingCertWithPrivateKey.cs
@@ -69,6 +69,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecryptUsingCertificateWithSameSubjectKeyIdentifierButDifferentKeyPair()
         {
             using (X509Certificate2 recipientCert = Certificates.RSAKeyTransfer4_ExplicitSki.GetCertificate())

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingExplicitPrivateKey.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/DecryptTestsUsingExplicitPrivateKey.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public DecryptTestsUsingExplicitPrivateKey() : base(true) { }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecryptUsingWrongPrivateKeyType()
         {
             byte[] content = new byte[] { 1, 2, 3, 4 };

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/EdgeCasesTests.cs
@@ -198,6 +198,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReuseEnvelopeCmsEncodeThenDecode()
         {
             // Test ability to encrypt, encode and decode all in one EnvelopedCms instance.
@@ -228,6 +229,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReuseEnvelopeCmsDecodeThenEncode()
         {
             byte[] encodedMessage =
@@ -310,6 +312,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EnvelopedCmsDecryptNullary()
         {
             byte[] encodedMessage =
@@ -427,6 +430,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CmsRecipient1AryCtor()
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
@@ -438,6 +442,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CmsRecipientPassUnknown()
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransfer1.GetCertificate())
@@ -518,6 +523,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptEnvelopedOctetStringWithIncompleteContent()
         {
             byte[] content = "04040203".HexToByteArray();
@@ -534,6 +540,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EncryptEnvelopedOneByteArray()
         {
             byte[] content = "04".HexToByteArray();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/GeneralTests.cs
@@ -19,6 +19,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static bool SupportsRsaOaepCerts => PlatformDetection.IsWindows;
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DefaultEncryptionAlgorithm()
         {
             EnvelopedCms cms1 = new EnvelopedCms();
@@ -42,6 +43,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeVersion0_RoundTrip()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -57,6 +59,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeVersion0_FixedValue()
         {
             byte[] encodedMessage =
@@ -95,6 +98,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeRecipients3_FixedValue()
         {
             byte[] encodedMessage =
@@ -139,6 +143,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecodeAllIndefinite()
         {
             byte[] encrypted = Convert.FromBase64String(
@@ -178,6 +183,7 @@ KoZIhvcNAwcECJ01qtX2EKx6oIAEEM7op+R2U3GQbYwlEj5X+h0AAAAAAAAAAAAA
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGetContentTypeEnveloped()
         {
             byte[] encodedMessage =
@@ -193,6 +199,7 @@ KoZIhvcNAwcECJ01qtX2EKx6oIAEEM7op+R2U3GQbYwlEj5X+h0AAAAAAAAAAAAA
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestContentTypeSigned()
         {
             byte[] encodedMessage =
@@ -219,6 +226,7 @@ KoZIhvcNAwcECJ01qtX2EKx6oIAEEM7op+R2U3GQbYwlEj5X+h0AAAAAAAAAAAAA
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestContent()
         {
             // Tests that the content is what it is expected to be, even if it's still encrypted. This prevents from ambiguous definitions of content.
@@ -345,6 +353,7 @@ KoZIhvcNAwcECJ01qtX2EKx6oIAEEM7op+R2U3GQbYwlEj5X+h0AAAAAAAAAAAAA
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Encrypt_Data_DoesNotIncreaseInSize()
         {
             byte[] content = new byte[15]; // One short of AES block size boundary

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyAgreeRecipientInfoTests.cs
@@ -20,6 +20,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         public static bool DoesNotSupportDiffieHellman => !SupportsDiffieHellman;
 
         [ConditionalFact(nameof(DoesNotSupportDiffieHellman))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyAgreement_PlatformNotSupported()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoRsaOaepCertTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoRsaOaepCertTests.cs
@@ -59,6 +59,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [ConditionalFact(nameof(DoesNotSupportRsaOaepCerts))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransEncryptKey_RsaOaepCertificate_NoPlatformSupport_Throws()
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 1, 2, 3 });

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoRsaPaddingModeTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoRsaPaddingModeTests.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
 
         [Theory]
         [MemberData(nameof(TestKeyTransEncryptedKey_RsaAlgorithmTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransEncryptedKey_RsaAlgorithms(RSAEncryptionPadding encryptionPadding, string expectedOid, byte[] expectedParameters)
         {
             KeyTransRecipientInfo recipientInfo1 = EncodeKeyTransl_Rsa2048(encryptionPadding, Certificates.RSA2048Sha256KeyTransfer1);
@@ -33,6 +34,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransEncryptedKey_RsaOaepMd5_Throws()
         {
             RSAEncryptionPadding oaepMd5Padding = RSAEncryptionPadding.CreateOaep(HashAlgorithmName.MD5);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/KeyTransRecipientInfoTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class KeyTransRecipientInfoTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransVersion_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -36,6 +37,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransType_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -50,6 +52,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransRecipientIdType_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -66,6 +69,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransRecipientIdValue_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -90,6 +94,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransRecipientIdType_Ski_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -106,6 +111,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransRecipientIdValue_Ski_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl(SubjectIdentifierType.SubjectKeyIdentifier);
@@ -157,6 +163,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransKeyEncryptionAlgorithm_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();
@@ -175,6 +182,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKeyTransEncryptedKey_RoundTrip()
         {
             KeyTransRecipientInfo recipient = EncodeKeyTransl();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/StateTests.cs
@@ -122,6 +122,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         //
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PostEncrypt_Version()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -137,6 +138,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PostEncrypt_RecipientInfos()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -151,6 +153,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PostEncrypt_Decrypt()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -163,6 +166,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PostEncrypt_ContentInfo()
         {
             ContentInfo expectedContentInfo = new ContentInfo(new byte[] { 1, 2, 3 });
@@ -429,6 +433,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PostEncode_DifferentData()
         {
             // This ensures that the decoding and encoding output different values to make sure Encrypt changes the state of the data.

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/SubjectIdentifierTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/SubjectIdentifierTests.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier)]
         [InlineData(SubjectIdentifierType.Unknown)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SubjectIdentifier_MatchesCert(SubjectIdentifierType type)
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransfer_ExplicitSki.GetCertificate())
@@ -28,6 +29,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier)]
         [InlineData(SubjectIdentifierType.Unknown)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SubjectIdentifier_DoesNotMatchCert(SubjectIdentifierType type)
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransfer_ExplicitSki.GetCertificate())

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/EnvelopedCms/UnprotectedAttributeTests.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
     public static partial class UnprotectedAttributeTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes0_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes();
@@ -43,6 +44,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_DocumentDescription_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(new Pkcs9DocumentDescription("My Description"));
@@ -73,6 +75,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_DocumenName_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(new Pkcs9DocumentName("My Name"));
@@ -103,6 +106,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_SigningTime_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(new Pkcs9SigningTime(new DateTime(2018, 4, 1, 8, 30, 05)));
@@ -135,6 +139,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_ContentType_RoundTrip()
         {
             byte[] rawData = "06072a9fa20082f300".HexToByteArray();
@@ -168,6 +173,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_MessageDigest_RoundTrip()
         {
             byte[] rawData = "0405032d58805d".HexToByteArray();
@@ -202,6 +208,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_Merge3_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -239,6 +246,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_Heterogenous3_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -315,6 +323,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_Arbitrary_RoundTrip()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(
@@ -349,6 +358,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes1_OutOfNamespace_RoundTrip()
         {
             byte[] constraintsRawData = "30070101ff02020100".HexToByteArray();
@@ -387,6 +397,7 @@ namespace System.Security.Cryptography.Pkcs.EnvelopedCmsTests.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestUnprotectedAttributes_AlwaysReturnsPkcs9AttributeObject()
         {
             byte[] encodedMessage = CreateEcmsWithAttributes(

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/CertBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/CertBagTests.cs
@@ -29,6 +29,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DataNotValidatedInCtor()
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())
@@ -79,6 +80,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertificateReadsSuccessfully()
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.GetCertificate())

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/KeyBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/KeyBagTests.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         private static readonly ReadOnlyMemory<byte> s_derNull = new byte[] { 0x05, 0x00 };
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildWithFactoryReadDirect()
         {
             using (RSA rsa = RSA.Create())

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12BuilderTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12BuilderTests.cs
@@ -370,6 +370,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildEmptyContents(bool withMac)
         {
             string password;
@@ -424,6 +425,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildWithoutContents(bool withMac)
         {
             string password;
@@ -477,6 +479,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildWithEmptySafeContents(bool encrypted)
         {
             string pw = nameof(BuildWithEmptySafeContents);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12InfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12InfoTests.cs
@@ -63,6 +63,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(100)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadIndefiniteEncodingNoMac(int trailingByteCount)
         {
             ReadOnlyMemory<byte> source = PadContents(Pkcs12Documents.IndefiniteEncodingNoMac, trailingByteCount);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/ShroudedKeyBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/ShroudedKeyBagTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         private static readonly ReadOnlyMemory<byte> s_derNull = new byte[] { 0x05, 0x00 };
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildWithCharsFactoryReadDirect()
         {
             using (RSA rsa = RSA.Create())
@@ -57,6 +58,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildWithBytesFactoryReadDirect()
         {
             using (RSA rsa = RSA.Create())

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/SimpleRead.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/SimpleRead.cs
@@ -14,6 +14,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
     public static class SimpleRead
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Test1()
         {
             var loader = (CertLoaderFromRawData)Certificates.RSAKeyTransferCapi1;
@@ -100,6 +101,7 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadWithEncryptedContents()
         {
             var loader = (CertLoaderFromRawData)Certificates.RSAKeyTransfer_ExplicitSki;

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs8PrivateKeyInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs8PrivateKeyInfoTests.cs
@@ -34,6 +34,7 @@ D9fVWpuVzYpEDfZm");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EnsureAttributesRoundtrip()
         {
             Pkcs8PrivateKeyInfo pkcs8Info;
@@ -70,6 +71,7 @@ D9fVWpuVzYpEDfZm");
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Decode_SkipCopyIsRespected(bool skipCopy)
         {
             Pkcs8PrivateKeyInfo pkcs8Info;
@@ -220,6 +222,7 @@ D9fVWpuVzYpEDfZm");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecryptionFailures()
         {
             using (RSA rsa = RSA.Create())
@@ -257,6 +260,7 @@ D9fVWpuVzYpEDfZm");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReencryptAndImport()
         {
             byte[] secret = { 42 };

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampRequestTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampRequestTests.cs
@@ -124,6 +124,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildFromSignerInfo()
         {
             ContentInfo content = new ContentInfo(new byte[] { 1, 2, 3, 4 });
@@ -263,6 +264,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(Rfc3161RequestResponseStatus.DoesNotParse, 5)]
         [InlineData(Rfc3161RequestResponseStatus.DoesNotParse, 6)]
         [InlineData(Rfc3161RequestResponseStatus.DoesNotParse, 7)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ProcessResponse_FreeTsa_WithCerts_NoNonce(Rfc3161RequestResponseStatus expectedStatus, int variant)
         {
             const string Padding = "0400";

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Rfc3161/TimestampTokenTests.cs
@@ -15,6 +15,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(nameof(TimestampTokenTestData.FreeTsaDotOrg1))]
         [InlineData(nameof(TimestampTokenTestData.Symantec1))]
         [InlineData(nameof(TimestampTokenTestData.DigiCert1))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ParseDocument(string testDataName)
         {
             TimestampTokenTestData testData = TimestampTokenTestData.GetTestData(testDataName);
@@ -26,6 +27,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(nameof(TimestampTokenTestData.FreeTsaDotOrg1))]
         [InlineData(nameof(TimestampTokenTestData.Symantec1))]
         [InlineData(nameof(TimestampTokenTestData.DigiCert1))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ParseDocument_ExcessData(string testDataName)
         {
             TimestampTokenTestData testData = TimestampTokenTestData.GetTestData(testDataName);
@@ -211,6 +213,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TryDecode_Fails_MalformedToken()
         {
             ContentInfo contentInfo = new ContentInfo(
@@ -240,6 +243,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(X509IncludeOption.None, SigningCertificateOption.ValidHashNoName)]
         [InlineData(X509IncludeOption.WholeChain, SigningCertificateOption.ValidHashWithName)]
         [InlineData(X509IncludeOption.None, SigningCertificateOption.ValidHashWithName)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void MatchV1(X509IncludeOption includeOption, SigningCertificateOption v1Option)
         {
             CustomBuild_CertMatch(
@@ -253,6 +257,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertHashMismatchV1(X509IncludeOption includeOption)
         {
             CustomBuild_CertMismatch(
@@ -280,6 +285,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             X509IncludeOption.None,
             SigningCertificateOption.ValidHashWithInvalidName,
             SubjectIdentifierType.IssuerAndSerialNumber)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertMismatchIssuerAndSerialV1(
             X509IncludeOption includeOption,
             SigningCertificateOption v1Option,
@@ -327,6 +333,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             X509IncludeOption.None,
             SigningCertificateOption.ValidHashWithName,
             "SHA384")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void MatchV2(
             X509IncludeOption includeOption,
             SigningCertificateOption v2Option,
@@ -350,6 +357,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(X509IncludeOption.None, "SHA1")]
         [InlineData(X509IncludeOption.WholeChain, "SHA384")]
         [InlineData(X509IncludeOption.None, "SHA384")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertHashMismatchV2(X509IncludeOption includeOption, string hashAlgName)
         {
             CustomBuild_CertMismatch(
@@ -402,6 +410,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             SigningCertificateOption.ValidHashWithInvalidName,
             SubjectIdentifierType.IssuerAndSerialNumber,
             "SHA384")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertMismatchIssuerAndSerialV2(
             X509IncludeOption includeOption,
             SigningCertificateOption v2Option,
@@ -499,6 +508,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             SigningCertificateOption.ValidHashWithName,
             SigningCertificateOption.ValidHashWithName,
             "SHA384")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertMatchV1AndV2(
             X509IncludeOption includeOption,
             SigningCertificateOption v1Option,
@@ -545,6 +555,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
             SigningCertificateOption.ValidHashNoName,
             SubjectIdentifierType.IssuerAndSerialNumber,
             null)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CertMismatchV1OrV2(
             X509IncludeOption includeOption,
             SigningCertificateOption v1Option,
@@ -565,6 +576,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TimestampTooOld(X509IncludeOption includeOption)
         {
             CertLoader loader = Certificates.ValidLookingTsaCert;
@@ -586,6 +598,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TimestampTooNew(X509IncludeOption includeOption)
         {
             CertLoader loader = Certificates.ValidLookingTsaCert;
@@ -607,6 +620,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoEkuExtension(X509IncludeOption includeOption)
         {
             CertLoader loader = Certificates.RSA2048SignatureOnly;
@@ -630,6 +644,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TwoEkuExtensions(X509IncludeOption includeOption)
         {
             CertLoader loader = Certificates.TwoEkuTsaCert;
@@ -660,6 +675,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NonCriticalEkuExtension(X509IncludeOption includeOption)
         {
             CertLoader loader = Certificates.NonCriticalTsaEku;
@@ -686,6 +702,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(X509IncludeOption.WholeChain)]
         [InlineData(X509IncludeOption.None)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NoTsaEku(X509IncludeOption includeOption)
         {
             CertLoader loader = Certificates.TlsClientServerCert;

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/CounterSigningDerOrder.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/CounterSigningDerOrder.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
     public static class CounterSigningDerOrder
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CounterSigningReindexes()
         {
             ContentInfo content = new ContentInfo(new byte[] { 7 });

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.cs
@@ -125,6 +125,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignedCms_SignerInfos_UniquePerCall()
         {
             SignedCms cms = new SignedCms();
@@ -143,6 +144,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignedCms_Certificates_UniquePerCall()
         {
             SignedCms cms = new SignedCms();
@@ -202,6 +204,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Decode_IgnoresExtraData()
         {
             byte[] basis = SignedDocuments.RsaPkcs1OneSignerIssuerAndSerialNumber;
@@ -248,6 +251,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveSignature_MatchesIssuerAndSerialNumber()
         {
             SignedCms cms = new SignedCms();
@@ -264,6 +268,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveSignature_MatchesSubjectKeyIdentifier()
         {
             SignedCms cms = new SignedCms();
@@ -294,6 +299,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveSignature_WithNoMatch()
         {
             SignedCms cms = new SignedCms();
@@ -308,6 +314,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveSignature_Null()
         {
             SignedCms cms = new SignedCms();
@@ -322,6 +329,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveSignature_OutOfRange()
         {
             SignedCms cms = new SignedCms();
@@ -456,6 +464,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber, true)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, false)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddFirstSigner_RSA(SubjectIdentifierType identifierType, bool detached)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -502,6 +511,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSignerWithNegativeSerial()
         {
             const string expectedSerial = "FD319CB1514B06AF49E00522277E43C8";
@@ -536,6 +546,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber, false)]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddFirstSigner_DSA(SubjectIdentifierType identifierType, bool detached)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -608,6 +619,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, false, Oids.Sha384)]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber, false, Oids.Sha512)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, true, Oids.Sha512)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddFirstSigner_ECDSA(SubjectIdentifierType identifierType, bool detached, string digestOid)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -675,6 +687,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddFirstSigner_NoSignature(bool detached, bool includeExtraCert)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -777,6 +790,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSecondSigner_NoSignature(bool detached)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -807,6 +821,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSecondSigner_NoSignature_AfterRemove(bool detached)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -848,6 +863,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSecondSigner_NoSignature_LoadUnsigned(bool detached)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -905,6 +921,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(false, true)]
         [InlineData(true, true)]
         [InlineData(true, false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSigner_DuplicateCert_RSA(bool skidFirst, bool detached)
         {
             ContentInfo contentInfo = new ContentInfo(new byte[] { 9, 8, 7, 6, 5 });
@@ -977,6 +994,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CannotSignEmptyContent()
         {
             SignedCms cms = new SignedCms();
@@ -1124,6 +1142,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void UntrustedCertFails_WhenTrustChecked()
         {
             SignedCms cms = new SignedCms();
@@ -1138,6 +1157,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EnsureDataIsolation_NewDocument(bool detached)
         {
             byte[] contentBytes = { 9, 8, 7, 6, 5 };
@@ -1205,6 +1225,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignWithImplicitSubjectKeyIdentifier()
         {
             byte[] contentBytes = { 9, 8, 7, 6, 5 };
@@ -1241,6 +1262,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignEnveloped(SubjectIdentifierType signerType)
         {
             using (X509Certificate2 cert = Certificates.RSAKeyTransferCapi1.TryGetCertificateWithPrivateKey())
@@ -1283,6 +1305,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData("0.0", "010100", false)]
         [InlineData(Oids.Pkcs7Hashed, "010100", false)]
         [InlineData(Oids.Pkcs7Hashed, "3000", false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignIdentifiedContent(string oidValue, string contentHex, bool netfxProblem)
         {
             SignedCms signedCms = new SignedCms(
@@ -1315,6 +1338,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyUnsortedAttributeSignature()
         {
             SignedCms cms = new SignedCms();
@@ -1325,6 +1349,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyUnsortedAttributeSignature_ImportExportImport()
         {
             SignedCms cms = new SignedCms();
@@ -1342,6 +1367,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSignerToUnsortedAttributeSignature()
         {
             SignedCms cms = new SignedCms();
@@ -1375,6 +1401,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_Pkcs1_RsaWithSha256()
         {
             SignedCms signedCms = new SignedCms();
@@ -1385,6 +1412,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_Pkcs1_Sha1_Declared_Sha256WithRsa()
         {
             SignedCms signedCms = new SignedCms();
@@ -1402,6 +1430,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(" 1.1", "010100", null)]
         [InlineData("1.1 ", "010100", null)]
         [InlineData("1 1", "010100", null)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignIdentifiedContent_BadOid(string oidValueIn, string contentHex, string oidValueOut)
         {
             SignedCms signedCms = new SignedCms(
@@ -1431,6 +1460,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignedEncrypted_IssuerSerial_FromNetFx()
         {
             CheckSignedEncrypted(
@@ -1439,6 +1469,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignedEncrypted_SKID_FromNetFx()
         {
             CheckSignedEncrypted(
@@ -1447,6 +1478,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignedEncrypted_IssuerSerial_FromCoreFx()
         {
             CheckSignedEncrypted(
@@ -1455,6 +1487,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignedEncrypted_SKID_FromCoreFx()
         {
             CheckSignedEncrypted(
@@ -1465,6 +1498,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36878", TestPlatforms.iOS)]
         public static void ReadAndWriteDocumentWithIndefiniteLengthContent(bool checkSignature)
         {
             SignedCms cms = new SignedCms();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsTests.netcoreapp.cs
@@ -20,6 +20,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CmsSignerKeyIsNullByDefaultWhenCertificateIsPassed()
         {
             using (X509Certificate2 cert = Certificates.RSA2048SignatureOnly.TryGetCertificateWithPrivateKey())
@@ -30,6 +31,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CmsSignerConstructorWithKeySetsProperty()
         {
             using (X509Certificate2 cert = Certificates.RSA2048SignatureOnly.TryGetCertificateWithPrivateKey())
@@ -41,6 +43,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SingUsingExplicitKeySetWithProperty()
         {
             using (X509Certificate2 cert = Certificates.RSA2048SignatureOnly.TryGetCertificateWithPrivateKey())
@@ -61,6 +64,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingExplicitRSAKey()
         {
             using (X509Certificate2 cert = Certificates.RSA2048SignatureOnly.TryGetCertificateWithPrivateKey())
@@ -71,6 +75,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingExplicitDSAKey()
         {
             using (X509Certificate2 cert = Certificates.Dsa1024.TryGetCertificateWithPrivateKey())
@@ -81,6 +86,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingExplicitECDsaKey()
         {
             using (X509Certificate2 cert = Certificates.ECDsaP256Win.TryGetCertificateWithPrivateKey())
@@ -91,6 +97,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingExplicitECDsaP521Key()
         {
             using (X509Certificate2 cert = Certificates.ECDsaP521Win.TryGetCertificateWithPrivateKey())
@@ -101,6 +108,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CounterSignCmsUsingExplicitRSAKeyForFirstSignerAndDSAForCounterSignature()
         {
             using (X509Certificate2 cert = Certificates.RSA2048SignatureOnly.TryGetCertificateWithPrivateKey())
@@ -113,6 +121,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CounterSignCmsUsingExplicitDSAKeyForFirstSignerAndECDsaForCounterSignature()
         {
             using (X509Certificate2 cert = Certificates.Dsa1024.TryGetCertificateWithPrivateKey())
@@ -125,6 +134,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CounterSignCmsUsingExplicitECDsaKeyForFirstSignerAndRSAForCounterSignature()
         {
             using (X509Certificate2 cert = Certificates.ECDsaP256Win.TryGetCertificateWithPrivateKey())
@@ -137,6 +147,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingRSACertAndECDsaKeyThrows()
         {
             byte[] content = { 9, 8, 7, 6, 5 };
@@ -153,6 +164,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingDSACertAndECDsaKeyThrows()
         {
             byte[] content = { 9, 8, 7, 6, 5 };
@@ -171,6 +183,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingEDCSaCertAndRSAaKeyThrows()
         {
             byte[] content = { 9, 8, 7, 6, 5 };
@@ -187,6 +200,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingRSACertWithNotMatchingKeyThrows()
         {
             byte[] content = { 9, 8, 7, 6, 5 };
@@ -222,6 +236,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignCmsUsingECDsaCertWithNotMatchingKeyThrows()
         {
             byte[] content = { 9, 8, 7, 6, 5 };
@@ -238,6 +253,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCertificate()
         {
             SignedCms cms = new SignedCms();
@@ -257,6 +273,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCertificateWithPrivateKey()
         {
             SignedCms cms = new SignedCms();
@@ -281,6 +298,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveCertificate()
         {
             SignedCms cms = new SignedCms();
@@ -310,6 +328,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveNonExistingCertificate()
         {
             SignedCms cms = new SignedCms();
@@ -322,6 +341,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveAllCertsAddBackSignerCert()
         {
             SignedCms cms = new SignedCms();
@@ -348,6 +368,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddExistingCertificate()
         {
             SignedCms cms = new SignedCms();
@@ -375,6 +396,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSigner_RSA_EphemeralKey()
         {
             using (RSA rsa = RSA.Create())
@@ -402,6 +424,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSigner_DSA_EphemeralKey()
         {
             using (DSA dsa = DSA.Create())
@@ -432,6 +455,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSigner_ECDSA_EphemeralKey()
         {
             using (ECDsa ecdsa = ECDsa.Create())
@@ -459,6 +483,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateSignature_DigestAlgorithmWithSignatureOid_Prohibited()
         {
             ContentInfo content = new ContentInfo(new byte[] { 1, 2, 3 });

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsWholeDocumentTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsWholeDocumentTests.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
     public static class SignedCmsWholeDocumentTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadRsaPssDocument()
         {
             SignedCms cms = new SignedCms();
@@ -120,6 +121,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadRsaPkcs1SimpleDocument()
         {
             SignedCms cms = new SignedCms();
@@ -188,6 +190,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadRsaPkcs1CounterSigned()
         {
             SignedCms cms = new SignedCms();
@@ -269,6 +272,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckNoSignatureDocument()
         {
             SignedCms cms = new SignedCms();
@@ -389,6 +393,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void NonEmbeddedCertificate()
         {
             SignedCms cms = new SignedCms();
@@ -502,6 +507,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadRsaPkcs1DoubleCounterSigned()
         {
             SignedCms cms = new SignedCms();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.cs
@@ -80,6 +80,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignerInfo_CounterSignerInfos_UniquePerCall_WhenNonEmpty()
         {
             SignedCms cms = new SignedCms();
@@ -156,6 +157,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 #endif
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignerInfo_Certificate_Same()
         {
             SignedCms cms = new SignedCms();
@@ -185,6 +187,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_ExtraStore_IsAdditional()
         {
             SignedCms cms = new SignedCms();
@@ -200,6 +203,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_MD5WithRSA()
         {
             SignedCms cms = new SignedCms();
@@ -214,6 +218,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_SHA1WithRSA()
         {
             SignedCms cms = new SignedCms();
@@ -228,6 +233,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_SHA256WithRSA()
         {
             SignedCms cms = new SignedCms();
@@ -242,6 +248,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_SHA384WithRSA()
         {
             SignedCms cms = new SignedCms();
@@ -256,6 +263,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_SHA512WithRSA()
         {
             SignedCms cms = new SignedCms();
@@ -270,6 +278,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_SHA256WithRSADigest_And_RSA256WithRSASignature()
         {
             SignedCms cms = new SignedCms();
@@ -284,6 +293,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckSignature_ECDSA256SignedWithRSASha256HashIdentifier()
         {
             SignedCms cms = new SignedCms();
@@ -299,6 +309,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveCounterSignature_MatchesIssuerAndSerialNumber()
         {
             SignedCms cms = new SignedCms();
@@ -330,6 +341,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveCounterSignature_MatchesSubjectKeyIdentifier()
         {
             SignedCms cms = new SignedCms();
@@ -363,6 +375,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveCounterSignature_MatchesNoSignature()
         {
             SignedCms cms = new SignedCms();
@@ -395,6 +408,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug in matching logic")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveCounterSignature_UsesLiveState()
         {
             SignedCms cms = new SignedCms();
@@ -445,6 +459,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(0)]
         [InlineData(1)]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "NetFx bug")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveCounterSignature_EncodedInSingleAttribute(int indexToRemove)
         {
             SignedCms cms = new SignedCms();
@@ -568,6 +583,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCounterSigner_DuplicateCert_RSA()
         {
             SignedCms cms = new SignedCms();
@@ -616,6 +632,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCounterSigner_RSA(SubjectIdentifierType identifierType)
         {
             SignedCms cms = new SignedCms();
@@ -662,6 +679,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Not supported by crypt32")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCounterSignerToUnsortedAttributeSignature()
         {
             SignedCms cms = new SignedCms();
@@ -699,6 +717,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCounterSigner_DSA()
         {
             SignedCms cms = new SignedCms();
@@ -767,6 +786,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, Oids.Sha384)]
         [InlineData(SubjectIdentifierType.IssuerAndSerialNumber, Oids.Sha512)]
         [InlineData(SubjectIdentifierType.SubjectKeyIdentifier, Oids.Sha512)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddCounterSigner_ECDSA(SubjectIdentifierType identifierType, string digestOid)
         {
             SignedCms cms = new SignedCms();
@@ -829,6 +849,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddFirstCounterSigner_NoSignature_NoPrivateKey()
         {
             SignedCms cms = new SignedCms();
@@ -862,6 +883,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddFirstCounterSigner_NoSignature()
         {
             SignedCms cms = new SignedCms();
@@ -914,6 +936,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSecondCounterSignature_NoSignature_WithCert(bool addExtraCert)
         {
             AddSecondCounterSignature_NoSignature(withCertificate: true, addExtraCert);
@@ -925,6 +948,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddSecondCounterSignature_NoSignature_WithoutCert(bool addExtraCert)
         {
             AddSecondCounterSignature_NoSignature(withCertificate: false, addExtraCert);
@@ -1025,6 +1049,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EnsureExtraCertsAdded()
         {
             SignedCms cms = new SignedCms();

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignerInfoTests.netcoreapp.cs
@@ -235,6 +235,7 @@ namespace System.Security.Cryptography.Pkcs.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignerInfo_AddRemoveUnsignedAttributes_JoinCounterSignaturesAttributesIntoOne()
         {
             byte[] message = { 1, 2, 3, 4, 5 };

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -25,6 +25,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509CertTest()
         {
             string certSubject = @"CN=Microsoft Corporate Root Authority, OU=ITG, O=Microsoft, L=Redmond, S=WA, C=US, E=pkit@microsoft.com";
@@ -68,6 +69,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Cert2Test()
         {
             string certName = @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US";
@@ -191,6 +193,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Cert2ToStringVerbose()
         {
             using (X509Store store = new X509Store("My", StoreLocation.CurrentUser))
@@ -207,6 +210,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2ToStringVerbose_WithPrivateKey(X509KeyStorageFlags keyStorageFlags)
         {
             using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, keyStorageFlags))
@@ -218,6 +222,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2ToStringVerbose_NoPrivateKey()
         {
             using (var cert = new X509Certificate2(TestData.MsCertificatePemBytes))
@@ -229,12 +234,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Cert2CreateFromEmptyPfx()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(TestData.EmptyPfx));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Cert2CreateFromPfxFile()
         {
             using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "DummyTcpServer.pfx")))
@@ -245,6 +252,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Cert2CreateFromPfxWithPassword()
         {
             using (X509Certificate2 cert2 = new X509Certificate2(Path.Combine("TestData", "test.pfx"), "test"))
@@ -255,24 +263,28 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2FromPkcs7DerFile()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(Path.Combine("TestData", "singlecert.p7b")));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2FromPkcs7PemFile()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(Path.Combine("TestData", "singlecert.p7c")));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2FromPkcs7DerBlob()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(TestData.Pkcs7SingleDerBytes));
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2FromPkcs7PemBlob()
         {
             Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(TestData.Pkcs7SinglePemBytes));
@@ -331,6 +343,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportPublicKeyAsPkcs12()
         {
             using (X509Certificate2 publicOnly = new X509Certificate2(TestData.MsCertificate))
@@ -353,6 +366,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2WithT61String()
         {
             string certSubject = @"E=mabaul@microsoft.com, OU=Engineering, O=Xamarin, S=Massachusetts, C=US, CN=test-server.local";

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestApiTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestApiTests.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
     public static class CertificateRequestApiTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ConstructorDefaults()
         {
             const string TestCN = "CN=Test";
@@ -25,6 +26,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ToPkcs10_ArgumentExceptions()
         {
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp256r1Data.KeyParameters))
@@ -36,6 +38,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SelfSign_ArgumentValidation()
         {
             using (RSA rsa = RSA.Create())
@@ -51,6 +54,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Sign_ArgumentValidation()
         {
             using (X509Certificate2 testRoot = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -84,6 +88,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CtorValidation_ECDSA_string()
         {
             string subjectName = null;
@@ -111,6 +116,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CtorValidation_ECDSA_X500DN()
         {
             X500DistinguishedName subjectName = null;
@@ -138,6 +144,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CtorValidation_RSA_string()
         {
             string subjectName = null;
@@ -172,6 +179,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CtorValidation_RSA_X500DN()
         {
             X500DistinguishedName subjectName = null;
@@ -206,6 +214,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CtorValidation_PublicKey_X500DN()
         {
             X500DistinguishedName subjectName = null;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestChainTests.cs
@@ -13,6 +13,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         public static bool PlatformSupportsPss { get; } = DetectPssSupport();
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateChain_ECC()
         {
             using (ECDsa rootKey = ECDsa.Create(ECCurve.NamedCurves.nistP521))
@@ -30,6 +31,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateChain_RSA()
         {
             using (RSA rootKey = RSA.Create(3072))
@@ -49,6 +51,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CreateChain_Hybrid()
         {
             using (ECDsa rootKey = ECDsa.Create(ECCurve.NamedCurves.nistP521))
@@ -93,6 +96,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData(true, true, X509KeyUsageFlags.KeyCertSign, true)]
         [InlineData(true, true, X509KeyUsageFlags.DigitalSignature, false)]
         [InlineData(true, true, X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.DigitalSignature, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ChainCertRequirements(bool useIntermed, bool? isCA, X509KeyUsageFlags keyUsage, bool expectSuccess)
         {
             HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA384;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/CertificateRequestUsageTests.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
     public static class CertificateRequestUsageTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReproduceBigExponentCsr()
         {
             X509Extension sanExtension = new X509Extension(
@@ -44,6 +45,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReproduceBigExponentCert()
         {
             DateTimeOffset notBefore = new DateTimeOffset(2016, 3, 2, 1, 48, 0, TimeSpan.Zero);
@@ -123,6 +125,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SimpleSelfSign_RSA(bool exportPfx)
         {
             using (RSA rsa = RSA.Create())
@@ -137,6 +140,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SimpleSelfSign_ECC(bool exportPfx)
         {
             using (ECDsa ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP521))
@@ -187,6 +191,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SelfSign_RSA_UseCertKeys()
         {
             X509Certificate2 cert;
@@ -226,6 +231,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SelfSign_ECC_UseCertKeys()
         {
             X509Certificate2 cert;
@@ -262,6 +268,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SelfSign_ECC_DiminishedPoint_UseCertKeys()
         {
             X509Certificate2 cert;
@@ -304,6 +311,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("0080", "0080")]
         [InlineData("00000080", "0080")]
         [InlineData("00000000", "00")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SerialNumber_AlwaysPositive(string desiredSerial, string expectedSerial)
         {
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp521r1_DiminishedPublic_Data.KeyParameters))
@@ -332,6 +340,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AlwaysVersion3()
         {
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp384r1Data.KeyParameters))
@@ -368,6 +377,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void UniqueExtensions()
         {
             using (RSA rsa = RSA.Create())
@@ -391,6 +401,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CheckTimeNested()
         {
             HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA256;
@@ -537,6 +548,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ECDSA_Signing_RSA()
         {
             using (RSA rsa = RSA.Create())
@@ -577,6 +589,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ECDSA_Signing_RSAPublicKey()
         {
             using (RSA rsa = RSA.Create())
@@ -618,6 +631,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RSA_Signing_ECDSA()
         {
             using (RSA rsa = RSA.Create())
@@ -657,6 +671,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RSACertificateNoPaddingMode()
         {
             using (RSA rsa = RSA.Create())
@@ -698,6 +713,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FractionalSecondsNotWritten(bool selfSigned)
         {
             using (X509Certificate2 savedCert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/ECDsaX509SignatureGeneratorTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/ECDsaX509SignatureGeneratorTests.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
 
         [Theory]
         [MemberData(nameof(GetApplicableTestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void PublicKeyEncoding(EccTestData testData)
         {
             ECParameters keyParameters = testData.KeyParameters;
@@ -60,6 +61,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("SHA256")]
         [InlineData("SHA384")]
         [InlineData("SHA512")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignatureAlgorithm_StableNotSame(string hashAlgorithmName)
         {
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp256r1Data.KeyParameters))
@@ -79,6 +81,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("MD5")]
         [InlineData("SHA1")]
         [InlineData("Potato")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignatureAlgorithm_NotSupported(string hashAlgorithmName)
         {
             using (ECDsa ecdsa = ECDsa.Create(EccTestData.Secp256r1Data.KeyParameters))
@@ -96,6 +99,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         [InlineData("SHA256")]
         [InlineData("SHA384")]
         [InlineData("SHA512")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SignatureAlgorithm_Encoding(string hashAlgorithmName)
         {
             string expectedAlgOid;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertificateCreation/PrivateKeyAssociationTests.cs
@@ -222,6 +222,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ThirdPartyProvider_RSA()
         {
             using (RSA rsaOther = new RSAOther())
@@ -427,6 +428,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ThirdPartyProvider_DSA()
         {
             using (DSA dsaOther = new DSAOther())
@@ -518,6 +520,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.CertificateCreatio
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ThirdPartyProvider_ECDsa()
         {
             using (ECDsaOther ecdsaOther = new ECDsaOther())

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -34,6 +34,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChain()
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -165,6 +166,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestResetMethod()
         {
             using (var sampleCert = new X509Certificate2(TestData.DssCer))
@@ -231,6 +233,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(true)]
         // Tests that the chain fails when no certificates are added to the custom root trust.
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SystemTrustCertificateWithCustomRootTrust(bool addCertificateToCustomRootTrust)
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -276,6 +279,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(true, X509ChainStatusFlags.NoError, BuildChainCustomTrustStoreTestArguments.UntrustedIntermediateTrustedRoot)]
         [InlineData(true, X509ChainStatusFlags.NoError, BuildChainCustomTrustStoreTestArguments.TrustedIntermediateTrustedRoot)]
         [InlineData(true, X509ChainStatusFlags.NoError, BuildChainCustomTrustStoreTestArguments.MultipleCalls)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChainCustomTrustStore(
             bool chainBuildsSuccessfully,
             X509ChainStatusFlags chainFlags,
@@ -328,6 +332,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChainWithSystemTrustAndCustomTrustCertificates()
         {
             using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
@@ -343,6 +348,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChainWithCustomRootTrustAndInvalidCustomCertificates()
         {
             using (var testCert = new X509Certificate2(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword))
@@ -429,6 +435,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(VerifyExpressionData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void VerifyExpiration_LocalTime(DateTime verificationTime, bool shouldBeValid)
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -459,6 +466,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChain_WithApplicationPolicy_Match()
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
@@ -480,6 +488,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChain_WithApplicationPolicy_NoMatch()
         {
             using (var cert = new X509Certificate2(TestData.MsCertificate))
@@ -510,6 +519,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChain_WithCertificatePolicy_Match()
         {
             using (var cert = new X509Certificate2(TestData.CertWithPolicies))
@@ -531,6 +541,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChain_WithCertificatePolicy_NoMatch()
         {
             using (var cert = new X509Certificate2(TestData.CertWithPolicies))
@@ -840,6 +851,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InvalidSelfSignedSignature()
         {
             X509ChainStatusFlags expectedFlags;
@@ -897,6 +909,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ChainErrorsAtMultipleLayers()
         {
             // These certificates were generated for this test using CertificateRequest
@@ -981,6 +994,7 @@ tHP28fj0LUop/QFojSZPsaPAW6JvoQ0t4hd6WoyX6z7FsA==
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ChainWithEmptySubject()
         {
             using (var cert = new X509Certificate2(TestData.EmptySubjectCertificate))
@@ -1203,6 +1217,7 @@ yY1kePIfwE+GFWvagZ2ehANB/6LgBTT8jFhR95Tw2oE3N0I=");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildChainForCertificateWithMD5Signature()
         {
             byte[] issuerCert = Convert.FromBase64String(@"

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionImportTests.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportEmpty_Pkcs12()
         {
             using (ImportedCollection ic = Cert.Import(TestData.EmptyPfx))
@@ -31,6 +32,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportX509DerBytes()
         {
             using (ImportedCollection ic = Cert.Import(TestData.MsCertificate))
@@ -41,6 +43,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportX509PemBytes()
         {
             using (ImportedCollection ic = Cert.Import(TestData.MsCertificatePemBytes))
@@ -51,6 +54,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportX509DerFile()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "MS.cer")))
@@ -61,6 +65,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportX509PemFile()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "MS.pem")))
@@ -71,6 +76,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7DerBytes_Empty()
         {
             using (ImportedCollection ic = Cert.Import(TestData.Pkcs7EmptyDerBytes))
@@ -81,6 +87,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7PemBytes_Empty()
         {
             using (ImportedCollection ic = Cert.Import(TestData.Pkcs7EmptyPemBytes))
@@ -91,6 +98,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7DerFile_Empty()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "empty.p7b")))
@@ -101,6 +109,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7PemFile_Empty()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "empty.p7c")))
@@ -111,6 +120,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7DerBytes_Single()
         {
             using (ImportedCollection ic = Cert.Import(TestData.Pkcs7SingleDerBytes))
@@ -123,6 +133,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7PemBytes_Single()
         {
             using (ImportedCollection ic = Cert.Import(TestData.Pkcs7SinglePemBytes))
@@ -135,6 +146,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7DerFile_Single()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "singlecert.p7b")))
@@ -147,6 +159,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7PemFile_Single()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "singlecert.p7c")))
@@ -159,6 +172,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7DerBytes_Chain()
         {
             using (ImportedCollection ic = Cert.Import(TestData.Pkcs7ChainDerBytes))
@@ -169,6 +183,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7PemBytes_Chain()
         {
             using (ImportedCollection ic = Cert.Import(TestData.Pkcs7ChainPemBytes))
@@ -179,6 +194,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7DerFile_Chain()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "certchain.p7b")))
@@ -189,6 +205,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs7PemFile_Chain()
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "certchain.p7c")))
@@ -200,6 +217,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs12Bytes_Single(X509KeyStorageFlags keyStorageFlags)
         {
             using (ImportedCollection ic = Cert.Import(TestData.PfxData, TestData.PfxDataPassword, keyStorageFlags))
@@ -212,6 +230,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs12Bytes_Single_VerifyContents(X509KeyStorageFlags keyStorageFlags)
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible))
@@ -236,6 +255,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs12File_Single(X509KeyStorageFlags keyStorageFlags)
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "My.pfx"), TestData.PfxDataPassword, keyStorageFlags))
@@ -248,6 +268,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs12Bytes_Chain(X509KeyStorageFlags keyStorageFlags)
         {
             using (ImportedCollection ic = Cert.Import(TestData.ChainPfxBytes, TestData.ChainPfxPassword, keyStorageFlags))
@@ -260,6 +281,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs12File_Chain(X509KeyStorageFlags keyStorageFlags)
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, keyStorageFlags))
@@ -272,6 +294,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportPkcs12File_Chain_VerifyContents(X509KeyStorageFlags keyStorageFlags)
         {
             using (ImportedCollection ic = Cert.Import(Path.Combine("TestData", "test.pfx"), TestData.ChainPfxPassword, keyStorageFlags))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -487,6 +487,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportStoreSavedAsCerData()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -578,6 +579,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportStoreSavedAsPfxData()
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
@@ -600,6 +602,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportInvalidData()
         {
             X509Certificate2Collection cc2 = new X509Certificate2Collection();
@@ -608,6 +611,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportFromFileTests(X509KeyStorageFlags storageFlags)
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, storageFlags))
@@ -631,6 +635,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ImportMultiplePrivateKeysPfx()
         {
             using (ImportedCollection ic = Cert.Import(TestData.MultiPrivateKeyPfx))
@@ -647,12 +652,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportCert()
         {
             TestExportSingleCert(X509ContentType.Cert);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportCert_SecureString()
         {
             TestExportSingleCert_SecureStringPassword(X509ContentType.Cert);
@@ -697,6 +704,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportPkcs7()
         {
             TestExportStore(X509ContentType.Pkcs7);
@@ -730,6 +738,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportUnrelatedPfx()
         {
             // Export multiple certificates which are not part of any kind of certificate chain.
@@ -776,6 +785,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void MultipleImport()
         {
             var collection = new X509Certificate2Collection();
@@ -795,6 +805,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportMultiplePrivateKeys()
         {
             var collection = new X509Certificate2Collection();
@@ -830,6 +841,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CanAddMultipleCertsWithSinglePrivateKey()
         {
             using (var oneWithKey = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable | Cert.EphemeralIfPossible))
@@ -881,6 +893,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ChainElementCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -903,6 +916,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ExtensionCollection_CopyTo_NonZeroLowerBound_ThrowsIndexOutOfRangeException()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible))
@@ -914,6 +928,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509CertificateCollectionIndexOf()
         {
             using (X509Certificate2 c1 = new X509Certificate2())
@@ -930,6 +945,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509CertificateCollectionRemove()
         {
             using (X509Certificate2 c1 = new X509Certificate2())
@@ -998,6 +1014,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2CollectionRemoveRangeArray()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -1044,6 +1061,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509Certificate2CollectionRemoveRangeCollection()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -1290,6 +1308,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ChainElementCollection_IndexerVsEnumerator()
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -1327,6 +1346,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ExtensionCollection_OidIndexer_ByOidValue()
         {
             const string SubjectKeyIdentifierOidValue = "2.5.29.14";
@@ -1346,6 +1366,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ExtensionCollection_OidIndexer_ByOidFriendlyName()
         {
             const string SubjectKeyIdentifierOidValue = "2.5.29.14";
@@ -1368,6 +1389,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ExtensionCollection_OidIndexer_NoMatchByValue()
         {
             const string RsaOidValue = "1.2.840.113549.1.1.1";
@@ -1382,6 +1404,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void X509ExtensionCollection_OidIndexer_NoMatchByFriendlyName()
         {
             const string RsaOidValue = "1.2.840.113549.1.1.1";

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ContentTypeTests.cs
@@ -13,6 +13,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData("My.pfx", X509ContentType.Pkcs12)]
         [InlineData("My.cer", X509ContentType.Cert)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFileContentType(string fileName, X509ContentType contentType)
         {
             string fullPath = Path.Combine("TestData", fileName);
@@ -22,6 +23,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(GetContentBlobsWithType))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBlobContentType(string caseName, byte[] blob, X509ContentType contentType)
         {
             _ = caseName;
@@ -30,6 +32,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestThrowsWhenGivenInvalidContent()
         {
             byte[] blob = new byte[] { 0x00, 0xFF, 0x00, 0xFF };

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -66,6 +66,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestConstructor_DER()
         {
             byte[] expectedThumbPrintSha1 =
@@ -99,6 +100,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestConstructor_PEM()
         {
             byte[] expectedThumbPrintSha1 =
@@ -143,6 +145,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestCopyConstructor_Pal()
         {
             using (var c1 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -185,6 +188,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestCopyConstructor_Lifetime_Independent()
         {
             var c1 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword);
@@ -212,6 +216,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestCopyConstructor_Lifetime_Cloned()
         {
             var c1 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword);
@@ -234,6 +239,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestCopyConstructor_Lifetime_Cloned_Reversed()
         {
             var c1 = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword);
@@ -303,6 +309,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestNullConstructorArguments()
         {
             Assert.Throws<ArgumentNullException>(() => new X509Certificate2((string)null));
@@ -347,6 +354,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void InvalidCertificateBlob()
         {
             CryptographicException ex = Assert.ThrowsAny<CryptographicException>(

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -54,6 +54,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(InvalidSignature3Cases))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BuildInvalidSignatureTwice(
             X509ChainStatusFlags endEntityErrors,
             X509ChainStatusFlags intermediateErrors,
@@ -203,6 +204,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BasicConstraints_ExceedMaximumPathLength()
         {
             X509Extension[] rootExtensions = new [] {
@@ -249,6 +251,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void BasicConstraints_ViolatesCaFalse()
         {
             X509Extension[] intermediateExtensions = new [] {
@@ -283,6 +286,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestLeafCertificateWithUnknownCriticalExtension()
         {
             using (RSA key = RSA.Create())
@@ -319,6 +323,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestInvalidAia()
         {
             using (RSA key = RSA.Create())
@@ -394,6 +399,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(true, X509ChainStatusFlags.NoError)]
         // Test with ExtraStore containing root certificate
         [InlineData(false, X509ChainStatusFlags.UntrustedRoot)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CustomRootTrustDoesNotTrustIntermediates(
             bool saveAllInCustomTrustStore,
             X509ChainStatusFlags chainFlags)
@@ -430,6 +436,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CustomTrustModeWithNoCustomTrustCerts()
         {
             TestDataGenerator.MakeTestChain3(

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ExportTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAsCert()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -48,6 +49,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAsPfx()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -64,6 +66,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAsPfxWithPassword()
         {
             const string password = "Cotton";
@@ -82,6 +85,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAsPfxVerifyPassword()
         {
             const string password = "Cotton";
@@ -94,6 +98,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAsPfxWithPrivateKeyVerifyPassword()
         {
             using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable))
@@ -115,6 +120,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportAsPfxWithPrivateKey()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ExtensionsTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadExtensions()
         {
             using (X509Certificate2 c = new X509Certificate2(TestData.MsCertificate))
@@ -389,6 +390,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SubjectKeyIdentifierExtension_PublicKey()
         {
             PublicKey pk;
@@ -409,6 +411,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SubjectKeyIdentifierExtension_PublicKeySha1()
         {
             TestSubjectKeyIdentifierExtension(
@@ -420,6 +423,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SubjectKeyIdentifierExtension_PublicKeyShortSha1()
         {
             TestSubjectKeyIdentifierExtension(
@@ -431,6 +435,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void SubjectKeyIdentifierExtension_PublicKeyCapiSha1()
         {
             TestSubjectKeyIdentifierExtension(

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/FindTests.cs
@@ -112,6 +112,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(GenerateInvalidInputs))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindWithWrongTypeValue(X509FindType findType, Type badValueType)
         {
             object badValue;
@@ -142,30 +143,35 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(GenerateInvalidOidInputs))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindWithBadOids(X509FindType findType, string badOid)
         {
             RunExceptionTest<ArgumentException>(findType, badOid);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByNullName()
         {
             RunExceptionTest<ArgumentNullException>(X509FindType.FindBySubjectName, null);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByInvalidThumbprint()
         {
             RunZeroMatchTest(X509FindType.FindByThumbprint, "Nothing");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByInvalidThumbprint_RightLength()
         {
             RunZeroMatchTest(X509FindType.FindByThumbprint, "ffffffffffffffffffffffffffffffffffffffff");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByValidThumbprint()
         {
             RunTest(
@@ -180,6 +186,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByThumbprint_WithLrm()
         {
             RunTest(
@@ -196,6 +203,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByValidThumbprint_ValidOnly(bool validOnly)
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
@@ -233,6 +241,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void FindByValidThumbprint_RootCert()
         {
             using (X509Store machineRoot = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
@@ -329,6 +338,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData("Nothing")]
         [InlineData("US, Redmond, Microsoft Corporation, MOPR, Microsoft Corporation")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSubjectName_NoMatch(string subjectQualifier)
         {
             RunZeroMatchTest(X509FindType.FindBySubjectName, subjectQualifier);
@@ -344,6 +354,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("Washington, Redmond")]
         [InlineData("US, Washington, Redmond, Microsoft Corporation, MOPR, Microsoft Corporation")]
         [InlineData("us, washington, redmond, microsoft corporation, mopr, microsoft corporation")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSubjectName_Match(string subjectQualifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectName, subjectQualifier);
@@ -357,6 +368,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Corporation,     OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US    ")]
         [InlineData("    CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDistinguishedSubjectName_NoMatch(string distinguishedSubjectName)
         {
             RunZeroMatchTest(X509FindType.FindBySubjectDistinguishedName, distinguishedSubjectName);
@@ -366,12 +378,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=microsoft corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("cn=microsoft corporation, ou=mopr, o=microsoft corporation, l=redmond, s=washington, c=us")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDistinguishedSubjectName_Match(string distinguishedSubjectName)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectDistinguishedName, distinguishedSubjectName);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestIssuerName_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindByIssuerName, "Nothing");
@@ -387,6 +401,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("Washington, Redmond")]
         [InlineData("US, Washington, Redmond, Microsoft Corporation, Microsoft Code Signing PCA")]
         [InlineData("us, washington, redmond, microsoft corporation, microsoft code signing pca")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestIssuerName_Match(string issuerQualifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindByIssuerName, issuerQualifier);
@@ -399,6 +414,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Code Signing PCA,     O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US    ")]
         [InlineData("    CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDistinguishedIssuerName_NoMatch(string issuerDistinguishedName)
         {
             RunZeroMatchTest(X509FindType.FindByIssuerDistinguishedName, issuerDistinguishedName);
@@ -408,12 +424,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("CN=microsoft Code signing pca, O=Microsoft Corporation, L=Redmond, S=Washington, C=US")]
         [InlineData("cn=microsoft code signing pca, o=microsoft corporation, l=redmond, s=washington, c=us")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDistinguishedIssuerName_Match(string issuerDistinguishedName)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindByIssuerDistinguishedName, issuerDistinguishedName);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTimeValid_Before()
         {
             RunTest(
@@ -434,6 +452,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTimeValid_After()
         {
             RunTest(
@@ -454,6 +473,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTimeValid_Between()
         {
             RunTest(
@@ -483,6 +503,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTimeValid_Match()
         {
             RunTest(
@@ -497,6 +518,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFindByTimeNotYetValid_Match()
         {
             RunTest(
@@ -527,6 +549,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFindByTimeNotYetValid_NoMatch()
         {
             RunTest(
@@ -557,6 +580,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFindByTimeExpired_Match()
         {
             RunTest(
@@ -587,6 +611,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFindByTimeExpired_NoMatch()
         {
             RunTest(
@@ -617,6 +642,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_Decimal()
         {
             // Decimal string is an allowed input format.
@@ -626,6 +652,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_DecimalLeadingZeros()
         {
             // Checking that leading zeros are ignored.
@@ -640,12 +667,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("0001137338006039264696476027508428304567989436592")]
         // Compat: Minus signs are ignored
         [InlineData("-1137338006039264696476027508428304567989436592")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_Decimal_CertB(string serialNumber)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySerialNumber, serialNumber);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_Hex()
         {
             // Hex string is also an allowed input format.
@@ -655,6 +684,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_HexIgnoreCase()
         {
             // Hex string is also an allowed input format and case-blind
@@ -664,6 +694,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_HexLeadingZeros()
         {
             // Checking that leading zeros are ignored.
@@ -673,6 +704,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_WithSpaces()
         {
             // Hex string is also an allowed input format and case-blind
@@ -682,6 +714,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_WithLRM()
         {
             // Hex string is also an allowed input format and case-blind
@@ -691,6 +724,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_NoMatch()
         {
             RunZeroMatchTest(
@@ -700,12 +734,14 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(GenerateWorkingFauxSerialNumbers))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySerialNumber_Match_NonDecimalInput(string input)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySerialNumber, input);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByExtension_FriendlyName()
         {
             // Cannot just say "Enhanced Key Usage" here because the extension name is localized.
@@ -714,6 +750,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByExtension_OidValue()
         {
             RunSingleMatchTest_MsCer(X509FindType.FindByExtension, "2.5.29.37");
@@ -721,6 +758,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         // Compat: Non-ASCII digits don't throw, but don't match.
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByExtension_OidValue_ArabicNumericChar()
         {
             // This uses the same OID as TestByExtension_OidValue, but uses "Arabic-Indic Digit Two" instead
@@ -730,18 +768,21 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByExtension_UnknownFriendlyName()
         {
             RunExceptionTest<ArgumentException>(X509FindType.FindByExtension, "BOGUS");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByExtension_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindByExtension, "2.9");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySubjectKeyIdentifier_UsingFallback()
         {
             RunSingleMatchTest_PfxCer(
@@ -764,6 +805,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("597 1A6 5A3 34D DA9 807 80F F84 1EB E87 F97 232 41F 2")]
         // Non-symmetric whitespace is allowed
         [InlineData("    5971A65   A334DDA980780FF84  1EBE87F97           23241F   2")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySubjectKeyIdentifier_ExtensionPresent(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
@@ -776,6 +818,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(LeftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2 3")]
         // Compat: Lone trailing nybbles are ignored, even if not hex
         [InlineData(LeftToRightMark + "59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 F9 72 32 41 F2 p")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySubjectKeyIdentifier_ExtensionPresentWithLTM(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
@@ -790,18 +833,21 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("59 71 A6 5A 33 4D DA 98 07 80 FF 84 1E BE 87 p9 72 32 41 F2")]
         // Compat: A non-hex character as the low nybble makes the whole byte FF.
         [InlineData("59 71 A6 5A 33 4D DA 98 07 80 0p 84 1E BE 87 F9 72 32 41 F2")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySubjectKeyIdentifier_Compat(string subjectKeyIdentifier)
         {
             RunSingleMatchTest_MsCer(X509FindType.FindBySubjectKeyIdentifier, subjectKeyIdentifier);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySubjectKeyIdentifier_NoMatch()
         {
             RunZeroMatchTest(X509FindType.FindBySubjectKeyIdentifier, "");
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestBySubjectKeyIdentifier_NoMatch_RightLength()
         {
             RunZeroMatchTest(
@@ -810,6 +856,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByApplicationPolicy_MatchAll()
         {
             RunTest(
@@ -829,6 +876,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByApplicationPolicy_NoPolicyAlwaysMatches()
         {
             // PfxCer doesn't have any application policies which means it's good for all usages (even nonsensical ones.)
@@ -836,6 +884,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByApplicationPolicy_NoMatch()
         {
             RunTest(
@@ -855,6 +904,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByCertificatePolicies_MatchA()
         {
             using (var policyCert = new X509Certificate2(TestData.CertWithPolicies))
@@ -868,6 +918,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByCertificatePolicies_MatchB()
         {
             using (var policyCert = new X509Certificate2(TestData.CertWithPolicies))
@@ -881,6 +932,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByCertificatePolicies_NoMatch()
         {
             using (var policyCert = new X509Certificate2(TestData.CertWithPolicies))
@@ -897,6 +949,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTemplate_MatchA()
         {
             using (var templatedCert = new X509Certificate2(TestData.CertWithTemplateData))
@@ -910,6 +963,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTemplate_MatchB()
         {
             using (var templatedCert = new X509Certificate2(TestData.CertWithTemplateData))
@@ -923,6 +977,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestByTemplate_NoMatch()
         {
             using (var templatedCert = new X509Certificate2(TestData.CertWithTemplateData))
@@ -944,6 +999,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(X509KeyUsageFlags.DigitalSignature)]
         [InlineData("DigitalSignature")]
         [InlineData("digitalSignature")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFindByKeyUsage_Match(object matchCriteria)
         {
             TestFindByKeyUsage(true, matchCriteria);
@@ -955,6 +1011,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(X509KeyUsageFlags.KeyEncipherment)]
         [InlineData("KeyEncipherment")]
         [InlineData("KEYEncipherment")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestFindByKeyUsage_NoMatch(object matchCriteria)
         {
             TestFindByKeyUsage(false, matchCriteria);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class LoadFromFileTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestIssuer()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -24,6 +25,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSubject()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -37,6 +39,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSerial()
         {
             string expectedSerialHex = "33000000B011AF0A8BD03B9FDD0001000000B0";
@@ -54,6 +57,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestThumbprint()
         {
             string expectedThumbPrintHex = "108E2BA23632620C427C570B6D9DB51AC31387FE";
@@ -78,6 +82,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData("SHA384", true)]
         [InlineData("SHA512", false)]
         [InlineData("SHA512", true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestThumbprint_ByHashAlgorithm(string hashAlgName, bool viaSpan)
         {
             string expectedThumbprintHex;
@@ -154,6 +159,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 #endif
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGetFormat()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -164,6 +170,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGetKeyAlgorithm()
         {
             using (X509Certificate2 c = LoadCertificateFromFile())
@@ -174,6 +181,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGetKeyAlgorithmParameters()
         {
             string expected = "0500";
@@ -188,6 +196,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGetPublicKey()
         {
             string expectedPublicKeyHex =
@@ -253,6 +262,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestLoadConcatenatedPemFile()
         {
             using (X509Certificate2 c = new X509Certificate2(TestData.ConcatenatedPemFile))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.SingleCertGenerator.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.SingleCertGenerator.cs
@@ -64,6 +64,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(AllSingleCertVariations))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCertWithOneKey(SingleCertOptions options)
         {
             bool sameContainer = (options & SingleCertOptions.KeyAndCertInSameContents) != 0;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxFormatTests.cs
@@ -67,6 +67,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             int altWin32Error = 0);
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EmptyPfx_NoMac()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -75,6 +76,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EmptyPfx_NoMac_ArbitraryPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -86,6 +88,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EmptyPfx_EmptyPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -97,6 +100,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EmptyPfx_NullPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -108,6 +112,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EmptyPfx_BadPassword()
         {
             Pkcs12Builder builder = new Pkcs12Builder();
@@ -118,6 +123,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_NoKeys_EncryptedNullPassword_NoMac()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
@@ -135,6 +141,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_NoKeys_EncryptedEmptyPassword_NoMac()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
@@ -156,6 +163,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_EncryptedEmptyPassword_OneKey_EncryptedNullPassword_NoMac(bool encryptKeySafe, bool associateKey)
         {
             // This test shows that while a null or empty password will result in both
@@ -197,6 +205,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_MismatchedKey()
         {
             string pw = nameof(OneCert_MismatchedKey);
@@ -245,6 +254,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_TwoKeys_FirstWins(bool correctKeyFirst)
         {
             string pw = nameof(OneCert_TwoKeys_FirstWins);
@@ -316,6 +326,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TwoCerts_OneKey(bool certWithKeyFirst)
         {
             string pw = nameof(TwoCerts_OneKey);
@@ -360,6 +371,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_ExtraKeyWithUnknownAlgorithm()
         {
             string pw = nameof(OneCert_ExtraKeyWithUnknownAlgorithm);
@@ -405,6 +417,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_ExtraKeyBadEncoding(bool badTag)
         {
             string pw = nameof(OneCert_ExtraKeyBadEncoding);
@@ -463,6 +476,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_NoKey_WithLocalKeyId()
         {
             string pw = nameof(OneCert_NoKey_WithLocalKeyId);
@@ -484,6 +498,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCert_TwentyKeys_NoMatches()
         {
             string pw = nameof(OneCert_NoKey_WithLocalKeyId);
@@ -522,6 +537,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TwoCerts_TwentyKeys_NoMatches(bool msCertFirst)
         {
             string pw = nameof(OneCert_NoKey_WithLocalKeyId);
@@ -577,6 +593,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void OneCorruptCert()
         {
             string pw = nameof(OneCorruptCert);
@@ -595,6 +612,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void CertAndKey_NoLocalKeyId()
         {
             string pw = nameof(CertAndKey_NoLocalKeyId);
@@ -621,6 +639,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SameCertTwice_NoKeys(bool addLocalKeyId)
         {
             string pw = nameof(SameCertTwice_NoKeys);
@@ -652,6 +671,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TwoCerts_CrossedKeys()
         {
             string pw = nameof(SameCertTwice_NoKeys);
@@ -690,6 +710,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(false, false)]
         [InlineData(true, false)]
         [InlineData(true, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void CertAndKeyTwice(bool addLocalKeyId, bool crossIdentifiers)
         {
             string pw = nameof(CertAndKeyTwice);
@@ -742,6 +763,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void CertAndKeyTwice_KeysUntagged()
         {
             string pw = nameof(CertAndKeyTwice);
@@ -782,6 +804,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void CertTwice_KeyOnce(bool addLocalKeyId)
         {
             string pw = nameof(CertTwice_KeyOnce);
@@ -822,6 +845,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(false, true)]
         [InlineData(true, false)]
         [InlineData(true, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void TwoCerts_TwoKeys_ManySafeContentsValues(bool invertCertOrder, bool invertKeyOrder)
         {
             string pw = nameof(TwoCerts_TwoKeys_ManySafeContentsValues);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PfxTests.cs
@@ -22,6 +22,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestConstructor(X509KeyStorageFlags keyStorageFlags)
         {
             using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, keyStorageFlags))
@@ -37,6 +38,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestConstructor_SecureString(X509KeyStorageFlags keyStorageFlags)
         {
             using (SecureString password = TestData.CreatePfxDataPasswordSecureString())
@@ -53,6 +55,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void EnsurePrivateKeyPreferred(X509KeyStorageFlags keyStorageFlags)
         {
             using (var cert = new X509Certificate2(TestData.ChainPfxBytes, TestData.ChainPfxPassword, keyStorageFlags))
@@ -66,6 +69,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestRawData(X509KeyStorageFlags keyStorageFlags)
         {
             byte[] expectedRawData = (
@@ -100,6 +104,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestPrivateKey(X509KeyStorageFlags keyStorageFlags)
         {
             using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, keyStorageFlags))
@@ -115,6 +120,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestPrivateKeyProperty()
         {
             using (var c = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, Cert.EphemeralIfPossible))
@@ -143,6 +149,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExportWithPrivateKey(X509KeyStorageFlags keyStorageFlags)
         {
             using (var cert = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword, X509KeyStorageFlags.Exportable | keyStorageFlags))
@@ -161,6 +168,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadECDsaPrivateKey_WindowsPfx(X509KeyStorageFlags keyStorageFlags)
         {
             using (var cert = new X509Certificate2(TestData.ECDsaP256_DigitalSignature_Pfx_Windows, "Test", keyStorageFlags))
@@ -173,6 +181,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ECDsaPrivateKeyProperty_WindowsPfx()
         {
             using (var cert = new X509Certificate2(TestData.ECDsaP256_DigitalSignature_Pfx_Windows, "Test", Cert.EphemeralIfPossible))
@@ -197,6 +206,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
 #if !NO_DSA_AVAILABLE
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DsaPrivateKeyProperty()
         {
             using (var cert = new X509Certificate2(TestData.Dsa1024Pfx, TestData.Dsa1024PfxPassword, Cert.EphemeralIfPossible))
@@ -230,6 +240,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Theory, MemberData(nameof(BrainpoolCurvesPfx))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadECDsaPrivateKey_BrainpoolP160r1_Pfx(byte[] pfxData)
         {
             try
@@ -257,6 +268,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData(nameof(StorageFlags))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadECDsaPrivateKey_OpenSslPfx(X509KeyStorageFlags keyStorageFlags)
         {
             using (var cert = new X509Certificate2(TestData.ECDsaP256_DigitalSignature_Pfx_OpenSsl, "Test", keyStorageFlags))
@@ -284,6 +296,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
 #if !NO_DSA_AVAILABLE
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadDSAPrivateKey()
         {
             byte[] data = { 1, 2, 3, 4, 5 };

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -33,6 +33,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSerialBytes()
         {
             byte[] expectedSerialBytes = "b00000000100dd9f3bd08b0aaf11b000000033".HexToByteArray();
@@ -59,6 +60,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         //       Readers SHOULD handle negative values.
         //       (Presumably readers also "should" handle long values created under the previous rules)
         [InlineData("My.cer", "D5B5BC1C458A558845BFF51CB4DFF31C")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSerialString(string fileName, string expectedSerial)
         {
             using (var c = new X509Certificate2(Path.Combine("TestData", fileName)))
@@ -139,6 +141,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void GetPublicKey_X509Signature_NoParameters()
         {
             // Normally RSA signature AlgorithmIdentifiers get represented as
@@ -193,6 +196,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestNotBefore()
         {
             DateTime expected = new DateTime(2013, 1, 24, 22, 33, 39, DateTimeKind.Utc).ToLocalTime();
@@ -204,6 +208,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestNotAfter()
         {
             DateTime expected = new DateTime(2014, 4, 24, 22, 33, 39, DateTimeKind.Utc).ToLocalTime();
@@ -224,6 +229,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSignatureAlgorithm()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -233,6 +239,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestHasPrivateKey()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -251,6 +258,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestVersion()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -334,6 +342,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestSubjectName()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -345,6 +354,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestIssuerName()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -357,6 +367,7 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestGetNameInfo()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
@@ -391,72 +402,84 @@ Wry5FNNo
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_SimpleName_Cert()
         {
             TestComplexGetNameInfo("cn.subject.example.org", X509NameType.SimpleName, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_SimpleName_Issuer()
         {
             TestComplexGetNameInfo("cn.issuer.example.org", X509NameType.SimpleName, true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_EmailName_Cert()
         {
             TestComplexGetNameInfo("sanemail1@example.org", X509NameType.EmailName, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_EmailName_Issuer()
         {
             TestComplexGetNameInfo("ianemail1@example.org", X509NameType.EmailName, true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_UpnName_Cert()
         {
             TestComplexGetNameInfo("subjectupn1@example.org", X509NameType.UpnName, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_UpnName_Issuer()
         {
             TestComplexGetNameInfo("issuerupn1@example.org", X509NameType.UpnName, true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_DnsName_Cert()
         {
             TestComplexGetNameInfo("dns1.subject.example.org", X509NameType.DnsName, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_DnsName_Issuer()
         {
             TestComplexGetNameInfo("dns1.issuer.example.org", X509NameType.DnsName, true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_DnsFromAlternativeName_Cert()
         {
             TestComplexGetNameInfo("dns1.subject.example.org", X509NameType.DnsFromAlternativeName, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_DnsFromAlternativeName_Issuer()
         {
             TestComplexGetNameInfo("dns1.issuer.example.org", X509NameType.DnsFromAlternativeName, true);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_UrlName_Cert()
         {
             TestComplexGetNameInfo("http://uri1.subject.example.org/", X509NameType.UrlName, false);
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ComplexGetNameInfo_UrlName_Issuer()
         {
             TestComplexGetNameInfo("http://uri1.issuer.example.org/", X509NameType.UrlName, true);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/PublicKeyTests.cs
@@ -55,6 +55,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestOid_RSA()
         {
             PublicKey pk = GetTestRsaKey();
@@ -62,6 +63,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestOid_DSA()
         {
             PublicKey pk = GetTestDsaKey();
@@ -69,6 +71,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestOid_ECDSA()
         {
             PublicKey pk = GetTestECDsaKey();
@@ -76,6 +79,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestPublicKey_Key_RSA()
         {
             PublicKey pk = GetTestRsaKey();
@@ -91,6 +95,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestPublicKey_Key_DSA()
         {
             PublicKey pk = GetTestDsaKey();
@@ -106,6 +111,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestPublicKey_Key_ECDSA()
         {
             PublicKey pk = GetTestECDsaKey();
@@ -141,6 +147,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestEncodedKeyValue_RSA()
         {
             byte[] expectedPublicKey = (
@@ -160,6 +167,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestEncodedKeyValue_DSA()
         {
             byte[] expectedPublicKey = (
@@ -175,6 +183,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestEncodedKeyValue_ECDSA()
         {
             // Uncompressed key (04), then the X coord, then the Y coord.
@@ -189,6 +198,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestEncodedParameters_RSA()
         {
             PublicKey pk = GetTestRsaKey();
@@ -199,6 +209,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestEncodedParameters_DSA()
         {
             byte[] expectedParameters = (
@@ -218,6 +229,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestEncodedParameters_ECDSA()
         {
             // OID: 1.2.840.10045.3.1.7
@@ -228,6 +240,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKey_RSA()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
@@ -288,6 +301,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKey_RSA384_ValidatesSignature()
         {
             byte[] signature =
@@ -310,6 +324,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Theory, MemberData(nameof(BrainpoolCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestKey_ECDsabrainpool_PublicKey(byte[] curveData, byte[] notUsed)
         {
             _ = notUsed;
@@ -337,6 +352,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestECDsaPublicKey()
         {
             byte[] helloBytes = Encoding.ASCII.GetBytes("Hello");
@@ -352,6 +368,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestECDsaPublicKey_ValidatesSignature()
         {
             // This signature was produced as the output of ECDsaCng.SignData with the same key
@@ -391,6 +408,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Theory, MemberData(nameof(BrainpoolCurves))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestECDsaPublicKey_BrainpoolP160r1_ValidatesSignature(byte[] curveData, byte[] existingSignature)
         {
             byte[] helloBytes = Encoding.ASCII.GetBytes("Hello");
@@ -427,6 +445,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestECDsaPublicKey_NonSignatureCert()
         {
             using (var cert = new X509Certificate2(TestData.EccCert_KeyAgreement))
@@ -441,6 +460,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestECDsa224PublicKey()
         {
             using (var cert = new X509Certificate2(TestData.ECDsa224Certificate))
@@ -478,6 +498,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
 #if !NO_DSA_AVAILABLE
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDSAPublicKey()
         {
             using (var cert = new X509Certificate2(TestData.DssCer))
@@ -489,6 +510,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDSAPublicKey_VerifiesSignature()
         {
             byte[] data = { 1, 2, 3, 4, 5 };
@@ -508,6 +530,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDSAPublicKey_RSACert()
         {
             using (var cert = new X509Certificate2(TestData.Rsa384CertificatePemBytes))
@@ -518,6 +541,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDSAPublicKey_ECDSACert()
         {
             using (var cert = new X509Certificate2(TestData.ECDsa256Certificate))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -17,6 +17,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public class X509StoreTests : FileCleanupTestBase
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void OpenMyStore()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -110,6 +111,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
 #if HAVE_STORE_ISOPEN
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Constructor_OpenFlags()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadOnly))
@@ -119,6 +121,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Constructor_OpenFlags_StoreName()
         {
             using (X509Store store = new X509Store("My", StoreLocation.CurrentUser, OpenFlags.ReadOnly))
@@ -128,6 +131,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Constructor_OpenFlags_OpenAnyway()
         {
             using (X509Store store = new X509Store("My", StoreLocation.CurrentUser, OpenFlags.ReadOnly))
@@ -138,6 +142,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Constructor_OpenFlags_NonExistingStoreName_Throws()
         {
             Assert.ThrowsAny<CryptographicException>(() =>
@@ -161,6 +166,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReadMyCertificates()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -179,6 +185,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void OpenNotExistent()
         {
             using (X509Store store = new X509Store(Guid.NewGuid().ToString("N"), StoreLocation.CurrentUser))
@@ -189,6 +196,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
 #if HAVE_STORE_ISOPEN
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Open_IsOpenTrue()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -199,6 +207,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Dispose_IsOpenFalse()
         {
             X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
@@ -208,6 +217,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ReOpen_IsOpenTrue()
         {
             X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
@@ -219,6 +229,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 #endif
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddReadOnlyThrows()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -240,6 +251,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddDisposedThrowsCryptographicException()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -253,6 +265,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddReadOnlyThrowsWhenCertificateExists()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -284,6 +297,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveReadOnlyThrowsWhenFound()
         {
             // This test is unfortunate, in that it will mostly never test.
@@ -311,6 +325,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveReadOnlyNonExistingDoesNotThrow()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -322,6 +337,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveDisposedIsIgnored()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -362,6 +378,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void AddClosedThrows()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -372,6 +389,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void RemoveClosedThrows()
         {
             using (X509Store store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
@@ -427,6 +445,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void MachineRootStore_NonEmpty()
         {
             // This test will fail on systems where the administrator has gone out of their

--- a/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/DSAKeyValueTest.cs
@@ -128,6 +128,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportDSAKeyValue()
         {
             string p = "6zJxhRqpk5yQ7sjFSr6mPepyVwpTAXSmw1oh+5Cn/z1DjFSpW6rC6sTOkE3CMNwWOwIzrpVS3bWep7wo9CaBrOPIIVe+E4sqpPeyM2wr10mQThHEsCQAjnxBhJJindf9amaBhi6sOtVNnyETFWV6yKDptZEm9c3xdl4L7ogEbX8=";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTest.cs
@@ -93,6 +93,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [Theory]
         [InlineData("System.Security.Cryptography.Xml.Tests.EncryptedXmlSample1.xml")]
         [InlineData("System.Security.Cryptography.Xml.Tests.EncryptedXmlSample3.xml")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RsaDecryption(string resourceName)
         {
             XmlDocument doc = new XmlDocument();
@@ -159,6 +160,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RoundtripSample1()
         {
             using (StringWriter sw = new StringWriter())
@@ -247,6 +249,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Encrypt_X509()
         {
             XmlDocument doc = new XmlDocument();
@@ -271,6 +274,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Encrypt_X509_XmlNull()
         {
             using (X509Certificate2 certificate = TestHelpers.GetSampleX509Certificate())
@@ -317,6 +321,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Encrypt_RSA()
         {
             using (RSA rsa = RSA.Create())
@@ -608,6 +613,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void EncryptKey_RSA_UseOAEP()
         {
             byte[] data = Encoding.ASCII.GetBytes("12345678");

--- a/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTests.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/EncryptedXmlTests.cs
@@ -12,6 +12,7 @@ namespace System.Security.Cryptography.Xml.Tests
     public static class EncryptedXmlTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DecryptWithCertificate_NotInStore()
         {
             const string SecretMessage = "Grilled cheese is tasty";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoTest.cs
@@ -72,6 +72,7 @@ namespace System.Security.Cryptography.Xml.Tests
         private static string xmlDSA = "<DSAKeyValue><P>" + dsaP + "</P><Q>" + dsaQ + "</Q><G>" + dsaG + "</G><Y>" + dsaY + "</Y></DSAKeyValue>";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DSAKeyValue()
         {
             using (DSA key = DSA.Create())
@@ -99,6 +100,7 @@ namespace System.Security.Cryptography.Xml.Tests
         private static string xmlRSA = "<RSAKeyValue><Modulus>" + rsaModulus + "</Modulus><Exponent>" + rsaExponent + "</Exponent></RSAKeyValue>";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void RSAKeyValue()
         {
             using (RSA key = RSA.Create())
@@ -135,6 +137,7 @@ namespace System.Security.Cryptography.Xml.Tests
             0xD9,0xB2,0xAB,0x8A,0x12,0xB6,0x30,0x78,0x68,0x11,0x7C,0x0D,0xF1,0x49,0x4D,0xA3,0xFD,0xB2,0xE9,0xFF,0x1D,0xF0,0x91,0xFA,0x54,0x85,0xFF,0x33,0x90,0xE8,0xC1,0xBF,0xA4,0x9B,0xA4,0x62,0x46,0xBD,0x61,0x12,0x59,0x98,0x41,0x89 };
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void X509Data()
         {
             using (X509Certificate x509 = new X509Certificate(cert))
@@ -199,6 +202,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportKeyNode()
         {
             string keyName = "Mono::";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/KeyInfoX509DataTest.cs
@@ -91,6 +91,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Constructor_X509Certificate()
         {
             KeyInfoX509Data data1 = new KeyInfoX509Data();
@@ -110,6 +111,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Constructor_X509Certificate_X509IncludeOption()
         {
             KeyInfoX509Data data = new KeyInfoX509Data(new X509Certificate(cert), X509IncludeOption.EndCertOnly);
@@ -127,6 +129,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Constructor_X509Certificate_X509IncludeOptionBad()
         {
             KeyInfoX509Data data = new KeyInfoX509Data(new X509Certificate(cert), (X509IncludeOption)int.MinValue);
@@ -220,6 +223,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Complex()
         {
             KeyInfoX509Data data1 = new KeyInfoX509Data(cert);
@@ -282,6 +286,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ImportX509Data()
         {
             string simple = "<X509Data xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><X509Certificate>MIIJuTCCCSKgAwIBAgIQIAs1Xs7EsGO33sY0uXA0RDANBgkqhkiG9w0BAQQFADBiMREwDwYDVQQHEwhJbnRlcm5ldDEXMBUGA1UEChMOVmVyaVNpZ24sIEluYy4xNDAyBgNVBAsTK1ZlcmlTaWduIENsYXNzIDEgQ0EgLSBJbmRpdmlkdWFsIFN1YnNjcmliZXIwHhcNOTYwODIxMDAwMDAwWhcNOTcwODIwMjM1OTU5WjCCAQoxETAPBgNVBAcTCEludGVybmV0MRcwFQYDVQQKEw5WZXJpU2lnbiwgSW5jLjE0MDIGA1UECxMrVmVyaVNpZ24gQ2xhc3MgMSBDQSAtIEluZGl2aWR1YWwgU3Vic2NyaWJlcjFGMEQGA1UECxM9d3d3LnZlcmlzaWduLmNvbS9yZXBvc2l0b3J5L0NQUyBJbmNvcnAuIGJ5IFJlZi4sTElBQi5MVEQoYyk5NjEmMCQGA1UECxMdRGlnaXRhbCBJRCBDbGFzcyAxIC0gTmV0c2NhcGUxFjAUBgNVBAMTDURhdmlkIFQuIEdyYXkxHjAcBgkqhkiG9w0BCQEWD2RhdmlkQGZvcm1hbC5pZTBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDFgQei6w+4//j4HO4y/78SNWr5a8i+L/s+rwRRSqzdECmozUBbZh6Y7/JMd/qPhtEhZ5JESsSJyYPPiJ9v4jI1AgMBAAGjggcIMIIHBDAJBgNVHRMEAjAAMIICHwYDVR0DBIICFjCCAhIwggIOMIICCgYLYIZIAYb4RQEHAQEwggH5FoIBp1RoaXMgY2VydGlmaWNhdGUgaW5jb3Jwb3JhdGVzIGJ5IHJlZmVyZW5jZSwgYW5kIGl0cyB1c2UgaXMgc3RyaWN0bHkgc3ViamVjdCB0bywgdGhlIFZlcmlTaWduIENlcnRpZmljYXRpb24gUHJhY3RpY2UgU3RhdGVtZW50IChDUFMpLCBhdmFpbGFibGUgYXQ6IGh0dHBzOi8vd3d3LnZlcmlzaWduLmNvbS9DUFM7IGJ5IEUtbWFpbCBhdCBDUFMtcmVxdWVzdHNAdmVyaXNpZ24uY29tOyBvciBieSBtYWlsIGF0IFZlcmlTaWduLCBJbmMuLCAyNTkzIENvYXN0IEF2ZS4sIE1vdW50YWluIFZpZXcsIENBIDk0MDQzIFVTQSBUZWwuICsxICg0MTUpIDk2MS04ODMwIENvcHlyaWdodCAoYykgMTk5NiBWZXJpU2lnbiwgSW5jLiAgQWxsIFJpZ2h0cyBSZXNlcnZlZC4gQ0VSVEFJTiBXQVJSQU5USUVTIERJU0NMQUlNRUQgYW5kIExJQUJJTElUWSBMSU1JVEVELqAOBgxghkgBhvhFAQcBAQGhDgYMYIZIAYb4RQEHAQECMCwwKhYoaHR0cHM6Ly93d3cudmVyaXNpZ24uY29tL3JlcG9zaXRvcnkvQ1BTIDARBglghkgBhvhCAQEEBAMCB4AwNgYJYIZIAYb4QgEIBCkWJ2h0dHBzOi8vd3d3LnZlcmlzaWduLmNvbS9yZXBvc2l0b3J5L0NQUzCCBIcGCWCGSAGG+EIBDQSCBHgWggR0Q0FVVElPTjogV";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/RSAKeyValueTest.cs
@@ -46,6 +46,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void GetXml()
         {
             RSAKeyValue rsa = new RSAKeyValue();
@@ -59,6 +60,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void GetXml_SameRsa()
         {
             using (RSA rsa = RSA.Create())
@@ -70,6 +72,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void LoadXml_LoadXml_GetXml()
         {
             string rsaKey = "<KeyValue xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><RSAKeyValue><Modulus>ogZ1/O7iks9ncETqNxLDKoPvgrT4nFx1a3lOmpywEmgbc5+8vI5dSzReH4v0YrflY75rIJx13CYWMsaHfQ78GtXvaeshHlQ3lLTuSdYEJceKll/URlBoKQtOj5qYIVSFOIVGHv4Y/0lnLftOzIydem29KKH6lJQlJawBBssR12s=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue>";
@@ -84,6 +87,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void LoadXml_GetXml_With_NS_Prefix()
         {
             string rsaKeyWithPrefix = "<ds:KeyValue xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:RSAKeyValue><ds:Modulus>ogZ1/O7iks9ncETqNxLDKoPvgrT4nFx1a3lOmpywEmgbc5+8vI5dSzReH4v0YrflY75rIJx13CYWMsaHfQ78GtXvaeshHlQ3lLTuSdYEJceKll/URlBoKQtOj5qYIVSFOIVGHv4Y/0lnLftOzIydem29KKH6lJQlJawBBssR12s=</ds:Modulus><ds:Exponent>AQAB</ds:Exponent></ds:RSAKeyValue></ds:KeyValue>";
@@ -150,6 +154,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
         [Theory]
         [MemberData(nameof(LoadXml_ValidXml_Source))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void LoadXml_ValidXml(string xml, byte[] expectedModulus, byte[] expectedExponent)
         {
             XmlDocument xmlDocument = new XmlDocument();

--- a/src/libraries/System.Security.Cryptography.Xml/tests/Reference_ArbitraryElements.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/Reference_ArbitraryElements.cs
@@ -40,6 +40,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Transforms_ExtraData_CData_Text()
         {
             string arbitraryData = @"text";
@@ -60,6 +61,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void Transforms_ExtraData_XmlProcessingInstruction()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -93,6 +95,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExtraAttributes()
         {
             foreach (string includeID in new string[] { "", $@" Id=""""" })
@@ -106,6 +109,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DuplicateLegalAttributes()
         {
             foreach (string includeID in new string[] { "", $@" Id=""""", $@" Id="""" Id=""""" })

--- a/src/libraries/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/Samples/EncryptingDecryptingAsymmetric.cs
@@ -79,10 +79,12 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void AsymmetricEncryptionRoundtripUseOAEP() =>
             AsymmetricEncryptionRoundtrip_Helper(useOAEP: true); // OAEP is recommended
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void AsymmetricEncryptionRoundtrip() =>
             AsymmetricEncryptionRoundtrip_Helper(useOAEP: false);
 

--- a/src/libraries/System.Security.Cryptography.Xml/tests/Samples/SigningVerifyingWithCustomSignatureMethod.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/Samples/SigningVerifyingWithCustomSignatureMethod.cs
@@ -66,6 +66,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha384", "http://www.w3.org/2001/04/xmldsig-more#sha384")]
         [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha512", "http://www.w3.org/2001/04/xmlenc#sha512")]
         [InlineData("http://www.w3.org/2001/04/xmldsig-more#rsa-sha256", "http://www.w3.org/2001/04/xmlenc#sha512")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignedXmlHasVerifiableSignature(string signatureMethod, string digestMethod)
         {
             using (RSA key = RSA.Create())

--- a/src/libraries/System.Security.Cryptography.Xml/tests/Samples/SigningVerifyingX509Cert.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/Samples/SigningVerifyingX509Cert.cs
@@ -60,6 +60,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignedXmlHasCertificateVerifiableSignature()
         {
             using (X509Certificate2 x509cert = TestHelpers.GetSampleX509Certificate())

--- a/src/libraries/System.Security.Cryptography.Xml/tests/Signature_ArbitraryElements.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/Signature_ArbitraryElements.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.Xml.Tests
     public class Signature_ArbitraryElements
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void CorrectAttributes()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?><a><b xmlns:ns1=""http://www.contoso.com/"">X<Signature xmlns=""http://www.w3.org/2000/09/xmldsig#"" Id=""id""><SignedInfo Id=""id""><CanonicalizationMethod Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/><SignatureMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#rsa-sha1""/><Reference URI="""" Id="""" Type=""""><Transforms><Transform Algorithm=""http://www.w3.org/2000/09/xmldsig#enveloped-signature""/><Transform Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/></Transforms><DigestMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#sha1""/><DigestValue>ZVZLYkc1BAx+YtaqeYlxanb2cGI=</DigestValue></Reference></SignedInfo><SignatureValue Id=""ID"">Kx8xs0of766gimu5girTqiTR5xoiWjN4XMx8uzDDhG70bIqpSzlhh6IA3iI54R5mpqCCPWrJJp85ps4jpQk8RGHe4KMejstbY6YXCfs7LtRPzkNzcoZB3vDbr3ijUSrbMk+0wTaZeyeYs8Z6cOicDIVN6bN6yC/Se5fbzTTCSmg=</SignatureValue><KeyInfo Id=""ID""><KeyValue><RSAKeyValue><Modulus>ww2w+NbXwY/GRBZfFcXqrAM2X+P1NQoU+QEvgLO1izMTB8kvx1i/bodBvHTrKMwAMGEO4kVATA1f1Vf5/lVnbqiCLMJPVRZU6rWKjOGD28T/VRaIGywTV+mC0HvMbe4DlEd3dBwJZLIMUNvOPsj5Ua+l9IS4EoszFNAg6F5Lsyk=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue></KeyInfo></Signature></b></a>";
@@ -23,6 +24,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void DifferentSignatureXMLNS()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?><a><b xmlns:ns1=""http://www.contoso.com/"">X<ds:Signature xmlns:ds=""http://www.w3.org/2000/09/xmldsig#""><ds:SignedInfo><ds:CanonicalizationMethod Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/><ds:SignatureMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#rsa-sha1""/><ds:Reference URI=""""><ds:Transforms><ds:Transform Algorithm=""http://www.w3.org/2000/09/xmldsig#enveloped-signature""/><ds:Transform Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/></ds:Transforms><ds:DigestMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#sha1""/><ds:DigestValue>ZVZLYkc1BAx+YtaqeYlxanb2cGI=</ds:DigestValue></ds:Reference></ds:SignedInfo><ds:SignatureValue>Kx8xs0of766gimu5girTqiTR5xoiWjN4XMx8uzDDhG70bIqpSzlhh6IA3iI54R5mpqCCPWrJJp85ps4jpQk8RGHe4KMejstbY6YXCfs7LtRPzkNzcoZB3vDbr3ijUSrbMk+0wTaZeyeYs8Z6cOicDIVN6bN6yC/Se5fbzTTCSmg=</ds:SignatureValue><ds:KeyInfo><ds:KeyValue><ds:RSAKeyValue><ds:Modulus>ww2w+NbXwY/GRBZfFcXqrAM2X+P1NQoU+QEvgLO1izMTB8kvx1i/bodBvHTrKMwAMGEO4kVATA1f1Vf5/lVnbqiCLMJPVRZU6rWKjOGD28T/VRaIGywTV+mC0HvMbe4DlEd3dBwJZLIMUNvOPsj5Ua+l9IS4EoszFNAg6F5Lsyk=</ds:Modulus><ds:Exponent>AQAB</ds:Exponent></ds:RSAKeyValue></ds:KeyValue></ds:KeyInfo></ds:Signature></b></a>";
@@ -37,6 +39,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExtraAttributes_WeirdXMLNS()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?><a><b xmlns:ns1=""http://www.contoso.com/"">X<Signature xmlns=""http://www.w3.org/2000/09/xmldsig#"" xmlns:lsj=""http://www.w3.org/2000/09/xmldsig#"" xmlns:fld=""http://www.w3.org/2000/09/xmldsig#""><SignedInfo><CanonicalizationMethod Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/><SignatureMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#rsa-sha1""/><Reference URI=""""><Transforms><Transform Algorithm=""http://www.w3.org/2000/09/xmldsig#enveloped-signature""/><Transform Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/></Transforms><DigestMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#sha1""/><DigestValue>ZVZLYkc1BAx+YtaqeYlxanb2cGI=</DigestValue></Reference></SignedInfo><SignatureValue>Kx8xs0of766gimu5girTqiTR5xoiWjN4XMx8uzDDhG70bIqpSzlhh6IA3iI54R5mpqCCPWrJJp85ps4jpQk8RGHe4KMejstbY6YXCfs7LtRPzkNzcoZB3vDbr3ijUSrbMk+0wTaZeyeYs8Z6cOicDIVN6bN6yC/Se5fbzTTCSmg=</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>ww2w+NbXwY/GRBZfFcXqrAM2X+P1NQoU+QEvgLO1izMTB8kvx1i/bodBvHTrKMwAMGEO4kVATA1f1Vf5/lVnbqiCLMJPVRZU6rWKjOGD28T/VRaIGywTV+mC0HvMbe4DlEd3dBwJZLIMUNvOPsj5Ua+l9IS4EoszFNAg6F5Lsyk=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue></KeyInfo></Signature></b></a>";
@@ -44,6 +47,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExtraAttributes_Preserve()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -62,6 +66,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExtraAttributes_Lang()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -71,6 +76,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExtraAttributes_Base()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>
@@ -108,6 +114,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [InlineData(@"this", true, false)] //CData_Text
         [InlineData(@"&amp;", true, false)] //EntityReference
         [InlineData(@"<?xml-stylesheet type='text / xsl' href='style.xsl'?>", true, false)] //EntityReference
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ExtraData(string arbitraryData, bool checkSignatureSucceeds, bool loadThrows)
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedInfo_ArbitraryElements.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedInfo_ArbitraryElements.cs
@@ -18,6 +18,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void OutOfOrder()
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?><a><b xmlns:ns1=""http://www.contoso.com/"">X<Signature xmlns=""http://www.w3.org/2000/09/xmldsig#""><SignedInfo><Reference URI=""""><Transforms><Transform Algorithm=""http://www.w3.org/2000/09/xmldsig#enveloped-signature""/><Transform Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/></Transforms><DigestMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#sha1""/><DigestValue>ZVZLYkc1BAx+YtaqeYlxanb2cGI=</DigestValue></Reference><SignatureMethod Algorithm=""http://www.w3.org/2000/09/xmldsig#rsa-sha1""/><CanonicalizationMethod Algorithm=""http://www.w3.org/TR/2001/REC-xml-c14n-20010315""/></SignedInfo><SignatureValue>Kx8xs0of766gimu5girTqiTR5xoiWjN4XMx8uzDDhG70bIqpSzlhh6IA3iI54R5mpqCCPWrJJp85ps4jpQk8RGHe4KMejstbY6YXCfs7LtRPzkNzcoZB3vDbr3ijUSrbMk+0wTaZeyeYs8Z6cOicDIVN6bN6yC/Se5fbzTTCSmg=</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>ww2w+NbXwY/GRBZfFcXqrAM2X+P1NQoU+QEvgLO1izMTB8kvx1i/bodBvHTrKMwAMGEO4kVATA1f1Vf5/lVnbqiCLMJPVRZU6rWKjOGD28T/VRaIGywTV+mC0HvMbe4DlEd3dBwJZLIMUNvOPsj5Ua+l9IS4EoszFNAg6F5Lsyk=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue></KeyInfo></Signature></b></a>";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXmlTest.cs
@@ -52,6 +52,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Constructor_Empty()
         {
             XmlDocument doc = new XmlDocument();
@@ -65,6 +66,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Constructor_XmlDocument()
         {
             XmlDocument doc = new XmlDocument();
@@ -85,6 +87,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void Constructor_XmlElement()
         {
             XmlDocument doc = new XmlDocument();
@@ -168,6 +171,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void AsymmetricRSASignature()
         {
             SignedXml signedXml = MSDNSample();
@@ -279,6 +283,7 @@ namespace System.Security.Cryptography.Xml.Tests
         private const string AsymmetricRSAMixedCaseAttributesResult = "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" /><SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\" /><Reference URI=\"#MyObjectId\"><DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\" /><DigestValue>0j1xLsePFtuRHfXEnVdTSLWtAm4=</DigestValue></Reference></SignedInfo><SignatureValue>hmrEBgns5Xx14aDhzqOyIh0qLNMUldtW8+fNPcvtD/2KtEhNZQGctnhs90CRa1NZ08TqzW2pUaEwmqvMAtF4v8KtWzC/zTuc1jH6nxQvQSQo0ABhuXdu7/hknZkXJ4yKBbdgbKjAsKfULwbWrP/PacLPoYfCO+wXSrt+wLMTTWU=</SignatureValue><KeyInfo><KeyValue><RSAKeyValue><Modulus>4h/rHDr54r6SZWk2IPCeHX7N+wR1za0VBLshuS6tq3RSWap4PY2BM8VdbKH2T9RzyZoiHufjng+1seUx430iMsXisOLUkPP+yGtMQOSZ3CQHAa+IYA+fplXipixI0rV1J1wJNXQm3HxXQqKWpIv5fkwBtj8o2k6CWMgPNgFCnxc=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue></KeyInfo><Object Id=\"MyObjectId\"><MyElement Aa=\"one\" Bb=\"two\" aa=\"three\" bb=\"four\" xmlns=\"samples\">This is some text</MyElement></Object></Signature>";
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void AsymmetricRSAMixedCaseAttributesVerifyWindows()
         {
             XmlDocument doc = new XmlDocument();
@@ -366,6 +371,7 @@ namespace System.Security.Cryptography.Xml.Tests
         // Using empty constructor
         // The two other constructors don't seems to apply in verifying signatures
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void AsymmetricRSAVerify()
         {
             string value = "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" /><SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\" /><Reference URI=\"#MyObjectId\"><DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\" /><DigestValue>/Vvq6sXEVbtZC8GwNtLQnGOy/VI=</DigestValue></Reference></SignedInfo><SignatureValue>A6XuE8Cy9iOffRXaW9b0+dUcMUJQnlmwLsiqtQnADbCtZXnXAaeJ6nGnQ4Mm0IGi0AJc7/2CoJReXl7iW4hltmFguG1e3nl0VxCyCTHKGOCo1u8R3K+B1rTaenFbSxs42EM7/D9KETsPlzfYfis36yM3PqatiCUOsoMsAiMGzlc=</SignatureValue><KeyInfo><KeyValue xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><RSAKeyValue><Modulus>tI8QYIpbG/m6JLyvP+S3X8mzcaAIayxomyTimSh9UCpEucRnGvLw0P73uStNpiF7wltTZA1HEsv+Ha39dY/0j/Wiy3RAodGDRNuKQao1wu34aNybZ673brbsbHFUfw/o7nlKD2xO84fbajBZmKtBBDy63NHt+QL+grSrREPfCTM=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue></KeyValue></KeyInfo><Object Id=\"MyObjectId\"><MyElement xmlns=\"samples\">This is some text</MyElement></Object></Signature>";
@@ -390,6 +396,7 @@ namespace System.Security.Cryptography.Xml.Tests
         // Using empty constructor
         // The two other constructors don't seems to apply in verifying signatures
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void AsymmetricDSAVerify()
         {
             string value = "<Signature xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><SignedInfo><CanonicalizationMethod Algorithm=\"http://www.w3.org/TR/2001/REC-xml-c14n-20010315\" /><SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#dsa-sha1\" /><Reference URI=\"#MyObjectId\"><DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha1\" /><DigestValue>/Vvq6sXEVbtZC8GwNtLQnGOy/VI=</DigestValue></Reference></SignedInfo><SignatureValue>BYz/qRGjGsN1yMFPxWa3awUZm1y4I/IxOQroMxkOteRGgk1HIwhRYw==</SignatureValue><KeyInfo><KeyValue xmlns=\"http://www.w3.org/2000/09/xmldsig#\"><DSAKeyValue><P>iglVaZ+LsSL8Y0aDXmFMBwva3xHqIypr3l/LtqBH9ziV2Sh1M4JVasAiKqytWIWt/s/Uk8Ckf2tO2Ww1vsNi1NL+Kg9T7FE52sn380/rF0miwGkZeidzm74OWhykb3J+wCTXaIwOzAWI1yN7FoeoN7wzF12jjlSXAXeqPMlViqk=</P><Q>u4sowiJMHilNRojtdmIuQY2YnB8=</Q><G>SdnN7d+wn1n+HH4Hr8MIryIRYgcXdbZ5TH7jAnuWc1koqRc1AZfcYAZ6RDf+orx6Lzn055FTFiN+1NHQfGUtXJCWW0zz0FVV1NJux7WRj8vGTldjJ5ef0oCenkpwDjcIxWsZgVobve4GPoyN1sAc1scnkJB59oupibklmF4y72A=</G><Y>XejzS8Z51yfl0zbYnxSYYbHqreSLjNCoGPB/KjM1TOyV5sMjz0StKtGrFWryTWc7EgvFY7kUth4e04VKf9HbK8z/FifHTXj8+Tszbjzw8GfInnBwLN+vJgbpnjtypmiI5Bm2nLiRbfkdAHP+OrKtr/EauM9GQfYuaxm3/Vj8B84=</Y><J>vGwGg9wqwwWP9xsoPoXu6kHArJtadiNKe9azBiUx5Ob883gd5wlKfEcGuKkBmBySGbgwxyOsIBovd9Kk48hF01ymfQzAAuHR0EdJECSsTsTTKVTLQNBU32O+PRbLYpv4E8kt6rNL83JLJCBY</J><Seed>sqzn8J6fd2gtEyq6YOqiUSHgPE8=</Seed><PgenCounter>sQ==</PgenCounter></DSAKeyValue></KeyValue></KeyInfo><Object Id=\"MyObjectId\"><MyElement xmlns=\"samples\">This is some text</MyElement></Object></Signature>";
@@ -429,6 +436,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
         [Fact]
         // adapted from http://bugzilla.ximian.com/show_bug.cgi?id=52084
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void GetIdElement()
         {
             XmlDocument doc = new XmlDocument();
@@ -443,6 +451,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void GetPublicKey()
         {
             XmlDocument doc = new XmlDocument();
@@ -642,6 +651,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DigestValue_CRLF()
         {
             XmlDocument doc = CreateSomeXml("\r\n");
@@ -701,6 +711,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void DigestValue_LF()
         {
             XmlDocument doc = CreateSomeXml("\n");
@@ -760,6 +771,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignedXML_CRLF_Invalid()
         {
             X509Certificate2 cert = new X509Certificate2(_pkcs12, "mono");
@@ -823,6 +835,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignedXML_CRLF_Valid()
         {
             X509Certificate2 cert = new X509Certificate2(_pkcs12, "mono");
@@ -880,6 +893,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void SignedXML_LF_Valid()
         {
             X509Certificate2 cert = new X509Certificate2(_pkcs12, "mono");
@@ -937,6 +951,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact] // part of bug #79454
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void MultipleX509Certificates()
         {
             XmlDocument doc = null;
@@ -1582,6 +1597,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void CoreFxSignedXmlUsesSha256ByDefault()
         {
             const string expectedSignatureMethod = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXml_Limits.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXml_Limits.cs
@@ -21,6 +21,7 @@ namespace System.Security.Cryptography.Xml.Tests
         [InlineData(MaxTransformsPerReference, MaxReferencesPerSignedInfo + 1, true)]
         [InlineData(MaxTransformsPerReference + 1, MaxReferencesPerSignedInfo, true)]
         [InlineData(MaxTransformsPerReference + 1, MaxReferencesPerSignedInfo + 1, true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestReferenceLimits(int numTransformsPerReference, int numReferencesPerSignedInfo, bool loadXmlThrows)
         {
             string xml = $@"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/src/libraries/System.Security.Cryptography.Xml/tests/SignedXml_SignatureMethodAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/SignedXml_SignatureMethodAlgorithm.cs
@@ -9,6 +9,7 @@ namespace System.Security.Cryptography.Xml.Tests
     public class SignedXml_SignatureMethodAlgorithm
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void TestDummySignatureAlgorithm()
         {
             string objectToConstruct = typeof(DummyClass).AssemblyQualifiedName;

--- a/src/libraries/System.Security.Cryptography.Xml/tests/XmlLicenseEncryptedRef.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/XmlLicenseEncryptedRef.cs
@@ -185,6 +185,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ItRoundTrips()
         {
             byte[] input = new byte[] { 1, 2, 7, 4 };

--- a/src/libraries/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
+++ b/src/libraries/System.Security.Cryptography.Xml/tests/XmlLicenseTransformTest.cs
@@ -135,6 +135,7 @@ namespace System.Security.Cryptography.Xml.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "https://github.com/dotnet/runtime/issues/21536")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public void ValidLicense()
         {
             XmlDocument doc = GetDocumentFromResource("System.Security.Cryptography.Xml.Tests.XmlLicenseSample.xml");
@@ -161,6 +162,7 @@ namespace System.Security.Cryptography.Xml.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static void ItDecryptsLicense()
         {
             using (var key = RSA.Create())

--- a/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/BasicScenarioTests.cs
@@ -45,6 +45,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Write_RSS_Feed()
         {
             string path = Path.GetTempFileName();
@@ -78,6 +79,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Write_RSS_Feed_()
         {
             string path = Path.GetTempFileName();
@@ -112,6 +114,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Write_Atom_Feed()
         {
             string path = Path.GetTempFileName();
@@ -145,6 +148,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Write_Atom_Feed_()
         {
             string path = Path.GetTempFileName();
@@ -233,6 +237,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Rss()
         {
             XmlReaderSettings setting = new XmlReaderSettings();
@@ -244,6 +249,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Atom()
         {
             XmlReaderSettings setting = new XmlReaderSettings();
@@ -256,6 +262,7 @@ namespace System.ServiceModel.Syndication.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disjoint items not supported on NetFX")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Rss_TestDisjointItems()
         {
             using (XmlReader reader = XmlReader.Create("TestFeeds/RssDisjointItems.xml"))
@@ -277,6 +284,7 @@ namespace System.ServiceModel.Syndication.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Disjoint items not supported on NetFX")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Atom_TestDisjointItems()
         {
             using (XmlReader reader = XmlReader.Create("TestFeeds/AtomDisjointItems.xml"))
@@ -297,6 +305,7 @@ namespace System.ServiceModel.Syndication.Tests
 
         [Fact]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Deferred date exception throwing not implemented on NetFX")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Rss_WrongDateFormat()
         {
             // *** SETUP *** \\
@@ -316,6 +325,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void AtomEntryPositiveTest()
         {
             string file = "TestFeeds/brief-entry-noerror.xml";
@@ -323,6 +333,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void AtomEntryPositiveTest_write()
         {
             string file = "TestFeeds/AtomEntryTest.xml";
@@ -370,6 +381,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void AtomFeedPositiveTest()
         {
             string dataFile = "TestFeeds/atom_feeds.dat";
@@ -383,6 +395,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void RssEntryPositiveTest()
         {
             string file = "TestFeeds/RssEntry.xml";
@@ -390,6 +403,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void RssFeedPositiveTest()
         {
             string dataFile = "TestFeeds/rss_feeds.dat";
@@ -403,6 +417,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void DiffAtomNsTest()
         {
             string file = "TestFeeds/FailureFeeds/diff_atom_ns.xml";
@@ -413,6 +428,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void DiffRssNsTest()
         {
             string file = "TestFeeds/FailureFeeds/diff_rss_ns.xml";
@@ -423,6 +439,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void DiffRssVersionTest()
         {
             string file = "TestFeeds/FailureFeeds/diff_rss_version.xml";
@@ -433,6 +450,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void NoRssVersionTest()
         {
             string file = "TestFeeds/FailureFeeds/no_rss_version.xml";

--- a/src/libraries/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/netcoreapp/BasicScenarioTests.netcoreapp.cs
@@ -12,6 +12,7 @@ namespace System.ServiceModel.Syndication.Tests
     public static partial class BasicScenarioTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Rss_DateTimeParser()
         {
             // *** SETUP *** \\
@@ -36,6 +37,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Rss_UriParser()
         {
             // *** SETUP *** \\
@@ -70,6 +72,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Atom_DateTimeParser()
         {
             // *** SETUP *** \\
@@ -100,6 +103,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Atom_UriParser()
         {
             // *** SETUP *** \\
@@ -132,6 +136,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_RSS_Optional_Elements()
         {
             using (XmlReader reader = XmlReader.Create("TestFeeds/rssSpecExample.xml"))
@@ -159,6 +164,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Write_RSS_With_Optional_Elements()
         {
             List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();
@@ -170,6 +176,7 @@ namespace System.ServiceModel.Syndication.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36898", TestPlatforms.iOS)]
         public static void SyndicationFeed_Load_Write_RSS_Use_Optional_Element_Properties()
         {
             List<AllowableDifference> allowableDifferences = GetRssFeedPositiveTestAllowableDifferences();

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -868,6 +868,7 @@ namespace System.Text.RegularExpressions.Tests
         [MemberData(nameof(Groups_CustomCulture_TestData_Danish))]
         [MemberData(nameof(Groups_CustomCulture_TestData_Turkish))]
         [MemberData(nameof(Groups_CustomCulture_TestData_AzeriLatin))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36900", TestPlatforms.iOS)]
         public void Groups(string cultureName, string pattern, string input, RegexOptions options, string[] expectedGroups)
         {
             if (cultureName is null)

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexCultureTests.cs
@@ -35,6 +35,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
         [InlineData(RegexOptions.Compiled)]
         [InlineData(RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36900", TestPlatforms.iOS)]
         public void CharactersComparedOneByOne_Invariant(RegexOptions options)
         {
             // Regex compares characters one by one.  If that changes, it could impact the behavior of
@@ -74,6 +75,7 @@ namespace System.Text.RegularExpressions.Tests
         [Theory]
         [InlineData(2)]
         [InlineData(256)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36900", TestPlatforms.iOS)]
         public void TurkishI_Is_Differently_LowerUpperCased_In_Turkish_Culture(int length)
         {
             var turkish = new CultureInfo("tr-TR");

--- a/src/libraries/System.ValueTuple/tests/ValueTupleTests.cs
+++ b/src/libraries/System.ValueTuple/tests/ValueTupleTests.cs
@@ -250,6 +250,7 @@ namespace System.Tests
                 }
             }
 
+            [ActiveIssue("https://github.com/dotnet/runtime/issues/36901", TestPlatforms.iOS)]
             public void TestCompareTo(ValueTupleTestDriver<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> other, int expectedResult, int expectedStructuralResult)
             {
                 Assert.Equal(expectedResult, ((IComparable)valueTuple).CompareTo(other.valueTuple));

--- a/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
+++ b/src/libraries/System.Xml.XDocument/ref/System.Xml.XDocument.cs
@@ -171,6 +171,7 @@ namespace System.Xml.Linq
         public System.Xml.Linq.XDocumentType DocumentType { get { throw null; } }
         public override System.Xml.XmlNodeType NodeType { get { throw null; } }
         public System.Xml.Linq.XElement Root { get { throw null; } }
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36897", TestPlatforms.iOS)]
         public static System.Xml.Linq.XDocument Load(System.IO.Stream stream) { throw null; }
         public static System.Xml.Linq.XDocument Load(System.IO.Stream stream, System.Xml.Linq.LoadOptions options) { throw null; }
         public static System.Xml.Linq.XDocument Load(System.IO.TextReader textReader) { throw null; }


### PR DESCRIPTION
This PR takes the iOS tests failures logged as issues on GitHub [here](https://github.com/dotnet/runtime/projects/48#column-9236436)  and adds the [ActiveIssue...] attribute to each failing method to be ignored on helix.

Accidentally closed #37419 