### PR TITLE
Fix BeginSendRequest and EndSendRequest on LdapConnection

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System.DirectoryServices.Protocols.csproj
@@ -100,6 +100,8 @@
     <Reference Include="System.Text.Encoding.Extensions" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
+    <Reference Include="System.Threading.Tasks" />
+    <Reference Include="System.Threading.Tasks.Extensions" />
     <Reference Include="System.Xml.ReaderWriter" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -2,17 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Globalization;
-using System.Net;
 using System.Collections;
 using System.ComponentModel;
-using System.Text;
 using System.Diagnostics;
+using System.Net;
 using System.Runtime.InteropServices;
-using System.Xml;
-using System.Threading;
 using System.Security.Cryptography.X509Certificates;
-using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
 
 namespace System.DirectoryServices.Protocols
 {
@@ -44,7 +43,6 @@ namespace System.DirectoryServices.Protocols
         private bool _needRebind = false;
         internal static Hashtable s_handleTable = null;
         internal static object s_objectLock = null;
-        private readonly GetLdapResponseCallback _fd = null;
         private static readonly Hashtable s_asyncResultTable = null;
         private static readonly LdapPartialResultsProcessor s_partialResultsProcessor = null;
         private static readonly ManualResetEvent s_waitHandle = null;
@@ -84,7 +82,6 @@ namespace System.DirectoryServices.Protocols
 
         public LdapConnection(LdapDirectoryIdentifier identifier, NetworkCredential credential, AuthType authType)
         {
-            _fd = new GetLdapResponseCallback(ConstructResponse);
             _directoryIdentifier = identifier;
             _directoryCredential = (credential != null) ? new NetworkCredential(credential.UserName, credential.Password, credential.Domain) : null;
 
@@ -288,7 +285,9 @@ namespace System.DirectoryServices.Protocols
 
             if (error == 0 && messageID != -1)
             {
-                return ConstructResponse(messageID, operation, ResultAll.LDAP_MSG_ALL, requestTimeout, true);
+                ValueTask<DirectoryResponse> vt = ConstructResponseAsync(messageID, operation, ResultAll.LDAP_MSG_ALL, requestTimeout, true, sync: true);
+                Debug.Assert(vt.IsCompleted);
+                return vt.GetAwaiter().GetResult();
             }
             else
             {
@@ -379,7 +378,30 @@ namespace System.DirectoryServices.Protocols
 
                     s_asyncResultTable.Add(asyncResult, messageID);
 
-                    _fd.BeginInvoke(messageID, operation, ResultAll.LDAP_MSG_ALL, requestTimeout, true, new AsyncCallback(ResponseCallback), requestState);
+                    ResponseCallback(ConstructResponseAsync(messageID, operation, ResultAll.LDAP_MSG_ALL, requestTimeout, true, sync: false), requestState);
+
+                    static async void ResponseCallback(ValueTask<DirectoryResponse> vt, LdapRequestState requestState)
+                    {
+                        try
+                        {
+                            DirectoryResponse response = await vt.ConfigureAwait(false);
+                            requestState._response = response;
+                        }
+                        catch (Exception e)
+                        {
+                            requestState._exception = e;
+                            requestState._response = null;
+                        }
+
+                        // Signal waitable object, indicate operation completed and fire callback.
+                        requestState._ldapAsync._manualResetEvent.Set();
+                        requestState._ldapAsync._completed = true;
+
+                        if (requestState._ldapAsync._callback != null && !requestState._abortCalled)
+                        {
+                            requestState._ldapAsync._callback(requestState._ldapAsync);
+                        }
+                    }
 
                     return asyncResult;
                 }
@@ -402,31 +424,6 @@ namespace System.DirectoryServices.Protocols
             }
 
             throw ConstructException(error, operation);
-        }
-
-        private void ResponseCallback(IAsyncResult asyncResult)
-        {
-            LdapRequestState requestState = (LdapRequestState)asyncResult.AsyncState;
-
-            try
-            {
-                DirectoryResponse response = _fd.EndInvoke(asyncResult);
-                requestState._response = response;
-            }
-            catch (Exception e)
-            {
-                requestState._exception = e;
-                requestState._response = null;
-            }
-
-            // Signal waitable object, indicate operation completed and fire callback.
-            requestState._ldapAsync._manualResetEvent.Set();
-            requestState._ldapAsync._completed = true;
-
-            if (requestState._ldapAsync._callback != null && !requestState._abortCalled)
-            {
-                requestState._ldapAsync._callback(requestState._ldapAsync);
-            }
         }
 
         public void Abort(IAsyncResult asyncResult)
@@ -1404,7 +1401,7 @@ namespace System.DirectoryServices.Protocols
             return attributes;
         }
 
-        internal DirectoryResponse ConstructResponse(int messageId, LdapOperation operation, ResultAll resultType, TimeSpan requestTimeOut, bool exceptionOnTimeOut)
+        internal async ValueTask<DirectoryResponse> ConstructResponseAsync(int messageId, LdapOperation operation, ResultAll resultType, TimeSpan requestTimeOut, bool exceptionOnTimeOut, bool sync)
         {
             var timeout = new LDAP_TIMEVAL()
             {
@@ -1436,7 +1433,30 @@ namespace System.DirectoryServices.Protocols
                 needAbandon = false;
             }
 
-            int error = LdapPal.GetResultFromAsyncOperation(_ldapHandle, messageId, (int)resultType, timeout, ref ldapResult);
+            int error;
+            if (sync)
+            {
+                error = LdapPal.GetResultFromAsyncOperation(_ldapHandle, messageId, (int)resultType, timeout, ref ldapResult);
+            }
+            else
+            {
+                // Given that we will be polling every millisecond, we need a stopwatch to make sure we track the timeout
+                timeout.tv_sec = 0;
+                timeout.tv_usec = 0;
+                error = 0;
+                Stopwatch watch = Stopwatch.StartNew();
+                while (watch.Elapsed < requestTimeOut)
+                {
+                    error = LdapPal.GetResultFromAsyncOperation(_ldapHandle, messageId, (int)resultType, timeout, ref ldapResult);
+                    if (error == 0 || error == -1)
+                    {
+                        break;
+                    }
+                    await Task.Delay(1).ConfigureAwait(false);
+                }
+                watch.Stop();
+            }
+
             if (error != -1 && error != 0)
             {
                 // parsing the result

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapConnection.cs
@@ -1442,15 +1442,16 @@ namespace System.DirectoryServices.Protocols
             {
                 timeout.tv_sec = 0;
                 timeout.tv_usec = 0;
+                // Initialize to 0
                 error = 0;
                 int iterationDelay = 1;
                 // Underlying native libraries don't support callback-based function, so we will instead use polling and
                 // use a Stopwatch to track the timeout manually.
                 Stopwatch watch = Stopwatch.StartNew();
-                while (watch.Elapsed < requestTimeOut)
+                while (true)
                 {
                     error = LdapPal.GetResultFromAsyncOperation(_ldapHandle, messageId, (int)resultType, timeout, ref ldapResult);
-                    if (error == 0 || error == -1)
+                    if (error == 0 || error == -1 || (requestTimeOut != Threading.Timeout.InfiniteTimeSpan && watch.Elapsed < requestTimeOut))
                     {
                         break;
                     }

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapPartialResultsProcessor.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Threading;
 using System.Collections;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace System.DirectoryServices.Protocols
 {
@@ -135,7 +136,9 @@ namespace System.DirectoryServices.Protocols
 
             try
             {
-                SearchResponse response = (SearchResponse)connection.ConstructResponse(asyncResult._messageID, LdapOperation.LdapSearch, resultType, asyncResult._requestTimeout, false);
+                ValueTask<DirectoryResponse> vt = connection.ConstructResponseAsync(asyncResult._messageID, LdapOperation.LdapSearch, resultType, asyncResult._requestTimeout, false, sync: true);
+                Debug.Assert(vt.IsCompleted);
+                SearchResponse response = (SearchResponse)vt.GetAwaiter().GetResult();
 
                 // This should only happen in the polling thread case.
                 if (response == null)

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Diagnostics;
 using System.DirectoryServices.Tests;
 using System.Globalization;
 using System.Net;
+using System.Threading;
 using Xunit;
 
 namespace System.DirectoryServices.Protocols.Tests
@@ -17,6 +19,12 @@ namespace System.DirectoryServices.Protocols.Tests
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void TestAddingOU()
         {
+            while(!Debugger.IsAttached)
+            {
+                Thread.Sleep(5000);
+            }
+            Debugger.Break();
+
             using (LdapConnection connection = GetConnection())
             {
                 string ouName = "ProtocolsGroup1";
@@ -534,7 +542,9 @@ namespace System.DirectoryServices.Protocols.Tests
         {
             string filter = $"(&(objectClass=organizationalUnit)(ou={ouName}))";
             SearchRequest searchRequest = new SearchRequest(rootDn, filter, SearchScope.OneLevel, null);
-            SearchResponse searchResponse = (SearchResponse) connection.SendRequest(searchRequest);
+            //SearchResponse searchResponse = (SearchResponse) connection.SendRequest(searchRequest);
+            var ar = connection.BeginSendRequest(searchRequest, PartialResultProcessing.NoPartialResultSupport, null, null);
+            SearchResponse searchResponse = (SearchResponse)connection.EndSendRequest(ar);
 
             if (searchResponse.Entries.Count > 0)
                 return searchResponse.Entries[0];

--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -19,12 +19,6 @@ namespace System.DirectoryServices.Protocols.Tests
         [ConditionalFact(nameof(IsLdapConfigurationExist))]
         public void TestAddingOU()
         {
-            while(!Debugger.IsAttached)
-            {
-                Thread.Sleep(5000);
-            }
-            Debugger.Break();
-
             using (LdapConnection connection = GetConnection())
             {
                 string ouName = "ProtocolsGroup1";
@@ -542,9 +536,8 @@ namespace System.DirectoryServices.Protocols.Tests
         {
             string filter = $"(&(objectClass=organizationalUnit)(ou={ouName}))";
             SearchRequest searchRequest = new SearchRequest(rootDn, filter, SearchScope.OneLevel, null);
-            //SearchResponse searchResponse = (SearchResponse) connection.SendRequest(searchRequest);
-            var ar = connection.BeginSendRequest(searchRequest, PartialResultProcessing.NoPartialResultSupport, null, null);
-            SearchResponse searchResponse = (SearchResponse)connection.EndSendRequest(ar);
+            IAsyncResult asyncResult = connection.BeginSendRequest(searchRequest, PartialResultProcessing.NoPartialResultSupport, null, null);
+            SearchResponse searchResponse = (SearchResponse)connection.EndSendRequest(asyncResult);
 
             if (searchResponse.Entries.Count > 0)
                 return searchResponse.Entries[0];


### PR DESCRIPTION
Fixes: #36690

cc: @tarekgh  @stephentoub 

LdapConnection had Async APM methods that never really worked in .NET Core as they were using Delegate.BeginInvoke and Delegate.EndInvoke which are not supported in .NET Core. These changes will make it so that they don't use that anymore and instead use Tasks and polling in order to not block a thread in the threadpool.

FYI: @blowdart @Tratcher @JunTaoLuo 