### PR TITLE
Refactor ComponentActivator

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -21,12 +21,7 @@ namespace Internal.Runtime.InteropServices
 
         private static string MarshalToString(IntPtr arg, string argName)
         {
-#if TARGET_WINDOWS
-            string? result = Marshal.PtrToStringUni(arg);
-#else
-            string? result = Marshal.PtrToStringUTF8(arg);
-#endif
-
+            string? result = Marshal.PtrToStringAuto(arg);
             if (result == null)
             {
                 throw new ArgumentNullException(argName);

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.cpp
@@ -252,7 +252,7 @@ namespace
         return _printable_delegate_name_t{ delegate_name };
     }
 
-    int call_delegate_flavour(
+    int call_load_assembly_and_get_function_pointer_flavour(
         load_assembly_and_get_function_pointer_fn delegate,
         const pal::char_t *assembly_path,
         const pal::char_t *type_name,
@@ -294,7 +294,7 @@ namespace
         return rc;
     }
 
-    bool load_assembly_and_get_function_pointer_test(
+    bool component_load_assembly_and_get_function_pointer_test(
         const hostfxr_exports &hostfxr,
         const pal::char_t *config_path,
         int argc,
@@ -327,7 +327,7 @@ namespace
             else
             {
                 test_output << log_prefix << _X("hostfxr_get_runtime_delegate succeeded: ") << std::hex << std::showbase << rc << std::endl;
-                rc = call_delegate_flavour(delegate, assembly_path, type_name, method_name, log_prefix, test_output);
+                rc = call_load_assembly_and_get_function_pointer_flavour(delegate, assembly_path, type_name, method_name, log_prefix, test_output);
             }
         }
 
@@ -370,7 +370,7 @@ namespace
             else
             {
                 test_output << log_prefix << _X("hostfxr_get_runtime_delegate succeeded: ") << std::hex << std::showbase << rc << std::endl;
-                rc = call_delegate_flavour(delegate, assembly_path, type_name, method_name, log_prefix, test_output);
+                rc = call_load_assembly_and_get_function_pointer_flavour(delegate, assembly_path, type_name, method_name, log_prefix, test_output);
             }
         }
 
@@ -603,7 +603,7 @@ bool host_context_test::non_context_mixed(
     return success;
 }
 
-bool host_context_test::load_assembly_and_get_function_pointer(
+bool host_context_test::component_load_assembly_and_get_function_pointer(
     const pal::string_t &hostfxr_path,
     const pal::char_t *config_path,
     int argc,
@@ -612,7 +612,7 @@ bool host_context_test::load_assembly_and_get_function_pointer(
 {
     hostfxr_exports hostfxr{ hostfxr_path };
 
-    return load_assembly_and_get_function_pointer_test(hostfxr, config_path, argc, argv, config_log_prefix, test_output);
+    return component_load_assembly_and_get_function_pointer_test(hostfxr, config_path, argc, argv, config_log_prefix, test_output);
 }
 
 bool host_context_test::app_load_assembly_and_get_function_pointer(

--- a/src/installer/corehost/cli/test/nativehost/host_context_test.h
+++ b/src/installer/corehost/cli/test/nativehost/host_context_test.h
@@ -59,7 +59,7 @@ namespace host_context_test
         int argc,
         const pal::char_t *argv[],
         pal::stringstream_t &test_output);
-    bool load_assembly_and_get_function_pointer(
+    bool component_load_assembly_and_get_function_pointer(
         const pal::string_t &hostfxr_path,
         const pal::char_t *config_path,
         int argc,

--- a/src/installer/corehost/cli/test/nativehost/nativehost.cpp
+++ b/src/installer/corehost/cli/test/nativehost/nativehost.cpp
@@ -215,7 +215,7 @@ int main(const int argc, const pal::char_t *argv[])
         std::cout << tostr(test_output.str()).data() << std::endl;
         return success ? EXIT_SUCCESS : EXIT_FAILURE;
     }
-    else if (pal::strcmp(command, _X("load_assembly_and_get_function_pointer")) == 0)
+    else if (pal::strcmp(command, _X("component_load_assembly_and_get_function_pointer")) == 0)
     {
         // args: ... <hostfxr_path> <app_or_config_path> <assembly_path> <type_name> <method_name> [<assembly_path> <type_name> <method_name>...]
         const int min_argc = 4;
@@ -236,7 +236,7 @@ int main(const int argc, const pal::char_t *argv[])
         pal::stringstream_t test_output;
         bool success = false;
 
-        success = host_context_test::load_assembly_and_get_function_pointer(hostfxr_path, app_or_config_path, remaining_argc, remaining_argv, test_output);
+        success = host_context_test::component_load_assembly_and_get_function_pointer(hostfxr_path, app_or_config_path, remaining_argc, remaining_argv, test_output);
 
         std::cout << tostr(test_output.str()).data() << std::endl;
         return success ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/src/installer/tests/Assets/TestProjects/ComponentWithNoDependencies/ComponentWithNoDependencies.csproj
+++ b/src/installer/tests/Assets/TestProjects/ComponentWithNoDependencies/ComponentWithNoDependencies.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 
 </Project>

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ComponentActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ComponentActivation.cs
@@ -91,6 +91,28 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             }
         }
 
+        [Fact]
+        public void CallDelegateFromSelfContainedApp()
+        {
+            var componentProject = sharedState.SelfContainedComponentWithNoDependenciesFixture.TestProject;
+            string[] args =
+            {
+                ComponentFromAppActivationArg,
+                sharedState.HostFxrPath,
+                componentProject.AppDll,
+                componentProject.AppDll,
+                sharedState.ComponentTypeName,
+                sharedState.ComponentEntryPoint1,
+            };
+            CommandResult result = sharedState.CreateNativeHostCommand(args, sharedState.DotNetRoot)
+                .Execute();
+
+            result.Should()
+                .InitializeContextForApp(componentProject.AppDll)
+                .And.Pass()
+                .And.ExecuteComponentEntryPoint(sharedState.ComponentEntryPoint1, 1, 1);
+        }
+
         [Theory]
         [InlineData(1, false)]
         [InlineData(1, true)]
@@ -211,6 +233,7 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
             public string DotNetRoot { get; }
 
             public TestProjectFixture ComponentWithNoDependenciesFixture { get; }
+            public TestProjectFixture SelfContainedComponentWithNoDependenciesFixture { get; }
             public string ComponentTypeName { get; }
             public string ComponentEntryPoint1 => "ComponentEntryPoint1";
             public string ComponentEntryPoint2 => "ComponentEntryPoint2";
@@ -225,6 +248,9 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
                 ComponentWithNoDependenciesFixture = new TestProjectFixture("ComponentWithNoDependencies", RepoDirectories)
                     .EnsureRestored(RepoDirectories.CorehostPackages)
                     .PublishProject();
+                SelfContainedComponentWithNoDependenciesFixture = new TestProjectFixture("ComponentWithNoDependencies", RepoDirectories)
+                    .EnsureRestored(RepoDirectories.CorehostPackages)
+                    .PublishProject(selfContained: "true");
                 ComponentTypeName = $"Component.Component, {ComponentWithNoDependenciesFixture.TestProject.AssemblyName}";
             }
 

--- a/src/installer/tests/HostActivation.Tests/NativeHosting/ComponentActivation.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHosting/ComponentActivation.cs
@@ -13,8 +13,8 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
 {
     public partial class ComponentActivation : IClassFixture<ComponentActivation.SharedTestState>
     {
-        private const string ComponentActivationArg = "load_assembly_and_get_function_pointer";
-        private const string ComponentFromAppActivationArg = "app_load_assembly_and_get_function_pointer";
+        private const string ComponentLoadAssemblyAndGetFunctionPointerArg = "component_load_assembly_and_get_function_pointer";
+        private const string AppLoadAssemblyAndGetFunctionPointerArg = "app_load_assembly_and_get_function_pointer";
 
         private readonly SharedTestState sharedState;
 
@@ -28,12 +28,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData(false, true, true)]
         [InlineData(true, false, true)]
         [InlineData(true, true, false)]
-        public void CallDelegate(bool validPath, bool validType, bool validMethod)
+        public void CallDelegateOnComponentContext(bool validPath, bool validType, bool validMethod)
         {
             var componentProject = sharedState.ComponentWithNoDependenciesFixture.TestProject;
             string[] args =
             {
-                ComponentActivationArg,
+                ComponentLoadAssemblyAndGetFunctionPointerArg,
                 sharedState.HostFxrPath,
                 componentProject.RuntimeConfigJson,
                 validPath ? componentProject.AppDll : "BadPath...",
@@ -62,12 +62,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData(false, true, true)]
         [InlineData(true, false, true)]
         [InlineData(true, true, false)]
-        public void CallDelegateFromApp(bool validPath, bool validType, bool validMethod)
+        public void CallDelegateOnApplicationContext(bool validPath, bool validType, bool validMethod)
         {
             var componentProject = sharedState.ComponentWithNoDependenciesFixture.TestProject;
             string[] args =
             {
-                ComponentFromAppActivationArg,
+                AppLoadAssemblyAndGetFunctionPointerArg,
                 sharedState.HostFxrPath,
                 componentProject.AppDll,
                 validPath ? componentProject.AppDll : "BadPath...",
@@ -92,12 +92,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        public void CallDelegateFromSelfContainedApp()
+        public void CallDelegateOnSelfContainedApplicationContext()
         {
             var componentProject = sharedState.SelfContainedComponentWithNoDependenciesFixture.TestProject;
             string[] args =
             {
-                ComponentFromAppActivationArg,
+                AppLoadAssemblyAndGetFunctionPointerArg,
                 sharedState.HostFxrPath,
                 componentProject.AppDll,
                 componentProject.AppDll,
@@ -118,12 +118,12 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [InlineData(1, true)]
         [InlineData(10, false)]
         [InlineData(10, true)]
-        public void CallDelegate_MultipleEntryPoints(int callCount, bool callUnmanaged)
+        public void CallDelegateOnComponentContext_MultipleEntryPoints(int callCount, bool callUnmanaged)
         {
             var componentProject = sharedState.ComponentWithNoDependenciesFixture.TestProject;
             string[] baseArgs =
             {
-                ComponentActivationArg,
+                ComponentLoadAssemblyAndGetFunctionPointerArg,
                 sharedState.HostFxrPath,
                 componentProject.RuntimeConfigJson,
             };
@@ -164,13 +164,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         [Theory]
         [InlineData(1)]
         [InlineData(10)]
-        public void CallDelegate_MultipleComponents(int callCount)
+        public void CallDelegateOnComponentContext_MultipleComponents(int callCount)
         {
             var componentProject = sharedState.ComponentWithNoDependenciesFixture.TestProject;
             var componentProjectCopy = componentProject.Copy();
             string[] baseArgs =
             {
-                ComponentActivationArg,
+                ComponentLoadAssemblyAndGetFunctionPointerArg,
                 sharedState.HostFxrPath,
                 componentProject.RuntimeConfigJson,
             };
@@ -206,13 +206,13 @@ namespace Microsoft.DotNet.CoreSetup.Test.HostActivation.NativeHosting
         }
 
         [Fact]
-        public void CallDelegate_UnhandledException()
+        public void CallDelegateOnComponentContext_UnhandledException()
         {
             string entryPoint = "ThrowException";
             var componentProject = sharedState.ComponentWithNoDependenciesFixture.TestProject;
             string[] args =
             {
-                ComponentActivationArg,
+                ComponentLoadAssemblyAndGetFunctionPointerArg,
                 sharedState.HostFxrPath,
                 componentProject.RuntimeConfigJson,
                 componentProject.AppDll,


### PR DESCRIPTION
Add ComponentActivation test for initialization from self-contained app.
Rename tests around load_assembly_and_get_function_pointer.

Basically addresses PR feedback in https://github.com/dotnet/runtime/pull/37696 from https://github.com/dotnet/runtime/pull/37473. Related to https://github.com/dotnet/runtime/issues/35465.