### PR TITLE
Fix BoundedChannel race condition between writes and canceled reads

### DIFF
--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -124,19 +124,6 @@ namespace System.Threading.Channels
         }
 
         /// <summary>Gets whether the operation has completed.</summary>
-        /// <remarks>
-        /// The operation is considered completed if both a) it's in the completed state,
-        /// AND b) it has a non-null continuation.  We need to consider both because they're
-        /// not set atomically.  If we only considered the state, then if we set the state to
-        /// completed and then set the continuation, it's possible for an awaiter to check
-        /// IsCompleted, see true, call GetResult, and return the object to the pool, and only
-        /// then do we try to store the continuation into an object we no longer own.  If we
-        /// only considered the state, then if we set the continuation and then set the state,
-        /// a racing awaiter could see the continuation set before the state has transitioned
-        /// to completed and could end up calling GetResult in an incomplete state.  And if we
-        /// only considered the continuation, then we have issues if OnCompleted is used before
-        /// the operation completes, as the continuation will be
-        /// </remarks>
         internal bool IsCompleted => ReferenceEquals(_continuation, s_completedSentinel);
 
         /// <summary>Gets the result of the operation.</summary>
@@ -301,7 +288,11 @@ namespace System.Threading.Channels
             }
         }
 
-        /// <summary>Unregisters from cancellation.</summary>
+        /// <summary>Unregisters from cancellation and returns whether cancellation already started.</summary>
+        /// <returns>
+        /// true if either the instance wasn't cancelable or cancellation successfully unregistered without cancellation having started.
+        /// false if cancellation successfully unregistered after cancellation was initiated.
+        /// </returns>
         /// <remarks>
         /// This is important for two reasons:
         /// 1. To avoid leaking a registration into a token, so it must be done prior to completing the operation.
@@ -309,7 +300,17 @@ namespace System.Threading.Channels
         /// that no one else will try to complete the operation (assuming the caller is properly constructed
         /// and themselves guarantees only a single completer other than through cancellation).
         /// </remarks>
-        public void UnregisterCancellation() => _registration.Dispose();
+        public bool UnregisterCancellation()
+        {
+            if (CancellationToken.CanBeCanceled)
+            {
+                _registration.Dispose(); // Dispose rather than Unregister is important to know work has quiesced
+                return _completionReserved == 0;
+            }
+
+            Debug.Assert(_registration == default);
+            return true;
+        }
 
         /// <summary>Completes the operation with a success state and the specified result.</summary>
         /// <param name="item">The result value.</param>

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/BoundedChannel.cs
@@ -356,8 +356,7 @@ namespace System.Threading.Channels
                         while (!parent._blockedReaders.IsEmpty)
                         {
                             AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
-                            r.UnregisterCancellation(); // ensure that once we grab it, we own its completion
-                            if (!r.IsCompleted)
+                            if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
                             {
                                 blockedReader = r;
                                 break;
@@ -517,8 +516,7 @@ namespace System.Threading.Channels
                         while (!parent._blockedReaders.IsEmpty)
                         {
                             AsyncOperation<T> r = parent._blockedReaders.DequeueHead();
-                            r.UnregisterCancellation(); // ensure that once we grab it, we own its completion
-                            if (!r.IsCompleted)
+                            if (r.UnregisterCancellation()) // ensure that once we grab it, we own its completion
                             {
                                 blockedReader = r;
                                 break;

--- a/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
+++ b/src/libraries/System.Threading.Channels/tests/System.Threading.Channels.Tests.csproj
@@ -9,12 +9,12 @@
     <Compile Include="ChannelTests.cs" />
     <Compile Include="TestBase.cs" />
     <Compile Include="UnboundedChannelTests.cs" />
-    <Compile Include="Stress.cs" />
     <Compile Include="DebugAttributeTests.cs" />
     <Compile Include="$(CommonTestPath)System\Diagnostics\DebuggerAttributes.cs"
              Link="Common\System\Diagnostics\DebuggerAttributes.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+    <Compile Include="Stress.cs" />
     <Compile Include="ChannelClosedExceptionTests.netcoreapp.cs" />
     <Compile Include="ChannelTestBase.netcoreapp.cs" />
   </ItemGroup>


### PR DESCRIPTION
When BoundedChannelWriter has an item to be written, if there are readers waiting, it needs to try to transfer that item to a waiting reader.  When it dequeues the next waiting reader, it needs to check to see if that reader has already been canceled, as that's the only way a reader in the queue might not be completable by the writer.  Our current check, however, is flawed, in that we're assuming that the reader's IsCompleted will have synchronously transitioned to true as part of cancellation being requested; however, due to an implementation detail of the AsyncOperation that represents the reader, it might _asynchronously_ transition to true, in which case we have a race condition where we might see the reader as not having been canceled even though it has been, and that causes us to lose data by the writer trying to complete the reader with its data and failing to do so (this condition would assert in debug builds but isn't checked in release builds as it should never happen).  The fix is simply changing the condition we check to factor in the right information.

Fixes https://github.com/dotnet/runtime/issues/37671
cc: @tarekgh, @springy76