### PR TITLE
Remove indexer from ref source of WebHeaderCollection

### DIFF
--- a/src/libraries/System.Net.WebHeaderCollection/ref/System.Net.WebHeaderCollection.cs
+++ b/src/libraries/System.Net.WebHeaderCollection/ref/System.Net.WebHeaderCollection.cs
@@ -92,7 +92,6 @@ namespace System.Net
         public override int Count { get { throw null; } }
         public string? this[System.Net.HttpRequestHeader header] { get { throw null; } set { } }
         public string? this[System.Net.HttpResponseHeader header] { get { throw null; } set { } }
-        public new string? this[string name] { get { throw null; } set { } }
         public override System.Collections.Specialized.NameObjectCollectionBase.KeysCollection Keys { get { throw null; } }
         public void Add(System.Net.HttpRequestHeader header, string? value) { }
         public void Add(System.Net.HttpResponseHeader header, string? value) { }


### PR DESCRIPTION
The indexer is not implemented on WebHeaderCollection. 

This fix extra indexer in the documentation: #4268. More details in the following comment: https://github.com/dotnet/dotnet-api-docs/pull/4268#discussion_r438025973