### PR TITLE
Include IP information in socket.ConnectAsync(endPoint) exceptions

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -239,7 +239,10 @@ namespace System.Net.Sockets
 
                 SocketAsyncEventArgs args = _internalArgs!;
                 args.RemoteEndPoint = new IPEndPoint(attemptAddress, _endPoint!.Port);
-                if (!attemptSocket.ConnectAsync(args))
+                bool pending = attemptSocket.ConnectAsync(args);
+                // Copy the socket address so we can use it in exception message.
+                _userArgs!._socketAddress = _internalArgs!._socketAddress;
+                if (!pending)
                 {
                     InternalConnectCallback(null, args);
                 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -6,6 +6,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Net.Internals;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
@@ -1140,7 +1141,10 @@ namespace System.Net.Sockets
 
             private Exception CreateException(SocketError error, bool forAsyncThrow = true)
             {
-                Exception e = new SocketException((int)error);
+                // When available, include the IP endpoint information in connection exceptions:
+                Exception e = LastOperation == SocketAsyncOperation.Connect && _socketAddress != null ?
+                    SocketExceptionFactory.CreateSocketException((int)error, _socketAddress.GetIPEndPoint()) :
+                    new SocketException((int)error);
 
                 if (forAsyncThrow)
                 {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -83,12 +83,14 @@ namespace System.Net.Sockets.Tests
         }
 
         [OuterLoop("Slow on Windows")]
-        [Fact]
-        public virtual async Task Connect_WhenFails_ThrowsSocketExceptionWithIPEndpointInfo()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual async Task Connect_WhenFails_ThrowsSocketExceptionWithIPEndpointInfo(bool useDns)
         {
             // Port 288 is unassigned:
             // https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
-            IPEndPoint badEndpoint = new IPEndPoint(IPAddress.Loopback, 288);
+            EndPoint badEndpoint = useDns ? (EndPoint)new DnsEndPoint("localhost", 288) : new IPEndPoint(IPAddress.Loopback, 288);
             using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             SocketException ex = await Assert.ThrowsAnyAsync<SocketException>(() => ConnectAsync(client, badEndpoint));
             Assert.Contains("127.0.0.1", ex.Message);
@@ -219,6 +221,6 @@ namespace System.Net.Sockets.Tests
         public ConnectEap(ITestOutputHelper output) : base(output) {}
 
         // We should skip this since the exception creation logic is defined in SocketHelperEap.
-        public override Task Connect_WhenFails_ThrowsSocketExceptionWithIPEndpointInfo() => Task.CompletedTask;
+        public override Task Connect_WhenFails_ThrowsSocketExceptionWithIPEndpointInfo(bool useDns) => Task.CompletedTask;
     }
 }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -83,6 +83,18 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        public async Task Connect_WhenUnavailable_ThrowsSocketExceptionWithInfo()
+        {
+            IPAddress badIp = IPAddress.Parse("4.3.2.1");
+            int badPort = 4321;
+            IPEndPoint badEndpoint = new IPEndPoint(badIp, badPort);
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            SocketException ex = await Assert.ThrowsAnyAsync<SocketException>(() => ConnectAsync(client, badEndpoint));
+            Assert.Contains("4.3.2.1", ex.Message);
+            Assert.Contains("4321", ex.Message);
+        }
+
+        [Fact]
         public async Task Connect_OnConnectedSocket_Fails()
         {
             int port;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -128,7 +128,7 @@ namespace System.Net.Sockets.Tests
                 }
                 else
                 {
-                    SocketException se = await Assert.ThrowsAsync<SocketException>(() => ConnectAsync(client, new IPEndPoint(IPAddress.Loopback, port)));
+                    SocketException se = await Assert.ThrowsAnyAsync<SocketException>(() => ConnectAsync(client, new IPEndPoint(IPAddress.Loopback, port)));
                     Assert.Equal(SocketError.IsConnected, se.SocketErrorCode);
                 }
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.cs
@@ -93,8 +93,7 @@ namespace System.Net.Sockets.Tests
             EndPoint badEndpoint = useDns ? (EndPoint)new DnsEndPoint("localhost", 288) : new IPEndPoint(IPAddress.Loopback, 288);
             using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             SocketException ex = await Assert.ThrowsAnyAsync<SocketException>(() => ConnectAsync(client, badEndpoint));
-            Assert.Contains("127.0.0.1", ex.Message);
-            Assert.Contains("288", ex.Message);
+            Assert.Contains("127.0.0.1:288", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Unlike the synchronous variant, the exception message of `SocketTaskExtensions.ConnectAsync(...)` failures did not include the IP+Port information.

Related to #1326, but does not solve the issue for `SocketsHttpHandler`. It could be considered as a step towards the long-term solution however (see https://github.com/dotnet/runtime/issues/1326#issuecomment-641613042).