### PR TITLE
Revert "Fix tizen rootfs build"

### DIFF
--- a/eng/common/cross/armel/tizen-build-rootfs.sh
+++ b/eng/common/cross/armel/tizen-build-rootfs.sh
@@ -9,6 +9,13 @@ if [[ -z "$ROOTFS_DIR" ]]; then
     exit 1;
 fi
 
+# Clean-up (TODO-Cleanup: We may already delete  $ROOTFS_DIR at ./cross/build-rootfs.sh.)
+# hk0110
+if [ -d "$ROOTFS_DIR" ]; then
+    umount $ROOTFS_DIR/*
+    rm -rf $ROOTFS_DIR
+fi
+
 TIZEN_TMP_DIR=$ROOTFS_DIR/tizen_tmp
 mkdir -p $TIZEN_TMP_DIR
 


### PR DESCRIPTION
Reverts dotnet/runtime#37891, it should go to arcade instead