### PR TITLE
Create Microsoft.NetCore.App.Ref targeting pack for NetCoreAppCurrent in libraries

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -42,7 +42,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fef373440d604c428950236fbc2b99ce0df368a9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20308.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20308.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fef373440d604c428950236fbc2b99ce0df368a9</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -42,7 +42,7 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fef373440d604c428950236fbc2b99ce0df368a9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20280.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk" Version="5.0.0-beta.20308.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>fef373440d604c428950236fbc2b99ce0df368a9</Sha>
     </Dependency>

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -20,7 +20,7 @@
       <AndroidAbi Condition="'$(TargetArchitecture)' == 'x86'">x86</AndroidAbi>
     </PropertyGroup>
 
-    <Error Condition="!Exists('$(RuntimePackRidDir)')" Text="RuntimePackRidDir=$(RuntimePackRidDir) doesn't exist" />
+    <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
 
     <!-- TEMP: consume OpenSSL binaries from external sources via env. variables -->
     <Copy Condition="'$(ANDROID_OPENSSL_AAR)' != ''"
@@ -36,7 +36,7 @@
     <AndroidAppBuilderTask
         Abi="$(AndroidAbi)"
         ProjectName="$(AssemblyName)"
-        MonoRuntimeHeaders="$(RuntimePackNativeDir)include\mono-2.0"
+        MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackNativeDir)include\mono-2.0"
         MainLibraryFileName="AndroidTestRunner.dll"
         StripDebugSymbols="False"
         OutputDir="$(BundleDir)"
@@ -59,7 +59,7 @@
   <Import Project="$(MonoAOTCompilerDir)MonoAOTCompiler.props" />
 
   <Target Condition="'$(TargetOS)' == 'iOS'" Name="BundleTestAppleApp">
-    <Error Condition="!Exists('$(RuntimePackRidDir)')" Text="RuntimePackRidDir=$(RuntimePackRidDir) doesn't exist" />
+    <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <Error Condition="('$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'arm') and '$(DevTeamProvisioning)' == ''"
            Text="'DevTeamProvisioning' needs to be set for device builds. Set it to 'UBF8T346G9' if you're part of the Microsoft team account." />
 
@@ -74,12 +74,12 @@
     </ItemGroup>
 
     <MonoAOTCompiler Condition="'$(RunAOTCompilation)' == 'true'"
-        CompilerBinaryPath="$(RuntimePackNativeDir)cross\mono-aot-cross"
+        CompilerBinaryPath="$(MicrosoftNetCoreAppRuntimePackNativeDir)cross\mono-aot-cross"
         Mode="Full"
         OutputType="AsmOnly"
         Assemblies="@(AotInputAssemblies)"
         UseLLVM="$(MonoEnableLLVM)"
-        LLVMPath="$(RuntimePackNativeDir)cross">
+        LLVMPath="$(MicrosoftNetCoreAppRuntimePackNativeDir)cross">
         <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>
 
@@ -89,7 +89,7 @@
     <AppleAppBuilderTask
         Arch="$(TargetArchitecture)"
         ProjectName="$(AssemblyName)"
-        MonoRuntimeHeaders="$(RuntimePackNativeDir)include\mono-2.0"
+        MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackNativeDir)include\mono-2.0"
         Assemblies="@(BundleAssemblies)"
         MainLibraryFileName="AppleTestRunner.dll"
         UseConsoleUITemplate="True"
@@ -114,10 +114,10 @@
     <ItemGroup>
       <AssemblySearchPaths Include="$(PublishDir)"/>
     </ItemGroup>
-    <Error Condition="!Exists('$(RuntimePackRidDir)')" Text="RuntimePackRidDir=$(RuntimePackRidDir) doesn't exist" />
+    <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <WasmAppBuilder
       AppDir="$(BundleDir)"
-      RuntimePackDir="$(RuntimePackRidDir)"
+      MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackRidDir)"
       MainAssembly="$(PublishDir)\WasmTestRunner.dll"
       MainJS="$(MonoProjectRoot)\wasm\runtime-test.js"
       ExtraAssemblies="$(PublishDir)\$(AssemblyName).dll"
@@ -144,7 +144,7 @@
   <Target Name="UpdateRuntimePack"
           DependsOnTargets="AddFrameworkReference;ResolveFrameworkReferences">
     <ItemGroup>
-      <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(RuntimePackDir)" />
+      <ResolvedRuntimePack Update="@(ResolvedRuntimePack)" PackageDirectory="$(MicrosoftNetCoreAppRuntimePackDir)" />
     </ItemGroup>
   </Target>
 

--- a/global.json
+++ b/global.json
@@ -12,7 +12,7 @@
     "python3": "3.7.1"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20280.1",
+    "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20308.5",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20280.1",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20280.1",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20280.1",

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -270,11 +270,14 @@
 
     <TestHostRootPath>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'testhost', '$(BuildSettings)'))</TestHostRootPath>
 
-    <RuntimePackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'lib-runtime-packs', '$(BuildSettings)'))</RuntimePackDir>
-    <RuntimePackRidDir>$([MSBuild]::NormalizeDirectory('$(RuntimePackDir)', 'runtimes', '$(PackageRID)'))</RuntimePackRidDir>
-    <RuntimePackLibDir>$([MSBuild]::NormalizeDirectory('$(RuntimePackRidDir)', 'lib', '$(NetCoreAppCurrent)'))</RuntimePackLibDir>
-    <RuntimePackNativeDir>$([MSBuild]::NormalizeDirectory('$(RuntimePackRidDir)', 'native'))</RuntimePackNativeDir>
-    <RuntimePackTargetFrameworkPath>runtimes/$(PackageRID)</RuntimePackTargetFrameworkPath>
+    <MicrosoftNetCoreAppRefPackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.ref', '$(Configuration)'))</MicrosoftNetCoreAppRefPackDir>
+    <MicrosoftNetCoreAppRefPackRefDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'ref'))</MicrosoftNetCoreAppRefPackRefDir>
+    <MicrosoftNetCoreAppRefPackDataDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRefPackDir)', 'data'))</MicrosoftNetCoreAppRefPackDataDir>
+
+    <MicrosoftNetCoreAppRuntimePackDir>$([MSBuild]::NormalizeDirectory('$(ArtifactsBinDir)', 'microsoft.netcore.app.runtime.$(PackageRID)', '$(Configuration)'))</MicrosoftNetCoreAppRuntimePackDir>
+    <MicrosoftNetCoreAppRuntimePackRidDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackDir)', 'runtimes', '$(PackageRID)'))</MicrosoftNetCoreAppRuntimePackRidDir>
+    <MicrosoftNetCoreAppRuntimePackRidLibTfmDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackRidDir)', 'lib', '$(NetCoreAppCurrent)'))</MicrosoftNetCoreAppRuntimePackRidLibTfmDir>
+    <MicrosoftNetCoreAppRuntimePackNativeDir>$([MSBuild]::NormalizeDirectory('$(MicrosoftNetCoreAppRuntimePackRidDir)', 'native'))</MicrosoftNetCoreAppRuntimePackNativeDir>
 
     <VersionFileForPackages Condition="'$(VersionFileForPackages)' == ''">$(ArtifactsObjDir)version.txt</VersionFileForPackages>
 
@@ -301,8 +304,6 @@
     <!-- We add extra binplacing for the test shared framework until we can get hardlinking with the runtime directory working on all platforms -->
     <BinPlaceTestSharedFramework Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">true</BinPlaceTestSharedFramework>
     <BinPlaceNETFXRuntime Condition="'$(BuildTargetFramework)' == '$(NetFrameworkCurrent)'">true</BinPlaceNETFXRuntime>
-
-    <BinPlaceTestRuntimePack Condition="'$(RuntimeFlavor)' == 'Mono'">true</BinPlaceTestRuntimePack>
 
     <NETCoreAppTestSharedFrameworkPath>$([MSBuild]::NormalizeDirectory('$(TestHostRootPath)', 'shared', 'Microsoft.NETCore.App', '$(ProductVersion)'))</NETCoreAppTestSharedFrameworkPath>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -102,9 +102,7 @@
     </BinPlaceTargetFrameworks>
     <!-- Corresponding libMono and system.native libraries are added to testhost shared framework -->
     <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)"
-                              Condition="'$(BinPlaceTestSharedFramework)' == 'true' and
-                                         '$(RuntimeFlavor)' == 'Mono' and
-                                         '$(TargetsMobile)' != 'true'">
+                              Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
       <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)</RuntimePath>
       <ItemName>TestHostBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -46,8 +46,8 @@
     <IsNETCoreAppRef Condition="'$(IsNETCoreAppRef)' == ''">$(IsNETCoreApp)</IsNETCoreAppRef>
     <IsNetFxNETStandardRef Condition="'$(IsNetFxNETStandardRef)' == ''">$(IsNetFxNETStandard)</IsNetFxNETStandardRef>
 
-    <BinPlaceRef Condition="'$(BinPlaceRef)' == '' And ('$(IsReferenceAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
-    <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' And ('$(IsRuntimeAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
+    <BinPlaceRef Condition="'$(BinPlaceRef)' == '' and ('$(IsReferenceAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRef>
+    <BinPlaceRuntime Condition="'$(BinPlaceRuntime)' == '' and ('$(IsRuntimeAssembly)' == 'true' or '$(IsRuntimeAndReferenceAssembly)' == 'true')">true</BinPlaceRuntime>
     <BinPlaceForTargetVertical Condition="'$(BinPlaceForTargetVertical)' == ''">true</BinPlaceForTargetVertical>
     <AllTargetFrameworks>net45;net451;net46;net461;net462;net47;net471;net472;netstandard1.0;netstandard1.1;netstandard1.2;netstandard1.3;netstandard1.4;netstandard1.5;netstandard1.6;netstandard2.0;netstandard2.0;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0;$(netcoreappCurrent);</AllTargetFrameworks>
   </PropertyGroup>
@@ -60,15 +60,18 @@
   <ItemGroup Condition="'@(BinPlaceTargetFrameworks)' == ''">
     <!-- binplace to directories for the target vertical -->
     <BinPlaceTargetFrameworks Include="$(BuildTargetFramework)-$(TargetOS)" Condition="'$(BinPlaceForTargetVertical)' == 'true'">
+      <NativePath>$(RuntimePath)</NativePath>
       <RefPath>$(BuildTargetFrameworkRefPath)</RefPath>
       <RuntimePath>$(RuntimePath)</RuntimePath>
     </BinPlaceTargetFrameworks>
     <!-- binplace to directories for packages -->
     <BinPlaceTargetFrameworks Condition="'$(IsNETCoreApp)' == 'true' and '$(BuildingNETCoreAppVertical)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
+      <PackageFileNativePath>$(NETCoreAppPackageRuntimePath)</PackageFileNativePath>
       <PackageFileRefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(NETCoreAppPackageRefPath)</PackageFileRefPath>
       <PackageFileRuntimePath>$(NETCoreAppPackageRuntimePath)</PackageFileRuntimePath>
-      <RuntimePath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\runtime\$(TargetOS)-$(Configuration)-$(TargetArchitecture)</RuntimePath>
+      <NativePath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\runtime\$(TargetOS)-$(Configuration)-$(TargetArchitecture)</NativePath>
       <RefPath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true' and '$(IsNETCoreAppRef)' == 'true'">$(RefRootPath)microsoft.netcore.app\$(Configuration)</RefPath>
+      <RuntimePath Condition="'$(BinPlaceNETCoreAppPackage)' == 'true'">$(NETCoreAppPackageRuntimePath)\..\runtime\$(TargetOS)-$(Configuration)-$(TargetArchitecture)</RuntimePath>
       <!-- enable trimming for any runtime project that's part of the shared framework and hasn't already set ILLinkTrimAssembly -->
       <SetProperties Condition="'$(BinPlaceRuntime)' == 'true' and '$(ILLinkTrimAssembly)' == ''">ILLinkTrimAssembly=true</SetProperties>
     </BinPlaceTargetFrameworks>
@@ -79,28 +82,33 @@
 
     <!-- Setup the shared framework directory for testing -->
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestSharedFramework)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
+      <NativePath>$(NETCoreAppTestSharedFrameworkPath)</NativePath>
       <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
     <BinPlaceTargetFrameworks Condition="'$(BinPlaceNETFXRuntime)' == 'true'" Include="$(NetFrameworkCurrent)-Windows_NT">
+      <NativePath>$(TestHostRootPath)</NativePath>
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
 
-    <!-- Setup the runtime pack structure for mobile platforms (for testing and installer) -->
-    <!-- Corresponding assemblies are added to lib -->
-    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
-      <RuntimePath>$(RuntimePackLibDir)</RuntimePath>
+    <!-- Microsoft.NetCore.App.Ref targeting pack binplacing. -->
+    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)">
+      <RefPath>$(MicrosoftNetCoreAppRefPackRefDir)</RefPath>
     </BinPlaceTargetFrameworks>
-    <!-- Corresponding libMono and system.native libraries are added to native -->
-    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
-      <RuntimePath>$(RuntimePackNativeDir)</RuntimePath>
-      <ItemName>NativeBinPlaceItem</ItemName>
+
+    <!--
+      Setup the runtime pack structure for mobile platforms (for testing and installer)
+      Corresponding assemblies are added to lib
+      Corresponding libMono and system.native libraries are added to native
+    -->
+    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)">
+      <NativePath>$(MicrosoftNetCoreAppRuntimePackNativeDir)</NativePath>
+      <RuntimePath>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</RuntimePath>
     </BinPlaceTargetFrameworks>
     <!-- Corresponding libMono and system.native libraries are added to testhost shared framework -->
-    <BinPlaceTargetFrameworks Condition="'$(BinPlaceTestRuntimePack)' == 'true' and '$(TargetsMobile)' != 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
+    <BinPlaceTargetFrameworks Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <RuntimePath>$(TestHostRuntimePath)</RuntimePath>
       <ItemName>TestHostBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>
-
 
     <!-- binplace targeting packs which may be different from Build TargetFramework -->
     <BinPlaceTargetFrameworks Include="netstandard2.0">

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -92,7 +92,7 @@
 
     <!-- Microsoft.NetCore.App.Ref targeting pack -->
     <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)">
-      <RefPath>$(MicrosoftNetCoreAppRefPackRefDir)</RefPath>
+      <RefPath Condition="'$(IsNETCoreAppRef)' == 'true'">$(MicrosoftNetCoreAppRefPackRefDir)</RefPath>
     </BinPlaceTargetFrameworks>
 
     <!-- Microsoft.NetCore.App.Runtime targeting pack -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -90,23 +90,22 @@
       <RuntimePath>$(TestHostRootPath)</RuntimePath>
     </BinPlaceTargetFrameworks>
 
-    <!-- Microsoft.NetCore.App.Ref targeting pack binplacing. -->
+    <!-- Microsoft.NetCore.App.Ref targeting pack -->
     <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)">
       <RefPath>$(MicrosoftNetCoreAppRefPackRefDir)</RefPath>
     </BinPlaceTargetFrameworks>
 
-    <!--
-      Setup the runtime pack structure for mobile platforms (for testing and installer)
-      Corresponding assemblies are added to lib
-      Corresponding libMono and system.native libraries are added to native
-    -->
+    <!-- Microsoft.NetCore.App.Runtime targeting pack -->
     <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)">
       <NativePath>$(MicrosoftNetCoreAppRuntimePackNativeDir)</NativePath>
       <RuntimePath>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</RuntimePath>
     </BinPlaceTargetFrameworks>
     <!-- Corresponding libMono and system.native libraries are added to testhost shared framework -->
-    <BinPlaceTargetFrameworks Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true'" Include="$(NetCoreAppCurrent)-$(TargetOS)">
-      <RuntimePath>$(TestHostRuntimePath)</RuntimePath>
+    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)"
+                              Condition="'$(BinPlaceTestSharedFramework)' == 'true' and
+                                         '$(RuntimeFlavor)' == 'Mono' and
+                                         '$(TargetsMobile)' != 'true'">
+      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)</RuntimePath>
       <ItemName>TestHostBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>
 
@@ -128,6 +127,7 @@
     </BinPlaceTargetFrameworks>
     <!-- for BuildAllConfigurations make sure runtimepaths are created for all vertical target frameworks. -->
     <BinPlaceTargetFrameworks Condition="'$(BuildAllConfigurations)' == 'true' and ('$(BinPlaceForTargetVertical)' == 'true' or ('$(TargetFramework)' != '$(NetCoreAppCurrent)' and '$(TargetFrameworkSuffix)' == ''))" Include="$(NetCoreAppCurrent)-$(TargetOS)">
+      <NativePath>$(ArtifactsBinDir)runtime/%(Identity)-$(Configuration)-$(TargetArchitecture)</NativePath>
       <RuntimePath>$(ArtifactsBinDir)runtime/%(Identity)-$(Configuration)-$(TargetArchitecture)</RuntimePath>
     </BinPlaceTargetFrameworks>
 

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -103,7 +103,7 @@
     <!-- Corresponding libMono and system.native libraries are added to testhost shared framework -->
     <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)"
                               Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
-      <RuntimePath>$(NETCoreAppTestSharedFrameworkPath)</RuntimePath>
+      <NativePath>$(NETCoreAppTestSharedFrameworkPath)</NativePath>
       <ItemName>TestHostBinPlaceItem</ItemName>
     </BinPlaceTargetFrameworks>
 

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -4,6 +4,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);netstandard2.0;$(NetFrameworkCurrent)</TargetFrameworks>
     <TargetFramework>$(BuildTargetFramework)</TargetFramework>
+    <BinPlaceRuntime>false</BinPlaceRuntime>
+    <BinPlaceNative>true</BinPlaceNative>
   </PropertyGroup>
 
   <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
@@ -11,22 +13,22 @@
   <!-- Ordering matters! Overriding GetBinPlaceItems and Build targets after the Sdk import. -->
   <Target Name="GetBinPlaceItems">
     <ItemGroup>
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.dll" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.pdb" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.lib" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.a" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.bc" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.so" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.dbg" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.dylib" />
-      <NativeBinPlaceItem Include="$(NativeBinDir)*.dwarf" />
-      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.js" />
-      <NativeBinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.wasm" />
+      <BinPlaceItem Include="$(NativeBinDir)*.dll" />
+      <BinPlaceItem Include="$(NativeBinDir)*.pdb" />
+      <BinPlaceItem Include="$(NativeBinDir)*.lib" />
+      <BinPlaceItem Include="$(NativeBinDir)*.a" />
+      <BinPlaceItem Include="$(NativeBinDir)*.bc" />
+      <BinPlaceItem Include="$(NativeBinDir)*.so" />
+      <BinPlaceItem Include="$(NativeBinDir)*.dbg" />
+      <BinPlaceItem Include="$(NativeBinDir)*.dylib" />
+      <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
+      <BinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.js" />
+      <BinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.wasm" />
 
-      <BinPlaceItem Condition="'$(BinPlaceTestRuntimePack)' != 'true'" Include="@(NativeBinPlaceItem)" />
       <FileWrites Include="@(NativeBinPlaceItem)" />
     </ItemGroup>
-    <ItemGroup Condition="'$(BinPlaceTestRuntimePack)' == 'true' and '$(TargetsMobile)' != 'true'">
+
+    <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true'">
       <TestHostBinPlaceItem Include="%(NativeBinPlaceItem.Identity)" />
       <FileWrites Include="@(TestHostBinPlaceItem)" />
     </ItemGroup>

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -24,12 +24,11 @@
       <BinPlaceItem Include="$(NativeBinDir)*.dwarf" />
       <BinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.js" />
       <BinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.wasm" />
-
-      <FileWrites Include="@(NativeBinPlaceItem)" />
+      <FileWrites Include="@(BinPlaceItem)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true'">
-      <TestHostBinPlaceItem Include="%(NativeBinPlaceItem.Identity)" />
+      <TestHostBinPlaceItem Include="@(BinPlaceItem)" />
       <FileWrites Include="@(TestHostBinPlaceItem)" />
     </ItemGroup>
   </Target>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -82,6 +82,7 @@
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
   <Target Name="GenerateFrameworkListFile"
+          Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'"
           AfterTargets="RestoreTestHost">
     <PropertyGroup>
       <_frameworkListFile>$(MicrosoftNetCoreAppRuntimePackDir)data\RuntimeList.xml</_frameworkListFile>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -13,7 +13,7 @@
 
   <!-- Explicitly build the runtime.depproj project first to correctly set up the testhost. -->
   <ItemGroup>
-    <RuntimeProject Include="restore\runtime\runtime.depproj" />
+    <RuntimeProject Include="$(MSBuildThisFileDirectory)restore\runtime\runtime.depproj" />
     <ProjectReference Include="@(RuntimeProject)" Condition="'$(MSBuildRestoreSessionId)' != ''" />
 
     <ProjectReference Include="$(CommonTestPath)AppleTestRunner\AppleTestRunner.csproj" Condition="'$(TargetOS)' == 'iOS' or '$(TargetOS)' == 'tvOS'"/>
@@ -35,7 +35,7 @@
 
   <!-- Microsoft.XmlSerializer.Generator should not be marked as a platform item and be copy-local instead. -->
   <Target Name="CollectSharedFrameworkRuntimeFiles"
-          Condition="'$(PlatformManifestFile)' != '' and '$(BuildingNETCoreAppVertical)' == 'true'">
+          Condition="'$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'">
     <ItemGroup>
       <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.OpenSsl.so" />
       <_manualSharedFrameworkRuntimeFiles Include="System.Security.Cryptography.Native.Apple.dylib" />
@@ -54,11 +54,16 @@
           Condition="'$(PlatformManifestFile)' != '' and '$(BuildTargetFramework)' == '$(NetCoreAppCurrent)'"
           AfterTargets="RestoreTestHost">
     <GenerateFileVersionProps Files="@(SharedFrameworkRuntimeFiles)"
-                              PackageId="Microsoft.NETCore.App"
+                              PackageId="$(SharedFrameworkName)"
                               PackageVersion="$(ProductVersion)"
                               PlatformManifestFile="$(PlatformManifestFile)"
-                              PreferredPackages="Microsoft.NetCore.App"
+                              PreferredPackages="$(SharedFrameworkName)"
                               PermitDllAndExeFilesLackingFileVersion="true" />
+
+    <Copy SourceFiles="$(PlatformManifestFile)"
+          DestinationFolder="$(MicrosoftNetCoreAppRefPackDataDir)"
+          UseHardlinksIfPossible="true"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <!--
@@ -77,20 +82,19 @@
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetBuildTasksSharedFrameworkTaskFile)"/>
   <Target Name="GenerateFrameworkListFile"
-          Condition="'$(BinPlaceTestRuntimePack)' == 'true'"
           AfterTargets="RestoreTestHost">
     <PropertyGroup>
-      <FrameworkListFilename>RuntimeList.xml</FrameworkListFilename>
-      <FrameworkListFile>$(RuntimePackDir)/data/$(FrameworkListFilename)</FrameworkListFile>
+      <_frameworkListFile>$(MicrosoftNetCoreAppRuntimePackDir)data\RuntimeList.xml</_frameworkListFile>
+      <_targetFrameworkPath>runtimes/$(PackageRID)/</_targetFrameworkPath>
     </PropertyGroup>
 
     <ItemGroup>
-      <_runtimePackLibFiles Include="$(RuntimePackLibDir)*.*">
-        <TargetPath>$(RuntimePackTargetFrameworkPath)/lib/$(NetCoreAppCurrent)</TargetPath>
+      <_runtimePackLibFiles Include="$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)*.*">
+        <TargetPath>$(_targetFrameworkPath)lib/$(NetCoreAppCurrent)</TargetPath>
         <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
       </_runtimePackLibFiles>
-      <_runtimePackNativeFiles Include="$(RuntimePackNativeDir)*.*">
-        <TargetPath>$(RuntimePackTargetFrameworkPath)/native</TargetPath>
+      <_runtimePackNativeFiles Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)*.*">
+        <TargetPath>$(_targetFrameworkPath)native</TargetPath>
         <IsNative>true</IsNative>
       </_runtimePackNativeFiles>
 
@@ -100,11 +104,15 @@
       <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFrameworkName)" />
     </ItemGroup>
 
-    <CreateFrameworkListFile
-      Files="@(_runtimePackLibFiles);@(_runtimePackNativeFiles)"
-      TargetFile="$(FrameworkListFile)"
-      TargetFilePrefixes="ref/;runtimes/"
-      RootAttributes="@(FrameworkListRootAttributes)" />
+    <CreateFrameworkListFile Files="@(_runtimePackLibFiles);@(_runtimePackNativeFiles)"
+                             TargetFile="$(_frameworkListFile)"
+                             TargetFilePrefixes="ref/;runtimes/"
+                             RootAttributes="@(FrameworkListRootAttributes)" />
+
+    <Copy SourceFiles="$(_frameworkListFile)"
+          DestinationFolder="$(MicrosoftNetCoreAppRefPackDataDir)"
+          UseHardlinksIfPossible="true"
+          SkipUnchangedFiles="true" />
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk" />

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -4,6 +4,8 @@
     <NoWarn>$(NoWarn);NU1603;NU1605</NoWarn>
     <SwapNativeForIL Condition="'$(SwapNativeForIL)' == '' and ('$(Configuration)' == 'Debug' or '$(Coverage)' == 'true') and '$(RuntimeFlavor)' != 'Mono'">true</SwapNativeForIL>
     <BinPlaceForTargetVertical>false</BinPlaceForTargetVertical>
+    <BinPlaceNative>true</BinPlaceNative>
+    <BinPlaceRuntime>false</BinPlaceRuntime>
     <TargetFrameworks>netcoreapp3.0-Windows_NT;netcoreapp3.0-Unix;$(netcoreappCurrent)-Windows_NT;$(netcoreappCurrent)-Unix</TargetFrameworks>
   </PropertyGroup>
 
@@ -81,13 +83,13 @@
           Condition="'$(RuntimeFlavor)' == 'Mono'"
           AfterTargets="AfterResolveReferences">
     <ItemGroup>
-      <NativeBinPlaceItem Include="@(RuntimeFiles)" />
-      <NativeBinPlaceItem Include="@(MonoCrossFiles)">
+      <BinPlaceItem Include="@(RuntimeFiles)" />
+      <BinPlaceItem Include="@(MonoCrossFiles)">
         <DestinationSubDirectory>cross/</DestinationSubDirectory>
-      </NativeBinPlaceItem>
-      <NativeBinPlaceItem Include="@(MonoIncludeFiles)">
+      </BinPlaceItem>
+      <BinPlaceItem Include="@(MonoIncludeFiles)">
         <DestinationSubDirectory>include/%(RecursiveDir)</DestinationSubDirectory>
-      </NativeBinPlaceItem>
+      </BinPlaceItem>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
       <TestHostBinPlaceItem Include="@(RuntimeFiles)" />

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -15,7 +15,7 @@
   <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <RuntimePack>
-        <PackageDirectory>$(ArtifactsDir)bin\microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-Android-$(Configuration)-$(Platform)</PackageDirectory>
+        <PackageDirectory>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)</PackageDirectory>
       </RuntimePack>
     </ItemGroup>
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -4,7 +4,7 @@
     <OutputPath>bin</OutputPath>
     <DebugType>Portable</DebugType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <RuntimePackDir>$(ArtifactsBinDir)lib-runtime-packs\$(NetCoreAppCurrent)-Android-$(Configuration)-$(TargetArchitecture)\runtimes\android-$(TargetArchitecture)</RuntimePackDir>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-Android-$(Configuration)-$(TargetArchitecture)\runtimes\android-$(TargetArchitecture)</MicrosoftNetCoreAppRuntimePackDir>
     <AndroidAppBuilderDir>$(ArtifactsBinDir)AndroidAppBuilder\$(Configuration)\$(NetCoreAppCurrent)</AndroidAppBuilderDir>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <PublishTrimmed>true</PublishTrimmed>
@@ -15,7 +15,7 @@
   <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <RuntimePack>
-        <PackageDirectory>$(ArtifactsDir)bin\lib-runtime-packs\$(NetCoreAppCurrent)-Android-$(Configuration)-$(Platform)</PackageDirectory>
+        <PackageDirectory>$(ArtifactsDir)bin\microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-Android-$(Configuration)-$(Platform)</PackageDirectory>
       </RuntimePack>
     </ItemGroup>
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />

--- a/src/mono/netcore/sample/Android/Program.csproj
+++ b/src/mono/netcore/sample/Android/Program.csproj
@@ -4,7 +4,7 @@
     <OutputPath>bin</OutputPath>
     <DebugType>Portable</DebugType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-Android-$(Configuration)-$(TargetArchitecture)\runtimes\android-$(TargetArchitecture)</MicrosoftNetCoreAppRuntimePackDir>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.android-$(TargetArchitecture)\$(Configuration)\runtimes\android-$(TargetArchitecture)</MicrosoftNetCoreAppRuntimePackDir>
     <AndroidAppBuilderDir>$(ArtifactsBinDir)AndroidAppBuilder\$(Configuration)\$(NetCoreAppCurrent)</AndroidAppBuilderDir>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -5,7 +5,7 @@
     <DebugType>Portable</DebugType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TargetOS>iOS</TargetOS>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)\runtimes\ios-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.ios-$(TargetArchitecture)\$(Configuration)\runtimes\ios-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <RuntimeIdentifier>ios-$(TargetArchitecture)</RuntimeIdentifier>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -5,7 +5,7 @@
     <DebugType>Portable</DebugType>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TargetOS>iOS</TargetOS>
-    <RuntimePackDir>$(ArtifactsBinDir)lib-runtime-packs\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)\runtimes\ios-$(TargetArchitecture)</RuntimePackDir>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)\runtimes\ios-$(TargetArchitecture)\</MicrosoftNetCoreAppRuntimePackDir>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <RuntimeIdentifier>ios-$(TargetArchitecture)</RuntimeIdentifier>
     <PublishTrimmed>true</PublishTrimmed>
@@ -17,13 +17,13 @@
   <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <RuntimePack>
-        <PackageDirectory>$(ArtifactsDir)bin\lib-runtime-packs\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)</PackageDirectory>
+        <PackageDirectory>$(ArtifactBinsDir)microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)</PackageDirectory>
       </RuntimePack>
     </ItemGroup>
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />
   </Target>
 
-  <Import Project="/Users/egorbo/prj/runtime/tools-local/tasks/mobile.tasks/AotCompilerTask/MonoAOTCompiler.props" />
+  <Import Project="$(RepoTasksDir)mobile.tasks\AotCompilerTask\MonoAOTCompiler.props" />
   <UsingTask TaskName="AppleAppBuilderTask"
              AssemblyFile="$(ArtifactsBinDir)AppleAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\AppleAppBuilder.dll" />
 
@@ -48,19 +48,19 @@
 
     <MonoAOTCompiler
         Condition="'$(IosSimulator)' == '' or '$(UseAotForSimulator)' == 'true'"
-        CompilerBinaryPath="$(RuntimePackDir)\native\cross\mono-aot-cross"
+        CompilerBinaryPath="$(MicrosoftNetCoreAppRuntimePackDir)native\cross\mono-aot-cross"
         Mode="Full"
         OutputType="AsmOnly"
         Assemblies="@(AotInputAssemblies)"
         UseLLVM="$(UseLLVM)"
-        LLVMPath="$(RuntimePackDir)\native\cross">
+        LLVMPath="$(MicrosoftNetCoreAppRuntimePackDir)native\cross">
         <Output TaskParameter="CompiledAssemblies" ItemName="BundleAssemblies" />
     </MonoAOTCompiler>
 
     <AppleAppBuilderTask
         Arch="$(TargetArchitecture)"
         ProjectName="HelloiOS"
-        MonoRuntimeHeaders="$(RuntimePackDir)\native\include\mono-2.0"
+        MonoRuntimeHeaders="$(MicrosoftNetCoreAppRuntimePackDir)native\include\mono-2.0"
         Assemblies="@(BundleAssemblies)"
         MainLibraryFileName="Program.dll"
         GenerateXcodeProject="True"

--- a/src/mono/netcore/sample/iOS/Program.csproj
+++ b/src/mono/netcore/sample/iOS/Program.csproj
@@ -17,7 +17,7 @@
   <Target Name="TrickRuntimePackLocation" AfterTargets="ProcessFrameworkReferences">
     <ItemGroup>
       <RuntimePack>
-        <PackageDirectory>$(ArtifactBinsDir)microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-iOS-$(Configuration)-$(TargetArchitecture)</PackageDirectory>
+        <PackageDirectory>$(ArtifactBinDir)microsoft.netcore.app.runtime.ios-$(TargetArchitecture)\$(Configuration)</PackageDirectory>
       </RuntimePack>
     </ItemGroup>
     <Message Text="Packaged ID: %(RuntimePack.PackageDirectory)" Importance="high" />

--- a/src/mono/netcore/sample/wasm/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/WasmSample.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TargetArchitecture>wasm</TargetArchitecture>
     <TargetOS>Browser</TargetOS>
-    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsDir)bin\microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsBinDir)microsoft.netcore.app.runtime.browser-wasm\$(Configuration)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
     <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\wasm</BuildDir>
     <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
   </PropertyGroup>

--- a/src/mono/netcore/sample/wasm/WasmSample.csproj
+++ b/src/mono/netcore/sample/wasm/WasmSample.csproj
@@ -6,30 +6,39 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <TargetArchitecture>wasm</TargetArchitecture>
     <TargetOS>Browser</TargetOS>
-    <RuntimePackDir>$(ArtifactsDir)bin\lib-runtime-packs\$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)\runtimes\browser-wasm</RuntimePackDir>
-    <BuildDir>$(MSBuildThisFileDirectory)\obj\$(Configuration)\wasm</BuildDir>
-    <AppDir>$(MSBuildThisFileDirectory)\bin\$(Configuration)\publish</AppDir>
+    <MicrosoftNetCoreAppRuntimePackDir>$(ArtifactsDir)bin\microsoft.netcore.app.runtime\$(NetCoreAppCurrent)-$(TargetOS)-$(Configuration)-$(TargetArchitecture)\runtimes\browser-wasm\</MicrosoftNetCoreAppRuntimePackDir>
+    <BuildDir>$(MSBuildThisFileDirectory)obj\$(Configuration)\wasm</BuildDir>
+    <AppDir>$(MSBuildThisFileDirectory)bin\$(Configuration)\publish</AppDir>
   </PropertyGroup>
 
   <Target Name="RebuildWasmAppBuilder">
-    <MSBuild Projects="$(RepoRoot)\tools-local\tasks\mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj"
-             Properties="Configuration=$(Configuration)" Targets="Restore;Build;Publish" />
+    <ItemGroup>
+      <WasmAppBuildProject Include="$(RepoTasksDir)mobile.tasks\WasmAppBuilder\WasmAppBuilder.csproj" />
+    </ItemGroup>
+
+    <MSBuild Projects="@(WasmAppBuildProject)"
+             Properties="Configuration=$(Configuration);MSBuildRestoreSessionId=$([System.Guid]::NewGuid())"
+             Targets="Restore"/>
+
+    <MSBuild Projects="@(WasmAppBuildProject)"
+             Properties="Configuration=$(Configuration)"
+             Targets="Build;Publish"/>
   </Target>
 
   <UsingTask TaskName="WasmAppBuilder" 
-      AssemblyFile="$(ArtifactsBinDir)\WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\WasmAppBuilder.dll"/>
+             AssemblyFile="$(ArtifactsBinDir)WasmAppBuilder\$(Configuration)\$(NetCoreAppCurrent)\publish\WasmAppBuilder.dll"/>
 
   <Target Name="BuildApp" DependsOnTargets="RebuildWasmAppBuilder;Build">
     <ItemGroup>
       <AssemblySearchPaths Include="bin"/>
-      <AssemblySearchPaths Include="$(RuntimePackDir)\native"/>
-      <AssemblySearchPaths Include="$(RuntimePackDir)\lib\$(NetCoreAppCurrent)"/>
+      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)native"/>
+      <AssemblySearchPaths Include="$(MicrosoftNetCoreAppRuntimePackDir)lib\$(NetCoreAppCurrent)"/>
     </ItemGroup>
     <WasmAppBuilder
       AppDir="$(AppDir)"
-      RuntimePackDir="$(RuntimePackDir)"
+      MicrosoftNetCoreAppRuntimePackDir="$(MicrosoftNetCoreAppRuntimePackDir)"
       MainAssembly="bin\WasmSample.dll"
-      MainJS="$(MonoProjectRoot)\wasm\runtime-test.js"
+      MainJS="$(MonoProjectRoot)wasm\runtime-test.js"
       AssemblySearchPaths="@(AssemblySearchPaths)"/>
     <Exec Command="chmod a+x $(AppDir)/run-v8.sh" />
   </Target>

--- a/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.cs
+++ b/tools-local/tasks/mobile.tasks/WasmAppBuilder/WasmAppBuilder.cs
@@ -21,7 +21,7 @@ public class WasmAppBuilder : Task
     [Required]
     public string? AppDir { get; set; }
     [Required]
-    public string? RuntimePackDir { get; set; }
+    public string? MicrosoftNetCoreAppRuntimePackDir { get; set; }
     [Required]
     public string? MainAssembly { get; set; }
     [Required]
@@ -73,7 +73,7 @@ public class WasmAppBuilder : Task
         foreach (var assembly in _assemblies!.Values)
             File.Copy(assembly.Location, Path.Join(AppDir, "managed", Path.GetFileName(assembly.Location)), true);
         foreach (var f in new string[] { "dotnet.wasm", "dotnet.js" })
-            File.Copy(Path.Join (RuntimePackDir, "native", f), Path.Join(AppDir, f), true);
+            File.Copy(Path.Join (MicrosoftNetCoreAppRuntimePackDir, "native", f), Path.Join(AppDir, f), true);
         File.Copy(MainJS!, Path.Join(AppDir, "runtime.js"),  true);
 
         if (ExtraFiles != null)


### PR DESCRIPTION
Binplace reference assemblies into a Microsoft.NetCore.App.Ref folder
and also copy data files like the RuntimeList.xml and the
PlatformManifest.txt there.

Rename the runtime pack to microsoft.netcore.app.runtime.$(RID) and always build it.

Fixing a restore issue in the wasm builder (restore and build should
not happen in the same msbuild invocation).

The ref pack will be consumed in https://github.com/dotnet/runtime/pull/35606.

cc @ericstj 