### PR TITLE
Fixes and improvements for removal of redundant zero inits

### DIFF
--- a/src/coreclr/src/jit/compiler.hpp
+++ b/src/coreclr/src/jit/compiler.hpp
@@ -4197,6 +4197,13 @@ bool Compiler::fgVarNeedsExplicitZeroInit(unsigned varNum, bool bbInALoop, bool 
 {
     LclVarDsc* varDsc = lvaGetDesc(varNum);
 
+    if (lvaIsFieldOfDependentlyPromotedStruct(varDsc))
+    {
+        // Fields of dependently promoted structs may only be initialized in the prolog when the whole
+        // struct is initialized in the prolog.
+        return fgVarNeedsExplicitZeroInit(varDsc->lvParentLcl, bbInALoop, bbIsReturn);
+    }
+
     if (bbInALoop && !bbIsReturn)
     {
         return true;

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_37666/GitHub_37666.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_37666/GitHub_37666.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+public struct TwoBools
+{
+    public bool b1;
+    public bool b2;
+
+    public TwoBools(bool b1, bool b2)
+    {
+        this.b1 = b1;
+        this.b2 = b2;
+    }
+}
+
+class Test
+{
+    public static int Main()
+    {
+        int result = 100;
+
+        RunTest(Test1, "Test1", ref result);
+        RunTest(Test2, "Test2", ref result);
+
+        return result;
+    }
+
+    delegate TwoBools TestZeroInit();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void RunTest(TestZeroInit test, string testName, ref int result)
+    {
+        if (test().b2)
+        {
+            Console.WriteLine(testName + " failed");
+            result = -1;
+        }
+        else
+        {
+            Console.WriteLine(testName + " passed");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static TwoBools Test1()
+    {
+        TwoBools result = CreateTwoBools();
+        result.b2 = false;
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static TwoBools Test2()
+    {
+        TwoBools result = default(TwoBools);
+        result.b2 = true;
+        result = default(TwoBools);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static TwoBools CreateTwoBools()
+    {
+        TwoBools result = new TwoBools(true, true);
+        return result;
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_37666/GitHub_37666.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_37666/GitHub_37666.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
1. Bug fix: when processing a zero assignment to a field of a promoted struct,
check the reference count of the parent struct.

2. Bug fix: when processing a zero assignment to a promoted struct, check the
reference counts of all fields.

3. Bug fix and improvement: a dependently promoted field is initialized in the prolog
iff its parent struct is initialized in the prolog so we can remove a field zero initialization
if the parent struct is already zero initialized.

4. Improvement: keep track of explicitly zero-initialized locals so that duplicate
explicit zero initializations can be eliminated.

Fixes #37666.