### PR TITLE
64-bit integer division produces incorrect results

### DIFF
--- a/src/coreclr/src/jit/utils.cpp
+++ b/src/coreclr/src/jit/utils.cpp
@@ -2399,10 +2399,9 @@ T GetSignedMagic(T denom, int* shift /*out*/)
     UT  q2;
     UT  t;
     T   result_magic;
-    int iters = 0;
 
     absDenom = abs(denom);
-    t        = two_nminus1 + ((unsigned int)denom >> 31);
+    t        = two_nminus1 + (UT(denom) >> bits_minus_1);
     absNc    = t - 1 - (t % absDenom);        // absolute value of nc
     p        = bits_minus_1;                  // initialize p
     q1       = two_nminus1 / absNc;           // initialize q1 = 2^p / abs(nc)
@@ -2412,7 +2411,6 @@ T GetSignedMagic(T denom, int* shift /*out*/)
 
     do
     {
-        iters++;
         p++;
         q1 *= 2; // update q1 = 2^p / abs(nc)
         r1 *= 2; // update r1 = rem(2^p / abs(nc))


### PR DESCRIPTION
Under rare conditions, a 64-bit signed integer division by a constant may produce incorrect results due to a bug in calculation of magic numbers used to replace the division with a multiplication.  This bug affected all 64-bit .NET releases starting with .NET Framework 2.0.

Namely, calculation of the `absNc` value in the `GetSignedMagic` function involves adding the sign bit of the denominator.  That calculation incorrectly used bit 31 of the denominator instead of bit 63.   The program below demonstrates difference in compile time (correct) and run time (incorrect) division results for x64 release build with tiered compilation off. @dotnet/jit-contrib 
```C#
using System;
using System.Runtime.CompilerServices;

static class Program
{
    const long Dividend = long.MinValue;
    const long Divisor = -77_158_673_929;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static long Quotient(long x) => x / Divisor;

    [MethodImpl(MethodImplOptions.NoInlining)]
    static long Remainder(long x) => x % Divisor;

    static void Main()
    {
        // Output for x64 release build with tiered compilation off:
        //
        // Compile time quotient  : 119,537,720
        // Run time quotient      : 119,537,721
        //
        // Compile time remainder : -77,158,673,928
        // Run time remainder     : 1

        Console.WriteLine("Compile time quotient  : {0:n0}", Dividend / Divisor);
        Console.WriteLine("Run time quotient      : {0:n0}", Quotient(Dividend));
        Console.WriteLine();
        Console.WriteLine("Compile time remainder : {0:n0}", Dividend % Divisor);
        Console.WriteLine("Run time remainder     : {0:n0}", Remainder(Dividend));
    }
}
```
