### PR TITLE
Obsolete PrincipalPermissionAttribute ctor as error

### DIFF
--- a/docs/project/list-of-obsoletions.md
+++ b/docs/project/list-of-obsoletions.md
@@ -1,0 +1,17 @@
+List of Obsoletions
+==================
+
+Per https://github.com/dotnet/designs/blob/master/accepted/2020/better-obsoletion/better-obsoletion.md, we now have a strategy in place for marking existing APIs as `[Obsolete]`. This takes advantage of the new diagnostic id and URL template mechanisms introduced to `ObsoleteAttribute` in .NET 5.
+
+When obsoleting an API, use the diagnostic ID `MSLIB####`, where _\#\#\#\#_ is the next four-digit identifier in the sequence, and add it to the list below. This helps us maintain a centralized location of all APIs that were obsoleted using this mechanism.
+
+The URL template we use for obsoletions is `https://aka.ms/dotnet-warnings/{0}`.
+
+Currently the identifiers `MSLIB0001` through `MSLIB0999` are carved out for obsoletions. If we wish to introduce analyzer warnings not related to obsoletion in the future, we should begin at a different range, such as `MSLIB2000`.
+
+## Current obsoletions (`MSLIB0001` - `MSLIB0999`)
+
+| Diagnostic ID    | Description |
+| :--------------- | :---------- |
+|  __`MSLIB0001`__ | (Reserved for `Encoding.UTF7`.) |
+|  __`MSLIB0002`__ | `PrincipalPermissionAttribute` is not honored by the runtime and must not be used. |

--- a/eng/CodeAnalysis.ruleset
+++ b/eng/CodeAnalysis.ruleset
@@ -126,7 +126,8 @@
       <Rule Id="CA2237" Action="None" />             <!-- Mark ISerializable types with serializable -->
       <Rule Id="CA2241" Action="Warning" />          <!-- Provide correct arguments to formatting methods -->
       <Rule Id="CA2242" Action="Warning" />          <!-- Test for NaN correctly -->
-      <Rule Id="CA2243" Action="Warning" />          <!-- Attribute string literals should parse correctly -->
+      <!-- CA2243 temporarily disabled: https://github.com/dotnet/roslyn-analyzers/issues/3635 -->
+      <Rule Id="CA2243" Action="None" />             <!-- Attribute string literals should parse correctly -->
       <Rule Id="CA2244" Action="None" />             <!-- Do not duplicate indexed element initializations -->
       <Rule Id="CA2245" Action="Warning" />          <!-- Do not assign a property to itself. -->
       <Rule Id="CA2246" Action="None" />             <!-- Assigning symbol and its member in the same statement. -->

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -1129,7 +1129,7 @@ namespace System.Security.Permissions
     public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
 #if CAS_OBSOLETIONS
-        [System.ObsoleteAttribute("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", true, DiagnosticId = "BCL0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [System.ObsoleteAttribute("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", true, DiagnosticId = "MSLIB0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
         public bool Authenticated { get { throw null; } set { } }

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -1128,6 +1128,9 @@ namespace System.Security.Permissions
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
     public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
+#if CAS_OBSOLETIONS
+        [System.ObsoleteAttribute("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", true, DiagnosticId = "BCL0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
         public PrincipalPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
         public bool Authenticated { get { throw null; } set { } }
         public string Name { get { throw null; } set { } }

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -8,6 +8,9 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly Condition="$(TargetFramework.StartsWith('net4'))">true</IsPartialFacadeAssembly>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <DefineConstants>$(DefineConstants);CAS_OBSOLETIONS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Permissions.cs" />
     <Compile Include="System.Security.Permissions.Forwards.cs" />

--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;net461;netcoreapp3.0;$(NetFrameworkCurrent)</TargetFrameworks>
-    <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->

--- a/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -5,6 +5,9 @@
     <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <DefineConstants>$(DefineConstants);CAS_OBSOLETIONS</DefineConstants>
+  </PropertyGroup>
   <ItemGroup Condition="!$(TargetFramework.StartsWith('net4'))">
     <Compile Include="System\ApplicationIdentity.cs" />
     <Compile Include="System\Configuration\ConfigurationPermission.cs" />

--- a/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
+++ b/src/libraries/System.Security.Permissions/src/System.Security.Permissions.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent);netcoreapp3.0;netstandard2.0;net461;$(NetFrameworkCurrent)</TargetFrameworks>
-    <ExcludeCurrentNetCoreAppFromPackage>true</ExcludeCurrentNetCoreAppFromPackage>
     <ExcludeCurrentFullFrameworkFromPackage>true</ExcludeCurrentFullFrameworkFromPackage>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
@@ -8,7 +8,7 @@ namespace System.Security.Permissions
     public sealed partial class PrincipalPermissionAttribute : CodeAccessSecurityAttribute
     {
 #if CAS_OBSOLETIONS
-        [Obsolete("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", error: true, DiagnosticId = "BCL0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        [Obsolete("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", error: true, DiagnosticId = "MSLIB0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
         public PrincipalPermissionAttribute(SecurityAction action) : base(default(SecurityAction)) { }
         public bool Authenticated { get; set; }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Permissions/PrincipalPermissionAttribute.cs
@@ -7,6 +7,9 @@ namespace System.Security.Permissions
     [AttributeUsage((AttributeTargets)(68), AllowMultiple = true, Inherited = false)]
     public sealed partial class PrincipalPermissionAttribute : CodeAccessSecurityAttribute
     {
+#if CAS_OBSOLETIONS
+        [Obsolete("PrincipalPermissionAttribute is not honored by the runtime and must not be used.", error: true, DiagnosticId = "BCL0002", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+#endif
         public PrincipalPermissionAttribute(SecurityAction action) : base(default(SecurityAction)) { }
         public bool Authenticated { get; set; }
         public string Name { get; set; }

--- a/src/libraries/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/libraries/System.Security.Permissions/tests/PermissionTests.cs
@@ -211,13 +211,6 @@ namespace System.Security.Permissions.Tests
         }
 
         [Fact]
-        public static void PrincipalPermissionAttributeCallMethods()
-        {
-            PrincipalPermissionAttribute ppa = new PrincipalPermissionAttribute(new Permissions.SecurityAction());
-            IPermission ip = ppa.CreatePermission();
-        }
-
-        [Fact]
         public static void PublisherIdentityPermissionCallMethods()
         {
             PublisherIdentityPermission pip = new PublisherIdentityPermission(new System.Security.Cryptography.X509Certificates.X509Certificate());


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/36972.
Resolves https://github.com/dotnet/runtime/issues/31279.

Source breaking change, not a runtime breaking change. (We didn't change the behavior of the APIs.)

/cc @terrajobst for the diagnostic ids and "better obsoletion" stuff.