### PR TITLE
Balance out arm jobs due to number of machines we have available

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -737,7 +737,6 @@ jobs:
     platforms:
     # - Windows_NT_x64
     #- OSX_x64
-    - Linux_arm64
     - Linux_x64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:
@@ -795,9 +794,7 @@ jobs:
     - Linux_x64
     - Linux_musl_x64
     - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - Linux_arm
       - Linux_arm64
-      - Linux_musl_arm64
     - ${{ if eq(variables['isFullMatrix'], false) }}:
       - Windows_NT_x86
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
@@ -846,7 +843,6 @@ jobs:
     - Windows_NT_x64
     - Linux_x64
     - Linux_musl_x64
-    - Linux_arm64
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
     helixQueueGroup: libraries
     jobParameters:


### PR DESCRIPTION
@jashook and I looked at the data of number of jobs we're sending on average in a day and we decided that given the current number of machines and the number of workitems we're sending to Linux arm queues, this was the best way to balance out.

Mono_interpreter should be covered by runtime tests in some sort; we can bring it back into rolling or outerloop once we come up with the better resiliency plan. 

Relates to: https://github.com/dotnet/runtime/issues/37823

Next steps, look how we can prune the size of payloads for library tests.

cc: @dotnet/runtime-infrastructure 