### PR TITLE
Avoid double-call to Trim

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/StringAttributeCollection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/StringAttributeCollection.cs
@@ -44,7 +44,7 @@ namespace System.Configuration
                 foreach (string item in items)
                 {
                     string trimmedItem = item.Trim();
-                    if (trimmedItem.Length != 0) Add(item.Trim());
+                    if (trimmedItem.Length != 0) Add(trimmedItem);
                 }
             }
             _originalString = ToString();


### PR DESCRIPTION
See [SharpLab](https://sharplab.io/#v2:C4LghgzgtgPgAgJgIwFgBQcDMACR2DC6A3utmbjnACzYAiA9gK4BGANgKYAqATgJZQAKOEgAMAbQC62XsHZQIASlLkSacuuwAzet3ZgAxgAtsQ0dNlRpAO3NzFyjdlWPHwkdmB8oUdgBMAkhbYALy2UAB0PPwCCgDcDi5kvJomnvw+ARbhADLsVgDmwMYAhKEiCrhIAJwCMnKRXjFxCeoAvgntauQJWLg0AMq8BRxRgm6SYfZdZM4u2roGxqbudZZDk0rTGrOJZG4eXhmBciFhDdHNW4nJqYd+xxG5BUXYpdjllTVp3vcWl4mdNroVpAA===)

The IL for the current approach has the `call System.String.TrimWhiteSpaceHelper(TrimType)` twice, while only one in the new approach.
