### PR TITLE
Fix nullable annotation of AsnEncodedData.RawData

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/ref/System.Security.Cryptography.Encoding.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/ref/System.Security.Cryptography.Encoding.cs
@@ -15,7 +15,8 @@ namespace System.Security.Cryptography
         public AsnEncodedData(System.Security.Cryptography.Oid? oid, byte[] rawData) { }
         public AsnEncodedData(string oid, byte[] rawData) { }
         public System.Security.Cryptography.Oid? Oid { get { throw null; } set { } }
-        public byte[] RawData { get { throw null; } set { } }
+        [System.Diagnostics.CodeAnalysis.DisallowNull]
+        public byte[]? RawData { get { throw null; } set { } }
         public virtual void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
         public virtual string Format(bool multiLine) { throw null; }
     }

--- a/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedData.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedData.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -23,7 +24,7 @@ namespace System.Security.Cryptography
         {
             if (asnEncodedData == null)
                 throw new ArgumentNullException(nameof(asnEncodedData));
-            Reset(asnEncodedData._oid, asnEncodedData._rawData);
+            Reset(asnEncodedData._oid, asnEncodedData._rawData!); // will throw if _rawData is null
         }
 
         public AsnEncodedData(Oid? oid, byte[] rawData)
@@ -49,7 +50,8 @@ namespace System.Security.Cryptography
             }
         }
 
-        public byte[] RawData
+        [DisallowNull]
+        public byte[]? RawData
         {
             get
             {
@@ -69,7 +71,7 @@ namespace System.Security.Cryptography
         {
             if (asnEncodedData == null)
                 throw new ArgumentNullException(nameof(asnEncodedData));
-            Reset(asnEncodedData._oid, asnEncodedData._rawData);
+            Reset(asnEncodedData._oid, asnEncodedData._rawData!); // will throw if _rawData is null
         }
 
         public virtual string Format(bool multiLine)
@@ -88,6 +90,6 @@ namespace System.Security.Cryptography
         }
 
         private Oid? _oid = null;
-        private byte[] _rawData = null!; // initialized in helper method Reset for all public constuctors
+        private byte[]? _rawData;
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/ref/System.Security.Cryptography.Pkcs.cs
@@ -156,7 +156,7 @@ namespace System.Security.Cryptography.Pkcs
     public sealed partial class Pkcs9ContentType : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
     {
         public Pkcs9ContentType() { }
-        public System.Security.Cryptography.Oid ContentType { get { throw null; } }
+        public System.Security.Cryptography.Oid? ContentType { get { throw null; } }
         public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
     }
     public sealed partial class Pkcs9DocumentDescription : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
@@ -164,7 +164,7 @@ namespace System.Security.Cryptography.Pkcs
         public Pkcs9DocumentDescription() { }
         public Pkcs9DocumentDescription(byte[] encodedDocumentDescription) { }
         public Pkcs9DocumentDescription(string documentDescription) { }
-        public string DocumentDescription { get { throw null; } }
+        public string? DocumentDescription { get { throw null; } }
         public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
     }
     public sealed partial class Pkcs9DocumentName : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
@@ -172,13 +172,13 @@ namespace System.Security.Cryptography.Pkcs
         public Pkcs9DocumentName() { }
         public Pkcs9DocumentName(byte[] encodedDocumentName) { }
         public Pkcs9DocumentName(string documentName) { }
-        public string DocumentName { get { throw null; } }
+        public string? DocumentName { get { throw null; } }
         public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
     }
     public sealed partial class Pkcs9MessageDigest : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject
     {
         public Pkcs9MessageDigest() { }
-        public byte[] MessageDigest { get { throw null; } }
+        public byte[]? MessageDigest { get { throw null; } }
         public override void CopyFrom(System.Security.Cryptography.AsnEncodedData asnEncodedData) { }
     }
     public sealed partial class Pkcs9SigningTime : System.Security.Cryptography.Pkcs.Pkcs9AttributeObject

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/Windows/PkcsPalWindows.Encrypt.cs
@@ -182,7 +182,7 @@ namespace Internal.Cryptography.Pal.Windows
                         DATA_BLOB* pValues = (DATA_BLOB*)(hb.Alloc(numValues, sizeof(DATA_BLOB)));
                         for (int j = 0; j < numValues; j++)
                         {
-                            byte[] rawData = values[j].RawData;
+                            byte[] rawData = values[j].RawData!;
                             pValues[j].cbData = (uint)(rawData.Length);
                             pValues[j].pbData = hb.AllocBytes(rawData);
                         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
@@ -24,11 +24,11 @@ namespace System.Security.Cryptography.Pkcs
         // Public properties.
         //
 
-        public Oid ContentType
+        public Oid? ContentType
         {
             get
             {
-                return _lazyContentType ?? (_lazyContentType = Decode(RawData));
+                return _lazyContentType ??= Decode(RawData);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
@@ -37,11 +37,11 @@ namespace System.Security.Cryptography.Pkcs
         // Public methods.
         //
 
-        public string DocumentDescription
+        public string? DocumentDescription
         {
             get
             {
-                return _lazyDocumentDescription ?? (_lazyDocumentDescription = Decode(RawData));
+                return _lazyDocumentDescription ??= Decode(RawData);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
@@ -37,11 +37,11 @@ namespace System.Security.Cryptography.Pkcs
         // Public methods.
         //
 
-        public string DocumentName
+        public string? DocumentName
         {
             get
             {
-                return _lazyDocumentName ?? (_lazyDocumentName = Decode(RawData));
+                return _lazyDocumentName ??= Decode(RawData);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
@@ -34,11 +34,11 @@ namespace System.Security.Cryptography.Pkcs
         // Public properties.
         //
 
-        public byte[] MessageDigest
+        public byte[]? MessageDigest
         {
             get
             {
-                return _lazyMessageDigest ?? (_lazyMessageDigest = Decode(RawData));
+                return _lazyMessageDigest ??= Decode(RawData);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SubjectIdentifier.cs
@@ -16,7 +16,7 @@ namespace System.Security.Cryptography.Pkcs
     {
         private const string DummySignerSubjectName = "CN=Dummy Signer";
         internal static readonly byte[] DummySignerEncodedValue =
-            new X500DistinguishedName(DummySignerSubjectName).RawData;
+            new X500DistinguishedName(DummySignerSubjectName).RawData!;
 
         internal SubjectIdentifier(SubjectIdentifierType type, object value)
         {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/CertificateExtensionsCommon.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/CertificateExtensionsCommon.cs
@@ -29,8 +29,8 @@ namespace Internal.Cryptography.Pal
             if (matchesConstraints != null && !matchesConstraints(certificate))
                 return null;
 
-            byte[] rawEncodedKeyValue = publicKey.EncodedKeyValue.RawData;
-            byte[] rawEncodedParameters = publicKey.EncodedParameters.RawData;
+            byte[] rawEncodedKeyValue = publicKey.EncodedKeyValue.RawData!;
+            byte[] rawEncodedParameters = publicKey.EncodedParameters.RawData!;
             return (T)(X509Pal.Instance.DecodePublicKey(algorithmOid, rawEncodedKeyValue, rawEncodedParameters, certificate.Pal));
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
@@ -225,10 +225,10 @@ namespace Internal.Cryptography.Pal
             {
                 fixed (byte* pszOidValue = key.Oid.ValueAsAscii())
                 {
-                    byte[] encodedParameters = key.EncodedParameters.RawData;
+                    byte[] encodedParameters = key.EncodedParameters.RawData!;
                     fixed (byte* pEncodedParameters = encodedParameters)
                     {
-                        byte[] encodedKeyValue = key.EncodedKeyValue.RawData;
+                        byte[] encodedKeyValue = key.EncodedKeyValue.RawData!;
                         fixed (byte* pEncodedKeyValue = encodedKeyValue)
                         {
                             CERT_PUBLIC_KEY_INFO publicKeyInfo = new CERT_PUBLIC_KEY_INFO()

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -33,7 +33,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         case Oids.Rsa:
                         case Oids.Dsa:
-                            _key = X509Pal.Instance.DecodePublicKey(_oid, EncodedKeyValue.RawData, EncodedParameters.RawData, null);
+                            _key = X509Pal.Instance.DecodePublicKey(_oid, EncodedKeyValue.RawData!, EncodedParameters.RawData!, null);
                             break;
 
                         default:

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
@@ -59,12 +59,12 @@ namespace System.Security.Cryptography.X509Certificates
         public string Decode(X500DistinguishedNameFlags flag)
         {
             ThrowIfInvalid(flag);
-            return X509Pal.Instance.X500DistinguishedNameDecode(RawData, flag);
+            return X509Pal.Instance.X500DistinguishedNameDecode(RawData!, flag);
         }
 
         public override string Format(bool multiLine)
         {
-            return X509Pal.Instance.X500DistinguishedNameFormat(RawData, multiLine);
+            return X509Pal.Instance.X500DistinguishedNameFormat(RawData!, multiLine);
         }
 
         private static byte[] Encode(string distinguishedName, X500DistinguishedNameFlags flags)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509BasicConstraintsExtension.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509BasicConstraintsExtension.cs
@@ -28,7 +28,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509BasicConstraintsExtension(AsnEncodedData encodedBasicConstraints, bool critical)
-            : base(Oids.BasicConstraints2, encodedBasicConstraints.RawData, critical)
+            : base(Oids.BasicConstraints2, encodedBasicConstraints.RawData!, critical)
         {
         }
 
@@ -82,9 +82,9 @@ namespace System.Security.Cryptography.X509Certificates
         private void DecodeExtension()
         {
             if (Oid!.Value == Oids.BasicConstraints)
-                X509Pal.Instance.DecodeX509BasicConstraintsExtension(RawData, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
+                X509Pal.Instance.DecodeX509BasicConstraintsExtension(RawData!, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
             else
-                X509Pal.Instance.DecodeX509BasicConstraints2Extension(RawData, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
+                X509Pal.Instance.DecodeX509BasicConstraints2Extension(RawData!, out _certificateAuthority, out _hasPathLenConstraint, out _pathLenConstraint);
 
             _decoded = true;
         }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509EnhancedKeyUsageExtension(AsnEncodedData encodedEnhancedKeyUsages, bool critical)
-            : base(Oids.EnhancedKeyUsage, encodedEnhancedKeyUsages.RawData, critical)
+            : base(Oids.EnhancedKeyUsage, encodedEnhancedKeyUsages.RawData!, critical)
         {
         }
 
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (!_decoded)
                 {
-                    X509Pal.Instance.DecodeX509EnhancedKeyUsageExtension(RawData, out _enhancedKeyUsages);
+                    X509Pal.Instance.DecodeX509EnhancedKeyUsageExtension(RawData!, out _enhancedKeyUsages);
                     _decoded = true;
                 }
                 OidCollection oids = new OidCollection();

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Extension.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Extension.cs
@@ -21,7 +21,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509Extension(AsnEncodedData encodedExtension, bool critical)
-            : this(encodedExtension.Oid!, encodedExtension.RawData, critical)
+            : this(encodedExtension.Oid!, encodedExtension.RawData!, critical)
         {
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509KeyUsageExtension(AsnEncodedData encodedKeyUsage, bool critical)
-            : base(Oids.KeyUsage, encodedKeyUsage.RawData, critical)
+            : base(Oids.KeyUsage, encodedKeyUsage.RawData!, critical)
         {
         }
 
@@ -38,7 +38,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 if (!_decoded)
                 {
-                    X509Pal.Instance.DecodeX509KeyUsageExtension(RawData, out _keyUsages);
+                    X509Pal.Instance.DecodeX509KeyUsageExtension(RawData!, out _keyUsages);
                     _decoded = true;
                 }
                 return _keyUsages;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -24,7 +24,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
         public X509SubjectKeyIdentifierExtension(AsnEncodedData encodedSubjectKeyIdentifier, bool critical)
-            : base(Oids.SubjectKeyIdentifier, encodedSubjectKeyIdentifier.RawData, critical)
+            : base(Oids.SubjectKeyIdentifier, encodedSubjectKeyIdentifier.RawData!, critical)
         {
         }
 
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.X509Certificates
                 if (!_decoded)
                 {
                     byte[] subjectKeyIdentifierValue;
-                    X509Pal.Instance.DecodeX509SubjectKeyIdentifierExtension(RawData, out subjectKeyIdentifierValue);
+                    X509Pal.Instance.DecodeX509SubjectKeyIdentifierExtension(RawData!, out subjectKeyIdentifierValue);
                     _subjectKeyIdentifier = subjectKeyIdentifierValue.ToHexStringUpper();
                     _decoded = true;
                 }
@@ -101,11 +101,11 @@ namespace System.Security.Cryptography.X509Certificates
             switch (algorithm)
             {
                 case X509SubjectKeyIdentifierHashAlgorithm.Sha1:
-                    return ComputeSha1(key.EncodedKeyValue.RawData);
+                    return ComputeSha1(key.EncodedKeyValue.RawData!);
 
                 case X509SubjectKeyIdentifierHashAlgorithm.ShortSha1:
                     {
-                        byte[] sha1 = ComputeSha1(key.EncodedKeyValue.RawData);
+                        byte[] sha1 = ComputeSha1(key.EncodedKeyValue.RawData!);
 
                         //  ShortSha1: The keyIdentifier is composed of a four bit type field with
                         //  the value 0100 followed by the least significant 60 bits of the


### PR DESCRIPTION
@bartonjs, this fixes the nullable annotation of AsnEncodedData.RawData to be nullable.

Are you sure you want to go this route, rather than making it so that RawData never returns null?  This is correct based on the current implementation, but the fallout is non-trivial, and it definitely seems to be penalizing the common case.