### PR TITLE
[browser][wasm] Fix key already exists error

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -195,7 +195,6 @@ namespace System.Runtime.InteropServices.JavaScript
                 {
                     if (!_rawToJS.TryGetValue(rawObj, out jsObject))
                     {
-                        _rawToJS.Add(jsId, jsObject = new JSObject(jsId, rawObj));
                         _rawToJS.Add(rawObj, jsObject = new JSObject(jsId, rawObj));
                     }
                 }

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Runtime.cs
@@ -196,6 +196,7 @@ namespace System.Runtime.InteropServices.JavaScript
                     if (!_rawToJS.TryGetValue(rawObj, out jsObject))
                     {
                         _rawToJS.Add(jsId, jsObject = new JSObject(jsId, rawObj));
+                        _rawToJS.Add(rawObj, jsObject = new JSObject(jsId, rawObj));
                     }
                 }
             }


### PR DESCRIPTION
- During the last cleanup the key that was added for bridged object was messed up.