### PR TITLE
Improve performance of Enum.CompareTo

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -2915,7 +2915,7 @@ public:
     // Get the element handle for an array of ref type.
     CORINFO_CLASS_HANDLE gtGetArrayElementClassHandle(GenTree* array);
     // Get a class handle from a helper call argument
-    CORINFO_CLASS_HANDLE gtGetHelperArgClassHandle(GenTree* array, GenTree** handleTree = nullptr);
+    CORINFO_CLASS_HANDLE gtGetHelperArgClassHandle(GenTree* array);
     // Get the class handle for a field
     CORINFO_CLASS_HANDLE gtGetFieldClassHandle(CORINFO_FIELD_HANDLE fieldHnd, bool* pIsExact, bool* pIsNonNull);
     // Check if this tree is a gc static base helper call

--- a/src/coreclr/src/vm/methodtable.inl
+++ b/src/coreclr/src/vm/methodtable.inl
@@ -19,7 +19,7 @@
 #include "threadstatics.h"
 
 //==========================================================================================
-inline PTR_EEClass MethodTable::GetClass_NoLogging()
+FORCEINLINE PTR_EEClass MethodTable::GetClass_NoLogging()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 

--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -2416,9 +2416,15 @@ FCIMPL1(INT32, ReflectionEnum::InternalGetCorElementType, Object *pRefThis) {
     if (pRefThis == NULL)
         FCThrowArgumentNull(NULL);
 
-    return pRefThis->GetMethodTable()->GetInternalCorElementType();
+    MethodTable* pMT = pRefThis->GetMethodTable();
+    _ASSERTE(pMT->IsEnum());
+
+    // MethodTable::GetInternalCorElementType has unnecessary overhead for enums
+    // Call EEClass::GetInternalCorElementType directly to avoid it
+    return pMT->GetClass_NoLogging()->GetInternalCorElementType();
 }
 FCIMPLEND
+#include <optdefault.h>
 
 //*******************************************************************************
 struct TempEnumValue


### PR DESCRIPTION
Enum.CompareTo was rewritten in C# recently. This set of fixes gets the performance on par with the previous C++ implementation

- Add optimization for obj1.GetType() == obj2.GetType() pattern the JIT
- Optimize FCall used by Enum.CompareTo

Fixes https://github.com/DrewScoggins/performance-2/issues/525