### PR TITLE
Fix casing of `COMPlus_GCStress` variable

### DIFF
--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_27924/GitHub_27924.csproj
@@ -8,14 +8,17 @@
     <Optimize>True</Optimize>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- This test requires GCStress to trigger the regression. Set COMPlus_GCStress here. However,
+         not all CI platforms support GCStress. In particular, macOS and Alpine do not (currently).
+         All Windows support GCStress. We don't have any way (currently) to determine if we're
+         running on a platform that supports GCStress. So, don't set GCStress for non-Windows (Bash).
+         The test will run under GCStress in normal, scheduled GCStress runs, when only the supported
+         platforms are run with GCStress.
+    -->
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
-set COMPlus_GcStress=0xc
+set COMPlus_GCStress=0xc
 ]]></CLRTestBatchPreCommands>
-    <BashCLRTestPreCommands><![CDATA[
-$(BashCLRTestPreCommands)
-export COMPlus_GcStress=0xc
-]]></BashCLRTestPreCommands>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
The Linux test wasn't actually testing with GCStress due to this.
