### PR TITLE
[browser][wasm] Remove the use of reflection when instantiating core objects

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -75,22 +75,17 @@ namespace System.Runtime.InteropServices.JavaScript
 
         public static int BindJSObject(int jsId, int mappedType)
         {
+            JSObject? obj;
             lock (_boundObjects)
             {
-                if (!_boundObjects.TryGetValue(jsId, out JSObject? obj))
+                if (!_boundObjects.TryGetValue(jsId, out obj))
                 {
-                    IntPtr jsIntPtr = (IntPtr)jsId;
-                    if (mappedType > 0)
-                    {
-                        return BindJSType(jsIntPtr, mappedType);
-                    }
-                    else
-                    {
-                        _boundObjects[jsId] = obj = new JSObject(jsIntPtr);
-                    }
+                  IntPtr jsIntPtr = (IntPtr)jsId;
+                  obj = mappedType > 0 ? BindJSType(jsIntPtr, mappedType) : new JSObject(jsIntPtr);
+                  _boundObjects.Add (jsId, obj);
                 }
-                return obj == null ? 0 : (int)(IntPtr)obj.Handle;
             }
+            return obj == null ? 0 : (int)(IntPtr)obj.Handle;
         }
 
         public static int BindCoreCLRObject(int jsId, int gcHandle)
@@ -115,7 +110,7 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        private static int BindJSType(IntPtr jsIntPtr, int coreType)
+        private static JSObject BindJSType(IntPtr jsIntPtr, int coreType)
         {
             int jsId = (int)jsIntPtr;
             CoreObject coreObject;
@@ -169,8 +164,7 @@ namespace System.Runtime.InteropServices.JavaScript
                 default:
                     throw new ArgumentOutOfRangeException(nameof(coreType));
             }
-            _boundObjects.Add(jsId, coreObject);
-            return (int)(IntPtr)coreObject.Handle;
+            return coreObject;
         }
 
         public static int UnBindJSObject(int jsId)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -79,13 +79,14 @@ namespace System.Runtime.InteropServices.JavaScript
             {
                 if (!_boundObjects.TryGetValue(jsId, out JSObject? obj))
                 {
+                    IntPtr jsIntPtr = (IntPtr)jsId;
                     if (mappedType > 0)
                     {
-                        return BindJSType(jsId, mappedType);
+                        return BindJSType(jsIntPtr, mappedType);
                     }
                     else
                     {
-                        _boundObjects[jsId] = obj = new JSObject((IntPtr)jsId);
+                        _boundObjects[jsId] = obj = new JSObject(jsIntPtr);
                     }
                 }
                 return obj == null ? 0 : (int)(IntPtr)obj.Handle;
@@ -114,67 +115,65 @@ namespace System.Runtime.InteropServices.JavaScript
             }
         }
 
-        public static int BindJSType(int jsId, int coreType)
+        private static int BindJSType(IntPtr jsIntPtr, int coreType)
         {
-            lock (_boundObjects)
+            int jsId = (int)jsIntPtr;
+            if (!_boundObjects.TryGetValue(jsId, out JSObject? obj))
             {
-                if (!_boundObjects.TryGetValue(jsId, out JSObject? obj))
+                CoreObject coreObject;
+                switch (coreType)
                 {
-                    CoreObject? coreObject;
-                    switch (coreType)
-                    {
-                        case 1:
-                            coreObject = new Array((IntPtr)jsId);
-                            break;
-                        case 2:
-                            coreObject = new ArrayBuffer((IntPtr)jsId);
-                            break;
-                        case 3:
-                            coreObject = new DataView((IntPtr)jsId);
-                            break;
-                        case 4:
-                            coreObject = new Function((IntPtr)jsId);
-                            break;
-                        case 5:
-                            coreObject = new Map((IntPtr)jsId);
-                            break;
-                        case 6:
-                            coreObject = new SharedArrayBuffer((IntPtr)jsId);
-                            break;
-                        case 10:
-                            coreObject = new Int8Array((IntPtr)jsId);
-                            break;
-                        case 11:
-                            coreObject = new Uint8Array((IntPtr)jsId);
-                            break;
-                        case 12:
-                            coreObject = new Uint8ClampedArray((IntPtr)jsId);
-                            break;
-                        case 13:
-                            coreObject = new Int16Array((IntPtr)jsId);
-                            break;
-                        case 14:
-                            coreObject = new Uint16Array((IntPtr)jsId);
-                            break;
-                        case 15:
-                            coreObject = new Int32Array((IntPtr)jsId);
-                            break;
-                        case 16:
-                            coreObject = new Uint32Array((IntPtr)jsId);
-                            break;
-                        case 17:
-                            coreObject = new Float32Array((IntPtr)jsId);
-                            break;
-                        case 18:
-                            coreObject = new Float64Array((IntPtr)jsId);
-                            break;
-                        default:
-                            return -1;
-                    }
-                    _boundObjects[jsId] = obj = coreObject;
+                    case 1:
+                        coreObject = new Array(jsIntPtr);
+                        break;
+                    case 2:
+                        coreObject = new ArrayBuffer(jsIntPtr);
+                        break;
+                    case 3:
+                        coreObject = new DataView(jsIntPtr);
+                        break;
+                    case 4:
+                        coreObject = new Function(jsIntPtr);
+                        break;
+                    case 5:
+                        coreObject = new Map(jsIntPtr);
+                        break;
+                    case 6:
+                        coreObject = new SharedArrayBuffer(jsIntPtr);
+                        break;
+                    case 10:
+                        coreObject = new Int8Array(jsIntPtr);
+                        break;
+                    case 11:
+                        coreObject = new Uint8Array(jsIntPtr);
+                        break;
+                    case 12:
+                        coreObject = new Uint8ClampedArray(jsIntPtr);
+                        break;
+                    case 13:
+                        coreObject = new Int16Array(jsIntPtr);
+                        break;
+                    case 14:
+                        coreObject = new Uint16Array(jsIntPtr);
+                        break;
+                    case 15:
+                        coreObject = new Int32Array(jsIntPtr);
+                        break;
+                    case 16:
+                        coreObject = new Uint32Array(jsIntPtr);
+                        break;
+                    case 17:
+                        coreObject = new Float32Array(jsIntPtr);
+                        break;
+                    case 18:
+                        coreObject = new Float64Array(jsIntPtr);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(coreType));
                 }
-                return obj == null ? 0 : (int)(IntPtr)obj.Handle;
+                _boundObjects.Add(jsId, obj = coreObject);
             }
+            return obj == null ? 0 : (int)(IntPtr)obj.Handle;
         }
 
         public static int UnBindJSObject(int jsId)

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -112,7 +112,6 @@ namespace System.Runtime.InteropServices.JavaScript
 
         private static JSObject BindJSType(IntPtr jsIntPtr, int coreType)
         {
-            int jsId = (int)jsIntPtr;
             CoreObject coreObject;
             switch (coreType)
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -118,62 +118,59 @@ namespace System.Runtime.InteropServices.JavaScript
         private static int BindJSType(IntPtr jsIntPtr, int coreType)
         {
             int jsId = (int)jsIntPtr;
-            if (!_boundObjects.TryGetValue(jsId, out JSObject? obj))
+            CoreObject coreObject;
+            switch (coreType)
             {
-                CoreObject coreObject;
-                switch (coreType)
-                {
-                    case 1:
-                        coreObject = new Array(jsIntPtr);
-                        break;
-                    case 2:
-                        coreObject = new ArrayBuffer(jsIntPtr);
-                        break;
-                    case 3:
-                        coreObject = new DataView(jsIntPtr);
-                        break;
-                    case 4:
-                        coreObject = new Function(jsIntPtr);
-                        break;
-                    case 5:
-                        coreObject = new Map(jsIntPtr);
-                        break;
-                    case 6:
-                        coreObject = new SharedArrayBuffer(jsIntPtr);
-                        break;
-                    case 10:
-                        coreObject = new Int8Array(jsIntPtr);
-                        break;
-                    case 11:
-                        coreObject = new Uint8Array(jsIntPtr);
-                        break;
-                    case 12:
-                        coreObject = new Uint8ClampedArray(jsIntPtr);
-                        break;
-                    case 13:
-                        coreObject = new Int16Array(jsIntPtr);
-                        break;
-                    case 14:
-                        coreObject = new Uint16Array(jsIntPtr);
-                        break;
-                    case 15:
-                        coreObject = new Int32Array(jsIntPtr);
-                        break;
-                    case 16:
-                        coreObject = new Uint32Array(jsIntPtr);
-                        break;
-                    case 17:
-                        coreObject = new Float32Array(jsIntPtr);
-                        break;
-                    case 18:
-                        coreObject = new Float64Array(jsIntPtr);
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException(nameof(coreType));
-                }
-                _boundObjects.Add(jsId, obj = coreObject);
+                case 1:
+                    coreObject = new Array(jsIntPtr);
+                    break;
+                case 2:
+                    coreObject = new ArrayBuffer(jsIntPtr);
+                    break;
+                case 3:
+                    coreObject = new DataView(jsIntPtr);
+                    break;
+                case 4:
+                    coreObject = new Function(jsIntPtr);
+                    break;
+                case 5:
+                    coreObject = new Map(jsIntPtr);
+                    break;
+                case 6:
+                    coreObject = new SharedArrayBuffer(jsIntPtr);
+                    break;
+                case 10:
+                    coreObject = new Int8Array(jsIntPtr);
+                    break;
+                case 11:
+                    coreObject = new Uint8Array(jsIntPtr);
+                    break;
+                case 12:
+                    coreObject = new Uint8ClampedArray(jsIntPtr);
+                    break;
+                case 13:
+                    coreObject = new Int16Array(jsIntPtr);
+                    break;
+                case 14:
+                    coreObject = new Uint16Array(jsIntPtr);
+                    break;
+                case 15:
+                    coreObject = new Int32Array(jsIntPtr);
+                    break;
+                case 16:
+                    coreObject = new Uint32Array(jsIntPtr);
+                    break;
+                case 17:
+                    coreObject = new Float32Array(jsIntPtr);
+                    break;
+                case 18:
+                    coreObject = new Float64Array(jsIntPtr);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(coreType));
             }
-            return obj == null ? 0 : (int)(IntPtr)obj.Handle;
+            _boundObjects.Add(jsId, coreObject);
+            return (int)(IntPtr)coreObject.Handle;
         }
 
         public static int UnBindJSObject(int jsId)

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -497,7 +497,7 @@ var BindingSupportLib = {
 		},
 		wasm_binding_obj_new: function (js_obj_id, type)
 		{
-			return this.call_method (this.bind_js_obj, null, "ii", [js_obj_id, ownsHandle, type]);
+			return this.call_method (this.bind_js_obj, null, "ii", [js_obj_id, type]);
 		},
 		wasm_bind_existing: function (mono_obj, js_id)
 		{

--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -89,7 +89,6 @@ var BindingSupportLib = {
 			this.box_js_double = get_method ("BoxDouble");
 			this.box_js_bool = get_method ("BoxBool");
 			this.is_simple_array = get_method ("IsSimpleArray");
-			this.get_core_type = get_method ("GetCoreType");
 			this.setup_js_cont = get_method ("SetupJSContinuation");
 
 			this.create_tcs = get_method ("CreateTaskSource");
@@ -498,7 +497,7 @@ var BindingSupportLib = {
 		},
 		wasm_binding_obj_new: function (js_obj_id, type)
 		{
-			return this.call_method (this.bind_js_obj, null, "io", [js_obj_id, type]);
+			return this.call_method (this.bind_js_obj, null, "ii", [js_obj_id, ownsHandle, type]);
 		},
 		wasm_bind_existing: function (mono_obj, js_id)
 		{
@@ -819,7 +818,41 @@ var BindingSupportLib = {
 		},
 		wasm_get_core_type: function (obj)
 		{
-			return this.call_method (this.get_core_type, null, "so", [ "WebAssembly.Core."+obj.constructor.name ]);
+			switch (true)
+			{
+				case obj instanceof Array:
+					return 1;
+				case obj instanceof ArrayBuffer:
+					return 2;
+				case obj instanceof DataView:
+					return 3;
+				case obj instanceof Function:
+					return 4;
+				case obj instanceof Map:
+					return 5;
+				case obj instanceof SharedArrayBuffer:
+					return 6;
+				case obj instanceof Int8Array:
+					return 10;
+				case obj instanceof Uint8Array:
+					return 11;
+				case obj instanceof Uint8ClampedArray:
+					return 12;
+				case obj instanceof Int16Array:
+					return 13;
+				case obj instanceof Uint16Array:
+					return 14;
+				case obj instanceof Int32Array:
+					return 15;
+				case obj instanceof Uint32Array:
+					return 16;
+				case obj instanceof Float32Array:
+					return 17;
+				case obj instanceof Float64Array:
+					return 18;
+				default:
+					return undefined;
+			}
 		},
 		get_wasm_type: function(obj) {
 			var coreType = obj[Symbol.for("wasm type")];
@@ -846,7 +879,7 @@ var BindingSupportLib = {
 					obj.__mono_jshandle__ = handle;
 					// Obtain the JS -> C# type mapping.
 					var wasm_type = this.get_wasm_type(obj);
-					gc_handle = obj.__mono_gchandle__ = this.wasm_binding_obj_new(handle + 1, wasm_type);
+					gc_handle = obj.__mono_gchandle__ = this.wasm_binding_obj_new(handle + 1, typeof wasm_type === "undefined" ? -1 : wasm_type);
 					this.mono_wasm_object_registry[handle] = obj;
 						
 				}


### PR DESCRIPTION
To make working with core javascript object faster remove the dependency on reflection for the implementation.