### PR TITLE
Parse CORE_LIBRARIES as a semicolon-separated list in the CoreRun

### DIFF
--- a/docs/workflow/testing/using-corerun.md
+++ b/docs/workflow/testing/using-corerun.md
@@ -19,8 +19,8 @@ It does this by looking at two environment variables.
 
  * `CORE_ROOT` - The directory where to find the runtime DLLs itself (e.g. CoreCLR.dll).
  Defaults to be next to the corerun.exe host itself.
- * `CORE_LIBRARIES` - A directory to look for DLLS to resolve any assembly references.
- It defaults CORE_ROOT if it is not specified.
+ * `CORE_LIBRARIES` - A semicolon-separated list of directories to look for DLLs to resolve any assembly references.
+ It defaults to `CORE_ROOT` if not specified.
 
 These simple rules can be used in a number of ways
 

--- a/src/coreclr/src/hosts/corerun/corerun.cpp
+++ b/src/coreclr/src/hosts/corerun/corerun.cpp
@@ -290,8 +290,19 @@ public:
             StackSString coreLibraries;
             if (WszGetEnvironmentVariable(W("CORE_LIBRARIES"), coreLibraries) > 0 && coreLibraries.GetCount() > 0)
             {
-                coreLibraries.Append(W('\\'));
-                AddFilesFromDirectoryToTPAList(coreLibraries, rgTPAExtensions, _countof(rgTPAExtensions));
+                StackSString separator { W('\\') };
+                StackSString::CIterator it = coreLibraries.Begin();
+                while (it != coreLibraries.End())
+                {
+                    coreLibraries.Skip(it, W(';'));
+                    StackSString::CIterator start = it;
+                    if (!coreLibraries.Find(it, W(';')))
+                        it = coreLibraries.End();
+                    StackSString item { coreLibraries, start, it };
+                    if (!item.EndsWith(separator))
+                        item.Append(separator);
+                    AddFilesFromDirectoryToTPAList(item, rgTPAExtensions, _countof(rgTPAExtensions));
+                }
             }
             else
             {


### PR DESCRIPTION
Fix #12450 by implementing the string splitting, instead of declaring it an invalid scenario. This patch allowed me to debug a complex issue with WinRT activation (recently removed from .NET runtime, ironic) in a WinForms app (with runtime, libraries and winforms built from source).

Note: applies only to `corerun`, not `unixcoreruncommon`.