### PR TITLE
Replace Create(ulong) with CreateScalar(uint) in PopCount

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/BitOperations.cs
@@ -241,11 +241,7 @@ namespace System.Numerics
             {
                 // PopCount works on vector so convert input value to vector first.
 
-                // Vector64.CreateScalar(uint) generates suboptimal code by storing and
-                // loading the result to memory.
-                // See https://github.com/dotnet/runtime/issues/35976 for details.
-                // Hence use Vector64.Create(ulong) to create Vector64<ulong> and operate on that.
-                Vector64<ulong> input = Vector64.Create((ulong)value);
+                Vector64<uint> input = Vector64.CreateScalar(value);
                 Vector64<byte> aggregated = AdvSimd.Arm64.AddAcross(AdvSimd.PopCount(input.AsByte()));
                 return aggregated.ToScalar();
             }

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -7,6 +7,7 @@ namespace System.Runtime.Intrinsics
     internal static class Vector64
     {
         public static Vector64<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
+        public static Vector64<uint> CreateScalar(uint value) => throw new PlatformNotSupportedException();
         public static Vector64<byte> AsByte<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector64<T>


### PR DESCRIPTION
In `PopCount(uint)` implementation, we were creating `Vector64<ulong>` of input by casting `uint` to `ulong` because of https://github.com/dotnet/runtime/issues/35976. However now that issue is fixed, revert to `Vector.CreateScalar(uint)` because that is more accurate readability wise and we generate equivalent optimal code.

Before:
```asm
G_M46009_IG02:
        2A0003E0          mov     w0, w0
        4E081C10          mov     v16.d[0], x0
        0E205A10          cnt     v16.8b, v16.8b
        0E31BA10          addv    b16, v16.8b
        0E013E00          umov    w0, v16.b[0]
                                                ;; bbWeight=1    PerfScore 5.50
```

After:
```asm
G_M46009_IG02:
        0F000410          movi    v16.2s, #0x00
        4E041C10          ins     v16.s[0], w0
        0E205A10          cnt     v16.8b, v16.8b
        0E31BA10          addv    b16, v16.8b
        0E013E00          umov    w0, v16.b[0]
                                                ;; bbWeight=1    PerfScore 5.50
```