### PR TITLE
allow access to crypto props from RemoteCertificateValidationCallback

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -484,7 +484,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -560,7 +560,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 return _context!.ConnectionInfo?.TlsCipherSuite ?? default(TlsCipherSuite);
             }
         }
@@ -569,7 +569,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -583,7 +583,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -598,7 +598,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -612,7 +612,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -627,7 +627,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -642,7 +642,7 @@ namespace System.Net.Security
         {
             get
             {
-                ThrowIfExceptionalOrNotAuthenticated();
+                ThrowIfExceptionalOrNotHandshake();
                 SslConnectionInfo? info = _context!.ConnectionInfo;
                 if (info == null)
                 {
@@ -858,6 +858,17 @@ namespace System.Net.Security
             ThrowIfExceptional();
 
             if (!IsAuthenticated)
+            {
+                ThrowNotAuthenticated();
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ThrowIfExceptionalOrNotHandshake()
+        {
+            ThrowIfExceptional();
+
+            if (!IsAuthenticated && _context?.ConnectionInfo == null)
             {
                 ThrowNotAuthenticated();
             }


### PR DESCRIPTION
The information is already ready. It is set by ProcessHandshakeSuccess() in CompleteHandshake() prior to calling VerifyRemoteCertificate(). The problem is that _handshakeCompleted is not yet set to true so attempt to access the properties from callback will throw. 

I did not want to touch _handshakeCompleted as that would change external behavior and set IsAutneticated prematurely. Instead, I added new helper function to allow access also if  ConnectionInfo is available e.g. we progressed far enough in the handshake. 

fixes  #919
