### PR TITLE
Optimize byte variants of IndexOfAny()

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -43,7 +43,7 @@ namespace System
                     break;  // The unsearched portion is now shorter than the sequence we're looking for. So it can't be there.
 
                 // Found the first element of "value". See if the tail matches.
-                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, offset + 1), ref valueTail, (nuint)valueTailLength))  // The (nunit)-cast is necessary to pick the correct overload
+                if (SequenceEqual(ref Unsafe.Add(ref searchSpace, offset + 1), ref valueTail, (nuint)valueTailLength))  // The (nuint)-cast is necessary to pick the correct overload
                     return offset;  // The tail matched. Return a successful find.
 
                 remainingSearchSpaceLength--;
@@ -601,7 +601,7 @@ namespace System
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
             nuint lengthToExamine = (nuint)(uint)length;
 
-            if (Sse2.IsSupported)
+            if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
@@ -780,6 +780,47 @@ namespace System
                     }
                 }
             }
+            else if (AdvSimd.Arm64.IsSupported)
+            {
+                if (offset < (nuint)(uint)length)
+                {
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+
+                    // Mask to help find the first lane in compareResult that is set.
+                    // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
+                    Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
+                    int matchedLane = 0;
+
+                    Vector128<byte> values0 = Vector128.Create(value0);
+                    Vector128<byte> values1 = Vector128.Create(value1);
+
+                    while (lengthToExamine > offset)
+                    {
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        Vector128<byte> compareResult = AdvSimd.Or(
+                            AdvSimd.CompareEqual(values0, search),
+                            AdvSimd.CompareEqual(values1, search));
+
+                        if (!TryFindFirstMatchedLane(mask, compareResult, ref matchedLane))
+                        {
+                            // Zero flags set so no matches
+                            offset += (nuint)Vector128<byte>.Count;
+                            continue;
+                        }
+
+                        // Find bitflag offset of first match and add to current offset
+                        return (int)(offset + (uint)matchedLane);
+                    }
+
+                    if (offset < (nuint)(uint)length)
+                    {
+                        lengthToExamine = ((nuint)(uint)length - offset);
+                        goto SequentialScan;
+                    }
+                }
+            }
             else if (Vector.IsHardwareAccelerated)
             {
                 if (offset < (nuint)(uint)length)
@@ -842,7 +883,7 @@ namespace System
             nuint offset = 0; // Use nuint for arithmetic to avoid unnecessary 64->32->64 truncations
             nuint lengthToExamine = (nuint)(uint)length;
 
-            if (Sse2.IsSupported)
+            if (Sse2.IsSupported || AdvSimd.Arm64.IsSupported)
             {
                 // Avx2 branch also operates on Sse2 sizes, so check is combined.
                 if (length >= Vector128<byte>.Count * 2)
@@ -1016,6 +1057,50 @@ namespace System
 
                         // Find bitflag offset of first match and add to current offset
                         return (int)(offset + (uint)BitOperations.TrailingZeroCount(matches));
+                    }
+
+                    if (offset < (nuint)(uint)length)
+                    {
+                        lengthToExamine = ((nuint)(uint)length - offset);
+                        goto SequentialScan;
+                    }
+                }
+            }
+            else if (AdvSimd.Arm64.IsSupported)
+            {
+                if (offset < (nuint)(uint)length)
+                {
+                    lengthToExamine = GetByteVector128SpanLength(offset, length);
+
+                    // Mask to help find the first lane in compareResult that is set.
+                    // LSB 0x01 corresponds to lane 0, 0x10 - to lane 1, and so on.
+                    Vector128<byte> mask = Vector128.Create((ushort)0x1001).AsByte();
+                    int matchedLane = 0;
+
+                    Vector128<byte> values0 = Vector128.Create(value0);
+                    Vector128<byte> values1 = Vector128.Create(value1);
+                    Vector128<byte> values2 = Vector128.Create(value2);
+
+                    while (lengthToExamine > offset)
+                    {
+                        Vector128<byte> search = LoadVector128(ref searchSpace, offset);
+
+                        // Same method as above
+                        Vector128<byte> matches0 = AdvSimd.CompareEqual(values0, search);
+                        Vector128<byte> matches1 = AdvSimd.CompareEqual(values1, search);
+                        Vector128<byte> matches2 = AdvSimd.CompareEqual(values2, search);
+
+                        Vector128<byte> compareResult = AdvSimd.Or(AdvSimd.Or(matches0, matches1), matches2);
+
+                        if (!TryFindFirstMatchedLane(mask, compareResult, ref matchedLane))
+                        {
+                            // Zero flags set so no matches
+                            offset += (nuint)Vector128<byte>.Count;
+                            continue;
+                        }
+
+                        // Find bitflag offset of first match and add to current offset
+                        return (int)(offset + (uint)matchedLane);
                     }
 
                     if (offset < (nuint)(uint)length)


### PR DESCRIPTION
Optimize following APIs from `System.SpanHelpers` using ARM64 hardware intrinsics:
* IndexOfAny(byte value0, byte value1)
* IndexOfAny(byte value0, byte value1, byte value2)

| Method                 | BEFORE      | AFTER       | Diff |
|---------------------|-------------|-------------|-----|
| IndexOfAnyTwoValues <byte>   | 74.94       | 69.16       | -8%  |
| IndexOfAnyThreeValues  <byte>  | 81.69       | 76.13       | -7%  |

The optimization done is similar to what done for `IndexOf` in https://github.com/dotnet/runtime/pull/37624. The lower performance improvement is because earlier the code would have taken `Vector.IsHardwareAccelerated` path which does decent job in finding the first matching index.

Contributes to #33308 and #33707.