### PR TITLE
Disable `JitDoOldStructRetyping` by default.

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1107,7 +1107,7 @@ void CodeGen::genCodeForBitCast(GenTreeOp* treeNode)
         JITDUMP("Changing type of BITCAST source to load directly.");
         genCodeForTreeNode(op1);
     }
-    else if (varTypeIsFloating(treeNode) != varTypeIsFloating(op1))
+    else if (varTypeUsesFloatReg(treeNode) != varTypeUsesFloatReg(op1))
     {
         regNumber srcReg = op1->GetRegNum();
         assert(genTypeSize(op1->TypeGet()) == genTypeSize(targetType));

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -985,6 +985,8 @@ public:
         return GetLayout()->GetRegisterType();
     }
 
+    bool CanBeReplacedWithItsField(Compiler* comp) const;
+
 #ifdef DEBUG
 public:
     const char* lvReason;
@@ -5602,6 +5604,7 @@ private:
     GenTree* fgMorphCopyBlock(GenTree* tree);
     GenTree* fgMorphForRegisterFP(GenTree* tree);
     GenTree* fgMorphSmpOp(GenTree* tree, MorphAddrContext* mac = nullptr);
+    GenTree* fgMorphRetInd(GenTreeUnOp* tree);
     GenTree* fgMorphModToSubMulDiv(GenTreeOp* tree);
     GenTree* fgMorphSmpOpOptional(GenTreeOp* tree);
 
@@ -9179,7 +9182,7 @@ public:
 
     // Returns true if the method returns a value in more than one return register,
     // it should replace/be  merged with compMethodReturnsMultiRegRetType when #36868 is fixed.
-    // The difference from original `compMethodReturnsMultiRegRetType` is in ARM64 SIMD16 handling,
+    // The difference from original `compMethodReturnsMultiRegRetType` is in ARM64 SIMD* handling,
     // this method correctly returns false for it (it is passed as HVA), when the original returns true.
     bool compMethodReturnsMultiRegRegTypeAlternate()
     {
@@ -9189,8 +9192,8 @@ public:
         return varTypeIsLong(info.compRetNativeType);
 #else // targets: X64-UNIX, ARM64 or ARM32
 #if defined(TARGET_ARM64)
-        // TYP_SIMD16 is returned in one register.
-        if (info.compRetNativeType == TYP_SIMD16)
+        // TYP_SIMD* are returned in one register.
+        if (varTypeIsSIMD(info.compRetNativeType))
         {
             return false;
         }

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -7974,7 +7974,7 @@ private:
     // vector type (i.e. do not analyze or promote its fields).
     // Note that all but the fixed vector types are opaque, even though they may
     // actually be declared as having fields.
-    bool isOpaqueSIMDType(CORINFO_CLASS_HANDLE structHandle)
+    bool isOpaqueSIMDType(CORINFO_CLASS_HANDLE structHandle) const
     {
         return ((m_simdHandleCache != nullptr) && (structHandle != m_simdHandleCache->SIMDVector2Handle) &&
                 (structHandle != m_simdHandleCache->SIMDVector3Handle) &&
@@ -7990,7 +7990,7 @@ private:
     }
 
     // Returns true if the lclVar is an opaque SIMD type.
-    bool isOpaqueSIMDLclVar(LclVarDsc* varDsc)
+    bool isOpaqueSIMDLclVar(const LclVarDsc* varDsc) const
     {
         if (!varDsc->lvSIMDType)
         {

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -89,7 +89,8 @@ void Compiler::fgInit()
     fgCurBBEpochSize         = 0;
     fgBBSetCountInSizeTUnits = 0;
 
-    genReturnBB = nullptr;
+    genReturnBB    = nullptr;
+    genReturnLocal = BAD_VAR_NUM;
 
     /* We haven't reached the global morphing phase */
     fgGlobalMorph = false;

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -439,7 +439,7 @@ CONFIG_INTEGER(JitSaveFpLrWithCalleeSavedRegisters, W("JitSaveFpLrWithCalleeSave
 #endif // defined(TARGET_ARM64)
 #endif // DEBUG
 
-CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 1) // Allow Jit to retype structs as primitive types
+CONFIG_INTEGER(JitDoOldStructRetyping, W("JitDoOldStructRetyping"), 0) // Allow Jit to retype structs as primitive types
                                                                        // when possible.
 
 #undef CONFIG_INTEGER

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -536,12 +536,13 @@ public:
                         // be merged separatly.
                         GenTreeLclVar* lclVar = retVal->AsLclVar();
                         unsigned       lclNum = lclVar->GetLclNum();
-                        if (!m_compiler->lvaIsImplicitByRefLocal(lclVar->GetLclNum()))
+                        if (!m_compiler->compMethodReturnsMultiRegRegTypeAlternate() &&
+                            !m_compiler->lvaIsImplicitByRefLocal(lclVar->GetLclNum()))
                         {
                             LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
                             if (varDsc->lvFieldCnt > 1)
                             {
-                                m_compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_IsStructArg));
+                                m_compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_BlockOp));
                             }
                         }
                     }

--- a/src/coreclr/src/jit/lclmorph.cpp
+++ b/src/coreclr/src/jit/lclmorph.cpp
@@ -521,6 +521,36 @@ public:
                 PopValue();
                 break;
 
+            case GT_RETURN:
+                if (TopValue(0).Node() != node)
+                {
+                    assert(TopValue(1).Node() == node);
+                    assert(TopValue(0).Node() == node->gtGetOp1());
+                    GenTreeUnOp* ret    = node->AsUnOp();
+                    GenTree*     retVal = ret->gtGetOp1();
+                    if (!m_compiler->compDoOldStructRetyping() && retVal->OperIs(GT_LCL_VAR))
+                    {
+                        // TODO-1stClassStructs: this block is a temporary workaround to keep diffs small,
+                        // having `doNotEnreg` affect block init and copy transformations that affect many methods.
+                        // I have a change that introduces more precise and effective solution for that, but it would
+                        // be merged separatly.
+                        GenTreeLclVar* lclVar = retVal->AsLclVar();
+                        unsigned       lclNum = lclVar->GetLclNum();
+                        if (!m_compiler->lvaIsImplicitByRefLocal(lclVar->GetLclNum()))
+                        {
+                            LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
+                            if (varDsc->lvFieldCnt > 1)
+                            {
+                                m_compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_IsStructArg));
+                            }
+                        }
+                    }
+
+                    EscapeValue(TopValue(0), node);
+                    PopValue();
+                }
+                break;
+
             default:
                 while (TopValue(0).Node() != node)
                 {

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -3684,17 +3684,9 @@ bool LclVarDsc::CanBeReplacedWithItsField(Compiler* comp) const
     // In order to do that we have to have its field `a` in memory. Right now lowering cannot
     // handle RETURN struct(multiple registers)->SIMD16(one register), but it can be improved.
     LclVarDsc* fieldDsc = comp->lvaGetDesc(lvFieldLclStart);
-    if (fieldDsc->TypeGet() == TYP_SIMD12 || fieldDsc->TypeGet() == TYP_SIMD16)
+    if (varTypeIsSIMD(fieldDsc))
     {
-#if defined(TARGET_ARM64)
-        if (!comp->isOpaqueSIMDLclVar(fieldDsc))
-        {
-            return false;
-        }
-#else  // !TARGET_ARM64
-        // TODO-X64-CQ: check for `isOpaqueSIMDLclVar` after https://github.com/dotnet/runtime/issues/9578.
         return false;
-#endif //! TARGET_ARM64
     }
 #endif // FEATURE_SIMD
 

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -1974,6 +1974,11 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
             shouldPromote = false;
         }
     }
+    else if (!compiler->compDoOldStructRetyping() && (lclNum == compiler->genReturnLocal) && (structPromotionInfo.fieldCnt > 1))
+    {
+        // TODO-1stClassStructs: a temporary solution to keep diffs small, it will be fixed later.
+        shouldPromote = false;
+    }
 
     //
     // If the lvRefCnt is zero and we have a struct promoted parameter we can end up with an extra store of

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -1974,7 +1974,8 @@ bool Compiler::StructPromotionHelper::ShouldPromoteStructVar(unsigned lclNum)
             shouldPromote = false;
         }
     }
-    else if (!compiler->compDoOldStructRetyping() && (lclNum == compiler->genReturnLocal) && (structPromotionInfo.fieldCnt > 1))
+    else if (!compiler->compDoOldStructRetyping() && (lclNum == compiler->genReturnLocal) &&
+             (structPromotionInfo.fieldCnt > 1))
     {
         // TODO-1stClassStructs: a temporary solution to keep diffs small, it will be fixed later.
         shouldPromote = false;
@@ -3643,6 +3644,53 @@ var_types LclVarDsc::lvaArgType()
 #endif // TARGET_AMD64
 
     return type;
+}
+
+//----------------------------------------------------------------------------------------------
+// CanBeReplacedWithItsField: check if a whole struct reference could be replaced by a field.
+//
+// Arguments:
+//    comp - the compiler instance;
+//
+// Return Value:
+//    true if that can be replaced, false otherwise.
+//
+// Notes:
+//    The replacement can be made only for independently promoted structs
+//    with 1 field without holes.
+//
+bool LclVarDsc::CanBeReplacedWithItsField(Compiler* comp) const
+{
+    if (!lvPromoted)
+    {
+        return false;
+    }
+
+    if (comp->lvaGetPromotionType(this) != Compiler::PROMOTION_TYPE_INDEPENDENT)
+    {
+        return false;
+    }
+    if (lvFieldCnt != 1)
+    {
+        return false;
+    }
+    if (lvContainsHoles)
+    {
+        return false;
+    }
+
+#if defined(FEATURE_SIMD)
+    // If we return `struct A { SIMD16 a; }` we split the struct into several fields.
+    // In order to do that we have to have its field in memory. Right now lowering cannot
+    // handle RETURN struct(multiple registers)->SIMD16(one register), but it can be improved.
+    LclVarDsc* fieldDsc = comp->lvaGetDesc(lvFieldLclStart);
+    if (fieldDsc->TypeGet() == TYP_SIMD12 || fieldDsc->TypeGet() == TYP_SIMD16)
+    {
+        return false;
+    }
+#endif // FEATURE_SIMD
+
+    return true;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -3680,13 +3680,19 @@ bool LclVarDsc::CanBeReplacedWithItsField(Compiler* comp) const
     }
 
 #if defined(FEATURE_SIMD)
+    assert(!comp->isOpaqueSIMDLclVar(this)); // opaque SIMD can't be promoted.
     // If we return `struct A { SIMD16 a; }` we split the struct into several fields.
-    // In order to do that we have to have its field in memory. Right now lowering cannot
+    // In order to do that we have to have its field `a` in memory. Right now lowering cannot
     // handle RETURN struct(multiple registers)->SIMD16(one register), but it can be improved.
     LclVarDsc* fieldDsc = comp->lvaGetDesc(lvFieldLclStart);
     if (fieldDsc->TypeGet() == TYP_SIMD12 || fieldDsc->TypeGet() == TYP_SIMD16)
     {
+#if defined(TARGET_ARM64)
         return false;
+#else  // !TARGET_ARM64
+        // TODO-X64-CQ: it will be reachable after https://github.com/dotnet/runtime/issues/9578.
+        unreached();
+#endif //! TARGET_ARM64
     }
 #endif // FEATURE_SIMD
 

--- a/src/coreclr/src/jit/lclvars.cpp
+++ b/src/coreclr/src/jit/lclvars.cpp
@@ -3680,7 +3680,6 @@ bool LclVarDsc::CanBeReplacedWithItsField(Compiler* comp) const
     }
 
 #if defined(FEATURE_SIMD)
-    assert(!comp->isOpaqueSIMDLclVar(this)); // opaque SIMD can't be promoted.
     // If we return `struct A { SIMD16 a; }` we split the struct into several fields.
     // In order to do that we have to have its field `a` in memory. Right now lowering cannot
     // handle RETURN struct(multiple registers)->SIMD16(one register), but it can be improved.
@@ -3688,10 +3687,13 @@ bool LclVarDsc::CanBeReplacedWithItsField(Compiler* comp) const
     if (fieldDsc->TypeGet() == TYP_SIMD12 || fieldDsc->TypeGet() == TYP_SIMD16)
     {
 #if defined(TARGET_ARM64)
-        return false;
+        if (!comp->isOpaqueSIMDLclVar(fieldDsc))
+        {
+            return false;
+        }
 #else  // !TARGET_ARM64
-        // TODO-X64-CQ: it will be reachable after https://github.com/dotnet/runtime/issues/9578.
-        unreached();
+        // TODO-X64-CQ: check for `isOpaqueSIMDLclVar` after https://github.com/dotnet/runtime/issues/9578.
+        return false;
 #endif //! TARGET_ARM64
     }
 #endif // FEATURE_SIMD

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -134,9 +134,9 @@ private:
     void LowerRet(GenTreeUnOp* ret);
     void LowerStoreLocCommon(GenTreeLclVarCommon* lclVar);
     void LowerRetStruct(GenTreeUnOp* ret);
-    void LowerRetStructLclVar(GenTreeUnOp* ret);
+    void LowerRetSingleRegStructLclVar(GenTreeUnOp* ret);
     void LowerCallStruct(GenTreeCall* call);
-    void LowerStoreCallStruct(GenTreeBlk* store);
+    void LowerStoreSingleRegCallStruct(GenTreeBlk* store);
 #if !defined(WINDOWS_AMD64_ABI)
     GenTreeLclVar* SpillStructCallResult(GenTreeCall* call) const;
 #endif // WINDOWS_AMD64_ABI

--- a/src/coreclr/src/jit/lsraarm.cpp
+++ b/src/coreclr/src/jit/lsraarm.cpp
@@ -764,7 +764,11 @@ int LinearScan::BuildNode(GenTree* tree)
         {
             assert(dstCount == 1);
             regNumber argReg  = tree->GetRegNum();
-            regMaskTP argMask = genRegMask(argReg);
+            regMaskTP argMask = RBM_NONE;
+            if (argReg != REG_COUNT)
+            {
+                argMask = genRegMask(argReg);
+            }
 
             // If type of node is `long` then it is actually `double`.
             // The actual `long` types must have been transformed as a field list with two fields.

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -10342,9 +10342,6 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
         if (varTypeIsStruct(varDsc) && varDsc->CanBeReplacedWithItsField(this))
         {
             JITDUMP(" not morphing a single reg call return\n");
-            // Set `lvIsMultiRegRet` to exclude it from SSA, it is a temporary solution,
-            // inspired by multi-reg call work. We should support SSA for such structs in the future.
-            varDsc->lvIsMultiRegRet = true;
             return tree;
         }
     }

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -444,7 +444,12 @@ LclSsaVarDsc* RangeCheck::GetSsaDefAsg(GenTreeLclVarCommon* lclUse)
         return nullptr;
     }
 
-    LclSsaVarDsc* ssaDef = m_pCompiler->lvaGetDesc(lclUse)->GetPerSsaData(ssaNum);
+    LclVarDsc* varDsc = m_pCompiler->lvaGetDesc(lclUse);
+    if (varDsc->CanBeReplacedWithItsField(m_pCompiler))
+    {
+        varDsc = m_pCompiler->lvaGetDesc(varDsc->lvFieldLclStart);
+    }
+    LclSsaVarDsc* ssaDef = varDsc->GetPerSsaData(ssaNum);
 
     // RangeCheck does not care about uninitialized variables.
     if (ssaDef->GetAssignment() == nullptr)
@@ -472,6 +477,11 @@ LclSsaVarDsc* RangeCheck::GetSsaDefAsg(GenTreeLclVarCommon* lclUse)
 #ifdef DEBUG
 UINT64 RangeCheck::HashCode(unsigned lclNum, unsigned ssaNum)
 {
+    LclVarDsc* varDsc = m_pCompiler->lvaGetDesc(lclNum);
+    if (varDsc->CanBeReplacedWithItsField(m_pCompiler))
+    {
+        lclNum = varDsc->lvFieldLclStart;
+    }
     assert(ssaNum != SsaConfig::RESERVED_SSA_NUM);
     return UINT64(lclNum) << 32 | ssaNum;
 }
@@ -499,7 +509,8 @@ RangeCheck::Location* RangeCheck::GetDef(unsigned lclNum, unsigned ssaNum)
 
 RangeCheck::Location* RangeCheck::GetDef(GenTreeLclVarCommon* lcl)
 {
-    return GetDef(lcl->GetLclNum(), lcl->GetSsaNum());
+    unsigned lclNum = lcl->GetLclNum();
+    return GetDef(lclNum, lcl->GetSsaNum());
 }
 
 // Add the def location to the hash table.
@@ -546,7 +557,12 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
         Limit      limit(Limit::keUndef);
         genTreeOps cmpOper = GT_NONE;
 
-        LclSsaVarDsc* ssaData     = m_pCompiler->lvaTable[lcl->GetLclNum()].GetPerSsaData(lcl->GetSsaNum());
+        LclVarDsc* varDsc = m_pCompiler->lvaGetDesc(lcl);
+        if (varDsc->CanBeReplacedWithItsField(m_pCompiler))
+        {
+            varDsc = m_pCompiler->lvaGetDesc(varDsc->lvFieldLclStart);
+        }
+        LclSsaVarDsc* ssaData     = varDsc->GetPerSsaData(lcl->GetSsaNum());
         ValueNum      normalLclVN = m_pCompiler->vnStore->VNConservativeNormalValue(ssaData->m_vnPair);
 
         // Current assertion is of the form (i < len - cns) != 0

--- a/src/coreclr/src/jit/ssabuilder.cpp
+++ b/src/coreclr/src/jit/ssabuilder.cpp
@@ -749,7 +749,15 @@ void SsaBuilder::RenameDef(GenTreeOp* asgNode, BasicBlock* block)
 
     if (isLocal)
     {
-        unsigned lclNum = lclNode->GetLclNum();
+        unsigned   lclNum = lclNode->GetLclNum();
+        LclVarDsc* varDsc = m_pCompiler->lvaGetDesc(lclNum);
+
+        if (!m_pCompiler->lvaInSsa(lclNum) && varDsc->CanBeReplacedWithItsField(m_pCompiler))
+        {
+            lclNum = varDsc->lvFieldLclStart;
+            varDsc = m_pCompiler->lvaGetDesc(lclNum);
+            assert(isFullDef);
+        }
 
         if (m_pCompiler->lvaInSsa(lclNum))
         {
@@ -758,7 +766,7 @@ void SsaBuilder::RenameDef(GenTreeOp* asgNode, BasicBlock* block)
             // This should have been marked as defintion.
             assert((lclNode->gtFlags & GTF_VAR_DEF) != 0);
 
-            unsigned ssaNum = m_pCompiler->lvaGetDesc(lclNum)->lvPerSsaData.AllocSsaNum(m_allocator, block, asgNode);
+            unsigned ssaNum = varDsc->lvPerSsaData.AllocSsaNum(m_allocator, block, asgNode);
 
             if (!isFullDef)
             {
@@ -787,7 +795,7 @@ void SsaBuilder::RenameDef(GenTreeOp* asgNode, BasicBlock* block)
             }
 
             // If it's a SSA local then it cannot be address exposed and thus does not define SSA memory.
-            assert(!m_pCompiler->lvaVarAddrExposed(lclNode->GetLclNum()));
+            assert(!m_pCompiler->lvaVarAddrExposed(lclNum));
             return;
         }
 

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -6859,6 +6859,12 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                 unsigned             lclNum = lcl->GetLclNum();
                 LclVarDsc*           varDsc = &lvaTable[lclNum];
 
+                if (varDsc->CanBeReplacedWithItsField(this))
+                {
+                    lclNum = varDsc->lvFieldLclStart;
+                    varDsc = &lvaTable[lclNum];
+                }
+
                 // Do we have a Use (read) of the LclVar?
                 //
                 if ((lcl->gtFlags & GTF_VAR_DEF) == 0 ||

--- a/src/coreclr/tests/src/JIT/Directed/StructABI/structreturn.cs
+++ b/src/coreclr/tests/src/JIT/Directed/StructABI/structreturn.cs
@@ -1078,7 +1078,7 @@ class TestHFAandHVA
 
     struct Vector2Wrapper
     {
-        Vector2 f1;
+        public Vector2 f1;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1087,9 +1087,20 @@ class TestHFAandHVA
         return new Vector2Wrapper();
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector2Wrapper ReturnVector2WrapperPromoted()
+    {
+        var a = new Vector2Wrapper
+        {
+            f1 = Vector2.Zero
+        };
+
+        return a;
+    }
+
     struct Vector3Wrapper
     {
-        Vector3 f1;
+        public Vector3 f1;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1098,15 +1109,37 @@ class TestHFAandHVA
         return new Vector3Wrapper();
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector3Wrapper ReturnVector3WrapperPromoted()
+    {
+        var a = new Vector3Wrapper
+        {
+            f1 = Vector3.Zero
+        };
+
+        return a;
+    }
+
     struct Vector4Wrapper
     {
-        Vector4 f1;
+        public Vector4 f1;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static Vector4Wrapper ReturnVector4Wrapper()
     {
         return new Vector4Wrapper();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static Vector4Wrapper ReturnVector4WrapperPromoted()
+    {
+        var a = new Vector4Wrapper
+        {
+            f1 = Vector4.Zero
+        };
+
+        return a;
     }
 
     struct Vector2x2Wrapper
@@ -1133,8 +1166,11 @@ class TestHFAandHVA
         ReturnFloats4Wrapper();
         ReturnDoubles4Wrapper();
         ReturnVector2Wrapper();
+        ReturnVector2WrapperPromoted();
         ReturnVector3Wrapper();
+        ReturnVector3WrapperPromoted();
         ReturnVector4Wrapper();
+        ReturnVector4WrapperPromoted();
         ReturnVector2x2Wrapper();
     }
 
@@ -1226,13 +1262,23 @@ class TestHFAandHVA
 
     struct VectorShortWrapper
     {
-        Vector<short> f;
+        public Vector<short> f;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     static VectorShortWrapper ReturnVectorShortWrapper()
     {
         return new VectorShortWrapper();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static VectorShortWrapper ReturnVectorShortWrapperPromoted()
+    {
+        var a = new VectorShortWrapper()
+        {
+            f = Vector<short>.Zero
+        };
+        return a;
     }
 
     struct VectorLongWrapper
@@ -1355,6 +1401,7 @@ class TestHFAandHVA
         ReturnVectorTWithMerge<Vector<Single>>(3, new Vector<Single>(0), new Vector<Single>(0), new Vector<Single>(0), new Vector<Single>(0));
 
         ReturnVectorShortWrapper();
+        ReturnVectorShortWrapperPromoted();
         ReturnVectorLongWrapper();
         ReturnVectorDoubleWrapper();
         ReturnVectorTWrapper<bool>();
@@ -1508,6 +1555,60 @@ class TestHFAandHVA
         }
     }
 
+    public struct Vector64Wrapped
+    {
+        public Vector64<float> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Vector64Wrapped TestReturnVector64WrappedPromoted()
+    {
+        var a = new Vector64Wrapped
+        {
+            f = Vector64<float>.Zero
+        };
+        return a;
+    }
+
+    public struct Vector128Wrapped
+    {
+        public Vector128<short> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Vector128Wrapped TestReturnVector128WrappedPromoted()
+    {
+        var a = new Vector128Wrapped
+        {
+            f = Vector128<short>.Zero
+        };
+        return a;
+    }
+
+    public struct Vector256Wrapped
+    {
+        public Vector256<byte> f;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Vector256Wrapped TestReturnVector256WrappedPromoted()
+    {
+        var a = new Vector256Wrapped
+        {
+            f = Vector256<byte>.Zero
+        };
+        return a;
+    }
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void TestReturnVectorNWrappedPromoted()
+    {
+        TestReturnVector64WrappedPromoted();
+        TestReturnVector128WrappedPromoted();
+        TestReturnVector256WrappedPromoted();
+    }
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void Test()
     {
@@ -1517,6 +1618,7 @@ class TestHFAandHVA
         TestReturnVector64(1);
         TestReturnVector128(1);
         TestReturnVector256(1);
+        TestReturnVectorNWrappedPromoted();
     }
 }
 


### PR DESCRIPTION
Commits:
f4324370f9c: Disable retyping by default.

06e7c52f2c1: Keep block init/copy as baseline.

f53bb305050: Don't mark LCL_VAR that is used in RETURN(IND(ADDR(LCL_VAR)) as address taken when possible.
It is a beginning for #11413, we fold (IND(ADDR()) and say that the user (in this case Return) has necessary information to do the case in lowering, improves `return Unsafe.As<long>(double)` etc.

3965e9d3b40: Replace 1-field structs with the field for returns.
It is needed for copy propagation optimizations, like when we do `ASG(LCL_FLD long V01, 1); return LCL_VAR V01` where V01 has only one field and we want to propagate `1` to the return. 

f7a90a380f0: Add SSA support.
That is particular SSA/CSE support for `ASG struct(LCL_VAR struct V01(with 1 promoted field), call struct)` that fixes most regressions. I do not like that commit, it doesn't look solid and it does not support VN for that `LCL_VAR struct` , because we have a check that tree type is enregistarable. However, it solves the problem, passes the tests and the rest could be done later, maybe after we design a general solution for multireg SSA nodes.

Framework libraries
  | Diff, bytes | Diff, % | improved | regressed
-- | -- | -- | -- | --
X64 windows, crossgen | -6764 | -0.02 | 862 | 323
X64 windows, PMI | -11591 | -0.02 | 1401 | 655
X64 Linux, crossgen | -6205 | -0.01 | 816 | 310
X64 Linux, PMI | -5970 | -0.01 | 1259 | 600
ARM64 Windows, crossgen | 1076 | 0 | 603 | 317
ARM64 Linux, PMI | -2388 | 0 | 1026 | 756
X86 windows, crossgen | -1865 | -0.01 | 502 | 250
X86 windows, PMI | -2170 | 0 | 949 | 614
X86 Linux, crossgen | -2719 | 0 | 504 | 239
X6 Linux, PMI | -1268 | 0 | 940 | 621
ARM Windows, crossgen | -286 | 0 | 443 | 955
ARM Linux, PMI | -1262 | 0 | 680 | 689

Runtime benchmarks
  | Diff, bytes | Diff, % | improved | regressed
-- | -- | -- | -- | --
X64 windows, crossgen | -212 | -0.06 | 5 | 1(more phi resolution moves from register to memory, instead of keeping   it in memory all the time)
X64 windows, PMI | -248 | -0.05 | 3 | 0
X64 Linux, crossgen | -188 | -0.02 | 5 | 1
X64 Linux, PMI | -149 | -0.03 | 2 | 1
ARM64 Windows, crossgen | -120 | -0.01 | 4 | 0
ARM64 Linux, PMI | -44 | -0.01 | 1 | 0

Improved benchmarks: SIMD\ConsoleMandel\ConsoleMandel\ConsoleMandel, SciMark\SciMark\SciMark.

Also, I was running dotnet/performance benchmarks to catch regressions, but have not seen any(there was a lot of noise in +-5% but without code size diffs), will check CI run after it is merged.
SIMD.ConsoleMandel:ScalarFloatSingleThreadADT: -77% (as expected);



<details>
  <summary>Regressions analysis</summary>

In short: nothing unexpected for x64 Crossgen so far, main issues are #8016, #11413. I am analyzing x64 PMI and arm64 crossgen diffs right now, but it is a long process, I will update the list once it is done.
```
136 (13.49% of base) : Microsoft.CodeAnalysis.CSharp.dasm - UnopEasyOut:TypeToIndex(TypeSymbol):Nullable`1
133 (13.12% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BinopEasyOut:TypeToIndex(TypeSymbol):Nullable`1
68 ( 3.82% of base) : Microsoft.CodeAnalysis.dasm - SyntaxDiffer:GetNextAction():DiffAction:this
35 (34.31% of base) : System.Private.DataContractSerialization.dasm - CodeGenerator:GetBranchCode(int):OpCode:this
34 ( 9.60% of base) : Microsoft.Extensions.DependencyInjection.dasm - CallSiteVisitor`2:VisitCallSiteMain(ServiceCallSite,__Canon):ILEmitCallSiteAnalysisResult:this
31 (13.78% of base) : Newtonsoft.Json.dasm - JsonValidatingReader:GetCurrentNodeSchemaType():Nullable`1:this
29 ( 9.03% of base) : Microsoft.Extensions.DependencyInjection.dasm - CallSiteVisitor`2:VisitCallSite(ServiceCallSite,__Canon):ILEmitCallSiteAnalysisResult:this
	can't enreg merged return struct with >1 field, https://github.com/dotnet/runtime/issues/8016
	
48 ( 5.87% of base) : Microsoft.CodeAnalysis.CSharp.dasm - TypeSymbol:ReportAnyMismatchedConstraints(MethodSymbol,TypeSymbol,MethodSymbol,DiagnosticBag)
	have to spill new enreg variables before calls, not a CQ regression.
	
	
35 ( 4.08% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MemberSignatureComparer:HaveSameParameterTypes(ImmutableArray`1,TypeMap,ImmutableArray`1,TypeMap,bool,bool,bool):bool
32 ( 5.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - MemberSignatureComparer:HaveSameReturnTypes(Symbol,TypeMap,Symbol,TypeMap,bool,bool):bool
84 ( 6.70% of base) : System.Security.Cryptography.X509Certificates.dasm - CertificatePal:CopyWithPrivateKey(RSA):ICertificatePal:this
32 ( 6.57% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - MethodSignatureComparer:HaveSameReturnTypes(MethodSymbol,TypeSubstitution,MethodSymbol,TypeSubstitution,bool):bool
28 ( 1.88% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - RetargetingSymbolTranslator:Retarget(NamedTypeSymbol,ubyte):NamedTypeSymbol:this
	mark as don't enreg after `OBJ<struct, 8>(ADDR(LCL_VAR ref/another struct<8>,long))` cast, https://github.com/dotnet/runtime/issues/11413

85 ( 6.31% of base) : xunit.console.dasm - ConsoleRunner:EntryPoint(ref):int:this
31 ( 1.52% of base) : System.Text.Json.dasm - JsonDocument:TryParseValue(byref,byref,bool):bool
	promote more fields, so getting more instructions to load individual fields on registers from memory, not a 100% CQ regression, but can be improved.

66 ( 5.96% of base) : Microsoft.Extensions.DependencyModel.dasm - DependencyContextJsonReader:ReadCompilationOptions(byref):CompilationOptions
	we decide to promote a local var, but it is assign as `ASG(LCL_VAR, call)`, so we have to forbid independent promotion.

56 ( 1.21% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Binder:BindCollectionRangeVariables(QueryClauseSyntax,BoundQueryClauseBase,SeparatedSyntaxList`1,byref,DiagnosticBag):BoundQueryClauseBase:this
	can't do an assertion prop after `OBJ<struct, 8>(ADDR(LCL_VAR ref/another struct<8>,long))` cast, https://github.com/dotnet/runtime/issues/11413


50 ( 1.25% of base) : Microsoft.CodeAnalysis.dasm - CommonCompiler:RunCore(TextWriter,ErrorLogger,CancellationToken):int:this
STORE_OBJ for a ref type generates worse code(does not try to create LEA), https://github.com/dotnet/runtime/issues/38538

31 ( 1.47% of base) : System.Text.Json.dasm - JsonSerializer:ReadValueCore(JsonSerializerOptions,byref,byref):__Canon
	allow to enreg two additional fields that go to r14 and t15, but have to push them in each FunclitProlog and pop in each epilogue, so 14 additional instructions of push/pop for 4 moves that could use registers(these fields have 2 uses each, 1 def, 1 use), sound like we should keep them in memory in this case, @carol?

27 ( 4.37% of base) : System.Reflection.Metadata.dasm - PEReader:TryOpenAssociatedPortablePdb(String,Func`2,byref,byref):bool:this
don't do a copy prop, need a better support for VN for asg(LCL_VAR struct(1 promoted field), call).
```

</details>

This change affects many issues, the main one it fixes #1231, the rest I will check and close after it goes in.