### PR TITLE
Revert "Update "LICENSE.txt" so that it's recognized as MIT"

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -1,6 +1,8 @@
+The MIT License (MIT)
+
 Copyright (c) .NET Foundation and Contributors
 
-MIT License
+All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -12,7 +14,7 @@ furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -23,7 +23,6 @@ pr:
     - eng/pipelines/*.*
     - CODE-OF-CONDUCT.md
     - CONTRIBUTING.md
-    - LICENSE.TXT
     - PATENTS.TXT
     - README.md
     - SECURITY.md


### PR DESCRIPTION
Reverts dotnet/runtime#36744

All PRs to dotnet/runtime are now failing with:
```
error : License file content '/Users/runner/runners/2.169.1/work/1/s/LICENSE.TXT' doesn't match the expected license '/Users/runner/runners/2.169.1/work/1/s/.packages/microsoft.dotnet.arcade.sdk/5.0.0-beta.20280.1/tools/Licenses/MIT.txt'.
```

cc: @richlander, @terrajobst, @jkotas