### PR TITLE
ComWrappers isolation

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -126,6 +126,9 @@ namespace System.Runtime.InteropServices
         /// </summary>
         private static ComWrappers? s_globalInstanceForMarshalling;
 
+        private static long s_instanceCounter;
+        private readonly long id = Interlocked.Increment(ref s_instanceCounter);
+
         /// <summary>
         /// Create a COM representation of the supplied object that can be passed to a non-managed environment.
         /// </summary>
@@ -152,16 +155,16 @@ namespace System.Runtime.InteropServices
         /// <remarks>
         /// If <paramref name="impl" /> is <c>null</c>, the global instance (if registered) will be used.
         /// </remarks>
-        private static bool TryGetOrCreateComInterfaceForObjectInternal(ComWrappers? impl, object instance, CreateComInterfaceFlags flags, out IntPtr retValue)
+        private static bool TryGetOrCreateComInterfaceForObjectInternal(ComWrappers impl, object instance, CreateComInterfaceFlags flags, out IntPtr retValue)
         {
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
 
-            return TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack.Create(ref impl), ObjectHandleOnStack.Create(ref instance), flags, out retValue);
+            return TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack.Create(ref impl), impl.id, ObjectHandleOnStack.Create(ref instance), flags, out retValue);
         }
 
         [DllImport(RuntimeHelpers.QCall)]
-        private static extern bool TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack comWrappersImpl, ObjectHandleOnStack instance, CreateComInterfaceFlags flags, out IntPtr retValue);
+        private static extern bool TryGetOrCreateComInterfaceForObjectInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, ObjectHandleOnStack instance, CreateComInterfaceFlags flags, out IntPtr retValue);
 
         /// <summary>
         /// Compute the desired Vtable for <paramref name="obj"/> respecting the values of <paramref name="flags"/>.
@@ -288,18 +291,18 @@ namespace System.Runtime.InteropServices
         /// <remarks>
         /// If <paramref name="impl" /> is <c>null</c>, the global instance (if registered) will be used.
         /// </remarks>
-        private static bool TryGetOrCreateObjectForComInstanceInternal(ComWrappers? impl, IntPtr externalComObject, CreateObjectFlags flags, object? wrapperMaybe, out object? retValue)
+        private static bool TryGetOrCreateObjectForComInstanceInternal(ComWrappers impl, IntPtr externalComObject, CreateObjectFlags flags, object? wrapperMaybe, out object? retValue)
         {
             if (externalComObject == IntPtr.Zero)
                 throw new ArgumentNullException(nameof(externalComObject));
 
             object? wrapperMaybeLocal = wrapperMaybe;
             retValue = null;
-            return TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack.Create(ref impl), externalComObject, flags, ObjectHandleOnStack.Create(ref wrapperMaybeLocal), ObjectHandleOnStack.Create(ref retValue));
+            return TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack.Create(ref impl), impl.id, externalComObject, flags, ObjectHandleOnStack.Create(ref wrapperMaybeLocal), ObjectHandleOnStack.Create(ref retValue));
         }
 
         [DllImport(RuntimeHelpers.QCall)]
-        private static extern bool TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack comWrappersImpl, IntPtr externalComObject, CreateObjectFlags flags, ObjectHandleOnStack wrapper, ObjectHandleOnStack retValue);
+        private static extern bool TryGetOrCreateObjectForComInstanceInternal(ObjectHandleOnStack comWrappersImpl, long wrapperId, IntPtr externalComObject, CreateObjectFlags flags, ObjectHandleOnStack wrapper, ObjectHandleOnStack retValue);
 
         /// <summary>
         /// Called when a request is made for a collection of objects to be released outside of normal object or COM interface lifetime.
@@ -332,13 +335,13 @@ namespace System.Runtime.InteropServices
                 throw new InvalidOperationException(SR.InvalidOperation_ResetGlobalComWrappersInstance);
             }
 
-            SetGlobalInstanceRegisteredForTrackerSupport();
+            SetGlobalInstanceRegisteredForTrackerSupport(instance.id);
         }
 
 
         [DllImport(RuntimeHelpers.QCall)]
         [SuppressGCTransition]
-        private static extern void SetGlobalInstanceRegisteredForTrackerSupport();
+        private static extern void SetGlobalInstanceRegisteredForTrackerSupport(long id);
 
         /// <summary>
         /// Register a <see cref="ComWrappers" /> instance to be used as the global instance for marshalling in the runtime.
@@ -366,12 +369,12 @@ namespace System.Runtime.InteropServices
             // Indicate to the runtime that a global instance has been registered for marshalling.
             // This allows the native runtime know to call into the managed ComWrappers only if a
             // global instance is registered for marshalling.
-            SetGlobalInstanceRegisteredForMarshalling();
+            SetGlobalInstanceRegisteredForMarshalling(instance.id);
         }
 
         [DllImport(RuntimeHelpers.QCall)]
         [SuppressGCTransition]
-        private static extern void SetGlobalInstanceRegisteredForMarshalling();
+        private static extern void SetGlobalInstanceRegisteredForMarshalling(long id);
 
         /// <summary>
         /// Get the runtime provided IUnknown implementation.

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -135,6 +135,11 @@ namespace System.Runtime.InteropServices
         /// <param name="instance">The managed object to expose outside the .NET runtime.</param>
         /// <param name="flags">Flags used to configure the generated interface.</param>
         /// <returns>The generated COM interface that can be passed outside the .NET runtime.</returns>
+        /// <remarks>
+        /// If a COM representation was previously created for the specified <paramref name="instance" /> using
+        /// this <see cref="ComWrappers" /> instance, the previously created COM interface will be returned.
+        /// If not, a new one will be created.
+        /// </remarks>
         public IntPtr GetOrCreateComInterfaceForObject(object instance, CreateComInterfaceFlags flags)
         {
             IntPtr ptr;
@@ -214,6 +219,11 @@ namespace System.Runtime.InteropServices
         /// <param name="externalComObject">Object to import for usage into the .NET runtime.</param>
         /// <param name="flags">Flags used to describe the external object.</param>
         /// <returns>Returns a managed object associated with the supplied external COM object.</returns>
+        /// <remarks>
+        /// If a managed object was previously created for the specified <paramref name="externalComObject" />
+        /// using this <see cref="ComWrappers" /> instance, the previously created object will be returned.
+        /// If not, a new one will be created.
+        /// </remarks>
         public object GetOrCreateObjectForComInstance(IntPtr externalComObject, CreateObjectFlags flags)
         {
             object? obj;

--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -1099,10 +1099,10 @@ public:
         return ::CreateRefcountedHandle(m_handleStore, object);
     }
 
-    OBJECTHANDLE CreateNativeComWeakHandle(OBJECTREF object, IWeakReference* pComWeakReference)
+    OBJECTHANDLE CreateNativeComWeakHandle(OBJECTREF object, NativeComWeakHandleInfo* pComWeakHandleInfo)
     {
         WRAPPER_NO_CONTRACT;
-        return ::CreateNativeComWeakHandle(m_handleStore, object, pComWeakReference);
+        return ::CreateNativeComWeakHandle(m_handleStore, object, pComWeakHandleInfo);
     }
 #endif // FEATURE_COMINTEROP
 

--- a/src/coreclr/src/vm/gchandleutilities.h
+++ b/src/coreclr/src/vm/gchandleutilities.h
@@ -201,9 +201,16 @@ inline OBJECTHANDLE CreateGlobalRefcountedHandle(OBJECTREF object)
 // Special handle creation convenience functions
 
 #ifdef FEATURE_COMINTEROP
-inline OBJECTHANDLE CreateNativeComWeakHandle(IGCHandleStore* store, OBJECTREF object, IWeakReference* pComWeakReference)
+
+struct NativeComWeakHandleInfo
 {
-    OBJECTHANDLE hnd = store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_WEAK_NATIVE_COM, (void*)pComWeakReference);
+    IWeakReference *WeakReference;
+    INT64 WrapperId;
+};
+
+inline OBJECTHANDLE CreateNativeComWeakHandle(IGCHandleStore* store, OBJECTREF object, NativeComWeakHandleInfo* pComWeakHandleInfo)
+{
+    OBJECTHANDLE hnd = store->CreateHandleWithExtraInfo(OBJECTREFToObject(object), HNDTYPE_WEAK_NATIVE_COM, (void*)pComWeakHandleInfo);
     if (!hnd)
     {
         COMPlusThrowOM();
@@ -374,14 +381,16 @@ inline void DestroyNativeComWeakHandle(OBJECTHANDLE handle)
     }
     CONTRACTL_END;
 
-    // Release the WinRT weak reference if we have one. We're assuming that this will not reenter the
-    // runtime, since if we are pointing at a managed object, we should not be using HNDTYPE_WEAK_NATIVE_COM
-    // but rather HNDTYPE_WEAK_SHORT or HNDTYPE_WEAK_LONG.
+    // Delete the COM info and release the weak reference if we have one. We're assuming that
+    // this will not reenter the runtime, since if we are pointing at a managed object, we should
+    // not be using HNDTYPE_WEAK_NATIVE_COM but rather HNDTYPE_WEAK_SHORT or HNDTYPE_WEAK_LONG.
     void* pExtraInfo = GCHandleUtilities::GetGCHandleManager()->GetExtraInfoFromHandle(handle);
-    IWeakReference* pWinRTWeakReference = reinterpret_cast<IWeakReference*>(pExtraInfo);
-    if (pWinRTWeakReference != nullptr)
+    NativeComWeakHandleInfo* comWeakHandleInfo = reinterpret_cast<NativeComWeakHandleInfo*>(pExtraInfo);
+    if (comWeakHandleInfo != nullptr)
     {
-        pWinRTWeakReference->Release();
+        _ASSERTE(comWeakHandleInfo->WeakReference != nullptr);
+        comWeakHandleInfo->WeakReference->Release();
+        delete comWeakHandleInfo;
     }
 
     DiagHandleDestroyed(handle);

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -103,9 +103,20 @@ namespace
                 , _wrapperId { wrapperId }
             {
                 _ASSERTE(identity != NULL);
+                _ASSERTE(wrapperId != ComWrappersNative::InvalidWrapperId);
             }
 
-            size_t Hash() const { return (size_t)_identity ^ (_wrapperId >> 32) ^ (_wrapperId & 0xFFFFFFFF); }
+            DWORD Hash() const
+            {
+                DWORD hash = (_wrapperId >> 32) ^ (_wrapperId & 0xFFFFFFFF);
+#if POINTER_BITS == 32
+                return hash ^ (DWORD)_identity;
+#else
+                INT64 identityInt64 = (INT64)_identity;
+                return hash ^ (identityInt64 >> 32) ^ (identityInt64 & 0xFFFFFFFF);
+#endif
+            }
+
             bool operator==(const Key & rhs) const { return _identity == rhs._identity && _wrapperId == rhs._wrapperId; }
 
         private:

--- a/src/coreclr/src/vm/interoplibinterface.cpp
+++ b/src/coreclr/src/vm/interoplibinterface.cpp
@@ -26,6 +26,7 @@ namespace
         void* Identity;
         void* ThreadContext;
         DWORD SyncBlockIndex;
+        INT64 WrapperId;
 
         enum
         {
@@ -41,6 +42,7 @@ namespace
             _In_ IUnknown* identity,
             _In_opt_ void* threadContext,
             _In_ DWORD syncBlockIndex,
+            _In_ INT64 wrapperId,
             _In_ DWORD flags)
         {
             CONTRACTL
@@ -57,6 +59,7 @@ namespace
             cxt->Identity = (void*)identity;
             cxt->ThreadContext = threadContext;
             cxt->SyncBlockIndex = syncBlockIndex;
+            cxt->WrapperId = wrapperId;
             cxt->Flags = flags;
         }
 
@@ -90,6 +93,29 @@ namespace
 
             _ASSERTE(IsActive());
             return ObjectToOBJECTREF(g_pSyncTable[SyncBlockIndex].m_Object);
+        }
+
+        struct Key
+        {
+        public:
+            Key(void* identity, INT64 wrapperId)
+                : _identity { identity }
+                , _wrapperId { wrapperId }
+            {
+                _ASSERTE(identity != NULL);
+            }
+
+            size_t Hash() const { return (size_t)_identity ^ (_wrapperId >> 32) ^ (_wrapperId & 0xFFFFFFFF); }
+            bool operator==(const Key & rhs) const { return _identity == rhs._identity && _wrapperId == rhs._wrapperId; }
+
+        private:
+            void* _identity;
+            INT64 _wrapperId;
+        };
+
+        Key GetKey() const
+        {
+            return Key(Identity, WrapperId);
         }
     };
 
@@ -171,10 +197,10 @@ namespace
         class Traits : public DefaultSHashTraits<ExternalObjectContext *>
         {
         public:
-            using key_t = void*;
-            static const key_t GetKey(_In_ element_t e) { LIMITED_METHOD_CONTRACT; return (key_t)e->Identity; }
-            static count_t Hash(_In_ key_t key) { LIMITED_METHOD_CONTRACT; return (count_t)(size_t)key; }
-            static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { LIMITED_METHOD_CONTRACT; return (lhs == rhs); }
+            using key_t = ExternalObjectContext::Key;
+            static const key_t GetKey(_In_ element_t e) { LIMITED_METHOD_CONTRACT; return e->GetKey(); }
+            static count_t Hash(_In_ key_t key) { LIMITED_METHOD_CONTRACT; return (count_t)key.Hash(); }
+            static bool Equals(_In_ key_t lhs, _In_ key_t rhs) { LIMITED_METHOD_CONTRACT; return lhs == rhs; }
         };
 
         // Alias some useful types
@@ -311,7 +337,7 @@ namespace
             RETURN gc.arrRef;
         }
 
-        ExternalObjectContext* Find(_In_ IUnknown* instance)
+        ExternalObjectContext* Find(_In_ const ExternalObjectContext::Key& key)
         {
             CONTRACT(ExternalObjectContext*)
             {
@@ -319,7 +345,6 @@ namespace
                 GC_NOTRIGGER;
                 MODE_COOPERATIVE;
                 PRECONDITION(IsLockHeld());
-                PRECONDITION(instance != NULL);
                 POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
             }
             CONTRACT_END;
@@ -327,7 +352,7 @@ namespace
             // Forbid the GC from messing with the hash table.
             GCX_FORBID();
 
-            RETURN _hashMap.Lookup(instance);
+            RETURN _hashMap.Lookup(key);
         }
 
         ExternalObjectContext* Add(_In_ ExternalObjectContext* cxt)
@@ -340,7 +365,7 @@ namespace
                 PRECONDITION(IsLockHeld());
                 PRECONDITION(!Traits::IsNull(cxt) && !Traits::IsDeleted(cxt));
                 PRECONDITION(cxt->Identity != NULL);
-                PRECONDITION(Find(static_cast<IUnknown*>(cxt->Identity)) == NULL);
+                PRECONDITION(Find(cxt->GetKey()) == NULL);
                 POSTCONDITION(RETVAL == cxt);
             }
             CONTRACT_END;
@@ -349,7 +374,7 @@ namespace
             RETURN cxt;
         }
 
-        ExternalObjectContext* FindOrAdd(_In_ IUnknown* key, _In_ ExternalObjectContext* newCxt)
+        ExternalObjectContext* FindOrAdd(_In_ const ExternalObjectContext::Key& key, _In_ ExternalObjectContext* newCxt)
         {
             CONTRACT(ExternalObjectContext*)
             {
@@ -357,9 +382,8 @@ namespace
                 GC_NOTRIGGER;
                 MODE_COOPERATIVE;
                 PRECONDITION(IsLockHeld());
-                PRECONDITION(key != NULL);
                 PRECONDITION(!Traits::IsNull(newCxt) && !Traits::IsDeleted(newCxt));
-                PRECONDITION(key == newCxt->Identity);
+                PRECONDITION(key == newCxt->GetKey());
                 POSTCONDITION(CheckPointer(RETVAL));
             }
             CONTRACT_END;
@@ -392,7 +416,7 @@ namespace
             }
             CONTRACTL_END;
 
-            _hashMap.Remove(cxt->Identity);
+            _hashMap.Remove(cxt->GetKey());
         }
     };
 
@@ -400,8 +424,8 @@ namespace
     Volatile<ExtObjCxtCache*> ExtObjCxtCache::g_Instance;
 
     // Indicator for if a ComWrappers implementation is globally registered
-    bool g_IsGlobalComWrappersRegisteredForMarshalling;
-    bool g_IsGlobalComWrappersRegisteredForTrackerSupport;
+    INT64 g_marshallingGlobalInstanceId = ComWrappersNative::InvalidWrapperId;
+    INT64 g_trackerSupportGlobalInstanceId = ComWrappersNative::InvalidWrapperId;
 
     // Defined handle types for the specific object uses.
     const HandleType InstanceHandleType{ HNDTYPE_STRONG };
@@ -522,6 +546,7 @@ namespace
 
     bool TryGetOrCreateComInterfaceForObjectInternal(
         _In_opt_ OBJECTREF impl,
+        _In_ INT64 wrapperId,
         _In_ OBJECTREF instance,
         _In_ CreateComInterfaceFlags flags,
         _In_ ComWrappersScenario scenario,
@@ -533,7 +558,8 @@ namespace
             MODE_COOPERATIVE;
             PRECONDITION(instance != NULL);
             PRECONDITION(wrapperRaw != NULL);
-            PRECONDITION((impl != NULL && scenario == ComWrappersScenario::Instance)|| (impl == NULL && scenario != ComWrappersScenario::Instance));
+            PRECONDITION((impl != NULL && scenario == ComWrappersScenario::Instance) || (impl == NULL && scenario != ComWrappersScenario::Instance));
+            PRECONDITION(wrapperId != ComWrappersNative::InvalidWrapperId);
         }
         CONTRACT_END;
 
@@ -559,7 +585,7 @@ namespace
         _ASSERTE(syncBlock->IsPrecious());
 
         // Query the associated InteropSyncBlockInfo for an existing managed object wrapper.
-        if (!interopInfo->TryGetManagedObjectComWrapper(&wrapperRawMaybe))
+        if (!interopInfo->TryGetManagedObjectComWrapper(wrapperId, &wrapperRawMaybe))
         {
             // Compute VTables for the new existing COM object using the supplied COM Wrappers implementation.
             //
@@ -570,7 +596,7 @@ namespace
             void* vtables = CallComputeVTables(scenario, &gc.implRef, &gc.instRef, flags, &vtableCount);
 
             // Re-query the associated InteropSyncBlockInfo for an existing managed object wrapper.
-            if (!interopInfo->TryGetManagedObjectComWrapper(&wrapperRawMaybe)
+            if (!interopInfo->TryGetManagedObjectComWrapper(wrapperId, &wrapperRawMaybe)
                 && ((vtables != nullptr && vtableCount > 0) || (vtableCount == 0)))
             {
                 OBJECTHANDLE instHandle = GetAppDomain()->CreateTypedHandle(gc.instRef, InstanceHandleType);
@@ -590,14 +616,14 @@ namespace
                 _ASSERTE(!newWrapper.IsNull());
 
                 // Try setting the newly created managed object wrapper on the InteropSyncBlockInfo.
-                if (!interopInfo->TrySetManagedObjectComWrapper(newWrapper))
+                if (!interopInfo->TrySetManagedObjectComWrapper(wrapperId, newWrapper))
                 {
                     // The new wrapper couldn't be set which means a wrapper already exists.
                     newWrapper.Release();
 
                     // If the managed object wrapper couldn't be set, then
                     // it should be possible to get the current one.
-                    if (!interopInfo->TryGetManagedObjectComWrapper(&wrapperRawMaybe))
+                    if (!interopInfo->TryGetManagedObjectComWrapper(wrapperId, &wrapperRawMaybe))
                     {
                         UNREACHABLE();
                     }
@@ -638,6 +664,7 @@ namespace
 
     bool TryGetOrCreateObjectForComInstanceInternal(
         _In_opt_ OBJECTREF impl,
+        _In_ INT64 wrapperId,
         _In_ IUnknown* identity,
         _In_ CreateObjectFlags flags,
         _In_ ComWrappersScenario scenario,
@@ -651,6 +678,7 @@ namespace
             PRECONDITION(identity != NULL);
             PRECONDITION(objRef != NULL);
             PRECONDITION((impl != NULL && scenario == ComWrappersScenario::Instance) || (impl == NULL && scenario != ComWrappersScenario::Instance));
+            PRECONDITION(wrapperId != ComWrappersNative::InvalidWrapperId);
         }
         CONTRACT_END;
 
@@ -672,13 +700,15 @@ namespace
         ExtObjCxtCache* cache = ExtObjCxtCache::GetInstance();
         InteropLib::OBJECTHANDLE handle = NULL;
 
+        ExternalObjectContext::Key cacheKey(identity, wrapperId);
+
         // Check if the user requested a unique instance.
         bool uniqueInstance = !!(flags & CreateObjectFlags::CreateObjectFlags_UniqueInstance);
         if (!uniqueInstance)
         {
             // Query the external object cache
             ExtObjCxtCache::LockHolder lock(cache);
-            extObjCxt = cache->Find(identity);
+            extObjCxt = cache->Find(cacheKey);
 
             // If is no object found in the cache, check if the object COM instance is actually the CCW
             // representing a managed object. For the scenario of marshalling through a global instance,
@@ -750,6 +780,7 @@ namespace
                     identity,
                     GetCurrentCtxCookie(),
                     gc.objRefMaybe->GetSyncBlockIndex(),
+                    wrapperId,
                     flags);
 
                 if (uniqueInstance)
@@ -760,7 +791,7 @@ namespace
                 {
                     // Attempt to insert the new context into the cache.
                     ExtObjCxtCache::LockHolder lock(cache);
-                    extObjCxt = cache->FindOrAdd(identity, resultHolder.GetContext());
+                    extObjCxt = cache->FindOrAdd(cacheKey, resultHolder.GetContext());
                 }
 
                 // If the returned context matches the new context it means the
@@ -1039,6 +1070,7 @@ namespace InteropLibImports
             // Get wrapper for external object
             bool success = TryGetOrCreateObjectForComInstanceInternal(
                 gc.implRef,
+                g_trackerSupportGlobalInstanceId,
                 externalComObject,
                 externalObjectFlags,
                 ComWrappersScenario::TrackerSupportGlobalInstance,
@@ -1051,6 +1083,7 @@ namespace InteropLibImports
             // Get wrapper for managed object
             success = TryGetOrCreateComInterfaceForObjectInternal(
                 gc.implRef,
+                g_trackerSupportGlobalInstanceId,
                 gc.objRef,
                 trackerTargetFlags,
                 ComWrappersScenario::TrackerSupportGlobalInstance,
@@ -1220,6 +1253,7 @@ namespace InteropLibImports
 
 BOOL QCALLTYPE ComWrappersNative::TryGetOrCreateComInterfaceForObject(
     _In_ QCall::ObjectHandleOnStack comWrappersImpl,
+    _In_ INT64 wrapperId,
     _In_ QCall::ObjectHandleOnStack instance,
     _In_ INT32 flags,
     _Outptr_ void** wrapper)
@@ -1236,6 +1270,7 @@ BOOL QCALLTYPE ComWrappersNative::TryGetOrCreateComInterfaceForObject(
         GCX_COOP();
         success = TryGetOrCreateComInterfaceForObjectInternal(
             ObjectToOBJECTREF(*comWrappersImpl.m_ppObject),
+            wrapperId,
             ObjectToOBJECTREF(*instance.m_ppObject),
             (CreateComInterfaceFlags)flags,
             ComWrappersScenario::Instance,
@@ -1249,6 +1284,7 @@ BOOL QCALLTYPE ComWrappersNative::TryGetOrCreateComInterfaceForObject(
 
 BOOL QCALLTYPE ComWrappersNative::TryGetOrCreateObjectForComInstance(
     _In_ QCall::ObjectHandleOnStack comWrappersImpl,
+    _In_ INT64 wrapperId,
     _In_ void* ext,
     _In_ INT32 flags,
     _In_ QCall::ObjectHandleOnStack wrapperMaybe,
@@ -1278,6 +1314,7 @@ BOOL QCALLTYPE ComWrappersNative::TryGetOrCreateObjectForComInstance(
         OBJECTREF newObj;
         success = TryGetOrCreateObjectForComInstanceInternal(
             ObjectToOBJECTREF(*comWrappersImpl.m_ppObject),
+            wrapperId,
             identity,
             (CreateObjectFlags)flags,
             ComWrappersScenario::Instance,
@@ -1387,19 +1424,25 @@ void ComWrappersNative::MarkWrapperAsComActivated(_In_ IUnknown* wrapperMaybe)
     _ASSERTE(SUCCEEDED(hr) || hr == E_INVALIDARG);
 }
 
-void QCALLTYPE GlobalComWrappersForMarshalling::SetGlobalInstanceRegisteredForMarshalling()
+void QCALLTYPE GlobalComWrappersForMarshalling::SetGlobalInstanceRegisteredForMarshalling(INT64 id)
 {
     QCALL_CONTRACT_NO_GC_TRANSITION;
 
-    _ASSERTE(!g_IsGlobalComWrappersRegisteredForMarshalling);
-    g_IsGlobalComWrappersRegisteredForMarshalling = true;
+    _ASSERTE(g_marshallingGlobalInstanceId == ComWrappersNative::InvalidWrapperId && id != ComWrappersNative::InvalidWrapperId);
+    g_marshallingGlobalInstanceId = id;
+}
+
+bool GlobalComWrappersForMarshalling::IsRegisteredInstance(INT64 id)
+{
+    return g_marshallingGlobalInstanceId != ComWrappersNative::InvalidWrapperId
+        && g_marshallingGlobalInstanceId == id;
 }
 
 bool GlobalComWrappersForMarshalling::TryGetOrCreateComInterfaceForObject(
     _In_ OBJECTREF instance,
     _Outptr_ void** wrapperRaw)
 {
-    if (!g_IsGlobalComWrappersRegisteredForMarshalling)
+    if (g_marshallingGlobalInstanceId == ComWrappersNative::InvalidWrapperId)
         return false;
 
     // Switch to Cooperative mode since object references
@@ -1412,6 +1455,7 @@ bool GlobalComWrappersForMarshalling::TryGetOrCreateComInterfaceForObject(
         // Passing NULL as the ComWrappers implementation indicates using the globally registered instance
         return TryGetOrCreateComInterfaceForObjectInternal(
             NULL,
+            g_marshallingGlobalInstanceId,
             instance,
             flags,
             ComWrappersScenario::MarshallingGlobalInstance,
@@ -1424,7 +1468,7 @@ bool GlobalComWrappersForMarshalling::TryGetOrCreateObjectForComInstance(
     _In_ INT32 objFromComIPFlags,
     _Out_ OBJECTREF* objRef)
 {
-    if (!g_IsGlobalComWrappersRegisteredForMarshalling)
+    if (g_marshallingGlobalInstanceId == ComWrappersNative::InvalidWrapperId)
         return false;
 
     // Determine the true identity of the object
@@ -1448,6 +1492,7 @@ bool GlobalComWrappersForMarshalling::TryGetOrCreateObjectForComInstance(
         // Passing NULL as the ComWrappers implementation indicates using the globally registered instance
         return TryGetOrCreateObjectForComInstanceInternal(
             NULL /*comWrappersImpl*/,
+            g_marshallingGlobalInstanceId,
             identity,
             (CreateObjectFlags)flags,
             ComWrappersScenario::MarshallingGlobalInstance,
@@ -1456,12 +1501,18 @@ bool GlobalComWrappersForMarshalling::TryGetOrCreateObjectForComInstance(
     }
 }
 
-void QCALLTYPE GlobalComWrappersForTrackerSupport::SetGlobalInstanceRegisteredForTrackerSupport()
+void QCALLTYPE GlobalComWrappersForTrackerSupport::SetGlobalInstanceRegisteredForTrackerSupport(INT64 id)
 {
     QCALL_CONTRACT_NO_GC_TRANSITION;
 
-    _ASSERTE(!g_IsGlobalComWrappersRegisteredForTrackerSupport);
-    g_IsGlobalComWrappersRegisteredForTrackerSupport = true;
+    _ASSERTE(g_trackerSupportGlobalInstanceId == ComWrappersNative::InvalidWrapperId && id != ComWrappersNative::InvalidWrapperId);
+    g_trackerSupportGlobalInstanceId = id;
+}
+
+bool GlobalComWrappersForTrackerSupport::IsRegisteredInstance(INT64 id)
+{
+    return g_trackerSupportGlobalInstanceId != ComWrappersNative::InvalidWrapperId
+        && g_trackerSupportGlobalInstanceId == id;
 }
 
 bool GlobalComWrappersForTrackerSupport::TryGetOrCreateComInterfaceForObject(
@@ -1475,12 +1526,13 @@ bool GlobalComWrappersForTrackerSupport::TryGetOrCreateComInterfaceForObject(
     }
     CONTRACTL_END;
 
-    if (!g_IsGlobalComWrappersRegisteredForTrackerSupport)
+    if (g_trackerSupportGlobalInstanceId == ComWrappersNative::InvalidWrapperId)
         return false;
 
     // Passing NULL as the ComWrappers implementation indicates using the globally registered instance
     return TryGetOrCreateComInterfaceForObjectInternal(
         NULL,
+        g_trackerSupportGlobalInstanceId,
         instance,
         CreateComInterfaceFlags::CreateComInterfaceFlags_TrackerSupport,
         ComWrappersScenario::TrackerSupportGlobalInstance,
@@ -1498,7 +1550,7 @@ bool GlobalComWrappersForTrackerSupport::TryGetOrCreateObjectForComInstance(
     }
     CONTRACTL_END;
 
-    if (!g_IsGlobalComWrappersRegisteredForTrackerSupport)
+    if (g_trackerSupportGlobalInstanceId == ComWrappersNative::InvalidWrapperId)
         return false;
 
     // Determine the true identity of the object
@@ -1513,6 +1565,7 @@ bool GlobalComWrappersForTrackerSupport::TryGetOrCreateObjectForComInstance(
     // Passing NULL as the ComWrappers implementation indicates using the globally registered instance
     return TryGetOrCreateObjectForComInstanceInternal(
         NULL /*comWrappersImpl*/,
+        g_trackerSupportGlobalInstanceId,
         identity,
         CreateObjectFlags::CreateObjectFlags_TrackerObject,
         ComWrappersScenario::TrackerSupportGlobalInstance,
@@ -1520,7 +1573,7 @@ bool GlobalComWrappersForTrackerSupport::TryGetOrCreateObjectForComInstance(
         objRef);
 }
 
-IUnknown* ComWrappersNative::GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid)
+IUnknown* ComWrappersNative::GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid, _Out_ INT64* wrapperId)
 {
     CONTRACTL
     {
@@ -1528,10 +1581,13 @@ IUnknown* ComWrappersNative::GetIdentityForObject(_In_ OBJECTREF* objectPROTECTE
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(objectPROTECTED));
+        PRECONDITION(CheckPointer(wrapperId));
     }
     CONTRACTL_END;
 
     ASSERT_PROTECTED(objectPROTECTED);
+
+    *wrapperId = ComWrappersNative::InvalidWrapperId;
 
     SyncBlock* syncBlock = (*objectPROTECTED)->PassiveGetSyncBlock();
     if (syncBlock == nullptr)
@@ -1545,10 +1601,13 @@ IUnknown* ComWrappersNative::GetIdentityForObject(_In_ OBJECTREF* objectPROTECTE
         return nullptr;
     }
 
-    void* context;
-    if (interopInfo->TryGetExternalComObjectContext(&context))
+    void* contextMaybe;
+    if (interopInfo->TryGetExternalComObjectContext(&contextMaybe))
     {
-        IUnknown* identity = reinterpret_cast<IUnknown*>(reinterpret_cast<ExternalObjectContext*>(context)->Identity);
+        ExternalObjectContext* context = reinterpret_cast<ExternalObjectContext*>(contextMaybe);
+        *wrapperId = context->WrapperId;
+
+        IUnknown* identity = reinterpret_cast<IUnknown*>(context->Identity);
         GCX_PREEMP();
         IUnknown* result;
         if (SUCCEEDED(identity->QueryInterface(riid, (void**)&result)))

--- a/src/coreclr/src/vm/interoplibinterface.h
+++ b/src/coreclr/src/vm/interoplibinterface.h
@@ -11,6 +11,9 @@
 // Native calls for the managed ComWrappers API
 class ComWrappersNative
 {
+public:
+    static const INT64 InvalidWrapperId = -1;
+
 public: // Native QCalls for the abstract ComWrappers managed type.
     static void QCALLTYPE GetIUnknownImpl(
         _Out_ void** fpQueryInterface,
@@ -19,12 +22,14 @@ public: // Native QCalls for the abstract ComWrappers managed type.
 
     static BOOL QCALLTYPE TryGetOrCreateComInterfaceForObject(
         _In_ QCall::ObjectHandleOnStack comWrappersImpl,
+        _In_ INT64 wrapperId,
         _In_ QCall::ObjectHandleOnStack instance,
         _In_ INT32 flags,
         _Outptr_ void** wrapperRaw);
 
     static BOOL QCALLTYPE TryGetOrCreateObjectForComInstance(
         _In_ QCall::ObjectHandleOnStack comWrappersImpl,
+        _In_ INT64 wrapperId,
         _In_ void* externalComObject,
         _In_ INT32 flags,
         _In_ QCall::ObjectHandleOnStack wrapperMaybe,
@@ -39,7 +44,7 @@ public: // COM activation
     static void MarkWrapperAsComActivated(_In_ IUnknown* wrapperMaybe);
 
 public: // Unwrapping support
-    static IUnknown* GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid);
+    static IUnknown* GetIdentityForObject(_In_ OBJECTREF* objectPROTECTED, _In_ REFIID riid, _Out_ INT64* wrapperId);
 };
 
 class GlobalComWrappersForMarshalling
@@ -48,9 +53,11 @@ public:
     // Native QCall for the ComWrappers managed type to indicate a global instance
     // is registered for marshalling. This should be set if the private static member
     // representing the global instance for marshalling on ComWrappers is non-null.
-    static void QCALLTYPE SetGlobalInstanceRegisteredForMarshalling();
+    static void QCALLTYPE SetGlobalInstanceRegisteredForMarshalling(_In_ INT64 id);
 
 public: // Functions operating on a registered global instance for marshalling
+    static bool IsRegisteredInstance(_In_ INT64 id);
+
     static bool TryGetOrCreateComInterfaceForObject(
         _In_ OBJECTREF instance,
         _Outptr_ void** wrapperRaw);
@@ -68,9 +75,11 @@ public:
     // Native QCall for the ComWrappers managed type to indicate a global instance
     // is registered for tracker support. This should be set if the private static member
     // representing the global instance for tracker support on ComWrappers is non-null.
-    static void QCALLTYPE SetGlobalInstanceRegisteredForTrackerSupport();
+    static void QCALLTYPE SetGlobalInstanceRegisteredForTrackerSupport(_In_ INT64 id);
 
 public: // Functions operating on a registered global instance for tracker support
+    static bool IsRegisteredInstance(_In_ INT64 id);
+
     static bool TryGetOrCreateComInterfaceForObject(
         _In_ OBJECTREF instance,
         _Outptr_ void** wrapperRaw);

--- a/src/coreclr/src/vm/interoplibinterface.h
+++ b/src/coreclr/src/vm/interoplibinterface.h
@@ -12,7 +12,7 @@
 class ComWrappersNative
 {
 public:
-    static const INT64 InvalidWrapperId = -1;
+    static const INT64 InvalidWrapperId = 0;
 
 public: // Native QCalls for the abstract ComWrappers managed type.
     static void QCALLTYPE GetIUnknownImpl(

--- a/src/coreclr/src/vm/interoputil.cpp
+++ b/src/coreclr/src/vm/interoputil.cpp
@@ -1321,10 +1321,7 @@ void CleanupSyncBlockComData(InteropSyncBlockInfo* pInteropInfo)
     }
 
 #ifdef FEATURE_COMWRAPPERS
-    pInteropInfo->ClearManagedObjectComWrappers([](void *mocw)
-        {
-            ComWrappersNative::DestroyManagedObjectComWrapper(mocw);
-        });
+    pInteropInfo->ClearManagedObjectComWrappers(&ComWrappersNative::DestroyManagedObjectComWrapper);
 
     void* eoc;
     if (pInteropInfo->TryGetExternalComObjectContext(&eoc))

--- a/src/coreclr/src/vm/interoputil.cpp
+++ b/src/coreclr/src/vm/interoputil.cpp
@@ -1321,12 +1321,10 @@ void CleanupSyncBlockComData(InteropSyncBlockInfo* pInteropInfo)
     }
 
 #ifdef FEATURE_COMWRAPPERS
-    void* mocw;
-    if (pInteropInfo->TryGetManagedObjectComWrapper(&mocw))
-    {
-        (void)pInteropInfo->TrySetManagedObjectComWrapper(NULL, mocw);
-        ComWrappersNative::DestroyManagedObjectComWrapper(mocw);
-    }
+    pInteropInfo->ClearManagedObjectComWrappers([](void *mocw)
+        {
+            ComWrappersNative::DestroyManagedObjectComWrapper(mocw);
+        });
 
     void* eoc;
     if (pInteropInfo->TryGetExternalComObjectContext(&eoc))

--- a/src/coreclr/src/vm/syncblk.h
+++ b/src/coreclr/src/vm/syncblk.h
@@ -602,6 +602,8 @@ class ComClassFactory;
 struct RCW;
 class RCWHolder;
 typedef DPTR(class ComCallWrapper)        PTR_ComCallWrapper;
+
+#include "shash.h"
 #endif // FEATURE_COMINTEROP
 
 class InteropSyncBlockInfo
@@ -791,22 +793,65 @@ public:
 #endif
 
 public:
-    bool TryGetManagedObjectComWrapper(_Out_ void** mocw)
+    bool TryGetManagedObjectComWrapper(_In_ INT64 wrapperId, _Out_ void** mocw)
     {
         LIMITED_METHOD_DAC_CONTRACT;
-        *mocw = m_managedObjectComWrapper;
-        return (*mocw != NULL);
+
+        *mocw = NULL;
+        if (m_managedObjectComWrapperMap == NULL)
+            return false;
+
+        CrstHolder lock(&m_managedObjectComWrapperLock);
+        return m_managedObjectComWrapperMap->Lookup(wrapperId, mocw);
     }
 
 #ifndef DACCESS_COMPILE
-    bool TrySetManagedObjectComWrapper(_In_ void* mocw, _In_ void* curr = NULL)
+    bool TrySetManagedObjectComWrapper(_In_ INT64 wrapperId, _In_ void* mocw, _In_ void* curr = NULL)
     {
         LIMITED_METHOD_CONTRACT;
 
-        return (FastInterlockCompareExchangePointer(
-                        &m_managedObjectComWrapper,
-                        mocw,
-                        curr) == curr);
+        if (m_managedObjectComWrapperMap == NULL)
+        {
+            NewHolder<ManagedObjectComWrapperByIdMap> map = new ManagedObjectComWrapperByIdMap();
+            if (FastInterlockCompareExchangePointer((ManagedObjectComWrapperByIdMap**)&m_managedObjectComWrapperMap, (ManagedObjectComWrapperByIdMap *)map, NULL) == NULL)
+            {
+                map.SuppressRelease();
+                m_managedObjectComWrapperLock.Init(CrstLeafLock);
+            }
+
+            _ASSERTE(m_managedObjectComWrapperMap != NULL);
+        }
+
+        CrstHolder lock(&m_managedObjectComWrapperLock);
+
+        if (m_managedObjectComWrapperMap->LookupPtr(wrapperId) != curr)
+            return false;
+
+        m_managedObjectComWrapperMap->Add(wrapperId, mocw);
+        return true;
+    }
+
+    using EnumWrappersCallback = void(void* mocw);
+    void ClearManagedObjectComWrappers(EnumWrappersCallback* callback)
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        if (m_managedObjectComWrapperMap == NULL)
+            return;
+
+        CrstHolder lock(&m_managedObjectComWrapperLock);
+
+        ManagedObjectComWrapperByIdMap::Iterator iter = m_managedObjectComWrapperMap->Begin();
+        if (callback != NULL)
+        {
+            while (iter != m_managedObjectComWrapperMap->End())
+            {
+                callback(iter->Value());
+                ++iter;
+            }
+        }
+
+        m_managedObjectComWrapperMap->RemoveAll();
     }
 #endif // !DACCESS_COMPILE
 
@@ -831,8 +876,11 @@ public:
 
 private:
     // See InteropLib API for usage.
-    void* m_managedObjectComWrapper;
     void* m_externalComObjectContext;
+
+    using ManagedObjectComWrapperByIdMap = MapSHash<INT64, void*>;
+    CrstExplicitInit m_managedObjectComWrapperLock;
+    NewHolder<ManagedObjectComWrapperByIdMap> m_managedObjectComWrapperMap;
 #endif // FEATURE_COMINTEROP
 
 };

--- a/src/coreclr/src/vm/syncblk.h
+++ b/src/coreclr/src/vm/syncblk.h
@@ -841,9 +841,9 @@ public:
 
         CrstHolder lock(&m_managedObjectComWrapperLock);
 
-        ManagedObjectComWrapperByIdMap::Iterator iter = m_managedObjectComWrapperMap->Begin();
         if (callback != NULL)
         {
+            ManagedObjectComWrapperByIdMap::Iterator iter = m_managedObjectComWrapperMap->Begin();
             while (iter != m_managedObjectComWrapperMap->End())
             {
                 callback(iter->Value());


### PR DESCRIPTION
- Assign/track ID of ComWrappers used to create object/wrapper.
- Only reuse object/wrapper created by same instance for GetOrCreate*
- Rehydrate RCW on WeakReference for global ComWrapper instances
  - Local instances do not rehydrate
  - Built-in system rehydrates

Resolves #37492

cc @AaronRobinsonMSFT @jkoritzinsky 