### PR TITLE
Revert updated minimum required sdk

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100-preview.6.20310.4",
+    "version": "5.0.100-preview.5.20251.2",
     "allowPrerelease": true,
     "rollForward": "major"
   },


### PR DESCRIPTION
https://github.com/dotnet/runtime/commit/60845429ba4fc481285b7a724c5c4a802712f27b should have only updated the runtime repo locally aquired sdk, but not the min version. Reverting the min version bump.

cc @safern 