### PR TITLE
Change additional PropertyPolicy terminology

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -111,13 +111,17 @@ namespace System.Text.Json
             JsonConverter converter,
             JsonSerializerOptions options)
         {
-            return CreateProperty(
+            JsonPropertyInfo jsonPropertyInfo = CreateProperty(
                 declaredPropertyType: declaredPropertyType,
                 runtimePropertyType: runtimePropertyType,
                 propertyInfo: null, // Not a real property so this is null.
                 parentClassType: typeof(object), // a dummy value (not used)
                 converter: converter,
                 options);
+
+            Debug.Assert(jsonPropertyInfo.IsForClassInfo);
+
+            return jsonPropertyInfo;
         }
 
         // AggressiveInlining used although a large method it is only called from one location and is on a hot path.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -23,9 +23,9 @@ namespace System.Text.Json
         public static JsonPropertyInfo GetPropertyPlaceholder()
         {
             JsonPropertyInfo info = new JsonPropertyInfo<object>();
-            Debug.Assert(info.IsForClassInfo == false);
-            Debug.Assert(info.ShouldDeserialize == false);
-            Debug.Assert(info.ShouldSerialize == false);
+            Debug.Assert(!info.IsForClassInfo);
+            Debug.Assert(!info.ShouldDeserialize);
+            Debug.Assert(!info.ShouldSerialize);
             return info;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -23,9 +23,9 @@ namespace System.Text.Json
         public static JsonPropertyInfo GetPropertyPlaceholder()
         {
             JsonPropertyInfo info = new JsonPropertyInfo<object>();
-            info.IsPropertyPolicy = false;
-            info.ShouldDeserialize = false;
-            info.ShouldSerialize = false;
+            Debug.Assert(info.IsForClassInfo == false);
+            Debug.Assert(info.ShouldDeserialize == false);
+            Debug.Assert(info.ShouldSerialize == false);
             return info;
         }
 
@@ -195,7 +195,10 @@ namespace System.Text.Json
         public bool IgnoreDefaultValuesOnRead { get; private set; }
         public bool IgnoreDefaultValuesOnWrite { get; private set; }
 
-        public bool IsPropertyPolicy { get; protected set; }
+        /// <summary>
+        /// True if the corresponding cref="JsonClassInfo.PropertyInfoForClassInfo"/> is this instance.
+        /// </summary>
+        public bool IsForClassInfo { get; protected set; }
 
         // There are 3 copies of the property name:
         // 1) NameAsString. The unescaped property name.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -63,7 +63,7 @@ namespace System.Text.Json
             }
             else
             {
-                IsPropertyPolicy = true;
+                IsForClassInfo = true;
                 HasGetter = true;
                 HasSetter = true;
             }
@@ -86,7 +86,7 @@ namespace System.Text.Json
 
         public override object? GetValueAsObject(object obj)
         {
-            if (IsPropertyPolicy)
+            if (IsForClassInfo)
             {
                 return obj;
             }


### PR DESCRIPTION
Clean up remaining usage of this term that was missed with the original issue https://github.com/dotnet/runtime/pull/33432

Also removed some unnecessary field assignments in GetPropertyPlaceholder().