### PR TITLE
Add explicit test for generic argument list with Type.GetType

### DIFF
--- a/src/libraries/System.Reflection/tests/GetTypeTests.cs
+++ b/src/libraries/System.Reflection/tests/GetTypeTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using System.IO;
 using Xunit;
 
 namespace System.Reflection.Tests
@@ -260,6 +261,15 @@ namespace System.Reflection.Tests
             Assert.Equal(typeof(int), Type.GetType("System.Int32", throwOnError: true));
             Assert.Equal(typeof(int), Type.GetType("system.int32", throwOnError: true, ignoreCase: true));
         }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37871", TestRuntimes.Mono)]
+        public void GetType_GenericTypeArgumentList()
+        {
+            Assert.NotNull(Type.GetType("System.Reflection.Tests.GenericClass`1", throwOnError: true));
+            Assert.Equal(typeof(System.Reflection.Tests.GenericClass<System.String>), Type.GetType("System.Reflection.Tests.GenericClass`1[[System.String, System.Private.CoreLib]]", throwOnError: true));
+            Assert.Throws<FileNotFoundException>(() => Type.GetType("System.Reflection.Tests.GenericClass`1[[Bogus, BogusAssembly]]", throwOnError: true));
+        }
     }
 
     namespace MyNamespace1
@@ -307,4 +317,6 @@ namespace System.Reflection.Tests
     }
 
     public class MyClass1 { }
+
+    public class GenericClass<T> { }
 }

--- a/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/AppDomainTests.cs
@@ -909,7 +909,7 @@ namespace System.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/34030", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37871", TestRuntimes.Mono)]
         public void AssemblyResolve_FirstChanceException()
         {
             RemoteExecutor.Invoke(() => {


### PR DESCRIPTION
And disable it for Mono, given our current bug. This is tested indirectly by the other test I've updated, but I think it ought to be more clear.