### PR TITLE
[mono] Add back sys/types.h include for clockid_t

### DIFF
--- a/src/mono/mono/utils/mono-time.h
+++ b/src/mono/mono/utils/mono-time.h
@@ -33,6 +33,7 @@ gint64 mono_100ns_datetime_from_timeval (struct timeval tv);
 #include <mach/clock.h>
 typedef clock_serv_t mono_clock_id_t;
 #elif defined(HAVE_CLOCKID_T)
+#include <sys/types.h>
 typedef clockid_t mono_clock_id_t;
 #else
 typedef void *mono_clock_id_t;


### PR DESCRIPTION
Looks like it was accidentally removed in https://github.com/dotnet/runtime/pull/37457