### PR TITLE
R2RTest - compile-serp large composite images

### DIFF
--- a/src/coreclr/src/tools/r2rtest/BuildOptions.cs
+++ b/src/coreclr/src/tools/r2rtest/BuildOptions.cs
@@ -117,7 +117,7 @@ namespace R2RTest
                 List<string> cpaotReferencePaths = new List<string>();
                 cpaotReferencePaths.Add(CoreRootOutputPath(CompilerIndex.CPAOT, isFramework));
                 cpaotReferencePaths.AddRange(overrideReferencePaths != null ? overrideReferencePaths : ReferencePaths());
-                runners.Add(new Crossgen2Runner(this, crossgen2RunnerOptions: null, cpaotReferencePaths));
+                runners.Add(new Crossgen2Runner(this, new Crossgen2RunnerOptions(), cpaotReferencePaths));
             }
 
             if (Crossgen)

--- a/src/coreclr/src/tools/r2rtest/ComputeManagedAssemblies.cs
+++ b/src/coreclr/src/tools/r2rtest/ComputeManagedAssemblies.cs
@@ -22,26 +22,6 @@ class ComputeManagedAssemblies
         }
     }
 
-    /// <summary>
-    /// Returns a list of assemblies in "folder" whose simple name does not exist in "simpleNames". Each discovered
-    /// assembly is added to "simpleNames" to build a list without duplicates. When collecting multiple folders of assemblies
-    /// consider the call order for this function so duplicates are ignored as expected. For exmaple, CORE_ROOT's S.P.CoreLib
-    /// should normally win.
-    /// </summary>
-    /// <param name="simpleNames">Used to keep track of which simple names were used across multiple invocations of this method</param>
-    public static IEnumerable<string> GetManagedAssembliesInFolderNoSimpleNameDuplicates(HashSet<string> simpleNames, string folder, string fileNamePattern = "*.*")
-    {
-        foreach (var file in GetManagedAssembliesInFolder(folder, fileNamePattern))
-        {
-            var simpleName = Path.GetFileNameWithoutExtension(file);
-            if (!simpleNames.Contains(simpleName))
-            {
-                yield return file;
-                simpleNames.Add(simpleName);
-            }
-        }
-    }
-
     static ConcurrentDictionary<string, bool> _isManagedCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
     public static bool IsManaged(string file)

--- a/src/coreclr/src/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/src/tools/r2rtest/Crossgen2Runner.cs
@@ -16,6 +16,7 @@ namespace R2RTest
         /// True for scenarios where the composite image has dependencies outside itself that should not be unrooted inputs
         /// </summary>
         public bool PartialComposite { get; set; }
+        public string CompositeRoot { get; set; }
     }
 
     /// <summary>
@@ -107,6 +108,11 @@ namespace R2RTest
             if (CompositeMode)
             {
                 yield return "--composite";
+            }
+
+            if (!string.IsNullOrEmpty(Crossgen2RunnerOptions.CompositeRoot))
+            {
+                yield return $"--compositerootpath={Crossgen2RunnerOptions.CompositeRoot}";
             }
 
             if (_options.Crossgen2Parallelism != 0)


### PR DESCRIPTION
Add new compilation scenario brought by https://github.com/dotnet/runtime/pull/37130, `SingleSerpAspNetSharedFrameworkComposite`, which compiles a single composite image containing Serp Core, Asp.Net, and Shared Fx. This is the closest to a shipping scenario and what we should run performance tests with. `SerpAspNetSharedFramework` is now less important but we can keep it around for a little while in case we want to compare the two.

cc @dotnet/crossgen-contrib 