### PR TITLE
Initialize AsnEncodedData.RawData to empty array

### DIFF
--- a/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedData.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedData.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Internal.Cryptography;
 
 namespace System.Security.Cryptography
@@ -12,6 +13,10 @@ namespace System.Security.Cryptography
     {
         protected AsnEncodedData()
         {
+            // Initialize _rawData to an empty array so that RawData may reasonably be a non-nullable byte[].
+            // It naturally is for the base type as well as for derived types behaving as intended.
+            // This, however, is a deviation from the original .NET Framework behavior.
+            _rawData = Array.Empty<byte>();
         }
 
         public AsnEncodedData(byte[] rawData)
@@ -57,6 +62,7 @@ namespace System.Security.Cryptography
                 return _rawData;
             }
 
+            [MemberNotNull(nameof(_rawData))]
             set
             {
                 if (value == null)
@@ -81,6 +87,7 @@ namespace System.Security.Cryptography
             return AsnFormatter.Instance.Format(_oid, _rawData, multiLine);
         }
 
+        [MemberNotNull(nameof(_rawData))]
         private void Reset(Oid? oid, byte[] rawData)
         {
             this.Oid = oid;
@@ -88,6 +95,6 @@ namespace System.Security.Cryptography
         }
 
         private Oid? _oid = null;
-        private byte[] _rawData = null!; // initialized in helper method Reset for all public constuctors
+        private byte[] _rawData;
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs9LocalKeyIdTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs9LocalKeyIdTests.cs
@@ -13,13 +13,13 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
         public static void DefaultCtor()
         {
             Pkcs9LocalKeyId localKeyId = new Pkcs9LocalKeyId();
-            Assert.Equal(0, localKeyId.KeyId.Length);
+            Assert.Throws<CryptographicException>(() => localKeyId.KeyId);
 
             Oid oid = localKeyId.Oid;
             Assert.NotNull(oid);
             Assert.Equal(Oids.LocalKeyId, oid.Value);
 
-            Assert.Null(localKeyId.RawData);
+            Assert.Empty(localKeyId.RawData);
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs9AttributeTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs9AttributeTests.cs
@@ -16,7 +16,14 @@ namespace System.Security.Cryptography.Pkcs.Tests
         {
             Pkcs9AttributeObject p = new Pkcs9AttributeObject();
             Assert.Null(p.Oid);
-            Assert.Null(p.RawData);
+            if (PlatformDetection.IsNetCore)
+            {
+                Assert.Empty(p.RawData);
+            }
+            else
+            {
+                Assert.Null(p.RawData);
+            }
         }
 
         [Fact]
@@ -147,8 +154,16 @@ namespace System.Security.Cryptography.Pkcs.Tests
         public static void DocumentDescriptionNullary()
         {
             Pkcs9DocumentDescription p = new Pkcs9DocumentDescription();
-            Assert.Null(p.RawData);
-            Assert.Null(p.DocumentDescription);
+            if (PlatformDetection.IsNetCore)
+            {
+                Assert.Empty(p.RawData);
+                Assert.Throws<CryptographicException>(() => p.DocumentDescription);
+            }
+            else
+            {
+                Assert.Null(p.RawData);
+                Assert.Null(p.DocumentDescription);
+            }
             string oid = p.Oid.Value;
             Assert.Equal(s_OidDocumentDescription, oid);
         }
@@ -188,8 +203,16 @@ namespace System.Security.Cryptography.Pkcs.Tests
         public static void DocumentNameNullary()
         {
             Pkcs9DocumentName p = new Pkcs9DocumentName();
-            Assert.Null(p.RawData);
-            Assert.Null(p.DocumentName);
+            if (PlatformDetection.IsNetCore)
+            {
+                Assert.Empty(p.RawData);
+                Assert.Throws<CryptographicException>(() => p.DocumentName);
+            }
+            else
+            {
+                Assert.Null(p.RawData);
+                Assert.Null(p.DocumentName);
+            }
             string oid = p.Oid.Value;
             Assert.Equal(s_OidDocumentName, oid);
         }
@@ -297,8 +320,16 @@ namespace System.Security.Cryptography.Pkcs.Tests
         public static void ContentTypeNullary()
         {
             Pkcs9ContentType p = new Pkcs9ContentType();
-            Assert.Null(p.RawData);
-            Assert.Null(p.ContentType);
+            if (PlatformDetection.IsNetCore)
+            {
+                Assert.Empty(p.RawData);
+                Assert.Throws<CryptographicException>(() => p.ContentType);
+            }
+            else
+            {
+                Assert.Null(p.RawData);
+                Assert.Null(p.ContentType);
+            }
             string oid = p.Oid.Value;
             Assert.Equal(s_OidContentType, oid);
         }
@@ -357,8 +388,16 @@ namespace System.Security.Cryptography.Pkcs.Tests
         public static void MessageDigestNullary()
         {
             Pkcs9MessageDigest p = new Pkcs9MessageDigest();
-            Assert.Null(p.RawData);
-            Assert.Null(p.MessageDigest);
+            if (PlatformDetection.IsNetCore)
+            {
+                Assert.Empty(p.RawData);
+                Assert.Throws<CryptographicException>(() => p.MessageDigest);
+            }
+            else
+            {
+                Assert.Null(p.RawData);
+                Assert.Null(p.MessageDigest);
+            }
             string oid = p.Oid.Value;
             Assert.Equal(s_OidMessageDigest, oid);
         }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -123,8 +123,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X509KeyUsageExtension e = new X509KeyUsageExtension();
             string oidValue = e.Oid.Value;
             Assert.Equal("2.5.29.15", oidValue);
-            byte[] r = e.RawData;
-            Assert.Null(r);
+            Assert.Empty(e.RawData);
             X509KeyUsageFlags keyUsages = e.KeyUsages;
             Assert.Equal(X509KeyUsageFlags.None, keyUsages);
         }
@@ -217,8 +216,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string oidValue = e.Oid.Value;
             Assert.Equal("2.5.29.19", oidValue);
 
-            byte[] rawData = e.RawData;
-            Assert.Null(rawData);
+            Assert.Empty(e.RawData);
 
             Assert.False(e.CertificateAuthority);
             Assert.False(e.HasPathLengthConstraint);
@@ -291,8 +289,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string oidValue = e.Oid.Value;
             Assert.Equal("2.5.29.37", oidValue);
 
-            byte[] rawData = e.RawData;
-            Assert.Null(rawData);
+            Assert.Empty(e.RawData);
 
             OidCollection usages = e.EnhancedKeyUsages;
             Assert.Equal(0, usages.Count);
@@ -353,8 +350,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string oidValue = e.Oid.Value;
             Assert.Equal("2.5.29.14", oidValue);
 
-            byte[] rawData = e.RawData;
-            Assert.Null(rawData);
+            Assert.Empty(e.RawData);
 
             string skid = e.SubjectKeyIdentifier;
             Assert.Null(skid);


### PR DESCRIPTION
Maintains nullable annotation on RawData.
Replaces https://github.com/dotnet/runtime/pull/37572

@bartonjs, if you're not comfortable with the cases that became exceptional, I'm going to punt and let you fix it ;-)