### PR TITLE
Simplify calendar construction for Invariant mode

### DIFF
--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -637,6 +637,18 @@ namespace System.Globalization.Tests
             Assert.True(cultureName.Equals(ci.CompareInfo.Name, StringComparison.OrdinalIgnoreCase));
         }
 
+        [Theory]
+        [MemberData(nameof(Cultures_TestData))]
+        public void SetCultureData(string cultureName)
+        {
+            CultureInfo ci = new CultureInfo(cultureName);
+
+            //
+            // DateTimeInfo
+            //
+            Assert.Throws<InvalidOperationException>(() => ci.DateTimeFormat.Calendar = new GregorianCalendar());
+        }
+
         [Fact]
         public void TestEnum()
         {

--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -646,7 +646,11 @@ namespace System.Globalization.Tests
             //
             // DateTimeInfo
             //
-            Assert.Throws<InvalidOperationException>(() => ci.DateTimeFormat.Calendar = new GregorianCalendar());
+            var calendar = new GregorianCalendar();
+            ci.DateTimeFormat.Calendar = calendar;
+            Assert.Equal(calendar, ci.DateTimeFormat.Calendar);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => ci.DateTimeFormat.Calendar = new TaiwanCalendar());
         }
 
         [Fact]

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Calendar.cs
@@ -123,7 +123,7 @@ namespace System.Globalization
                 if (_currentEraValue == -1)
                 {
                     Debug.Assert(BaseCalendarID != CalendarId.UNINITIALIZED_VALUE, "[Calendar.CurrentEraValue] Expected a real calendar ID");
-                    _currentEraValue = CalendarData.GetCalendarData(BaseCalendarID).iCurrentEra;
+                    _currentEraValue = CalendarData.GetCalendarCurrentEra(this);
                 }
 
                 return _currentEraValue;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.cs
@@ -324,6 +324,11 @@ namespace System.Globalization
 
         internal static CalendarData GetCalendarData(CalendarId calendarId)
         {
+            if (GlobalizationMode.Invariant)
+            {
+                return CalendarData.Invariant;
+            }
+
             //
             // Get a calendar.
             // Unfortunately we depend on the locale in the OS, so we need a locale

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.cs
@@ -42,7 +42,7 @@ namespace System.Globalization
 
         // Integers at end to make marshaller happier
         internal int iTwoDigitYearMax = 2029; // Max 2 digit year (for Y2K bug data entry)
-        internal int iCurrentEra = 0;  // current era # (usually 1)
+        private int iCurrentEra = 0;  // current era # (usually 1)
 
         // Use overrides?
         internal bool bUseUserOverrides; // True if we want user overrides.
@@ -322,11 +322,11 @@ namespace System.Globalization
             }
         }
 
-        internal static CalendarData GetCalendarData(CalendarId calendarId)
+        internal static int GetCalendarCurrentEra(Calendar calendar)
         {
             if (GlobalizationMode.Invariant)
             {
-                return CalendarData.Invariant;
+                return CalendarData.Invariant.iCurrentEra;
             }
 
             //
@@ -338,10 +338,11 @@ namespace System.Globalization
 
             // Get a culture name
             // TODO: Note that this doesn't handle the new calendars (lunisolar, etc)
+            CalendarId calendarId = calendar.BaseCalendarID;
             string culture = CalendarIdToCultureName(calendarId);
 
             // Return our calendar
-            return CultureInfo.GetCultureInfo(culture)._cultureData.GetCalendar(calendarId);
+            return CultureInfo.GetCultureInfo(culture)._cultureData.GetCalendar(calendarId).iCurrentEra;
         }
 
         private static string CalendarIdToCultureName(CalendarId calendarId)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -626,11 +626,11 @@ namespace System.Globalization
             invariant._iFirstDayOfWeek = 0;                      // first day of week
             invariant._iFirstWeekOfYear = 0;                      // first week of year
 
+            // all available calendar type(s).  The first one is the default calendar
+            invariant._waCalendars = new CalendarId[] { CalendarId.GREGORIAN };
+
             if (!GlobalizationMode.Invariant)
             {
-                // all available calendar type(s).  The first one is the default calendar
-                invariant._waCalendars = new CalendarId[] { CalendarId.GREGORIAN };
-
                 // Store for specific data about each calendar
                 invariant._calendars = new CalendarData[CalendarData.MAX_CALENDARS];
                 invariant._calendars[0] = CalendarData.Invariant;
@@ -1671,7 +1671,7 @@ namespace System.Globalization
         {
             get
             {
-                if (_waCalendars == null)
+                if (_waCalendars == null && !GlobalizationMode.Invariant)
                 {
                     // We pass in an array of ints, and native side fills it up with count calendars.
                     // We then have to copy that list to a new array of the right size.
@@ -1739,7 +1739,7 @@ namespace System.Globalization
                     }
                 }
 
-                return _waCalendars;
+                return _waCalendars!;
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -625,7 +625,16 @@ namespace System.Globalization
             // Calendar specific data
             invariant._iFirstDayOfWeek = 0;                      // first day of week
             invariant._iFirstWeekOfYear = 0;                      // first week of year
-            invariant._waCalendars = new CalendarId[] { CalendarId.GREGORIAN };       // all available calendar type(s).  The first one is the default calendar
+
+            if (!GlobalizationMode.Invariant)
+            {
+                // all available calendar type(s).  The first one is the default calendar
+                invariant._waCalendars = new CalendarId[] { CalendarId.GREGORIAN };
+
+                // Store for specific data about each calendar
+                invariant._calendars = new CalendarData[CalendarData.MAX_CALENDARS];
+                invariant._calendars[0] = CalendarData.Invariant;
+            }
 
             // Text information
             invariant._iReadingLayout = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -627,10 +627,6 @@ namespace System.Globalization
             invariant._iFirstWeekOfYear = 0;                      // first week of year
             invariant._waCalendars = new CalendarId[] { CalendarId.GREGORIAN };       // all available calendar type(s).  The first one is the default calendar
 
-            // Store for specific data about each calendar
-            invariant._calendars = new CalendarData[CalendarData.MAX_CALENDARS];
-            invariant._calendars[0] = CalendarData.Invariant;
-
             // Text information
             invariant._iReadingLayout = 0;
 
@@ -1749,6 +1745,11 @@ namespace System.Globalization
 
         internal CalendarData GetCalendar(CalendarId calendarId)
         {
+            if (GlobalizationMode.Invariant)
+            {
+                return CalendarData.Invariant;
+            }
+
             Debug.Assert(calendarId > 0 && calendarId <= CalendarId.LAST_CALENDAR,
                 "[CultureData.GetCalendar] Expect calendarId to be in a valid range");
 
@@ -1927,7 +1928,7 @@ namespace System.Globalization
             {
                 if (GlobalizationMode.Invariant)
                 {
-                    return CultureInfo.GetCalendarInstance(CalendarIds[0]);
+                    return new GregorianCalendar();
                 }
 
                 CalendarId defaultCalId = (CalendarId)GetLocaleInfoCore(LocaleNumberData.CalendarType);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -727,9 +727,19 @@ namespace System.Globalization
             {
                 if (_dateTimeInfo == null)
                 {
-                    // Change the calendar of DTFI to the specified calendar of this CultureInfo.
-                    DateTimeFormatInfo temp = new DateTimeFormatInfo(_cultureData, this.Calendar);
-                    temp._isReadOnly = _isReadOnly;
+                    DateTimeFormatInfo temp;
+                    if (GlobalizationMode.Invariant)
+                    {
+                        temp = DateTimeFormatInfo.InvariantInfo;
+                    }
+                    else
+                    {
+                        // Change the calendar of DTFI to the specified calendar of this CultureInfo.
+                        temp = new DateTimeFormatInfo(_cultureData, this.Calendar)
+                        {
+                            _isReadOnly = _isReadOnly
+                        };
+                    }
                     Interlocked.CompareExchange(ref _dateTimeInfo, temp, null);
                 }
                 return _dateTimeInfo!;
@@ -775,6 +785,8 @@ namespace System.Globalization
         /// </remarks>
         internal static Calendar GetCalendarInstance(CalendarId calType)
         {
+            Debug.Assert(!GlobalizationMode.Invariant);
+
             if (calType == CalendarId.GREGORIAN)
             {
                 return new GregorianCalendar();
@@ -829,7 +841,6 @@ namespace System.Globalization
             {
                 if (_calendar == null)
                 {
-                    Debug.Assert(_cultureData.CalendarIds.Length > 0, "_cultureData.CalendarIds.Length > 0");
                     // Get the default calendar for this culture.  Note that the value can be
                     // from registry if this is a user default culture.
                     Calendar newObj = _cultureData.DefaultCalendar;
@@ -850,6 +861,11 @@ namespace System.Globalization
             get
             {
                 // This property always returns a new copy of the calendar array.
+                if (GlobalizationMode.Invariant)
+                {
+                    return new[] { new GregorianCalendar() };
+                }
+
                 CalendarId[] calID = _cultureData.CalendarIds;
                 Calendar[] cals = new Calendar[calID.Length];
                 for (int i = 0; i < cals.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -727,19 +727,9 @@ namespace System.Globalization
             {
                 if (_dateTimeInfo == null)
                 {
-                    DateTimeFormatInfo temp;
-                    if (GlobalizationMode.Invariant)
-                    {
-                        temp = DateTimeFormatInfo.InvariantInfo;
-                    }
-                    else
-                    {
-                        // Change the calendar of DTFI to the specified calendar of this CultureInfo.
-                        temp = new DateTimeFormatInfo(_cultureData, this.Calendar)
-                        {
-                            _isReadOnly = _isReadOnly
-                        };
-                    }
+                    // Change the calendar of DTFI to the specified calendar of this CultureInfo.
+                    DateTimeFormatInfo temp = new DateTimeFormatInfo(_cultureData, this.Calendar);
+                    temp._isReadOnly = _isReadOnly;
                     Interlocked.CompareExchange(ref _dateTimeInfo, temp, null);
                 }
                 return _dateTimeInfo!;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -243,8 +243,8 @@ namespace System.Globalization
 
             // Remember our culture
             _cultureData = cultureData;
-
-            Calendar = cal;
+            calendar = cal;
+            InitializeOverridableProperties(cultureData, calendar.ID);
         }
 
         private void InitializeOverridableProperties(CultureData cultureData, CalendarId calendarId)
@@ -409,9 +409,7 @@ namespace System.Globalization
 
                 if (GlobalizationMode.Invariant)
                 {
-                    if (value.ID == calendar?.ID)
-                        return;
-
+                    Debug.Assert(calendar != null, "DateTimeFormatInfo.Calendar: calendar != null");
                     throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -407,17 +407,6 @@ namespace System.Globalization
                     return;
                 }
 
-                if (GlobalizationMode.Invariant)
-                {
-                    if (value.ID == CalendarId.GREGORIAN)
-                    {
-                        calendar = value;
-                        return;
-                    }
-
-                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);
-                }
-
                 for (int i = 0; i < OptionalCalendars.Length; i++)
                 {
                     if (OptionalCalendars[i] == value.ID)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -393,9 +393,8 @@ namespace System.Globalization
             [MemberNotNull(nameof(calendar))]
             set
             {
-                if (IsReadOnly || GlobalizationMode.Invariant)
+                if (IsReadOnly)
                 {
-                    Debug.Assert(IsReadOnly, "Invariant Calendar is always readonly");
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 }
                 if (value == null)
@@ -406,6 +405,17 @@ namespace System.Globalization
                 if (value == calendar)
                 {
                     return;
+                }
+
+                if (GlobalizationMode.Invariant)
+                {
+                    if (value.ID == CalendarId.GREGORIAN)
+                    {
+                        calendar = value;
+                        return;
+                    }
+
+                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);
                 }
 
                 for (int i = 0; i < OptionalCalendars.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -409,7 +409,7 @@ namespace System.Globalization
 
                 if (GlobalizationMode.Invariant)
                 {
-                    if (value.ID == calendar.ID)
+                    if (value.ID == calendar?.ID)
                         return;
 
                     throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -409,7 +409,7 @@ namespace System.Globalization
 
                 if (GlobalizationMode.Invariant)
                 {
-                    Debug.Assert(calendar != null, "DateTimeFormatInfo.Calendar: calendar != null");
+                    Debug.Fail("Invariant Calendar is always readonly");
                     throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -393,8 +393,9 @@ namespace System.Globalization
             [MemberNotNull(nameof(calendar))]
             set
             {
-                if (IsReadOnly)
+                if (IsReadOnly || GlobalizationMode.Invariant)
                 {
+                    Debug.Assert(IsReadOnly, "Invariant Calendar is always readonly");
                     throw new InvalidOperationException(SR.InvalidOperation_ReadOnly);
                 }
                 if (value == null)
@@ -405,12 +406,6 @@ namespace System.Globalization
                 if (value == calendar)
                 {
                     return;
-                }
-
-                if (GlobalizationMode.Invariant)
-                {
-                    Debug.Fail("Invariant Calendar is always readonly");
-                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);
                 }
 
                 for (int i = 0; i < OptionalCalendars.Length; i++)

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormatInfo.cs
@@ -407,6 +407,14 @@ namespace System.Globalization
                     return;
                 }
 
+                if (GlobalizationMode.Invariant)
+                {
+                    if (value.ID == calendar.ID)
+                        return;
+
+                    throw new ArgumentOutOfRangeException(nameof(value), value, SR.Argument_InvalidCalendar);
+                }
+
                 for (int i = 0; i < OptionalCalendars.Length; i++)
                 {
                     if (OptionalCalendars[i] == value.ID)


### PR DESCRIPTION
Allows illinker to save more in invariant globalization mode

Not very accurate data for browser-wasm hello world as they will change as we progress on size trimming
|Mode  | SPC Size |
|-|-|
|Default| 1449KB | 
|Invariant| 1396KB | 
