### PR TITLE
Fix XML .tt/.ttinclude files to match sources

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.cs
@@ -449,7 +449,7 @@ namespace System.Xml
 
             if (_elementPropertySearch == null)
             {
-                //_elementPropertySearch should be init last for the mutli thread safe situation.
+                // _elementPropertySearch should be init last for the mutli thread safe situation.
                 _attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
                 _elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlEncodedRawTextWriter.tt
@@ -1,11 +1,10 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterEncoded.ttinclude" #>
-<#
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterEncoded.ttinclude"
+#><#
     ClassName = "HtmlEncodedRawTextWriter";
     ClassNameIndent = "HtmlEncodedRawTextWriterIndent";
     BaseClassName = "XmlEncodedRawTextWriter";
-#>
-<#@ include file="HtmlRawTextWriterGenerator.ttinclude" #>
+#><#@ include file="HtmlRawTextWriterGenerator.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlRawTextWriterGenerator.ttinclude
@@ -1,6 +1,5 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
+<#@ import namespace="System"
+#><#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -33,15 +32,15 @@ namespace System.Xml
         protected static TernaryTreeReadOnly _attributePropertySearch;
 
         private const int StackIncrement = 10;
-<# if (WriterType == RawTextWriterType.Encoded) { #>
 
-        public <#= ClassName #>(TextWriter writer, XmlWriterSettings settings) : base(writer, settings)
+<# if (WriterType == RawTextWriterType.Encoded) {
+#>        public <#= ClassName #>(TextWriter writer, XmlWriterSettings settings) : base(writer, settings)
         {
             Init(settings);
         }
-<# } #>
 
-        public <#= ClassName #>(Stream stream, XmlWriterSettings settings) : base(stream, settings)
+<# }
+#>        public <#= ClassName #>(Stream stream, XmlWriterSettings settings) : base(stream, settings)
         {
             Init(settings);
         }
@@ -80,27 +79,27 @@ namespace System.Xml
                     RawText("\" \"");
                     RawText(sysid);
                 }
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else if (sysid != null)
             {
                 RawText(" SYSTEM \"");
                 RawText(sysid);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
             }
 
             if (subset != null)
             {
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)'[';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'[';
                 RawText(subset);
-                <#= BufferName #>[bufPos++] = (<#= BufferType #>)']';
+                <#= BufferName #>[_bufPos++] = (<#= BufferType #>)']';
             }
 
-            <#= BufferName #>[bufPos++] = (<#= BufferType #>)'>';
+            <#= BufferName #>[_bufPos++] = (<#= BufferType #>)'>';
         }
 
         // For the HTML element, it should call this method with ns and prefix as String.Empty
@@ -117,9 +116,9 @@ namespace System.Xml
 #><#= SetTextContentMark(4, false) #>
 
                 _currentElementProperties = (ElementProperties)_elementPropertySearch.FindCaseInsensitiveString(localName);
-                base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
+                base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
                 base.RawText(localName);
-                base.attrEndPos = bufPos;
+                base._attrEndPos = _bufPos;
             }
             else
             {
@@ -133,10 +132,10 @@ namespace System.Xml
         // Output >. For HTML needs to output META info
         internal override void StartElementContent()
         {
-            base.<#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'>';
+            base.<#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'>';
 
             // Detect whether content is output
-            contentPos = bufPos;
+            _contentPos = _bufPos;
 
             if ((_currentElementProperties & ElementProperties.HEAD) != 0)
             {
@@ -158,10 +157,10 @@ namespace System.Xml
 
                 if ((_currentElementProperties & ElementProperties.EMPTY) == 0)
                 {
-                    <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'<';
-                    <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'/';
+                    <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'<';
+                    <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'/';
                     base.RawText(localName);
-                    <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'>';
+                    <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'>';
                 }
             }
             else
@@ -183,10 +182,10 @@ namespace System.Xml
 
                 if ((_currentElementProperties & ElementProperties.EMPTY) == 0)
                 {
-                    <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'<';
-                    <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'/';
+                    <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'<';
+                    <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'/';
                     base.RawText(localName);
-                    <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'>';
+                    <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'>';
                 }
             }
             else
@@ -305,9 +304,9 @@ namespace System.Xml
 
 #><#= SetTextContentMark(4, false) #>
 
-                if (base.attrEndPos == bufPos)
+                if (base._attrEndPos == _bufPos)
                 {
-                    base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)' ';
+                    base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)' ';
                 }
                 base.RawText(localName);
 
@@ -318,7 +317,7 @@ namespace System.Xml
 
                     if ((_currentAttributeProperties & AttributeProperties.BOOLEAN) != 0)
                     {
-                        base.inAttributeValue = true;
+                        base._inAttributeValue = true;
                         return;
                     }
                 }
@@ -327,8 +326,8 @@ namespace System.Xml
                     _currentAttributeProperties = AttributeProperties.DEFAULT;
                 }
 
-                base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'=';
-                base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'=';
+                base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
             else
             {
@@ -336,7 +335,7 @@ namespace System.Xml
                 _currentAttributeProperties = AttributeProperties.DEFAULT;
             }
 
-            base.inAttributeValue = true;
+            base._inAttributeValue = true;
         }
 
         // Output the amp; at end of EndAttribute
@@ -344,7 +343,7 @@ namespace System.Xml
         {
             if ((_currentAttributeProperties & AttributeProperties.BOOLEAN) != 0)
             {
-                base.attrEndPos = bufPos;
+                base._attrEndPos = _bufPos;
             }
             else
             {
@@ -356,10 +355,10 @@ namespace System.Xml
 
 #><#= SetTextContentMark(4, false) #>
 
-                base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'"';
+                base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'"';
             }
-            base.inAttributeValue = false;
-            base.attrEndPos = bufPos;
+            base._inAttributeValue = false;
+            base._attrEndPos = _bufPos;
         }
 
         // HTML PI's use ">" to terminate rather than "?>".
@@ -369,16 +368,16 @@ namespace System.Xml
 
 #><#= SetTextContentMark(3, false) #>
 
-            <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'<';
-            <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'?';
+            <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'<';
+            <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'?';
             base.RawText(target);
-            <#= BufferName #>[base.bufPos++] = (<#= BufferType #>)' ';
+            <#= BufferName #>[base._bufPos++] = (<#= BufferType #>)' ';
 
             base.WriteCommentOrPi(text, '?');
 
-            base.<#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'>';
+            base.<#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'>';
 
-            if (base.bufPos > base.bufLen)
+            if (base._bufPos > base._bufLen)
             {
                 FlushBuffer();
             }
@@ -394,7 +393,7 @@ namespace System.Xml
             fixed (char* pSrc = text)
             {
                 char* pSrcEnd = pSrc + text.Length;
-                if (base.inAttributeValue)
+                if (base._inAttributeValue)
                 {
                     WriteHtmlAttributeTextBlock(pSrc, pSrcEnd);
                 }
@@ -430,7 +429,7 @@ namespace System.Xml
 
             fixed (char* pSrcBegin = &buffer[index])
             {
-                if (inAttributeValue)
+                if (_inAttributeValue)
                 {
                     WriteAttributeTextBlock(pSrcBegin, pSrcBegin + count);
                 }
@@ -453,7 +452,7 @@ namespace System.Xml
 
             if (_elementPropertySearch == null)
             {
-                //_elementPropertySearch should be init last for the mutli thread safe situation.
+                // _elementPropertySearch should be init last for the mutli thread safe situation.
                 _attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
                 _elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
             }
@@ -478,7 +477,7 @@ namespace System.Xml
             base.RawText(" content=\"");
             base.RawText(_mediaType);
             base.RawText("; charset=");
-            base.RawText(base.encoding.WebName);
+            base.RawText(base._encoding.WebName);
             base.RawText("\">");
         }
 
@@ -565,23 +564,22 @@ namespace System.Xml
 
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 char ch = (char)0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
-
-<# if (WriterType == RawTextWriterType.Utf8) { #>
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
+<# if (WriterType == RawTextWriterType.Utf8) {#>
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
-                    while (pDst < pDstEnd && xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+                    while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
+<# }
+#>                    {
                         *pDst++ = (<#= BufferType #>)ch;
                         pSrc++;
                     }
@@ -596,7 +594,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -640,7 +638,7 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
@@ -657,18 +655,18 @@ namespace System.Xml
 
             fixed (<#= BufferType #>* pDstBegin = <#= BufferName #>)
             {
-                <#= BufferType #>* pDst = pDstBegin + bufPos;
+                <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 char ch = (char)0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
-                    if (pDstEnd > pDstBegin + bufLen)
+                    if (pDstEnd > pDstBegin + _bufLen)
                     {
-                        pDstEnd = pDstBegin + bufLen;
+                        pDstEnd = pDstBegin + _bufLen;
                     }
 
-                    while (pDst < pDstEnd && (xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch < 0x80))
+                    while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch < 0x80))
                     {
                         *pDst++ = (<#= BufferType #>)ch;
                         pSrc++;
@@ -684,7 +682,7 @@ namespace System.Xml
                     // end of buffer
                     if (pDst >= pDstEnd)
                     {
-                        bufPos = (int)(pDst - pDstBegin);
+                        _bufPos = (int)(pDst - pDstBegin);
                         FlushBuffer();
                         pDst = pDstBegin + 1;
                         continue;
@@ -743,17 +741,17 @@ namespace System.Xml
                     }
                     pSrc++;
                 }
-                bufPos = (int)(pDst - pDstBegin);
+                _bufPos = (int)(pDst - pDstBegin);
             }
         }
 
         // For handling &{ in Html text field. If & is not followed by {, it still needs to be escaped.
         private void OutputRestAmps()
         {
-            base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'a';
-            base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'m';
-            base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'p';
-            base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)';';
+            base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'a';
+            base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'m';
+            base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'p';
+            base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)';';
         }
     }
 
@@ -812,13 +810,12 @@ namespace System.Xml
         // Constructors
         //
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-
         public <#= ClassNameIndent #>(TextWriter writer, XmlWriterSettings settings) : base(writer, settings)
         {
             Init(settings);
         }
-<# } #>
-
+<# }
+#>
         public <#= ClassNameIndent #>(Stream stream, XmlWriterSettings settings) : base(stream, settings)
         {
             Init(settings);
@@ -835,7 +832,7 @@ namespace System.Xml
             base.WriteDocType(name, pubid, sysid, subset);
 
             // Allow indentation after DocTypeDecl
-            _endBlockPos = base.bufPos;
+            _endBlockPos = base._bufPos;
         }
 
         public override void WriteStartElement(string prefix, string localName, string ns)
@@ -852,52 +849,52 @@ namespace System.Xml
 
                 base._currentElementProperties = (ElementProperties)_elementPropertySearch.FindCaseInsensitiveString(localName);
 
-                if (_endBlockPos == base.bufPos && (base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
+                if (_endBlockPos == base._bufPos && (base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
                 {
                     WriteIndent();
                 }
                 _indentLevel++;
 
-                base.<#= BufferName #>[bufPos++] = (<#= BufferType #>)'<';
+                base.<#= BufferName #>[_bufPos++] = (<#= BufferType #>)'<';
             }
             else
             {
                 base._currentElementProperties = ElementProperties.HAS_NS | ElementProperties.BLOCK_WS;
 
-                if (_endBlockPos == base.bufPos)
+                if (_endBlockPos == base._bufPos)
                 {
                     WriteIndent();
                 }
                 _indentLevel++;
 
-                base.<#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'<';
+                base.<#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'<';
                 if (prefix.Length != 0)
                 {
                     base.RawText(prefix);
-                    base.<#= BufferName #>[base.bufPos++] = (<#= BufferType #>)':';
+                    base.<#= BufferName #>[base._bufPos++] = (<#= BufferType #>)':';
                 }
             }
             base.RawText(localName);
-            base.attrEndPos = bufPos;
+            base._attrEndPos = _bufPos;
         }
 
         internal override void StartElementContent()
         {
-            base.<#= BufferName #>[base.bufPos++] = (<#= BufferType #>)'>';
+            base.<#= BufferName #>[base._bufPos++] = (<#= BufferType #>)'>';
 
             // Detect whether content is output
-            base.contentPos = base.bufPos;
+            base._contentPos = base._bufPos;
 
             if ((_currentElementProperties & ElementProperties.HEAD) != 0)
             {
                 WriteIndent();
                 WriteMetaElement();
-                _endBlockPos = base.bufPos;
+                _endBlockPos = base._bufPos;
             }
             else if ((base._currentElementProperties & ElementProperties.BLOCK_WS) != 0)
             {
                 // store the element block position
-                _endBlockPos = base.bufPos;
+                _endBlockPos = base._bufPos;
             }
         }
 
@@ -914,7 +911,7 @@ namespace System.Xml
             {
                 // And if the last node to be output had block whitespace properties,
                 // And if content was output within this element,
-                if (_endBlockPos == base.bufPos && base.contentPos != base.bufPos)
+                if (_endBlockPos == base._bufPos && base._contentPos != base._bufPos)
                 {
                     // Then indent
                     WriteIndent();
@@ -924,12 +921,12 @@ namespace System.Xml
             base.WriteEndElement(prefix, localName, ns);
 
             // Reset contentPos in case of empty elements
-            base.contentPos = 0;
+            base._contentPos = 0;
 
             // Mark end of element in buffer for element's with block whitespace properties
             if (isBlockWs)
             {
-                _endBlockPos = base.bufPos;
+                _endBlockPos = base._bufPos;
             }
         }
 
@@ -937,7 +934,7 @@ namespace System.Xml
         {
             if (_newLineOnAttributes)
             {
-                RawText(base.newLineChars);
+                RawText(base._newLineChars);
                 _indentLevel++;
                 WriteIndent();
                 _indentLevel--;
@@ -948,7 +945,7 @@ namespace System.Xml
         protected override void FlushBuffer()
         {
             // Make sure the buffer will reset the block position
-            _endBlockPos = (_endBlockPos == base.bufPos) ? 1 : 0;
+            _endBlockPos = (_endBlockPos == base._bufPos) ? 1 : 0;
             base.FlushBuffer();
         }
 
@@ -976,7 +973,7 @@ namespace System.Xml
             // <inline><?PI?>   -- suppress ws betw <inline> and PI
             // <inline><!-- --> -- suppress ws betw <inline> and comment
 
-            RawText(base.newLineChars);
+            RawText(base._newLineChars);
             for (int i = _indentLevel; i > 0; i--)
             {
                 RawText(_indentChars);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.cs
@@ -426,7 +426,7 @@ namespace System.Xml
 
             if (_elementPropertySearch == null)
             {
-                //elementPropertySearch should be init last for the mutli thread safe situation.
+                // _elementPropertySearch should be init last for the mutli thread safe situation.
                 _attributePropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlAttributes);
                 _elementPropertySearch = new TernaryTreeReadOnly(HtmlTernaryTree.htmlElements);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/HtmlUtf8RawTextWriter.tt
@@ -1,11 +1,10 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterUtf8.ttinclude" #>
-<#
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterUtf8.ttinclude"
+#><#
     ClassName = "HtmlUtf8RawTextWriter";
     ClassNameIndent = "HtmlUtf8RawTextWriterIndent";
     BaseClassName = "XmlUtf8RawTextWriter";
-#>
-<#@ include file="HtmlRawTextWriterGenerator.ttinclude" #>
+#><#@ include file="HtmlRawTextWriterGenerator.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriter.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriter.ttinclude
@@ -1,7 +1,6 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ import namespace="System" #>
-<#@ import namespace="System.Text" #>
-<#
+﻿<#@ import namespace="System"
+#><#@ import namespace="System.Text"
+#><#
 switch (WriterType)
 {
     case RawTextWriterType.Utf8:
@@ -12,8 +11,7 @@ switch (WriterType)
             "WriterType", WriterType,
             "Unknown value for WriterType.");
 }
-#>
-<#+
+#><#+
     private const string newline = "\r\n";
 
     public enum RawTextWriterType {
@@ -92,7 +90,7 @@ switch (WriterType)
         }
 
         StringBuilder sb = new StringBuilder(code.Length);
-        string[] lines = code.Split(new string[] { newline }, StringSplitOptions.None);
+        string[] lines = code.Replace("\r\n", "\n").Split(new string[] { "\n" }, StringSplitOptions.None);
         string indentation = new string(' ', indentAmount * 4);
 
         for (int i = 0; i < lines.Length; ++i)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriter.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriter.ttinclude
@@ -90,7 +90,7 @@ switch (WriterType)
         }
 
         StringBuilder sb = new StringBuilder(code.Length);
-        string[] lines = code.Replace("\r\n", "\n").Split(new string[] { "\n" }, StringSplitOptions.None);
+        string[] lines = code.Replace(newline , "\n").Split(new string[] { "\n" }, StringSplitOptions.None);
         string indentation = new string(' ', indentAmount * 4);
 
         for (int i = 0; i < lines.Length; ++i)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriterEncoded.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriterEncoded.ttinclude
@@ -1,7 +1,6 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #><#
+<#@ assembly name="System.Core"
+#><#@ import namespace="System"
+#><#
     WriterType = RawTextWriterType.Encoded;
     ClassName = "XmlEncodedRawTextWriter";
     ClassNameIndent = "XmlEncodedRawTextWriterIndent";
@@ -14,7 +13,7 @@ if (XmlCharType.IsSurrogate(ch))
     pSrc += 2;
 }
 /* Invalid XML character */
-else  if (ch <= 0x7F || ch >= 0xFFFE)
+else if (ch <= 0x7F || ch >= 0xFFFE)
 {
     pDst = InvalidXmlChar(ch, pDst, _entitizeInvalidChars_);
     pSrc++;
@@ -26,5 +25,5 @@ else
     pDst++;
     pSrc++;
 }";
-    SetTextContentMarkBody = @"if (trackTextContent && inTextContent != _value_) { ChangeTextContentMark(_value_); }";
+    SetTextContentMarkBody = @"if (_trackTextContent && _inTextContent != _value_) { ChangeTextContentMark(_value_); }";
 #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriterUtf8.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/RawTextWriterUtf8.ttinclude
@@ -1,11 +1,9 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #><#
+<#@ assembly name="System.Core"
+#><#@ import namespace="System" #><#
     WriterType = RawTextWriterType.Utf8;
     ClassName = "XmlUtf8RawTextWriter";
     ClassNameIndent = "XmlUtf8RawTextWriterIndent";
-    BufferName = "bufBytes";
+    BufferName = "_bufBytes";
     BufferType = "byte";
     EncodeCharBody = @"/* Surrogate character */
 if (XmlCharType.IsSurrogate(ch))

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextEncodedRawTextWriter.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextEncodedRawTextWriter.tt
@@ -1,10 +1,9 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterEncoded.ttinclude" #>
-<#
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterEncoded.ttinclude"
+#><#
     ClassName = "TextEncodedRawTextWriter";
     BaseClassName = "XmlEncodedRawTextWriter";
-#>
-<#@ include file="TextRawTextWriterGenerator.ttinclude" #>
+#><#@ include file="TextRawTextWriterGenerator.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextRawTextWriterGenerator.ttinclude
@@ -1,6 +1,5 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
+<#@ import namespace="System"
+#><#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -22,13 +21,12 @@ namespace System.Xml
     // operation with serialization in order to achieve better performance.
     // </summary>
     internal class <#= ClassName #> : <#= BaseClassName #>
-    {
-<# if (WriterType == RawTextWriterType.Encoded) { #>
+    {<#
+if (WriterType == RawTextWriterType.Encoded) { #>
         // Construct an instance of this class that outputs text to the TextWriter interface.
         public <#= ClassName #>(TextWriter writer, XmlWriterSettings settings) : base(writer, settings)
         {
         }
-
 <# } #>
         // Construct an instance of this class that serializes to a Stream interface.
         public <#= ClassName #>(Stream stream, XmlWriterSettings settings) : base(stream, settings)
@@ -71,12 +69,12 @@ namespace System.Xml
         // Ignore attributes
         public override void WriteStartAttribute(string prefix, string localName, string ns)
         {
-            base.inAttributeValue = true;
+            base._inAttributeValue = true;
         }
 
         public override void WriteEndAttribute()
         {
-            base.inAttributeValue = false;
+            base._inAttributeValue = false;
         }
 
         // Ignore namespace declarations
@@ -122,7 +120,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteWhitespace(string ws)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(ws);
             }
@@ -131,7 +129,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteString(string textBlock)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(textBlock);
             }
@@ -140,7 +138,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteChars(char[] buffer, int index, int count)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(buffer, index, count);
             }
@@ -149,7 +147,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteRaw(char[] buffer, int index, int count)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(buffer, index, count);
             }
@@ -158,7 +156,7 @@ namespace System.Xml
         // Output text content without any escaping; ignore attribute values
         public override void WriteRaw(string data)
         {
-            if (!base.inAttributeValue)
+            if (!base._inAttributeValue)
             {
                 base.WriteRaw(data);
             }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/TextUtf8RawTextWriter.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/TextUtf8RawTextWriter.tt
@@ -1,10 +1,9 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterUtf8.ttinclude" #>
-<#
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterUtf8.ttinclude"
+#><#
     ClassName = "TextUtf8RawTextWriter";
     BaseClassName = "XmlUtf8RawTextWriter";
-#>
-<#@ include file="TextRawTextWriterGenerator.ttinclude" #>
+#><#@ include file="TextRawTextWriterGenerator.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
 // WARNING: This file is generated and should not be modified directly.
 // Instead, modify XmlRawTextWriterGenerator.ttinclude
 
@@ -44,7 +39,7 @@ namespace System.Xml
 
         // buffer positions
         protected int _bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
-                                       // close an empty element or in CDATA section detection of double ]; bufChars[0] will always be 0
+                                       // close an empty element or in CDATA section detection of double ]; _bufChars[0] will always be 0
         protected int _textPos = 1;    // text end position; don't indent first element, pi, or comment
         protected int _contentPos;     // element content end position
         protected int _cdataPos;       // cdata end position
@@ -179,7 +174,7 @@ namespace System.Xml
 
             _encoder = _encoding.GetEncoder();
 
-            if (!stream.CanSeek || stream.Position == 0)
+            if (!_stream.CanSeek || _stream.Position == 0)
             {
                 if (bom.Length != 0)
                 {
@@ -229,7 +224,6 @@ namespace System.Xml
             if (!_omitXmlDeclaration && !_autoXmlDeclaration)
             {
                 if (_trackTextContent && _inTextContent != false) { ChangeTextContentMark(false); }
-
                 RawText("<?xml version=\"");
 
                 // Version
@@ -776,6 +770,7 @@ namespace System.Xml
         {
             FlushBuffer();
             FlushEncoder();
+
             if (_stream != null)
             {
                 _stream.Flush();
@@ -848,7 +843,7 @@ namespace System.Xml
                 _contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
                 _cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
                 _bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
-                                   // close an empty element or in CDATA section detection of double ]; bufChars[0] will always be 0
+                                   // close an empty element or in CDATA section detection of double ]; _bufChars[0] will always be 0
             }
         }
 
@@ -920,6 +915,7 @@ namespace System.Xml
                         pDst++;
                         pSrc++;
                     }
+
                     Debug.Assert(pSrc <= pSrcEnd);
 
                     // end of value
@@ -1532,7 +1528,7 @@ namespace System.Xml
                     {
                         case '>':
                             if (_hadDoubleBracket && pDst[-1] == (char)']')
-                            {   // pDst[-1] will always correct - there is a padding character at bufChars[0]
+                            {   // pDst[-1] will always correct - there is a padding character at _bufChars[0]
                                 // The characters "]]>" were found within the CData text
                                 pDst = RawEndCData(pDst);
                                 pDst = RawStartCData(pDst);
@@ -1542,7 +1538,7 @@ namespace System.Xml
                             break;
                         case ']':
                             if (pDst[-1] == (char)']')
-                            {   // pDst[-1] will always correct - there is a padding character at bufChars[0]
+                            {   // pDst[-1] will always correct - there is a padding character at _bufChars[0]
                                 _hadDoubleBracket = true;
                             }
                             else
@@ -1616,7 +1612,6 @@ namespace System.Xml
             }
         }
 
-
         private static unsafe char* EncodeSurrogate(char* pSrc, char* pSrcEnd, char* pDst)
         {
             Debug.Assert(XmlCharType.IsSurrogate(*pSrc));
@@ -1663,6 +1658,7 @@ namespace System.Xml
                 {
                     *pDst = (char)ch;
                     pDst++;
+
                     return pDst;
                 }
             }
@@ -1712,6 +1708,7 @@ namespace System.Xml
             Array.Copy(_textContentMarks, newTextContentMarks, _textContentMarks.Length);
             _textContentMarks = newTextContentMarks;
         }
+
         // Write NewLineChars to the specified buffer position and return an updated position.
         protected unsafe char* WriteNewLine(char* pDst)
         {
@@ -1854,7 +1851,7 @@ namespace System.Xml
             return pDst + 3;
         }
 
-        protected unsafe void ValidateContentChars(string chars, string propertyName, bool allowOnlyWhitespace)
+        protected void ValidateContentChars(string chars, string propertyName, bool allowOnlyWhitespace)
         {
             if (allowOnlyWhitespace)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.cs
@@ -174,7 +174,7 @@ namespace System.Xml
 
             _encoder = _encoding.GetEncoder();
 
-            if (!_stream.CanSeek || _stream.Position == 0)
+            if (!stream.CanSeek || stream.Position == 0)
             {
                 if (bom.Length != 0)
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriter.tt
@@ -1,6 +1,6 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterEncoded.ttinclude" #>
-<#@ include file="XmlRawTextWriterGenerator.ttinclude" #>
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterEncoded.ttinclude"
+#><#@ include file="XmlRawTextWriterGenerator.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -51,7 +51,7 @@ namespace System.Xml
                 }
 
                 // Standalone
-                if (standalone != XmlStandalone.Omit)
+                if (_standalone != XmlStandalone.Omit)
                 {
                     await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
                     await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);
@@ -671,6 +671,7 @@ namespace System.Xml
                                    // close an empty element or in CDATA section detection of double ]; _BUFFER[0] will always be 0
             }
         }
+
         private async Task EncodeCharsAsync(int startOffset, int endOffset, bool writeAllToStream)
         {
             // Write encoded text to stream
@@ -947,6 +948,7 @@ namespace System.Xml
                         pDst++;
                         pSrc++;
                     }
+
                     Debug.Assert(pSrc <= pSrcEnd);
 
                     // end of value

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -51,7 +51,7 @@ namespace System.Xml
                 }
 
                 // Standalone
-                if (_standalone != XmlStandalone.Omit)
+                if (standalone != XmlStandalone.Omit)
                 {
                     await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
                     await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.tt
@@ -1,6 +1,6 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterEncoded.ttinclude" #>
-<#@ include file="XmlRawTextWriterGeneratorAsync.ttinclude" #>
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterEncoded.ttinclude"
+#><#@ include file="XmlRawTextWriterGeneratorAsync.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
@@ -1,6 +1,5 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
+<#@ import namespace="System"
+#><#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -52,7 +51,6 @@ namespace System.Xml
         protected bool _writeToNull;
         protected bool _hadDoubleBracket;
         protected bool _inAttributeValue;
-
 <# if (WriterType == RawTextWriterType.Encoded) { #>
         protected int _bufBytesUsed;
         protected char[] _bufChars;
@@ -69,9 +67,9 @@ namespace System.Xml
         private int _lastMarkPos;
         private int[] _textContentMarks;   // even indices contain text content start positions
                                            // odd indices contain markup start positions
-        private CharEntityEncoderFallback _charEntityFallback;
-<# } #>
-
+        private readonly CharEntityEncoderFallback _charEntityFallback;
+<# }
+#>
         // writer settings
         protected NewLineHandling _newLineHandling;
         protected bool _closeOutput;
@@ -91,8 +89,9 @@ namespace System.Xml
         private const int BUFSIZE = 2048 * 3;       // Should be greater than default FileStream size (4096), otherwise the FileStream will try to cache the data
         private const int ASYNCBUFSIZE = 64 * 1024; // Set async buffer size to 64KB
         private const int OVERFLOW = 32;            // Allow overflow in order to reduce checks when writing out constant size markup
-        private const int INIT_MARKS_COUNT = 64;
-
+<# if (WriterType != RawTextWriterType.Utf8) {
+#>        private const int INIT_MARKS_COUNT = 64;
+<# } #>
         //
         // Constructors
         //
@@ -118,7 +117,6 @@ namespace System.Xml
             }
         }
 <# if (WriterType == RawTextWriterType.Encoded) { #>
-
         // Construct an instance of this class that outputs text to the TextWriter interface.
         public <#= ClassName #>(TextWriter writer, XmlWriterSettings settings) : this(settings)
         {
@@ -141,7 +139,6 @@ namespace System.Xml
             }
         }
 <# } #>
-
         // Construct an instance of this class that serializes to a Stream interface.
         public <#= ClassName #>(Stream stream, XmlWriterSettings settings) : this(settings)
         {
@@ -156,8 +153,8 @@ namespace System.Xml
                 _bufLen = ASYNCBUFSIZE;
             }
 
-            <#= BufferName #> = new <#= BufferType #>[_bufLen + OVERFLOW];
-<# if (WriterType == RawTextWriterType.Utf8) { #>
+            <#= BufferName #> = new <#= BufferType #>[_bufLen + OVERFLOW];<#
+if (WriterType == RawTextWriterType.Utf8) { #>
             // Output UTF-8 byte order mark if Encoding object wants it
             if (!stream.CanSeek || stream.Position == 0)
             {
@@ -201,7 +198,6 @@ namespace System.Xml
                 }
             }
 <# } #>
-
             // Write the xml declaration
             if (settings.AutoXmlDeclaration)
             {
@@ -759,8 +755,8 @@ namespace System.Xml
                             _stream = null;
                         }
                     }
-                }
-<# if (WriterType == RawTextWriterType.Encoded) { #>
+                }<#
+if (WriterType == RawTextWriterType.Encoded) { #>
                 else if (_writer != null)
                 {
                     try
@@ -781,8 +777,8 @@ namespace System.Xml
                             _writer = null;
                         }
                     }
-                }
-<# } #>
+                }<#
+} #>
             }
         }
 
@@ -795,8 +791,8 @@ namespace System.Xml
             if (_stream != null)
             {
                 _stream.Flush();
-            }
-<# } else { #>
+            }<#
+} else { #>
             if (_stream != null)
             {
                 _stream.Flush();
@@ -804,8 +800,8 @@ namespace System.Xml
             else if (_writer != null)
             {
                 _writer.Flush();
-            }
-<# } #>
+            }<#
+} #>
         }
 
         //
@@ -818,14 +814,14 @@ namespace System.Xml
             {
                 // Output all characters (except for previous characters stored at beginning of buffer)
                 if (!_writeToNull)
-                {
-<# if (WriterType == RawTextWriterType.Utf8) { #>
+                {<#
+if (WriterType == RawTextWriterType.Utf8) { #>
                     if (_bufPos - 1 > 0)
                     {
                         Debug.Assert(_stream != null);
                         _stream.Write(<#= BufferName #>, 1, _bufPos - 1);
-                    }
-<# } else { #>
+                    }<#
+} else { #>
                     Debug.Assert(_stream != null || _writer != null);
 
                     if (_stream != null)
@@ -857,8 +853,8 @@ namespace System.Xml
                             // Write text to TextWriter
                             _writer.Write(<#= BufferName #>, 1, _bufPos - 1);
                         }
-                    }
-<# } #>
+                    }<#
+} #>
                 }
             }
             catch
@@ -881,7 +877,6 @@ namespace System.Xml
                     <#= BufferName #>[3] = <#= BufferName #>[_bufPos + 2];
                 }
 <# } #>
-
                 // Reset buffer position
                 _textPos = (_textPos == _bufPos) ? 1 : 0;
                 _attrEndPos = (_attrEndPos == _bufPos) ? 1 : 0;
@@ -891,7 +886,6 @@ namespace System.Xml
                                    // close an empty element or in CDATA section detection of double ]; <#= BufferName #>[0] will always be 0
             }
         }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
         private void FlushEncoder()
         {
@@ -944,7 +938,6 @@ namespace System.Xml
             }
         }
 <# } #>
-
         // Serialize text that is part of an attribute value.  The '&', '<', '>', and '"' characters
         // are entitized.
         protected unsafe void WriteAttributeTextBlock(char* pSrc, char* pSrcEnd)
@@ -954,24 +947,24 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + _bufLen)
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
                     }
+
                     Debug.Assert(pSrc <= pSrcEnd);
 
                     // end of value
@@ -1063,20 +1056,19 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + _bufLen)
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
@@ -1180,20 +1172,19 @@ namespace System.Xml
                 char* pSrc = pSrcBegin;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + _bufLen)
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && ((ch = *pSrc) <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && ((ch = *pSrc) < XmlCharType.SurHighStart))
-<# } #>
-                    {
+<# }
+#>                    {
                         pSrc++;
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
@@ -1230,20 +1221,19 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + _bufLen)
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && _xmlCharType.IsTextChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
@@ -1336,20 +1326,19 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + _bufLen)
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
@@ -1473,20 +1462,19 @@ namespace System.Xml
                 <#= BufferType #>* pDst = pDstBegin + _bufPos;
 
                 int ch = 0;
-                for (;;)
+                while (true)
                 {
                     <#= BufferType #>* pDstEnd = pDst + (pSrcEnd - pSrc);
                     if (pDstEnd > pDstBegin + _bufLen)
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']' && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
@@ -1579,7 +1567,6 @@ namespace System.Xml
                 _bufPos = (int)(pDst - pDstBegin);
             }
         }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
         // Returns true if UTF8 encoded byte is first of four bytes that encode a surrogate pair.
         // To do this, detect the bit pattern 11110xxx.
@@ -1588,7 +1575,6 @@ namespace System.Xml
             return (b & 0xF8) == 0xF0;
         }
 <# } #>
-
         private static unsafe <#= BufferType #>* EncodeSurrogate(char* pSrc, char* pSrcEnd, <#= BufferType #>* pDst)
         {
             Debug.Assert(XmlCharType.IsSurrogate(*pSrc));
@@ -1601,8 +1587,8 @@ namespace System.Xml
                     int lowChar = pSrc[1];
                     if (lowChar >= XmlCharType.SurLowStart &&
                         (LocalAppContextSwitches.DontThrowOnInvalidSurrogatePairs || lowChar <= XmlCharType.SurLowEnd))
-                    {
-<# if (WriterType == RawTextWriterType.Utf8) { #>
+                    {<#
+if (WriterType == RawTextWriterType.Utf8) { #>
                         // Calculate Unicode scalar value for easier manipulations (see section 3.7 in Unicode spec)
                         // The scalar value repositions surrogate values to start at 0x10000.
 
@@ -1618,7 +1604,6 @@ namespace System.Xml
                         pDst[1] = (<#= BufferType #>)lowChar;
                         pDst += 2;
 <# } #>
-
                         return pDst;
                     }
                     throw XmlConvert.CreateInvalidSurrogatePairException((char)lowChar, (char)ch);
@@ -1645,19 +1630,20 @@ namespace System.Xml
                     return CharEntity(pDst, (char)ch);
                 }
                 else
-                {
-<# if (WriterType == RawTextWriterType.Utf8) { #>
+                {<#
+if (WriterType == RawTextWriterType.Utf8) { #>
                     if (ch < 0x80)
                     {
-<# } #>
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
-<# if (WriterType == RawTextWriterType.Utf8) { #>
                     }
                     else
                     {
                         pDst = EncodeMultibyteUTF8(ch, pDst);
                     }
+<# } else { #>
+                    *pDst = (<#= BufferType #>)ch;
+                    pDst++;
 <# } #>
                     return pDst;
                 }
@@ -1670,8 +1656,8 @@ namespace System.Xml
 <#= EncodeChar(3, false) #>
         }
 
-<# if (WriterType == RawTextWriterType.Utf8) { #>
-        internal static unsafe byte* EncodeMultibyteUTF8(int ch, byte* pDst)
+<# if (WriterType == RawTextWriterType.Utf8) {
+#>        internal static unsafe byte* EncodeMultibyteUTF8(int ch, byte* pDst)
         {
             Debug.Assert(ch >= 0x80 && !XmlCharType.IsSurrogate(ch));
 
@@ -1719,9 +1705,8 @@ namespace System.Xml
                 pSrc++;
             }
         }
-<# } #>
-
-<# if (WriterType == RawTextWriterType.Encoded) { #>
+<# }
+if (WriterType == RawTextWriterType.Encoded) { #>
         protected void ChangeTextContentMark(bool value)
         {
             Debug.Assert(_inTextContent != value);
@@ -1884,7 +1869,7 @@ namespace System.Xml
             return pDst + 3;
         }
 
-        protected unsafe void ValidateContentChars(string chars, string propertyName, bool allowOnlyWhitespace)
+        protected void ValidateContentChars(string chars, string propertyName, bool allowOnlyWhitespace)
         {
             if (allowOnlyWhitespace)
             {
@@ -1959,15 +1944,13 @@ namespace System.Xml
 
         //
         // Constructors
-        //
-<# if (WriterType == RawTextWriterType.Encoded) { #>
-
+        //<#
+if (WriterType == RawTextWriterType.Encoded) { #>
         public <#= ClassNameIndent #>(TextWriter writer, XmlWriterSettings settings) : base(writer, settings)
         {
             Init(settings);
         }
 <# } #>
-
         public <#= ClassNameIndent #>(Stream stream, XmlWriterSettings settings) : base(stream, settings)
         {
             Init(settings);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGenerator.ttinclude
@@ -190,7 +190,7 @@ if (WriterType == RawTextWriterType.Utf8) { #>
 
             _encoder = _encoding.GetEncoder();
 
-            if (!_stream.CanSeek || _stream.Position == 0)
+            if (!stream.CanSeek || stream.Position == 0)
             {
                 if (bom.Length != 0)
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -1,6 +1,5 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
+<#@ import namespace="System"
+#><#@ include file="RawTextWriter.ttinclude" #>// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -107,8 +106,8 @@ namespace System.Xml
                         }
                     }
                 }
-<# if (WriterType == RawTextWriterType.Encoded) { #>
-                else if (_writer != null)
+<# if (WriterType == RawTextWriterType.Encoded) {
+#>                else if (_writer != null)
                 {
                     try
                     {
@@ -129,8 +128,8 @@ namespace System.Xml
                         }
                     }
                 }
-<# } #>
-            }
+<# }
+#>            }
         }
 
         // Serialize the document type declaration.
@@ -592,22 +591,22 @@ namespace System.Xml
         public override async Task FlushAsync()
         {
             CheckAsyncCall();
-            await FlushBufferAsync().ConfigureAwait(false);
-<# if (WriterType == RawTextWriterType.Encoded) { #>
-            await FlushEncoderAsync().ConfigureAwait(false);
-<# } #>
+            await FlushBufferAsync().ConfigureAwait(false);<#
+if (WriterType == RawTextWriterType.Encoded) { #>
+            await FlushEncoderAsync().ConfigureAwait(false);<#
+} #>
 
             if (_stream != null)
             {
                 await _stream.FlushAsync().ConfigureAwait(false);
             }
-<# if (WriterType == RawTextWriterType.Encoded) { #>
-            else if (_writer != null)
+<# if (WriterType == RawTextWriterType.Encoded) {
+#>            else if (_writer != null)
             {
                 await _writer.FlushAsync().ConfigureAwait(false);
             }
-<# } #>
-        }
+<# }
+#>        }
 
         //
         // Implementation methods
@@ -620,14 +619,14 @@ namespace System.Xml
                 // Output all characters (except for previous characters stored at beginning of buffer)
                 if (!_writeToNull)
                 {
-<# if (WriterType == RawTextWriterType.Utf8) { #>
-                    if (_bufPos - 1 > 0)
+<# if (WriterType == RawTextWriterType.Utf8) {
+#>                    if (_bufPos - 1 > 0)
                     {
                         Debug.Assert(_stream != null);
                         await _stream.WriteAsync(_bufBytes.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
-                    }
-<# } else { #>
-                    Debug.Assert(_stream != null || _writer != null);
+                    }<#
+} else {
+#>                    Debug.Assert(_stream != null || _writer != null);
 
                     if (_stream != null)
                     {
@@ -658,8 +657,8 @@ namespace System.Xml
                             // Write text to TextWriter
                             await _writer.WriteAsync(<#= BufferName #>.AsMemory(1, _bufPos - 1)).ConfigureAwait(false);
                         }
-                    }
-<# } #>
+                    }<#
+} #>
                 }
             }
             catch
@@ -673,8 +672,8 @@ namespace System.Xml
                 // Move last buffer character to the beginning of the buffer (so that previous character can always be determined)
                 <#= BufferName #>[0] = <#= BufferName #>[_bufPos - 1];
 
-<# if (WriterType == RawTextWriterType.Utf8) { #>
-                if (IsSurrogateByte(_bufBytes[0]))
+<# if (WriterType == RawTextWriterType.Utf8) {
+#>                if (IsSurrogateByte(_bufBytes[0]))
                 {
                     // Last character was the first byte in a surrogate encoding, so move last three
                     // bytes of encoding to the beginning of the buffer.
@@ -683,7 +682,6 @@ namespace System.Xml
                     _bufBytes[3] = _bufBytes[_bufPos + 2];
                 }
 <# } #>
-
                 // Reset buffer position
                 _textPos = (_textPos == _bufPos) ? 1 : 0;
                 _attrEndPos = (_attrEndPos == _bufPos) ? 1 : 0;
@@ -741,7 +739,6 @@ namespace System.Xml
             return Task.CompletedTask;
         }
 <# } #>
-
         // Serialize text that is part of an attribute value.  The '&', '<', '>', and '"' characters
         // are entitized.
         protected unsafe int WriteAttributeTextBlockNoFlush(char* pSrc, char* pSrcEnd)
@@ -760,13 +757,12 @@ namespace System.Xml
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
@@ -950,17 +946,17 @@ namespace System.Xml
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && _xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
                     }
+
                     Debug.Assert(pSrc <= pSrcEnd);
 
                     // end of value
@@ -1176,13 +1172,12 @@ namespace System.Xml
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && ((ch = *pSrc) <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && ((ch = *pSrc) < XmlCharType.SurHighStart))
-<# } #>
-                    {
+<# }
+#>                    {
                         pSrc++;
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
@@ -1337,13 +1332,12 @@ namespace System.Xml
                     {
                         pDstEnd = pDstBegin + _bufLen;
                     }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                     while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch <= 0x7F))
 <# } else { #>
                     while (pDst < pDstEnd && _xmlCharType.IsTextChar((char)(ch = *pSrc)))
-<# } #>
-                    {
+<# }
+#>                    {
                         *pDst = (<#= BufferType #>)ch;
                         pDst++;
                         pSrc++;
@@ -1525,13 +1519,12 @@ namespace System.Xml
                         {
                             pDstEnd = pDstBegin + _bufLen;
                         }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                         while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar && ch <= 0x7F))
 <# } else { #>
                         while (pDst < pDstEnd && (_xmlCharType.IsTextChar((char)(ch = *pSrc)) && ch != stopChar))
-<# } #>
-                        {
+<# }
+#>                        {
                             *pDst = (<#= BufferType #>)ch;
                             pDst++;
                             pSrc++;
@@ -1701,13 +1694,12 @@ namespace System.Xml
                         {
                             pDstEnd = pDstBegin + _bufLen;
                         }
-
 <# if (WriterType == RawTextWriterType.Utf8) { #>
                         while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']' && ch <= 0x7F))
 <# } else { #>
                         while (pDst < pDstEnd && (_xmlCharType.IsAttributeValueChar((char)(ch = *pSrc)) && ch != ']'))
-<# } #>
-                        {
+<# }
+#>                        {
                             *pDst = (<#= BufferType #>)ch;
                             pDst++;
                             pSrc++;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawTextWriterGeneratorAsync.ttinclude
@@ -52,7 +52,7 @@ namespace System.Xml
                 }
 
                 // Standalone
-                if (_standalone != XmlStandalone.Omit)
+                if (standalone != XmlStandalone.Omit)
                 {
                     await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
                     await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.cs
@@ -39,7 +39,7 @@ namespace System.Xml
 
         // buffer positions
         protected int _bufPos = 1;     // buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
-                                       // close an empty element or in CDATA section detection of double ]; bufBytes[0] will always be 0
+                                       // close an empty element or in CDATA section detection of double ]; _bufBytes[0] will always be 0
         protected int _textPos = 1;    // text end position; don't indent first element, pi, or comment
         protected int _contentPos;     // element content end position
         protected int _cdataPos;       // cdata end position
@@ -50,7 +50,6 @@ namespace System.Xml
         protected bool _writeToNull;
         protected bool _hadDoubleBracket;
         protected bool _inAttributeValue;
-
 
         // writer settings
         protected NewLineHandling _newLineHandling;
@@ -653,6 +652,7 @@ namespace System.Xml
         {
             FlushBuffer();
             FlushEncoder();
+
             if (_stream != null)
             {
                 _stream.Flush();
@@ -687,6 +687,7 @@ namespace System.Xml
             {
                 // Move last buffer character to the beginning of the buffer (so that previous character can always be determined)
                 _bufBytes[0] = _bufBytes[_bufPos - 1];
+
                 if (IsSurrogateByte(_bufBytes[0]))
                 {
                     // Last character was the first byte in a surrogate encoding, so move last three
@@ -702,7 +703,7 @@ namespace System.Xml
                 _contentPos = 0;    // Needs to be zero, since overwriting '>' character is no longer possible
                 _cdataPos = 0;      // Needs to be zero, since overwriting ']]>' characters is no longer possible
                 _bufPos = 1;        // Buffer position starts at 1, because we need to be able to safely step back -1 in case we need to
-                                   // close an empty element or in CDATA section detection of double ]; bufBytes[0] will always be 0
+                                   // close an empty element or in CDATA section detection of double ]; _bufBytes[0] will always be 0
             }
         }
 
@@ -735,6 +736,7 @@ namespace System.Xml
                         pDst++;
                         pSrc++;
                     }
+
                     Debug.Assert(pSrc <= pSrcEnd);
 
                     // end of value
@@ -1342,7 +1344,7 @@ namespace System.Xml
                     {
                         case '>':
                             if (_hadDoubleBracket && pDst[-1] == (byte)']')
-                            {   // pDst[-1] will always correct - there is a padding character at bufBytes[0]
+                            {   // pDst[-1] will always correct - there is a padding character at _bufBytes[0]
                                 // The characters "]]>" were found within the CData text
                                 pDst = RawEndCData(pDst);
                                 pDst = RawStartCData(pDst);
@@ -1352,7 +1354,7 @@ namespace System.Xml
                             break;
                         case ']':
                             if (pDst[-1] == (byte)']')
-                            {   // pDst[-1] will always correct - there is a padding character at bufBytes[0]
+                            {   // pDst[-1] will always correct - there is a padding character at _bufBytes[0]
                                 _hadDoubleBracket = true;
                             }
                             else
@@ -1492,6 +1494,7 @@ namespace System.Xml
                     {
                         pDst = EncodeMultibyteUTF8(ch, pDst);
                     }
+
                     return pDst;
                 }
             }
@@ -1787,7 +1790,6 @@ namespace System.Xml
         //
         // Constructors
         //
-
         public XmlUtf8RawTextWriterIndent(Stream stream, XmlWriterSettings settings) : base(stream, settings)
         {
             Init(settings);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriter.tt
@@ -1,6 +1,6 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterUtf8.ttinclude" #>
-<#@ include file="XmlRawTextWriterGenerator.ttinclude" #>
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterUtf8.ttinclude"
+#><#@ include file="XmlRawTextWriterGenerator.ttinclude" #>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -50,7 +50,7 @@ namespace System.Xml
                 }
 
                 // Standalone
-                if (_standalone != XmlStandalone.Omit)
+                if (standalone != XmlStandalone.Omit)
                 {
                     await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
                     await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -50,7 +50,7 @@ namespace System.Xml
                 }
 
                 // Standalone
-                if (standalone != XmlStandalone.Omit)
+                if (_standalone != XmlStandalone.Omit)
                 {
                     await RawTextAsync("\" standalone=\"").ConfigureAwait(false);
                     await RawTextAsync(standalone == XmlStandalone.Yes ? "yes" : "no").ConfigureAwait(false);
@@ -814,6 +814,7 @@ namespace System.Xml
                         pDst++;
                         pSrc++;
                     }
+
                     Debug.Assert(pSrc <= pSrcEnd);
 
                     // end of value

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.tt
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.tt
@@ -1,6 +1,6 @@
-<#@ template debug="false" hostspecific="false" language="C#" #>
-<#@ assembly name="System.Core" #>
-<#@ output extension=".cs" #>
-<#@ import namespace="System" #>
-<#@ include file="RawTextWriterUtf8.ttinclude" #>
-<#@ include file="XmlRawTextWriterGeneratorAsync.ttinclude" #>
+<#@ template debug="false" hostspecific="false" language="C#"
+#><#@ assembly name="System.Core"
+#><#@ output extension=".cs"
+#><#@ import namespace="System"
+#><#@ include file="RawTextWriterUtf8.ttinclude"
+#><#@ include file="XmlRawTextWriterGeneratorAsync.ttinclude" #>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/37365

This is needed to make nullable annotations easier on those files