### PR TITLE
Avoid checking per object heap limit if the commit is not related to a specific object heap

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -5610,7 +5610,7 @@ bool gc_heap::virtual_commit (void* address, size_t size, gc_oh_num oh, int h_nu
 
         if (heap_hard_limit_oh[0] != 0)
         {
-            if ((committed_by_oh[oh] + size) > heap_hard_limit_oh[oh])
+            if ((oh != gc_oh_num::none) && (committed_by_oh[oh] + size) > heap_hard_limit_oh[oh])
             {
                 exceeded_p = true;
             }


### PR DESCRIPTION
This bug slipped in when I addressed a code review feedback to make `committed_by_oh` an array to avoid code duplication.