### PR TITLE
Enable nullable reference types for full facades

### DIFF
--- a/src/libraries/System.AppContext/ref/System.AppContext.csproj
+++ b/src/libraries/System.AppContext/ref/System.AppContext.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.AppContext.Forwards.cs" />

--- a/src/libraries/System.AppContext/src/System.AppContext.csproj
+++ b/src/libraries/System.AppContext/src/System.AppContext.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.AppContext</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Buffers/src/System.Buffers.csproj
+++ b/src/libraries/System.Buffers/src/System.Buffers.csproj
@@ -4,6 +4,7 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <ExcludeResourcesImport>true</ExcludeResourcesImport>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Diagnostics.Contracts/src/System.Diagnostics.Contracts.csproj
+++ b/src/libraries/System.Diagnostics.Contracts/src/System.Diagnostics.Contracts.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Diagnostics.Contracts</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/libraries/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Diagnostics.Debug</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Diagnostics.Tools/ref/System.Diagnostics.Tools.csproj
+++ b/src/libraries/System.Diagnostics.Tools/ref/System.Diagnostics.Tools.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Diagnostics.Tools.Forwards.cs" />

--- a/src/libraries/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
+++ b/src/libraries/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Diagnostics.Tools</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
+++ b/src/libraries/System.Drawing.Primitives/src/System.Drawing.Primitives.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>System.Drawing.Primitives</AssemblyName>
     <DefineConstants Condition="'$(TargetsWindows)' == 'true'">$(DefineConstants);FEATURE_WINDOWS_SYSTEM_COLORS</DefineConstants>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
-    <nullable>enable</nullable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Collections" />

--- a/src/libraries/System.Globalization.Calendars/ref/System.Globalization.Calendars.csproj
+++ b/src/libraries/System.Globalization.Calendars/ref/System.Globalization.Calendars.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Globalization.Calendars.Forwards.cs" />

--- a/src/libraries/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
+++ b/src/libraries/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Globalization.Calendars</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Globalization.Extensions/ref/System.Globalization.Extensions.csproj
+++ b/src/libraries/System.Globalization.Extensions/ref/System.Globalization.Extensions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Globalization.Extensions.Forwards.cs" />

--- a/src/libraries/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
+++ b/src/libraries/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Globalization/ref/System.Globalization.csproj
+++ b/src/libraries/System.Globalization/ref/System.Globalization.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Globalization.Forwards.cs" />

--- a/src/libraries/System.Globalization/src/System.Globalization.csproj
+++ b/src/libraries/System.Globalization/src/System.Globalization.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Globalization</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.IO.FileSystem.Primitives/ref/System.IO.FileSystem.Primitives.csproj
+++ b/src/libraries/System.IO.FileSystem.Primitives/ref/System.IO.FileSystem.Primitives.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.FileSystem.Primitives.cs" />

--- a/src/libraries/System.IO.FileSystem.Primitives/src/System.IO.FileSystem.Primitives.csproj
+++ b/src/libraries/System.IO.FileSystem.Primitives/src/System.IO.FileSystem.Primitives.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.IO.FileSystem.Primitives</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.IO.UnmanagedMemoryStream/ref/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/libraries/System.IO.UnmanagedMemoryStream/ref/System.IO.UnmanagedMemoryStream.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.UnmanagedMemoryStream.Forwards.cs" />

--- a/src/libraries/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/libraries/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.IO.UnmanagedMemoryStream</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.IO/ref/System.IO.csproj
+++ b/src/libraries/System.IO/ref/System.IO.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.IO.Forwards.cs" />

--- a/src/libraries/System.IO/src/System.IO.csproj
+++ b/src/libraries/System.IO/src/System.IO.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.IO</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/libraries/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Reflection.Emit.ILGeneration/src/System.Reflection.Emit.ILGeneration.csproj
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/src/System.Reflection.Emit.ILGeneration.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Reflection.Emit.ILGeneration</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Reflection.Emit.Lightweight/src/System.Reflection.Emit.Lightweight.csproj
+++ b/src/libraries/System.Reflection.Emit.Lightweight/src/System.Reflection.Emit.Lightweight.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <AssemblyName>System.Reflection.Emit.Lightweight</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>  
+    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
+++ b/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Reflection.Extensions/ref/System.Reflection.Extensions.csproj
+++ b/src/libraries/System.Reflection.Extensions/ref/System.Reflection.Extensions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.Extensions.Forwards.cs" />

--- a/src/libraries/System.Reflection.Extensions/src/System.Reflection.Extensions.csproj
+++ b/src/libraries/System.Reflection.Extensions/src/System.Reflection.Extensions.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Reflection.Extensions</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Reflection.Primitives/src/System.Reflection.Primitives.csproj
+++ b/src/libraries/System.Reflection.Primitives/src/System.Reflection.Primitives.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Reflection.Primitives</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Reflection/ref/System.Reflection.csproj
+++ b/src/libraries/System.Reflection/ref/System.Reflection.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.Forwards.cs" />

--- a/src/libraries/System.Reflection/src/System.Reflection.csproj
+++ b/src/libraries/System.Reflection/src/System.Reflection.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Reflection</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Resources.Reader/ref/System.Resources.Reader.csproj
+++ b/src/libraries/System.Resources.Reader/ref/System.Resources.Reader.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Resources.Reader.Forwards.cs" />

--- a/src/libraries/System.Resources.Reader/src/System.Resources.Reader.csproj
+++ b/src/libraries/System.Resources.Reader/src/System.Resources.Reader.csproj
@@ -4,6 +4,7 @@
     <RootNamespace>System.Resources</RootNamespace>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
+++ b/src/libraries/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Resources.ResourceManager</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
+++ b/src/libraries/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Extensions.Forwards.cs" />

--- a/src/libraries/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/libraries/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />

--- a/src/libraries/System.Runtime.Handles/ref/System.Runtime.Handles.csproj
+++ b/src/libraries/System.Runtime.Handles/ref/System.Runtime.Handles.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Handles.Forwards.cs" />

--- a/src/libraries/System.Runtime.Handles/src/System.Runtime.Handles.csproj
+++ b/src/libraries/System.Runtime.Handles/src/System.Runtime.Handles.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Runtime.Handles</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Runtime.Intrinsics.Experimental/ref/System.Runtime.Intrinsics.Experimental.csproj
+++ b/src/libraries/System.Runtime.Intrinsics.Experimental/ref/System.Runtime.Intrinsics.Experimental.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Runtime.Intrinsics.Experimental.cs" />

--- a/src/libraries/System.Runtime.Intrinsics.Experimental/src/System.Runtime.Intrinsics.Experimental.csproj
+++ b/src/libraries/System.Runtime.Intrinsics.Experimental/src/System.Runtime.Intrinsics.Experimental.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Runtime.Intrinsics.Experimental</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Runtime.Intrinsics/src/System.Runtime.Intrinsics.csproj
+++ b/src/libraries/System.Runtime.Intrinsics/src/System.Runtime.Intrinsics.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Runtime.Loader/src/System.Runtime.Loader.csproj
+++ b/src/libraries/System.Runtime.Loader/src/System.Runtime.Loader.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Runtime.Loader</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Runtime/src/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/src/System.Runtime.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Runtime</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <!-- Compiler throws error if you try to use System.Void and instructs you to use void keyword instead. So we have manually added a typeforward for this type. -->  

--- a/src/libraries/System.Security.Principal/ref/System.Security.Principal.csproj
+++ b/src/libraries/System.Security.Principal/ref/System.Security.Principal.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.Principal.Forwards.cs" />

--- a/src/libraries/System.Security.Principal/src/System.Security.Principal.csproj
+++ b/src/libraries/System.Security.Principal/src/System.Security.Principal.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Security.Principal</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Security.SecureString/ref/System.Security.SecureString.csproj
+++ b/src/libraries/System.Security.SecureString/ref/System.Security.SecureString.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Security.SecureString.cs" />

--- a/src/libraries/System.Security.SecureString/src/System.Security.SecureString.csproj
+++ b/src/libraries/System.Security.SecureString/src/System.Security.SecureString.csproj
@@ -4,6 +4,7 @@
     <AssemblyName>System.Security.SecureString</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />

--- a/src/libraries/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
+++ b/src/libraries/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Text.Encoding.Extensions</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Text.Encoding/ref/System.Text.Encoding.csproj
+++ b/src/libraries/System.Text.Encoding/ref/System.Text.Encoding.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Text.Encoding.Forwards.cs" />

--- a/src/libraries/System.Text.Encoding/src/System.Text.Encoding.csproj
+++ b/src/libraries/System.Text.Encoding/src/System.Text.Encoding.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Text.Encoding</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
+++ b/src/libraries/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
@@ -4,6 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
+++ b/src/libraries/System.Threading.Tasks.Extensions/ref/System.Threading.Tasks.Extensions.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Tasks.Extensions.Forwards.cs" />

--- a/src/libraries/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/libraries/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Threading.Tasks/ref/System.Threading.Tasks.csproj
+++ b/src/libraries/System.Threading.Tasks/ref/System.Threading.Tasks.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Tasks.Forwards.cs" />

--- a/src/libraries/System.Threading.Tasks/src/System.Threading.Tasks.csproj
+++ b/src/libraries/System.Threading.Tasks/src/System.Threading.Tasks.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Threading.Tasks</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Threading.Thread/src/System.Threading.Thread.csproj
+++ b/src/libraries/System.Threading.Thread/src/System.Threading.Thread.csproj
@@ -4,6 +4,7 @@
     <OutputType>Library</OutputType>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
+++ b/src/libraries/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Threading.ThreadPool</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.Threading.Timer/ref/System.Threading.Timer.csproj
+++ b/src/libraries/System.Threading.Timer/ref/System.Threading.Timer.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Threading.Timer.Forwards.cs" />

--- a/src/libraries/System.Threading.Timer/src/System.Threading.Timer.csproj
+++ b/src/libraries/System.Threading.Timer/src/System.Threading.Timer.csproj
@@ -3,6 +3,7 @@
     <AssemblyName>System.Threading.Timer</AssemblyName>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ReferenceFromRuntime Include="System.Private.CoreLib" />

--- a/src/libraries/System.ValueTuple/ref/System.ValueTuple.csproj
+++ b/src/libraries/System.ValueTuple/ref/System.ValueTuple.csproj
@@ -4,6 +4,7 @@
          Can be removed when API is added and this assembly is versioned to 4.1.* -->
     <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <TargetFrameworks>$(NetCoreAppCurrent);_$(NetFrameworkCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.ValueTuple.TypeForwards.cs" />

--- a/src/libraries/System.ValueTuple/src/System.ValueTuple.csproj
+++ b/src/libraries/System.ValueTuple/src/System.ValueTuple.csproj
@@ -3,6 +3,7 @@
     <!-- rev'ed to 4.0.1.0 even though 4.0.0.0 never shipped so that we can drop pre-release down to beta -->
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <TargetFrameworks>$(NetCoreAppCurrent);_$(NetFrameworkCurrent)</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />


### PR DESCRIPTION
Some of our full facades are missing `<Nullable>enable</Nullable>`.  I don't think the lack of these causes any issues, but having them makes it easy to confirm what ref assemblies remain to be annotated.

Contributes to https://github.com/dotnet/runtime/issues/2339
cc: @buyaa-n 