### PR TITLE
Update mono CoreLib.sln to make VS happy

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.sln
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.sln
@@ -1,4 +1,3 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.28902.138
@@ -10,23 +9,24 @@ EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		..\..\..\libraries\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems*{845c8b26-350b-4e63-bd11-2c8150444e28}*SharedItemsImports = 13
+		..\..\..\libraries\System.Private.CoreLib\src\System.Private.CoreLib.Shared.projitems*{8fbeb036-6f52-464c-8bc9-b0b5f18262a6}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Checked|amd64 = Checked|amd64
 		Checked|arm = Checked|arm
 		Checked|arm64 = Checked|arm64
-		Checked|x86 = Checked|x86
 		Checked|wasm32 = Checked|wasm32
+		Checked|x86 = Checked|x86
 		Debug|amd64 = Debug|amd64
 		Debug|arm = Debug|arm
 		Debug|arm64 = Debug|arm64
-		Debug|x86 = Debug|x86
 		Debug|wasm32 = Debug|wasm32
+		Debug|x86 = Debug|x86
 		Release|amd64 = Release|amd64
 		Release|arm = Release|arm
 		Release|arm64 = Release|arm64
-		Release|x86 = Release|x86
 		Release|wasm32 = Release|wasm32
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|amd64.ActiveCfg = Checked|x64
@@ -35,30 +35,27 @@ Global
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|arm.Build.0 = Checked|arm
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|arm64.ActiveCfg = Checked|arm64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|arm64.Build.0 = Checked|arm64
+		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|wasm32.ActiveCfg = Checked|x86
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|x86.ActiveCfg = Checked|x86
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|x86.Build.0 = Checked|x86
-		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|wasm32.ActiveCfg = Checked|wasm32
-		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Checked|wasm32.Build.0 = Checked|wasm32
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|amd64.ActiveCfg = Debug|x64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|amd64.Build.0 = Debug|x64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|arm.ActiveCfg = Debug|arm
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|arm.Build.0 = Debug|arm
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|arm64.ActiveCfg = Debug|arm64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|arm64.Build.0 = Debug|arm64
+		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|wasm32.ActiveCfg = Debug|x86
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|x86.ActiveCfg = Debug|x86
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|x86.Build.0 = Debug|x86
-		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|wasm32.ActiveCfg = Debug|wasm32
-		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Debug|wasm32.Build.0 = Debug|wasm32
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|amd64.ActiveCfg = Release|x64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|amd64.Build.0 = Release|x64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|arm.ActiveCfg = Release|arm
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|arm.Build.0 = Release|arm
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|arm64.ActiveCfg = Release|arm64
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|arm64.Build.0 = Release|arm64
+		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|wasm32.ActiveCfg = Release|x86
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|x86.ActiveCfg = Release|x86
 		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|x86.Build.0 = Release|x86
-		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|wasm32.ActiveCfg = Release|wasm32
-		{8FBEB036-6F52-464C-8BC9-B0B5F18262A6}.Release|wasm32.Build.0 = Release|wasm32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
VS will modify the .sln every time it is opened, which forces developers to have to fight VS to undo the changes. This fix will stop VS from editing the .sln file.