### PR TITLE
Fix regression in Array.Sort for floats/doubles

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -290,7 +290,9 @@ namespace System.Collections.Generic
                         // For floating-point, do a pre-pass to move all NaNs to the beginning
                         // so that we can do an optimized comparison as part of the actual sort
                         // on the remainder of the values.
-                        if (typeof(T) == typeof(double) || typeof(T) == typeof(float))
+                        if (typeof(T) == typeof(double) ||
+                            typeof(T) == typeof(float) ||
+                            typeof(T) == typeof(Half))
                         {
                             int nanLeft = SortUtils.MoveNansToFront(keys, default(Span<byte>));
                             if (nanLeft == keys.Length)
@@ -794,7 +796,9 @@ namespace System.Collections.Generic
                         // For floating-point, do a pre-pass to move all NaNs to the beginning
                         // so that we can do an optimized comparison as part of the actual sort
                         // on the remainder of the values.
-                        if (typeof(TKey) == typeof(double) || typeof(TKey) == typeof(float))
+                        if (typeof(TKey) == typeof(double) ||
+                            typeof(TKey) == typeof(float) ||
+                            typeof(TKey) == typeof(Half))
                         {
                             int nanLeft = SortUtils.MoveNansToFront(keys, values);
                             if (nanLeft == keys.Length)
@@ -1043,6 +1047,7 @@ namespace System.Collections.Generic
             if (typeof(T) == typeof(nint)) return (nint)(object)left < (nint)(object)right ? true : false;
             if (typeof(T) == typeof(float)) return (float)(object)left < (float)(object)right ? true : false;
             if (typeof(T) == typeof(double)) return (double)(object)left < (double)(object)right ? true : false;
+            if (typeof(T) == typeof(Half)) return (Half)(object)left < (Half)(object)right ? true : false;
             return left.CompareTo(right) < 0 ? true : false;
         }
 
@@ -1061,6 +1066,7 @@ namespace System.Collections.Generic
             if (typeof(T) == typeof(nint)) return (nint)(object)left > (nint)(object)right ? true : false;
             if (typeof(T) == typeof(float)) return (float)(object)left > (float)(object)right ? true : false;
             if (typeof(T) == typeof(double)) return (double)(object)left > (double)(object)right ? true : false;
+            if (typeof(T) == typeof(Half)) return (Half)(object)left > (Half)(object)right ? true : false;
             return left.CompareTo(right) > 0 ? true : false;
         }
 
@@ -1073,7 +1079,8 @@ namespace System.Collections.Generic
             for (int i = 0; i < keys.Length; i++)
             {
                 if ((typeof(TKey) == typeof(double) && double.IsNaN((double)(object)keys[i])) ||
-                    (typeof(TKey) == typeof(float) && float.IsNaN((float)(object)keys[i])))
+                    (typeof(TKey) == typeof(float) && float.IsNaN((float)(object)keys[i])) ||
+                    (typeof(TKey) == typeof(Half) && Half.IsNaN((Half)(object)keys[i])))
                 {
                     TKey temp = keys[left];
                     keys[left] = keys[i];


### PR DESCRIPTION
Several months back we moved the sorting logic for primtive types out of native code into managed.  Doing so helped to make the logic reusable for spans and helped to reduce GC latency, and also actually helped with throughput in a variety of cases.  But it ended up regressing throughput for sorting larger arrays of floating-point values, with float/double.CompareTo not getting inlined, and even if it were inlined, containing much more logic than was present in the native implementation.  The native implementation did a pre-pass to move all NaNs to the front and then just used simple < and > comparison operations, so the managed implementation now does as well.

With the exception of a large array of already-sorted Int32 values where there is still a small regression after this PR, all of the cases I've tested are either as good or better than .NET Core 3.1.

@jkotas, @GrabYourPitchforks, @tannergooding, thanks for your offline suggestions on approaches here; I tried out a variety of them, including vectorized float/double.CompareTo as well as unsafe casts to wrapper types with customized IComparable implementations, and this ended up being the best overall.  Thanks as well to @nietras for pointing out the regression.

Benchmark:
```C#
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;
using System;
using System.Diagnostics.CodeAnalysis;
using System.Linq;

[MemoryDiagnoser]
public class Program
{
    static void Main(string[] args) => BenchmarkSwitcher.FromAssemblies(new[] { typeof(Program).Assembly }).Run(args);
}

public class DoubleSorting : Sorting<double> { protected override double GetNext() => _random.Next(); }
public class Int32Sorting : Sorting<int> { protected override int GetNext() => _random.Next(); }
public class StringSorting : Sorting<string>
{
    protected override string GetNext() => string.Create(_random.Next(1, 5), _random, (dest, r) =>
    {
        for (int i = 0; i < dest.Length; i++) dest[i] = (char)('a' + r.Next(26));
    });
}

public abstract class Sorting<T>
{
    protected Random _random;
    private T[] _orig, _array;

    [Params(10, 100_000)]
    public int Size { get; set; }

    protected abstract T GetNext();

    [GlobalSetup]
    public void Setup()
    {
        _random = new Random(42);
        _orig = Enumerable.Range(0, Size).Select(_ => GetNext()).ToArray();
        _array = (T[])_orig.Clone();
        Array.Sort(_array);
    }

    [Benchmark]
    public void Sorted() => Array.Sort(_array);

    [Benchmark]
    public void Random()
    {
        _orig.AsSpan().CopyTo(_array);
        Array.Sort(_array);
    }
}
```

|                Type | Method | Toolchain |   Size |              Mean | Ratio |
|-------------------- |------- |---------- |------- |------------------:|------:|
|       DoubleSorting | Sorted | netcore31 |     10 |          59.58 ns |  2.13 |
|       DoubleSorting | Sorted |    master |     10 |          30.52 ns |  1.09 |
|       DoubleSorting | Sorted |        pr |     10 |          28.01 ns |  1.00 |
|                     |        |           |        |                   |       |
|       DoubleSorting | Random | netcore31 |     10 |          77.50 ns |  1.71 |
|       DoubleSorting | Random |    master |     10 |          67.61 ns |  1.49 |
|       DoubleSorting | Random |        pr |     10 |          45.44 ns |  1.00 |
|                     |        |           |        |                   |       |
|       DoubleSorting | Sorted | netcore31 | 100000 |     990,325.98 ns |  1.27 |
|       DoubleSorting | Sorted |    master | 100000 |   2,898,290.96 ns |  3.73 |
|       DoubleSorting | Sorted |        pr | 100000 |     777,209.08 ns |  1.00 |
|                     |        |           |        |                   |       |
|       DoubleSorting | Random | netcore31 | 100000 |   5,940,056.30 ns |  1.08 |
|       DoubleSorting | Random |    master | 100000 |   7,880,560.62 ns |  1.44 |
|       DoubleSorting | Random |        pr | 100000 |   5,473,335.58 ns |  1.00 |
|                     |        |           |        |                   |       |
|        Int32Sorting | Sorted | netcore31 |     10 |          38.02 ns |  2.31 |
|        Int32Sorting | Sorted |    master |     10 |          17.09 ns |  1.04 |
|        Int32Sorting | Sorted |        pr |     10 |          16.49 ns |  1.00 |
|                     |        |           |        |                   |       |
|        Int32Sorting | Random | netcore31 |     10 |          49.97 ns |  1.63 |
|        Int32Sorting | Random |    master |     10 |          31.30 ns |  1.02 |
|        Int32Sorting | Random |        pr |     10 |          30.63 ns |  1.00 |
|                     |        |           |        |                   |       |
|        Int32Sorting | Sorted | netcore31 | 100000 |     572,908.37 ns |  0.90 |
|        Int32Sorting | Sorted |    master | 100000 |     640,966.00 ns |  1.00 |
|        Int32Sorting | Sorted |        pr | 100000 |     639,118.53 ns |  1.00 |
|                     |        |           |        |                   |       |
|        Int32Sorting | Random | netcore31 | 100000 |   5,072,236.56 ns |  1.06 |
|        Int32Sorting | Random |    master | 100000 |   5,024,276.17 ns |  1.05 |
|        Int32Sorting | Random |        pr | 100000 |   4,801,833.82 ns |  1.00 |
|                     |        |           |        |                   |       |
|       StringSorting | Sorted | netcore31 |     10 |         575.87 ns |  1.24 |
|       StringSorting | Sorted |    master |     10 |         432.40 ns |  0.93 |
|       StringSorting | Sorted |        pr |     10 |         465.86 ns |  1.00 |
|                     |        |           |        |                   |       |
|       StringSorting | Random | netcore31 |     10 |       1,758.64 ns |  1.15 |
|       StringSorting | Random |    master |     10 |       1,425.75 ns |  0.93 |
|       StringSorting | Random |        pr |     10 |       1,532.01 ns |  1.00 |
|                     |        |           |        |                   |       |
|       StringSorting | Sorted | netcore31 | 100000 |  83,774,554.44 ns |  1.14 |
|       StringSorting | Sorted |    master | 100000 |  74,485,247.25 ns |  1.01 |
|       StringSorting | Sorted |        pr | 100000 |  73,450,518.68 ns |  1.00 |
|                     |        |           |        |                   |       |
|       StringSorting | Random | netcore31 | 100000 | 103,108,672.31 ns |  1.14 |
|       StringSorting | Random |    master | 100000 |  89,373,058.33 ns |  0.99 |
|       StringSorting | Random |        pr | 100000 |  90,577,543.59 ns |  1.00 |