### PR TITLE
Reduce allocation in NegotiateStream.Read/Write{Async}

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -35,9 +35,10 @@ namespace System.Net.Security
 
         private readonly byte[] _readHeader;
         private IIdentity? _remoteIdentity;
-        private byte[] _buffer;
-        private int _bufferOffset;
-        private int _bufferCount;
+        private byte[] _readBuffer;
+        private int _readBufferOffset;
+        private int _readBufferCount;
+        private byte[]? _writeBuffer;
 
         private volatile int _writeInProgress;
         private volatile int _readInProgress;
@@ -66,7 +67,7 @@ namespace System.Net.Security
         public NegotiateStream(Stream innerStream, bool leaveInnerStreamOpen) : base(innerStream, leaveInnerStreamOpen)
         {
             _readHeader = new byte[4];
-            _buffer = Array.Empty<byte>();
+            _readBuffer = Array.Empty<byte>();
         }
 
         protected override void Dispose(bool disposing)
@@ -348,14 +349,14 @@ namespace System.Net.Security
 
             try
             {
-                if (_bufferCount != 0)
+                if (_readBufferCount != 0)
                 {
-                    int copyBytes = Math.Min(_bufferCount, buffer.Length);
+                    int copyBytes = Math.Min(_readBufferCount, buffer.Length);
                     if (copyBytes != 0)
                     {
-                        _buffer.AsMemory(_bufferOffset, copyBytes).CopyTo(buffer);
-                        _bufferOffset += copyBytes;
-                        _bufferCount -= copyBytes;
+                        _readBuffer.AsMemory(_readBufferOffset, copyBytes).CopyTo(buffer);
+                        _readBufferOffset += copyBytes;
+                        _readBufferCount -= copyBytes;
                     }
                     return copyBytes;
                 }
@@ -380,13 +381,13 @@ namespace System.Net.Security
 
                     // Always pass InternalBuffer for SSPI "in place" decryption.
                     // A user buffer can be shared by many threads in that case decryption/integrity check may fail cause of data corruption.
-                    _bufferCount = readBytes;
-                    _bufferOffset = 0;
-                    if (_buffer.Length < readBytes)
+                    _readBufferCount = readBytes;
+                    _readBufferOffset = 0;
+                    if (_readBuffer.Length < readBytes)
                     {
-                        _buffer = new byte[readBytes];
+                        _readBuffer = new byte[readBytes];
                     }
-                    readBytes = await adapter.ReadAllAsync(new Memory<byte>(_buffer, 0, readBytes)).ConfigureAwait(false);
+                    readBytes = await adapter.ReadAllAsync(new Memory<byte>(_readBuffer, 0, readBytes)).ConfigureAwait(false);
                     if (readBytes == 0)
                     {
                         // We already checked that the frame body is bigger than 0 bytes. Hence, this is an EOF.
@@ -395,7 +396,7 @@ namespace System.Net.Security
 
                     // Decrypt into internal buffer, change "readBytes" to count now _Decrypted Bytes_
                     // Decrypted data start from zero offset, the size can be shrunk after decryption.
-                    _bufferCount = readBytes = DecryptData(_buffer!, 0, readBytes, out _bufferOffset);
+                    _readBufferCount = readBytes = DecryptData(_readBuffer!, 0, readBytes, out _readBufferOffset);
                     if (readBytes == 0 && buffer.Length != 0)
                     {
                         // Read again.
@@ -407,9 +408,9 @@ namespace System.Net.Security
                         readBytes = buffer.Length;
                     }
 
-                    _buffer.AsMemory(_bufferOffset, readBytes).CopyTo(buffer);
-                    _bufferOffset += readBytes;
-                    _bufferCount -= readBytes;
+                    _readBuffer.AsMemory(_readBufferOffset, readBytes).CopyTo(buffer);
+                    _readBufferOffset += readBytes;
+                    _readBufferCount -= readBytes;
 
                     return readBytes;
                 }
@@ -471,21 +472,20 @@ namespace System.Net.Security
 
             try
             {
-                byte[]? outBuffer = null;
                 while (!buffer.IsEmpty)
                 {
                     int chunkBytes = Math.Min(buffer.Length, MaxWriteDataSize);
                     int encryptedBytes;
                     try
                     {
-                        encryptedBytes = EncryptData(buffer.Slice(0, chunkBytes).Span, ref outBuffer);
+                        encryptedBytes = EncryptData(buffer.Slice(0, chunkBytes).Span, ref _writeBuffer);
                     }
                     catch (Exception e)
                     {
                         throw new IOException(SR.net_io_encrypt, e);
                     }
 
-                    await adapter.WriteAsync(outBuffer, 0, encryptedBytes).ConfigureAwait(false);
+                    await adapter.WriteAsync(_writeBuffer, 0, encryptedBytes).ConfigureAwait(false);
                     buffer = buffer.Slice(chunkBytes);
                 }
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/ReadWriteAdapter.cs
@@ -19,29 +19,6 @@ namespace System.Net.Security
         Task FlushAsync();
 
         CancellationToken CancellationToken { get; }
-
-        public async ValueTask<int> ReadAllAsync(Memory<byte> buffer)
-        {
-            int length = buffer.Length;
-
-            do
-            {
-                int bytes = await ReadAsync(buffer).ConfigureAwait(false);
-                if (bytes == 0)
-                {
-                    if (!buffer.IsEmpty)
-                    {
-                        throw new IOException(SR.net_io_eof);
-                    }
-                    break;
-                }
-
-                buffer = buffer.Slice(bytes);
-            }
-            while (!buffer.IsEmpty);
-
-            return length;
-        }
     }
 
     internal readonly struct AsyncReadWriteAdapter : IReadWriteAdapter


### PR DESCRIPTION
1. Each time we call Write{Async}, we're allocating a new byte[] to store the encoded message to be written.  Instead, just save the byte[] and reuse it, only allocating a new one if the existing one isn't big enough.
2. In both Read/Write{Async}, we call into an EncryptDecryptHelper (on Windows) that allocates a byte[][].  It never has more than three buffers.  We can just stack allocate it.
3. In my previous change to switch to async/await, I used a default interface method.  But when such a method is invoked on a struct implementing the interface, the struct gets boxed.  Just move that instance off and avoid several allocations per read.

|    Method | Toolchain |     Mean | Ratio |   Gen 0 | Allocated |
|---------- |---------- |---------:|------:|--------:|----------:|
| WriteRead | netcore31 | 14.99 ms |  1.00 | 93.7500 |  616001 B |
| WriteRead |    master | 13.24 ms |  0.88 | 31.2500 |  200001 B |
| WriteRead |        pr | 12.82 ms |  0.85 |       - |       1 B |
|           |           |          |       |         |           |
| ReadWrite | netcore31 | 34.49 ms |  1.00 | 71.4286 |  760230 B |
| ReadWrite |    master | 33.30 ms |  0.97 | 62.5000 |  528230 B |
| ReadWrite |        pr | 32.76 ms |  0.95 |       - |  336240 B |

```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System.IO;
using System.Net;
using System.Net.Security;
using System.Net.Sockets;
using System.Threading.Tasks;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);

    private Stream _client, _server;

    [GlobalSetup]
    public void ReadWriteSetup()
    {
        using (var listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
        {
            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
            listener.Listen(1);

            var client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
            client.Connect(listener.LocalEndPoint);
            var server = listener.Accept();
            var clientStream = new NegotiateStream(new NetworkStream(client, ownsSocket: true), leaveInnerStreamOpen: true);
            var serverStream = new NegotiateStream(new NetworkStream(server, ownsSocket: true), leaveInnerStreamOpen: true);

            Task ca = clientStream.AuthenticateAsClientAsync();
            Task sa = serverStream.AuthenticateAsServerAsync();
            Task.WaitAll(ca, sa);

            _client = clientStream;
            _server = serverStream;
        }
    }

    private byte[] _oneByteBuffer = new byte[1];

    [Benchmark]
    public async Task WriteRead()
    {
        for (int i = 0; i < 1_000; i++)
        {
            await _server.WriteAsync(_oneByteBuffer);
            await _client.ReadAsync(_oneByteBuffer);
        }
    }

    [Benchmark]
    public async Task ReadWrite()
    {
        for (int i = 0; i < 1_000; i++)
        {
            var r = _client.ReadAsync(_oneByteBuffer);
            await _server.WriteAsync(_oneByteBuffer);
            await r;
        }
    }
}
```