### PR TITLE
Consistently use inline stackallocs with ValueStringBuilder

### DIFF
--- a/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Text/ValueStringBuilderTests.cs
@@ -283,8 +283,7 @@ namespace System.Text.Tests
         {
             // Note: constants used here may be dependent on minimal buffer size
             // the ArrayPool is able to return.
-            Span<char> initialBuffer = stackalloc char[32];
-            var builder = new ValueStringBuilder(initialBuffer);
+            var builder = new ValueStringBuilder(stackalloc char[32]);
 
             builder.EnsureCapacity(65);
 
@@ -294,8 +293,7 @@ namespace System.Text.Tests
         [Fact]
         public void EnsureCapacity_IfBufferTimesTwoWins()
         {
-            Span<char> initialBuffer = stackalloc char[32];
-            var builder = new ValueStringBuilder(initialBuffer);
+            var builder = new ValueStringBuilder(stackalloc char[32]);
 
             builder.EnsureCapacity(33);
 
@@ -307,8 +305,7 @@ namespace System.Text.Tests
         {
             // Note: constants used here may be dependent on minimal buffer size
             // the ArrayPool is able to return.
-            Span<char> initialBuffer = stackalloc char[64];
-            var builder = new ValueStringBuilder(initialBuffer);
+            var builder = new ValueStringBuilder(stackalloc char[64]);
 
             builder.EnsureCapacity(16);
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Windows.cs
@@ -580,8 +580,7 @@ namespace System
         {
             get
             {
-                Span<char> initialBuffer = stackalloc char[256];
-                ValueStringBuilder builder = new ValueStringBuilder(initialBuffer);
+                ValueStringBuilder builder = new ValueStringBuilder(stackalloc char[256]);
 
                 while (true)
                 {

--- a/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemName.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/Enumeration/FileSystemName.cs
@@ -38,8 +38,7 @@ namespace System.IO.Enumeration
                 return "*";
 
             bool modified = false;
-            Span<char> stackSpace = stackalloc char[32];
-            ValueStringBuilder sb = new ValueStringBuilder(stackSpace);
+            ValueStringBuilder sb = new ValueStringBuilder(stackalloc char[32]);
             int length = expression.Length;
             for (int i = 0; i < length; i++)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/ApplicationId.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ApplicationId.cs
@@ -38,8 +38,7 @@ namespace System
 
         public override string ToString()
         {
-            Span<char> charSpan = stackalloc char[128];
-            var sb = new ValueStringBuilder(charSpan);
+            var sb = new ValueStringBuilder(stackalloc char[128]);
             sb.Append(Name);
             if (Culture != null)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs
@@ -52,11 +52,8 @@ namespace System.Net
             // characters need to be encoded.
             // For larger string we rent the input string's length plus a fixed
             // conservative amount of chars from the ArrayPool.
-            Span<char> buffer = value.Length < 80 ?
-                stackalloc char[256] :
-                null;
-            ValueStringBuilder sb = buffer != null ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder sb = value.Length < 80 ?
+                new ValueStringBuilder(stackalloc char[256]) :
                 new ValueStringBuilder(value.Length + 200);
 
             sb.Append(valueSpan.Slice(0, index));
@@ -92,11 +89,8 @@ namespace System.Net
             // characters need to be encoded.
             // For larger string we rent the input string's length plus a fixed
             // conservative amount of chars from the ArrayPool.
-            Span<char> buffer = value.Length < 80 ?
-                stackalloc char[256] :
-                null;
-            ValueStringBuilder sb = buffer != null ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder sb = value.Length < 80 ?
+                new ValueStringBuilder(stackalloc char[256]) :
                 new ValueStringBuilder(value.Length + 200);
 
             sb.Append(valueSpan.Slice(0, index));
@@ -201,11 +195,8 @@ namespace System.Net
 
             // In the worst case the decoded string has the same length.
             // For small inputs we use stack allocation.
-            Span<char> buffer = value.Length <= 256 ?
-                stackalloc char[256] :
-                null;
-            ValueStringBuilder sb = buffer != null ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder sb = value.Length <= 256 ?
+                new ValueStringBuilder(stackalloc char[256]) :
                 new ValueStringBuilder(value.Length);
 
             sb.Append(valueSpan.Slice(0, index));
@@ -238,11 +229,8 @@ namespace System.Net
 
             // In the worst case the decoded string has the same length.
             // For small inputs we use stack allocation.
-            Span<char> buffer = value.Length <= 256 ?
-                stackalloc char[256] :
-                null;
-            ValueStringBuilder sb = buffer != null ?
-                new ValueStringBuilder(buffer) :
+            ValueStringBuilder sb = value.Length <= 256 ?
+                new ValueStringBuilder(stackalloc char[256]) :
                 new ValueStringBuilder(value.Length);
 
             sb.Append(valueSpan.Slice(0, index));

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -378,15 +378,13 @@ namespace System
 
         public static string FormatDouble(double value, string? format, NumberFormatInfo info)
         {
-            Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-            var sb = new ValueStringBuilder(stackBuffer);
+            var sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
             return FormatDouble(ref sb, value, format, info) ?? sb.ToString();
         }
 
         public static bool TryFormatDouble(double value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
         {
-            Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-            var sb = new ValueStringBuilder(stackBuffer);
+            var sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
             string? s = FormatDouble(ref sb, value, format, info);
             return s != null ?
                 TryCopyTo(s, destination, out charsWritten) :
@@ -586,15 +584,13 @@ namespace System
 
         public static string FormatSingle(float value, string? format, NumberFormatInfo info)
         {
-            Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-            var sb = new ValueStringBuilder(stackBuffer);
+            var sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
             return FormatSingle(ref sb, value, format, info) ?? sb.ToString();
         }
 
         public static bool TryFormatSingle(float value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<char> destination, out int charsWritten)
         {
-            Span<char> stackBuffer = stackalloc char[CharStackBufferSize];
-            var sb = new ValueStringBuilder(stackBuffer);
+            var sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
             string? s = FormatSingle(ref sb, value, format, info);
             return s != null ?
                 TryCopyTo(s, destination, out charsWritten) :

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigNumber.cs
@@ -519,8 +519,7 @@ namespace System.Numerics
             }
             bits = bits.Slice(0, bytesWrittenOrNeeded);
 
-            Span<char> stackSpace = stackalloc char[128]; // each byte is typically two chars
-            var sb = new ValueStringBuilder(stackSpace);
+            var sb = new ValueStringBuilder(stackalloc char[128]); // each byte is typically two chars
 
             int cur = bits.Length - 1;
             if (cur > -1)
@@ -729,8 +728,7 @@ namespace System.Numerics
                 int precision = 29;
                 int scale = cchMax - ichDst;
 
-                Span<char> stackSpace = stackalloc char[128]; // arbitrary stack cut-off
-                var sb = new ValueStringBuilder(stackSpace);
+                var sb = new ValueStringBuilder(stackalloc char[128]); // arbitrary stack cut-off
                 FormatProvider.FormatBigInteger(ref sb, precision, scale, sign, formatSpan, info, rgch, ichDst);
 
                 if (targetSpan)

--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceController.cs
@@ -538,8 +538,7 @@ namespace System.ServiceProcess
         /// </summary>
         private unsafe string? GetServiceKeyName(SafeServiceHandle? SCMHandle, string serviceDisplayName)
         {
-            Span<char> initialBuffer = stackalloc char[256];
-            var builder = new ValueStringBuilder(initialBuffer);
+            var builder = new ValueStringBuilder(stackalloc char[256]);
             int bufLen;
             while (true)
             {


### PR DESCRIPTION
Primarily for style consistency.