### PR TITLE
SetNonBlocking should change UnderlyingHandleNonBlocking state

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
@@ -116,9 +116,15 @@ namespace System.Net.Sockets
             // We don't care about synchronization because this is idempotent
             if (!_underlyingHandleNonBlocking)
             {
-                AsyncContext.SetNonBlocking();
-                _underlyingHandleNonBlocking = true;
+                // Calls back into MarkNonBlocking()
+                AsyncContext.SetNonBlockingIfNotSet();
             }
+        }
+
+        internal void MarkNonBlocking()
+        {
+            // We don't care about synchronization because this is idempotent
+            _underlyingHandleNonBlocking = true;
         }
 
         internal bool IsNonBlocking


### PR DESCRIPTION
It should represent the actual stack of the socket and not whether `IsNonBlocking = true` has been called (which is represented by `IsNonBlocking`)

i.e. it should also change when an xAsync method is called.

/cc @tmds 