### PR TITLE
2 small CQ optimizations.

### DIFF
--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -2733,8 +2733,10 @@ bool LinearScan::isMatchingConstant(RegRecord* physRegRecord, RefPosition* refPo
         switch (otherTreeNode->OperGet())
         {
             case GT_CNS_INT:
-                if ((refPosition->treeNode->AsIntCon()->IconValue() == otherTreeNode->AsIntCon()->IconValue()) &&
-                    (varTypeGCtype(refPosition->treeNode) == varTypeGCtype(otherTreeNode)))
+            {
+                ssize_t v1 = refPosition->treeNode->AsIntCon()->IconValue();
+                ssize_t v2 = otherTreeNode->AsIntCon()->IconValue();
+                if ((v1 == v2) && (varTypeGCtype(refPosition->treeNode) == varTypeGCtype(otherTreeNode) || v1 == 0))
                 {
 #ifdef TARGET_64BIT
                     // If the constant is negative, only reuse registers of the same type.
@@ -2743,14 +2745,14 @@ bool LinearScan::isMatchingConstant(RegRecord* physRegRecord, RefPosition* refPo
                     // This doesn't apply to a 32-bit system, on which long values occupy multiple registers.
                     // (We could sign-extend, but we would have to always sign-extend, because if we reuse more
                     // than once, we won't have access to the instruction that originally defines the constant).
-                    if ((refPosition->treeNode->TypeGet() == otherTreeNode->TypeGet()) ||
-                        (refPosition->treeNode->AsIntCon()->IconValue() >= 0))
+                    if ((refPosition->treeNode->TypeGet() == otherTreeNode->TypeGet()) || (v1 >= 0))
 #endif // TARGET_64BIT
                     {
                         return true;
                     }
                 }
                 break;
+            }
             case GT_CNS_DBL:
             {
                 // For floating point constants, the values must be identical, not simply compare


### PR DESCRIPTION
Found during `JitDoOldStructRetyping` work.

Diffs are positive:
```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -31060 (-0.10% of base)
3169 total methods with Code Size differences (3167 improved, 2 regressed)

PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -40121 (-0.08% of base)
4964 total methods with Code Size differences (4952 improved, 12 regressed)
```


Need these changes to get rid of some regressions with `!JitDoOldStructRetyping`.

A simple diff example, `-38 (-35.85% of base) : System.Private.CoreLib.dasm - Math:Truncate(Decimal):Decimal`:
before
```
IN0001: 000008 mov      ecx, dword ptr [rdx]
IN0002: 00000A mov      dword ptr [V05 rsp+20H], ecx
IN0003: 00000E mov      ecx, dword ptr [rdx+4]
IN0004: 000011 mov      dword ptr [V06 rsp+24H], ecx
IN0005: 000015 mov      ecx, dword ptr [rdx+8]
IN0006: 000018 mov      dword ptr [V07 rsp+28H], ecx
IN0007: 00001C mov      edx, dword ptr [rdx+12]
IN0008: 00001F mov      dword ptr [V08 rsp+2CH], edx
IN0009: 000023 mov      edx, dword ptr [V05 rsp+20H]
```
after:
```
IN0001: 000008 movups   xmm0, xmmword ptr [rdx]
IN0002: 00000B movups   xmmword ptr [V03 rsp+20H], xmm0
IN0003: 000010 mov      edx, dword ptr [V05 rsp+20H]
```