### PR TITLE
Fix global-build official build arg evaluation

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -41,9 +41,9 @@ jobs:
         value: /p:CrossBuild=${{ ne(parameters.crossrootfsDir, '') }}
 
       - name: _officialBuildParameter
-        $ {{ if eq(parameters.isOfficialBuild, true) }}:
+        ${{ if eq(parameters.isOfficialBuild, true) }}:
           value: /p:OfficialBuildId=$(Build.BuildNumber)
-        $ {{ if ne(parameters.isOfficialBuild, true) }}:
+        ${{ if ne(parameters.isOfficialBuild, true) }}:
           value: ''
 
       - ${{ parameters.variables }}


### PR DESCRIPTION
Mono runtime pack versions were created with -ci because of this subtle typo 🤦.

Test official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=678962&view=results