### PR TITLE
Added fast path to BinaryWriter.Write(string)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -359,8 +359,8 @@ namespace System.IO
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            int bytesLeft = _encoding.GetByteCount(value);
-            Write7BitEncodedInt(bytesLeft);
+            int totalBytes = _encoding.GetByteCount(value);
+            Write7BitEncodedInt(totalBytes);
 
             if (_largeByteBuffer == null)
             {
@@ -368,10 +368,10 @@ namespace System.IO
                 _maxChars = _largeByteBuffer.Length / _encoding.GetMaxByteCount(1);
             }
 
-            if (bytesLeft <= _largeByteBuffer.Length)
+            if (totalBytes <= _largeByteBuffer.Length)
             {
                 _encoding.GetBytes(value, _largeByteBuffer);
-                OutStream.Write(_largeByteBuffer, 0, bytesLeft);
+                OutStream.Write(_largeByteBuffer, 0, totalBytes);
                 return;
             }
 
@@ -394,14 +394,13 @@ namespace System.IO
 
                     OutStream.Write(_largeByteBuffer, 0, byteCount);
                     charStart += charCount;
-                    bytesLeft -= byteCount;
                     numLeft -= charCount;
                 }
             }
 
             else
             {
-                WriteWhenCharCountAlignsWithBufferSize(value, bytesLeft);
+                WriteWhenCharCountAlignsWithBufferSize(value, totalBytes);
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -400,11 +400,11 @@ namespace System.IO
 
             else
             {
-                WriteWhenCharCountAlignsWithBufferSize(value, totalBytes);
+                WriteWhenEncodingIsNotUtf8(value, totalBytes);
             }
         }
 
-        private unsafe void WriteWhenCharCountAlignsWithBufferSize(string value, int len)
+        private unsafe void WriteWhenEncodingIsNotUtf8(string value, int len)
         {
             // This method should only be called from BinaryWriter(string), which does a null-check
             Debug.Assert(_largeByteBuffer != null);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -386,11 +386,9 @@ namespace System.IO
             // However, in scenarios where the number of characters aligns perfectly with the buffer size the new
             // implementation saw some performance regressions, therefore in such scenarios (ASCIIEncoding)
             // work will be delegated to the previous implementation.
-            Type encodingType = _encoding.GetType();
-            if (encodingType == typeof(UTF32Encoding) || encodingType == typeof(UTF8Encoding) ||
-                encodingType == typeof(UnicodeEncoding) || encodingType == typeof(UTF7Encoding))
+            if (_encoding.GetType() == typeof(UTF8Encoding))
             {
-                while (bytesLeft > 0)
+                while (numLeft > 0)
                 {
                     _encoder.Convert(str.Slice(charStart), _largeByteBuffer, numLeft <= _maxChars, out int charCount, out int byteCount, out bool _);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -351,7 +351,7 @@ namespace System.IO
 
         // Writes a length-prefixed string to this stream in the BinaryWriter's
         // current Encoding. This method first writes the length of the string as
-        // a four-byte unsigned integer, and then writes that many characters
+        // an encoded unsigned integer with variable length, and then writes that many characters
         // to the stream.
         //
         public virtual unsafe void Write(string value)
@@ -359,8 +359,8 @@ namespace System.IO
             if (value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            int len = _encoding.GetByteCount(value);
-            Write7BitEncodedInt(len);
+            int bytesLeft = _encoding.GetByteCount(value);
+            Write7BitEncodedInt(bytesLeft);
 
             if (_largeByteBuffer == null)
             {
@@ -368,54 +368,89 @@ namespace System.IO
                 _maxChars = _largeByteBuffer.Length / _encoding.GetMaxByteCount(1);
             }
 
-            if (len <= _largeByteBuffer.Length)
+            if (bytesLeft <= _largeByteBuffer.Length)
             {
-                _encoding.GetBytes(value, 0, value.Length, _largeByteBuffer, 0);
-                OutStream.Write(_largeByteBuffer, 0, len);
+                _encoding.GetBytes(value, _largeByteBuffer);
+                OutStream.Write(_largeByteBuffer, 0, bytesLeft);
+                return;
             }
-            else
-            {
-                // Aggressively try to not allocate memory in this loop for
-                // runtime performance reasons.  Use an Encoder to write out
-                // the string correctly (handling surrogates crossing buffer
-                // boundaries properly).
-                int charStart = 0;
-                int numLeft = value.Length;
-#if DEBUG
-                int totalBytes = 0;
-#endif
-                while (numLeft > 0)
-                {
-                    // Figure out how many chars to process this round.
-                    int charCount = (numLeft > _maxChars) ? _maxChars : numLeft;
-                    int byteLen;
 
-                    checked
-                    {
-                        if (charStart < 0 || charCount < 0 || charStart > value.Length - charCount)
-                        {
-                            throw new ArgumentOutOfRangeException(nameof(value));
-                        }
-                        fixed (char* pChars = value)
-                        {
-                            fixed (byte* pBytes = &_largeByteBuffer[0])
-                            {
-                                byteLen = _encoder.GetBytes(pChars + charStart, charCount, pBytes, _largeByteBuffer.Length, charCount == numLeft);
-                            }
-                        }
-                    }
-#if DEBUG
-                    totalBytes += byteLen;
-                    Debug.Assert(totalBytes <= len && byteLen <= _largeByteBuffer.Length, "BinaryWriter::Write(String) - More bytes encoded than expected!");
-#endif
-                    OutStream.Write(_largeByteBuffer, 0, byteLen);
+            int numLeft = value.Length;
+            int charStart = 0;
+            ReadOnlySpan<char> str = value;
+
+            // The previous implementation had significant issues packing encoded
+            // characters efficiently into the byte buffer. This was due to the assumption,
+            // that every input character will take up the maximum possible size of a character in any given encoding,
+            // thus resulting in a lot of unused space within the byte buffer.
+            // However, in scenarios where the number of characters aligns perfectly with the buffer size the new
+            // implementation saw some performance regressions, therefore in such scenarios (ASCIIEncoding)
+            // work will be delegated to the previous implementation.
+            if (_maxChars != LargeByteBufferSize)
+            {
+                while (bytesLeft > 0)
+                {
+                    _encoder.Convert(str.Slice(charStart), _largeByteBuffer, numLeft <= _maxChars, out int charCount, out int byteCount, out bool _);
+
+                    OutStream.Write(_largeByteBuffer, 0, byteCount);
                     charStart += charCount;
+                    bytesLeft -= byteCount;
                     numLeft -= charCount;
                 }
-#if DEBUG
-                Debug.Assert(totalBytes == len, "BinaryWriter::Write(String) - Didn't write out all the bytes!");
-#endif
             }
+
+            else
+            {
+                WriteWhenCharCountAlignsWithBufferSize(value, bytesLeft);
+            }
+        }
+
+        private unsafe void WriteWhenCharCountAlignsWithBufferSize(string value, int len)
+        {
+            // This method should only be called from BinaryWriter(string), which does a null-check
+            Debug.Assert(_largeByteBuffer != null);
+
+            int numLeft = value.Length;
+            int charStart = 0;
+
+            // Aggressively try to not allocate memory in this loop for
+            // runtime performance reasons.  Use an Encoder to write out
+            // the string correctly (handling surrogates crossing buffer
+            // boundaries properly).
+#if DEBUG
+            int totalBytes = 0;
+#endif
+            while (numLeft > 0)
+            {
+                // Figure out how many chars to process this round.
+                int charCount = (numLeft > _maxChars) ? _maxChars : numLeft;
+                int byteLen;
+
+                checked
+                {
+                    if (charStart < 0 || charCount < 0 || charStart > value.Length - charCount)
+                    {
+                        throw new ArgumentOutOfRangeException(nameof(value));
+                    }
+                    fixed (char* pChars = value)
+                    {
+                        fixed (byte* pBytes = &_largeByteBuffer[0])
+                        {
+                            byteLen = _encoder.GetBytes(pChars + charStart, charCount, pBytes, _largeByteBuffer.Length, charCount == numLeft);
+                        }
+                    }
+                }
+#if DEBUG
+                totalBytes += byteLen;
+                Debug.Assert(totalBytes <= len && byteLen <= _largeByteBuffer.Length, "BinaryWriter::Write(String) - More bytes encoded than expected!");
+#endif
+                OutStream.Write(_largeByteBuffer, 0, byteLen);
+                charStart += charCount;
+                numLeft -= charCount;
+            }
+#if DEBUG
+            Debug.Assert(totalBytes == len, "BinaryWriter::Write(String) - Didn't write out all the bytes!");
+#endif
         }
 
         public virtual void Write(ReadOnlySpan<byte> buffer)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryWriter.cs
@@ -386,7 +386,9 @@ namespace System.IO
             // However, in scenarios where the number of characters aligns perfectly with the buffer size the new
             // implementation saw some performance regressions, therefore in such scenarios (ASCIIEncoding)
             // work will be delegated to the previous implementation.
-            if (_maxChars != LargeByteBufferSize)
+            Type encodingType = _encoding.GetType();
+            if (encodingType == typeof(UTF32Encoding) || encodingType == typeof(UTF8Encoding) ||
+                encodingType == typeof(UnicodeEncoding) || encodingType == typeof(UTF7Encoding))
             {
                 while (bytesLeft > 0)
                 {


### PR DESCRIPTION
This PR improves the code path for `BinaryWriter.Write(string)` especially in scenarios where the encoding specified is variable in length. The previous implementation made a blanket assumption that each character within the input string is always the maximum size of any given character in the output encoding; leading to inefficient packing of the byte buffer.

Due to this, the previous implementation performs poorly when writing characters that take up less space than the maximum size of a character in an encoding i.e. strings constrained to ASCII with a UTF-8 encoder.

If however an encoding is used, in which the input characters end up filling the byte buffer, the new implementation is quite a bit slower. This is why in such cases this PR delegates to the old implementation to not introduce any performance regressions.

The only thing left is to decide in which specific cases the previous path should be taken. As you can see on the benchmarks (below) the only instances in which regressions appear seem to be pertaining to ASCIIEncoding. A simple predicate could simply whitelist the encodings which do not experience any performance loss, but then the optimisation will not carry over to any custom encodings. Maybe someone has a better idea!

Also fixes: https://github.com/dotnet/runtime/issues/37158

I ran numerous benchmarks in different scenarios, so the full table of benchmarks can be found here: https://gist.github.com/bbartels/7cc70209a64e01d4fa663546fe035e0a

The Benchmarks were run with a MemoryStream backing the BinaryWriter.
The Benchmarks were also run without the old implementation in place for ASCIIEncoding. If the current PR would be benched, the ASCIIEncoding benchmarks would have equivalent performance.

CharSize = Average char size of output encoding
Size = The Number of input chars

Below are a couple notable excerpts

Improvements:

| Method | Impl |    CharSize |    Size | Encoding |            Mean | Ratio |
|------- |------|------------ |-------- |--------- |----------------:|------:|
|  Write | Old  |    1 Byte   |     500 |   UTF-8  |        545.4 ns |  1.00 |
|  Write | New  |    1 Byte   |     500 |   UTF-8  |        350.5 ns |  0.64 |
|        |      |             |         |          |                 |       |
|  Write | Old  |    1 Byte   |   10000 |   UTF-8  |      7,022.4 ns |  1.00 |
|  Write | New  |    1 Byte   |   10000 |   UTF-8  |      3,706.2 ns |  0.53 |
|        |      |             |         |          |                 |       |
|  Write | Old  |  1.1 Byte   |     500 |   UTF-8  |        754.0 ns |  1.00 |
|  Write | New  |  1.1 Byte   |     500 |   UTF-8  |        628.5 ns |  0.83 |
|        |      |             |         |          |                 |       |
|  Write | Old  |  1.1 Byte   |   10000 |   UTF-8  |     10,878.3 ns |  1.00 |
|  Write | New  |  1.1 Byte   |   10000 |   UTF-8  |      8,280.9 ns |  0.76 |
|        |      |             |         |          |                 |       |
|  Write | Old  |    4 Byte   | 1000000 |   UTF-16 |      4,926.7 ns |  1.00 |
|  Write | New  |    4 Byte   | 1000000 |   UTF-16 |      4,005.1 ns |  0.81 |

Regressions:

| Method | Impl |    CharSize |    Size | Encoding |            Mean | Ratio |
|------- |------|------------ |-------- |--------- |----------------:|------:|
|  Write | Old  |    1 Byte   |   10000 |   ASCII  |      2,557.0 ns |  1.00 |
|  Write | New  |    1 Byte   |   10000 |   ASCII  |      3,178.9 ns |  1.24 |
|        |      |             |         |          |                 |       |
|  Write | Old  |    1 Byte   | 1000000 |   ASCII  |    240,853.0 ns |  1.00 |
|  Write | New  |    1 Byte   | 1000000 |   ASCII  |    299,498.3 ns |  1.24 |
|        |      |             |         |          |                 |       |
