### PR TITLE
Use ExecutionContext.Restore rather than EC.Run callback

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -200,30 +200,16 @@ namespace System.Threading
             edi?.Throw();
         }
 
-        // Direct copy of the above RunInternal overload, except that it passes the state into the callback strongly-typed and by ref.
-        internal static void RunInternal<TState>(ExecutionContext? executionContext, ContextCallback<TState> callback, ref TState state)
+        internal static void Restore(ExecutionContext? executionContext)
         {
-            // Note: ExecutionContext.RunInternal is an extremely hot function and used by every await, ThreadPool execution, etc.
-            // Note: Manual enregistering may be addressed by "Exception Handling Write Through Optimization"
-            //       https://github.com/dotnet/runtime/blob/master/docs/design/features/eh-writethru.md
+            Thread currentThread = Thread.CurrentThread;
 
-            // Enregister variables with 0 post-fix so they can be used in registers without EH forcing them to stack
-            // Capture references to Thread Contexts
-            Thread currentThread0 = Thread.CurrentThread;
-            Thread currentThread = currentThread0;
-            ExecutionContext? previousExecutionCtx0 = currentThread0._executionContext;
-            if (previousExecutionCtx0 != null && previousExecutionCtx0.m_isDefault)
+            ExecutionContext? currentExecutionCtx = currentThread._executionContext;
+            if (currentExecutionCtx != null && currentExecutionCtx.m_isDefault)
             {
                 // Default is a null ExecutionContext internally
-                previousExecutionCtx0 = null;
+                currentExecutionCtx = null;
             }
-
-            // Store current ExecutionContext and SynchronizationContext as "previousXxx".
-            // This allows us to restore them and undo any Context changes made in callback.Invoke
-            // so that they won't "leak" back into caller.
-            // These variables will cross EH so be forced to stack
-            ExecutionContext? previousExecutionCtx = previousExecutionCtx0;
-            SynchronizationContext? previousSyncCtx = currentThread0._synchronizationContext;
 
             if (executionContext != null && executionContext.m_isDefault)
             {
@@ -231,43 +217,10 @@ namespace System.Threading
                 executionContext = null;
             }
 
-            if (previousExecutionCtx0 != executionContext)
+            if (currentExecutionCtx != executionContext)
             {
-                RestoreChangedContextToThread(currentThread0, executionContext, previousExecutionCtx0);
+                RestoreChangedContextToThread(currentThread, executionContext, currentExecutionCtx);
             }
-
-            ExceptionDispatchInfo? edi = null;
-            try
-            {
-                callback.Invoke(ref state);
-            }
-            catch (Exception ex)
-            {
-                // Note: we have a "catch" rather than a "finally" because we want
-                // to stop the first pass of EH here.  That way we can restore the previous
-                // context before any of our callers' EH filters run.
-                edi = ExceptionDispatchInfo.Capture(ex);
-            }
-
-            // Re-enregistrer variables post EH with 1 post-fix so they can be used in registers rather than from stack
-            SynchronizationContext? previousSyncCtx1 = previousSyncCtx;
-            Thread currentThread1 = currentThread;
-            // The common case is that these have not changed, so avoid the cost of a write barrier if not needed.
-            if (currentThread1._synchronizationContext != previousSyncCtx1)
-            {
-                // Restore changed SynchronizationContext back to previous
-                currentThread1._synchronizationContext = previousSyncCtx1;
-            }
-
-            ExecutionContext? previousExecutionCtx1 = previousExecutionCtx;
-            ExecutionContext? currentExecutionCtx1 = currentThread1._executionContext;
-            if (currentExecutionCtx1 != previousExecutionCtx1)
-            {
-                RestoreChangedContextToThread(currentThread1, previousExecutionCtx1, currentExecutionCtx1);
-            }
-
-            // If exception was thrown by callback, rethrow it now original contexts are restored
-            edi?.Throw();
         }
 
         internal static void RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, object state)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -270,6 +270,10 @@ namespace System.Threading.Tasks.Sources
         /// </summary>
         private ExceptionDispatchInfo? InvokeInlineContinuation()
         {
+            // This is in a helper as the error handling causes the generated asm
+            // for the surrounding code to become less efficent (stack spills etc)
+            // and it is an uncommon path.
+
             Debug.Assert(_continuation != null);
             Debug.Assert(_capturedContext == null);
             Debug.Assert(!RunContinuationsAsynchronously);


### PR DESCRIPTION
Only running inline needs to do extra work and error handling for post run restore

@stephentoub this would be the change for `ManualResetValueTaskSourceCore` to use `ExecutionContext.Restore` rather than a generic `ref` passing callback based `ExecutionContext.Run`