### PR TITLE
Use Microsoft prefix for merge conflict SDK entry

### DIFF
--- a/global.json
+++ b/global.json
@@ -16,7 +16,7 @@
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20309.1",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20309.1",
     "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20309.1",
-    "FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
+    "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.4.20202.18",
     "Microsoft.Build.NoTargets": "1.0.53",
     "Microsoft.Build.Traversal": "2.0.34"


### PR DESCRIPTION
Use the Microsoft prefix which is reserved on NuGet for Microsoft employees.