### PR TITLE
Fix detection of static readonly field re-initialization via reflection

### DIFF
--- a/src/coreclr/src/vm/invokeutil.cpp
+++ b/src/coreclr/src/vm/invokeutil.cpp
@@ -950,7 +950,7 @@ void InvokeUtil::SetValidField(CorElementType fldType,
         pDeclMT = declaringType.GetMethodTable();
 
         // We don't allow setting the field of nullable<T> (hasValue and value)
-        // Because you can't independantly set them for this type.
+        // Because you can't independently set them for this type.
         if (Nullable::IsNullableType(pDeclMT))
             COMPlusThrow(kNotSupportedException);
 
@@ -1171,7 +1171,7 @@ OBJECTREF InvokeUtil::GetFieldValue(FieldDesc* pField, TypeHandle fieldType, OBJ
         pDeclMT = declaringType.GetMethodTable();
 
         // We don't allow getting the field just so we don't have more specical
-        // cases than we need to.  Then we need at least the throw check to insure
+        // cases than we need to.  Then we need at least the throw check to ensure
         // we don't allow data corruption.
         if (Nullable::IsNullableType(pDeclMT))
             COMPlusThrow(kNotSupportedException);

--- a/src/coreclr/src/vm/invokeutil.cpp
+++ b/src/coreclr/src/vm/invokeutil.cpp
@@ -941,11 +941,6 @@ void InvokeUtil::SetValidField(CorElementType fldType,
     }
     CONTRACTL_END;
 
-    // We don't allow setting the field of nullable<T> (hasValue and value)
-    // Because you can't independantly set them for this type.
-    if (!declaringType.IsNull() && Nullable::IsNullableType(declaringType.GetMethodTable()))
-        COMPlusThrow(kNotSupportedException);
-
     // call the <cinit>
     OBJECTREF Throwable = NULL;
 
@@ -954,26 +949,27 @@ void InvokeUtil::SetValidField(CorElementType fldType,
     {
         pDeclMT = declaringType.GetMethodTable();
 
+        // We don't allow setting the field of nullable<T> (hasValue and value)
+        // Because you can't independantly set them for this type.
+        if (Nullable::IsNullableType(pDeclMT))
+            COMPlusThrow(kNotSupportedException);
+
         if (pDeclMT->IsSharedByGenericInstantiations())
             COMPlusThrow(kNotSupportedException, W("NotSupported_Type"));
+    }
+    else
+    {
+        pDeclMT = pField->GetModule()->GetGlobalMethodTable();
     }
 
     if (*pDomainInitialized == FALSE)
     {
         EX_TRY
         {
-        if (declaringType.IsNull())
-        {
-            pField->GetModule()->GetGlobalMethodTable()->EnsureInstanceActive();
-            pField->GetModule()->GetGlobalMethodTable()->CheckRunClassInitThrowing();
-        }
-        else
-        {
             pDeclMT->EnsureInstanceActive();
             pDeclMT->CheckRunClassInitThrowing();
 
             *pDomainInitialized = TRUE;
-        }
         }
         EX_CATCH_THROWABLE(&Throwable);
     }
@@ -988,6 +984,18 @@ void InvokeUtil::SetValidField(CorElementType fldType,
         OBJECTREF except = CreateTargetExcept(&Throwable);
         COMPlusThrow(except);
         GCPROTECT_END();
+    }
+
+    // Verify we're not trying to set the value of a static initonly field
+    // once the class has been initialized.
+    if (pField->IsStatic() && pDeclMT->IsClassInited() && IsFdInitOnly(pField->GetAttributes()))
+    {
+        DefineFullyQualifiedNameForClassW();
+        SString ssFieldName(SString::Utf8, pField->GetName());
+        COMPlusThrow(kFieldAccessException,
+            IDS_EE_CANNOT_SET_INITONLY_STATIC_FIELD,
+            ssFieldName.GetUnicode(),
+            GetFullyQualifiedNameForClassW(pDeclMT));
     }
 
     // Set the field
@@ -1162,26 +1170,28 @@ OBJECTREF InvokeUtil::GetFieldValue(FieldDesc* pField, TypeHandle fieldType, OBJ
     {
         pDeclMT = declaringType.GetMethodTable();
 
+        // We don't allow getting the field just so we don't have more specical
+        // cases than we need to.  Then we need at least the throw check to insure
+        // we don't allow data corruption.
+        if (Nullable::IsNullableType(pDeclMT))
+            COMPlusThrow(kNotSupportedException);
+
         if (pDeclMT->IsSharedByGenericInstantiations())
             COMPlusThrow(kNotSupportedException, W("NotSupported_Type"));
+    }
+    else
+    {
+        pDeclMT = pField->GetModule()->GetGlobalMethodTable();
     }
 
     if (*pDomainInitialized == FALSE)
     {
         EX_TRY
         {
-        if (declaringType.IsNull())
-        {
-            pField->GetModule()->GetGlobalMethodTable()->EnsureInstanceActive();
-            pField->GetModule()->GetGlobalMethodTable()->CheckRunClassInitThrowing();
-        }
-        else
-        {
             pDeclMT->EnsureInstanceActive();
             pDeclMT->CheckRunClassInitThrowing();
 
             *pDomainInitialized = TRUE;
-        }
         }
         EX_CATCH_THROWABLE(&Throwable);
     }
@@ -1198,12 +1208,6 @@ OBJECTREF InvokeUtil::GetFieldValue(FieldDesc* pField, TypeHandle fieldType, OBJ
         COMPlusThrow(except);
         GCPROTECT_END();
     }
-
-    // We don't allow getting the field just so we don't have more specical
-    // cases than we need to.  The we need at least the throw check to insure
-    // we don't allow data corruption, but
-    if (!declaringType.IsNull() && Nullable::IsNullableType(pDeclMT))
-        COMPlusThrow(kNotSupportedException);
 
     CorElementType fieldElementType = pField->GetFieldType();
 

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -118,9 +118,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/AddThresholdTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/36850</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField2/**">
-            <Issue>https://github.com/dotnet/runtime/issues/37899</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
             <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
         </ExcludeList>
@@ -1573,6 +1570,9 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField/**">
             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField2/**">
+            <Issue>https://github.com/dotnet/runtime/issues/37899</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/15241/genericcontext/**">
             <Issue>needs triage</Issue>

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -118,6 +118,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/GC/API/GC/AddThresholdTest/**">
             <Issue>https://github.com/dotnet/runtime/issues/36850</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/reflection/SetValue/TrySetReadonlyStaticField2/**">
+            <Issue>https://github.com/dotnet/runtime/issues/37899</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
             <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/src/reflection/SetValue/TrySetReadonlyStaticField2.cs
+++ b/src/coreclr/tests/src/reflection/SetValue/TrySetReadonlyStaticField2.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+
+public class TestSetValue
+{
+    public static readonly long MagicNumber = 42;
+}
+
+public class TestSetValueDirect
+{
+    public static readonly string MagicString = "";
+}
+
+class Test
+{
+    public static int Main()
+    {
+        // Validate that the readonly static field cannot be set via reflection when the static constructor is triggered 
+        // by the reflection SetValue operation itself.
+
+        try
+        {
+            typeof(TestSetValue).GetField(nameof(TestSetValue.MagicNumber)).SetValue(null, 0x123456789);
+            Console.WriteLine("FAILED: TestSetValue - Exception expected");
+            return -1;
+        }
+        catch (FieldAccessException)
+        {
+            Console.WriteLine("TestSetValue - Caught expected exception");
+        }
+
+        try 
+        {
+            int i = 0;
+            typeof(TestSetValueDirect).GetField(nameof(TestSetValueDirect.MagicString)).SetValueDirect(__makeref(i), "Hello");
+            Console.WriteLine("FAILED: TestSetValueDirect - Exception expected");
+            return -1;
+        }
+        catch (FieldAccessException)
+        {
+            Console.WriteLine("TestSetValueDirect - Caught expected exception");
+        }
+        return 100;
+    }
+}
+
+

--- a/src/coreclr/tests/src/reflection/SetValue/TrySetReadonlyStaticField2.csproj
+++ b/src/coreclr/tests/src/reflection/SetValue/TrySetReadonlyStaticField2.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TrySetReadonlyStaticField2.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Move the check for static readonly field re-initialization after the static constructor is triggered.

Fixes #37796