### PR TITLE
Don't produce windows runtime packs for mono

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -87,7 +87,7 @@ stages:
       - Linux_musl_x64
       - Browser_wasm
       # - Linux_musl_arm64
-      - Windows_NT_x64
+      # - Windows_NT_x64 enable once coreclr.dll has a version header: https://github.com/dotnet/runtime/issues/37503
       # - Windows_NT_x86
       # - Windows_NT_arm
       # - Windows_NT_arm64

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <FrameworkPackageName>Microsoft.NETCore.App</FrameworkPackageName>
     <BuildFullPlatformManifest>false</BuildFullPlatformManifest>
-    <!-- Workaround for https://github.com/dotnet/runtime/issues/37503 -->
-    <PermitDllAndExeFilesLackingFileVersion Condition="'$(OS)' == 'Windows_NT' and '$(RuntimeFlavor)' == 'Mono'">true</PermitDllAndExeFilesLackingFileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I realized that symbol publishing validates that the files contain a version header. So the official build is failing, in order to be able to publish this correctly we need to fix the version header issue: https://github.com/dotnet/runtime/issues/37503

cc: @dotnet/runtime-infrastructure 