### PR TITLE
Align ROS.Split handling of zero-length target strings with String.Split

### DIFF
--- a/src/libraries/System.Memory/tests/ReadOnlySpan/Split.char.cs
+++ b/src/libraries/System.Memory/tests/ReadOnlySpan/Split.char.cs
@@ -69,12 +69,12 @@ namespace System.SpanTests
 
             SpanSplitEnumerator<char>  enumerator = buffer.Split(default(char));
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split(' ');
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             // Empty buffer
@@ -82,12 +82,12 @@ namespace System.SpanTests
 
             enumerator = buffer.Split(default(char));
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split(' ');
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             // Single whitespace buffer
@@ -114,17 +114,17 @@ namespace System.SpanTests
 
             SpanSplitEnumerator<char> enumerator = buffer.Split(null); // null is treated as empty string
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split("");
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split(" ");
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             // Empty buffer
@@ -132,17 +132,17 @@ namespace System.SpanTests
 
             enumerator = buffer.Split(null);
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split("");
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split(" ");
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             // Single whitespace buffer
@@ -150,24 +150,24 @@ namespace System.SpanTests
 
             enumerator = buffer.Split(null); // null is treated as empty string
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(1, 1));
+            Assert.Equal(new Range(1, 1), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split("");
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(1, 1));
+            Assert.Equal(new Range(1, 1), enumerator.Current);
             Assert.False(enumerator.MoveNext());
 
             enumerator = buffer.Split(" ");
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(0, 0));
+            Assert.Equal(new Range(0, 0), enumerator.Current);
             Assert.True(enumerator.MoveNext());
-            Assert.Equal(enumerator.Current, new Range(1, 1));
+            Assert.Equal(new Range(1, 1), enumerator.Current);
             Assert.False(enumerator.MoveNext());
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/SpanSplitEnumerator.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanSplitEnumerator.T.cs
@@ -43,7 +43,7 @@ namespace System
             _separators = separators;
             _separator = default!;
             _splitOnSingleToken = false;
-            _separatorLength = _separators.Length != 0 ? _separators.Length : 1;
+            _separatorLength = _separators.Length;
             _startCurrent = 0;
             _endCurrent = 0;
             _startNext = 0;
@@ -76,7 +76,22 @@ namespace System
             ReadOnlySpan<T> slice = _buffer.Slice(_startNext);
             _startCurrent = _startNext;
 
-            int separatorIndex = _splitOnSingleToken ? slice.IndexOf(_separator) : slice.IndexOf(_separators);
+            int separatorIndex;
+            if (_splitOnSingleToken)
+            {
+                separatorIndex = slice.IndexOf(_separator);
+            }
+            else if (_separators.Length > 0)
+            {
+                separatorIndex = slice.IndexOf(_separators);
+            }
+            else
+            {
+                _endCurrent = _startCurrent + slice.Length;
+                _startNext = _endCurrent + 1;
+                return true;
+            }
+
             int elementLength = (separatorIndex != -1 ? separatorIndex : slice.Length);
 
             _endCurrent = _startCurrent + elementLength;


### PR DESCRIPTION
Follow up of https://github.com/dotnet/runtime/pull/295.

First commit is clean-up. Review can start from second commit.

cc @bbartels 