### PR TITLE
[wasm] Make some System.Console test pass with accordance to WASM PNSE behavior

### DIFF
--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -258,7 +258,7 @@ public class ReadAndWrite
         }
     }
 
-    [Fact] 
+    [Fact]
     [PlatformSpecific(~TestPlatforms.Browser)]
     public static unsafe void OutputEncodingPreamble()
     {
@@ -282,14 +282,7 @@ public class ReadAndWrite
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.Browser)]
-    public static unsafe void OutputEncodingPreamble_Browser()
-    {
-        Encoding curEncoding = Console.OutputEncoding;
-        Assert.Throws<PlatformNotSupportedException>(() => Console.OutputEncoding = curEncoding );
-    }
-
-    [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static unsafe void OutputEncoding()
     {
         Encoding curEncoding = Console.OutputEncoding;
@@ -312,6 +305,15 @@ public class ReadAndWrite
         {
             Console.OutputEncoding = curEncoding;
         }
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void OutputEncoding_Browser()
+    {
+        Encoding curEncoding = Console.OutputEncoding;
+        Assert.Equal(Encoding.Unicode, curEncoding);
+        Assert.Throws<PlatformNotSupportedException>(() => Console.OutputEncoding = curEncoding );
     }
 
     static readonly string[] s_testLines = new string[] {

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -258,7 +258,8 @@ public class ReadAndWrite
         }
     }
 
-    [Fact]
+    [Fact] 
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static unsafe void OutputEncodingPreamble()
     {
         Encoding curEncoding = Console.OutputEncoding;
@@ -278,6 +279,14 @@ public class ReadAndWrite
         {
             Console.OutputEncoding = curEncoding;
         }
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static unsafe void OutputEncodingPreamble_Browser()
+    {
+        Encoding curEncoding = Console.OutputEncoding;
+        Assert.Throws<PlatformNotSupportedException>(() => Console.OutputEncoding = curEncoding );
     }
 
     [Fact]


### PR DESCRIPTION
This PR is to get any feedback on how to align the existing library tests with WASM behavior where it just throws PlatformNotSupportedException.
In this change <s>one of the System.Console tests is fixed  with the help of `RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"))`.</s>
two of the existing System.Console tests are marked with `[PlatformSpecific(~TestPlatforms.Browser)]` and one wasm-specific test is added to check if PNSE is thrown.


cc @steveisok 