### PR TITLE
ARM64: Fix the alignment for Vector64 to 8 bytes

### DIFF
--- a/src/coreclr/src/jit/simd.cpp
+++ b/src/coreclr/src/jit/simd.cpp
@@ -75,11 +75,12 @@ int Compiler::getSIMDVectorLength(CORINFO_CLASS_HANDLE typeHnd)
 //
 int Compiler::getSIMDTypeAlignment(var_types simdType)
 {
+    unsigned size = genTypeSize(simdType);
+
 #ifdef TARGET_XARCH
     // Fixed length vectors have the following alignment preference
     // Vector2   = 8 byte alignment
     // Vector3/4 = 16-byte alignment
-    unsigned size = genTypeSize(simdType);
 
     // preferred alignment for SSE2 128-bit vectors is 16-bytes
     if (size == 8)
@@ -97,7 +98,9 @@ int Compiler::getSIMDTypeAlignment(var_types simdType)
         return 32;
     }
 #elif defined(TARGET_ARM64)
-    return 16;
+    // preferred alignment for 64-bit vectors is 8-bytes.
+    // For everything else, 16-bytes.
+    return (size == 8) ? 8 : 16;
 #else
     assert(!"getSIMDTypeAlignment() unimplemented on target arch");
     unreached();


### PR DESCRIPTION
Fix the alignment for `Vector64` on ARM64 to be 8-bytes instead of 16-bytes.

```csharp
private static Vector128<int> int_Create(Vector64<int> lower, Vector64<int> upper)
{
    return Vector128.Create(lower, upper);
}
```

Before, we were creating the following:
```asm
G_M60438_IG01:
        A9BD7BFD          stp     fp, lr, [sp,#-48]!
        910003FD          mov     fp, sp
        FD0017A0          str     d0, [fp,#40]
        FD000FA1          str     d1, [fp,#24]
                                                ;; bbWeight=1    PerfScore 3.50
G_M60438_IG02:
        FD4017B0          ldr     d16, [fp,#40]
        FD400FB1          ldr     d17, [fp,#24]
        4E083E20          umov    x0, v17.d[0]
        4E181C10          ins     v16.d[1], x0
        4EB01E00          mov     v0.16b, v16.16b
                                                ;; bbWeight=1    PerfScore 6.50
G_M60438_IG03:
        A8C37BFD          ldp     fp, lr, [sp],#48
        D65F03C0          ret     lr
```

Now, we don't allocate lot of stack space:
```asm
G_M60438_IG01:
        A9BE7BFD          stp     fp, lr, [sp,#-32]!
        910003FD          mov     fp, sp
        FD000FA0          str     d0, [fp,#24]
        FD000BA1          str     d1, [fp,#16]
                                                ;; bbWeight=1    PerfScore 3.50
G_M60438_IG02:
        FD400FB0          ldr     d16, [fp,#24]
        FD400BB1          ldr     d17, [fp,#16]
        4E083E20          umov    x0, v17.d[0]
        4E181C10          ins     v16.d[1], x0
        4EB01E00          mov     v0.16b, v16.16b
                                                ;; bbWeight=1    PerfScore 6.50
G_M60438_IG03:
        A8C27BFD          ldp     fp, lr, [sp],#32
        D65F03C0          ret     lr
                                                ;; bbWeight=1    PerfScore 2.00
```

Fixes: https://github.com/dotnet/runtime/issues/37429