### PR TITLE
Fix missing `throw new NotSupportedException(SR.Arg_TypeNotSupported);`.

### DIFF
--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_37506/Runtime_36584.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_37506/Runtime_36584.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Numerics;
+using System.Diagnostics;
+
+class Runtime_37506
+{
+    public static int Main()
+    {
+        var a = new Vector<Vector4>(new Vector4(1));
+        try
+        {
+            a = a + a;
+            Debug.Assert(false, "unreachable");
+        }
+        catch (System.NotSupportedException)
+        {
+        }
+        return 100;
+
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_37506/Runtime_36584.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/Runtime_37506/Runtime_36584.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
@@ -823,6 +823,10 @@ namespace System.Numerics
                         sum.register.double_0 = (double)(left.register.double_0 + right.register.double_0);
                         sum.register.double_1 = (double)(left.register.double_1 + right.register.double_1);
                     }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
+                    }
                     return sum;
                 }
             }
@@ -1034,6 +1038,10 @@ namespace System.Numerics
                     {
                         difference.register.double_0 = (double)(left.register.double_0 - right.register.double_0);
                         difference.register.double_1 = (double)(left.register.double_1 - right.register.double_1);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                     return difference;
                 }
@@ -1247,6 +1255,10 @@ namespace System.Numerics
                     {
                         product.register.double_0 = (double)(left.register.double_0 * right.register.double_0);
                         product.register.double_1 = (double)(left.register.double_1 * right.register.double_1);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                     return product;
                 }
@@ -1480,6 +1492,10 @@ namespace System.Numerics
                     {
                         quotient.register.double_0 = (double)(left.register.double_0 / right.register.double_0);
                         quotient.register.double_1 = (double)(left.register.double_1 / right.register.double_1);
+                    }
+                    else
+                    {
+                        throw new NotSupportedException(SR.Arg_TypeNotSupported);
                     }
                     return quotient;
                 }


### PR DESCRIPTION
Fix for #37506

Note: I have a small experience with C# library code. Please review as if a monkey wrote this change.