### PR TITLE
[wasm] Throw PlatformNotSupportedException instead of NotSupportedException when starting threads/waiting on monitors.

### DIFF
--- a/src/mono/mono/metadata/monitor.c
+++ b/src/mono/mono/metadata/monitor.c
@@ -1412,7 +1412,7 @@ mono_monitor_wait (MonoObjectHandle obj_handle, guint32 ms, MonoBoolean allow_in
 
 #ifdef DISABLE_THREADS
 	if (ms == MONO_INFINITE_WAIT) {
-		mono_error_set_synchronization_lock (error, "Cannot wait on monitors on this runtime.");
+		mono_error_set_platform_not_supported (error, "Cannot wait on monitors on this runtime.");
 		return FALSE;
 	}
 #endif

--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -1710,7 +1710,7 @@ ves_icall_System_Threading_Thread_Thread_internal (MonoThreadObjectHandle thread
 	MonoObject *start = MONO_HANDLE_RAW (start_handle);
 
 #ifdef DISABLE_THREADS
-	mono_error_set_not_supported (error, "Cannot start threads on this runtime.");
+	mono_error_set_platform_not_supported (error, "Cannot start threads on this runtime.");
 	return FALSE;
 #endif
 
@@ -6744,7 +6744,7 @@ ves_icall_System_Threading_Thread_StartInternal (MonoThreadObjectHandle thread_h
 	gboolean res;
 
 #ifdef DISABLE_THREADS
-	mono_error_set_not_supported (error, "Cannot start threads on this runtime.");
+	mono_error_set_platform_not_supported (error, "Cannot start threads on this runtime.");
 	return;
 #endif
 

--- a/src/mono/mono/utils/mono-error-internals.h
+++ b/src/mono/mono/utils/mono-error-internals.h
@@ -278,6 +278,11 @@ mono_error_set_cannot_unload_appdomain (MonoError *error, const char *message)
 	mono_error_set_generic_error (error, "System", "CannotUnloadAppDomainException", "%s", message);
 }
 
+static inline void
+mono_error_set_platform_not_supported (MonoError *error, const char *message)
+{
+	mono_error_set_generic_error (error, "System", "PlatformNotSupportedException", "%s", message);
+}
 
 MonoException*
 mono_error_prepare_exception (MonoError *error, MonoError *error_out);


### PR DESCRIPTION
!! This PR is a copy of mono/mono#19937,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/><!--
Thank you for your Pull Request!

If you are new to contributing to Mono, please try to do your best at conforming to our coding guidelines http://www.mono-project.com/community/contributing/coding-guidelines/ but don't worry if you get something wrong. One of the project members will help you to get things landed.

Does your pull request fix any of the existing issues? Please use the following format: Fixes #issue-number
-->