### PR TITLE
[libraries] Extend PlatformDetection.IsOSX to include all Apple OS

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -32,6 +32,10 @@ namespace System
         public static bool IsFedora => IsDistroAndVersion("fedora");
 
         // OSX family
+        public static bool IsApple =>
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
         public static bool IsOSX => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
         public static bool IsNotOSX => !IsOSX;
         public static bool IsMacOsHighSierraOrHigher => IsOSX && Environment.OSVersion.Version >= new Version(10, 13);
@@ -45,16 +49,12 @@ namespace System
         public static bool IsRedHatFamily7 => IsRedHatFamilyAndVersion(7);
         public static bool IsNotFedoraOrRedHatFamily => !IsFedora && !IsRedHatFamily;
         public static bool IsNotDebian10 => !IsDebian10;
-        public static bool IsNotApple =>
-            !RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) &&
-            !RuntimeInformation.IsOSPlatform(OSPlatform.OSX) &&
-            !RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
 
         public static bool IsSuperUser => !IsWindows ?
             libc.geteuid() == 0 :
             throw new PlatformNotSupportedException();
 
-        public static Version OpenSslVersion => IsNotApple && !IsWindows ?
+        public static Version OpenSslVersion => !IsApple && !IsWindows ?
             GetOpenSslVersion() :
             throw new PlatformNotSupportedException();
 

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -32,7 +32,7 @@ namespace System
         public static bool IsFedora => IsDistroAndVersion("fedora");
 
         // OSX family
-        public static bool IsApple =>
+        public static bool IsOSXLike =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ||
             RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS"));
@@ -54,7 +54,7 @@ namespace System
             libc.geteuid() == 0 :
             throw new PlatformNotSupportedException();
 
-        public static Version OpenSslVersion => !IsApple && !IsWindows ?
+        public static Version OpenSslVersion => !IsOSXLike && !IsWindows ?
             GetOpenSslVersion() :
             throw new PlatformNotSupportedException();
 

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
@@ -26,7 +26,7 @@ namespace System.DirectoryServices.Protocols.Tests
 #if NETCOREAPP
                 if (!_isLibLdapInstalled.HasValue)
                 {
-                    if (PlatformDetection.IsApple)
+                    if (PlatformDetection.IsOSXLike)
                     {
                         _isLibLdapInstalled = NativeLibrary.TryLoad("libldap.dylib", out _);
                     }

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesTestHelpers.cs
@@ -26,7 +26,7 @@ namespace System.DirectoryServices.Protocols.Tests
 #if NETCOREAPP
                 if (!_isLibLdapInstalled.HasValue)
                 {
-                    if (PlatformDetection.IsOSX)
+                    if (PlatformDetection.IsApple)
                     {
                         _isLibLdapInstalled = NativeLibrary.TryLoad("libldap.dylib", out _);
                     }

--- a/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
@@ -8,7 +8,7 @@ namespace System.Drawing.Tests
 {
     public class GdiplusTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsApple))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSXLike))]
         public void IsAtLeastLibgdiplus6()
         {
             Assert.True(Helpers.GetIsWindowsOrAtLeastLibgdiplus6());

--- a/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
@@ -8,7 +8,7 @@ namespace System.Drawing.Tests
 {
     public class GdiplusTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSXLike))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSX))]
         public void IsAtLeastLibgdiplus6()
         {
             Assert.True(Helpers.GetIsWindowsOrAtLeastLibgdiplus6());

--- a/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GdiplusTests.cs
@@ -8,7 +8,7 @@ namespace System.Drawing.Tests
 {
     public class GdiplusTests
     {
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsOSX))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsApple))]
         public void IsAtLeastLibgdiplus6()
         {
             Assert.True(Helpers.GetIsWindowsOrAtLeastLibgdiplus6());

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -29,19 +29,11 @@ namespace System.Globalization.Tests
 
         public static string[] FrFRDayNames()
         {
-            if (PlatformDetection.IsApple)
-            {
-                return new string[] { "Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi" };
-            }
             return new string[] { "dimanche", "lundi", "mardi", "mercredi", "jeudi", "vendredi", "samedi" };
         }
 
         public static string[] FrFRAbbreviatedDayNames()
         {
-            if (PlatformDetection.IsApple)
-            {
-                return new string[] { "Dim.", "Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam." };
-            }
             return new string[] { "dim.", "lun.", "mar.", "mer.", "jeu.", "ven.", "sam." };
         }
 

--- a/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/libraries/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -29,7 +29,7 @@ namespace System.Globalization.Tests
 
         public static string[] FrFRDayNames()
         {
-            if (PlatformDetection.IsOSX && Environment.OSVersion.Version < new Version(10, 12))
+            if (PlatformDetection.IsApple)
             {
                 return new string[] { "Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi" };
             }
@@ -38,7 +38,7 @@ namespace System.Globalization.Tests
 
         public static string[] FrFRAbbreviatedDayNames()
         {
-            if (PlatformDetection.IsOSX  && Environment.OSVersion.Version < new Version(10, 12))
+            if (PlatformDetection.IsApple)
             {
                 return new string[] { "Dim.", "Lun.", "Mar.", "Mer.", "Jeu.", "Ven.", "Sam." };
             }

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -241,7 +241,7 @@ namespace System.IO.Tests
             watcher.Filter = "abc.dll";
             Assert.Equal("abc.dll", watcher.Filter);
 
-            if (!PlatformDetection.IsApple)
+            if (!PlatformDetection.IsOSXLike)
             {
                 watcher.Filter = "ABC.DLL";
                 Assert.Equal("ABC.DLL", watcher.Filter);

--- a/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -241,7 +241,7 @@ namespace System.IO.Tests
             watcher.Filter = "abc.dll";
             Assert.Equal("abc.dll", watcher.Filter);
 
-            if (!(PlatformDetection.IsOSX))
+            if (!PlatformDetection.IsApple)
             {
                 watcher.Filter = "ABC.DLL";
                 Assert.Equal("ABC.DLL", watcher.Filter);

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -14,7 +14,7 @@ namespace System.IO.Tests
     {
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
-        private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsApple);
+        private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsOSXLike);
 
         protected override string GetExistingItem()
         {

--- a/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/GetSetTimes.cs
@@ -14,7 +14,7 @@ namespace System.IO.Tests
     {
         // OSX has the limitation of setting upto 2262-04-11T23:47:16 (long.Max) date.
         // 32bit Unix has time_t up to ~ 2038.
-        private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsOSX);
+        private static bool SupportsLongMaxDateTime => PlatformDetection.IsWindows || (RuntimeInformation.ProcessArchitecture != Architecture.Arm && RuntimeInformation.ProcessArchitecture != Architecture.X86 && !PlatformDetection.IsApple);
 
         protected override string GetExistingItem()
         {

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -43,7 +43,7 @@ namespace System.IO.Tests
 
             if (!HasNonZeroNanoseconds(fileinfo.LastWriteTime))
             {
-                if (PlatformDetection.IsApple)
+                if (PlatformDetection.IsOSXLike)
                     return null;
 
                 DateTime dt = fileinfo.LastWriteTime;

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -43,7 +43,7 @@ namespace System.IO.Tests
 
             if (!HasNonZeroNanoseconds(fileinfo.LastWriteTime))
             {
-                if (PlatformDetection.IsOSX)
+                if (PlatformDetection.IsApple)
                     return null;
 
                 DateTime dt = fileinfo.LastWriteTime;

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -54,7 +54,7 @@ namespace System.Net.NetworkInformation.Tests
 
         private static void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses, ITestOutputHelper output)
         {
-            if (pingReply.Status == IPStatus.TimedOut && pingReply.Address.AddressFamily == AddressFamily.InterNetworkV6 && PlatformDetection.IsApple)
+            if (pingReply.Status == IPStatus.TimedOut && pingReply.Address.AddressFamily == AddressFamily.InterNetworkV6 && PlatformDetection.IsOSXLike)
             {
                 // Workaround OSX ping6 bug, see https://github.com/dotnet/runtime/issues/19861
                 return;

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -54,7 +54,7 @@ namespace System.Net.NetworkInformation.Tests
 
         private static void PingResultValidator(PingReply pingReply, IPAddress[] localIpAddresses, ITestOutputHelper output)
         {
-            if (pingReply.Status == IPStatus.TimedOut && pingReply.Address.AddressFamily == AddressFamily.InterNetworkV6 && PlatformDetection.IsOSX)
+            if (pingReply.Status == IPStatus.TimedOut && pingReply.Address.AddressFamily == AddressFamily.InterNetworkV6 && PlatformDetection.IsApple)
             {
                 // Workaround OSX ping6 bug, see https://github.com/dotnet/runtime/issues/19861
                 return;

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -112,7 +112,7 @@ namespace System.Net.Sockets.Tests
 
                         // OOB data read, read pointer at mark.
                         Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                        Assert.Equal(PlatformDetection.IsOSX ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
+                        Assert.Equal(PlatformDetection.IsApple ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
                     }
                 }
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/OSSupport.cs
@@ -112,7 +112,7 @@ namespace System.Net.Sockets.Tests
 
                         // OOB data read, read pointer at mark.
                         Assert.Equal(4, client.IOControl(IOControlCode.OobDataRead, null, siocatmarkResult));
-                        Assert.Equal(PlatformDetection.IsApple ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
+                        Assert.Equal(PlatformDetection.IsOSXLike ? 0 : 1, BitConverter.ToInt32(siocatmarkResult, 0));
                     }
                 }
             }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -231,7 +231,7 @@ namespace System.Net.Sockets.Tests
 
                     // On OSX, we're unable to unblock the on-going socket operations and
                     // perform an abortive close.
-                    if (!PlatformDetection.IsOSX)
+                    if (!PlatformDetection.IsApple)
                     {
                         SocketError? peerSocketError = null;
                         var receiveBuffer = new byte[4096];

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendFile.cs
@@ -231,7 +231,7 @@ namespace System.Net.Sockets.Tests
 
                     // On OSX, we're unable to unblock the on-going socket operations and
                     // perform an abortive close.
-                    if (!PlatformDetection.IsApple)
+                    if (!PlatformDetection.IsOSXLike)
                     {
                         SocketError? peerSocketError = null;
                         var receiveBuffer = new byte[4096];

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1069,7 +1069,7 @@ namespace System.Net.Sockets.Tests
 
                     // On OSX, we're unable to unblock the on-going socket operations and
                     // perform an abortive close.
-                    if (!(UsesSync && PlatformDetection.IsApple))
+                    if (!(UsesSync && PlatformDetection.IsOSXLike))
                     {
                         SocketError? peerSocketError = null;
                         var receiveBuffer = new ArraySegment<byte>(new byte[4096]);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -1069,7 +1069,7 @@ namespace System.Net.Sockets.Tests
 
                     // On OSX, we're unable to unblock the on-going socket operations and
                     // perform an abortive close.
-                    if (!(UsesSync && PlatformDetection.IsOSX))
+                    if (!(UsesSync && PlatformDetection.IsApple))
                     {
                         SocketError? peerSocketError = null;
                         var receiveBuffer = new ArraySegment<byte>(new byte[4096]);

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
@@ -26,11 +26,11 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsApple);
+                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsOSXLike);
             }
         }
 
-        public bool SupportsKeyGeneration => !PlatformDetection.IsApple;
+        public bool SupportsKeyGeneration => !PlatformDetection.IsOSXLike;
     }
 
     public partial class DSAFactory

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultDSAProvider.cs
@@ -26,11 +26,11 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsOSX);
+                return !(PlatformDetection.IsWindows7 || PlatformDetection.IsApple);
             }
         }
 
-        public bool SupportsKeyGeneration => !PlatformDetection.IsOSX;
+        public bool SupportsKeyGeneration => !PlatformDetection.IsApple;
     }
 
     public partial class DSAFactory

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
     {
         public bool IsCurveValid(Oid oid)
         {
-            if (PlatformDetection.IsApple)
+            if (PlatformDetection.IsOSXLike)
             {
                 return false;
             }
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         {
             get
             {
-                if (PlatformDetection.IsApple)
+                if (PlatformDetection.IsOSXLike)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDiffieHellmanProvider.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
     {
         public bool IsCurveValid(Oid oid)
         {
-            if (PlatformDetection.IsOSX)
+            if (PlatformDetection.IsApple)
             {
                 return false;
             }
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.EcDiffieHellman.Tests
         {
             get
             {
-                if (PlatformDetection.IsOSX)
+                if (PlatformDetection.IsApple)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     {
         public bool IsCurveValid(Oid oid)
         {
-            if (PlatformDetection.IsApple)
+            if (PlatformDetection.IsOSXLike)
             {
                 return false;
             }
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                if (PlatformDetection.IsApple)
+                if (PlatformDetection.IsOSXLike)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/DefaultECDsaProvider.Unix.cs
@@ -10,7 +10,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
     {
         public bool IsCurveValid(Oid oid)
         {
-            if (PlatformDetection.IsOSX)
+            if (PlatformDetection.IsApple)
             {
                 return false;
             }
@@ -26,7 +26,7 @@ namespace System.Security.Cryptography.EcDsa.Tests
         {
             get
             {
-                if (PlatformDetection.IsOSX)
+                if (PlatformDetection.IsApple)
                 {
                     return false;
                 }

--- a/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         public bool SupportsFips186_3 => false;
-        public bool SupportsKeyGeneration => !PlatformDetection.IsOSX;
+        public bool SupportsKeyGeneration => !PlatformDetection.IsApple;
     }
 
     public partial class DSAFactory

--- a/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/tests/DSACryptoServiceProviderProvider.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         }
 
         public bool SupportsFips186_3 => false;
-        public bool SupportsKeyGeneration => !PlatformDetection.IsApple;
+        public bool SupportsKeyGeneration => !PlatformDetection.IsOSXLike;
     }
 
     public partial class DSAFactory


### PR DESCRIPTION
This PR looks to extend situations in which `PlatformDetection.IsOSX` was used to specify Apple OS platforms with `PlatformDetection.IsNotApple` which includes `TVOS`, `IOS`, and `OSX`.