### PR TITLE
Add required dependency to .vsconfig (-allconfigurations)

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -47,6 +47,7 @@
     "Microsoft.VisualStudio.Component.Git",
     "Microsoft.VisualStudio.Component.LinqToSql",
     "Microsoft.Net.Component.4.6.2.SDK",
-    "Microsoft.Net.Component.4.7.SDK"
+    "Microsoft.Net.Component.4.7.SDK",
+    "Microsoft.Net.Component.4.7.1.TargetingPack"
   ]
 }


### PR DESCRIPTION
I was running into the following build error using the currently provided .vsconfig to install required dependencies to build dotnet/runtime.

```
D:\dotnet\runtime\.dotnet\sdk\5.0.100-preview.6.20266.3\Microsoft.Common.CurrentVersion.targets(1177,5):
error MSB3644: The reference assemblies for .NETFramework,Version=v4.7.1 were not found.
To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application.
You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [D:\dotnet\runtime\src\libraries\restore\netfx\netfx.depproj]
```

Installing the .NET 4.7.1 Targeting Pack through the VS Installer (and rebooting) fixed this issue. This PR adds the missing dependency to the .vsconfig.

If desired, I could add a commit to sort the strings in the .vsconfig alphabetically for better structure, assuming order is irrelevant for the VS Installer.