### PR TITLE
[libraries] Add assembly level ActiveIssue for System.Globalization

### DIFF
--- a/src/libraries/System.Globalization/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Globalization/tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/36883", TestPlatforms.iOS)]

--- a/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/libraries/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -7,6 +7,7 @@
     <UnicodeUcdVersion>13.0</UnicodeUcdVersion>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="IcuTests.cs" />
     <Compile Include="CompareInfo\CompareInfoTests.cs" />
     <Compile Include="CompareInfo\CompareInfoTests.IndexOf.cs" />


### PR DESCRIPTION
A significant portion of System.Globalization failures on iOS won't pass until ICU is done. 
This PR looks to add an assembly level test skip for System.Globalization on iOS, and will reduce the size of #37501.

After changes:
```
  info: test[0]
        Starting test for ios-simulator-64..
  info: test[0]
        Starting application 'System.Globalization.Tests' on ios-simulator-64
  info: test[0]
        Application finished the test run successfully with some failed tests
  info: test[0]
        Tests run: 0 Passed: 0 Inconclusive: 0 Failed: 0 Ignored: 0
```

Note: Running tests for System.Globalization with this skip will fail with `XHarness exit code: 1` being tracked [here](https://github.com/dotnet/xharness/issues/258)
