### PR TITLE
Prevent use of LINQ in managed type system

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Common/LinqPoison.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/LinqPoison.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    //
+    // The type system needs to be low level enough to be usable as
+    // an actual runtime type system.
+    //
+    // LINQ is not low level enough to be allowable in the type system.
+    //
+    // It also has performance characteristics that make it a poor choice
+    // in high performance components such as the type system.
+    //
+    // If you get an error pointing to here, the fix is to remove
+    // "using System.Linq" from your file. Do not modify this file or
+    // remove it from the project.
+    //
+    internal class Linq { }
+}

--- a/src/coreclr/src/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Ecma/EcmaSignatureParser.cs
@@ -6,7 +6,6 @@ using System;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
-using System.Linq;
 
 using Internal.TypeSystem;
 using System.Collections.Generic;

--- a/src/coreclr/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/crossgen2/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -217,6 +217,9 @@
     <Compile Include="..\..\Common\TypeSystem\Common\LayoutInt.cs">
       <Link>TypeSystem\Common\LayoutInt.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\LinqPoison.cs">
+      <Link>TypeSystem\Common\LinqPoison.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\MetadataType.cs">
       <Link>TypeSystem\Common\MetadataType.cs</Link>
     </Compile>


### PR DESCRIPTION
    //
    // The type system needs to be low level enough to be usable as
    // an actual runtime type system.
    //
    // LINQ is not low level enough to be allowable in the type system.
    //
    // It also has performance characteristics that make it a poor choice
    // in high performance components such as the type system.
    //