### PR TITLE
Use sync IO when the physical path is available

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Runtime.ExceptionServices;
 using System.Text;
 using System.Threading;
+using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.Extensions.Configuration
@@ -35,7 +36,8 @@ namespace Microsoft.Extensions.Configuration
             {
                 _changeTokenRegistration = ChangeToken.OnChange(
                     () => Source.FileProvider.Watch(Source.Path),
-                    () => {
+                    () =>
+                    {
                         Thread.Sleep(Source.ReloadDelay);
                         Load(reload: true);
                     });
@@ -46,7 +48,7 @@ namespace Microsoft.Extensions.Configuration
         /// The source settings for this provider.
         /// </summary>
         public FileConfigurationSource Source { get; }
-        
+
         /// <summary>
         /// Generates a string representing this provider name and relevant details.
         /// </summary>
@@ -80,16 +82,35 @@ namespace Microsoft.Extensions.Configuration
                 {
                     Data = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
                 }
-                using (var stream = file.CreateReadStream())
+
+                static Stream OpenRead(IFileInfo fileInfo)
                 {
-                    try
+                    if (fileInfo.PhysicalPath != null)
                     {
-                        Load(stream);
+                        // The default physical file info assumes asynchronous IO which results in unnecessary overload
+                        // especally since the configuration system is synchronous. This uses the same settings
+                        // and disables async IO.
+                        return new FileStream(
+                            fileInfo.PhysicalPath,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FileShare.ReadWrite,
+                            bufferSize: 1,
+                            FileOptions.SequentialScan);
                     }
-                    catch (Exception e)
-                    {
-                        HandleException(ExceptionDispatchInfo.Capture(e));
-                    }
+
+                    return fileInfo.CreateReadStream();
+                }
+
+                using Stream stream = OpenRead(file);
+
+                try
+                {
+                    Load(stream);
+                }
+                catch (Exception e)
+                {
+                    HandleException(ExceptionDispatchInfo.Capture(e));
                 }
             }
             // REVIEW: Should we raise this in the base as well / instead?

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Configuration
                 {
                     if (fileInfo.PhysicalPath != null)
                     {
-                        // The default physical file info assumes asynchronous IO which results in unnecessary overload
+                        // The default physical file info assumes asynchronous IO which results in unnecessary overhead
                         // especally since the configuration system is synchronous. This uses the same settings
                         // and disables async IO.
                         return new FileStream(
@@ -103,7 +103,6 @@ namespace Microsoft.Extensions.Configuration
                 }
 
                 using Stream stream = OpenRead(file);
-
                 try
                 {
                     Load(stream);

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/Common/TestStreamHelpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/Common/TestStreamHelpers.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Extensions.Configuration.Test
             {
                 get
                 {
-                    throw new NotImplementedException();
+                    return 0;
                 }
             }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Configuration.Test
             {
                 get
                 {
-                    throw new NotImplementedException();
+                    return null;
                 }
             }
 
@@ -72,7 +72,7 @@ namespace Microsoft.Extensions.Configuration.Test
             {
                 get
                 {
-                    throw new NotImplementedException();
+                    return null;
                 }
             }
 


### PR DESCRIPTION
- This should remove the overhead of doing async io for the synchronous configuration system

Found this when looking at a memory profile:

![image](https://user-images.githubusercontent.com/95136/84558989-fcfdb980-aceb-11ea-8e5d-ff2ad9283e83.png)
