### PR TITLE
Perf improvements for small or value-type POCOs

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -40,6 +40,7 @@
     <Compile Include="System\Text\Json\JsonException.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.cs" />
     <Compile Include="System\Text\Json\JsonHelpers.Date.cs" />
+    <Compile Include="System\Text\Json\JsonHelpers.Escaping.cs" />
     <Compile Include="System\Text\Json\JsonTokenType.cs" />
     <Compile Include="System\Text\Json\Reader\ConsumeNumberResult.cs" />
     <Compile Include="System\Text\Json\Reader\ConsumeTokenResult.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -117,7 +117,7 @@ namespace System.Text.Json
 
             if (idx != -1)
             {
-                return new JsonEncodedText(JsonHelpers.GetEscapedString(utf8Value, idx, encoder));
+                return new JsonEncodedText(JsonHelpers.EscapeValue(utf8Value, idx, encoder));
             }
             else
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonEncodedText.cs
@@ -32,15 +32,6 @@ namespace System.Text.Json
             _utf8Value = utf8Value;
         }
 
-        private JsonEncodedText(string stringValue, byte[] utf8Value)
-        {
-            Debug.Assert(stringValue != null);
-            Debug.Assert(utf8Value != null);
-
-            _value = stringValue;
-            _utf8Value = utf8Value;
-        }
-
         /// <summary>
         /// Encodes the string text value as a JSON string.
         /// </summary>
@@ -126,68 +117,12 @@ namespace System.Text.Json
 
             if (idx != -1)
             {
-                return new JsonEncodedText(GetEscapedString(utf8Value, idx, encoder));
+                return new JsonEncodedText(JsonHelpers.GetEscapedString(utf8Value, idx, encoder));
             }
             else
             {
                 return new JsonEncodedText(utf8Value.ToArray());
             }
-        }
-
-        /// <summary>
-        /// Internal version that keeps the existing string and byte[] references if there is no escaping required.
-        /// </summary>
-        internal static JsonEncodedText Encode(string stringValue, byte[] utf8Value, JavaScriptEncoder? encoder = null)
-        {
-            Debug.Assert(stringValue.Equals(JsonHelpers.Utf8GetString(utf8Value)));
-
-            if (utf8Value.Length == 0)
-            {
-                return new JsonEncodedText(stringValue, utf8Value);
-            }
-
-            JsonWriterHelper.ValidateValue(utf8Value);
-            return EncodeHelper(stringValue, utf8Value, encoder);
-        }
-
-        private static JsonEncodedText EncodeHelper(string stringValue, byte[] utf8Value, JavaScriptEncoder? encoder)
-        {
-            int idx = JsonWriterHelper.NeedsEscaping(utf8Value, encoder);
-
-            if (idx != -1)
-            {
-                return new JsonEncodedText(GetEscapedString(utf8Value, idx, encoder));
-            }
-            else
-            {
-                // Encoding is not necessary; use the same stringValue and utf8Value references.
-                return new JsonEncodedText(stringValue, utf8Value);
-            }
-        }
-
-        private static byte[] GetEscapedString(ReadOnlySpan<byte> utf8Value, int firstEscapeIndexVal, JavaScriptEncoder? encoder)
-        {
-            Debug.Assert(int.MaxValue / JsonConstants.MaxExpansionFactorWhileEscaping >= utf8Value.Length);
-            Debug.Assert(firstEscapeIndexVal >= 0 && firstEscapeIndexVal < utf8Value.Length);
-
-            byte[]? valueArray = null;
-
-            int length = JsonWriterHelper.GetMaxEscapedLength(utf8Value.Length, firstEscapeIndexVal);
-
-            Span<byte> escapedValue = length <= JsonConstants.StackallocThreshold ?
-                stackalloc byte[length] :
-                (valueArray = ArrayPool<byte>.Shared.Rent(length));
-
-            JsonWriterHelper.EscapeString(utf8Value, escapedValue, firstEscapeIndexVal, encoder, out int written);
-
-            byte[] escapedString = escapedValue.Slice(0, written).ToArray();
-
-            if (valueArray != null)
-            {
-                ArrayPool<byte>.Shared.Return(valueArray);
-            }
-
-            return escapedString;
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Escaping.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json
     internal static partial class JsonHelpers
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static byte[] GetEscapedPropertyNameSection(ReadOnlySpan<byte> utf8Value, JavaScriptEncoder? encoder)
+        public static byte[] GetEscapedPropertyNameSection(ReadOnlySpan<byte> utf8Value, JavaScriptEncoder? encoder)
         {
             int idx = JsonWriterHelper.NeedsEscaping(utf8Value, encoder);
 
@@ -26,7 +26,7 @@ namespace System.Text.Json
             }
         }
 
-        internal static byte[] GetEscapedString(
+        public static byte[] EscapeValue(
             ReadOnlySpan<byte> utf8Value,
             int firstEscapeIndexVal,
             JavaScriptEncoder? encoder)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Escaping.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.Escaping.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Encodings.Web;
+
+namespace System.Text.Json
+{
+    internal static partial class JsonHelpers
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static byte[] GetEscapedPropertyNameSection(ReadOnlySpan<byte> utf8Value, JavaScriptEncoder? encoder)
+        {
+            int idx = JsonWriterHelper.NeedsEscaping(utf8Value, encoder);
+
+            if (idx != -1)
+            {
+                return GetEscapedPropertyNameSection(utf8Value, idx, encoder);
+            }
+            else
+            {
+                return GetPropertyNameSection(utf8Value);
+            }
+        }
+
+        internal static byte[] GetEscapedString(
+            ReadOnlySpan<byte> utf8Value,
+            int firstEscapeIndexVal,
+            JavaScriptEncoder? encoder)
+        {
+            Debug.Assert(int.MaxValue / JsonConstants.MaxExpansionFactorWhileEscaping >= utf8Value.Length);
+            Debug.Assert(firstEscapeIndexVal >= 0 && firstEscapeIndexVal < utf8Value.Length);
+
+            byte[]? valueArray = null;
+
+            int length = JsonWriterHelper.GetMaxEscapedLength(utf8Value.Length, firstEscapeIndexVal);
+
+            Span<byte> escapedValue = length <= JsonConstants.StackallocThreshold ?
+                stackalloc byte[length] :
+                (valueArray = ArrayPool<byte>.Shared.Rent(length));
+
+            JsonWriterHelper.EscapeString(utf8Value, escapedValue, firstEscapeIndexVal, encoder, out int written);
+
+            byte[] escapedString = escapedValue.Slice(0, written).ToArray();
+
+            if (valueArray != null)
+            {
+                ArrayPool<byte>.Shared.Return(valueArray);
+            }
+
+            return escapedString;
+        }
+
+        private static byte[] GetEscapedPropertyNameSection(
+            ReadOnlySpan<byte> utf8Value,
+            int firstEscapeIndexVal,
+            JavaScriptEncoder? encoder)
+        {
+            Debug.Assert(int.MaxValue / JsonConstants.MaxExpansionFactorWhileEscaping >= utf8Value.Length);
+            Debug.Assert(firstEscapeIndexVal >= 0 && firstEscapeIndexVal < utf8Value.Length);
+
+            byte[]? valueArray = null;
+
+            int length = JsonWriterHelper.GetMaxEscapedLength(utf8Value.Length, firstEscapeIndexVal);
+
+            Span<byte> escapedValue = length <= JsonConstants.StackallocThreshold ?
+                stackalloc byte[length] :
+                (valueArray = ArrayPool<byte>.Shared.Rent(length));
+
+            JsonWriterHelper.EscapeString(utf8Value, escapedValue, firstEscapeIndexVal, encoder, out int written);
+
+            byte[] propertySection = GetPropertyNameSection(escapedValue.Slice(0, written));
+
+            if (valueArray != null)
+            {
+                ArrayPool<byte>.Shared.Return(valueArray);
+            }
+
+            return propertySection;
+        }
+
+        private static byte[] GetPropertyNameSection(ReadOnlySpan<byte> utf8Value)
+        {
+            int length = utf8Value.Length;
+            byte[] propertySection = new byte[length + 3];
+
+            propertySection[0] = JsonConstants.Quote;
+            utf8Value.CopyTo(propertySection.AsSpan(1, length));
+            propertySection[++length] = JsonConstants.Quote;
+            propertySection[++length] = JsonConstants.KeyValueSeperator;
+
+            return propertySection;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -91,7 +91,7 @@ namespace System.Text.Json
         /// </summary>
         /// <param name="bytes">The utf8 bytes to convert.</param>
         /// <returns></returns>
-        internal static string Utf8GetString(ReadOnlySpan<byte> bytes)
+        public static string Utf8GetString(ReadOnlySpan<byte> bytes)
         {
             return Encoding.UTF8.GetString(bytes
 #if NETSTANDARD2_0 || NETFRAMEWORK
@@ -103,7 +103,7 @@ namespace System.Text.Json
         /// <summary>
         /// Emulates Dictionary.TryAdd on netstandard.
         /// </summary>
-        internal static bool TryAdd<TKey, TValue>(Dictionary<TKey, TValue> dictionary, in TKey key, in TValue value) where TKey : notnull
+        public static bool TryAdd<TKey, TValue>(Dictionary<TKey, TValue> dictionary, in TKey key, in TValue value) where TKey : notnull
         {
 #if NETSTANDARD2_0 || NETFRAMEWORK
             if (!dictionary.ContainsKey(key))
@@ -118,7 +118,7 @@ namespace System.Text.Json
 #endif
         }
 
-        internal static bool IsFinite(double value)
+        public static bool IsFinite(double value)
         {
 #if BUILDING_INBOX_LIBRARY
             return double.IsFinite(value);
@@ -127,7 +127,7 @@ namespace System.Text.Json
 #endif
         }
 
-        internal static bool IsFinite(float value)
+        public static bool IsFinite(float value)
         {
 #if BUILDING_INBOX_LIBRARY
             return float.IsFinite(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonHelpers.cs
@@ -103,7 +103,7 @@ namespace System.Text.Json
         /// <summary>
         /// Emulates Dictionary.TryAdd on netstandard.
         /// </summary>
-        internal static bool TryAdd<TKey, TValue>(Dictionary<TKey, TValue> dictionary, TKey key, TValue value) where TKey : notnull
+        internal static bool TryAdd<TKey, TValue>(Dictionary<TKey, TValue> dictionary, in TKey key, in TValue value) where TKey : notnull
         {
 #if NETSTANDARD2_0 || NETFRAMEWORK
             if (!dictionary.ContainsKey(key))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
     {
         internal override bool CanHaveIdMetadata => false;
 
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentQueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentQueueOfTConverter.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : ConcurrentQueue<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Enqueue(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentStackOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ConcurrentStackOfTConverter.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : ConcurrentStack<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Push(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -16,7 +16,7 @@ namespace System.Text.Json.Serialization.Converters
         /// <summary>
         /// When overridden, adds the value to the collection.
         /// </summary>
-        protected abstract void Add(TValue value, JsonSerializerOptions options, ref ReadStack state);
+        protected abstract void Add(in TValue value, JsonSerializerOptions options, ref ReadStack state);
 
         /// <summary>
         /// When overridden, converts the temporary collection held in state.Current.ReturnValue to the final collection.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfStringTValueConverter.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Converters
         : DictionaryDefaultConverter<TCollection, TValue>
         where TCollection : Dictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(in TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             string key = state.Current.JsonPropertyNameAsString!;
             ((TCollection)state.Current.ReturnValue!)[key] = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ICollectionOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ICollectionOfTConverter.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : ICollection<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((ICollection<TElement>)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization.Converters
         : DictionaryDefaultConverter<TCollection, object?>
         where TCollection : IDictionary
     {
-        protected override void Add(object? value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(in object? value, JsonSerializerOptions options, ref ReadStack state)
         {
             string key = state.Current.JsonPropertyNameAsString!;
             ((IDictionary)state.Current.ReturnValue!)[key] = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfStringTValueConverter.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Converters
         : DictionaryDefaultConverter<TCollection, TValue>
         where TCollection : IDictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(in TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             string key = state.Current.JsonPropertyNameAsString!;
             ((TCollection)state.Current.ReturnValue!)[key] = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverter.cs
@@ -15,7 +15,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, object?>
         where TCollection : IEnumerable
     {
-        protected override void Add(object? value, ref ReadStack state)
+        protected override void Add(in object? value, ref ReadStack state)
         {
             ((List<object?>)state.Current.ReturnValue!).Add(value);
         }
@@ -62,7 +62,8 @@ namespace System.Text.Json.Serialization.Converters
                     return false;
                 }
 
-                if (!converter.TryWrite(writer, enumerator.Current, options, ref state))
+                object? element = enumerator.Current;
+                if (!converter.TryWrite(writer, element, options, ref state))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -46,7 +46,7 @@ namespace System.Text.Json.Serialization
 
             Type? baseTypeToCheck = type;
 
-            while (baseTypeToCheck != null && baseTypeToCheck != typeof(object))
+            while (baseTypeToCheck != null && baseTypeToCheck != JsonClassInfo.ObjectType)
             {
                 if (baseTypeToCheck.IsGenericType)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Converters
     internal abstract class IEnumerableDefaultConverter<TCollection, TElement>
         : JsonCollectionConverter<TCollection, TElement>
     {
-        protected abstract void Add(TElement value, ref ReadStack state);
+        protected abstract void Add(in TElement value, ref ReadStack state);
         protected abstract void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options);
         protected virtual void ConvertCollection(ref ReadStack state, JsonSerializerOptions options) { }
 
@@ -242,7 +242,11 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
-        internal sealed override bool OnTryWrite(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
+        internal sealed override bool OnTryWrite(
+            Utf8JsonWriter writer,
+            TCollection value,
+            JsonSerializerOptions options,
+            ref WriteStack state)
         {
             bool success;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
@@ -14,7 +14,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : IEnumerable<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableWithAddMethodConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableWithAddMethodConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, object?>
         where TCollection : IEnumerable
     {
-        protected override void Add(object? value, ref ReadStack state)
+        protected override void Add(in object? value, ref ReadStack state)
         {
             ((Action<TCollection, object?>)state.Current.AddMethodDelegate!)((TCollection)state.Current.ReturnValue!, value);
         }
@@ -53,7 +53,8 @@ namespace System.Text.Json.Serialization.Converters
                     return false;
                 }
 
-                if (!converter.TryWrite(writer, enumerator.Current, options, ref state))
+                object? element = enumerator.Current;
+                if (!converter.TryWrite(writer, element, options, ref state))
                 {
                     state.Current.CollectionEnumerator = enumerator;
                     return false;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, object?>
         where TCollection : IList
     {
-        protected override void Add(in  object? value, ref ReadStack state)
+        protected override void Add(in object? value, ref ReadStack state)
         {
             ((IList)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -12,7 +12,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, object?>
         where TCollection : IList
     {
-        protected override void Add(object? value, ref ReadStack state)
+        protected override void Add(in  object? value, ref ReadStack state)
         {
             ((IList)state.Current.ReturnValue!).Add(value);
         }
@@ -74,7 +74,6 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 object? element = enumerator.Current;
-
                 if (!converter.TryWrite(writer, element, options, ref state))
                 {
                     state.Current.CollectionEnumerator = enumerator;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListOfTConverter.cs
@@ -13,7 +13,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : IList<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfStringTValueConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : DictionaryDefaultConverter<TCollection, TValue>
         where TCollection : IReadOnlyDictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(in TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             string key = state.Current.JsonPropertyNameAsString!;
             ((Dictionary<string, TValue>)state.Current.ReturnValue!)[key] = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ISetOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ISetOfTConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : ISet<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfStringTValueConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : DictionaryDefaultConverter<TCollection, TValue>
         where TCollection : IReadOnlyDictionary<string, TValue>
     {
-        protected override void Add(TValue value, JsonSerializerOptions options, ref ReadStack state)
+        protected override void Add(in TValue value, JsonSerializerOptions options, ref ReadStack state)
         {
             string key = state.Current.JsonPropertyNameAsString!;
             ((Dictionary<string, TValue>)state.Current.ReturnValue!)[key] = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableEnumerableOfTConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : IEnumerable<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -11,7 +11,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection: List<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Add(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/QueueOfTConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : Queue<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Enqueue(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/StackOfTConverter.cs
@@ -10,7 +10,7 @@ namespace System.Text.Json.Serialization.Converters
         : IEnumerableDefaultConverter<TCollection, TElement>
         where TCollection : Stack<TElement>
     {
-        protected override void Add(TElement value, ref ReadStack state)
+        protected override void Add(in TElement value, ref ReadStack state)
         {
             ((TCollection)state.Current.ReturnValue!).Push(value);
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectConverterFactory.cs
@@ -43,7 +43,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if (parameterCount <= JsonConstants.UnboxedParameterCountThreshold)
                 {
-                    Type placeHolderType = typeof(object);
+                    Type placeHolderType = JsonClassInfo.ObjectType;
                     Type[] typeArguments = new Type[JsonConstants.UnboxedParameterCountThreshold + 1];
 
                     typeArguments[0] = typeToConvert;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -4,6 +4,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json.Serialization.Converters
 {
@@ -48,10 +49,10 @@ namespace System.Text.Json.Serialization.Converters
                     // Read method would have thrown if otherwise.
                     Debug.Assert(tokenType == JsonTokenType.PropertyName);
 
+                    ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
                     JsonPropertyInfo jsonPropertyInfo = JsonSerializer.LookupProperty(
                         obj,
-                        ref reader,
-                        options,
+                        unescapedPropertyName,
                         ref state,
                         out bool useExtensionProperty);
 
@@ -152,10 +153,10 @@ namespace System.Text.Json.Serialization.Converters
                         // Read method would have thrown if otherwise.
                         Debug.Assert(tokenType == JsonTokenType.PropertyName);
 
+                        ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
                         jsonPropertyInfo = JsonSerializer.LookupProperty(
                             obj,
-                            ref reader,
-                            options,
+                            unescapedPropertyName,
                             ref state,
                             out bool useExtensionProperty);
 
@@ -229,7 +230,11 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
-        internal sealed override bool OnTryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
+        internal sealed override bool OnTryWrite(
+            Utf8JsonWriter writer,
+            T value,
+            JsonSerializerOptions options,
+            ref WriteStack state)
         {
             // Minimize boxing for structs by only boxing once here
             object objectValue = value!;
@@ -356,6 +361,8 @@ namespace System.Text.Json.Serialization.Converters
             }
         }
 
+        // AggressiveInlining since this method is only called from two locations and is on a hot path.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void ReadPropertyValue(
             object obj,
             ref ReadStack state,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -188,10 +188,10 @@ namespace System.Text.Json.Serialization.Converters
                 }
                 else
                 {
+                    ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
                     JsonPropertyInfo jsonPropertyInfo = JsonSerializer.LookupProperty(
                         obj: null!,
-                        ref reader,
-                        options,
+                        unescapedPropertyName,
                         ref state,
                         out _,
                         createExtensionProperty: false);
@@ -273,10 +273,10 @@ namespace System.Text.Json.Serialization.Converters
                     }
                     else
                     {
+                        ReadOnlySpan<byte> unescapedPropertyName = JsonSerializer.GetPropertyName(ref state, ref reader, options);
                         jsonPropertyInfo = JsonSerializer.LookupProperty(
                             obj: null!,
-                            ref reader,
-                            options,
+                            unescapedPropertyName,
                             ref state,
                             out bool useExtensionProperty,
                             createExtensionProperty: false);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -14,6 +14,11 @@ namespace System.Text.Json
     [DebuggerDisplay("ClassType.{ClassType}, {Type.Name}")]
     internal sealed partial class JsonClassInfo
     {
+        /// <summary>
+        /// Cached typeof(object). It is faster to cache this than to call typeof(object) multiple times.
+        /// </summary>
+        public static readonly Type ObjectType = typeof(object);
+
         // The length of the property name embedded in the key (in bytes).
         // The key is a ulong (8 bytes) containing the first 7 bytes of the property name
         // followed by a byte representing the length.
@@ -115,7 +120,7 @@ namespace System.Text.Json
                 declaredPropertyType: declaredPropertyType,
                 runtimePropertyType: runtimePropertyType,
                 propertyInfo: null, // Not a real property so this is null.
-                parentClassType: typeof(object), // a dummy value (not used)
+                parentClassType: JsonClassInfo.ObjectType, // a dummy value (not used)
                 converter: converter,
                 options);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -444,7 +444,7 @@ namespace System.Text.Json
             {
                 key = MemoryMarshal.Read<ulong>(propertyName)
                     & 0x00FFFFFFFFFFFFFF
-                    // Include the length with a max of 0xFF so we force comparisons when length >=0xFF.
+                    // Include the length with a max of 0xFF.
                     | ((ulong)Math.Min(length, 0xFF)) << (7 * BitsInByte);
             }
             else if (length > 3)
@@ -501,17 +501,17 @@ namespace System.Text.Json
 
             // Verify key contains the embedded bytes as expected.
             Debug.Assert(
-                // Verify embedded characters.
-                (length < 1 || propertyName[0] == ((key & ((ulong)0xFF << 8 * 0)) >> 8 * 0)) &&
-                (length < 2 || propertyName[1] == ((key & ((ulong)0xFF << 8 * 1)) >> 8 * 1)) &&
-                (length < 3 || propertyName[2] == ((key & ((ulong)0xFF << 8 * 2)) >> 8 * 2)) &&
-                (length < 4 || propertyName[3] == ((key & ((ulong)0xFF << 8 * 3)) >> 8 * 3)) &&
-                (length < 5 || propertyName[4] == ((key & ((ulong)0xFF << 8 * 4)) >> 8 * 4)) &&
-                (length < 6 || propertyName[5] == ((key & ((ulong)0xFF << 8 * 5)) >> 8 * 5)) &&
-                (length < 7 || propertyName[6] == ((key & ((ulong)0xFF << 8 * 6)) >> 8 * 6)) &&
+                // Verify embedded property name.
+                (length < 1 || propertyName[0] == ((key & ((ulong)0xFF << BitsInByte * 0)) >> BitsInByte * 0)) &&
+                (length < 2 || propertyName[1] == ((key & ((ulong)0xFF << BitsInByte * 1)) >> BitsInByte * 1)) &&
+                (length < 3 || propertyName[2] == ((key & ((ulong)0xFF << BitsInByte * 2)) >> BitsInByte * 2)) &&
+                (length < 4 || propertyName[3] == ((key & ((ulong)0xFF << BitsInByte * 3)) >> BitsInByte * 3)) &&
+                (length < 5 || propertyName[4] == ((key & ((ulong)0xFF << BitsInByte * 4)) >> BitsInByte * 4)) &&
+                (length < 6 || propertyName[5] == ((key & ((ulong)0xFF << BitsInByte * 5)) >> BitsInByte * 5)) &&
+                (length < 7 || propertyName[6] == ((key & ((ulong)0xFF << BitsInByte * 6)) >> BitsInByte * 6)) &&
                 // Verify embedded length.
-                ((length >= 0xFF || (key & ((ulong)0xFF << 8 * 7)) >> 8 * 7 == (ulong)length)) &&
-                ((length < 0xFF || (key & ((ulong)0xFF << 8 * 7)) >> 8 * 7 == 0xFF)));
+                (length >= 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == (ulong)length) &&
+                (length < 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == 0xFF));
 
             return key;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -170,7 +170,7 @@ namespace System.Text.Json
                         if (DetermineExtensionDataProperty(cache))
                         {
                             // Remove from cache since it is handled independently.
-                            cache.Remove(DataExtensionProperty!.NameAsString!);
+                            cache.Remove(DataExtensionProperty!.NameAsString);
 
                             cacheArray = new JsonPropertyInfo[cache.Count + 1];
 
@@ -265,10 +265,10 @@ namespace System.Text.Json
 
                         // One object property cannot map to multiple constructor
                         // parameters (ConvertName above can't return multiple strings).
-                        parameterCache.Add(jsonPropertyInfo.NameAsString!, jsonParameterInfo);
+                        parameterCache.Add(jsonPropertyInfo.NameAsString, jsonParameterInfo);
 
                         // Remove property from deserialization cache to reduce the number of JsonPropertyInfos considered during JSON matching.
-                        propertyCache.Remove(jsonPropertyInfo.NameAsString!);
+                        propertyCache.Remove(jsonPropertyInfo.NameAsString);
 
                         isBound = true;
                         firstMatch = propertyInfo;
@@ -278,7 +278,7 @@ namespace System.Text.Json
 
             // It is invalid for the extension data property to bind with a constructor argument.
             if (DataExtensionProperty != null &&
-                parameterCache.ContainsKey(DataExtensionProperty.NameAsString!))
+                parameterCache.ContainsKey(DataExtensionProperty.NameAsString))
             {
                 ThrowHelper.ThrowInvalidOperationException_ExtensionDataCannotBindToCtorParam(DataExtensionProperty.PropertyInfo!, Type, constructorInfo);
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.WriteCore.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization
 
         internal bool WriteCore(
             Utf8JsonWriter writer,
-            T value,
+            in T value,
             JsonSerializerOptions options,
             ref WriteStack state)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -22,7 +22,7 @@ namespace System.Text.Json.Serialization
         {
             // Today only typeof(object) can have polymorphic writes.
             // In the future, this will be check for !IsSealed (and excluding value types).
-            CanBePolymorphic = TypeToConvert == typeof(object);
+            CanBePolymorphic = TypeToConvert == JsonClassInfo.ObjectType;
             IsValueType = TypeToConvert.IsValueType;
             HandleNull = IsValueType;
             CanBeNull = !IsValueType || Nullable.GetUnderlyingType(TypeToConvert) != null;
@@ -268,7 +268,7 @@ namespace System.Text.Json.Serialization
                 }
 
                 Type type = value.GetType();
-                if (type == typeof(object))
+                if (type == JsonClassInfo.ObjectType)
                 {
                     writer.WriteStartObject();
                     writer.WriteEndObject();

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -239,7 +239,7 @@ namespace System.Text.Json.Serialization
             return success;
         }
 
-        internal bool TryWrite(Utf8JsonWriter writer, T value, JsonSerializerOptions options, ref WriteStack state)
+        internal bool TryWrite(Utf8JsonWriter writer, in T value, JsonSerializerOptions options, ref WriteStack state)
         {
             if (writer.CurrentDepth >= options.EffectiveMaxDepth)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -243,7 +243,7 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    JsonConverter<object> converter = (JsonConverter<object>)Options.GetConverter(typeof(object));
+                    JsonConverter<object> converter = (JsonConverter<object>)Options.GetConverter(JsonClassInfo.ObjectType);
 
                     if (!converter.TryRead(ref reader, typeof(JsonElement), Options, ref state, out object? value))
                     {
@@ -281,7 +281,7 @@ namespace System.Text.Json
         {
             Debug.Assert(this == state.Current.JsonClassInfo.DataExtensionProperty);
 
-            if (RuntimeClassInfo.ElementType == typeof(object) && reader.TokenType == JsonTokenType.Null)
+            if (RuntimeClassInfo.ElementType == JsonClassInfo.ObjectType && reader.TokenType == JsonTokenType.Null)
             {
                 value = null;
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -108,7 +108,7 @@ namespace System.Text.Json
                 Debug.Assert(genericArgs.Length == 2);
                 Debug.Assert(genericArgs[0].UnderlyingSystemType == typeof(string));
                 Debug.Assert(
-                    genericArgs[1].UnderlyingSystemType == typeof(object) ||
+                    genericArgs[1].UnderlyingSystemType == JsonClassInfo.ObjectType ||
                     genericArgs[1].UnderlyingSystemType == typeof(JsonElement));
 #endif
                 if (jsonPropertyInfo.RuntimeClassInfo.CreateObject == null)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -15,12 +15,9 @@ namespace System.Text.Json
         /// Lookup the property given its name (obtained from the reader) and return it.
         /// Also sets state.Current.JsonPropertyInfo to a non-null value.
         /// </summary>
-        // AggressiveInlining used although a large method it is only called from two locations and is on a hot path.
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static JsonPropertyInfo LookupProperty(
             object obj,
-            ref Utf8JsonReader reader,
-            JsonSerializerOptions options,
+            ReadOnlySpan<byte> unescapedPropertyName,
             ref ReadStack state,
             out bool useExtensionProperty,
             bool createExtensionProperty = true)
@@ -28,8 +25,6 @@ namespace System.Text.Json
             Debug.Assert(state.Current.JsonClassInfo.ClassType == ClassType.Object);
 
             useExtensionProperty = false;
-
-            ReadOnlySpan<byte> unescapedPropertyName = GetPropertyName(ref state, ref reader, options);
 
             JsonPropertyInfo jsonPropertyInfo = state.Current.JsonClassInfo.GetProperty(
                 unescapedPropertyName,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.ByteArray.cs
@@ -53,7 +53,7 @@ namespace System.Text.Json
             return WriteCoreBytes<object>(value!, inputType, options);
         }
 
-        private static byte[] WriteCoreBytes<TValue>(TValue value, Type inputType, JsonSerializerOptions? options)
+        private static byte[] WriteCoreBytes<TValue>(in TValue value, Type inputType, JsonSerializerOptions? options)
         {
             if (options == null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -9,19 +9,22 @@ namespace System.Text.Json
 {
     public static partial class JsonSerializer
     {
-        private static void WriteCore<TValue>(Utf8JsonWriter writer, TValue value, Type inputType, JsonSerializerOptions options)
+        private static void WriteCore<TValue>(
+            Utf8JsonWriter writer,
+            in TValue value,
+            Type inputType,
+            JsonSerializerOptions options)
         {
             Debug.Assert(writer != null);
 
             //  We treat typeof(object) special and allow polymorphic behavior.
-            if (inputType == typeof(object) && value != null)
+            if (value != null && inputType == typeof(object))
             {
                 inputType = value!.GetType();
             }
 
             WriteStack state = default;
-            state.Initialize(inputType, options, supportContinuation: false);
-            JsonConverter jsonConverter = state.Current.JsonClassInfo!.PropertyInfoForClassInfo.ConverterBase;
+            JsonConverter jsonConverter = state.Initialize(inputType, options, supportContinuation: false);
 
             bool success = WriteCore(jsonConverter, writer, value, options, ref state);
             Debug.Assert(success);
@@ -30,7 +33,7 @@ namespace System.Text.Json
         private static bool WriteCore<TValue>(
             JsonConverter jsonConverter,
             Utf8JsonWriter writer,
-            TValue value,
+            in TValue value,
             JsonSerializerOptions options,
             ref WriteStack state)
         {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Helpers.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json
             Debug.Assert(writer != null);
 
             //  We treat typeof(object) special and allow polymorphic behavior.
-            if (value != null && inputType == typeof(object))
+            if (value != null && inputType == JsonClassInfo.ObjectType)
             {
                 inputType = value!.GetType();
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -114,9 +114,7 @@ namespace System.Text.Json
                 }
 
                 WriteStack state = default;
-                state.Initialize(inputType, options, supportContinuation: true);
-
-                JsonConverter converterBase = state.Current.JsonClassInfo!.PropertyInfoForClassInfo.ConverterBase;
+                JsonConverter converterBase = state.Initialize(inputType, options, supportContinuation: true);
 
                 bool isFinalBlock;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -108,7 +108,7 @@ namespace System.Text.Json
             using (var writer = new Utf8JsonWriter(bufferWriter, writerOptions))
             {
                 //  We treat typeof(object) special and allow polymorphic behavior.
-                if (inputType == typeof(object) && value != null)
+                if (inputType == JsonClassInfo.ObjectType && value != null)
                 {
                     inputType = value!.GetType();
                 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.String.cs
@@ -58,7 +58,7 @@ namespace System.Text.Json
             return Serialize<object?>(value, inputType, options);
         }
 
-        private static string Serialize<TValue>(TValue value, Type inputType, JsonSerializerOptions? options)
+        private static string Serialize<TValue>(in TValue value, Type inputType, JsonSerializerOptions? options)
         {
             if (options == null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Utf8JsonWriter.cs
@@ -59,7 +59,7 @@ namespace System.Text.Json
             Serialize<object?>(writer, value, inputType, options);
         }
 
-        private static void Serialize<TValue>(Utf8JsonWriter writer, TValue value, Type type, JsonSerializerOptions? options)
+        private static void Serialize<TValue>(Utf8JsonWriter writer, in TValue value, Type type, JsonSerializerOptions? options)
         {
             if (options == null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -21,6 +21,10 @@ namespace System.Text.Json
 
         private readonly ConcurrentDictionary<Type, JsonClassInfo> _classes = new ConcurrentDictionary<Type, JsonClassInfo>();
 
+        // Simple LRU cache for the public (de)serialize entry points that avoid some lookups in _classes.
+        // Although this may be written by multiple threads, 'volatile' was not added since any local affinity is fine.
+        internal JsonClassInfo? LastClass { get; set; }
+
         // For any new option added, adding it to the options copied in the copy constructor below must be considered.
 
         private MemberAccessor? _memberAccessorStrategy;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -23,7 +23,7 @@ namespace System.Text.Json
 
         // Simple LRU cache for the public (de)serialize entry points that avoid some lookups in _classes.
         // Although this may be written by multiple threads, 'volatile' was not added since any local affinity is fine.
-        internal JsonClassInfo? LastClass { get; set; }
+        private JsonClassInfo? _lastClass { get; set; }
 
         // For any new option added, adding it to the options copied in the copy constructor below must be considered.
 
@@ -449,6 +449,22 @@ namespace System.Text.Json
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Return the ClassInfo for root API calls.
+        /// This has a LRU cache that is intended only for public API calls that specify the root type.
+        /// </summary>
+        internal JsonClassInfo GetOrAddClassForRootType(Type type)
+        {
+            JsonClassInfo? jsonClassInfo = _lastClass;
+            if (jsonClassInfo?.Type != type)
+            {
+                jsonClassInfo = GetOrAddClass(type);
+                _lastClass = jsonClassInfo;
+            }
+
+            return jsonClassInfo;
         }
 
         internal bool TypeIsCached(Type type)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -82,13 +82,7 @@ namespace System.Text.Json
 
         public void Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
-            JsonClassInfo? jsonClassInfo = options.LastClass;
-            if (jsonClassInfo?.Type != type)
-            {
-                jsonClassInfo = options.GetOrAddClass(type);
-                options.LastClass = jsonClassInfo;
-            }
-
+            JsonClassInfo jsonClassInfo = options.GetOrAddClassForRootType(type);
             Current.JsonClassInfo = jsonClassInfo;
 
             // The initial JsonPropertyInfo will be used to obtain the converter.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStack.cs
@@ -82,7 +82,12 @@ namespace System.Text.Json
 
         public void Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
-            JsonClassInfo jsonClassInfo = options.GetOrAddClass(type);
+            JsonClassInfo? jsonClassInfo = options.LastClass;
+            if (jsonClassInfo?.Type != type)
+            {
+                jsonClassInfo = options.GetOrAddClass(type);
+                options.LastClass = jsonClassInfo;
+            }
 
             Current.JsonClassInfo = jsonClassInfo;
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionEmitMemberAccessor.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization
 
             var dynamicMethod = new DynamicMethod(
                 ConstructorInfo.ConstructorName,
-                typeof(object),
+                JsonClassInfo.ObjectType,
                 Type.EmptyTypes,
                 typeof(ReflectionEmitMemberAccessor).Module,
                 skipVisibility: true);
@@ -158,7 +158,7 @@ namespace System.Text.Json.Serialization
             var dynamicMethod = new DynamicMethod(
                 realMethod.Name,
                 typeof(void),
-                new[] { collectionType, typeof(object) },
+                new[] { collectionType, JsonClassInfo.ObjectType },
                 typeof(ReflectionEmitMemberAccessor).Module,
                 skipVisibility: true);
 
@@ -226,7 +226,7 @@ namespace System.Text.Json.Serialization
         private static DynamicMethod CreatePropertyGetter(PropertyInfo propertyInfo, Type classType, Type propertyType)
         {
             MethodInfo? realMethod = propertyInfo.GetMethod;
-            Type objectType = typeof(object);
+            Type objectType = JsonClassInfo.ObjectType;
 
             Debug.Assert(realMethod != null);
             var dynamicMethod = new DynamicMethod(
@@ -262,7 +262,7 @@ namespace System.Text.Json.Serialization
         private static DynamicMethod CreatePropertySetter(PropertyInfo propertyInfo, Type classType, Type propertyType)
         {
             MethodInfo? realMethod = propertyInfo.SetMethod;
-            Type objectType = typeof(object);
+            Type objectType = JsonClassInfo.ObjectType;
 
             Debug.Assert(realMethod != null);
             var dynamicMethod = new DynamicMethod(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReflectionMemberAccessor.cs
@@ -113,7 +113,7 @@ namespace System.Text.Json.Serialization
         public override Action<TCollection, object?> CreateAddMethodDelegate<TCollection>()
         {
             Type collectionType = typeof(TCollection);
-            Type elementType = typeof(object);
+            Type elementType = JsonClassInfo.ObjectType;
 
             // We verified this won't be null when we created the converter for the collection type.
             MethodInfo addMethod = (collectionType.GetMethod("Push") ?? collectionType.GetMethod("Enqueue"))!;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -68,13 +68,7 @@ namespace System.Text.Json
         /// </summary>
         public JsonConverter Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
-            JsonClassInfo? jsonClassInfo = options.LastClass;
-            if (jsonClassInfo?.Type != type)
-            {
-                jsonClassInfo = options.GetOrAddClass(type);
-                options.LastClass = jsonClassInfo;
-            }
-
+            JsonClassInfo jsonClassInfo = options.GetOrAddClassForRootType(type);
             Current.JsonClassInfo = jsonClassInfo;
 
             if ((jsonClassInfo.ClassType & (ClassType.Enumerable | ClassType.Dictionary)) == 0)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.String.cs
@@ -4,6 +4,7 @@
 
 using System.Buffers;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 
 namespace System.Text.Json
 {
@@ -18,6 +19,26 @@ namespace System.Text.Json
         /// </exception>
         public void WritePropertyName(JsonEncodedText propertyName)
             => WritePropertyNameHelper(propertyName.EncodedUtf8Bytes);
+
+        internal void WritePropertyNameSection(ReadOnlySpan<byte> escapedPropertyNameSection)
+        {
+            if (_options.Indented)
+            {
+                ReadOnlySpan<byte> escapedPropertyName =
+                    escapedPropertyNameSection.Slice(1, escapedPropertyNameSection.Length - 3);
+
+                WritePropertyNameHelper(escapedPropertyName);
+            }
+            else
+            {
+                Debug.Assert(escapedPropertyNameSection.Length <= JsonConstants.MaxUnescapedTokenSize - 3);
+
+                WriteStringPropertyNameSection(escapedPropertyNameSection);
+
+                _currentDepth &= JsonConstants.RemoveFlagsBitMask;
+                _tokenType = JsonTokenType.PropertyName;
+            }
+        }
 
         private void WritePropertyNameHelper(ReadOnlySpan<byte> utf8PropertyName)
         {
@@ -285,6 +306,8 @@ namespace System.Text.Json
             }
         }
 
+        // AggressiveInlining used since this is only called from one location.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteStringMinimizedPropertyName(ReadOnlySpan<byte> escapedPropertyName)
         {
             Debug.Assert(escapedPropertyName.Length <= JsonConstants.MaxEscapedTokenSize);
@@ -313,6 +336,33 @@ namespace System.Text.Json
             output[BytesPending++] = JsonConstants.KeyValueSeperator;
         }
 
+        // AggressiveInlining used since this is only called from one location.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void WriteStringPropertyNameSection(ReadOnlySpan<byte> escapedPropertyNameSection)
+        {
+            Debug.Assert(escapedPropertyNameSection.Length <= JsonConstants.MaxEscapedTokenSize - 3);
+            Debug.Assert(escapedPropertyNameSection.Length < int.MaxValue - 4);
+
+            int maxRequired = escapedPropertyNameSection.Length + 1; // Optionally, 1 list separator
+
+            if (_memory.Length - BytesPending < maxRequired)
+            {
+                Grow(maxRequired);
+            }
+
+            Span<byte> output = _memory.Span;
+
+            if (_currentDepth < 0)
+            {
+                output[BytesPending++] = JsonConstants.ListSeparator;
+            }
+
+            escapedPropertyNameSection.CopyTo(output.Slice(BytesPending));
+            BytesPending += escapedPropertyNameSection.Length;
+        }
+
+        // AggressiveInlining used since this is only called from one location.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void WriteStringIndentedPropertyName(ReadOnlySpan<byte> escapedPropertyName)
         {
             int indent = Indentation;

--- a/src/libraries/System.Text.Json/tests/Serialization/CacheTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/CacheTests.cs
@@ -12,18 +12,18 @@ namespace System.Text.Json.Serialization.Tests
     public static class CacheTests
     {
         [Fact, OuterLoop]
-        public static void MultipleThreadsLooping()
+        public static void MultipleThreads_SameType_DifferentJson_Looping()
         {
             const int Iterations = 100;
 
             for (int i = 0; i < Iterations; i++)
             {
-                MultipleThreads();
+                MultipleThreads_SameType_DifferentJson();
             }
         }
 
         [Fact]
-        public static void MultipleThreads()
+        public static void MultipleThreads_SameType_DifferentJson()
         {
             // Use local options to avoid obtaining already cached metadata from the default options.
             var options = new JsonSerializerOptions();
@@ -69,6 +69,58 @@ namespace System.Text.Json.Serialization.Tests
                 // Ensure no exceptions on serialization
                 tasks[i + 3] = Task.Run(() => SerializeObject());
             };
+
+            Task.WaitAll(tasks);
+        }
+
+        [Fact, OuterLoop]
+        public static void MultipleThreads_DifferentTypes_Looping()
+        {
+            const int Iterations = 100;
+
+            for (int i = 0; i < Iterations; i++)
+            {
+                MultipleThreads_DifferentTypes();
+            }
+        }
+
+        [Fact]
+        public static void MultipleThreads_DifferentTypes()
+        {
+            // Use local options to avoid obtaining already cached metadata from the default options.
+            var options = new JsonSerializerOptions();
+
+            const int TestClassCount = 2;
+
+            var testObjects = new ITestClass[TestClassCount]
+            {
+                new SimpleTestClassWithNulls(),
+                new SimpleTestClass(),
+            };
+
+            foreach (ITestClass obj in testObjects)
+            {
+                obj.Initialize();
+            }
+
+            void Test(int i)
+            {
+                Type testClassType = testObjects[i].GetType();
+
+                string json = JsonSerializer.Serialize(testObjects[i], testClassType, options);
+
+                ITestClass obj = (ITestClass)JsonSerializer.Deserialize(json, testClassType, options);
+                obj.Verify();
+            };
+
+            const int OuterCount = 12;
+            Task[] tasks = new Task[OuterCount * TestClassCount];
+
+            for (int i = 0; i < tasks.Length; i += TestClassCount)
+            {
+                tasks[i + 0] = Task.Run(() => Test(TestClassCount - 1));
+                tasks[i + 1] = Task.Run(() => Test(TestClassCount - 2));
+            }
 
             Task.WaitAll(tasks);
         }


### PR DESCRIPTION
For a TechEmPower benchmark which uses a one-property struct, this shows a ~1.2x serialization improvement during serialization.

Note a value-type (struct) POCO is not common and should only be used when there are very few properties -- instead a POCO should be a reference-type (class).

Fixes https://github.com/dotnet/runtime/issues/36635

Summary of changes:
- Add a LRU cache before the dictionary access that returns the metadata for the root type being (de)serialized. This is the biggest savings for small POCOs; larger POCOs are not affected since the dictionary access becomes insignificant compared to the rest of the work. Also this LRU helps most when there is low concurrency (few threads) or the same type is being repeatedly (de)serialized.
- In internal code, pass the value types using `in` to avoid unnecessary copies. The more serializable properties a value-type contains, the bigger the savings.
- Optimize property writes to include the quotes and colon as suggested by @Tornhoof. This also allowed for some `AggressiveInlining` fast-path changes to since the code path is now internal and specific to this optimization.
- Other `AggressiveInlining` changes. Both added and removed. The crossgen size of STJ.dll is now 15K smaller (1071K to 1056K).
- Property lookup for cache misses (due to case-insensitivity or different property ordering across JSON payloads for a given Type) is faster since the length is now embedded into the `ulong` key avoiding calls to `SequenceEquals()` when the length is different. This doesn't affect the TechEmPower scenarios.
- Other smaller misc changes.

<details>
  <summary>Click to expand for benchmarks</summary>
Note the items in the "Slower" section appear to be random differences on my machine.

Changes <= 2% are ignored.

**summary:
better: 60, geomean: 1.081
worse: 6, geomean: 1.042
total diff: 66**


| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.06 |        399455.00 |        422447.04 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.05 |        415556.58 |        436781.25 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.04 |        421354.56 |        438918.92 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Hashtable>.DeserializeFromUtf8Byte |      1.04 |         60123.19 |         62395.95 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ImmutableDictionary<String, Strin |      1.04 |         22739.64 |         23542.93 |         |
| System.Text.Json.Serialization.Tests.WriteJson<MyEventsListerViewModel>.Serializ |      1.03 |        393763.91 |        405899.18 |         |

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.Json.Serialization.Tests.ReadJson<Int32>.DeserializeFromUtf8Bytes    |      1.27 |           110.28 |            86.93 |         |
| System.Text.Json.Serialization.Tests.TechEmPower.SerializeWithCachedBufferAndWri |      1.22 |           157.92 |           128.98 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeToUtf8Bytes       |      1.21 |           136.89 |           112.73 |         |
| System.Text.Json.Serialization.Tests.TechEmPower.SerializeWithCachedBuffer       |      1.20 |           168.65 |           140.95 |         |
| System.Text.Json.Serialization.Tests.WriteJson<HashSet<String>>.SerializeToUtf8B |      1.19 |          6923.56 |          5839.37 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Int32>.DeserializeFromString       |      1.18 |           153.13 |           130.14 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeToString          |      1.16 |           151.17 |           129.87 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.15 |           320.42 |           278.51 |         |
| System.Text.Json.Serialization.Tests.ReadJson<SimpleStructWithProperties>.Deseri |      1.14 |           304.91 |           267.69 |         |
| System.Text.Json.Serialization.Tests.ReadMissingAndCaseInsensitive<Location>.Cas |      1.14 |          1303.16 |          1145.62 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.13 |           237.91 |           209.73 |         |
| System.Text.Json.Serialization.Tests.WriteJson<BinaryData>.SerializeToString     |      1.12 |           576.65 |           514.93 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeToStream          |      1.12 |           188.54 |           168.38 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToUtf8By |      1.12 |           316.44 |           282.72 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.11 |           261.98 |           235.15 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToStream |      1.11 |           400.38 |           360.51 |         |
| System.Text.Json.Serialization.Tests.WriteJson<BinaryData>.SerializeToStream     |      1.11 |           443.86 |           400.77 |         |
| System.Text.Json.Serialization.Tests.ReadJson<SimpleStructWithProperties>.Deseri |      1.10 |           361.03 |           326.98 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Int32>.DeserializeFromStream       |      1.09 |           287.03 |           263.85 |         |
| System.Text.Json.Serialization.Tests.WriteJson<SimpleStructWithProperties>.Seria |      1.08 |           436.69 |           403.47 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.08 |           682.21 |           631.29 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToStream       |      1.08 |           858.27 |           794.58 |         |
| System.Text.Json.Serialization.Tests.ReadJson<SimpleStructWithProperties>.Deseri |      1.08 |           532.88 |           493.99 |         |
| System.Text.Json.Serialization.Tests.WriteJson<BinaryData>.SerializeToUtf8Bytes  |      1.08 |           400.49 |           371.56 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeToString |      1.08 |           348.29 |           323.17 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.08 |           641.82 |           595.65 |         |
| System.Text.Json.Serialization.Tests.ReadJson<BinaryData>.DeserializeFromUtf8Byt |      1.07 |           481.45 |           448.85 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LoginViewModel>.DeserializeFromUtf |      1.07 |           416.76 |           388.67 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ArrayList>.SerializeObjectPropert |      1.07 |         11685.38 |         10908.28 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LargeStructWithProperties>.Deseria |      1.07 |          1536.53 |          1435.71 |         |
| System.Text.Json.Serialization.Tests.ReadJson<BinaryData>.DeserializeFromString  |      1.07 |           611.60 |           571.62 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToString       |      1.07 |           825.48 |           774.76 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Int32>.SerializeObjectProperty    |      1.06 |           240.80 |           226.22 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.06 |           851.35 |           805.19 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ArrayList>.SerializeToString      |      1.05 |         11071.73 |         10494.79 |         |
| System.Text.Json.Serialization.Tests.ReadJson<BinaryData>.DeserializeFromStream  |      1.05 |           798.38 |           760.46 |         |
| System.Text.Json.Serialization.Tests.ReadJson<IndexViewModel>.DeserializeFromStr |      1.05 |         29917.50 |         28523.15 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeObjectProperty |      1.05 |           965.81 |           921.32 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Location>.SerializeToUtf8Bytes    |      1.05 |           773.55 |           738.47 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LoginViewModel>.SerializeObjectPr |      1.05 |           497.30 |           474.84 |         |
| System.Text.Json.Serialization.Tests.ReadJson<MyEventsListerViewModel>.Deseriali |      1.05 |        306043.34 |        292656.13 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LoginViewModel>.DeserializeFromStr |      1.05 |           481.74 |           460.92 |         |
| System.Text.Json.Serialization.Tests.ReadMissingAndCaseInsensitive<Location>.Mis |      1.04 |           797.91 |           765.76 |         |
| System.Text.Json.Serialization.Tests.WriteJson<LargeStructWithProperties>.Serial |      1.04 |           751.29 |           721.58 |         |
| System.Text.Json.Serialization.Tests.ReadJson<ImmutableSortedDictionary<String,  |      1.04 |         69278.46 |         66565.23 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Hashtable>.SerializeToString      |      1.04 |         17390.87 |         16731.64 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LargeStructWithProperties>.Deseria |      1.04 |          1067.42 |          1028.77 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Hashtable>.DeserializeFromStream   |      1.04 |         62911.90 |         60661.09 |         |
| System.Text.Json.Serialization.Tests.ReadMissingAndCaseInsensitive<Location>.Bas |      1.04 |          1191.68 |          1149.92 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ImmutableSortedDictionary<String, |      1.04 |         16905.74 |         16313.72 |         |
| System.Text.Json.Serialization.Tests.WriteJson<ArrayList>.SerializeToStream      |      1.04 |         10598.59 |         10235.46 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Hashtable>.DeserializeFromString   |      1.03 |         63096.82 |         61013.44 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Hashtable>.SerializeToUtf8Bytes   |      1.03 |         16751.03 |         16241.27 |         |
| System.Text.Json.Serialization.Tests.ReadJson<Location>.DeserializeFromString    |      1.03 |          1176.87 |          1142.29 |         |
| System.Text.Json.Serialization.Tests.WriteJson<HashSet<String>>.SerializeToStrin |      1.03 |          6308.08 |          6126.69 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LargeStructWithProperties>.Deseria |      1.03 |          1154.10 |          1121.70 |         |
| System.Text.Json.Serialization.Tests.ReadJson<LoginViewModel>.DeserializeFromStr |      1.03 |           693.37 |           674.69 |         |
| System.Text.Json.Serialization.Tests.WriteJson<IndexViewModel>.SerializeToUtf8By |      1.03 |         15614.74 |         15212.41 |         |
| System.Text.Json.Serialization.Tests.ReadMissingAndCaseInsensitive<Location>.Cas |      1.03 |          1181.37 |          1152.01 |         |
| System.Text.Json.Serialization.Tests.WriteJson<Hashtable>.SerializeToStream      |      1.02 |         16290.03 |         15892.85 |         |
</details>

<details>
  <summary>Click to expand for temporary TechEmpower benchmark</summary>

Summary: 1.22x faster (when using a cached buffer)

Before:
|                             Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|          SerializeWithCachedBuffer | 169.0 ns | 1.15 ns | 1.08 ns | 169.0 ns | 167.2 ns | 170.5 ns | 0.0227 |     - |     - |     144 B |
| SerializeWithCachedBufferAndWriter | 155.3 ns | 1.19 ns | 1.11 ns | 155.5 ns | 153.3 ns | 157.3 ns | 0.0038 |     - |     - |      24 B |
|            SerializeWithManualCode | 116.4 ns | 0.57 ns | 0.48 ns | 116.5 ns | 115.6 ns | 117.2 ns | 0.0188 |     - |     - |     120 B |

After:
|                             Method |     Mean |   Error |  StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------------- |---------:|--------:|--------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|          SerializeWithCachedBuffer | 141.6 ns | 2.33 ns | 2.18 ns | 141.2 ns | 138.0 ns | 144.8 ns | 0.0227 |     - |     - |     144 B |
| SerializeWithCachedBufferAndWriter | 130.8 ns | 1.50 ns | 1.40 ns | 130.9 ns | 128.6 ns | 133.0 ns | 0.0037 |     - |     - |      24 B |
|            SerializeWithManualCode | 112.1 ns | 1.14 ns | 1.07 ns | 112.4 ns | 110.5 ns | 113.7 ns | 0.0188 |     - |     - |     120 B |


Code:
```cs
using BenchmarkDotNet.Attributes;
using MicroBenchmarks;
using System.Buffers;
using System.Threading.Tasks;

namespace System.Text.Json.Serialization.Tests
{
    public struct JsonMessage
    {
        public string message { get; set; }
    }

    public class TechEmPower
    {
        private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions();

        ArrayBufferWriter<byte> _bufferWriter = new ArrayBufferWriter<byte>(160 * 16);
        Utf8JsonWriter _utf8Jsonwriter;


        [GlobalSetup]
        public void Setup()
        {
            _utf8Jsonwriter = new Utf8JsonWriter(_bufferWriter, new JsonWriterOptions { SkipValidation = true });
        }

        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
        [Benchmark]
        public void SerializeWithCachedBuffer()
        {
            _bufferWriter.Clear();
            var utf8JsonWriter = new Utf8JsonWriter(_bufferWriter, new JsonWriterOptions { SkipValidation = true });
            JsonSerializer.Serialize<JsonMessage>(utf8JsonWriter, new JsonMessage { message = "Hello, World!" }, SerializerOptions);
        }

        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
        [Benchmark]
        public void SerializeWithCachedBufferAndWriter()
        {
            _bufferWriter.Clear();
            JsonSerializer.Serialize<JsonMessage>(_utf8Jsonwriter, new JsonMessage { message = "Hello, World!" }, SerializerOptions);
        }

        [BenchmarkCategory(Categories.Libraries, Categories.JSON)]
        [Benchmark]
        public void SerializeWithManualCode()
        {
            _bufferWriter.Clear();
            using (var utf8JsonWriter = new Utf8JsonWriter(_bufferWriter))
            {
                var message = new JsonMessage { message = "Hello, World!" };
                utf8JsonWriter.WriteStartObject();
                utf8JsonWriter.WriteString("message", message.message);
                utf8JsonWriter.WriteEndObject();
            }
        }
    }
}
```