### PR TITLE
Added Json string to bool (and vice-versa) converter

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -117,6 +117,7 @@
     <Compile Include="System\Text\Json\Serialization\Converters\Value\ObjectConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\SByteConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\SingleConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Value\StringBooleanConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\StringConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\TypeConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Value\UInt16Converter.cs" />
@@ -156,6 +157,7 @@
     <Compile Include="System\Text\Json\Serialization\JsonSerializerDefaults.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.Converters.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonSerializerOptions.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonStringBooleanConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonStringEnumConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\MemberAccessor.cs" />
     <Compile Include="System\Text\Json\Serialization\MetadataPropertyName.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringBooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringBooleanConverter.cs
@@ -1,0 +1,34 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal sealed class StringBooleanConverter : JsonConverter<bool>
+    {
+        private readonly bool _convertBooleanToString;
+
+        public StringBooleanConverter(bool convertBooleanToString)
+        {
+            _convertBooleanToString = convertBooleanToString;
+        }
+
+        public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var incomingValue = reader.GetString();
+            if (incomingValue.ToLowerInvariant() == bool.TrueString.ToLowerInvariant())
+                return true;
+            if (incomingValue.ToLowerInvariant() == bool.FalseString.ToLowerInvariant())
+                return false;
+            throw new JsonException("The string value could not be converted to System.Boolean");
+        }
+
+        public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+        {
+            if (_convertBooleanToString)
+                writer.WriteStringValue(value.ToString());
+            else
+                writer.WriteBooleanValue(value);
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringBooleanConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonStringBooleanConverter.cs
@@ -1,0 +1,50 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Reflection;
+using System.Text.Json.Serialization.Converters;
+
+namespace System.Text.Json.System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Converter to convert boolean to and from strings.
+    /// </summary>
+    public sealed class JsonStringBooleanConverter : JsonConverterFactory
+    {
+        private readonly bool _convertBooleanToString;
+
+        /// <summary>
+        /// Constructor. Creates the <see cref="JsonStringEnumConverter"/>
+        /// </summary>
+        /// <param name="convertBooleanToString">Flag to allow boolean to be written into string</param>
+        public JsonStringBooleanConverter(bool convertBooleanToString)
+        {
+            _convertBooleanToString = convertBooleanToString;
+        }
+
+        /// <summary>
+        /// Constructor. Creates the <see cref="JsonStringEnumConverter"/> allowing boolean to be written into string
+        /// </summary>
+        public JsonStringBooleanConverter() : this(true) { }
+
+        /// <inheritdoc />
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(bool);
+        }
+
+        /// <inheritdoc />
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            JsonConverter converter = (JsonConverter)Activator.CreateInstance(
+                typeof(StringBooleanConverter),
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                new object[] { _convertBooleanToString },
+                culture: null)!;
+
+            return converter;
+        }
+    }
+}


### PR DESCRIPTION
Added a converter to convert string to boolean during deserialization.
`var options = new JsonSerializerOptions(); 
options.Add(new JsonStringBooleanConverter(convertBooleanToString: false));`