### PR TITLE
enable crossgen2 composite with extended timeout

### DIFF
--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -152,7 +152,7 @@
       <PayloadDirectory>$(WorkItemDirectory)\ScenarioCorrelation</PayloadDirectory>
       <Command>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\test.py crossgen2 --single System.Private.CoreLib.dll --core-root %HELIX_CORRELATION_PAYLOAD%\Core_Root</Command>
     </HelixWorkItem>
-    <HelixWorkItem Include="Crossgen2 Composite Framework R2R">	
+    <HelixWorkItem Include="Crossgen2 Composite Framework R2R">
       <PayloadDirectory>$(WorkItemDirectory)\ScenarioCorrelation</PayloadDirectory>	
       <Command>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\test.py crossgen2 --composite %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\framework-r2r.dll.rsp --core-root %HELIX_CORRELATION_PAYLOAD%\Core_Root</Command>	
       <Timeout>1:00</Timeout>  

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -155,7 +155,7 @@
     <HelixWorkItem Include="Crossgen2 Composite Framework R2R">
       <PayloadDirectory>$(WorkItemDirectory)\ScenarioCorrelation</PayloadDirectory>	
       <Command>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\test.py crossgen2 --composite %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\framework-r2r.dll.rsp --core-root %HELIX_CORRELATION_PAYLOAD%\Core_Root</Command>	
-      <Timeout>1:00</Timeout>  
+      <Timeout>1:00</Timeout>
     </HelixWorkItem>
 
   </ItemGroup>

--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -152,6 +152,11 @@
       <PayloadDirectory>$(WorkItemDirectory)\ScenarioCorrelation</PayloadDirectory>
       <Command>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\test.py crossgen2 --single System.Private.CoreLib.dll --core-root %HELIX_CORRELATION_PAYLOAD%\Core_Root</Command>
     </HelixWorkItem>
+    <HelixWorkItem Include="Crossgen2 Composite Framework R2R">	
+      <PayloadDirectory>$(WorkItemDirectory)\ScenarioCorrelation</PayloadDirectory>	
+      <Command>$(Python) %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\test.py crossgen2 --composite %HELIX_CORRELATION_PAYLOAD%\performance\src\scenarios\crossgen2\framework-r2r.dll.rsp --core-root %HELIX_CORRELATION_PAYLOAD%\Core_Root</Command>	
+      <Timeout>1:00</Timeout>  
+    </HelixWorkItem>
 
   </ItemGroup>
 </Project>

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -86,7 +86,7 @@ if ($RunFromPerformanceRepo) {
     robocopy $SourceDirectory $PerformanceDirectory /E /XD $PayloadDirectory $SourceDirectory\artifacts $SourceDirectory\.git
 }
 else {
-    git clone --branch master --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
+    git clone --branch output-to-folder --depth 1 --quiet https://github.com/ooooolivia/performance $PerformanceDirectory
 }
 
 if($MonoDotnet -ne "")

--- a/eng/common/performance/performance-setup.ps1
+++ b/eng/common/performance/performance-setup.ps1
@@ -86,7 +86,7 @@ if ($RunFromPerformanceRepo) {
     robocopy $SourceDirectory $PerformanceDirectory /E /XD $PayloadDirectory $SourceDirectory\artifacts $SourceDirectory\.git
 }
 else {
-    git clone --branch output-to-folder --depth 1 --quiet https://github.com/ooooolivia/performance $PerformanceDirectory
+    git clone --branch master --depth 1 --quiet https://github.com/dotnet/performance $PerformanceDirectory
 }
 
 if($MonoDotnet -ne "")


### PR DESCRIPTION
The previous issue that caused crossgen2 composite scenario failure was the short timeout, so it's automatically killed by Helix.  Adding the workitem back with extended timeout. Will update the file in Arcade as well when the test PR builds are stable here. 