### PR TITLE
Add IncrementalHash.GetCurrentHash

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/HashProvider.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/HashProvider.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 
 namespace Internal.Cryptography
 {
@@ -34,9 +35,31 @@ namespace Internal.Cryptography
         public abstract void AppendHashData(ReadOnlySpan<byte> data);
 
         // Compute the hash based on the appended data and resets the HashProvider for more hashing.
-        public abstract byte[] FinalizeHashAndReset();
+        public abstract int FinalizeHashAndReset(Span<byte> destination);
 
-        public abstract bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten);
+        public abstract int GetCurrentHash(Span<byte> destination);
+
+        public byte[] FinalizeHashAndReset()
+        {
+            byte[] ret = new byte[HashSizeInBytes];
+
+            int written = FinalizeHashAndReset(ret);
+            Debug.Assert(written == HashSizeInBytes);
+
+            return ret;
+        }
+
+        public bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
+        {
+            if (destination.Length < HashSizeInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = FinalizeHashAndReset(destination);
+            return true;
+        }
 
         // Returns the length of the byte array returned by FinalizeHashAndReset.
         public abstract int HashSizeInBytes { get; }

--- a/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/HashProviderCng.cs
@@ -81,22 +81,9 @@ namespace Internal.Cryptography
             }
         }
 
-        public sealed override byte[] FinalizeHashAndReset()
+        public override int FinalizeHashAndReset(Span<byte> destination)
         {
-            var hash = new byte[_hashSize];
-            bool success = TryFinalizeHashAndReset(hash, out int bytesWritten);
-            Debug.Assert(success);
-            Debug.Assert(hash.Length == bytesWritten);
-            return hash;
-        }
-
-        public override bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
-        {
-            if (destination.Length < _hashSize)
-            {
-                bytesWritten = 0;
-                return false;
-            }
+            Debug.Assert(destination.Length >= _hashSize);
 
             Debug.Assert(_hHash != null);
             NTSTATUS ntStatus = Interop.BCrypt.BCryptFinishHash(_hHash, destination, _hashSize, 0);
@@ -105,9 +92,27 @@ namespace Internal.Cryptography
                 throw Interop.BCrypt.CreateCryptographicException(ntStatus);
             }
 
-            bytesWritten = _hashSize;
             ResetHashObject();
-            return true;
+            return _hashSize;
+        }
+
+        public override int GetCurrentHash(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length >= _hashSize);
+
+            Debug.Assert(_hHash != null);
+
+            using (SafeBCryptHashHandle tmpHash = Interop.BCrypt.BCryptDuplicateHash(_hHash))
+            {
+                NTSTATUS ntStatus = Interop.BCrypt.BCryptFinishHash(tmpHash, destination, _hashSize, 0);
+
+                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                {
+                    throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+                }
+
+                return _hashSize;
+            }
         }
 
         public sealed override void Dispose(bool disposing)

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Digest.cs
@@ -16,17 +16,23 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCreate")]
         internal static extern SafeDigestCtxHandle DigestCreate(PAL_HashAlgorithm algorithm, out int cbDigest);
 
-        internal static int DigestUpdate(SafeDigestCtxHandle ctx, ReadOnlySpan<byte> pbData, int cbData) =>
-            DigestUpdate(ctx, ref MemoryMarshal.GetReference(pbData), cbData);
+        internal static int DigestUpdate(SafeDigestCtxHandle ctx, ReadOnlySpan<byte> data) =>
+            DigestUpdate(ctx, ref MemoryMarshal.GetReference(data), data.Length);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestUpdate")]
         private static extern int DigestUpdate(SafeDigestCtxHandle ctx, ref byte pbData, int cbData);
 
-        internal static int DigestFinal(SafeDigestCtxHandle ctx, Span<byte> pbOutput, int cbOutput) =>
-            DigestFinal(ctx, ref MemoryMarshal.GetReference(pbOutput), cbOutput);
+        internal static int DigestFinal(SafeDigestCtxHandle ctx, Span<byte> output) =>
+            DigestFinal(ctx, ref MemoryMarshal.GetReference(output), output.Length);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestFinal")]
         private static extern int DigestFinal(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
+
+        internal static int DigestCurrent(SafeDigestCtxHandle ctx, Span<byte> output) =>
+            DigestCurrent(ctx, ref MemoryMarshal.GetReference(output), output.Length);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_DigestCurrent")]
+        private static extern int DigestCurrent(SafeDigestCtxHandle ctx, ref byte pbOutput, int cbOutput);
     }
 }
 

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Hmac.cs
@@ -19,17 +19,23 @@ internal static partial class Interop
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacInit")]
         internal static extern unsafe int HmacInit(SafeHmacHandle ctx, [In] byte[] pbKey, int cbKey);
 
-        internal static int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> pbData, int cbData) =>
-            HmacUpdate(ctx, ref MemoryMarshal.GetReference(pbData), cbData);
+        internal static int HmacUpdate(SafeHmacHandle ctx, ReadOnlySpan<byte> data) =>
+            HmacUpdate(ctx, ref MemoryMarshal.GetReference(data), data.Length);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacUpdate")]
         private static extern int HmacUpdate(SafeHmacHandle ctx, ref byte pbData, int cbData);
 
-        internal static int HmacFinal(SafeHmacHandle ctx, ReadOnlySpan<byte> pbOutput, int cbOutput) =>
-            HmacFinal(ctx, ref MemoryMarshal.GetReference(pbOutput), cbOutput);
+        internal static int HmacFinal(SafeHmacHandle ctx, ReadOnlySpan<byte> output) =>
+            HmacFinal(ctx, ref MemoryMarshal.GetReference(output), output.Length);
 
         [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacFinal")]
-        private static extern unsafe int HmacFinal(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
+        private static extern int HmacFinal(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
+
+        internal static int HmacCurrent(SafeHmacHandle ctx, ReadOnlySpan<byte> output) =>
+            HmacCurrent(ctx, ref MemoryMarshal.GetReference(output), output.Length);
+
+        [DllImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_HmacCurrent")]
+        private static extern int HmacCurrent(SafeHmacHandle ctx, ref byte pbOutput, int cbOutput);
     }
 }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
@@ -28,9 +28,11 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
         internal static extern int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestCurrent")]
+        internal static extern int EvpDigestCurrent(SafeEvpMdCtxHandle ctx, ref byte md, ref uint s);
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdSize")]
         internal static extern int EvpMdSize(IntPtr md);
-
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMd5")]
         internal static extern IntPtr EvpMd5();

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
@@ -27,5 +27,8 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
         internal static extern int HmacFinal(SafeHmacCtxHandle ctx, ref byte data, ref int len);
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCurrent")]
+        internal static extern int HmacCurrent(SafeHmacCtxHandle ctx, ref byte data, ref int len);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptDuplicateHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptDuplicateHash.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class BCrypt
+    {
+        internal static SafeBCryptHashHandle BCryptDuplicateHash(SafeBCryptHashHandle hHash)
+        {
+            SafeBCryptHashHandle newHash;
+            NTSTATUS status = BCryptDuplicateHash(hHash, out newHash, IntPtr.Zero, 0, 0);
+
+            if (status != NTSTATUS.STATUS_SUCCESS)
+            {
+                newHash.Dispose();
+                throw CreateCryptographicException(status);
+            }
+
+            return newHash;
+        }
+
+        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        private static extern NTSTATUS BCryptDuplicateHash(
+            SafeBCryptHashHandle hHash,
+            out SafeBCryptHashHandle phNewHash,
+            IntPtr pbHashObject,
+            int cbHashObject,
+            int dwFlags);
+    }
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.c
@@ -163,3 +163,12 @@ int32_t AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t 
             return -2;
     }
 }
+
+int32_t AppleCryptoNative_DigestCurrent(const DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput)
+{
+    if (ctx == NULL || pOutput == NULL || cbOutput < ctx->cbDigest)
+        return -1;
+
+    DigestCtx dup = *ctx;
+    return AppleCryptoNative_DigestFinal(&dup, pOutput, cbOutput);
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_digest.h
@@ -50,3 +50,10 @@ Complete the digest in ctx, copying the results to pOutput, and reset ctx for a 
 Returns 1 on success, 0 on failure, any other value on invalid inputs/state.
 */
 PALEXPORT int32_t AppleCryptoNative_DigestFinal(DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput);
+
+/*
+Get the digest of the data already loaded into ctx, without resetting ctx.
+
+Returns 1 on success, 0 on failure, any other value on invalid inputs/state.
+*/
+PALEXPORT int32_t AppleCryptoNative_DigestCurrent(const DigestCtx* ctx, uint8_t* pOutput, int32_t cbOutput);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.c
@@ -112,3 +112,12 @@ int32_t AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput)
     CCHmacFinal(&ctx->hmac, pbOutput);
     return 1;
 }
+
+int32_t AppleCryptoNative_HmacCurrent(const HmacCtx* ctx, uint8_t* pbOutput)
+{
+    if (ctx == NULL || pbOutput == NULL)
+        return 0;
+    
+    HmacCtx dup = *ctx;
+    return AppleCryptoNative_HmacFinal(&dup, pbOutput);
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_hmac.h
@@ -45,3 +45,10 @@ Complete the HMAC and copy the result into pbOutput.
 Returns 1 on success, 0 on error.
 */
 PALEXPORT int32_t AppleCryptoNative_HmacFinal(HmacCtx* ctx, uint8_t* pbOutput);
+
+/*
+Computes the HMAC of the accumulated data in ctx without resetting the state.
+
+Returns 1 on success, 0 on error.
+*/
+PALEXPORT int32_t AppleCryptoNative_HmacCurrent(const HmacCtx* ctx, uint8_t* pbOutput);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -340,7 +340,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(EVP_DigestUpdate) \
     REQUIRED_FUNCTION(EVP_get_digestbyname) \
     REQUIRED_FUNCTION(EVP_md5) \
-    REQUIRED_FUNCTION(EVP_MD_CTX_copy) \
+    REQUIRED_FUNCTION(EVP_MD_CTX_copy_ex) \
     RENAMED_FUNCTION(EVP_MD_CTX_free, EVP_MD_CTX_destroy) \
     RENAMED_FUNCTION(EVP_MD_CTX_new, EVP_MD_CTX_create) \
     REQUIRED_FUNCTION(EVP_MD_size) \
@@ -732,7 +732,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_DigestUpdate EVP_DigestUpdate_ptr
 #define EVP_get_digestbyname EVP_get_digestbyname_ptr
 #define EVP_md5 EVP_md5_ptr
-#define EVP_MD_CTX_copy EVP_MD_CTX_copy_ptr
+#define EVP_MD_CTX_copy_ex EVP_MD_CTX_copy_ex_ptr
 #define EVP_MD_CTX_free EVP_MD_CTX_free_ptr
 #define EVP_MD_CTX_new EVP_MD_CTX_new_ptr
 #define EVP_MD_size EVP_MD_size_ptr

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -340,6 +340,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(EVP_DigestUpdate) \
     REQUIRED_FUNCTION(EVP_get_digestbyname) \
     REQUIRED_FUNCTION(EVP_md5) \
+    REQUIRED_FUNCTION(EVP_MD_CTX_copy) \
     RENAMED_FUNCTION(EVP_MD_CTX_free, EVP_MD_CTX_destroy) \
     RENAMED_FUNCTION(EVP_MD_CTX_new, EVP_MD_CTX_create) \
     REQUIRED_FUNCTION(EVP_MD_size) \
@@ -366,6 +367,7 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     REQUIRED_FUNCTION(EXTENDED_KEY_USAGE_free) \
     REQUIRED_FUNCTION(GENERAL_NAMES_free) \
     LEGACY_FUNCTION(HMAC_CTX_cleanup) \
+    REQUIRED_FUNCTION(HMAC_CTX_copy) \
     FALLBACK_FUNCTION(HMAC_CTX_free) \
     LEGACY_FUNCTION(HMAC_CTX_init) \
     FALLBACK_FUNCTION(HMAC_CTX_new) \
@@ -730,6 +732,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EVP_DigestUpdate EVP_DigestUpdate_ptr
 #define EVP_get_digestbyname EVP_get_digestbyname_ptr
 #define EVP_md5 EVP_md5_ptr
+#define EVP_MD_CTX_copy EVP_MD_CTX_copy_ptr
 #define EVP_MD_CTX_free EVP_MD_CTX_free_ptr
 #define EVP_MD_CTX_new EVP_MD_CTX_new_ptr
 #define EVP_MD_size EVP_MD_size_ptr
@@ -756,6 +759,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #define EXTENDED_KEY_USAGE_free EXTENDED_KEY_USAGE_free_ptr
 #define GENERAL_NAMES_free GENERAL_NAMES_free_ptr
 #define HMAC_CTX_cleanup HMAC_CTX_cleanup_ptr
+#define HMAC_CTX_copy HMAC_CTX_copy_ptr
 #define HMAC_CTX_free HMAC_CTX_free_ptr
 #define HMAC_CTX_init HMAC_CTX_init_ptr
 #define HMAC_CTX_new HMAC_CTX_new_ptr

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
@@ -71,7 +71,7 @@ EVP_MD_CTX* CryptoNative_EvpDup(const EVP_MD_CTX* ctx)
         return NULL;
     }
 
-    if (!EVP_MD_CTX_copy(dup, ctx))
+    if (!EVP_MD_CTX_copy_ex(dup, ctx))
     {
         EVP_MD_CTX_free(dup);
         return NULL;

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
@@ -57,7 +57,7 @@ int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
     return ret;
 }
 
-EVP_MD_CTX* CryptoNative_EvpDup(const EVP_MD_CTX* ctx)
+static EVP_MD_CTX* CryptoNative_EvpDup(const EVP_MD_CTX* ctx)
 {
     if (ctx == NULL)
     {

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.c
@@ -57,6 +57,43 @@ int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
     return ret;
 }
 
+EVP_MD_CTX* CryptoNative_EvpDup(const EVP_MD_CTX* ctx)
+{
+    if (ctx == NULL)
+    {
+        return NULL;
+    }
+
+    EVP_MD_CTX* dup = EVP_MD_CTX_new();
+
+    if (dup == NULL)
+    {
+        return NULL;
+    }
+
+    if (!EVP_MD_CTX_copy(dup, ctx))
+    {
+        EVP_MD_CTX_free(dup);
+        return NULL;
+    }
+
+    return dup;
+}
+
+int32_t CryptoNative_EvpDigestCurrent(const EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
+{
+    EVP_MD_CTX* dup = CryptoNative_EvpDup(ctx);
+
+    if (dup != NULL)
+    {
+        int ret = CryptoNative_EvpDigestFinalEx(dup, md, s);
+        EVP_MD_CTX_free(dup);
+        return ret;
+    }
+
+    return 0;
+}
+
 int32_t CryptoNative_EvpMdSize(const EVP_MD* md)
 {
     return EVP_MD_size(md);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
@@ -52,6 +52,22 @@ PALEXPORT int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, ui
 
 /*
 Function:
+EvpDup
+
+Returns an EVP_MD_CTX* representing the same state as ctx.
+*/
+PALEXPORT EVP_MD_CTX* CryptoNative_EvpDup(const EVP_MD_CTX* ctx);
+
+/*
+Function:
+EvpDigestCurrent
+
+Shims EVP_DigestFinal_ex on a duplicated value of ctx.
+*/
+PALEXPORT int32_t CryptoNative_EvpDigestCurrent(const EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s);
+
+/*
+Function:
 EvpMdSize
 
 Direct shim to EVP_MD_size.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_evp.h
@@ -52,14 +52,6 @@ PALEXPORT int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, ui
 
 /*
 Function:
-EvpDup
-
-Returns an EVP_MD_CTX* representing the same state as ctx.
-*/
-PALEXPORT EVP_MD_CTX* CryptoNative_EvpDup(const EVP_MD_CTX* ctx);
-
-/*
-Function:
 EvpDigestCurrent
 
 Shims EVP_DigestFinal_ex on a duplicated value of ctx.

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
@@ -85,7 +85,7 @@ int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len)
     return ret;
 }
 
-HMAC_CTX* CryptoNative_HmacDup(const HMAC_CTX* ctx)
+static HMAC_CTX* CryptoNative_HmacDup(const HMAC_CTX* ctx)
 {
     assert(ctx != NULL);
 

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.c
@@ -84,3 +84,50 @@ int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len)
     *len = Uint32ToInt32(unsignedLen);
     return ret;
 }
+
+HMAC_CTX* CryptoNative_HmacDup(const HMAC_CTX* ctx)
+{
+    assert(ctx != NULL);
+
+    HMAC_CTX* dup = HMAC_CTX_new();
+
+    if (dup == NULL)
+    {
+        return NULL;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-qual"
+    if (!HMAC_CTX_copy(dup, (HMAC_CTX*)ctx))
+#pragma clang diagnostic pop
+    {
+        HMAC_CTX_free(dup);
+        return NULL;
+    }
+
+    return dup;
+}
+
+int32_t CryptoNative_HmacCurrent(const HMAC_CTX* ctx, uint8_t* md, int32_t* len)
+{
+    assert(ctx != NULL);
+    assert(len != NULL);
+    assert(md != NULL || *len == 0);
+    assert(*len >= 0);
+
+    if (len == NULL || *len < 0)
+    {
+        return 0;
+    }
+
+    HMAC_CTX* dup = CryptoNative_HmacDup(ctx);
+
+    if (dup != NULL)
+    {
+        int ret = CryptoNative_HmacFinal(dup, md, len);
+        HMAC_CTX_free(dup);
+        return ret;
+    }
+
+    return 0;
+}

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
@@ -63,3 +63,17 @@ PALEXPORT int32_t CryptoNative_HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, in
  * Returns 1 for success or 0 for failure. (Always succeeds on platforms where HMAC_Update returns void.)
  */
 PALEXPORT int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len);
+
+/**
+ * Duplicates the state of an HMAC_CTX into a new HMAC_CTX.
+ *
+ * Returns the duplicated HMAC_CTX on success, NULL on failure.
+ */
+PALEXPORT HMAC_CTX* CryptoNative_HmacDup(const HMAC_CTX* ctx);
+
+/**
+ * Retrieves the HMAC for the data already accumulated in ctx without finalizing the state.
+ *
+ * Returns 1 for success or 0 for failure.
+ */
+PALEXPORT int32_t CryptoNative_HmacCurrent(const HMAC_CTX* ctx, uint8_t* md, int32_t* len);

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/pal_hmac.h
@@ -65,13 +65,6 @@ PALEXPORT int32_t CryptoNative_HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, in
 PALEXPORT int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len);
 
 /**
- * Duplicates the state of an HMAC_CTX into a new HMAC_CTX.
- *
- * Returns the duplicated HMAC_CTX on success, NULL on failure.
- */
-PALEXPORT HMAC_CTX* CryptoNative_HmacDup(const HMAC_CTX* ctx);
-
-/**
  * Retrieves the HMAC for the data already accumulated in ctx without finalizing the state.
  *
  * Returns 1 for success or 0 for failure.

--- a/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/ref/System.Security.Cryptography.Algorithms.cs
@@ -465,13 +465,18 @@ namespace System.Security.Cryptography
     {
         internal IncrementalHash() { }
         public System.Security.Cryptography.HashAlgorithmName AlgorithmName { get { throw null; } }
+        public int HashLengthInBytes { get { throw null; } }
         public void AppendData(byte[] data) { }
         public void AppendData(byte[] data, int offset, int count) { }
         public void AppendData(System.ReadOnlySpan<byte> data) { }
         public static System.Security.Cryptography.IncrementalHash CreateHash(System.Security.Cryptography.HashAlgorithmName hashAlgorithm) { throw null; }
         public static System.Security.Cryptography.IncrementalHash CreateHMAC(System.Security.Cryptography.HashAlgorithmName hashAlgorithm, byte[] key) { throw null; }
         public void Dispose() { }
+        public byte[] GetCurrentHash() { throw null; }
+        public int GetCurrentHash(System.Span<byte> destination) { throw null; }
         public byte[] GetHashAndReset() { throw null; }
+        public int GetHashAndReset(System.Span<byte> destination) { throw null; }
+        public bool TryGetCurrentHash(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public bool TryGetHashAndReset(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
     public abstract partial class MaskGenerationMethod

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HMACCommon.cs
@@ -41,6 +41,7 @@ namespace Internal.Cryptography
         }
 
         public int HashSizeInBits => _hMacProvider.HashSizeInBytes * 8;
+        public int HashSizeInBytes => _hMacProvider.HashSizeInBytes;
 
         public void ChangeKey(byte[] key)
         {
@@ -88,8 +89,14 @@ namespace Internal.Cryptography
         public byte[] FinalizeHashAndReset() =>
             _hMacProvider.FinalizeHashAndReset();
 
+        public int FinalizeHashAndReset(Span<byte> destination) =>
+            _hMacProvider.FinalizeHashAndReset(destination);
+
         public bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten) =>
             _hMacProvider.TryFinalizeHashAndReset(destination, out bytesWritten);
+
+        public int GetCurrentHash(Span<byte> destination) =>
+            _hMacProvider.GetCurrentHash(destination);
 
         public void Dispose(bool disposing)
         {

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Android.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Android.cs
@@ -63,12 +63,12 @@ namespace Internal.Cryptography
                 throw new NotImplementedException();
             }
 
-            public override byte[] FinalizeHashAndReset()
+            public override int FinalizeHashAndReset(Span<byte> destination)
             {
                 throw new NotImplementedException();
             }
 
-            public override bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
+            public override int GetCurrentHash(Span<byte> destination)
             {
                 throw new NotImplementedException();
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.OSX.cs
@@ -93,7 +93,7 @@ namespace Internal.Cryptography
                     SetKey();
                 }
 
-                if (Interop.AppleCrypto.HmacUpdate(_ctx, data, data.Length) != 1)
+                if (Interop.AppleCrypto.HmacUpdate(_ctx, data) != 1)
                 {
                     throw new CryptographicException();
                 }
@@ -109,36 +109,39 @@ namespace Internal.Cryptography
                 _running = true;
             }
 
-            public override unsafe byte[] FinalizeHashAndReset()
+            public override unsafe int FinalizeHashAndReset(Span<byte> destination)
             {
-                var output = new byte[HashSizeInBytes];
-                bool success = TryFinalizeHashAndReset(output, out int bytesWritten);
-                Debug.Assert(success);
-                Debug.Assert(bytesWritten == output.Length);
-                return output;
-            }
-
-            public override bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
-            {
-                if (destination.Length < HashSizeInBytes)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
+                Debug.Assert(destination.Length >= HashSizeInBytes);
 
                 if (!_running)
                 {
                     SetKey();
                 }
 
-                if (Interop.AppleCrypto.HmacFinal(_ctx, destination, destination.Length) != 1)
+                if (Interop.AppleCrypto.HmacFinal(_ctx, destination) != 1)
                 {
                     throw new CryptographicException();
                 }
 
-                bytesWritten = HashSizeInBytes;
                 _running = false;
-                return true;
+                return HashSizeInBytes;
+            }
+
+            public override unsafe int GetCurrentHash(Span<byte> destination)
+            {
+                Debug.Assert(destination.Length >= HashSizeInBytes);
+
+                if (!_running)
+                {
+                    SetKey();
+                }
+
+                if (Interop.AppleCrypto.HmacCurrent(_ctx, destination) != 1)
+                {
+                    throw new CryptographicException();
+                }
+
+                return HashSizeInBytes;
             }
 
             public override void Dispose(bool disposing)
@@ -182,7 +185,8 @@ namespace Internal.Cryptography
 
             public override void AppendHashData(ReadOnlySpan<byte> data)
             {
-                int ret = Interop.AppleCrypto.DigestUpdate(_ctx, data, data.Length);
+                int ret = Interop.AppleCrypto.DigestUpdate(_ctx, data);
+
                 if (ret != 1)
                 {
                     Debug.Assert(ret == 0, $"DigestUpdate return value {ret} was not 0 or 1");
@@ -190,32 +194,34 @@ namespace Internal.Cryptography
                 }
             }
 
-            public override byte[] FinalizeHashAndReset()
+            public override int FinalizeHashAndReset(Span<byte> destination)
             {
-                var hash = new byte[HashSizeInBytes];
-                bool success = TryFinalizeHashAndReset(hash, out int bytesWritten);
-                Debug.Assert(success);
-                Debug.Assert(bytesWritten == hash.Length);
-                return hash;
-            }
+                Debug.Assert(destination.Length >= HashSizeInBytes);
 
-            public override bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
-            {
-                if (destination.Length < HashSizeInBytes)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
+                int ret = Interop.AppleCrypto.DigestFinal(_ctx, destination);
 
-                int ret = Interop.AppleCrypto.DigestFinal(_ctx, destination, destination.Length);
                 if (ret != 1)
                 {
                     Debug.Assert(ret == 0, $"DigestFinal return value {ret} was not 0 or 1");
                     throw new CryptographicException();
                 }
 
-                bytesWritten = HashSizeInBytes;
-                return true;
+                return HashSizeInBytes;
+            }
+
+            public override int GetCurrentHash(Span<byte> destination)
+            {
+                Debug.Assert(destination.Length >= HashSizeInBytes);
+
+                int ret = Interop.AppleCrypto.DigestCurrent(_ctx, destination);
+
+                if (ret != 1)
+                {
+                    Debug.Assert(ret == 0, $"DigestFinal return value {ret} was not 0 or 1");
+                    throw new CryptographicException();
+                }
+
+                return HashSizeInBytes;
             }
 
             public override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -77,32 +77,29 @@ namespace Internal.Cryptography
             public override void AppendHashData(ReadOnlySpan<byte> data) =>
                 Check(Interop.Crypto.EvpDigestUpdate(_ctx, data, data.Length));
 
-            public override byte[] FinalizeHashAndReset()
+            public override int FinalizeHashAndReset(Span<byte> destination)
             {
-                var result = new byte[_hashSize];
-                bool success = TryFinalizeHashAndReset(result, out int bytesWritten);
-                Debug.Assert(success);
-                Debug.Assert(result.Length == bytesWritten);
-                return result;
-            }
-
-            public override bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
-            {
-                if (destination.Length < _hashSize)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
+                Debug.Assert(destination.Length >= _hashSize);
 
                 uint length = (uint)destination.Length;
                 Check(Interop.Crypto.EvpDigestFinalEx(_ctx, ref MemoryMarshal.GetReference(destination), ref length));
                 Debug.Assert(length == _hashSize);
-                bytesWritten = (int)length;
 
                 // Reset the algorithm provider.
                 Check(Interop.Crypto.EvpDigestReset(_ctx, _algorithmEvp));
 
-                return true;
+                return _hashSize;
+            }
+
+            public override int GetCurrentHash(Span<byte> destination)
+            {
+                Debug.Assert(destination.Length >= _hashSize);
+
+                uint length = (uint)destination.Length;
+                Check(Interop.Crypto.EvpDigestCurrent(_ctx, ref MemoryMarshal.GetReference(destination), ref length));
+                Debug.Assert(length == _hashSize);
+
+                return _hashSize;
             }
 
             public override int HashSizeInBytes => _hashSize;
@@ -138,30 +135,27 @@ namespace Internal.Cryptography
             public override void AppendHashData(ReadOnlySpan<byte> data) =>
                 Check(Interop.Crypto.HmacUpdate(_hmacCtx, data, data.Length));
 
-            public override byte[] FinalizeHashAndReset()
+            public override int FinalizeHashAndReset(Span<byte> destination)
             {
-                var hash = new byte[_hashSize];
-                bool success = TryFinalizeHashAndReset(hash, out int bytesWritten);
-                Debug.Assert(success);
-                Debug.Assert(hash.Length == bytesWritten);
-                return hash;
-            }
-
-            public override unsafe bool TryFinalizeHashAndReset(Span<byte> destination, out int bytesWritten)
-            {
-                if (destination.Length < _hashSize)
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
+                Debug.Assert(destination.Length >= _hashSize);
 
                 int length = destination.Length;
                 Check(Interop.Crypto.HmacFinal(_hmacCtx, ref MemoryMarshal.GetReference(destination), ref length));
                 Debug.Assert(length == _hashSize);
-                bytesWritten = length;
 
                 Check(Interop.Crypto.HmacReset(_hmacCtx));
-                return true;
+                return _hashSize;
+            }
+
+            public override int GetCurrentHash(Span<byte> destination)
+            {
+                Debug.Assert(destination.Length >= _hashSize);
+
+                int length = destination.Length;
+                Check(Interop.Crypto.HmacCurrent(_hmacCtx, ref MemoryMarshal.GetReference(destination), ref length));
+                Debug.Assert(length == _hashSize);
+
+                return _hashSize;
             }
 
             public override int HashSizeInBytes => _hashSize;

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -63,8 +63,8 @@
   <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
     <value>Positive number required.</value>
   </data>
-  <data name="Argument_EncodeDestinationTooSmall" xml:space="preserve">
-    <value>The destination is too small to hold the encoded value.</value>
+  <data name="Argument_DestinationTooShort" xml:space="preserve">
+    <value>Destination is too short.</value>
   </data>
   <data name="Argument_InvalidRandomRange" xml:space="preserve">
     <value>Range of random number does not contain at least one possibility.</value>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -311,10 +311,12 @@
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs" />
-    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs"
-             Link="Common\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDuplicateHash.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptDuplicateHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptHashData.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptHashData.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs"

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/IncrementalHash.cs
@@ -17,6 +17,14 @@ namespace System.Security.Cryptography
         private HMACCommon? _hmac;
         private bool _disposed;
 
+        /// <summary>
+        ///   Gets the output size of this hash or HMAC algorithm, in bytes.
+        /// </summary>
+        /// <value>
+        ///   The output size of this hash or HMAC algorithm, in bytes.
+        /// </value>
+        public int HashLengthInBytes { get; }
+
         private IncrementalHash(HashAlgorithmName name, HashProvider hash)
         {
             Debug.Assert(!string.IsNullOrEmpty(name.Name));
@@ -24,6 +32,7 @@ namespace System.Security.Cryptography
 
             _algorithmName = name;
             _hash = hash;
+            HashLengthInBytes = _hash.HashSizeInBytes;
         }
 
         private IncrementalHash(HashAlgorithmName name, HMACCommon hmac)
@@ -33,6 +42,7 @@ namespace System.Security.Cryptography
 
             _algorithmName = new HashAlgorithmName("HMAC" + name.Name);
             _hmac = hmac;
+            HashLengthInBytes = _hmac.HashSizeInBytes;
         }
 
         /// <summary>
@@ -51,7 +61,7 @@ namespace System.Security.Cryptography
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
 
-            AppendData(data, 0, data.Length);
+            AppendData(new ReadOnlySpan<byte>(data));
         }
 
         /// <summary>
@@ -85,7 +95,7 @@ namespace System.Security.Cryptography
             if ((data.Length - count) < offset)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             if (_disposed)
-                throw new ObjectDisposedException(typeof(IncrementalHash).Name);
+                throw new ObjectDisposedException(nameof(IncrementalHash));
 
             AppendData(new ReadOnlySpan<byte>(data, offset, count));
         }
@@ -94,7 +104,7 @@ namespace System.Security.Cryptography
         {
             if (_disposed)
             {
-                throw new ObjectDisposedException(typeof(IncrementalHash).Name);
+                throw new ObjectDisposedException(nameof(IncrementalHash));
             }
 
             Debug.Assert((_hash != null) ^ (_hmac != null));
@@ -118,27 +128,159 @@ namespace System.Security.Cryptography
         public byte[] GetHashAndReset()
         {
             if (_disposed)
-            {
-                throw new ObjectDisposedException(typeof(IncrementalHash).Name);
-            }
+                throw new ObjectDisposedException(nameof(IncrementalHash));
 
-            Debug.Assert((_hash != null) ^ (_hmac != null));
-            return _hash != null ?
-                _hash.FinalizeHashAndReset() :
-                _hmac!.FinalizeHashAndReset();
+            byte[] ret = new byte[HashLengthInBytes];
+
+            int written = GetHashAndResetCore(ret);
+            Debug.Assert(written == HashLengthInBytes);
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Retrieves the hash or Hash-based Message Authentication Code (HMAC) for the data
+        ///   accumulated from prior calls to the
+        ///   <see cref="AppendData(ReadOnlySpan{byte})" />
+        ///   methods, and resets the object to its initial state.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the hash or HMAC value.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="destination"/> has a <see cref="Span{T}.Length"/> value less
+        ///   than <see cref="HashLengthInBytes"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public int GetHashAndReset(Span<byte> destination)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(IncrementalHash));
+            if (destination.Length < HashLengthInBytes)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return GetHashAndResetCore(destination);
         }
 
         public bool TryGetHashAndReset(Span<byte> destination, out int bytesWritten)
         {
             if (_disposed)
+                throw new ObjectDisposedException(nameof(IncrementalHash));
+
+            if (destination.Length < HashLengthInBytes)
             {
-                throw new ObjectDisposedException(typeof(IncrementalHash).Name);
+                bytesWritten = 0;
+                return false;
             }
+
+            bytesWritten = GetHashAndResetCore(destination);
+            return true;
+        }
+
+        private int GetHashAndResetCore(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length >= HashLengthInBytes);
 
             Debug.Assert((_hash != null) ^ (_hmac != null));
             return _hash != null ?
-                _hash.TryFinalizeHashAndReset(destination, out bytesWritten) :
-                _hmac!.TryFinalizeHashAndReset(destination, out bytesWritten);
+                _hash.FinalizeHashAndReset(destination) :
+                _hmac!.FinalizeHashAndReset(destination);
+        }
+
+        /// <summary>
+        ///   Retrieves the hash or Hash-based Message Authentication Code (HMAC) for the data
+        ///   accumulated from prior calls to the
+        ///   <see cref="AppendData(ReadOnlySpan{byte})" />
+        ///   methods, without resetting the object to its initial state.
+        /// </summary>
+        /// <returns>
+        ///   The computed hash or HMAC.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public byte[] GetCurrentHash()
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(IncrementalHash));
+
+            byte[] ret = new byte[HashLengthInBytes];
+
+            int written = GetCurrentHashCore(ret);
+            Debug.Assert(written == HashLengthInBytes);
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Retrieves the hash or Hash-based Message Authentication Code (HMAC) for the data
+        ///   accumulated from prior calls to the
+        ///   <see cref="AppendData(ReadOnlySpan{byte})" />
+        ///   methods, without resetting the object to its initial state.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the hash or HMAC value.
+        /// </param>
+        /// <returns>
+        ///   The number of bytes written to <paramref name="destination"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="destination"/> has a <see cref="Span{T}.Length"/> value less
+        ///   than <see cref="HashLengthInBytes"/>.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public int GetCurrentHash(Span<byte> destination)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(IncrementalHash));
+            if (destination.Length < HashLengthInBytes)
+                throw new ArgumentException(SR.Argument_DestinationTooShort, nameof(destination));
+
+            return GetCurrentHashCore(destination);
+        }
+
+        /// <summary>
+        ///   Attempts to retrieve the hash or Hash-based Message Authentication Code (HMAC) for
+        ///   the data accumulated from prior calls to the
+        ///   <see cref="AppendData(ReadOnlySpan{byte})" />
+        ///   methods, without resetting the object to its initial state.
+        /// </summary>
+        /// <param name="destination">
+        ///   The buffer to receive the hash or HMAC value.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   When this method returns, the total number of bytes written into <paramref name="destination" />.
+        ///   This parameter is treated as uninitialized.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true" /> if <paramref name="destination" /> is long enough to receive
+        ///   the hash or HMAC value; otherwise, <see langword="false" />.
+        /// </returns>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public bool TryGetCurrentHash(Span<byte> destination, out int bytesWritten)
+        {
+            if (_disposed)
+                throw new ObjectDisposedException(nameof(IncrementalHash));
+
+            if (destination.Length < HashLengthInBytes)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+
+            bytesWritten = GetCurrentHashCore(destination);
+            return true;
+        }
+
+        private int GetCurrentHashCore(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length >= HashLengthInBytes);
+
+            Debug.Assert((_hash != null) ^ (_hmac != null));
+            return _hash != null ?
+                _hash.GetCurrentHash(destination) :
+                _hmac!.GetCurrentHash(destination);
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/tests/IncrementalHashTests.cs
@@ -429,11 +429,19 @@ namespace System.Security.Cryptography.Algorithms.Tests
             var incrementalHash = IncrementalHash.CreateHash(hashAlgorithm);
             incrementalHash.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new byte[1]));
-            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new ReadOnlySpan<byte>(new byte[1])));
+            byte[] tmpDest = new byte[1];
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(tmpDest));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(tmpDest, 0, 0));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new ReadOnlySpan<byte>(tmpDest)));
 
             Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetHashAndReset());
-            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetHashAndReset(new byte[1], out int _));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetHashAndReset(tmpDest));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetHashAndReset(tmpDest, out int _));
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetCurrentHash());
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetCurrentHash(tmpDest));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetCurrentHash(tmpDest, out int _));
         }
 
         [Theory]
@@ -444,11 +452,246 @@ namespace System.Security.Cryptography.Algorithms.Tests
             var incrementalHash = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey);
             incrementalHash.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new byte[1]));
-            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new ReadOnlySpan<byte>(new byte[1])));
+            byte[] tmpDest = new byte[1];
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(tmpDest));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(tmpDest, 0, 0));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.AppendData(new ReadOnlySpan<byte>(tmpDest)));
 
             Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetHashAndReset());
-            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetHashAndReset(new byte[1], out int _));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetHashAndReset(tmpDest));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetHashAndReset(tmpDest, out int _));
+
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetCurrentHash());
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.GetCurrentHash(tmpDest));
+            Assert.Throws<ObjectDisposedException>(() => incrementalHash.TryGetCurrentHash(tmpDest, out int _));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void VerifyGetCurrentHash_Digest(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            referenceAlgorithm.Dispose();
+            
+            using (IncrementalHash single = IncrementalHash.CreateHash(hashAlgorithm))
+            using (IncrementalHash accumulated = IncrementalHash.CreateHash(hashAlgorithm))
+            {
+                VerifyGetCurrentHash(single, accumulated);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void VerifyGetCurrentHash_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            referenceAlgorithm.Dispose();
+
+            using (IncrementalHash single = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            using (IncrementalHash accumulated = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            {
+                VerifyGetCurrentHash(single, accumulated);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void VerifyBounds_GetCurrentHash_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incremental = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            {
+                referenceAlgorithm.Key = s_hmacKey;
+                byte[] comparison = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+
+                VerifyBounds(
+                    comparison,
+                    incremental,
+                    inc => inc.GetCurrentHash(),
+                    (inc, dest) => inc.GetCurrentHash(dest),
+                    (IncrementalHash inc, Span<byte> dest, out int bytesWritten) =>
+                        inc.TryGetCurrentHash(dest, out bytesWritten));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHMACs))]
+        public static void VerifyBounds_GetHashAndReset_HMAC(HMAC referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incremental = IncrementalHash.CreateHMAC(hashAlgorithm, s_hmacKey))
+            {
+                referenceAlgorithm.Key = s_hmacKey;
+                byte[] comparison = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+
+                VerifyBounds(
+                    comparison,
+                    incremental,
+                    inc => inc.GetHashAndReset(),
+                    (inc, dest) => inc.GetHashAndReset(dest),
+                    (IncrementalHash inc, Span<byte> dest, out int bytesWritten) =>
+                        inc.TryGetHashAndReset(dest, out bytesWritten));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void VerifyBounds_GetCurrentHash_Hash(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incremental = IncrementalHash.CreateHash(hashAlgorithm))
+            {
+                byte[] comparison = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+
+                VerifyBounds(
+                    comparison,
+                    incremental,
+                    inc => inc.GetCurrentHash(),
+                    (inc, dest) => inc.GetCurrentHash(dest),
+                    (IncrementalHash inc, Span<byte> dest, out int bytesWritten) =>
+                        inc.TryGetCurrentHash(dest, out bytesWritten));
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetHashAlgorithms))]
+        public static void VerifyBounds_GetHashAndReset_Hash(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithm)
+        {
+            using (referenceAlgorithm)
+            using (IncrementalHash incremental = IncrementalHash.CreateHash(hashAlgorithm))
+            {
+                byte[] comparison = referenceAlgorithm.ComputeHash(Array.Empty<byte>());
+
+                VerifyBounds(
+                    comparison,
+                    incremental,
+                    inc => inc.GetHashAndReset(),
+                    (inc, dest) => inc.GetHashAndReset(dest),
+                    (IncrementalHash inc, Span<byte> dest, out int bytesWritten) =>
+                        inc.TryGetHashAndReset(dest, out bytesWritten));
+            }
+        }
+
+        private static void VerifyGetCurrentHash(IncrementalHash single, IncrementalHash accumulated)
+        {
+            Span<byte> buf = stackalloc byte[2048];
+            Span<byte> fullDigest = stackalloc byte[512 / 8];
+            Span<byte> curDigest = stackalloc byte[fullDigest.Length];
+            SequenceFill(buf);
+
+            int count = 0;
+            const int Step = 13;
+            int writtenA;
+            int writtenB;
+
+            while (count + Step < buf.Length)
+            {
+                // Accumulate only the current slice
+                accumulated.AppendData(buf.Slice(count, Step));
+
+                // The comparison needs the whole thing, since we're
+                // comparing GetHashAndReset vs GetCurrentHash.
+                count += Step;
+                single.AppendData(buf.Slice(0, count));
+
+                writtenA = single.GetHashAndReset(fullDigest);
+                writtenB = accumulated.GetCurrentHash(curDigest);
+
+                Assert.Equal(
+                    fullDigest.Slice(0, writtenA).ByteArrayToHex(),
+                    curDigest.Slice(0, writtenB).ByteArrayToHex());
+            }
+
+            accumulated.AppendData(buf.Slice(count));
+            single.AppendData(buf);
+
+            writtenA = single.GetHashAndReset(fullDigest);
+
+            // Drain/reset accumulated with this last call
+            writtenB = accumulated.GetHashAndReset(curDigest);
+
+            Assert.Equal(
+                fullDigest.Slice(0, writtenA).ByteArrayToHex(),
+                curDigest.Slice(0, writtenB).ByteArrayToHex());
+        }
+
+        private delegate int SpanWriter(
+            IncrementalHash incremental,
+            Span<byte> destination);
+
+        private delegate bool TrySpanWriter(
+            IncrementalHash incremental,
+            Span<byte> destination,
+            out int bytesWritten);
+
+        private static void VerifyBounds(
+            byte[] comparison,
+            IncrementalHash incremental,
+            Func<IncrementalHash, byte[]> oneShot,
+            SpanWriter spanWriter,
+            TrySpanWriter trySpanWriter)
+        {
+            string comparisonHex = comparison.ByteArrayToHex();
+            Span<byte> dest = stackalloc byte[512 / 8 + 1];
+
+            // Empty
+            Assert.False(trySpanWriter(incremental, Span<byte>.Empty, out int written));
+            Assert.Equal(0, written);
+
+            AssertExtensions.Throws<ArgumentException>(
+                "destination",
+                () => spanWriter(incremental, Array.Empty<byte>()));
+
+            // HashLengthInBytes - 1
+            Assert.False(
+                trySpanWriter(incremental, comparison.AsSpan(0, comparison.Length - 1), out written));
+            Assert.Equal(0, written);
+
+            AssertExtensions.Throws<ArgumentException>(
+                "destination",
+                () => spanWriter(incremental, comparison.AsSpan(0, comparison.Length - 1)));
+
+            // Ensure comparison wasn't overwritten
+            Assert.Equal(comparisonHex, comparison.ByteArrayToHex());
+
+            // > HashLengthInBytes
+            Assert.True(trySpanWriter(incremental, dest, out written));
+            Assert.Equal(comparison.Length, written);
+            Assert.Equal(incremental.HashLengthInBytes, written);
+            Assert.Equal(comparisonHex, dest.Slice(0, written).ByteArrayToHex());
+
+            dest.Clear();
+            written = spanWriter(incremental, dest);
+            Assert.Equal(comparison.Length, written);
+            Assert.Equal(incremental.HashLengthInBytes, written);
+            Assert.Equal(comparisonHex, dest.Slice(0, written).ByteArrayToHex());
+
+            // == HashLengthInBytes
+            dest = dest.Slice(0, written);
+            dest.Clear();
+
+            Assert.True(trySpanWriter(incremental, dest, out written));
+            Assert.Equal(comparison.Length, written);
+            Assert.Equal(incremental.HashLengthInBytes, written);
+            Assert.Equal(comparisonHex, dest.Slice(0, written).ByteArrayToHex());
+
+            dest.Clear();
+            written = spanWriter(incremental, dest);
+            Assert.Equal(comparison.Length, written);
+            Assert.Equal(incremental.HashLengthInBytes, written);
+            Assert.Equal(comparisonHex, dest.Slice(0, written).ByteArrayToHex());
+
+            byte[] returned = oneShot(incremental);
+            Assert.Equal(comparison.Length, returned.Length);
+            Assert.Equal(incremental.HashLengthInBytes, returned.Length);
+            Assert.Equal(comparisonHex, returned.ByteArrayToHex());
+        }
+
+        private static void SequenceFill(Span<byte> span)
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] = (byte)i;
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
+++ b/src/libraries/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.csproj
@@ -95,10 +95,12 @@
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptOpenAlgorithmProvider.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptCloseAlgorithmProvider.cs" />
-    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs"
-             Link="Common\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptCreateHash.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDuplicateHash.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptDuplicateHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptHashData.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptHashData.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs"


### PR DESCRIPTION
This adds

* `int IncrementalHash::GetHashAndReset(Span<byte>)`
* `byte[] IncrementalHash::GetCurrentHash()`
* `int IncrementalHash::GetCurrentHash(Span<byte>)`
* `bool IncrementalHash::TryGetCurrentHash(Span<byte>, out int)`

While simplifying the internal logic (all three variants of GetHashAndReset collapse to the PAL `int GetHashAndReset(Span<byte>)`, and similarly for all three variants of GetCurrentHash).

This change also drives the code coverage for the IncrementalHash class up to 100%.

Fixes #1968.