### PR TITLE
Remove JsonParameterInfo.ReadJson and ReadJsonTyped

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Buffers;
+using System.Diagnostics;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -14,7 +15,10 @@ namespace System.Text.Json.Serialization.Converters
     {
         protected override bool ReadAndCacheConstructorArgument(ref ReadStack state, ref Utf8JsonReader reader, JsonParameterInfo jsonParameterInfo)
         {
-            bool success = jsonParameterInfo.ConverterBase.TryReadAsObject(ref reader, jsonParameterInfo.Options, ref state, out object? arg);
+            Debug.Assert(jsonParameterInfo.ShouldDeserialize);
+            Debug.Assert(jsonParameterInfo.Options != null);
+
+            bool success = jsonParameterInfo.ConverterBase.TryReadAsObject(ref reader, jsonParameterInfo.Options!, ref state, out object? arg);
 
             if (success)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Large.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Converters
     {
         protected override bool ReadAndCacheConstructorArgument(ref ReadStack state, ref Utf8JsonReader reader, JsonParameterInfo jsonParameterInfo)
         {
-            bool success = jsonParameterInfo.ReadJson(ref state, ref reader, out object? arg);
+            bool success = jsonParameterInfo.ConverterBase.TryReadAsObject(ref reader, jsonParameterInfo.Options, ref state, out object? arg);
 
             if (success)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.Small.cs
@@ -30,33 +30,49 @@ namespace System.Text.Json.Serialization.Converters
             switch (jsonParameterInfo.Position)
             {
                 case 0:
-                    success = ((JsonParameterInfo<TArg0>)jsonParameterInfo).ReadJsonTyped(ref state, ref reader, out TArg0 arg0);
-                    if (success)
                     {
-                        arguments.Arg0 = arg0!;
+                        var info = (JsonParameterInfo<TArg0>)jsonParameterInfo;
+                        var converter = (JsonConverter<TArg0>)jsonParameterInfo.ConverterBase;
+                        success = converter.TryRead(ref reader, info.RuntimePropertyType, info.Options, ref state, out TArg0 arg0);
+                        if (success)
+                        {
+                            arguments.Arg0 = arg0!;
+                        }
+                        break;
                     }
-                    break;
                 case 1:
-                    success = ((JsonParameterInfo<TArg1>)jsonParameterInfo).ReadJsonTyped(ref state, ref reader, out TArg1 arg1);
-                    if (success)
                     {
-                        arguments.Arg1 = arg1!;
+                        var info = (JsonParameterInfo<TArg1>)jsonParameterInfo;
+                        var converter = (JsonConverter<TArg1>)jsonParameterInfo.ConverterBase;
+                        success = converter.TryRead(ref reader, info.RuntimePropertyType, info.Options, ref state, out TArg1 arg1);
+                        if (success)
+                        {
+                            arguments.Arg1 = arg1!;
+                        }
+                        break;
                     }
-                    break;
                 case 2:
-                    success = ((JsonParameterInfo<TArg2>)jsonParameterInfo).ReadJsonTyped(ref state, ref reader, out TArg2 arg2);
-                    if (success)
                     {
-                        arguments.Arg2 = arg2!;
+                        var info = (JsonParameterInfo<TArg2>)jsonParameterInfo;
+                        var converter = (JsonConverter<TArg2>)jsonParameterInfo.ConverterBase;
+                        success = converter.TryRead(ref reader, info.RuntimePropertyType, info.Options, ref state, out TArg2 arg2);
+                        if (success)
+                        {
+                            arguments.Arg2 = arg2!;
+                        }
+                        break;
                     }
-                    break;
                 case 3:
-                    success = ((JsonParameterInfo<TArg3>)jsonParameterInfo).ReadJsonTyped(ref state, ref reader, out TArg3 arg3);
-                    if (success)
                     {
-                        arguments.Arg3 = arg3!;
+                        var info = (JsonParameterInfo<TArg3>)jsonParameterInfo;
+                        var converter = (JsonConverter<TArg3>)jsonParameterInfo.ConverterBase;
+                        success = converter.TryRead(ref reader, info.RuntimePropertyType, info.Options, ref state, out TArg3 arg3);
+                        if (success)
+                        {
+                            arguments.Arg3 = arg3!;
+                        }
+                        break;
                     }
-                    break;
                 default:
                     Debug.Fail("More than 4 params: we should be in override for LargeObjectWithParameterizedConstructorConverter.");
                     throw new InvalidOperationException();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -342,14 +342,13 @@ namespace System.Text.Json
         {
             if (jsonPropertyInfo.IsIgnored)
             {
-                return JsonParameterInfo.CreateIgnoredParameterPlaceholder(parameterInfo, jsonPropertyInfo, options);
+                return JsonParameterInfo.CreateIgnoredParameterPlaceholder(jsonPropertyInfo, options);
             }
 
             JsonConverter converter = jsonPropertyInfo.ConverterBase;
 
             JsonParameterInfo jsonParameterInfo = converter.CreateJsonParameterInfo();
             jsonParameterInfo.Initialize(
-                jsonPropertyInfo.DeclaredPropertyType,
                 jsonPropertyInfo.RuntimePropertyType!,
                 parameterInfo,
                 jsonPropertyInfo,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -62,6 +62,8 @@ namespace System.Text.Json.Serialization
         // This is used internally to quickly determine the type being converted for JsonConverter<T>.
         internal abstract Type TypeToConvert { get; }
 
+        internal abstract bool TryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, ref ReadStack state, out object? value);
+
         internal abstract bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state);
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterFactory.cs
@@ -77,6 +77,17 @@ namespace System.Text.Json.Serialization
             throw new InvalidOperationException();
         }
 
+        internal sealed override bool TryReadAsObject(
+            ref Utf8JsonReader reader,
+            JsonSerializerOptions options,
+            ref ReadStack state,
+            out object? value)
+        {
+            Debug.Fail("We should never get here.");
+
+            throw new InvalidOperationException();
+        }
+
         internal sealed override bool TryWriteAsObject(
             Utf8JsonWriter writer,
             object? value,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -5,6 +5,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json.Serialization
 {
@@ -219,7 +220,7 @@ namespace System.Text.Json.Serialization
                     VerifyRead(
                         state.Current.OriginalTokenType,
                         state.Current.OriginalDepth,
-                        bytesConsumed : 0,
+                        bytesConsumed: 0,
                         isValueConverter: false,
                         ref reader);
 
@@ -228,6 +229,13 @@ namespace System.Text.Json.Serialization
             }
 
             state.Pop(success);
+            return success;
+        }
+
+        internal override sealed bool TryReadAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, ref ReadStack state, out object? value)
+        {
+            bool success = TryRead(ref reader, TypeToConvert, options, ref state, out T typedValue);
+            value = typedValue;
             return success;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
@@ -15,13 +15,13 @@ namespace System.Text.Json
     internal abstract class JsonParameterInfo
     {
 
-        public JsonConverter ConverterBase { get; set; } = null!;
+        public JsonConverter ConverterBase { get; private set; } = null!;
 
         // The default value of the parameter. This is `DefaultValue` of the `ParameterInfo`, if specified, or the CLR `default` for the `ParameterType`.
         public object? DefaultValue { get; protected set; }
 
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonClassInfo that is cached on JsonSerializerOptions.
-        protected internal JsonSerializerOptions Options { get; set; } = null!; // initialized in Init method
+        public JsonSerializerOptions? Options { get; set; } // initialized in Init method
 
         // The name of the parameter as UTF-8 bytes.
         public byte[] NameAsUtf8Bytes { get; private set; } = null!;
@@ -34,9 +34,11 @@ namespace System.Text.Json
         {
             get
             {
+                Debug.Assert(ShouldDeserialize);
                 if (_runtimeClassInfo == null)
                 {
-                    _runtimeClassInfo = Options.GetOrAddClass(RuntimePropertyType);
+                    Debug.Assert(Options != null);
+                    _runtimeClassInfo = Options!.GetOrAddClass(RuntimePropertyType);
                 }
 
                 return _runtimeClassInfo;
@@ -58,6 +60,7 @@ namespace System.Text.Json
             NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!;
             Options = options;
             ShouldDeserialize = true;
+            ConverterBase = matchingProperty.ConverterBase;
         }
 
         // Create a parameter that is ignored at run-time. It uses the same type (typeof(sbyte)) to help
@@ -70,7 +73,6 @@ namespace System.Text.Json
             {
                 RuntimePropertyType = typeof(sbyte),
                 NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!,
-                Options = options
             };
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
@@ -12,20 +12,16 @@ namespace System.Text.Json
     /// Holds relevant state about a method parameter, like the default value of
     /// the parameter, and the position in the method's parameter list.
     /// </summary>
-    [DebuggerDisplay("ParameterInfo={ParameterInfo}")]
     internal abstract class JsonParameterInfo
     {
-        private Type _runtimePropertyType = null!;
 
-        public abstract JsonConverter ConverterBase { get; }
+        public JsonConverter ConverterBase { get; set; } = null!;
 
         // The default value of the parameter. This is `DefaultValue` of the `ParameterInfo`, if specified, or the CLR `default` for the `ParameterType`.
         public object? DefaultValue { get; protected set; }
 
         // Options can be referenced here since all JsonPropertyInfos originate from a JsonClassInfo that is cached on JsonSerializerOptions.
-        protected JsonSerializerOptions Options { get; set; } = null!; // initialized in Init method
-
-        public ParameterInfo ParameterInfo { get; private set; } = null!;
+        protected internal JsonSerializerOptions Options { get; set; } = null!; // initialized in Init method
 
         // The name of the parameter as UTF-8 bytes.
         public byte[] NameAsUtf8Bytes { get; private set; } = null!;
@@ -40,54 +36,42 @@ namespace System.Text.Json
             {
                 if (_runtimeClassInfo == null)
                 {
-                    _runtimeClassInfo = Options.GetOrAddClass(_runtimePropertyType);
+                    _runtimeClassInfo = Options.GetOrAddClass(RuntimePropertyType);
                 }
 
                 return _runtimeClassInfo;
             }
         }
 
+        internal Type RuntimePropertyType { get; set; } = null!;
+
         public bool ShouldDeserialize { get; private set; }
 
         public virtual void Initialize(
-            Type declaredPropertyType,
             Type runtimePropertyType,
             ParameterInfo parameterInfo,
             JsonPropertyInfo matchingProperty,
             JsonSerializerOptions options)
         {
-            _runtimePropertyType = runtimePropertyType;
-
-            Options = options;
-            ParameterInfo = parameterInfo;
+            RuntimePropertyType = runtimePropertyType;
             Position = parameterInfo.Position;
-            ShouldDeserialize = true;
-
-            DetermineParameterName(matchingProperty);
-        }
-
-        private void DetermineParameterName(JsonPropertyInfo matchingProperty)
-        {
             NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!;
+            Options = options;
+            ShouldDeserialize = true;
         }
 
         // Create a parameter that is ignored at run-time. It uses the same type (typeof(sbyte)) to help
         // prevent issues with unsupported types and helps ensure we don't accidently (de)serialize it.
         public static JsonParameterInfo CreateIgnoredParameterPlaceholder(
-            ParameterInfo parameterInfo,
             JsonPropertyInfo matchingProperty,
             JsonSerializerOptions options)
         {
-            JsonParameterInfo jsonParameterInfo = new JsonParameterInfo<sbyte>();
-            jsonParameterInfo.Options = options;
-            jsonParameterInfo.ParameterInfo = parameterInfo;
-            jsonParameterInfo.ShouldDeserialize = false;
-
-            jsonParameterInfo.DetermineParameterName(matchingProperty);
-
-            return jsonParameterInfo;
+            return new JsonParameterInfo<sbyte>
+            {
+                RuntimePropertyType = typeof(sbyte),
+                NameAsUtf8Bytes = matchingProperty.NameAsUtf8Bytes!,
+                Options = options
+            };
         }
-
-        public abstract bool ReadJson(ref ReadStack state, ref Utf8JsonReader reader, out object? argument);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfoOfT.cs
@@ -26,8 +26,6 @@ namespace System.Text.Json
                 matchingProperty,
                 options);
 
-            ConverterBase = matchingProperty.ConverterBase;
-
             if (parameterInfo.HasDefaultValue)
             {
                 DefaultValue = parameterInfo.DefaultValue;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfoOfT.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {
@@ -14,29 +12,21 @@ namespace System.Text.Json
     /// </summary>
     internal class JsonParameterInfo<T> : JsonParameterInfo
     {
-        private JsonConverter<T> _converter = null!;
-        private Type _runtimePropertyType = null!;
-
-        public override JsonConverter ConverterBase => _converter;
-
         public T TypedDefaultValue { get; private set; } = default!;
 
         public override void Initialize(
-            Type declaredPropertyType,
             Type runtimePropertyType,
             ParameterInfo parameterInfo,
             JsonPropertyInfo matchingProperty,
             JsonSerializerOptions options)
         {
             base.Initialize(
-                declaredPropertyType,
                 runtimePropertyType,
                 parameterInfo,
                 matchingProperty,
                 options);
 
-            _converter = (JsonConverter<T>)matchingProperty.ConverterBase;
-            _runtimePropertyType = runtimePropertyType;
+            ConverterBase = matchingProperty.ConverterBase;
 
             if (parameterInfo.HasDefaultValue)
             {
@@ -47,73 +37,6 @@ namespace System.Text.Json
             {
                 DefaultValue = TypedDefaultValue;
             }
-        }
-
-        public override bool ReadJson(ref ReadStack state, ref Utf8JsonReader reader, out object? value)
-        {
-            bool success;
-            bool isNullToken = reader.TokenType == JsonTokenType.Null;
-
-            if (isNullToken && !_converter.HandleNull && !state.IsContinuation)
-            {
-                if (!_converter.CanBeNull)
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(_converter.TypeToConvert);
-                }
-
-                // Don't have to check for IgnoreNullValue option here because we set the default value regardless.
-                value = DefaultValue;
-                return true;
-            }
-            else
-            {
-                // Optimize for internal converters by avoiding the extra call to TryRead.
-                if (_converter.CanUseDirectReadOrWrite)
-                {
-                    value = _converter.Read(ref reader, _runtimePropertyType, Options);
-                    return true;
-                }
-                else
-                {
-                    success = _converter.TryRead(ref reader, _runtimePropertyType, Options, ref state, out T typedValue);
-                    value = typedValue;
-                }
-            }
-
-            return success;
-        }
-
-        public bool ReadJsonTyped(ref ReadStack state, ref Utf8JsonReader reader, [MaybeNull] out T value)
-        {
-            bool success;
-            bool isNullToken = reader.TokenType == JsonTokenType.Null;
-
-            if (isNullToken && !_converter.HandleNull && !state.IsContinuation)
-            {
-                if (!_converter.CanBeNull)
-                {
-                    ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue(_converter.TypeToConvert);
-                }
-
-                // Don't have to check for IgnoreNullValue option here because we set the default value regardless.
-                value = TypedDefaultValue;
-                return true;
-            }
-            else
-            {
-                // Optimize for internal converters by avoiding the extra call to TryRead.
-                if (_converter.CanUseDirectReadOrWrite)
-                {
-                    value = _converter.Read(ref reader, _runtimePropertyType, Options);
-                    return true;
-                }
-                else
-                {
-                    success = _converter.TryRead(ref reader, _runtimePropertyType, Options, ref state, out value);
-                }
-            }
-
-            return success;
         }
     }
 }


### PR DESCRIPTION
Removes the two implementations of JsonParameterInfo's ReadJson and replaces calls to them with calls to the already existing method `JsonConverter.TryRead` and calls to a new loosely-typed wrapper `JsonConverter.TryReadAsObject` that calls `TryRead`.

This should prevent any potential issues in the future by sharing existing code and it removes a bit of code and unused fields.

Also since this removes one generic method and generic variable, it saves ~7K in the assembly's crossgen'd size due to value types closing the generic T parameter in `JsonParameterInfo<T>`.
```
BEFORE
Input file size:              299008
Output file size:            1103360
Input file size/Output file size ratio:	    3.69x

AFTER
Input file size:              299008
Output file size:            1096192
Input file size/Output file size ratio:	    3.67x
```
