### PR TITLE
Allow X509Certificates to be trimmed in HttpClientHandler.

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -243,7 +243,10 @@ namespace System.Net.Http
                 _underlyingHandler.SendAsync(request, cancellationToken);
         }
 
-        public static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator { get; } = delegate { return true; };
+        // lazy-load the validator func so it can be trimmed by the ILLinker if it isn't used.
+        private static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? s_dangerousAcceptAnyServerCertificateValidator;
+        public static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator =>
+            s_dangerousAcceptAnyServerCertificateValidator ??= delegate { return true; };
 
         private void ThrowForModifiedManagedSslOptionsIfStarted()
         {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -246,7 +246,9 @@ namespace System.Net.Http
         // lazy-load the validator func so it can be trimmed by the ILLinker if it isn't used.
         private static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool>? s_dangerousAcceptAnyServerCertificateValidator;
         public static Func<HttpRequestMessage, X509Certificate2?, X509Chain?, SslPolicyErrors, bool> DangerousAcceptAnyServerCertificateValidator =>
-            s_dangerousAcceptAnyServerCertificateValidator ??= delegate { return true; };
+            Volatile.Read(ref s_dangerousAcceptAnyServerCertificateValidator) ??
+            Interlocked.CompareExchange(ref s_dangerousAcceptAnyServerCertificateValidator, delegate { return true; }, null) ??
+            s_dangerousAcceptAnyServerCertificateValidator;
 
         private void ThrowForModifiedManagedSslOptionsIfStarted()
         {


### PR DESCRIPTION
When DangerousAcceptAnyServerCertificateValidator is never used, the backing static field won't be trimmed by the ILLinker. This will keep empty X509Certificate2 and X509Chain types around, which is the only thing in the X509Certificates assembly.

See https://github.com/mono/linker/issues/1270