### PR TITLE
CG2 ARM64 composite run

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -22,8 +22,10 @@ jobs:
     buildConfig: checked
     platforms:
     - Linux_x64
+    - Linux_arm64
     - OSX_x64
     - Windows_NT_x64
+    - Windows_NT_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
       testGroup: innerloop
@@ -45,8 +47,10 @@ jobs:
     buildConfig: checked
     platforms:
     - Linux_x64
+    - Linux_arm64
     - OSX_x64
     - Windows_NT_x64
+    - Windows_NT_arm64
     jobParameters:
       testGroup: innerloop
       readyToRun: true

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -710,7 +710,7 @@ namespace ILCompiler.PEWriter
                 sectionAlignment = fileAlignment;
             }
 
-            dllCharacteristics &= ~DllCharacteristics.AppContainer;
+            dllCharacteristics &= DllCharacteristics.AppContainer;
 
             // In Crossgen1, this is under a debug-specific condition 'if (0 == CLRConfig::GetConfigValue(CLRConfig::INTERNAL_NoASLRForNgen))'
             dllCharacteristics |= DllCharacteristics.DynamicBase;

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/R2RPEBuilder.cs
@@ -710,10 +710,13 @@ namespace ILCompiler.PEWriter
                 sectionAlignment = fileAlignment;
             }
 
-            dllCharacteristics &= (DllCharacteristics.NxCompatible | DllCharacteristics.TerminalServerAware | DllCharacteristics.AppContainer);
+            dllCharacteristics &= ~DllCharacteristics.AppContainer;
 
             // In Crossgen1, this is under a debug-specific condition 'if (0 == CLRConfig::GetConfigValue(CLRConfig::INTERNAL_NoASLRForNgen))'
             dllCharacteristics |= DllCharacteristics.DynamicBase;
+
+            // Without NxCompatible the PE executable cannot execute on Windows ARM64
+            dllCharacteristics |= DllCharacteristics.NxCompatible | DllCharacteristics.TerminalServerAware;
 
             if (is64BitTarget)
             {

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/SectionBuilder.cs
@@ -674,7 +674,10 @@ namespace ILCompiler.PEWriter
                 FlushRelocationBlock(builder, baseRVA, offsetsAndTypes);
             }
 
-            _relocationDirectoryEntry = new DirectoryEntry(sectionLocation.RelativeVirtualAddress, builder.Count);
+            if (builder.Count != 0)
+            {
+                _relocationDirectoryEntry = new DirectoryEntry(sectionLocation.RelativeVirtualAddress, builder.Count);
+            }
 
             return builder;
         }


### PR DESCRIPTION
This change introduces Crossgen2 composite ARM64 runs and fixes two issues I found in local debugging (thanks to Anton for granting me access to his ARM64 laptop in Redmond). Apparently the OS loader is somewhat more picky on ARM64 so it complained about the following issues:

1) In the multifolder test I tested this on, we end up copying around some component assemblies with no PE-level relocations. Previously, we ended up emitting a relocation directory entry with a non-zero RVA and zero size. The OS loader is apparently unhappy about this so I added a zero check.

2) For whatever reason the executable needs the NxCompatible flag in the PE header to be set, otherwise the OS loader refuses to load it. I have modified the PEHeaderProvider logic to always inject this flag along with TerminalServerSupport that Roslyn also seems to set on arbitrary MSIL assemblies.

Thanks

Tomas