### PR TITLE
Enhance DAC to allow getting AssemblyLoadContext for objects

### DIFF
--- a/src/coreclr/src/binder/inc/clrprivbinderassemblyloadcontext.h
+++ b/src/coreclr/src/binder/inc/clrprivbinderassemblyloadcontext.h
@@ -59,11 +59,6 @@ public:
         return &m_appContext;
     }
 
-    inline INT_PTR GetManagedAssemblyLoadContext()
-    {
-        return m_ptrManagedAssemblyLoadContext;
-    }
-
     HRESULT BindUsingPEImage( /* in */ PEImage *pPEImage,
                               /* in */ BOOL fIsNativeImage,
                               /* [retval][out] */ ICLRPrivAssembly **ppAssembly);
@@ -78,8 +73,6 @@ private:
 
     CLRPrivBinderCoreCLR *m_pTPABinder;
 
-    // A long weak GC handle to the managed AssemblyLoadContext
-    INT_PTR m_ptrManagedAssemblyLoadContext;
     // A strong GC handle to the managed AssemblyLoadContext. This handle is set when the unload of the AssemblyLoadContext is initiated
     // to keep the managed AssemblyLoadContext alive until the unload is finished.
     // We still keep the weak handle pointing to the same managed AssemblyLoadContext so that native code can use the handle above 

--- a/src/coreclr/src/binder/inc/clrprivbindercoreclr.h
+++ b/src/coreclr/src/binder/inc/clrprivbindercoreclr.h
@@ -59,23 +59,11 @@ public:
             BINDER_SPACE::Assembly **ppCoreCLRFoundAssembly,
             bool excludeAppPaths);
 
-    INT_PTR GetManagedAssemblyLoadContext()
-    {
-        return m_ptrManagedAssemblyLoadContext;
-    }
-
-    void SetManagedAssemblyLoadContext(INT_PTR ptrManagedTPABinderInstance)
-    {
-        m_ptrManagedAssemblyLoadContext = ptrManagedTPABinderInstance;
-    }
-
     //=========================================================================
     // Internal implementation details
     //-------------------------------------------------------------------------
 private:
     BINDER_SPACE::ApplicationContext m_appContext;
-
-    INT_PTR m_ptrManagedAssemblyLoadContext;
 };
 
 #endif // __CLR_PRIV_BINDER_CORECLR_H__

--- a/src/coreclr/src/debug/daccess/dacfn.cpp
+++ b/src/coreclr/src/debug/daccess/dacfn.cpp
@@ -22,7 +22,6 @@
 #include "gcinterface.h"
 #include "gcinterface.dac.h"
 
-
 DacTableInfo g_dacTableInfo;
 DacGlobals g_dacGlobals;
 

--- a/src/coreclr/src/debug/daccess/dacimpl.h
+++ b/src/coreclr/src/debug/daccess/dacimpl.h
@@ -1204,6 +1204,8 @@ public:
     virtual HRESULT STDMETHODCALLTYPE GetGenerationTableSvr(CLRDATA_ADDRESS heapAddr, unsigned int cGenerations, struct DacpGenerationData *pGenerationData, unsigned int *pNeeded);
     virtual HRESULT STDMETHODCALLTYPE GetFinalizationFillPointersSvr(CLRDATA_ADDRESS heapAddr, unsigned int cFillPointers, CLRDATA_ADDRESS *pFinalizationFillPointers, unsigned int *pNeeded);
 
+    virtual HRESULT STDMETHODCALLTYPE GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDATA_ADDRESS* assemblyLoadContext);
+
     //
     // ClrDataAccess.
     //

--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -4699,3 +4699,29 @@ HRESULT ClrDataAccess::GetFinalizationFillPointersSvr(CLRDATA_ADDRESS heapAddr, 
     SOSDacLeave();
     return hr;
 }
+
+HRESULT ClrDataAccess::GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDATA_ADDRESS* assemblyLoadContext)
+{
+    if (methodTable == 0 || assemblyLoadContext == NULL)
+        return E_INVALIDARG;
+
+    SOSDacEnter();
+    PTR_MethodTable pMT = PTR_MethodTable(TO_TADDR(methodTable));
+    PTR_Module pModule = pMT->GetModule();
+
+    PTR_PEFile pPEFile = pModule->GetFile();
+    PTR_AssemblyLoadContext pAssemblyLoadContext = pPEFile->GetAssemblyLoadContext();
+
+    INT_PTR managedAssemblyLoadContextHandle = pAssemblyLoadContext->GetManagedAssemblyLoadContext();
+
+    TADDR managedAssemblyLoadContextAddr = 0;
+    if (managedAssemblyLoadContextHandle != 0)
+    {
+        DacReadAll(managedAssemblyLoadContextHandle,&managedAssemblyLoadContextAddr,sizeof(TADDR),true);
+    }
+
+    *assemblyLoadContext = TO_CDADDR(managedAssemblyLoadContextAddr);
+
+    SOSDacLeave();
+    return hr;
+}

--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -4706,7 +4706,7 @@ HRESULT ClrDataAccess::GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDA
         return E_INVALIDARG;
 
     SOSDacEnter();
-    PTR_MethodTable pMT = PTR_MethodTable(TO_TADDR(methodTable));
+    PTR_MethodTable pMT = PTR_MethodTable(CLRDATA_ADDRESS_TO_TADDR(methodTable));
     PTR_Module pModule = pMT->GetModule();
 
     PTR_PEFile pPEFile = pModule->GetFile();

--- a/src/coreclr/src/inc/sospriv.idl
+++ b/src/coreclr/src/inc/sospriv.idl
@@ -407,4 +407,6 @@ interface ISOSDacInterface8 : IUnknown
     // SVR
     HRESULT GetGenerationTableSvr(CLRDATA_ADDRESS heapAddr, unsigned int cGenerations, struct DacpGenerationData *pGenerationData, unsigned int *pNeeded);
     HRESULT GetFinalizationFillPointersSvr(CLRDATA_ADDRESS heapAddr, unsigned int cFillPointers, CLRDATA_ADDRESS *pFinalizationFillPointers, unsigned int *pNeeded);
+
+    HRESULT GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDATA_ADDRESS* assemblyLoadContext);
 }

--- a/src/coreclr/src/pal/prebuilt/inc/sospriv.h
+++ b/src/coreclr/src/pal/prebuilt/inc/sospriv.h
@@ -2548,6 +2548,9 @@ EXTERN_C const IID IID_ISOSDacInterface8;
             CLRDATA_ADDRESS *pFinalizationFillPointers,
             unsigned int *pNeeded) = 0;
 
+        virtual HRESULT STDMETHODCALLTYPE GetAssemblyLoadContext(
+            CLRDATA_ADDRESS methodTable,
+            CLRDATA_ADDRESS* assemblyLoadContext) = 0;
     };
 
 
@@ -2599,6 +2602,11 @@ EXTERN_C const IID IID_ISOSDacInterface8;
             CLRDATA_ADDRESS *pFinalizationFillPointers,
             unsigned int *pNeeded);
 
+        HRESULT ( STDMETHODCALLTYPE *GetAssemblyLoadContext )(
+            ISOSDacInterface8 * This,
+            CLRDATA_ADDRESS methodTable,
+            CLRDATA_ADDRESS *assemblyLoadContext);
+           
         END_INTERFACE
     } ISOSDacInterface8Vtbl;
 
@@ -2606,7 +2614,6 @@ EXTERN_C const IID IID_ISOSDacInterface8;
     {
         CONST_VTBL struct ISOSDacInterface8Vtbl *lpVtbl;
     };
-
 
 
 #ifdef COBJMACROS
@@ -2636,6 +2643,9 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 
 #define ISOSDacInterface8_GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) \
     ( (This)->lpVtbl -> GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) )
+
+#define ISOSDacInterface8_GetAssemblyLoadContext(This,methodTable,assemblyLoadContext)	\
+    ( (This)->lpVtbl -> GetAssemblyLoadContext(This,methodTable,assemblyLoadContext) )
 
 #endif /* COBJMACROS */
 

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -4582,9 +4582,9 @@ IUnknown *AppDomain::CreateBinderContext()
         IfFailThrow(CCoreCLRBinderHelper::DefaultBinderSetupContext(DefaultADID, &m_pTPABinderContext));
 
         // Since the PEAssembly for the System.Private.CoreLib.dll is created before the binder (the AssemblyLoadContext),
-        // we need to set the AssemblyLoadContext pointer in that PEAssembly now. For other assemblies, it is
+        // we need to update the AssemblyLoadContext pointer in that PEAssembly now. For other assemblies, it is
         // set in the PEFile constructor.
-        SystemDomain::SystemFile()->SetAssemblyLoadContext(m_pTPABinderContext);
+        SystemDomain::SystemFile()->SetupAssemblyLoadContext();
     }
 
     RETURN m_pTPABinderContext;

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -4580,6 +4580,8 @@ IUnknown *AppDomain::CreateBinderContext()
 
         // Initialize the assembly binder for the default context loads for CoreCLR.
         IfFailThrow(CCoreCLRBinderHelper::DefaultBinderSetupContext(DefaultADID, &m_pTPABinderContext));
+
+        SystemDomain::SystemFile()->SetAssemblyLoadContext(m_pTPABinderContext);
     }
 
     RETURN m_pTPABinderContext;

--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -4581,6 +4581,9 @@ IUnknown *AppDomain::CreateBinderContext()
         // Initialize the assembly binder for the default context loads for CoreCLR.
         IfFailThrow(CCoreCLRBinderHelper::DefaultBinderSetupContext(DefaultADID, &m_pTPABinderContext));
 
+        // Since the PEAssembly for the System.Private.CoreLib.dll is created before the binder (the AssemblyLoadContext),
+        // we need to set the AssemblyLoadContext pointer in that PEAssembly now. For other assemblies, it is
+        // set in the PEFile constructor.
         SystemDomain::SystemFile()->SetAssemblyLoadContext(m_pTPABinderContext);
     }
 

--- a/src/coreclr/src/vm/assemblyloadcontext.h
+++ b/src/coreclr/src/vm/assemblyloadcontext.h
@@ -23,6 +23,24 @@ public:
         /* [retval][out] */ UINT_PTR* pBinderId);
 
     NativeImage *LoadNativeImage(Module *componentModule, LPCUTF8 nativeImageName);
+
+    INT_PTR GetManagedAssemblyLoadContext()
+    {
+        return m_ptrManagedAssemblyLoadContext;
+    }
+
+    void SetManagedAssemblyLoadContext(INT_PTR ptrManagedTPABinderInstance)
+    {
+        m_ptrManagedAssemblyLoadContext = ptrManagedTPABinderInstance;
+    }
+
+protected:
+    // A GC handle to the managed AssemblyLoadContext.
+    // It is a long weak handle for collectible AssemblyLoadContexts and strong handle for non-collectible ones.
+    INT_PTR m_ptrManagedAssemblyLoadContext;
+
+private:
+    SArray<NativeImage *> m_nativeImages;
 };
 
 #endif

--- a/src/coreclr/src/vm/common.h
+++ b/src/coreclr/src/vm/common.h
@@ -112,6 +112,7 @@ typedef DPTR(class ArrayBase)           PTR_ArrayBase;
 typedef DPTR(class Assembly)            PTR_Assembly;
 typedef DPTR(class AssemblyBaseObject)  PTR_AssemblyBaseObject;
 typedef DPTR(class AssemblyLoadContextBaseObject) PTR_AssemblyLoadContextBaseObject;
+typedef DPTR(class AssemblyLoadContext) PTR_AssemblyLoadContext;
 typedef DPTR(class AssemblyNameBaseObject) PTR_AssemblyNameBaseObject;
 typedef VPTR(class BaseDomain)          PTR_BaseDomain;
 typedef DPTR(class ClassLoader)         PTR_ClassLoader;

--- a/src/coreclr/src/vm/pefile.cpp
+++ b/src/coreclr/src/vm/pefile.cpp
@@ -1923,8 +1923,7 @@ PEAssembly::PEAssembly(
     m_pDebugName = m_debugName;
 #endif
 
-    AssemblyLoadContext* pAssemblyLoadContext = LookupAssemblyLoadContext();
-    SetAssemblyLoadContext(pAssemblyLoadContext);
+    SetupAssemblyLoadContext();
 }
 #endif // !DACCESS_COMPILE
 
@@ -2335,7 +2334,7 @@ void PEFile::EnsureImageOpened()
         GetILimage()->GetLayout(PEImageLayout::LAYOUT_ANY,PEImage::LAYOUT_CREATEIFNEEDED)->Release();
 }
 
-AssemblyLoadContext* PEFile::LookupAssemblyLoadContext()
+void PEFile::SetupAssemblyLoadContext()
 {
     PTR_ICLRPrivBinder pBindingContext = GetBindingContext();
     ICLRPrivBinder* pOpaqueBinder = NULL;
@@ -2348,7 +2347,7 @@ AssemblyLoadContext* PEFile::LookupAssemblyLoadContext()
         pOpaqueBinder = reinterpret_cast<ICLRPrivBinder*>(assemblyBinderID);
     }
 
-    return (pOpaqueBinder != NULL) ?
+    m_pAssemblyLoadContext = (pOpaqueBinder != NULL) ?
         (AssemblyLoadContext*)pOpaqueBinder :
         AppDomain::GetCurrentDomain()->GetTPABinderContext();
 }

--- a/src/coreclr/src/vm/pefile.cpp
+++ b/src/coreclr/src/vm/pefile.cpp
@@ -63,9 +63,9 @@ PEFile::PEFile(PEImage *identity) :
     m_pMetadataLock(::new SimpleRWLock(PREEMPTIVE, LOCK_TYPE_DEFAULT)),
     m_refCount(1),
     m_flags(0),
+    m_pAssemblyLoadContext(nullptr),
     m_pHostAssembly(nullptr),
-    m_pFallbackLoadContextBinder(nullptr),
-    m_pAssemblyLoadContext(nullptr)
+    m_pFallbackLoadContextBinder(nullptr)
 {
     CONTRACTL
     {

--- a/src/coreclr/src/vm/pefile.h
+++ b/src/coreclr/src/vm/pefile.h
@@ -479,7 +479,10 @@ protected:
     IMetaDataEmit           *m_pEmitter;
     SimpleRWLock            *m_pMetadataLock;
     Volatile<LONG>           m_refCount;
-    int                     m_flags;
+    int                      m_flags;
+
+    // AssemblyLoadContext that this PEFile is associated with
+    PTR_AssemblyLoadContext  m_pAssemblyLoadContext;
 
 #ifdef DEBUGGING_SUPPORTED
 #ifdef FEATURE_PREJIT
@@ -566,7 +569,19 @@ public:
     // Returns the ICLRPrivBinder* instance associated with the PEFile
     PTR_ICLRPrivBinder GetBindingContext();
 
-    AssemblyLoadContext* GetAssemblyLoadContext();
+#ifndef DACCESS_COMPILE
+    void SetAssemblyLoadContext(AssemblyLoadContext* pAssemblyLoadContext)
+    {
+        m_pAssemblyLoadContext = pAssemblyLoadContext;
+    }
+#endif //!DACCESS_COMPILE
+
+    PTR_AssemblyLoadContext GetAssemblyLoadContext()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_pAssemblyLoadContext;
+    }
 
     bool HasHostAssembly()
     { STATIC_CONTRACT_WRAPPER; return GetHostAssembly() != nullptr; }

--- a/src/coreclr/src/vm/pefile.h
+++ b/src/coreclr/src/vm/pefile.h
@@ -148,6 +148,9 @@ private:
 
 protected:
     IMDInternalImportHolder GetMDImport();
+#ifndef DACCESS_COMPILE
+    AssemblyLoadContext* LookupAssemblyLoadContext();
+#endif // !DACCESS_COMPILE
 
 public:
     // ------------------------------------------------------------
@@ -574,6 +577,14 @@ public:
     {
         m_pAssemblyLoadContext = pAssemblyLoadContext;
     }
+
+    void SetFallbackLoadContextBinder(PTR_ICLRPrivBinder pFallbackLoadContextBinder)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_pFallbackLoadContextBinder = pFallbackLoadContextBinder;
+        SetAssemblyLoadContext(LookupAssemblyLoadContext());
+    }
+
 #endif //!DACCESS_COMPILE
 
     PTR_AssemblyLoadContext GetAssemblyLoadContext()
@@ -588,12 +599,6 @@ public:
 
     bool CanUseWithBindingCache()
     { LIMITED_METHOD_CONTRACT; return !HasHostAssembly(); }
-
-    void SetFallbackLoadContextBinder(PTR_ICLRPrivBinder pFallbackLoadContextBinder)
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_pFallbackLoadContextBinder = pFallbackLoadContextBinder;
-    }
 
     PTR_ICLRPrivBinder GetFallbackLoadContextBinder()
     {

--- a/src/coreclr/src/vm/pefile.h
+++ b/src/coreclr/src/vm/pefile.h
@@ -148,9 +148,6 @@ private:
 
 protected:
     IMDInternalImportHolder GetMDImport();
-#ifndef DACCESS_COMPILE
-    AssemblyLoadContext* LookupAssemblyLoadContext();
-#endif // !DACCESS_COMPILE
 
 public:
     // ------------------------------------------------------------
@@ -573,16 +570,13 @@ public:
     PTR_ICLRPrivBinder GetBindingContext();
 
 #ifndef DACCESS_COMPILE
-    void SetAssemblyLoadContext(AssemblyLoadContext* pAssemblyLoadContext)
-    {
-        m_pAssemblyLoadContext = pAssemblyLoadContext;
-    }
+    void SetupAssemblyLoadContext();
 
     void SetFallbackLoadContextBinder(PTR_ICLRPrivBinder pFallbackLoadContextBinder)
     {
         LIMITED_METHOD_CONTRACT;
         m_pFallbackLoadContextBinder = pFallbackLoadContextBinder;
-        SetAssemblyLoadContext(LookupAssemblyLoadContext());
+        SetupAssemblyLoadContext();
     }
 
 #endif //!DACCESS_COMPILE
@@ -591,6 +585,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
 
+        _ASSERTE(m_pAssemblyLoadContext != NULL);
         return m_pAssemblyLoadContext;
     }
 


### PR DESCRIPTION
This change adds support to DAC for getting AssemblyLoadContext
for a MethodTable. The returned AsseblyLoadContext is the context
into which the related type was loaded.