### PR TITLE
Remove quirks for macOS Sierra.

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -49,7 +49,7 @@ namespace System.Net.Http.Functional.Tests
         {
             // Overriding flag for the same reason we skip tests on Catalina
             // On OSX 10.13-10.14 we can override this flag to enable the scenario
-            requestOnlyThisProtocol |= acceptedProtocol == SslProtocols.Tls;
+            requestOnlyThisProtocol |= PlatformDetection.IsOSX && acceptedProtocol == SslProtocols.Tls;
 
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (HttpClient client = CreateHttpClient(handler))

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.AcceptAllCerts.cs
@@ -49,7 +49,7 @@ namespace System.Net.Http.Functional.Tests
         {
             // Overriding flag for the same reason we skip tests on Catalina
             // On OSX 10.13-10.14 we can override this flag to enable the scenario
-            requestOnlyThisProtocol |= PlatformDetection.IsMacOsHighSierraOrHigher && acceptedProtocol == SslProtocols.Tls;
+            requestOnlyThisProtocol |= acceptedProtocol == SslProtocols.Tls;
 
             using (HttpClientHandler handler = CreateHttpClientHandler())
             using (HttpClient client = CreateHttpClient(handler))

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -34,8 +34,6 @@ namespace System
         // OSX family
         public static bool IsOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsNotOSX => !IsOSX;
-        public static bool IsMacOsHighSierraOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 13);
-        public static bool IsNotMacOsHighSierraOrHigher => !IsMacOsHighSierraOrHigher;
         public static bool IsMacOsMojaveOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 14);
         public static bool IsMacOsCatalinaOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 15);
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -4,16 +4,8 @@
 
 #include "pal_x509chain.h"
 
-#ifndef kCFCoreFoundationVersionNumber10_12
-#define kCFCoreFoundationVersionNumber10_12 1348.00
-#endif
-
 SecPolicyRef AppleCryptoNative_X509ChainCreateDefaultPolicy()
 {
-    // Disable on macOS 10.11 and lower due to segfaults within Security.framework.
-    if (kCFCoreFoundationVersionNumber < kCFCoreFoundationVersionNumber10_12)
-        return NULL;
-
     return SecPolicyCreateBasicX509();
 }
 

--- a/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/TimeZoneInfoTests.cs
@@ -19,7 +19,6 @@ namespace System.Tests
     {
         private static readonly bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         private static readonly bool s_isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-        private static readonly bool s_isOSXAndNotHighSierra = s_isOSX && !PlatformDetection.IsMacOsHighSierraOrHigher;
 
         private static string s_strPacific = s_isWindows ? "Pacific Standard Time" : "America/Los_Angeles";
         private static string s_strSydney = s_isWindows ? "AUS Eastern Standard Time" : "Australia/Sydney";
@@ -2403,9 +2402,6 @@ namespace System.Tests
         /// <remarks>
         /// Windows uses the current daylight savings rules for early times.
         ///
-        /// OSX before High Sierra version has V1 tzfiles, which means for early times it uses the first standard offset in the tzfile.
-        /// For Pacific Standard Time it is UTC-8.  For Sydney, it is UTC+10.
-        ///
         /// Other Unix distros use V2 tzfiles, which use local mean time (LMT), which is based on the solar time.
         /// The Pacific Standard Time LMT is UTC-07:53.  For Sydney, LMT is UTC+10:04.
         /// </remarks>
@@ -2413,7 +2409,7 @@ namespace System.Tests
         {
             if (timeZoneId == s_strPacific)
             {
-                if (s_isWindows || s_isOSXAndNotHighSierra)
+                if (s_isWindows)
                 {
                     return TimeSpan.FromHours(-8);
                 }
@@ -2427,10 +2423,6 @@ namespace System.Tests
                 if (s_isWindows)
                 {
                     return TimeSpan.FromHours(11);
-                }
-                else if (s_isOSXAndNotHighSierra)
-                {
-                    return TimeSpan.FromHours(10);
                 }
                 else
                 {

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -122,6 +122,22 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 Assert.True(success, "MicrosoftDotComIssuerBytes");
             }
+
+            // High Sierra fails to build a chain for a self-signed certificate with revocation enabled.
+            // https://github.com/dotnet/runtime/issues/22625
+            if (PlatformDetection.IsNotOSX)
+            {
+                using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
+                {
+                    // NotAfter=7/17/2036
+                    success = microsoftDotComRoot.Verify();
+                    if (!success)
+                    {
+                        LogVerifyErrors(microsoftDotComRoot, "MicrosoftDotComRootBytes");
+                    }
+                    Assert.True(success, "MicrosoftDotComRootBytes");
+                }
+            }
         }
 
         private void LogVerifyErrors(X509Certificate2 cert, string testName)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -122,22 +122,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 Assert.True(success, "MicrosoftDotComIssuerBytes");
             }
-
-            // High Sierra fails to build a chain for a self-signed certificate with revocation enabled.
-            // https://github.com/dotnet/runtime/issues/22625
-            if (!PlatformDetection.IsMacOsHighSierraOrHigher)
-            {
-                using (var microsoftDotComRoot = new X509Certificate2(TestData.MicrosoftDotComRootBytes))
-                {
-                    // NotAfter=7/17/2036
-                    success = microsoftDotComRoot.Verify();
-                    if (!success)
-                    {
-                        LogVerifyErrors(microsoftDotComRoot, "MicrosoftDotComRootBytes");
-                    }
-                    Assert.True(success, "MicrosoftDotComRootBytes");
-                }
-            }
         }
 
         private void LogVerifyErrors(X509Certificate2 cert, string testName)

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -122,13 +122,9 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 {
                     rootErrors &= ~X509ChainStatusFlags.NotSignatureValid;
 
-                    // On 10.12 this is just UntrustedRoot.
                     // On 10.13+ it becomes PartialChain, and UntrustedRoot goes away.
-                    if (PlatformDetection.IsMacOsHighSierraOrHigher)
-                    {
-                        rootErrors &= ~X509ChainStatusFlags.UntrustedRoot;
-                        rootErrors |= X509ChainStatusFlags.PartialChain;
-                    }
+                    rootErrors &= ~X509ChainStatusFlags.UntrustedRoot;
+                    rootErrors |= X509ChainStatusFlags.PartialChain;
                 }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/DynamicChainTests.cs
@@ -123,8 +123,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     rootErrors &= ~X509ChainStatusFlags.NotSignatureValid;
 
                     // On 10.13+ it becomes PartialChain, and UntrustedRoot goes away.
-                    rootErrors &= ~X509ChainStatusFlags.UntrustedRoot;
-                    rootErrors |= X509ChainStatusFlags.PartialChain;
+                    if (PlatformDetection.IsOSX)
+                    {
+                        rootErrors &= ~X509ChainStatusFlags.UntrustedRoot;
+                        rootErrors |= X509ChainStatusFlags.PartialChain;
+                    }
                 }
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
This removes quirks in code for macOS 10.12 and below, as .NET Core 3.1 and 5 require a minimum of 10.13 (High Sierra).

The only change that is not a test-code change is in the X509 PAL, which was quirked for 10.11.