### PR TITLE
WindowsService: Set the event log entry type according to whether it is an error or an information

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -954,7 +954,8 @@ namespace System.ServiceProcess
             {
                 if (AutoLog)
                 {
-                    EventLog.WriteEntry(message);
+                    EventLogEntryType eventLogEntryType = error ? EventLogEntryType.Error : EventLogEntryType.Information;
+                    EventLog.WriteEntry(message, eventLogEntryType);
                 }
             }
             catch

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/ServiceBaseTests.cs
@@ -201,6 +201,21 @@ namespace System.ServiceProcess.Tests
             testService.DeleteTestServices();
         }
 
+        [ConditionalFact(nameof(IsElevatedAndSupportsEventLogs))]
+        public void PropagateExceptionFromOnStartResultsInCorrectEventLogSeverity()
+        {
+            string serviceName = nameof(PropagateExceptionFromOnStartResultsInCorrectEventLogSeverity) + Guid.NewGuid().ToString();
+            var testService = new TestServiceProvider(serviceName);
+            Assert.True(EventLog.SourceExists(serviceName));
+
+            EventLog log = new EventLog(serviceName);
+            EventLogEntryCollection eventLogEntries = log.Entries;
+            Assert.True(eventLogEntries.Count == 1);
+            Assert.True(eventLogEntries[0].EntryType == EventLogEntryType.Error);
+
+            testService.DeleteTestServices();
+        }
+
         private ServiceController ConnectToServer()
         {
             _testService.Client.Connect(connectionTimeout);


### PR DESCRIPTION
Distinguish between an `information` or an `error` when creating an event log entry in `System.ServiceProcess.ServiceBase`

Fix for #37360
