### PR TITLE
[browser][wasm] Default Debug Write to StdErr

### DIFF
--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -54,7 +54,7 @@ MONO_LIBS = \
 	${SYS_NATIVE_DIR}/libSystem.Native.a
 
 EMCC_FLAGS=--profiling-funcs -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s BINARYEN=1 -s ALIASING_FUNCTION_POINTERS=0 -s NO_EXIT_RUNTIME=1 -s "EXTRA_EXPORTED_RUNTIME_METHODS=['ccall', 'FS_createPath', 'FS_createDataFile', 'cwrap', 'setValue', 'getValue', 'UTF8ToString', 'addFunction']" -s "EXPORTED_FUNCTIONS=['_putchar']" --source-map-base http://example.com  -s WASM_OBJECT_FILES=0 -s FORCE_FILESYSTEM=1 -s USE_ZLIB=1
-EMCC_DEBUG_FLAGS =-g -Os -s ASSERTIONS=1 -DENABLE_NETCORE=1
+EMCC_DEBUG_FLAGS =-g -Os -s ASSERTIONS=1 -DENABLE_NETCORE=1 -DDEBUG=1
 EMCC_RELEASE_FLAGS=-Oz --llvm-opts 2 --llvm-lto 1 -DENABLE_NETCORE=1
 
 #

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -313,12 +313,14 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 {
 	const char *interp_opts = "";
 
-	//monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 0);
-	//monoeg_g_setenv ("MONO_LOG_MASK", "gc", 0);
+#ifdef DEBUG
+	monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 0);
+	monoeg_g_setenv ("MONO_LOG_MASK", "gc", 0);
     // Setting this env var allows Diagnostic.Debug to write to stderr.  In a browser environment this
     // output will be sent to the console.  Right now this is the only way to emit debug logging from
     // corlib assemblies.
 	monoeg_g_setenv ("COMPlus_DebugWriteToStdErr", "1", 0);
+#endif
 #ifdef ENABLE_NETCORE
 	monoeg_g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", 0);
 #endif

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -315,6 +315,7 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 
 	//monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 0);
 	//monoeg_g_setenv ("MONO_LOG_MASK", "gc", 0);
+	monoeg_g_setenv ("COMPlus_DebugWriteToStdErr", "1", 0);
 #ifdef ENABLE_NETCORE
 	monoeg_g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", 0);
 #endif

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -315,6 +315,9 @@ mono_wasm_load_runtime (const char *managed_path, int enable_debugging)
 
 	//monoeg_g_setenv ("MONO_LOG_LEVEL", "debug", 0);
 	//monoeg_g_setenv ("MONO_LOG_MASK", "gc", 0);
+    // Setting this env var allows Diagnostic.Debug to write to stderr.  In a browser environment this
+    // output will be sent to the console.  Right now this is the only way to emit debug logging from
+    // corlib assemblies.
 	monoeg_g_setenv ("COMPlus_DebugWriteToStdErr", "1", 0);
 #ifdef ENABLE_NETCORE
 	monoeg_g_setenv ("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT", "1", 0);


### PR DESCRIPTION
- COMPlus_DebugWriteToStdErr environment variable when set to `1` will write to `stderr` so it show up in the browser console log.