### PR TITLE
Devirtualized default value comparison

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -75,8 +74,6 @@ namespace System.Text.Json.Serialization
         /// Is the converter built-in.
         /// </summary>
         internal bool IsInternalConverter { get; set; }
-
-        internal readonly EqualityComparer<T> _defaultComparer = EqualityComparer<T>.Default;
 
         // This non-generic API is sealed as it just forwards to the generic version.
         internal sealed override bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -97,13 +97,16 @@ namespace System.Text.Json
         {
             T value = Get!(obj);
 
+            // Since devirtualization only works in non-shared generics,
+            // the default comparer is uded only for value types for now.
+            // For reference types there is a quick check for null.
             if (IgnoreDefaultValuesOnWrite && (
-                default(T) is null ? value is null : EqualityComparer<T>.Default.Equals(default, value)))
+                default(T) == null ? value == null : EqualityComparer<T>.Default.Equals(default, value)))
             {
                 return true;
             }
 
-            if (value is null)
+            if (value == null)
             {
                 Debug.Assert(Converter.CanBeNull);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -2,9 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 namespace System.Text.Json
@@ -16,8 +16,6 @@ namespace System.Text.Json
     /// or a type's converter, if the current instance is a <see cref="JsonClassInfo.PropertyInfoForClassInfo"/>.
     internal sealed class JsonPropertyInfo<T> : JsonPropertyInfo
     {
-        private static readonly T s_defaultValue = default!;
-
         public Func<object, T>? Get { get; private set; }
         public Action<object, T>? Set { get; private set; }
 
@@ -102,7 +100,7 @@ namespace System.Text.Json
 
             if (value == null)
             {
-                Debug.Assert(s_defaultValue == null && Converter.CanBeNull);
+                Debug.Assert(default(T) == null && Converter.CanBeNull);
 
                 success = true;
                 if (!IgnoreDefaultValuesOnWrite)
@@ -131,9 +129,9 @@ namespace System.Text.Json
                     }
                 }
             }
-            else if (IgnoreDefaultValuesOnWrite && Converter._defaultComparer.Equals(s_defaultValue, value))
+            else if (IgnoreDefaultValuesOnWrite && EqualityComparer<T>.Default.Equals(default, value))
             {
-                Debug.Assert(s_defaultValue != null && !Converter.CanBeNull);
+                Debug.Assert(default(T) != null && !Converter.CanBeNull);
                 success = true;
             }
             else
@@ -179,7 +177,7 @@ namespace System.Text.Json
                     ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(Converter.TypeToConvert);
                 }
 
-                Debug.Assert(s_defaultValue == null);
+                Debug.Assert(default(T) == null);
 
                 if (!IgnoreDefaultValuesOnRead)
                 {


### PR DESCRIPTION
Since there is https://github.com/dotnet/coreclr/pull/14125 made with love by Andy it's possible to inline default value comparison, but this requires direct calls to `EqualityComparer<T>.Default` followed by `Equals`. This change removes storing the default comparer in a field and forces devirtualization for value types. As a plus it removes the default value field to avoid unnecessary memory reads and for better optimizations by the JIT.

/cc @stephentoub