### PR TITLE
Annotate System.Net.Http.WinHttpHandler for nullable reference types

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.cs
@@ -28,21 +28,21 @@ namespace System.Net.Http
         public bool CheckCertificateRevocationList { get { throw null; } set { } }
         public System.Net.Http.ClientCertificateOption ClientCertificateOption { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509Certificate2Collection ClientCertificates { get { throw null; } }
-        public System.Net.CookieContainer CookieContainer { get { throw null; } set { } }
+        public System.Net.CookieContainer? CookieContainer { get { throw null; } set { } }
         public System.Net.Http.CookieUsePolicy CookieUsePolicy { get { throw null; } set { } }
-        public System.Net.ICredentials DefaultProxyCredentials { get { throw null; } set { } }
+        public System.Net.ICredentials? DefaultProxyCredentials { get { throw null; } set { } }
         public int MaxAutomaticRedirections { get { throw null; } set { } }
         public int MaxConnectionsPerServer { get { throw null; } set { } }
         public int MaxResponseDrainSize { get { throw null; } set { } }
         public int MaxResponseHeadersLength { get { throw null; } set { } }
         public bool PreAuthenticate { get { throw null; } set { } }
         public System.Collections.Generic.IDictionary<string, object> Properties { get { throw null; } }
-        public System.Net.IWebProxy Proxy { get { throw null; } set { } }
+        public System.Net.IWebProxy? Proxy { get { throw null; } set { } }
         public System.TimeSpan ReceiveDataTimeout { get { throw null; } set { } }
         public System.TimeSpan ReceiveHeadersTimeout { get { throw null; } set { } }
         public System.TimeSpan SendTimeout { get { throw null; } set { } }
-        public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool> ServerCertificateValidationCallback { get { throw null; } set { } }
-        public System.Net.ICredentials ServerCredentials { get { throw null; } set { } }
+        public System.Func<System.Net.Http.HttpRequestMessage, System.Security.Cryptography.X509Certificates.X509Certificate2, System.Security.Cryptography.X509Certificates.X509Chain, System.Net.Security.SslPolicyErrors, bool>? ServerCertificateValidationCallback { get { throw null; } set { } }
+        public System.Net.ICredentials? ServerCredentials { get { throw null; } set { } }
         public System.Security.Authentication.SslProtocols SslProtocols { get { throw null; } set { } }
         public System.Net.Http.WindowsProxyUsePolicy WindowsProxyUsePolicy { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }

--- a/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/ref/System.Net.Http.WinHttpHandler.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Net.Http.WinHttpHandler.cs" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.csproj
@@ -6,7 +6,7 @@
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);WINHTTPHANDLER_DLL</DefineConstants>
-    <Nullable>annotations</Nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NoWriteNoSeekStreamContent.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/NoWriteNoSeekStreamContent.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Diagnostics;
 using System.IO;
 using System.Threading;

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -160,7 +160,7 @@ namespace System.Net.Http
             }
         }
 
-        public CookieContainer CookieContainer
+        public CookieContainer? CookieContainer
         {
             get
             {
@@ -193,7 +193,7 @@ namespace System.Net.Http
             X509Certificate2,
             X509Chain,
             SslPolicyErrors,
-            bool> ServerCertificateValidationCallback
+            bool>? ServerCertificateValidationCallback
         {
             get
             {
@@ -273,7 +273,7 @@ namespace System.Net.Http
             }
         }
 
-        public ICredentials ServerCredentials
+        public ICredentials? ServerCredentials
         {
             get
             {
@@ -308,7 +308,7 @@ namespace System.Net.Http
             }
         }
 
-        public ICredentials DefaultProxyCredentials
+        public ICredentials? DefaultProxyCredentials
         {
             get
             {
@@ -322,7 +322,7 @@ namespace System.Net.Http
             }
         }
 
-        public IWebProxy Proxy
+        public IWebProxy? Proxy
         {
             get
             {


### PR DESCRIPTION
cc: @buyaa-n, @davidsh 
Contributes to #2339

This is just annotating the public surface area.  We have all nullable warnings disabled when building against netfx and netstandard2.0.