### PR TITLE
Allow individual projects to override LangVersion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -86,6 +86,9 @@
 
   <!-- Language configuration -->
   <PropertyGroup>
+    <!-- default to allowing all language features -->
+    <LangVersion>preview</LangVersion>
+    <LangVersion Condition="'$(MSBuildProjectExtension)' == '.vbproj'">latest</LangVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,11 +20,4 @@
     <NETCoreAppMaximumVersion>$(MajorVersion).$(MinorVersion)</NETCoreAppMaximumVersion>
   </PropertyGroup>
 
-  <!-- Language configuration -->
-  <PropertyGroup>
-    <!-- default to allowing all language features -->
-    <LangVersion>preview</LangVersion>
-    <LangVersion Condition="'$(Language)' == 'VB'">latest</LangVersion>
-  </PropertyGroup>
-
 </Project>

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj
@@ -14,6 +14,7 @@
     <OutputPath>$(BinDir)</OutputPath>
     <Platforms>AnyCPU;x64</Platforms>
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Setting LangVersion in a .targets file makes it hard to override LangVersion in individual projects. Instead, move the default project setting back to the .props file and condition VB based on $(MSBuildProjectExtension), which is available in the .props file.

ILCompiler.Reflection.ReadyToRun needs to set LangVersion to 7.3 so it doesn't break ILSpy.

Fix #37498

cc @stephentoub 