### PR TITLE
Add telemetry to System.Net.Http

### DIFF
--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -43,6 +43,7 @@
     <Compile Include="System\Net\Http\HttpRequestMessage.cs" />
     <Compile Include="System\Net\Http\HttpResponseMessage.cs" />
     <Compile Include="System\Net\Http\HttpRuleParser.cs" />
+    <Compile Include="System\Net\Http\HttpTelemetry.cs" />
     <Compile Include="System\Net\Http\HttpUtilities.cs" />
     <Compile Include="System\Net\Http\MessageProcessingHandler.cs" />
     <Compile Include="System\Net\Http\MultipartContent.cs" />

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -1,0 +1,104 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+// TODO: Get rid of this once I figure out how to handle build errors like these given the current lazy creation pattern:
+//     System\Net\Http\HttpTelemetry.cs(19,32): error CS8618: Non-nullable field '_startedRequestsCounter' is uninitialized.
+//     Consider declaring the field as nullable. [S:\GitHub\runtime\src\libraries\System.Net.Http\src\System.Net.Http.csproj]
+#nullable disable
+
+namespace System.Net.Http
+{
+    [EventSource(Name = "System.Net.Http")]
+    internal sealed class HttpTelemetry : EventSource
+    {
+        public static readonly HttpTelemetry Log = new HttpTelemetry();
+
+        private IncrementingPollingCounter _requestsPerSecondCounter;
+        private PollingCounter _startedRequestsCounter;
+        private PollingCounter _currentRequestsCounter;
+        private PollingCounter _abortedRequestsCounter;
+
+        private long _startedRequests;
+        private long _currentRequests;
+        private long _abortedRequests;
+
+        public static new bool IsEnabled => Log.IsEnabled();
+
+        // NOTE
+        // - The 'Start' and 'Stop' suffixes on the following event names have special meaning in EventSource. They
+        //   enable creating 'activities'.
+        //   For more information, take a look at the following blog post:
+        //   https://blogs.msdn.microsoft.com/vancem/2015/09/14/exploring-eventsource-activity-correlation-and-causation-features/
+        // - A stop event's event id must be next one after its start event.
+
+        [Event(1, Level = EventLevel.Informational)]
+        public void RequestStart(string host, int port)
+        {
+            Interlocked.Increment(ref _startedRequests);
+            Interlocked.Increment(ref _currentRequests);
+            WriteEvent(1, host, port);
+        }
+
+        [Event(2, Level = EventLevel.Informational)]
+        public void RequestStop(string host, int port)
+        {
+            Interlocked.Decrement(ref _currentRequests);
+            WriteEvent(2, host, port);
+        }
+
+        [NonEvent]
+        public void RequestAbort()
+        {
+            Interlocked.Increment(ref _abortedRequests);
+        }
+
+        protected override void OnEventCommand(EventCommandEventArgs command)
+        {
+            if (command.Command == EventCommand.Enable)
+            {
+                // This is the convention for initializing counters in the RuntimeEventSource (lazily on the first enable command).
+                // They aren't disabled afterwards...
+
+                // The cumulative number of HTTP requests started since the process started.
+                _startedRequestsCounter ??= new PollingCounter("requests-started", this, () => _startedRequests)
+                {
+                    DisplayName = "Requests Started",
+                };
+
+                // The number of HTTP requests started per second since the process started.
+                _requestsPerSecondCounter ??= new IncrementingPollingCounter("requests-started-per-second", this, () => _startedRequests)
+                {
+                    DisplayName = "Requests Started Rate",
+                    DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+                };
+
+                // The cumulative number of HTTP requests aborted since the process started.
+                // Aborted means that an exception occurred during the handler's Send(Async) call as a result of a
+                // connection related error, timeout, or explicitly cancelled.
+                _abortedRequestsCounter ??= new PollingCounter("requests-aborted", this, () => _abortedRequests)
+                {
+                    DisplayName = "Requests Aborted"
+                };
+
+                // The number of HTTP requests aborted per second since the process started.
+                _requestsPerSecondCounter ??= new IncrementingPollingCounter("requests-aborted-per-second", this, () => _abortedRequests)
+                {
+                    DisplayName = "Requests Aborted Rate",
+                    DisplayRateTimeScale = TimeSpan.FromSeconds(1)
+                };
+
+                // The current number of active HTTP requests that have started but not yet completed or aborted.
+                _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => _currentRequests)
+                {
+                    DisplayName = "Current Requests"
+                };
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -37,21 +37,21 @@ namespace System.Net.Http
         public void RequestStart(string scheme, string host, int port, string pathAndQuery, int versionMajor, int versionMinor)
         {
             Interlocked.Increment(ref _startedRequests);
-            WriteEvent(1, scheme, host, port, pathAndQuery, versionMajor, versionMinor);
+            WriteEvent(eventId: 1, scheme, host, port, pathAndQuery, versionMajor, versionMinor);
         }
 
         [Event(2, Level = EventLevel.Informational)]
         public void RequestStop()
         {
             Interlocked.Increment(ref _stoppedRequests);
-            WriteEvent(2);
+            WriteEvent(eventId: 2);
         }
 
         [Event(3, Level = EventLevel.Error)]
         public void RequestAborted()
         {
             Interlocked.Increment(ref _abortedRequests);
-            WriteEvent(3);
+            WriteEvent(eventId: 3);
         }
 
         protected override void OnEventCommand(EventCommandEventArgs command)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -90,7 +90,9 @@ namespace System.Net.Http
                 };
 
                 // The current number of active HTTP requests that have started but not yet completed or aborted.
-                _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => Interlocked.Read(ref _startedRequests) - Interlocked.Read(ref _stoppedRequests))
+                // Use (-_stoppedRequests + _startedRequests) to avoid returning a negative value if _stoppedRequests is
+                // incremented after reading _startedRequests due to race conditions with completing the HTTP request.
+                _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => -Interlocked.Read(ref _stoppedRequests) + Interlocked.Read(ref _startedRequests))
                 {
                     DisplayName = "Current Requests"
                 };

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -57,6 +57,7 @@ namespace System.Net.Http
                     if (_connection == null)
                     {
                         // Fully consumed the response in ReadChunksFromConnectionBuffer.
+                        if (HttpTelemetry.IsEnabled) LogRequestStop();
                         return 0;
                     }
 
@@ -362,6 +363,7 @@ namespace System.Net.Http
                                     cancellationRegistration.Dispose();
                                     CancellationHelper.ThrowIfCancellationRequested(cancellationRegistration.Token);
 
+                                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                                     _state = ParsingState.Done;
                                     _connection.CompleteResponse();
                                     _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -29,6 +29,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
+                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -81,6 +82,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
+                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -142,6 +144,7 @@ namespace System.Net.Http
             private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
+                if (HttpTelemetry.IsEnabled) LogRequestStop();
                 _connection = null;
                 connection.Dispose();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -48,6 +48,7 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     // End of response body
+                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                     _connection.CompleteResponse();
                     _connection = null;
                 }
@@ -110,6 +111,7 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     // End of response body
+                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                     _connection.CompleteResponse();
                     _connection = null;
                 }
@@ -164,6 +166,7 @@ namespace System.Net.Http
 
             private void Finish()
             {
+                if (HttpTelemetry.IsEnabled) LogRequestStop();
                 _contentBytesRemaining = 0;
                 _connection!.CompleteResponse();
                 _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -346,6 +346,8 @@ namespace System.Net.Http
                     w.Dispose();
                     _creditWaiter = null;
                 }
+
+                if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
             }
 
             private void Cancel()
@@ -380,6 +382,8 @@ namespace System.Net.Http
                 {
                     _waitSource.SetResult(true);
                 }
+
+                if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestAborted();
             }
 
             // Returns whether the waiter should be signalled or not.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -606,6 +606,7 @@ namespace System.Net.Http
                 Stream responseStream;
                 if (ReferenceEquals(normalizedMethod, HttpMethod.Head) || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
                 {
+                    if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
                     responseStream = EmptyReadStream.Instance;
                     CompleteResponse();
                 }
@@ -628,6 +629,7 @@ namespace System.Net.Http
                     long contentLength = response.Content.Headers.ContentLength.GetValueOrDefault();
                     if (contentLength <= 0)
                     {
+                        if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
                         responseStream = EmptyReadStream.Instance;
                         CompleteResponse();
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -365,7 +365,7 @@ namespace System.Net.Http
                 throw;
             }
 
-            bool LogException(Exception e)
+            static bool LogException(Exception e)
             {
                 HttpTelemetry.Log.RequestAborted();
                 HttpTelemetry.Log.RequestStop();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -359,11 +359,20 @@ namespace System.Net.Http
             {
                 return await SendAsyncHelper(request, doRequestAuth, cancellationToken).ConfigureAwait(false);
             }
-            catch
+            catch (Exception e) when (LogException(e))
+            {
+                // This code should never run.
+                throw;
+            }
+
+            bool LogException(Exception e)
             {
                 HttpTelemetry.Log.RequestAborted();
                 HttpTelemetry.Log.RequestStop();
-                throw;
+
+                // Returning false means the catch handler isn't run.
+                // So the exception isn't considered to be caught so it will now propagate up the stack.
+                return false;
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -340,6 +340,35 @@ namespace System.Net.Http
 
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
         {
+            return HttpTelemetry.IsEnabled && request.RequestUri != null ?
+                SendAsyncWithLogging(request, doRequestAuth, cancellationToken) :
+                SendAsyncHelper(request, doRequestAuth, cancellationToken);
+        }
+
+        private async Task<HttpResponseMessage> SendAsyncWithLogging(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
+        {
+            Debug.Assert(request.RequestUri != null);
+            HttpTelemetry.Log.RequestStart(
+                request.RequestUri.Scheme,
+                request.RequestUri.IdnHost,
+                request.RequestUri.Port,
+                request.RequestUri.PathAndQuery,
+                request.Version.Major,
+                request.Version.Minor);
+            try
+            {
+                return await SendAsyncHelper(request, doRequestAuth, cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                HttpTelemetry.Log.RequestAborted();
+                HttpTelemetry.Log.RequestStop();
+                throw;
+            }
+        }
+
+        private Task<HttpResponseMessage> SendAsyncHelper(HttpRequestMessage request, bool doRequestAuth, CancellationToken cancellationToken)
+        {
             if (_proxy == null)
             {
                 return SendAsyncCore(request, null, doRequestAuth, isProxyConnect: false, cancellationToken);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentStream.cs
@@ -2,11 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+
 namespace System.Net.Http
 {
     internal abstract class HttpContentStream : HttpBaseStream
     {
         protected HttpConnection? _connection;
+
+        // Makes sure we don't call HttpTelemetry events more than once.
+        private int _requestStopCalled; // 0==no, 1==yes
 
         public HttpContentStream(HttpConnection connection)
         {
@@ -34,6 +39,14 @@ namespace System.Net.Http
                 // it, which is misuse, or held onto it and tried to use it later after we've disposed of it,
                 // which is also misuse.
                 ThrowObjectDisposedException();
+        }
+
+        protected void LogRequestStop()
+        {
+            if (Interlocked.Exchange(ref _requestStopCalled, 1) == 0)
+            {
+                HttpTelemetry.Log.RequestStop();
+            }
         }
 
         private HttpConnection ThrowObjectDisposedException() => throw new ObjectDisposedException(GetType().Name);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -34,6 +34,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
+                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -81,6 +82,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
+                    if (HttpTelemetry.IsEnabled) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -142,6 +144,7 @@ namespace System.Net.Http
             private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
+                if (HttpTelemetry.IsEnabled) LogRequestStop();
                 connection.Dispose();
                 _connection = null;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SocketsHttpHandler.cs
@@ -346,28 +346,7 @@ namespace System.Net.Http
                 return Task.FromException<HttpResponseMessage>(error);
             }
 
-            return HttpTelemetry.IsEnabled && request.RequestUri != null ?
-                WithLogging(handler, request, cancellationToken) :
-                handler.SendAsync(request, cancellationToken);
-
-            static async Task<HttpResponseMessage> WithLogging(HttpMessageHandler handler, HttpRequestMessage request, CancellationToken cancellationToken)
-            {
-                Debug.Assert(request.RequestUri != null);
-                HttpTelemetry.Log.RequestStart(request.RequestUri.IdnHost, request.RequestUri.Port);
-                try
-                {
-                    return await handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                }
-                catch
-                {
-                    HttpTelemetry.Log.RequestAbort(request.RequestUri.IdnHost, request.RequestUri.Port);
-                    throw;
-                }
-                finally
-                {
-                    HttpTelemetry.Log.RequestStop(request.RequestUri.IdnHost, request.RequestUri.Port);
-                }
-            }
+            return handler.SendAsync(request, cancellationToken);
         }
 
         private Exception? ValidateAndNormalizeRequest(HttpRequestMessage request)


### PR DESCRIPTION
This is the first of several PRs to add telemetry focused events and counters.

A few things to note:

* Added a new dedicated namespace for telemetry. Current feedback from partners is that our
existing events are "confusing and a mess" due to their focus on low-level diagnostics and verbose
debugging. See discussion in #37428 regarding reasons for a new namespace.

* Please comment on the naming patterns for the events, counters, and
display names, etc. I looked at ASP.NET events/counters and @anurse older guidance in
https://gist.github.com/anurse/af1859663ac91c6cf69c820cebe92303. But there are inconsistencies
between all of that. So, I'd like to get agreement on naming patterns for events/counters
(i.e. noun-verb vs. verb-noun, present tense vs. past tense, etc.).

* No automated tests were added at this time. The current discussions with others (reverse proxy
team) is that automated tests are brittle in CI. But manual tests will be run.

Contributes to #37428