### PR TITLE
Collapse mono runtime pack builds in official build

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -40,6 +40,12 @@ jobs:
       - name: _crossBuildPropertyArg
         value: /p:CrossBuild=${{ ne(parameters.crossrootfsDir, '') }}
 
+      - name: _officialBuildParameter
+        $ {{ if eq(parameters.isOfficialBuild, true) }}:
+          value: /p:OfficialBuildId=$(Build.BuildNumber)
+        $ {{ if ne(parameters.isOfficialBuild, true) }}:
+          value: ''
+
       - ${{ parameters.variables }}
 
     steps:
@@ -58,7 +64,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_crossBuildPropertyArg)
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_officialBuildParameter) $(_crossBuildPropertyArg)
       displayName: Build product
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS','tvOS') }}: 

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -6,10 +6,12 @@ parameters:
   osGroup: ''
   osSubgroup: ''
   container: ''
+  crossrootfsDir: ''
   variables: {}
   timeoutInMinutes: ''
   pool: ''
   condition: true
+  isOfficialBuild: false
   extraStepsTemplate: ''
   extraStepsParameters: {}
 
@@ -34,10 +36,17 @@ jobs:
         - name: _osParameter
           value: /p:RuntimeOS=linux-musl /p:OutputRid=linux-musl-${{ parameters.archType }}
 
+      # Do not rename as it clashes with MSBuild property in libraries/build-native.proj
+      - name: _crossBuildPropertyArg
+        value: /p:CrossBuild=${{ ne(parameters.crossrootfsDir, '') }}
+
       - ${{ parameters.variables }}
 
     steps:
     - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
+
+    - ${{ if eq(parameters.isOfficialBuild, true) }}:
+      - template: /eng/pipelines/common/restore-internal-tools.yml
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS', 'tvOS') }}:
       - script: $(Build.SourcesDirectory)/eng/install-native-dependencies.sh ${{ parameters.osGroup }}
@@ -49,7 +58,7 @@ jobs:
         displayName: Disk Usage before Build
 
     # Build
-    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }}
+    - script: $(Build.SourcesDirectory)$(dir)build$(scriptExt) -ci -arch ${{ parameters.archType }} $(_osParameter) ${{ parameters.buildArgs }} $(_crossBuildPropertyArg)
       displayName: Build product
 
     - ${{ if in(parameters.osGroup, 'OSX', 'iOS','tvOS') }}: 
@@ -57,15 +66,6 @@ jobs:
           du -sh $(Build.SourcesDirectory)/*
           df -h
         displayName: Disk Usage after Build
-
-    - task: PublishBuildArtifacts@1
-      displayName: Publish Logs
-      inputs:
-        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
-        PublishLocation: Container
-        ArtifactName: Logs_Build_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
-      continueOnError: true
-      condition: always()
 
       # If intended to send extra steps after regular build add them here.
     - ${{ if ne(parameters.extraStepsTemplate, '') }}:
@@ -76,3 +76,12 @@ jobs:
           archType: ${{ parameters.archType }}
           buildConfig: ${{ parameters.buildConfig }}
           ${{ insert }}: ${{ parameters.extraStepsParameters }}
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish Logs
+      inputs:
+        PathtoPublish: '$(Build.SourcesDirectory)/artifacts/log/'
+        PublishLocation: Container
+        ArtifactName: Logs_Build_${{ parameters.osGroup }}_${{ parameters.osSubGroup }}_${{ parameters.archType }}_${{ parameters.buildConfig }}_${{ parameters.nameSuffix }}
+      continueOnError: true
+      condition: always()

--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -27,7 +27,6 @@ parameters:
 jobs:
 
 # Linux arm
-
 - ${{ if or(containsValue(parameters.platforms, 'Linux_arm'), in(parameters.platformGroup, 'all', 'gcstress')) }}:
   - template: xplat-setup.yml
     parameters:

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -77,14 +77,6 @@ jobs:
   - name: SignType
     value: test
 
-  - ${{ if eq(parameters.runtimeVariant, 'llvmjit') }}:
-    - name: llvmParameter
-      value: /p:MonoEnableLLVM=true
-
-  - ${{ if eq(parameters.runtimeVariant, 'llvmaot') }}:
-    - name: llvmParameter
-      value: /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
-
   # Set up non-PR build from internal project
   - ${{ if eq(parameters.isOfficialBuild, true) }}:
     - name: SignType

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -397,9 +397,11 @@ jobs:
       buildType: current
       downloadType: specific
       downloadPath: '$(Build.SourcesDirectory)/__download__/AllPlatforms/'
+      allowPartiallySucceededBuilds: true
       itemPattern: |
         $(runtimeFlavorName)Product_*/**
         libraries_bin_*/**
+        !*Logs*
 
   - ${{ if eq(parameters.buildFullPlatformManifest, true) }}:
     - ${{ each platform in parameters.platforms }}:

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -62,13 +62,13 @@ stages:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
 
   #
-  # Build Mono release
+  # Build Mono runtime packs
   #
   - template: /eng/pipelines/common/platform-matrix.yml
     parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
+      jobTemplate: /eng/pipelines/common/global-build-job.yml
       buildConfig: release
+      runtimeFlavor: mono
       platforms:
       - Android_x64
       - Android_x86
@@ -92,16 +92,19 @@ stages:
       # - Windows_NT_arm
       # - Windows_NT_arm64
       jobParameters:
+        buildArgs: -s mono+libs+installer -c $(_BuildConfig)
+                  /p:OfficialBuildId=$(Build.BuildNumber)
+        nameSuffix: AllSubsets_Mono
         isOfficialBuild: ${{ variables.isOfficialBuild }}
+        extraStepsTemplate: /eng/pipelines/common/upload-unsigned-artifacts-step.yml
+        extraStepsParameters:
+          name: MonoRuntimePacks
 
   #
-  # Build Mono LLVM release
+  # Build Mono LLVM runtime packs
   #
-  - template: /eng/pipelines/common/platform-matrix.yml
+  - template: /eng/pipelines/common/platform-matrix-multijob.yml
     parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
       platforms:
       - OSX_x64
       - Linux_x64
@@ -113,29 +116,33 @@ stages:
       # - Windows_NT_x86
       # - Windows_NT_arm
       # - Windows_NT_arm64
-      jobParameters:
-        runtimeVariant: LLVMJIT
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/mono/templates/build-job.yml
-      runtimeFlavor: mono
-      buildConfig: release
-      platforms:
-      - OSX_x64
-      - Linux_x64
-      # - Linux_arm
-      # - Linux_arm64
-      # - Linux_musl_x64
-      # - Linux_musl_arm64
-      # - Windows_NT_x64
-      # - Windows_NT_x86
-      # - Windows_NT_arm
-      # - Windows_NT_arm64
-      jobParameters:
-        runtimeVariant: LLVMAOT
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
+      jobTemplates:
+      # LLVMJIT
+      - jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        jobParameters:
+          buildArgs: -s mono+libs+installer -c $(_BuildConfig)
+                      /p:OfficialBuildId=$(Build.BuildNumber) /p:MonoEnableLLVM=true
+          nameSuffix: AllSubsets_Mono_LLVMJIT
+          runtimeVariant: LLVMJIT
+          isOfficialBuild: ${{ variables.isOfficialBuild }}
+          extraStepsTemplate: /eng/pipelines/common/upload-unsigned-artifacts-step.yml
+          extraStepsParameters:
+            name: MonoRuntimePacks
+      #LLVMAOT
+      - jobTemplate: /eng/pipelines/common/global-build-job.yml
+        buildConfig: release
+        runtimeFlavor: mono
+        jobParameters:
+          buildArgs: -s mono+libs+installer -c $(_BuildConfig)
+                      /p:OfficialBuildId=$(Build.BuildNumber) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+          nameSuffix: AllSubsets_Mono_LLVMAOT
+          runtimeVariant: LLVMAOT
+          isOfficialBuild: ${{ variables.isOfficialBuild }}
+          extraStepsTemplate: /eng/pipelines/common/upload-unsigned-artifacts-step.yml
+          extraStepsParameters:
+            name: MonoRuntimePacks
 
   #
   # Build libraries using live CoreLib from CoreCLR
@@ -155,30 +162,6 @@ stages:
       - Windows_NT_x64
       - Windows_NT_arm
       - Windows_NT_arm64
-      jobParameters:
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        liveRuntimeBuildConfig: release
-
-  #
-  # Build libraries using live CoreLib from Mono
-  #
-  - template: /eng/pipelines/common/platform-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/libraries/build-job.yml
-      buildConfig: Release
-      runtimeFlavor: mono
-      platforms:
-      - Android_x64
-      - Android_x86
-      - Android_arm
-      - Android_arm64
-      - tvOS_x64
-      - tvOS_arm64
-      - iOS_x64
-      - iOS_x86
-      - iOS_arm
-      - iOS_arm64
-      - Browser_wasm
       jobParameters:
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         liveRuntimeBuildConfig: release
@@ -220,64 +203,6 @@ stages:
       - Windows_NT_x64
       - Windows_NT_arm
       - Windows_NT_arm64
-
-    #
-    # Installer Build for platforms using Mono
-    #
-  - template: /eng/pipelines/installer/installer-matrix.yml
-    parameters:
-      jobParameters:
-        liveRuntimeBuildConfig: release
-        liveLibrariesBuildConfig: Release
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        useOfficialAllConfigurations: false
-        buildFullPlatformManifest: false
-      runtimeFlavor: mono
-      platforms:
-      - OSX_x64
-      - Linux_x64
-      - tvOS_x64
-      - tvOS_arm64
-      - iOS_arm
-      - iOS_arm64
-      - iOS_x64
-      - iOS_x86
-      - Android_arm
-      - Android_arm64
-      - Android_x64
-      - Android_x86
-      - Browser_wasm
-
-    #
-    # Installer Build for platforms using Mono
-    #
-  - template: /eng/pipelines/installer/installer-matrix.yml
-    parameters:
-      jobParameters:
-        liveRuntimeBuildConfig: release
-        liveLibrariesBuildConfig: Release
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        useOfficialAllConfigurations: false
-        buildFullPlatformManifest: false
-        runtimeVariant: LLVMJIT
-      runtimeFlavor: mono
-      platforms:
-      - OSX_x64
-      - Linux_x64
-
-  - template: /eng/pipelines/installer/installer-matrix.yml
-    parameters:
-      jobParameters:
-        liveRuntimeBuildConfig: release
-        liveLibrariesBuildConfig: Release
-        isOfficialBuild: ${{ variables.isOfficialBuild }}
-        useOfficialAllConfigurations: false
-        buildFullPlatformManifest: false
-        runtimeVariant: LLVMAOT
-      runtimeFlavor: mono
-      platforms:
-      - OSX_x64
-      - Linux_x64
 
 - ${{ if eq(variables.isOfficialBuild, true) }}:
   - template: /eng/pipelines/official/stages/publish.yml

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -93,7 +93,6 @@ stages:
       # - Windows_NT_arm64
       jobParameters:
         buildArgs: -s mono+libs+installer -c $(_BuildConfig)
-                  /p:OfficialBuildId=$(Build.BuildNumber)
         nameSuffix: AllSubsets_Mono
         isOfficialBuild: ${{ variables.isOfficialBuild }}
         extraStepsTemplate: /eng/pipelines/common/upload-unsigned-artifacts-step.yml
@@ -122,8 +121,7 @@ stages:
         buildConfig: release
         runtimeFlavor: mono
         jobParameters:
-          buildArgs: -s mono+libs+installer -c $(_BuildConfig)
-                      /p:OfficialBuildId=$(Build.BuildNumber) /p:MonoEnableLLVM=true
+          buildArgs: -s mono+libs+installer -c $(_BuildConfig) /p:MonoEnableLLVM=true
           nameSuffix: AllSubsets_Mono_LLVMJIT
           runtimeVariant: LLVMJIT
           isOfficialBuild: ${{ variables.isOfficialBuild }}
@@ -136,7 +134,7 @@ stages:
         runtimeFlavor: mono
         jobParameters:
           buildArgs: -s mono+libs+installer -c $(_BuildConfig)
-                      /p:OfficialBuildId=$(Build.BuildNumber) /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
+                      /p:MonoEnableLLVM=true /p:MonoBundleLLVMOptimizer=true
           nameSuffix: AllSubsets_Mono_LLVMAOT
           runtimeVariant: LLVMAOT
           isOfficialBuild: ${{ variables.isOfficialBuild }}

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <FrameworkPackageName>Microsoft.NETCore.App</FrameworkPackageName>
     <BuildFullPlatformManifest>false</BuildFullPlatformManifest>
+    <!-- Workaround for https://github.com/dotnet/runtime/issues/37503 -->
+    <PermitDllAndExeFilesLackingFileVersion Condition="'$(OS)' == 'Windows_NT' and '$(RuntimeFlavor)' == 'Mono'">true</PermitDllAndExeFilesLackingFileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/pkg/Directory.Build.props
+++ b/src/libraries/pkg/Directory.Build.props
@@ -15,7 +15,7 @@
 
   <!-- Packages opt-in to automatic RID-specific builds by placing a *.RID.props next to their project
        that defines the OfficialBuildRID item: all RIDs targeted by the package -->
-  <Import Project="$(MSBuildProjectDirectory)\*.rids.props" />
+  <Import Project="$(MSBuildProjectDirectory)\*.rids.props" Condition="'$(BuildingAnOfficialBuildLeg)' != 'true' or '$(RuntimeFlavor)' != 'Mono'"/>
 
   <!-- create the "BuildRID" item which is the set of all supported RIDs, with metadata.
        We'll add a RID for the current platform even if it isn't in the officially supported set -->


### PR DESCRIPTION
Collapses the official builds to produce mono runtime packs into single legs. This also adds windows mono runtime pack as we were accidentally not producing it.

This reduces the job count for the build stage from 81 to 53 jobs. 

Test build: https://dev.azure.com/dnceng/internal/_build/results?buildId=674175&view=results
FYI: @mmitche @marek-safar 

