### PR TITLE
Annotate System.Reflection.Context for nullable reference types

### DIFF
--- a/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.cs
+++ b/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.cs
@@ -12,8 +12,8 @@ namespace System.Reflection.Context
         protected CustomReflectionContext() { }
         protected CustomReflectionContext(System.Reflection.ReflectionContext source) { }
         protected virtual System.Collections.Generic.IEnumerable<System.Reflection.PropertyInfo> AddProperties(System.Type type) { throw null; }
-        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object> getter, System.Action<object, object> setter) { throw null; }
-        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object> getter, System.Action<object, object> setter, System.Collections.Generic.IEnumerable<System.Attribute> propertyCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute> getterCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute> setterCustomAttributes) { throw null; }
+        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object>? getter, System.Action<object, object>? setter) { throw null; }
+        protected System.Reflection.PropertyInfo CreateProperty(System.Type propertyType, string name, System.Func<object, object>? getter, System.Action<object, object>? setter, System.Collections.Generic.IEnumerable<System.Attribute>? propertyCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute>? getterCustomAttributes, System.Collections.Generic.IEnumerable<System.Attribute>? setterCustomAttributes) { throw null; }
         protected virtual System.Collections.Generic.IEnumerable<object> GetCustomAttributes(System.Reflection.MemberInfo member, System.Collections.Generic.IEnumerable<object> declaredAttributes) { throw null; }
         protected virtual System.Collections.Generic.IEnumerable<object> GetCustomAttributes(System.Reflection.ParameterInfo parameter, System.Collections.Generic.IEnumerable<object> declaredAttributes) { throw null; }
         public override System.Reflection.Assembly MapAssembly(System.Reflection.Assembly assembly) { throw null; }

--- a/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.csproj
+++ b/src/libraries/System.Reflection.Context/ref/System.Reflection.Context.csproj
@@ -5,6 +5,7 @@
          to a different assembly. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <TargetFrameworks>netstandard2.0;netstandard1.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.Reflection.Context.cs" />

--- a/src/libraries/System.Reflection.Context/src/System.Reflection.Context.csproj
+++ b/src/libraries/System.Reflection.Context/src/System.Reflection.Context.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.1;netstandard2.1</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
+++ b/src/libraries/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
@@ -67,8 +67,8 @@ namespace System.Reflection.Context
         protected PropertyInfo CreateProperty(
             Type propertyType,
             string name,
-            Func<object, object> getter,
-            Action<object, object> setter)
+            Func<object, object>? getter,
+            Action<object, object>? setter)
         {
             return new VirtualPropertyInfo(
                 name,
@@ -84,11 +84,11 @@ namespace System.Reflection.Context
         protected PropertyInfo CreateProperty(
             Type propertyType,
             string name,
-            Func<object, object> getter,
-            Action<object, object> setter,
-            IEnumerable<Attribute> propertyCustomAttributes,
-            IEnumerable<Attribute> getterCustomAttributes,
-            IEnumerable<Attribute> setterCustomAttributes)
+            Func<object, object>? getter,
+            Action<object, object>? setter,
+            IEnumerable<Attribute>? propertyCustomAttributes,
+            IEnumerable<Attribute>? getterCustomAttributes,
+            IEnumerable<Attribute>? setterCustomAttributes)
         {
             return new VirtualPropertyInfo(
                 name,


### PR DESCRIPTION
cc: @buyaa-n, @steveharter, @GrabYourPitchforks
Contributes to https://github.com/dotnet/runtime/issues/2339