### PR TITLE
[wasm] Disable some existing System.Console library tests throwing PNSE

### DIFF
--- a/src/libraries/System.Console/tests/CancelKeyPress.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.cs
@@ -14,6 +14,7 @@ public partial class CancelKeyPressTests
     private const int WaitFailTestTimeoutSeconds = 30;
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void CanAddAndRemoveHandler()
     {
         ConsoleCancelEventHandler handler = (sender, e) =>

--- a/src/libraries/System.Console/tests/Color.cs
+++ b/src/libraries/System.Console/tests/Color.cs
@@ -13,6 +13,7 @@ using Xunit;
 public class Color
 {
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void InvalidColors()
     {
         AssertExtensions.Throws<ArgumentException>(null, () => Console.BackgroundColor = (ConsoleColor)42);
@@ -20,6 +21,7 @@ public class Color
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void RoundtrippingColor()
     {
         Console.BackgroundColor = Console.BackgroundColor;
@@ -32,6 +34,15 @@ public class Color
     }
 
     [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void RoundtrippingColor_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor = Console.BackgroundColor );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor = Console.ForegroundColor );
+    }
+
+    [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void RedirectedOutputDoesNotUseAnsiSequences()
     {
         // Make sure that redirecting to a memory stream causes Console not to write out the ANSI sequences

--- a/src/libraries/System.Console/tests/Color.cs
+++ b/src/libraries/System.Console/tests/Color.cs
@@ -35,10 +35,18 @@ public class Color
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public static void RoundtrippingColor_Browser()
+    public static void ForegroundColor_Throws_PlatformNotSupportedException()
     {
-        Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor = Console.BackgroundColor );
-        Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor = Console.ForegroundColor );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor);
+        Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor = ConsoleColor.Red);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void BackgroundColor_Throws_PlatformNotSupportedException()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor);
+        Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor = ConsoleColor.Red);
     }
 
     [Fact]

--- a/src/libraries/System.Console/tests/ConsoleEncoding.cs
+++ b/src/libraries/System.Console/tests/ConsoleEncoding.cs
@@ -23,6 +23,7 @@ public partial class ConsoleEncoding
 
     [Theory]
     [MemberData(nameof(InputData))]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void TestEncoding(string inputString)
     {
         TextWriter outConsoleStream = Console.Out;
@@ -79,6 +80,7 @@ public partial class ConsoleEncoding
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void TestValidEncodings()
     {
         Action<Encoding> check = encoding =>
@@ -98,7 +100,6 @@ public partial class ConsoleEncoding
         {
             check(Encoding.ASCII);
         }
-
     }
 
     public class NonexistentCodePageEncoding : Encoding

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -309,18 +309,24 @@ public class ReadAndWrite
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public static void OutputEncoding_Browser()
+    public static void OutputEncoding_Getter_Returns_Unicode()
     {
         Encoding curEncoding = Console.OutputEncoding;
         Assert.Equal(Encoding.Unicode, curEncoding);
-        Assert.Throws<PlatformNotSupportedException>(() => Console.OutputEncoding = curEncoding );
     }
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public static void InputEncoding_Browser()
+    public static void OutputEncoding_Setter_Throws_PlatformNotSupportedException()
     {
-        Assert.Throws<PlatformNotSupportedException>(() => Console.InputEncoding );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.OutputEncoding = Encoding.Unicode);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void InputEncoding_Getter_Throws_PlatformNotSupportedException()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.InputEncoding);
     }
 
     static readonly string[] s_testLines = new string[] {

--- a/src/libraries/System.Console/tests/ReadAndWrite.cs
+++ b/src/libraries/System.Console/tests/ReadAndWrite.cs
@@ -316,6 +316,13 @@ public class ReadAndWrite
         Assert.Throws<PlatformNotSupportedException>(() => Console.OutputEncoding = curEncoding );
     }
 
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void InputEncoding_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.InputEncoding );
+    }
+
     static readonly string[] s_testLines = new string[] {
         "3232 Hello32 Hello 5032 Hello 50 532 Hello 50 5 aTrueaabcdbc1.23123.4561.23439505050System.ObjectHello World",
         "32",
@@ -344,6 +351,7 @@ public class ReadAndWrite
     };
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void ReadAndReadLine()
     {
         TextWriter savedStandardOutput = Console.Out;

--- a/src/libraries/System.Console/tests/ReadKey.cs
+++ b/src/libraries/System.Console/tests/ReadKey.cs
@@ -39,17 +39,31 @@ public class ReadKey
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
     public void NumberLock_GetUnix_ThrowsPlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.NumberLock);
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public void NumberLock_Browser()
+    {
+        Assert.False(Console.NumberLock);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
     public void CapsLock_GetUnix_ThrowsPlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.CapsLock);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public void CapsLock_Browser()
+    {
+        Assert.False(Console.CapsLock);
     }
 
     private static void RunRemote(Func<int> func, ProcessStartInfo psi = null)

--- a/src/libraries/System.Console/tests/ReadKey.cs
+++ b/src/libraries/System.Console/tests/ReadKey.cs
@@ -47,7 +47,7 @@ public class ReadKey
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public void NumberLock_Browser()
+    public void NumberLock_Getter_Returns_False()
     {
         Assert.False(Console.NumberLock);
     }
@@ -61,7 +61,7 @@ public class ReadKey
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public void CapsLock_Browser()
+    public void CapsLock_Getter_Returns_False()
     {
         Assert.False(Console.CapsLock);
     }

--- a/src/libraries/System.Console/tests/SetIn.cs
+++ b/src/libraries/System.Console/tests/SetIn.cs
@@ -12,6 +12,7 @@ using Xunit;
 public class SetIn
 {
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void SetInThrowsOnNull()
     {
         TextReader savedIn = Console.In;
@@ -26,6 +27,7 @@ public class SetIn
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void SetInReadLine()
     {
         const string TextStringFormat = "Test {0}";

--- a/src/libraries/System.Console/tests/SyncTextReader.cs
+++ b/src/libraries/System.Console/tests/SyncTextReader.cs
@@ -79,6 +79,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void ReadToEnd()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);
@@ -93,6 +94,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void ReadBlock()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -111,6 +113,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void Read()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -129,6 +132,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void Peek()
     {
         const string expected = "ABC";
@@ -142,6 +146,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void ReadToEndAsync()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);
@@ -156,6 +161,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void ReadBlockAsync()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -180,6 +186,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void ReadAsync()
     {
         var expected = new[] { 'H', 'e', 'l', 'l', 'o' };
@@ -204,6 +211,7 @@ public class SyncTextReader
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void ReadLineAsync()
     {
         var expected = string.Join(Environment.NewLine, s_testLines);

--- a/src/libraries/System.Console/tests/ThreadSafety.cs
+++ b/src/libraries/System.Console/tests/ThreadSafety.cs
@@ -13,6 +13,7 @@ public class ThreadSafety
     const int NumberOfIterations = 100;
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void OpenStandardXXXCanBeCalledConcurrently()
     {
         Parallel.For(0, NumberOfIterations, i =>
@@ -41,6 +42,7 @@ public class ThreadSafety
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void SetStandardXXXCanBeCalledConcurrently()
     {
         TextReader savedStandardInput = Console.In;
@@ -83,6 +85,7 @@ public class ThreadSafety
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void ReadMayBeCalledConcurrently()
     {
         const char TestChar = '+';

--- a/src/libraries/System.Console/tests/Timeout.cs
+++ b/src/libraries/System.Console/tests/Timeout.cs
@@ -12,6 +12,7 @@ using Xunit;
 public class TimeOut
 {
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void OpenStandardXXX_WriteTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -27,6 +28,7 @@ public class TimeOut
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void OpenStandardXXX_ReadTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -42,6 +44,7 @@ public class TimeOut
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void OpenStandardXXX_CanTimeOut()
     {
         using (Stream standardOut = Console.OpenStandardOutput(), standardIn = Console.OpenStandardInput(), standardError = Console.OpenStandardError())
@@ -50,5 +53,12 @@ public class TimeOut
             Assert.False(standardIn.CanTimeout);
             Assert.False(standardError.CanTimeout);
         }
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void OpenStandardInput_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.OpenStandardInput() );
     }
 }

--- a/src/libraries/System.Console/tests/Timeout.cs
+++ b/src/libraries/System.Console/tests/Timeout.cs
@@ -57,8 +57,8 @@ public class TimeOut
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public static void OpenStandardInput_Browser()
+    public static void OpenStandardInput_Throws_PlatformNotSupportedException()
     {
-        Assert.Throws<PlatformNotSupportedException>(() => Console.OpenStandardInput() );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.OpenStandardInput());
     }
 }

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -129,10 +129,16 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public static void WindowHeightAndWidth_Browser()
+    public static void WindowHeight_Getter_Throws_PlatformNotSupportedException()
     {
-        Assert.Throws<PlatformNotSupportedException>(() => Console.WindowHeight );
-        Assert.Throws<PlatformNotSupportedException>(() => Console.WindowWidth );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.WindowHeight);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void WindowWidth_Getter_Throws_PlatformNotSupportedException()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.WindowWidth);
     }
 
     [Fact]
@@ -327,9 +333,9 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public static void SetCursorPosition_Browser()
+    public static void SetCursorPosition_Throws_PlatformNotSupportedException()
     {
-        Assert.Throws<PlatformNotSupportedException>(() => Console.SetCursorPosition(0, 0) );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.SetCursorPosition(0, 0));
     }
 
     [Fact]
@@ -424,9 +430,9 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public void CursorLeft_Browser()
+    public void CursorLeft_Setter_Throws_PlatformNotSupportedException()
     {
-        Assert.Throws<PlatformNotSupportedException>(() => Console.CursorLeft = 0 );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.CursorLeft = 0);
     }
 
     [Fact]
@@ -467,7 +473,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public void CursorTop_Browser()
+    public void CursorTop_Setter_Throws_PlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.CursorTop = 0 );
     }
@@ -509,7 +515,7 @@ public class WindowAndCursorProps
 
     [Fact]
     [PlatformSpecific(TestPlatforms.Browser)]
-    public void CursorSize_Browser()
+    public void CursorSize_Getter_Throws_PlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.CursorSize);
     }

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -13,7 +13,7 @@ using Xunit;
 public class WindowAndCursorProps
 {
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void BufferWidth_GetUnix_ReturnsWindowWidth()
     {
         Assert.Equal(Console.WindowWidth, Console.BufferWidth);
@@ -27,7 +27,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void BufferHeight_GetUnix_ReturnsWindowHeight()
     {
         Assert.Equal(Console.WindowHeight, Console.BufferHeight);
@@ -64,7 +64,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void WindowWidth_GetUnix_Success()
     {
         // Validate that Console.WindowWidth returns some value in a non-redirected o/p.
@@ -73,7 +73,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void WindowWidth_SetUnix_ThrowsPlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.WindowWidth = 100);
@@ -96,7 +96,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void WindowHeight_GetUnix_Success()
     {
         // Validate that Console.WindowHeight returns some value in a non-redirected o/p.
@@ -112,7 +112,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void LargestWindowWidth_UnixGet_ReturnsExpected()
     {
         Helpers.RunInNonRedirectedOutput((data) => Assert.Equal(Console.WindowWidth, Console.LargestWindowWidth));
@@ -120,7 +120,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void LargestWindowHeight_UnixGet_ReturnsExpected()
     {
         Helpers.RunInNonRedirectedOutput((data) => Assert.Equal(Console.WindowHeight, Console.LargestWindowHeight));
@@ -128,7 +128,15 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void WindowHeightAndWidth_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.WindowHeight );
+        Assert.Throws<PlatformNotSupportedException>(() => Console.WindowWidth );
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void WindowLeft_GetUnix_ReturnsZero()
     {
         Assert.Equal(0, Console.WindowLeft);
@@ -142,7 +150,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     public static void WindowTop_GetUnix_ReturnsZero()
     {
         Assert.Equal(0, Console.WindowTop);
@@ -179,7 +187,7 @@ public class WindowAndCursorProps
     }
 
     [Theory]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
     [InlineData(true)]
     [InlineData(false)]
     public static void CursorVisible_SetUnixRedirected_Nop(bool value)
@@ -318,6 +326,14 @@ public class WindowAndCursorProps
     }
 
     [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public static void SetCursorPosition_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.SetCursorPosition(0, 0) );
+    }
+
+    [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void SetCursorPosition_Invoke_Success()
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (!Console.IsInputRedirected && !Console.IsOutputRedirected))
@@ -344,6 +360,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public static void GetCursorPosition_Invoke_ReturnsExpected()
     {
         if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
@@ -370,6 +387,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void CursorLeft_Set_GetReturnsExpected()
     {
         if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
@@ -391,6 +409,7 @@ public class WindowAndCursorProps
     [Theory]
     [InlineData(-1)]
     [InlineData(short.MaxValue + 1)]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void CursorLeft_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
     {
         if (PlatformDetection.IsWindows && Console.IsOutputRedirected)
@@ -404,6 +423,14 @@ public class WindowAndCursorProps
     }
 
     [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public void CursorLeft_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.CursorLeft = 0 );
+    }
+
+    [Fact]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void CursorTop_Set_GetReturnsExpected()
     {
         if (!Console.IsInputRedirected && !Console.IsOutputRedirected)
@@ -425,6 +452,7 @@ public class WindowAndCursorProps
     [Theory]
     [InlineData(-1)]
     [InlineData(short.MaxValue + 1)]
+    [PlatformSpecific(~TestPlatforms.Browser)]
     public void CursorTop_SetInvalid_ThrowsArgumentOutOfRangeException(int value)
     {
         if (PlatformDetection.IsWindows & Console.IsOutputRedirected)
@@ -435,6 +463,13 @@ public class WindowAndCursorProps
         {
             AssertExtensions.Throws<ArgumentOutOfRangeException>("top", () => Console.CursorTop = value);
         }
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public void CursorTop_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.CursorTop = 0 );
     }
 
     [Fact]
@@ -466,10 +501,17 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix)]
+    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
     public void CursorSize_GetUnix_ReturnsExpected()
     {
         Assert.Equal(100, Console.CursorSize);
+    }
+
+    [Fact]
+    [PlatformSpecific(TestPlatforms.Browser)]
+    public void CursorSize_Browser()
+    {
+        Assert.Throws<PlatformNotSupportedException>(() => Console.CursorSize);
     }
 
     [Fact]


### PR DESCRIPTION
- Disabled the existing System.Console library tests which fail on WASM with PlatformNotSupportedException
- Added several tests to reflect WASM PNSE-behavior.

This is the follow up for https://github.com/dotnet/runtime/pull/37645

cc @steveisok 