### PR TITLE
Remove WinRT specific code from EventSource.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -228,7 +228,7 @@ namespace System.Diagnostics.Tracing
                 }
                 catch (NotImplementedException)
                 {
-#if (!ES_BUILD_PCL && !ES_BUILD_PN)
+#if (!ES_BUILD_PCL)
                     // send message to debugger without delay
                     System.Diagnostics.Debugger.Log(0, null, "Activity Enabled() called but AsyncLocals Not Supported (pre V4.6).  Ignoring Enable");
 #endif
@@ -381,7 +381,7 @@ namespace System.Diagnostics.Tracing
                     {
                         // TODO FIXME - differentiate between AD inside PCL
                         int appDomainID = 0;
-#if (!ES_BUILD_STANDALONE && !ES_BUILD_PN)
+#if (!ES_BUILD_STANDALONE)
                         appDomainID = System.Threading.Thread.GetDomainID();
 #endif
                         // We start with the appdomain number to make this unique among appdomains.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventDescriptor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventDescriptor.cs
@@ -18,21 +18,7 @@ namespace System.Diagnostics.Tracing
 #if ES_BUILD_STANDALONE
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
 #endif
-
-    /*
-     EventDescriptor was public in the separate System.Diagnostics.Tracing assembly(pre NS2.0),
-     now the move to CoreLib marked them as private.
-     While they are technically private (it's a contract used between the library and the ILC toolchain),
-     we need them to be rooted and exported from shared library for the system to work.
-     For now I'm simply marking them as public again.A cleaner solution might be to use.rd.xml to
-     root them and modify shared library definition to force export them.
-     */
-#if ES_BUILD_PN
-    public
-#else
-    internal
-#endif
-    struct EventDescriptor
+    internal struct EventDescriptor
     {
         #region private
         [FieldOffset(0)]

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -610,7 +610,7 @@ namespace System.Diagnostics.Tracing
             dataStart = 0;
             if (filterData == null)
             {
-#if (!ES_BUILD_PCL && !ES_BUILD_PN && TARGET_WINDOWS)
+#if (!ES_BUILD_PCL && TARGET_WINDOWS)
                 string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
                 if (IntPtr.Size == 8)
                     regKey = @"Software\Wow6432Node" + regKey;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/StubEnvironment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/StubEnvironment.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-#if ES_BUILD_PCL || ES_BUILD_PN
+#if ES_BUILD_PCL
 using System.Collections.Generic;
 #endif
 using System.Reflection;
@@ -209,7 +209,7 @@ namespace Microsoft.Reflection
 #endif
     internal static class ReflectionExtensions
     {
-#if (!ES_BUILD_PCL && !ES_BUILD_PN)
+#if (!ES_BUILD_PCL)
 
         //
         // Type extension methods
@@ -239,11 +239,7 @@ namespace Microsoft.Reflection
         public static Assembly Assembly(this Type type) { return type.GetTypeInfo().Assembly; }
         public static IEnumerable<PropertyInfo> GetProperties(this Type type)
         {
-#if ES_BUILD_PN
-            return type.GetProperties();
-#else
             return type.GetRuntimeProperties();
-#endif
         }
         public static MethodInfo? GetGetMethod(this PropertyInfo propInfo) { return propInfo.GetMethod; }
         public static Type[] GetGenericArguments(this Type type) { return type.GenericTypeArguments; }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -21,13 +21,7 @@ namespace System.Diagnostics.Tracing
     ///
     /// To get the value of a property quickly, use a delegate produced by <see cref="PropertyValue.GetPropertyGetter(PropertyInfo)"/>.
     /// </summary>
-#if ES_BUILD_PN
-    [CLSCompliant(false)]
-    public
-#else
-    internal
-#endif
-    readonly unsafe struct PropertyValue
+    internal readonly unsafe struct PropertyValue
     {
         /// <summary>
         /// Union of well-known value types, to avoid boxing those types.
@@ -208,12 +202,7 @@ namespace System.Diagnostics.Tracing
             return helper.GetPropertyGetter(property);
         }
 
-#if ES_BUILD_PN
-        public
-#else
-        private
-#endif
-        abstract class TypeHelper
+        private abstract class TypeHelper
         {
             public abstract Func<PropertyValue, PropertyValue> GetPropertyGetter(PropertyInfo property);
 
@@ -223,12 +212,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-#if ES_BUILD_PN
-        public
-#else
-        private
-#endif
-        sealed class ReferenceTypeHelper<TContainer> : TypeHelper where TContainer : class?
+        private sealed class ReferenceTypeHelper<TContainer> : TypeHelper where TContainer : class?
         {
             public override Func<PropertyValue, PropertyValue> GetPropertyGetter(PropertyInfo property)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/Statics.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/Statics.cs
@@ -360,7 +360,7 @@ namespace System.Diagnostics.Tracing
         public static MethodInfo? GetDeclaredStaticMethod(Type declaringType, string name)
         {
             MethodInfo? result;
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
             result = declaringType.GetTypeInfo().GetDeclaredMethod(name);
 #else
             result = declaringType.GetMethod(
@@ -375,7 +375,7 @@ namespace System.Diagnostics.Tracing
             Type attributeType)
         {
             bool result;
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
             result = propInfo.IsDefined(attributeType);
 #else
             object[] attributes = propInfo.GetCustomAttributes(
@@ -390,7 +390,7 @@ namespace System.Diagnostics.Tracing
             where AttributeType : Attribute
         {
             AttributeType? result = null;
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
             foreach (var attrib in propInfo.GetCustomAttributes<AttributeType>(false))
             {
                 result = attrib;
@@ -410,7 +410,7 @@ namespace System.Diagnostics.Tracing
             where AttributeType : Attribute
         {
             AttributeType? result = null;
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
             foreach (var attrib in type.GetTypeInfo().GetCustomAttributes<AttributeType>(false))
             {
                 result = attrib;
@@ -441,7 +441,7 @@ namespace System.Diagnostics.Tracing
             }
             else
             {
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
                 IEnumerable<Type> ifaceTypes = type.GetTypeInfo().ImplementedInterfaces;
 #else
                 Type[] ifaceTypes = type.FindInterfaces(IsGenericMatch, typeof(IEnumerable<>));
@@ -449,7 +449,7 @@ namespace System.Diagnostics.Tracing
 
                 foreach (Type ifaceType in ifaceTypes)
                 {
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
                     if (!IsGenericMatch(ifaceType, typeof(IEnumerable<>)))
                     {
                         continue;
@@ -478,7 +478,7 @@ namespace System.Diagnostics.Tracing
         public static Delegate CreateDelegate(Type delegateType, MethodInfo methodInfo)
         {
             Delegate result;
-#if (ES_BUILD_PCL || ES_BUILD_PN)
+#if (ES_BUILD_PCL)
             result = methodInfo.CreateDelegate(
                 delegateType);
 #else

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -441,7 +441,7 @@ namespace System.Diagnostics.Tracing
                 descriptors[1].SetMetadata(pMetadata1, nameInfo.nameMetadata.Length, 1);
                 descriptors[2].SetMetadata(pMetadata2, eventTypes.typeMetadata.Length, 1);
 
-#if (!ES_BUILD_PCL && !ES_BUILD_PN)
+#if (!ES_BUILD_PCL)
                 System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegions();
 #endif
                 try
@@ -625,7 +625,7 @@ namespace System.Diagnostics.Tracing
                         descriptors[2].SetMetadata(pMetadata2, eventTypes.typeMetadata.Length, 1);
 #endif // FEATURE_MANAGED_ETW
 
-#if (!ES_BUILD_PCL && !ES_BUILD_PN)
+#if (!ES_BUILD_PCL)
                         System.Runtime.CompilerServices.RuntimeHelpers.PrepareConstrainedRegions();
 #endif
                         EventOpcode opcode = (EventOpcode)descriptor.Opcode;
@@ -732,7 +732,7 @@ namespace System.Diagnostics.Tracing
             DispatchToAllListeners(-1, eventCallbackArgs);
         }
 
-#if (!ES_BUILD_PCL && !ES_BUILD_PN)
+#if (!ES_BUILD_PCL)
         [System.Runtime.ConstrainedExecution.ReliabilityContract(
             System.Runtime.ConstrainedExecution.Consistency.WillNotCorruptState,
             System.Runtime.ConstrainedExecution.Cer.Success)]


### PR DESCRIPTION
Since we no longer have WinRT specific code in the runtime, we don't need these build defines in the EventSource code. No one is setting these defines, and it is confusing when looking at the code what types are public and what aren't.

Follow up to #36715

cc @brianrob 