### PR TITLE
Support the Encoding enumeration in the Encoding Providers

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -291,9 +291,8 @@ namespace System.Text
                 GetEncoding(EncodingTable.GetCodePageFromName(name), encoderFallback, decoderFallback);
         }
 
-        // Return a list of all EncodingInfo objects describing all of our encodings
         /// <summary>
-        /// Get the <see cref="EncodingProvider"/> list from the runtime and all registered encoding providers
+        /// Get the <see cref="EncodingInfo"/> list from the runtime and all registered encoding providers
         /// </summary>
         /// <returns>The list of the <see cref="EncodingProvider"/> objects</returns>
         public static EncodingInfo[] GetEncodings()

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -291,7 +292,15 @@ namespace System.Text
         }
 
         // Return a list of all EncodingInfo objects describing all of our encodings
-        public static EncodingInfo[] GetEncodings() => EncodingTable.GetEncodings();
+        /// <summary>
+        /// Get the <see cref="EncodingProvider"/> list from the runtime and all registered encoding providers
+        /// </summary>
+        /// <returns>The list of the <see cref="EncodingProvider"/> objects</returns>
+        public static EncodingInfo[] GetEncodings()
+        {
+            Dictionary<int, EncodingInfo>? result = EncodingProvider.GetEncodingListFromProviders();
+            return result == null ? EncodingTable.GetEncodings() : EncodingTable.GetEncodings(result);
+        }
 
         public virtual byte[] GetPreamble() => Array.Empty<byte>();
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingInfo.cs
@@ -53,17 +53,7 @@ namespace System.Text
         /// Get the <see cref="Encoding"/> object match the information in the <see cref="EncodingInfo"/> object
         /// </summary>
         /// <returns>The <see cref="Encoding"/> object</returns>
-        public Encoding GetEncoding()
-        {
-            Encoding? encoding = null;
-
-            if (Provider != null)
-            {
-                encoding = Provider.GetEncoding(CodePage);
-            }
-
-            return encoding ?? Encoding.GetEncoding(CodePage);
-        }
+        public Encoding GetEncoding() => Provider?.GetEncoding(CodePage) ?? Encoding.GetEncoding(CodePage);
 
         /// <summary>
         /// Compare this <see cref="EncodingInfo"/> object to other object.
@@ -88,6 +78,6 @@ namespace System.Text
             return CodePage;
         }
 
-        internal EncodingProvider? Provider {get;}
+        internal EncodingProvider? Provider { get; }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingInfo.cs
@@ -59,20 +59,13 @@ namespace System.Text
         /// Compare this <see cref="EncodingInfo"/> object to other object.
         /// </summary>
         /// <param name="value">The other object to compare with this object</param>
-        /// <returns>True if the value object is EncodingInfo object and has a codepage equals to this EncodingInfo object codepage. Othewise, it returns False</returns>
-        public override bool Equals(object? value)
-        {
-            if (value is EncodingInfo that)
-            {
-                return CodePage == that.CodePage;
-            }
-            return false;
-        }
+        /// <returns>True if the value object is EncodingInfo object and has a codepage equals to this EncodingInfo object codepage. Otherwise, it returns False</returns>
+        public override bool Equals(object? value) => value is EncodingInfo that && CodePage == that.CodePage;
 
         /// <summary>
-        /// Get a hashcode represent the current EncodingInfo object
+        /// Get a hashcode representing the current EncodingInfo object.
         /// </summary>
-        /// <returns>The integer value represent the hash code of the EncodingInfo object. The hashcode is basically the encoding codepage value</returns>
+        /// <returns>The integer value representing the hash code of the EncodingInfo object.</returns>
         public override int GetHashCode()
         {
             return CodePage;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingInfo.cs
@@ -6,6 +6,24 @@ namespace System.Text
 {
     public sealed class EncodingInfo
     {
+        /// <summary>
+        /// Construct an <see cref="EncodingInfo"/> object.
+        /// </summary>
+        /// <param name="provider">The <see cref="EncodingProvider"/> object which created this <see cref="EncodingInfo"/> object</param>
+        /// <param name="codePage">The encoding codepage</param>
+        /// <param name="name">The encoding name</param>
+        /// <param name="displayName">The encoding display name</param>
+        /// <returns></returns>
+        public EncodingInfo(EncodingProvider provider, int codePage, string name, string displayName) : this(codePage, name, displayName)
+        {
+            if (name == null || displayName == null || provider == null)
+            {
+                throw new ArgumentNullException(name == null ? nameof(name) : (displayName == null ? nameof(displayName) : nameof(provider)));
+            }
+
+            Provider = provider;
+        }
+
         internal EncodingInfo(int codePage, string name, string displayName)
         {
             CodePage = codePage;
@@ -13,27 +31,63 @@ namespace System.Text
             DisplayName = displayName;
         }
 
+        /// <summary>
+        /// Get the encoding codepage number
+        /// </summary>
+        /// <value>The codepage integer number</value>
         public int CodePage { get; }
+
+        /// <summary>
+        /// Get the encoding name
+        /// </summary>
+        /// <value>The encoding name string</value>
         public string Name { get; }
+
+        /// <summary>
+        /// Get the encoding display name
+        /// </summary>
+        /// <value>The encoding display name string</value>
         public string DisplayName { get; }
 
+        /// <summary>
+        /// Get the <see cref="Encoding"/> object match the information in the <see cref="EncodingInfo"/> object
+        /// </summary>
+        /// <returns>The <see cref="Encoding"/> object</returns>
         public Encoding GetEncoding()
         {
-            return Encoding.GetEncoding(CodePage);
+            Encoding? encoding = null;
+
+            if (Provider != null)
+            {
+                encoding = Provider.GetEncoding(CodePage);
+            }
+
+            return encoding ?? Encoding.GetEncoding(CodePage);
         }
 
+        /// <summary>
+        /// Compare this <see cref="EncodingInfo"/> object to other object.
+        /// </summary>
+        /// <param name="value">The other object to compare with this object</param>
+        /// <returns>True if the value object is EncodingInfo object and has a codepage equals to this EncodingInfo object codepage. Othewise, it returns False</returns>
         public override bool Equals(object? value)
         {
             if (value is EncodingInfo that)
             {
-                return this.CodePage == that.CodePage;
+                return CodePage == that.CodePage;
             }
             return false;
         }
 
+        /// <summary>
+        /// Get a hashcode represent the current EncodingInfo object
+        /// </summary>
+        /// <returns>The integer value represent the hash code of the EncodingInfo object. The hashcode is basically the encoding codepage value</returns>
         public override int GetHashCode()
         {
             return CodePage;
         }
+
+        internal EncodingProvider? Provider {get;}
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingProvider.cs
@@ -68,10 +68,10 @@ namespace System.Text
 
         internal static Encoding? GetEncodingFromProvider(int codepage)
         {
-            if (s_providers == null)
+            EncodingProvider[]? providers = s_providers;
+            if (providers == null)
                 return null;
 
-            EncodingProvider[] providers = s_providers;
             foreach (EncodingProvider provider in providers)
             {
                 Encoding? enc = provider.GetEncoding(codepage);
@@ -84,10 +84,10 @@ namespace System.Text
 
         internal static Dictionary<int, EncodingInfo>? GetEncodingListFromProviders()
         {
-            if (s_providers == null)
+            EncodingProvider[]? providers = s_providers;
+            if (providers == null)
                 return null;
 
-            EncodingProvider[] providers = s_providers;
             Dictionary<int, EncodingInfo> result = new Dictionary<int, EncodingInfo>();
 
             foreach (EncodingProvider provider in providers)
@@ -97,10 +97,7 @@ namespace System.Text
                 {
                     foreach (EncodingInfo ei in encodingInfoList)
                     {
-                        if (!result.TryGetValue(ei.CodePage, out _))
-                        {
-                            result[ei.CodePage] = ei;
-                        }
+                        result.TryAdd(ei.CodePage, ei);
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
@@ -117,6 +118,26 @@ namespace System.Text
             }
 
             return arrayEncodingInfo;
+        }
+
+        internal static EncodingInfo[] GetEncodings(Dictionary<int, EncodingInfo> encodingInfoList)
+        {
+            Debug.Assert(encodingInfoList != null);
+
+            for (int i = 0; i < s_mappedCodePages.Length; i++)
+            {
+                if (!encodingInfoList.TryGetValue(s_mappedCodePages[i], out _))
+                {
+                    encodingInfoList[s_mappedCodePages[i]] = new EncodingInfo(s_mappedCodePages[i], s_webNames[s_webNameIndices[i]..s_webNameIndices[i + 1]],
+                                                                              GetDisplayName(s_mappedCodePages[i], i));
+                }
+            }
+
+            var collection = encodingInfoList.Values;
+            EncodingInfo[] result = new EncodingInfo[collection.Count];
+            collection.CopyTo(result, 0);
+
+            return result;
         }
 
         internal static CodePageDataItem? GetCodePageDataItem(int codePage)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -132,10 +132,10 @@ namespace System.Text
 
             for (int i = 0; i < mappedCodePages.Length; i++)
             {
-                if (!encodingInfoList.TryGetValue(mappedCodePages[i], out _))
+                if (!encodingInfoList.ContainsKey(mappedCodePages[i]))
                 {
                     encodingInfoList[mappedCodePages[i]] = new EncodingInfo(mappedCodePages[i], webNames[webNameIndices[i]..webNameIndices[i + 1]],
-                                                                              GetDisplayName(mappedCodePages[i], i));
+                                                                            GetDisplayName(mappedCodePages[i], i));
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -106,14 +106,17 @@ namespace System.Text
         // Return a list of all EncodingInfo objects describing all of our encodings
         internal static EncodingInfo[] GetEncodings()
         {
-            EncodingInfo[] arrayEncodingInfo = new EncodingInfo[s_mappedCodePages.Length];
+            ushort[] mappedCodePages = s_mappedCodePages;
+            EncodingInfo[] arrayEncodingInfo = new EncodingInfo[mappedCodePages.Length];
+            string webNames = s_webNames;
+            int[] webNameIndices = s_webNameIndices;
 
-            for (int i = 0; i < s_mappedCodePages.Length; i++)
+            for (int i = 0; i < mappedCodePages.Length; i++)
             {
                 arrayEncodingInfo[i] = new EncodingInfo(
-                    s_mappedCodePages[i],
-                    s_webNames[s_webNameIndices[i]..s_webNameIndices[i + 1]],
-                    GetDisplayName(s_mappedCodePages[i], i)
+                    mappedCodePages[i],
+                    webNames[webNameIndices[i]..webNameIndices[i + 1]],
+                    GetDisplayName(mappedCodePages[i], i)
                     );
             }
 
@@ -123,19 +126,25 @@ namespace System.Text
         internal static EncodingInfo[] GetEncodings(Dictionary<int, EncodingInfo> encodingInfoList)
         {
             Debug.Assert(encodingInfoList != null);
+            ushort[] mappedCodePages = s_mappedCodePages;
+            string webNames = s_webNames;
+            int[] webNameIndices = s_webNameIndices;
 
-            for (int i = 0; i < s_mappedCodePages.Length; i++)
+            for (int i = 0; i < mappedCodePages.Length; i++)
             {
-                if (!encodingInfoList.TryGetValue(s_mappedCodePages[i], out _))
+                if (!encodingInfoList.TryGetValue(mappedCodePages[i], out _))
                 {
-                    encodingInfoList[s_mappedCodePages[i]] = new EncodingInfo(s_mappedCodePages[i], s_webNames[s_webNameIndices[i]..s_webNameIndices[i + 1]],
-                                                                              GetDisplayName(s_mappedCodePages[i], i));
+                    encodingInfoList[mappedCodePages[i]] = new EncodingInfo(mappedCodePages[i], webNames[webNameIndices[i]..webNameIndices[i + 1]],
+                                                                              GetDisplayName(mappedCodePages[i], i));
                 }
             }
 
-            var collection = encodingInfoList.Values;
-            EncodingInfo[] result = new EncodingInfo[collection.Count];
-            collection.CopyTo(result, 0);
+            var result = new EncodingInfo[encodingInfoList.Count];
+            int j = 0;
+            foreach (KeyValuePair<int, EncodingInfo> pair in encodingInfoList)
+            {
+                result[j++] = pair.Value;
+            }
 
             return result;
         }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10262,7 +10262,7 @@ namespace System.Text
     }
     public sealed partial class EncodingInfo
     {
-        internal EncodingInfo() { }
+        public EncodingInfo(System.Text.EncodingProvider provider, int codePage, string name, string displayName) {}
         public int CodePage { get { throw null; } }
         public string DisplayName { get { throw null; } }
         public string Name { get { throw null; } }
@@ -10277,6 +10277,7 @@ namespace System.Text
         public virtual System.Text.Encoding? GetEncoding(int codepage, System.Text.EncoderFallback encoderFallback, System.Text.DecoderFallback decoderFallback) { throw null; }
         public abstract System.Text.Encoding? GetEncoding(string name);
         public virtual System.Text.Encoding? GetEncoding(string name, System.Text.EncoderFallback encoderFallback, System.Text.DecoderFallback decoderFallback) { throw null; }
+        public virtual System.Collections.Generic.IEnumerable<System.Text.EncodingInfo> GetEncodings() { throw null; }
     }
     public enum NormalizationForm
     {

--- a/src/libraries/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.csproj
@@ -1,9 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Text.Encoding.CodePages.cs" />
+    <Compile Include="System.Text.Encoding.CodePages.netcoreapp.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <ProjectReference Include="../../System.Runtime/ref/System.Runtime.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.netcoreapp.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/ref/System.Text.Encoding.CodePages.netcoreapp.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Text
+{
+    public sealed partial class CodePagesEncodingProvider : System.Text.EncodingProvider
+    {
+        public override System.Collections.Generic.IEnumerable<System.Text.EncodingInfo> GetEncodings() { throw null; }
+    }
+}

--- a/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -48,6 +48,9 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) and '$(TargetsWindows)' != 'true' ">
     <Compile Include="System\Text\CodePagesEncodingProvider.Default.cs" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)' and '$(TargetsWindows)' != 'true' ">
+    <Compile Include="System\Text\CodePagesEncodingProvider.Default.cs" />
+  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
     <Compile Include="System\Text\CodePagesEncodingProvider.netcoreapp.cs" />
   </ItemGroup>

--- a/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
     <Compile Include="System\Text\CodePagesEncodingProvider.netcoreapp.cs" />
+    <Compile Include="System\Text\BaseCodePageEncoding.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\codepages.nlp">

--- a/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System.Text.Encoding.CodePages.csproj
@@ -2,13 +2,13 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;netstandard2.0;netcoreapp2.0-Windows_NT;netstandard2.0-Windows_NT</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppCurrent)-Windows_NT;netstandard2.0;netcoreapp2.0-Windows_NT;netstandard2.0-Windows_NT</TargetFrameworks>
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
     <!-- copy the Windows-specific implementation to net461 folder so that restore without a RID works -->
-    <PackageTargetFramework Condition="$(TargetFramework.StartsWith('netstandard')) and '$(TargetsWindows)' == 'true'">netstandard2.0;net461</PackageTargetFramework>    
+    <PackageTargetFramework Condition="$(TargetFramework.StartsWith('netstandard')) and '$(TargetsWindows)' == 'true'">netstandard2.0;net461</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Microsoft\Win32\SafeHandles\SafeAllocHHandle.cs" />
@@ -47,6 +47,9 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard')) and '$(TargetsWindows)' != 'true' ">
     <Compile Include="System\Text\CodePagesEncodingProvider.Default.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Compile Include="System\Text\CodePagesEncodingProvider.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Data\codepages.nlp">

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.netcoreapp.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.netcoreapp.cs
@@ -1,0 +1,60 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.CompilerServices;
+
+namespace System.Text
+{
+    internal abstract partial class BaseCodePageEncoding : EncodingNLS, ISerializable
+    {
+        internal static unsafe EncodingInfo [] GetEncodings(CodePagesEncodingProvider provider)
+        {
+            lock (s_streamLock)
+            {
+                s_codePagesEncodingDataStream.Seek(CODEPAGE_DATA_FILE_HEADER_SIZE, SeekOrigin.Begin);
+
+                int codePagesCount;
+                fixed (byte* pBytes = &s_codePagesDataHeader[0])
+                {
+                    CodePageDataFileHeader* pDataHeader = (CodePageDataFileHeader*)pBytes;
+                    codePagesCount = pDataHeader->CodePageCount;
+                }
+
+                EncodingInfo [] encodingInfoList = new EncodingInfo[codePagesCount];
+
+                Span<byte> pCodePageIndexBytes = stackalloc byte[sizeof(CodePageIndex)]; // 40 bytes
+                CodePageIndex* pCodePageIndex = (CodePageIndex*) Unsafe.AsPointer(ref pCodePageIndexBytes.GetPinnableReference());
+
+                for (int i = 0; i < codePagesCount; i++)
+                {
+                    s_codePagesEncodingDataStream.Read(pCodePageIndexBytes);
+
+                    string codePageName;
+                    switch (pCodePageIndex->CodePage)
+                    {
+                        // Fixup some encoding names.
+                        case 950:   codePageName = "big5"; break;
+                        case 10002: codePageName = "x-mac-chinesetrad"; break;
+                        case 20833: codePageName = "x-ebcdic-koreanextended"; break;
+                        default:    codePageName = new string((char*) pCodePageIndex); break;
+                    }
+
+                    string? resourceName = EncodingNLS.GetLocalizedEncodingNameResource(pCodePageIndex->CodePage);
+                    string? displayName = null;
+
+                    if (resourceName != null && resourceName.StartsWith("Globalization_cp_", StringComparison.OrdinalIgnoreCase))
+                    {
+                        displayName = SR.GetResourceString(resourceName);
+                    }
+
+                    encodingInfoList[i] = new EncodingInfo(provider, pCodePageIndex->CodePage, codePageName, displayName ?? codePageName);
+                }
+
+                return encodingInfoList;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/CodePagesEncodingProvider.netcoreapp.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/CodePagesEncodingProvider.netcoreapp.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+
+namespace System.Text
+{
+    public sealed partial class CodePagesEncodingProvider : EncodingProvider
+    {
+        public override System.Collections.Generic.IEnumerable<System.Text.EncodingInfo> GetEncodings() => BaseCodePageEncoding.GetEncodings(this);
+    }
+}

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -392,7 +392,7 @@ namespace System.Text
             }
         }
 
-        private static string? GetLocalizedEncodingNameResource(int codePage) =>
+        internal static string? GetLocalizedEncodingNameResource(int codePage) =>
             codePage switch
             {
                 37 => SR.Globalization_cp_37,
@@ -549,12 +549,45 @@ namespace System.Text
                     _webName = EncodingTable.GetWebNameFromCodePage(CodePage);
                     if (_webName == null)
                     {
-                        throw new NotSupportedException(
-                            SR.Format(SR.NotSupported_NoCodepageData, CodePage));
+                        throw new NotSupportedException(SR.Format(SR.NotSupported_NoCodepageData, CodePage));
                     }
                 }
                 return _webName;
             }
         }
+
+        public override string HeaderName
+        {
+            get
+            {
+                switch (CodePage)
+                {
+                    case 932: return "iso-2022-jp";
+                    case 50221: return "iso-2022-jp";
+                    case 50225: return "euc-kr";
+                    default: return WebName;
+                }
+            }
+        }
+
+        public override string BodyName
+        {
+            get
+            {
+                switch (CodePage)
+                {
+                    case 932: return "iso-2022-jp";
+                    case 1250: return "iso-8859-2";
+                    case 1251: return "koi8-r";
+                    case 1252: return "iso-8859-1";
+                    case 1253: return "iso-8859-7";
+                    case 1254: return "iso-8859-9";
+                    case 50221: return "iso-2022-jp";
+                    case 50225: return "iso-2022-kr";
+                    default: return WebName;
+                }
+            }
+        }
+
     }
 }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -556,38 +556,27 @@ namespace System.Text
             }
         }
 
-        public override string HeaderName
-        {
-            get
+        public override string HeaderName =>
+            CodePage switch
             {
-                switch (CodePage)
-                {
-                    case 932: return "iso-2022-jp";
-                    case 50221: return "iso-2022-jp";
-                    case 50225: return "euc-kr";
-                    default: return WebName;
-                }
-            }
-        }
+                932 => "iso-2022-jp",
+                50221 => "iso-2022-jp",
+                50225 => "euc-kr",
+                _ => WebName,
+            };
 
-        public override string BodyName
-        {
-            get
+        public override string BodyName =>
+            CodePage switch
             {
-                switch (CodePage)
-                {
-                    case 932: return "iso-2022-jp";
-                    case 1250: return "iso-8859-2";
-                    case 1251: return "koi8-r";
-                    case 1252: return "iso-8859-1";
-                    case 1253: return "iso-8859-7";
-                    case 1254: return "iso-8859-9";
-                    case 50221: return "iso-2022-jp";
-                    case 50225: return "iso-2022-kr";
-                    default: return WebName;
-                }
-            }
-        }
-
+                932 =>   "iso-2022-jp",
+                1250 =>  "iso-8859-2",
+                1251 =>  "koi8-r",
+                1252 =>  "iso-8859-1",
+                1253 =>  "iso-8859-7",
+                1254 =>  "iso-8859-9",
+                50221 => "iso-2022-jp",
+                50225 => "iso-2022-kr",
+                _ => WebName,
+            };
     }
 }

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingTable.cs
@@ -188,7 +188,7 @@ namespace System.Text
                 }
             }
 
-            //Nope, we didn't find it.
+            // Nope, we didn't find it.
             return null;
         }
     }

--- a/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.netcoreapp.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.netcoreapp.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.DotNet.RemoteExecutor;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Xunit;
+
+namespace System.Text.Tests
+{
+    public partial class EncodingTest : IClassFixture<CultureSetup>
+    {
+        private class EncodingInformation
+        {
+            public EncodingInformation(int codePage, string name)
+            {
+                CodePage = codePage;
+                Name = name;
+            }
+
+            public int CodePage { get; }
+            public string Name { get; }
+        }
+
+        private static EncodingInformation [] s_defaultEncoding = new EncodingInformation []
+        {
+            new EncodingInformation(1200, "utf-16"),
+            new EncodingInformation(1201, "utf-16BE"),
+            new EncodingInformation(12000, "utf-32"),
+            new EncodingInformation(12001, "utf-32BE"),
+            new EncodingInformation(20127, "us-ascii"),
+            new EncodingInformation(28591, "iso-8859-1"),
+            new EncodingInformation(65001, "utf-8")
+        };
+
+        [Fact]
+        public void TestGetEncodings()
+        {
+            RemoteExecutor.Invoke(() => {
+                EncodingInfo [] list = Encoding.GetEncodings();
+
+                foreach (EncodingInformation eInfo in s_defaultEncoding)
+                {
+                    Assert.NotNull(list.FirstOrDefault(o => o.CodePage == eInfo.CodePage && o.Name == eInfo.Name));
+                }
+            }).Dispose();
+        }
+
+        [Fact]
+        public void TestGetEncodingsWithProvider()
+        {
+            RemoteExecutor.Invoke(() => {
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+                foreach (EncodingInfo ei in Encoding.GetEncodings())
+                {
+                    Encoding encoding = ei.GetEncoding();
+                    Assert.Equal(ei.CodePage, encoding.CodePage);
+
+                    Assert.True(ei.Name.Equals(encoding.WebName, StringComparison.OrdinalIgnoreCase), $"Encodinginfo.Name `{ei.Name}` != Encoding.WebName `{encoding.WebName}`");
+                }
+            }).Dispose();
+        }
+    }
+}

--- a/src/libraries/System.Text.Encoding.CodePages/tests/System.Text.Encoding.CodePages.Tests.csproj
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/System.Text.Encoding.CodePages.Tests.csproj
@@ -6,5 +6,6 @@
   <ItemGroup>
     <Compile Include="EncoderFallbackBufferHelper.cs" />
     <Compile Include="EncodingCodePages.cs" />
+    <Compile Include="EncodingCodePages.netcoreapp.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/25819

This change allows the encoding providers to enumerate its supported encoding through `EncodingProvider.GetEncodings()` method and having `Encoding.GetEncodings()` list all encodings from all registered providers. 
Also, the change fixes the Encoding.BodyName and Encoding.HeaderName properties in our EncodingCodePageProvider implementation to return correct values instead of throwing.