### PR TITLE
[eng] Build Mono Arm64 Release on runtime test builds

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -401,7 +401,6 @@ jobs:
     buildConfig: release
     platforms:
     - Linux_x64
-    - Linux_arm64
     # - Linux_musl_arm64
     - Windows_NT_x64
     # - Windows_NT_x86
@@ -425,6 +424,7 @@ jobs:
     buildConfig: release
     platforms:
     - OSX_x64
+    - Linux_arm64
     jobParameters:
       condition: >-
         or(


### PR DESCRIPTION
This change will build Mono on Arm64 if the runtime tests are changed. This is required so that the runtime tests will run on arm64 if the tests are changed. 