### PR TITLE
Improve R2RTest compile-serp

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -31,7 +31,6 @@ namespace R2RTest
         public bool Release { get; set; }
         public bool LargeBubble { get; set; }
         public bool Composite { get; set; }
-        public bool PartialComposite { get; set; }
         public int Crossgen2Parallelism { get; set; }
         public int CompilationTimeoutMinutes { get; set; }
         public int ExecutionTimeoutMinutes { get; set; }
@@ -42,6 +41,7 @@ namespace R2RTest
         public DirectoryInfo[] RewriteOldPath { get; set; }
         public DirectoryInfo[] RewriteNewPath { get; set; }
         public DirectoryInfo AspNetPath { get; set; }
+        public SerpCompositeScenario CompositeScenario { get; set; }
         public bool MeasurePerf { get; set; }
         public string InputFileSearchString { get; set; }
         public string ConfigurationSuffix => (Release ? "-ret.out" : "-chk.out");
@@ -117,7 +117,7 @@ namespace R2RTest
                 List<string> cpaotReferencePaths = new List<string>();
                 cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
                 cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new CpaotRunner(this, cpaotReferencePaths));
+                runners.Add(new Crossgen2Runner(this, crossgen2RunnerOptions: null, cpaotReferencePaths));
             }
 
             if (Crossgen)

--- a/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/CommandLineOptions.cs
@@ -144,13 +144,15 @@ namespace R2RTest
                     new Option[]
                     {
                         InputDirectory(),
-                        OutputDirectory(),
                         DegreeOfParallelism(),
                         AspNetPath(),
-                        Composite(),
-                        PartialComposite(),
+                        CompositeScenario()
                     },
-                    CompileSerpCommand.CompileSerpAssemblies);
+                    options => 
+                    {
+                        var compileSerp = new CompileSerpCommand(options);
+                        return compileSerp.CompileSerpAssemblies();
+                    });
 
             // Todo: Input / Output directories should be required arguments to the command when they're made available to handlers
             // https://github.com/dotnet/command-line-api/issues/297
@@ -259,8 +261,8 @@ namespace R2RTest
             Option AspNetPath() =>
                 new Option<DirectoryInfo>(new[] { "--asp-net-path", "-asp" }, "Path to SERP's ASP.NET Core folder").ExistingOnly();
 
-            Option PartialComposite() =>
-                new Option<bool>(new[] { "--partial-composite", "-pc" }, "Add references to framework and asp.net instead of unrooted inputs");
+            Option CompositeScenario() =>
+                new Option<SerpCompositeScenario>(new [] { "--composite-scenario", "-cs" }, "Specifies which layers of a shared framework application are compiled as composite" );
         }
     }
 }

--- a/src/coreclr/src/tools/r2rtest/Commands/CompileSerpCommand.cs
+++ b/src/coreclr/src/tools/r2rtest/Commands/CompileSerpCommand.cs
@@ -12,154 +12,327 @@ using System.Text;
 
 namespace R2RTest
 {
+    public enum SerpCompositeScenario
+    {
+        /// <summary>
+        /// Compiles all Serp, Asp.Net, and Framework assemblies in their own version bubble
+        /// </summary>
+        NoComposite,
+        /// <summary>
+        /// Compiles Serp Core, Asp.Net, and Framework into their own composite images. Compiles Serp packages assemblies individually.
+        /// </summary>
+        SerpAspNetSharedFramework,
+    }
+
     class CompileSerpCommand
     {
-        public static int CompileSerpAssemblies(BuildOptions options)
+        private static readonly string BackupFolder  = "backup";
+        private static readonly string CompileFolder  = "compile";
+
+        private List<string> _packageCompileAssemblies;
+        private List<string> _packageReferenceAssemblies;
+        private List<string> _coreCompileAssemblies = new List<string>();
+        private List<string> _coreReferenceAssemblies = new List<string>();
+        private List<string> _frameworkCompileAssemblies = new List<string>();
+        private List<string> _frameworkReferenceAssemblies = new List<string>();
+        private List<string> _aspCompileAssemblies = new List<string>();
+        private List<string> _aspReferenceAssemblies = new List<string>();
+        private string SerpDir { get; set; }
+        private string BinDir { get;set; }
+        private BuildOptions _options;
+
+        public CompileSerpCommand(BuildOptions options)
         {
-            if (options.InputDirectory == null)
-            {
-                Console.Error.WriteLine("Specify --response-file or --input-directory containing multiple response files.");
-                return 1;
-            }
-
-            if (options.CoreRootDirectory == null)
-            {
-                Console.Error.WriteLine("--core-root-directory (--cr) is a required argument.");
-                return 1;
-            }
-
-
             // This command does not work in the context of an app, just a loose set of rsp files so don't execute anything we compile
             options.NoJit = true;
             options.NoEtw = true;
+            options.Release = true;
 
-            string serpDir = options.InputDirectory.FullName;
-            if (!File.Exists(Path.Combine(serpDir, "runserp.cmd")))
+            _options = options;
+
+            if (_options.InputDirectory == null)
             {
-                Console.Error.WriteLine($"Error: InputDirectory must point at a SERP build. Could not find {Path.Combine(serpDir, "runserp.cmd")}");
-                return 1;
+                throw new ArgumentException("Specify --response-file or --input-directory containing multiple response files.");
             }
 
-            string whiteListFilePath = Path.Combine(serpDir, "WhitelistDlls.txt");
+            if (_options.CoreRootDirectory == null)
+            {
+                throw new ArgumentException("--core-root-directory (--cr) is a required argument.");
+            }
+
+            if (_options.AspNetPath == null || !File.Exists(Path.Combine(_options.AspNetPath.FullName, "Microsoft.AspNetCore.dll")))
+            {
+                throw new ArgumentException($"Error: Asp.NET Core path must contain Microsoft.AspNetCore.dll");
+            }
+            
+            SerpDir = _options.InputDirectory.FullName;
+            BinDir = Path.Combine(SerpDir, "bin");
+
+            if (!File.Exists(Path.Combine(SerpDir, "runserp.cmd")))
+            {
+                throw new ArgumentException($"Error: InputDirectory must point at a SERP build. Could not find {Path.Combine(SerpDir, "runserp.cmd")}");
+            }
+
+            string whiteListFilePath = Path.Combine(SerpDir, "WhitelistDlls.txt");
             if (!File.Exists(whiteListFilePath))
             {
-                Console.Error.WriteLine($"File {whiteListFilePath} was not found");
-                return 1;
-            }
-
-            if (!File.Exists(Path.Combine(options.AspNetPath.FullName, "Microsoft.AspNetCore.dll")))
-            {
-                Console.Error.WriteLine($"Error: Asp.NET Core path must contain Microsoft.AspNetCore.dll");
-                return 1;
-            }
-
-            string binDir = Path.Combine(serpDir, "bin");
-
-            // Remove existing native images
-            foreach (var file in Directory.GetFiles(Path.Combine(serpDir, "App_Data\\Answers\\Services\\Packages"), "*.dll", SearchOption.AllDirectories))
-            {
-                if (file.EndsWith(".ni.dll") || file.EndsWith(".ni.exe"))
-                {
-                    File.Delete(file);
-                }
-            }
-
-            foreach (var file in Directory.GetFiles(binDir, "*.dll", SearchOption.AllDirectories))
-            {
-                if (file.EndsWith(".ni.dll") || file.EndsWith(".ni.exe"))
-                {
-                    File.Delete(file);
-                }
+                throw new ArgumentException($"File {whiteListFilePath} was not found");
             }
 
             // Add all assemblies from the various SERP packages (filtered by ShouldInclude)
-            List<string> binFiles = Directory.GetFiles(Path.Combine(serpDir, "App_Data\\Answers\\Services\\Packages"), "*.dll", SearchOption.AllDirectories)
-                .Where((string x) => ShouldInclude(x))
-                .ToList();
-
-            // Add a whitelist of assemblies from bin
-            foreach (string item in new HashSet<string>(File.ReadAllLines(whiteListFilePath)))
+            _packageCompileAssemblies = Directory.GetFiles(Path.Combine(SerpDir, "App_Data\\Answers\\Services\\Packages"), "*.dll", SearchOption.AllDirectories)
+                    .Where((string x) => ShouldInclude(x))
+                    .ToList();
+            _packageReferenceAssemblies = new List<string>();
             {
-                binFiles.Add(Path.Combine(binDir, item));
-            }
-
-            HashSet<string> referenceAssemblyDirectories = new HashSet<string>();
-            foreach (var binFile in binFiles)
-            {
-                var directory = Path.GetDirectoryName(binFile);
-                if (!referenceAssemblyDirectories.Contains(directory))
-                    referenceAssemblyDirectories.Add(directory);
-            }
-
-            // TestILC needs a list of all directories containing assemblies that are referenced from crossgen
-            List<string> referenceAssemblies = new List<string>();
-            HashSet<string> simpleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            // Reference all managed assemblies in /bin and /App_Data/answers/services/packages
-            foreach (string binFile in ResolveReferences(referenceAssemblyDirectories))
-            {
-                simpleNames.Add(Path.GetFileNameWithoutExtension(binFile));
-                referenceAssemblies.Add(binFile);
-            }
-
-            referenceAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolderNoSimpleNameDuplicates(simpleNames, options.AspNetPath.FullName, "*.dll"));
-
-            // Add CoreRoot last because it contains various non-framework assemblies that are duplicated in SERP and we want SERP's to be used
-            referenceAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolderNoSimpleNameDuplicates(simpleNames, options.CoreRootDirectory.FullName, "System.*.dll"));
-            referenceAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolderNoSimpleNameDuplicates(simpleNames, options.CoreRootDirectory.FullName, "Microsoft.*.dll"));
-            referenceAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "mscorlib.dll"));
-            referenceAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "netstandard.dll"));
-
-            //
-            // binFiles is now all the assemblies that we want to compile (either individually or as composite)
-            // referenceAssemblies is all managed assemblies that are referenceable
-            //
-
-            // Remove all bin files except serp.dll so they're just referenced (eventually we'll be able to compile all these in a single composite)
-            foreach (string item in new HashSet<string>(File.ReadAllLines(whiteListFilePath)))
-            {
-                if (item == "Serp.dll")
-                    continue;
-
-                binFiles.Remove(Path.Combine(binDir, item));
-            }
-
-            List<ProcessInfo> fileCompilations = new List<ProcessInfo>();
-            if (options.Composite)
-            {
-                string serpDll = Path.Combine(binDir, "Serp.dll");
-                var runner = new CpaotRunner(options, referenceAssemblies);
-                var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, Path.ChangeExtension(serpDll, ".ni.dll"), binFiles));
-                fileCompilations.Add(compilationProcess);
-            }
-            else
-            {
-                var runner = new CpaotRunner(options, referenceAssemblies);
-                foreach (string assemblyName in binFiles)
+                HashSet<string> packageReferenceAssemblyDirectories = new HashSet<string>();
+                foreach (var binFile in _packageCompileAssemblies)
                 {
-                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, Path.ChangeExtension(assemblyName, ".ni.dll"), new string[] {assemblyName}));
+                    var directory = Path.GetDirectoryName(binFile);
+                    if (!packageReferenceAssemblyDirectories.Contains(directory))
+                        packageReferenceAssemblyDirectories.Add(directory);
+                }
+
+                foreach (string binFile in ResolveReferences(packageReferenceAssemblyDirectories))
+                {
+                    _packageReferenceAssemblies.Add(binFile);
+                }
+            }
+
+            _coreCompileAssemblies = new List<string>();
+            _coreReferenceAssemblies = new List<string>();
+            {
+                // Add a whitelist of assemblies from bin
+                foreach (string item in new HashSet<string>(File.ReadAllLines(whiteListFilePath)))
+                {
+                    string binAssembly = Path.Combine(BinDir, item);
+                    _coreCompileAssemblies.Add(binAssembly);
+                }
+
+                HashSet<string> coreReferenceAssemblyDirectories = new HashSet<string>();
+                foreach (var binFile in _coreCompileAssemblies)
+                {
+                    var directory = Path.GetDirectoryName(binFile);
+                    if (!coreReferenceAssemblyDirectories.Contains(directory))
+                        coreReferenceAssemblyDirectories.Add(directory);
+                }
+
+                foreach (string binFile in ResolveReferences(coreReferenceAssemblyDirectories))
+                {
+                    _coreReferenceAssemblies.Add(binFile);
+                }
+            }
+
+            _frameworkCompileAssemblies = new List<string>();
+            _frameworkReferenceAssemblies = new List<string>();
+            {
+                foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(options.CoreRootDirectory.FullName, "System.*.dll"))
+                {
+                    string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
+                    if (!FrameworkExclusion.Exclude(simpleName, CompilerIndex.CPAOT, out string reason))
+                    {
+                        _frameworkCompileAssemblies.Add(frameworkDll);
+                    }
+                }
+                foreach (string frameworkDll in ComputeManagedAssemblies.GetManagedAssembliesInFolder(options.CoreRootDirectory.FullName, "Microsoft.*.dll"))
+                {
+                    string simpleName = Path.GetFileNameWithoutExtension(frameworkDll);
+                    if (!FrameworkExclusion.Exclude(simpleName, CompilerIndex.CPAOT, out string reason))
+                    {
+                        _frameworkCompileAssemblies.Add(frameworkDll);
+                    }
+                }
+                _frameworkCompileAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "mscorlib.dll"));
+                _frameworkCompileAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "netstandard.dll"));
+                _frameworkReferenceAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolder(options.CoreRootDirectory.FullName, "System.*.dll"));
+                _frameworkReferenceAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolder(options.CoreRootDirectory.FullName, "Microsoft.*.dll"));
+                _frameworkReferenceAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "mscorlib.dll"));
+                _frameworkReferenceAssemblies.Add(Path.Combine(options.CoreRootDirectory.FullName, "netstandard.dll"));
+            }
+
+            _aspCompileAssemblies = new List<string>();
+            _aspReferenceAssemblies = new List<string>();
+            {
+                _aspCompileAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolder(options.AspNetPath.FullName, "Microsoft.AspNetCore.*.dll"));
+                _aspCompileAssemblies.AddRange(ComputeManagedAssemblies.GetManagedAssembliesInFolder(options.AspNetPath.FullName, "Microsoft.Extensions.*.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "Microsoft.JSInterop.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "Microsoft.Net.Http.Headers.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "Microsoft.Win32.SystemEvents.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.Diagnostics.EventLog.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.Drawing.Common.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.IO.Pipelines.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.Security.Cryptography.Pkcs.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.Security.Cryptography.Xml.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.Security.Permissions.dll"));
+                _aspCompileAssemblies.Add(Path.Combine(options.AspNetPath.FullName, "System.Windows.Extensions.dll"));
+
+                _aspReferenceAssemblies = new List<string>(_aspCompileAssemblies);
+            }
+
+        }
+        public int CompileSerpAssemblies()
+        {
+            Console.WriteLine($"Compiling serp in {_options.CompositeScenario} scenario");
+
+            string serpRoot = Directory.GetParent(SerpDir).Parent.Parent.Parent.FullName;
+            string compileOutRoot = Path.Combine(serpRoot, CompileFolder);
+            if (Directory.Exists(compileOutRoot))
+                Directory.Delete(compileOutRoot, true);
+            
+            // Composite FX, Composite ASP.NET, Composite Serp core, Individual package assemblies
+            List<ProcessInfo> fileCompilations = new List<ProcessInfo>();
+
+            bool compositeFramework = false;
+            bool compositeAspNet = false;
+            bool compositeSerpCore = false;
+            if (_options.CompositeScenario == SerpCompositeScenario.SerpAspNetSharedFramework)
+            {
+                compositeFramework = true;
+                compositeAspNet = true;
+                compositeSerpCore = true;
+            }
+
+            // Composite FX
+            {
+                List<string> frameworkCompileAssembliesBackup = BackupAndUseOriginalAssemblies(serpRoot, _frameworkCompileAssemblies);
+                string frameworkCompositeDll = Path.Combine(_options.CoreRootDirectory.FullName, "framework-r2r.dll");
+                if (File.Exists(frameworkCompositeDll))
+                    File.Delete(frameworkCompositeDll);
+
+                // Always restore the framework from the backup if present first since we run CG2 on it
+                var backupFrameworkDir = Path.GetDirectoryName(GetBackupFile(serpRoot, frameworkCompositeDll));
+                var backedUpFiles = Directory.GetFiles(backupFrameworkDir, "*.dll", SearchOption.AllDirectories);
+                foreach (var file in backedUpFiles)
+                {
+                    string destinationFile = GetOriginalFile(serpRoot, file);
+                    File.Copy(file, destinationFile, true);
+                }
+
+                if (compositeFramework)
+                {
+                    string frameworkCompositeDllCompile = GetCompileFile(serpRoot, frameworkCompositeDll);
+                    Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = true };
+                    var runner = new Crossgen2Runner(_options, crossgen2Options, new List<string>());
+                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, frameworkCompositeDllCompile, frameworkCompileAssembliesBackup));
+                    fileCompilations.Add(compilationProcess);
+                }
+                else
+                {
+                    Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = false };
+                    var runner = new Crossgen2Runner(_options, crossgen2Options, new List<string>());
+                    foreach (string assembly in frameworkCompileAssembliesBackup)
+                    {
+                        string dllCompile = GetCompileFile(serpRoot, assembly);
+                        var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, dllCompile, new string[] { assembly }));
+                        fileCompilations.Add(compilationProcess);
+                    }
+                }
+            }
+
+            // Composite Asp.Net
+            {
+                List<string> aspCombinedReferencesBackup = BackupAndUseOriginalAssemblies(serpRoot, new List<string>(_frameworkReferenceAssemblies));
+                List<string> aspCompileAssembliesBackup = BackupAndUseOriginalAssemblies(serpRoot, _aspCompileAssemblies);
+                string aspCompositeDll = Path.Combine(_options.AspNetPath.FullName, "asp-r2r.dll");
+                if (File.Exists(aspCompositeDll))
+                    File.Delete(aspCompositeDll);
+
+                if (compositeAspNet)
+                {
+                    string aspCompositeDllCompile = GetCompileFile(serpRoot, aspCompositeDll);
+                    Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = true, PartialComposite = true };
+                    var runner = new Crossgen2Runner(_options, crossgen2Options, aspCombinedReferencesBackup);
+                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, aspCompositeDllCompile, aspCompileAssembliesBackup));
+                    fileCompilations.Add(compilationProcess);
+                }
+                else
+                {
+                    Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = false };
+                    var runner = new Crossgen2Runner(_options, crossgen2Options, aspCombinedReferencesBackup);
+                    foreach (string assembly in aspCompileAssembliesBackup)
+                    {
+                        string dllCompile = GetCompileFile(serpRoot, assembly);
+                        var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, dllCompile, new string[] { assembly }));
+                        fileCompilations.Add(compilationProcess);
+                    }
+                }
+            }
+
+            // Composite Serp core
+            {
+                List<string> coreCombinedReferences = new List<string>();
+                coreCombinedReferences.AddRange(_coreReferenceAssemblies);
+                coreCombinedReferences.AddRange(_aspReferenceAssemblies);
+                coreCombinedReferences.AddRange(_frameworkReferenceAssemblies);
+                List<string> coreCombinedReferencesBackup = BackupAndUseOriginalAssemblies(serpRoot, coreCombinedReferences);
+                List<string> coreCompileAssembliesBackup = BackupAndUseOriginalAssemblies(serpRoot, _coreCompileAssemblies);
+                string serpCompositeDll = Path.Combine(BinDir, "serp-r2r.dll");
+                if (File.Exists(serpCompositeDll))
+                    File.Delete(serpCompositeDll);
+
+                if (compositeSerpCore)
+                {
+                    string coreCompositeDllCompile = GetCompileFile(serpRoot, serpCompositeDll);
+                    Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = true, PartialComposite = true };
+                    var runner = new Crossgen2Runner(_options, crossgen2Options, coreCombinedReferencesBackup);
+                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, coreCompositeDllCompile, coreCompileAssembliesBackup));
+                    fileCompilations.Add(compilationProcess);
+                }
+                else
+                {
+                    Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = false };
+                    var runner = new Crossgen2Runner(_options, crossgen2Options, coreCombinedReferencesBackup);
+                    foreach (string assembly in coreCompileAssembliesBackup)
+                    {
+                        string dllCompile = GetCompileFile(serpRoot, assembly);
+                        var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, dllCompile, new string[] { assembly }));
+                        fileCompilations.Add(compilationProcess);
+                    }
+                }
+            }
+
+            // Individual Serp package assemblies
+            {
+                List<string> packageCombinedReferences = new List<string>();
+                packageCombinedReferences.AddRange(_packageReferenceAssemblies);
+                packageCombinedReferences.AddRange(_coreReferenceAssemblies);
+                packageCombinedReferences.AddRange(_aspReferenceAssemblies);
+                packageCombinedReferences.AddRange(_frameworkReferenceAssemblies);
+                List<string> packageCombinedReferencesBackup = BackupAndUseOriginalAssemblies(serpRoot, packageCombinedReferences);
+                List<string> packageCompileAssembliesBackup = BackupAndUseOriginalAssemblies(serpRoot, _packageCompileAssemblies);
+
+                Crossgen2RunnerOptions crossgen2Options = new Crossgen2RunnerOptions() { Composite = false };
+                var runner = new Crossgen2Runner(_options, crossgen2Options, packageCombinedReferencesBackup);
+                foreach (string assembly in packageCompileAssembliesBackup)
+                {
+                    string dllCompile = GetCompileFile(serpRoot, assembly);
+                    var compilationProcess = new ProcessInfo(new CompilationProcessConstructor(runner, dllCompile, new string[] { assembly }));
                     fileCompilations.Add(compilationProcess);
                 }
             }
-            
-            ParallelRunner.Run(fileCompilations, options.DegreeOfParallelism);
+
+            ParallelRunner.Run(fileCompilations, _options.DegreeOfParallelism);
             
             bool success = true;
-            int compilationFailures = 0;
             foreach (var compilationProcess in fileCompilations)
             {
                 if (!compilationProcess.Succeeded)
                 {
                     success = false;
-                    compilationFailures++;
-
                     Console.WriteLine($"Failed compiling {compilationProcess.Parameters.OutputFileName}");
                 }
             }
 
-            Console.WriteLine("Serp Compilation Results");
-            Console.WriteLine($"Total compilations: {fileCompilations.Count}");
-            Console.WriteLine($"Compilation failures: {compilationFailures}");
+            if (!success)
+                return 1;
+
+            // Move everything we compiled to the main directory structure
+            var compiledFiles = Directory.GetFiles(Path.Combine(serpRoot, CompileFolder), "*.dll", SearchOption.AllDirectories);
+            foreach (var file in compiledFiles)
+            {
+                string destinationFile = GetOriginalFile(serpRoot, file);
+                File.Move(file, destinationFile, true);
+            }
 
             return success ? 0 : 1;
         }
@@ -168,15 +341,18 @@ namespace R2RTest
         {
             if (!string.IsNullOrEmpty(file))
             {
-                if (file.EndsWith(".ni.dll", StringComparison.OrdinalIgnoreCase) || file.EndsWith(".ni.exe", StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
                 if (file.EndsWith("Shared.Exports.dll", StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }
                 if (file.EndsWith(".parallax.dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+                // These assemblies regressed single assembly CG2 compilation
+                if (file.EndsWith(".FitnessRoutine.dll") ||
+                    file.EndsWith(".Intent.dll") ||
+                    file.EndsWith(".VisualSystem.dll"))
                 {
                     return false;
                 }
@@ -194,11 +370,73 @@ namespace R2RTest
             {
                 foreach (string reference in ComputeManagedAssemblies.GetManagedAssembliesInFolder(referenceFolder))
                 {
-                    if (reference.EndsWith(".ni.dll"))
-                        continue;
                     yield return reference;
                 }
             }
+        }
+
+        /// <summary>
+        /// Backs up the assemblies to a separate folder tree and replaces each file with the original reference
+        /// in the output list. This keeps the Serp folder clean of junk.
+        /// </summary>
+        private static List<string> BackupAndUseOriginalAssemblies(string rootFolder, List<string> assemblies)
+        {
+            List<string> rewrittenList = new List<string>();
+
+            foreach (var assembly in assemblies)
+            {
+                rewrittenList.Add(BackupAndUseOriginalAssembly(rootFolder, assembly));
+            }
+
+            return rewrittenList;
+        }
+
+        private static string BackupAndUseOriginalAssembly(string rootFolder, string assembly)
+        {
+            string backupFile = GetBackupFile(rootFolder, assembly);
+            string backupDir = Path.GetDirectoryName(backupFile);
+
+            if (!Directory.Exists(backupDir))
+                Directory.CreateDirectory(backupDir);
+
+            if (!File.Exists(backupFile))
+            {
+                File.Copy(assembly, backupFile);
+            }
+
+            return backupFile;
+        }
+
+        private static string GetBackupFile(string rootFolder, string assembly)
+        {
+            string relativePath = GetOriginalFileRelativePath(rootFolder, assembly);
+            return Path.Combine(rootFolder, BackupFolder, relativePath);
+        }
+
+        private static string GetCompileFile(string rootFolder, string assembly)
+        {
+            string relativePath = GetOriginalFileRelativePath(rootFolder, assembly);
+            return Path.Combine(rootFolder, CompileFolder, relativePath);
+        }
+
+        private static string GetOriginalFile(string rootFolder, string assembly)
+        {
+            string relativePath = GetOriginalFileRelativePath(rootFolder, assembly);
+            return Path.Combine(rootFolder, relativePath);
+        }
+
+        private static string GetOriginalFileRelativePath(string rootFolder, string assembly)
+        {
+            string relativePath = Path.GetRelativePath(rootFolder, assembly);
+            if (relativePath.StartsWith(CompileFolder))
+            {
+                relativePath = Path.GetRelativePath(Path.Combine(rootFolder, CompileFolder), assembly);
+            }
+            else if (relativePath.StartsWith(BackupFolder))
+            {
+                relativePath = Path.GetRelativePath(Path.Combine(rootFolder, BackupFolder), assembly);
+            }
+            return relativePath;
         }
     }
 }


### PR DESCRIPTION
* Improve the robustness and idempotence of compile-serp by backing up all MSIL assemblies that are compiled / referenced. Use those backups during compilations.
* Add `--composite-scenario` switch which currently supports two modes: each assembly is compiled separately, and another where the shared framework, Asp.Net, and Serp core each get a composite image.
* Added new `Crossgen2RunnerOptions` config class we can pass per-compile settings instead of relying on the process-wide `BuildOptions` object. This is needed to allow a single parallel batch of compilations where some are composite images and some are not.