### PR TITLE
Add Math.Tau, MathF.Tau

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -29,6 +29,8 @@ namespace System
 
         public const double PI = 3.14159265358979323846;
 
+        public const double Tau = 6.283185307179586476925;
+
         private const int maxRoundingDigits = 15;
 
         private const double doubleRoundLimit = 1e16d;

--- a/src/libraries/System.Private.CoreLib/src/System/MathF.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MathF.cs
@@ -23,6 +23,8 @@ namespace System
 
         public const float PI = 3.14159265f;
 
+        public const float Tau = 6.283185307f;
+
         private const int maxRoundingDigits = 6;
 
         // This table is required for the Round function which can specify the number of digits to round to

--- a/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Math.cs
@@ -153,6 +153,24 @@ namespace System.Tests
             }
         }
 
+        [Fact]
+        public static void E()
+        {
+            Assert.Equal(unchecked((long)0x4005BF0A8B145769), BitConverter.DoubleToInt64Bits(Math.E));
+        }
+
+        [Fact]
+        public static void Pi()
+        {
+            Assert.Equal(unchecked((long)0x400921FB54442D18), BitConverter.DoubleToInt64Bits(Math.PI));
+        }
+
+        [Fact]
+        public static void Tau()
+        {
+            Assert.Equal(unchecked((long)0x401921FB54442D18), BitConverter.DoubleToInt64Bits(Math.Tau));
+        }
+
         /// <summary>Verifies that two <see cref="float"/> values are equal, within the <paramref name="variance"/>.</summary>
         /// <param name="expected">The expected value</param>
         /// <param name="actual">The value to be compared against</param>

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -179,6 +179,24 @@ namespace System.Tests
             }
         }
 
+        [Fact]
+        public static void E()
+        {
+            Assert.Equal(unchecked((int)0x402DF854), BitConverter.SingleToInt32Bits(MathF.E));
+        }
+
+        [Fact]
+        public static void Pi()
+        {
+            Assert.Equal(unchecked((int)0x40490FDB), BitConverter.SingleToInt32Bits(MathF.PI));
+        }
+
+        [Fact]
+        public static void Tau()
+        {
+            Assert.Equal(unchecked((int)0x401921FB60000000), BitConverter.SingleToInt32Bits(MathF.Tau));
+        }
+
         [Theory]
         [InlineData( float.NegativeInfinity, float.PositiveInfinity, 0.0f)]
         [InlineData(-3.14159265f,            3.14159265f,            CrossPlatformMachineEpsilon * 10)]     // value: -(pi)             expected: (pi)

--- a/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/MathF.cs
@@ -182,19 +182,19 @@ namespace System.Tests
         [Fact]
         public static void E()
         {
-            Assert.Equal(unchecked((int)0x402DF854), BitConverter.SingleToInt32Bits(MathF.E));
+            Assert.Equal(0x402DF854, BitConverter.SingleToInt32Bits(MathF.E));
         }
 
         [Fact]
         public static void Pi()
         {
-            Assert.Equal(unchecked((int)0x40490FDB), BitConverter.SingleToInt32Bits(MathF.PI));
+            Assert.Equal(0x40490FDB, BitConverter.SingleToInt32Bits(MathF.PI));
         }
 
         [Fact]
         public static void Tau()
         {
-            Assert.Equal(unchecked((int)0x401921FB60000000), BitConverter.SingleToInt32Bits(MathF.Tau));
+            Assert.Equal(0x40C90FDB, BitConverter.SingleToInt32Bits(MathF.Tau));
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -2532,6 +2532,7 @@ namespace System
     {
         public const double E = 2.718281828459045;
         public const double PI = 3.141592653589793;
+        public const double Tau = 6.283185307179586;
         public static decimal Abs(decimal value) { throw null; }
         public static double Abs(double value) { throw null; }
         public static short Abs(short value) { throw null; }
@@ -2648,6 +2649,7 @@ namespace System
     {
         public const float E = 2.7182817f;
         public const float PI = 3.1415927f;
+        public const float Tau = 6.2831855f;
         public static float Abs(float x) { throw null; }
         public static float Acos(float x) { throw null; }
         public static float Acosh(float x) { throw null; }


### PR DESCRIPTION
Added `Math.Tau` and `MathF.Tau` constants. Tests for `Math/F.E` and `Math/F.PI` were also introduced to check they are the expected value for consistency 😄 

Fixes #24678