### PR TITLE
System.Text.Json: Support for IAsyncEnumerable

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -63,10 +63,15 @@
     <Compile Include="System\Text\Json\Serialization\ClassType.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterList.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ArrayConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\AsyncEnumerableList.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ConcurrentQueueOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ConcurrentStackOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\DictionaryDefaultConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\DictionaryOfStringTValueConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\IAsyncEnumerableConverterFactory.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\IAsyncEnumerableOfTConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\IAsyncEnumerableOfTObjectConverter.cs" />
+    <Compile Include="System\Text\Json\Serialization\Converters\Collection\IAsyncEnumerableOfTValueConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\ICollectionOfTConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IDictionaryConverter.cs" />
     <Compile Include="System\Text\Json\Serialization\Converters\Collection\IDictionaryOfStringTValueConverter.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/AsyncEnumerableList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/AsyncEnumerableList.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    internal class AsyncEnumerableList<T>
+        : List<T>, IAsyncEnumerable<T>
+    {
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            => new AsyncEnumerator(GetEnumerator());
+
+        private class AsyncEnumerator : IAsyncEnumerator<T>
+        {
+            private IEnumerator<T> _enumerator;
+
+            public AsyncEnumerator(IEnumerator<T> enumerator)
+            {
+                _enumerator = enumerator;
+            }
+
+            public T Current => _enumerator.Current;
+            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+            public ValueTask<bool> MoveNextAsync() => new ValueTask<bool>(_enumerator.MoveNext());
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/AsyncEnumerableList.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/AsyncEnumerableList.cs
@@ -24,7 +24,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             public T Current => _enumerator.Current;
-            public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+            public ValueTask DisposeAsync() => new ValueTask(Task.CompletedTask);
             public ValueTask<bool> MoveNextAsync() => new ValueTask<bool>(_enumerator.MoveNext());
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableConverterFactory.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableConverterFactory.cs
@@ -1,0 +1,83 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Converter factory for all IEnumerable types.
+    /// </summary>
+    internal class IAsyncEnumerableConverterFactory : JsonConverterFactory
+    {
+        public override bool CanConvert(Type typeToConvert)
+            => GetConverterType(typeToConvert, out _, out _);
+
+        [PreserveDependency(".ctor", "System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTConverter`2")]
+        [PreserveDependency(".ctor", "System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTObjectConverter`2")]
+        [PreserveDependency(".ctor", "System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTValueConverter`2")]
+        private static bool GetConverterType(Type typeToConvert, out Type converterType, out Type[] genericArguments)
+        {
+            // Try the supplied type directly.
+            if (typeToConvert.IsGenericType
+             && typeToConvert.IsInterface
+             && (typeToConvert.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>)))
+            {
+                var elementType = typeToConvert.GetGenericArguments()[0];
+
+                genericArguments = new[] { typeToConvert, elementType };
+
+                converterType = elementType.IsValueType
+                    ? typeof(IAsyncEnumerableOfTValueConverter<,>)
+                    : typeof(IAsyncEnumerableOfTObjectConverter<,>);
+
+                return true;
+            }
+
+            // Check all interfaces implemented by the supplied type.
+            foreach (var interfaceType in typeToConvert.GetInterfaces())
+            {
+                if (GetConverterType(interfaceType, out converterType, out genericArguments))
+                {
+                    genericArguments[0] = typeToConvert;
+                    return true;
+                }
+            }
+
+            // No match.
+            converterType = default!;
+            genericArguments = default!;
+
+            return false;
+        }
+
+        [PreserveDependency(".ctor", "System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTConverter`2")]
+        [PreserveDependency(".ctor", "System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTObjectConverter`2")]
+        [PreserveDependency(".ctor", "System.Text.Json.Serialization.Converters.IAsyncEnumerableOfTValueConverter`2")]
+        public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+        {
+            GetConverterType(
+                typeToConvert,
+                out Type converterType,
+                out Type[] genericArguments);
+
+            Debug.Assert(converterType != null);
+            Debug.Assert(genericArguments != null);
+
+            Type genericType = converterType.MakeGenericType(genericArguments);
+
+            JsonConverter converter = (JsonConverter)Activator.CreateInstance(
+                genericType,
+                BindingFlags.Instance | BindingFlags.Public,
+                binder: null,
+                args: null,
+                culture: null)!;
+
+            return converter!;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTConverter.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Converter for <cref>System.Collections.Generic.IAsyncEnumerable{TElement} where TElement is a reference type</cref>.
+    /// </summary>
+    internal abstract class IAsyncEnumerableOfTConverter<TCollection, TElement>
+        : IEnumerableDefaultConverter<TCollection, TElement>
+        where TCollection : IAsyncEnumerable<TElement>
+    {
+        private static T GetTaskResult<T>(ValueTask<T> valueTask)
+        {
+            if (valueTask.IsCompleted)
+                return valueTask.Result;
+            else
+            {
+                var task = valueTask.AsTask();
+
+                task.ConfigureAwait(false);
+
+                return task.GetAwaiter().GetResult();
+            }
+        }
+
+        protected override void Add(TElement value, ref ReadStack state)
+            => ((IList<TElement>)state.Current.ReturnValue!).Add(value);
+
+        protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        {
+            if (TypeToConvert.IsAssignableFrom(RuntimeType))
+            {
+                state.Current.ReturnValue = new AsyncEnumerableList<TElement>();
+            }
+            else if (typeof(IList<TElement>).IsAssignableFrom(TypeToConvert) && (TypeToConvert.GetConstructor(Type.EmptyTypes) is ConstructorInfo defaultCtor))
+            {
+                state.Current.ReturnValue = defaultCtor.Invoke(null);
+            }
+            else
+            {
+                ThrowHelper.ThrowNotSupportedException_CannotPopulateCollection(TypeToConvert, ref reader, ref state);
+            }
+        }
+
+        protected override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
+        {
+            IAsyncEnumerator<TElement> enumerator;
+            if (state.Current.AsyncEnumerator == null)
+            {
+                enumerator = value.GetAsyncEnumerator();
+
+                if (!GetTaskResult(enumerator.MoveNextAsync()))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                Debug.Assert(state.Current.AsyncEnumerator is IAsyncEnumerator<TElement>);
+                enumerator = RetrieveEnumerator(ref state);
+            }
+
+            JsonConverter<TElement> converter = GetElementConverter(ref state);
+            do
+            {
+                if (ShouldFlush(writer, ref state))
+                {
+                    StoreEnumerator(ref state, enumerator);
+                    return false;
+                }
+
+                TElement element = enumerator.Current;
+                if (!converter.TryWrite(writer, element, options, ref state))
+                {
+                    StoreEnumerator(ref state, enumerator);
+                    return false;
+                }
+            } while (GetTaskResult(enumerator.MoveNextAsync()));
+
+            ClearStoredEnumerator(ref state);
+
+            return true;
+        }
+
+        protected abstract void StoreEnumerator(ref WriteStack state, IAsyncEnumerator<TElement> enumerator);
+        protected abstract IAsyncEnumerator<TElement> RetrieveEnumerator(ref WriteStack state);
+        protected abstract void ClearStoredEnumerator(ref WriteStack state);
+
+        internal override Type RuntimeType => typeof(AsyncEnumerableList<TElement>);
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTObjectConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTObjectConverter.cs
@@ -1,0 +1,45 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Converter for <cref>System.Collections.Generic.IAsyncEnumerable{TElement} where TElement is a reference type</cref>.
+    /// </summary>
+    internal sealed class IAsyncEnumerableOfTObjectConverter<TCollection, TElement>
+        : IAsyncEnumerableOfTConverter<TCollection, TElement>
+        where TCollection : IAsyncEnumerable<TElement>
+        where TElement : class
+    {
+        // When leaving & re-entering the write stack frame, we need a place to store an IAsyncEnumerable<T>
+        // where T is a reference type. The IAsyncEnumerable interface has type covariance on its generic
+        // type argument, so an IAsyncEnumerable<object> reference can point at any kind of IAsyncEnumerable<T>.
+        //
+        // We cannot avoid some cast back, as WriteStackFrame has no knowledge of TElement. Casting the type
+        // back in here simplifies the code in the caller's TryWrite implementation.
+
+        protected sealed override void StoreEnumerator(ref WriteStack state, IAsyncEnumerator<TElement> enumerator)
+        {
+            state.Current.AsyncEnumerator = enumerator;
+        }
+
+        protected sealed override IAsyncEnumerator<TElement> RetrieveEnumerator(ref WriteStack state)
+        {
+            if (state.Current.AsyncEnumerator == null)
+                throw new InvalidOperationException("Unable to retrieve IAsyncEnumerator<TClass> from write stack because no enumerator is present.");
+
+            return (IAsyncEnumerator<TElement>)state.Current.AsyncEnumerator;
+        }
+
+        protected sealed override void ClearStoredEnumerator(ref WriteStack state)
+        {
+            state.Current.AsyncEnumerator = null;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IAsyncEnumerableOfTValueConverter.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Text.Json.Serialization.Converters
+{
+    /// <summary>
+    /// Converter for <cref>System.Collections.Generic.IAsyncEnumerable{TElement} where TElement is a reference type</cref>.
+    /// </summary>
+    internal sealed class IAsyncEnumerableOfTValueConverter<TCollection, TElement>
+        : IAsyncEnumerableOfTConverter<TCollection, TElement>
+        where TCollection : IAsyncEnumerable<TElement>
+        where TElement : struct
+    {
+        // When leaving & re-entering the write stack frame, we need a place to store an IAsyncEnumerator<T>
+        // where T is a value type. This means that type covariance on the interface will not work. The
+        // simplest place to stash this in the WriteStackFrame structure without extending the structure
+        // is within the IEnumerator enumerator property, which can be any IEnumerator implementation,
+        // including this one which simply stores a supplied value in its Current property.
+
+        private class StoragePlaceEnumerator : IEnumerator
+        {
+            public StoragePlaceEnumerator(object valueToStore)
+            {
+                Current = valueToStore;
+            }
+
+            public object? Current { get; private set; }
+
+            public bool MoveNext() => true;
+            public void Reset() { }
+        }
+
+        protected override void StoreEnumerator(ref WriteStack state, IAsyncEnumerator<TElement> enumerator)
+        {
+            state.Current.CollectionEnumerator = new StoragePlaceEnumerator(enumerator);
+        }
+
+        protected override IAsyncEnumerator<TElement> RetrieveEnumerator(ref WriteStack state)
+        {
+            if (!(state.Current.CollectionEnumerator is StoragePlaceEnumerator storagePlaceEnumerator))
+                throw new InvalidOperationException("Unable to retrieve IAsyncEnumerator<TStruct> from write stack because no enumerator is present.");
+
+            Debug.Assert(storagePlaceEnumerator.Current is IAsyncEnumerable<TElement>);
+
+            return (IAsyncEnumerator<TElement>)storagePlaceEnumerator.Current;
+        }
+
+        protected override void ClearStoredEnumerator(ref WriteStack state)
+        {
+            state.Current.CollectionEnumerator = null;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -26,6 +26,8 @@ namespace System.Text.Json
             new NullableConverterFactory(),
             new EnumConverterFactory(),
             new KeyValuePairConverterFactory(),
+            // IAsyncEnumerable should precede IEnumerable, just in case an object implements both.
+            new IAsyncEnumerableConverterFactory(),
             // IEnumerable should always be second to last since they can convert any IEnumerable.
             new IEnumerableConverterFactory(),
             // Object should always be last since it converts any type.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 
@@ -15,6 +16,11 @@ namespace System.Text.Json
         /// The enumerator for resumable collections.
         /// </summary>
         public IEnumerator? CollectionEnumerator;
+
+        /// <summary>
+        /// The enumerator for resumable async enumerations.
+        /// </summary>
+        public IAsyncEnumerator<object>? AsyncEnumerator;
 
         /// <summary>
         /// The original JsonPropertyInfo that is not changed. It contains all properties.

--- a/src/libraries/System.Text.Json/tests/Serialization/IAsyncEnumerableTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/IAsyncEnumerableTests.cs
@@ -1,0 +1,400 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static class IAsyncEnumerableTests
+    {
+        [Fact]
+        public static async Task ReadIAsyncEnumerableOfReferenceType()
+        {
+            // Arrange
+            string data = "[\"a\",\"b\",\"c\"]";
+
+            var expected = new Queue<string>(JsonSerializer.Deserialize<IEnumerable<string>>(data));
+
+            // Act
+            var actual = JsonSerializer.Deserialize<IAsyncEnumerable<string>>(data);
+
+            // Assert
+            await foreach (var actualItem in actual)
+                Assert.Equal(expected.Dequeue(), actualItem);
+        }
+
+        [Fact]
+        public static async Task ReadNestedIAsyncEnumerableOfReferenceTypeDepthFirst()
+        {
+            // Arrange
+            string data = "[[\"a\",\"b\",\"c\"],[\"d\",\"e\",\"f\"],[\"g\",\"h\",\"i\"]]";
+
+            var expectedSequences = new Queue<Queue<string>>(
+                JsonSerializer.Deserialize<IEnumerable<IEnumerable<string>>>(data)
+                    .Select(x => new Queue<string>(x)));
+
+            // Act
+            var actual = JsonSerializer.Deserialize<IAsyncEnumerable<IAsyncEnumerable<string>>>(data);
+
+            // Assert
+            await foreach (var actualNested in actual)
+            {
+                var expectedNested = expectedSequences.Dequeue();
+
+                await foreach (var actualItem in actualNested)
+                    Assert.Equal(expectedNested.Dequeue(), actualItem);
+            }
+        }
+
+        [Fact]
+        public static async Task ReadNestedIAsyncEnumerableOfReferenceTypeInterleaved()
+        {
+            // Arrange
+            string data = "[[\"a\",\"b\",\"c\"],[\"d\",\"e\",\"f\"],[\"g\",\"h\",\"i\"]]";
+
+            var expectedSequences = JsonSerializer.Deserialize<IEnumerable<IEnumerable<string>>>(data)
+                    .Select(x => new Queue<string>(x));
+
+            // Act
+            var actual = JsonSerializer.Deserialize<IAsyncEnumerable<IAsyncEnumerable<string>>>(data);
+
+            // Assert
+            var expectedEnumerators = expectedSequences.Select(seq => seq.GetEnumerator()).ToArray();
+            var actualEnumerators = new List<IAsyncEnumerator<string>>();
+
+            await foreach (var actualNested in actual)
+                actualEnumerators.Add(actualNested.GetAsyncEnumerator());
+
+            for (int elementIndex = 0; elementIndex < 3; elementIndex++)
+            {
+                for (int enumeratorIndex = 0; enumeratorIndex < 3; enumeratorIndex++)
+                {
+                    Assert.True(expectedEnumerators[enumeratorIndex].MoveNext(), $"Test integrity error: Expected value enumerator with index {enumeratorIndex} should have produced a value");
+                    Assert.True(await actualEnumerators[enumeratorIndex].MoveNextAsync(), $"test failed: IAsyncEnumerator with index {enumeratorIndex} should have produced a value");
+
+                    var expectedValue = expectedEnumerators[enumeratorIndex].Current;
+                    var actualValue = actualEnumerators[enumeratorIndex].Current;
+
+                    Assert.Equal(expectedValue, actualValue);
+                }
+            }
+
+            for (int enumeratorIndex = 0; enumeratorIndex < 3; enumeratorIndex++)
+            {
+                Assert.False(expectedEnumerators[enumeratorIndex].MoveNext(), $"Test integrity error: Expected value enumerator with index {enumeratorIndex} should be at end state");
+                Assert.False(await actualEnumerators[enumeratorIndex].MoveNextAsync(), $"Test failed: IAsyncEnumerator with index {enumeratorIndex} should be at end state");
+
+                expectedEnumerators[enumeratorIndex].Dispose();
+                await actualEnumerators[enumeratorIndex].DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public static async Task ReadIAsyncEnumerableOfValueType()
+        {
+            // Arrange
+            string data = "[12,34,56]";
+
+            var expected = new Queue<int>(JsonSerializer.Deserialize<IEnumerable<int>>(data));
+
+            // Act
+            var actual = JsonSerializer.Deserialize<IAsyncEnumerable<int>>(data);
+
+            // Assert
+            await foreach (var actualItem in actual)
+                Assert.Equal(expected.Dequeue(), actualItem);
+        }
+
+        [Fact]
+        public static async Task ReadNestedIAsyncEnumerableOfValueTypeDepthFirst()
+        {
+            // Arrange
+            string data = "[[12,34,56],[23,45,67],[345,456,567]]";
+
+            var expectedSequences = new Queue<Queue<int>>(
+                JsonSerializer.Deserialize<IEnumerable<IEnumerable<int>>>(data)
+                    .Select(x => new Queue<int>(x)));
+
+            // Act
+            var actual = JsonSerializer.Deserialize<IAsyncEnumerable<IAsyncEnumerable<int>>>(data);
+
+            // Assert
+            await foreach (var actualNested in actual)
+            {
+                var expectedNested = expectedSequences.Dequeue();
+
+                await foreach (var actualItem in actualNested)
+                    Assert.Equal(expectedNested.Dequeue(), actualItem);
+            }
+        }
+
+        [Fact]
+        public static async Task ReadNestedIAsyncEnumerableOfValueTypeInterleaved()
+        {
+            // Arrange
+            string data = "[[12,34,56],[23,45,67],[345,456,567]]";
+
+            var expectedSequences = JsonSerializer.Deserialize<IEnumerable<IEnumerable<int>>>(data)
+                    .Select(x => new Queue<int>(x));
+
+            // Act
+            var actual = JsonSerializer.Deserialize<IAsyncEnumerable<IAsyncEnumerable<int>>>(data);
+
+            // Assert
+            var expectedEnumerators = expectedSequences.Select(seq => seq.GetEnumerator()).ToArray();
+            var actualEnumerators = new List<IAsyncEnumerator<int>>();
+
+            await foreach (var actualNested in actual)
+                actualEnumerators.Add(actualNested.GetAsyncEnumerator());
+
+            for (int elementIndex = 0; elementIndex < 3; elementIndex++)
+            {
+                for (int enumeratorIndex = 0; enumeratorIndex < 3; enumeratorIndex++)
+                {
+                    Assert.True(expectedEnumerators[enumeratorIndex].MoveNext(), $"Test integrity error: Expected value enumerator with index {enumeratorIndex} should have produced a value");
+                    Assert.True(await actualEnumerators[enumeratorIndex].MoveNextAsync(), $"test failed: IAsyncEnumerator with index {enumeratorIndex} should have produced a value");
+
+                    var expectedValue = expectedEnumerators[enumeratorIndex].Current;
+                    var actualValue = actualEnumerators[enumeratorIndex].Current;
+
+                    Assert.Equal(expectedValue, actualValue);
+                }
+            }
+
+            for (int enumeratorIndex = 0; enumeratorIndex < 3; enumeratorIndex++)
+            {
+                Assert.False(expectedEnumerators[enumeratorIndex].MoveNext(), $"Test integrity error: Expected value enumerator with index {enumeratorIndex} should be at end state");
+                Assert.False(await actualEnumerators[enumeratorIndex].MoveNextAsync(), $"Test failed: IAsyncEnumerator with index {enumeratorIndex} should be at end state");
+
+                expectedEnumerators[enumeratorIndex].Dispose();
+                await actualEnumerators[enumeratorIndex].DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public static void ReadIAsyncEnumerableIntoCustomType()
+        {
+            // Arrange
+            var data = "[\"a\",\"b\"]";
+
+            var expected = JsonSerializer.Deserialize<string[]>(data);
+
+            // Act
+            var actual = JsonSerializer.Deserialize<CustomAsyncEnumerableType>(data);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        class CustomAsyncEnumerableType : List<string>, IAsyncEnumerable<string>
+        {
+            public IAsyncEnumerator<string> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+        }
+
+        [Fact]
+        public static void WriteIAsyncEnumerableOfReferenceTypeWhenNull()
+        {
+            // Arrange
+            var expected = JsonSerializer.Serialize<string[]>(null);
+
+            // Act
+            var actual = JsonSerializer.Serialize<TestingAsyncEnumerable<string>>(null);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void WriteIAsyncEnumerableOfReferenceType()
+        {
+            // Arrange
+            string[] data =
+                new[]
+                {
+                    "The best proof that there's",
+                    "intelligent life in the universe is",
+                    "the fact that it hasn't come here.",
+                };
+
+            var input = new TestingAsyncEnumerable<string>(data);
+
+            var expected = JsonSerializer.Serialize(data);
+
+            // Act
+            var actual = JsonSerializer.Serialize(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void WriteNestedIAsyncEnumerableOfReferenceType()
+        {
+            // Arrange
+            IAsyncEnumerable<string> CreateSequence()
+            {
+                var items = Enumerable.Range(1, 5).Select(_ => Guid.NewGuid().ToString()).ToArray();
+
+                return new TestingAsyncEnumerable<string>(items);
+            }
+
+            IAsyncEnumerable<IAsyncEnumerable<string>> CreateSequenceOfSequences()
+            {
+                var items = Enumerable.Range(1, 3).Select(_ => CreateSequence()).ToArray();
+
+                return new TestingAsyncEnumerable<IAsyncEnumerable<string>>(items);
+            }
+
+            var input = CreateSequenceOfSequences();
+
+            var data = Collapse(input);
+
+            var expected = JsonSerializer.Serialize(data);
+
+            // Act
+            var actual = JsonSerializer.Serialize(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void WriteIAsyncEnumerableOfValueTypeWhenNull()
+        {
+            // Arrange
+            var expected = JsonSerializer.Serialize<int[]>(null);
+
+            // Act
+            var actual = JsonSerializer.Serialize<TestingAsyncEnumerable<int>>(null);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void WriteIAsyncEnumerableOfValueType()
+        {
+            // Arrange
+            long[] data =
+                new[]
+                {
+                    1, 1, 2, 5, 14, 42, 132, 429, 1430, 4862, 16796, 58786, 208012, 742900, 2674440,
+                    9694845, 35357670, 129644790, 477638700, 1767263190, 6564120420, 24466267020,
+                    91482563640, 343059613650, 1289904147324, 4861946401452, 18367353072152,
+                    69533550916004, 263747951750360, 1002242216651368, 3814986502092304
+                };
+
+            var input = new TestingAsyncEnumerable<long>(data);
+
+            var expected = JsonSerializer.Serialize(data);
+
+            // Act
+            var actual = JsonSerializer.Serialize(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public static void WriteNestedIAsyncEnumerableOfValueType()
+        {
+            // Arrange
+            var rnd = new Random();
+
+            IAsyncEnumerable<int> CreateSequence()
+            {
+                var items = Enumerable.Range(1, 5).Select(_ => rnd.Next()).ToArray();
+
+                return new TestingAsyncEnumerable<int>(items);
+            }
+
+            IAsyncEnumerable<IAsyncEnumerable<int>> CreateSequenceOfSequences()
+            {
+                var items = Enumerable.Range(1, 3).Select(_ => CreateSequence()).ToArray();
+
+                return new TestingAsyncEnumerable<IAsyncEnumerable<int>>(items);
+            }
+
+            var input = CreateSequenceOfSequences();
+
+            var data = Collapse(input);
+
+            var expected = JsonSerializer.Serialize(data);
+
+            // Act
+            var actual = JsonSerializer.Serialize(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        static System.Collections.IEnumerable Collapse<T>(IAsyncEnumerable<T> t)
+        {
+            // We know that TestingAsyncEnumerable has, in practice, synchronous implementations of
+            // all the interface members. This method would not work on a generalized IAsyncEnumerable<T>
+            // because it makes no attempt to await async results.
+
+            var enumerator = t.GetAsyncEnumerator();
+
+            Func<object, object> Unwrap = x => x;
+
+            if (typeof(T).IsGenericType && (typeof(T).GetGenericTypeDefinition() == typeof(TestingAsyncEnumerable<>)))
+            {
+                var methodInfo = typeof(IAsyncEnumerableTests).GetMethod(nameof(Collapse), BindingFlags.Static | BindingFlags.NonPublic)
+                    .MakeGenericMethod(typeof(T).GetGenericArguments());
+
+                Unwrap = x => methodInfo.Invoke(null, new object[] { x });
+            }
+
+            try
+            {
+                while (enumerator.MoveNextAsync().Result)
+                    yield return Unwrap(enumerator.Current);
+            }
+            finally
+            {
+                enumerator.DisposeAsync();
+            }
+        }
+
+        private class TestingAsyncEnumerable<TElement> : IAsyncEnumerable<TElement>
+        {
+            TElement[] _data;
+
+            public TestingAsyncEnumerable(TElement[] data)
+            {
+                _data = data;
+            }
+
+            public IAsyncEnumerator<TElement> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+            {
+                return new TestingAsyncEnumerator<TElement>(_data);
+            }
+        }
+
+        private class TestingAsyncEnumerator<TElement> : IAsyncEnumerator<TElement>
+        {
+            TElement[] _data;
+            int _index = -1;
+
+            public TestingAsyncEnumerator(TElement[] data)
+            {
+                _data = data;
+            }
+
+            public TElement Current => _data[_index];
+
+            public ValueTask DisposeAsync() => default;
+
+            public ValueTask<bool> MoveNextAsync()
+            {
+                _index++;
+                return new ValueTask<bool>(_index < _data.Length);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\WrappedMemoryStream.cs" Link="CommonTest\System\IO\WrappedMemoryStream.cs" />
+    <Compile Include="Serialization\IAsyncEnumerableTests.cs" />
     <Compile Include="BitStackTests.cs" />
     <Compile Include="BufferFactory.cs" />
     <Compile Include="BufferSegment.cs" />


### PR DESCRIPTION
This is my first pass at support for IAsyncEnumerable in System.Text.Json, which should satisfy issues #1569 and #1570 (except that, as commented in #1570, I don't think the deserialization can actually be asynchronous, because the object graph might have multiple `IAsyncEnumerable`s in it, and each one would need its own pointer into the underlying stream).

This is my first time doing any work with C# 8, and also my first time doing any work with the .NET codebase, so I'm fully expecting there to be some things I overlooked, both in style and substance. :-)

My implementation builds upon `IEnumerableDefaultConverter`, which already has logic for reading a JSON array and passing the elements off to a collection that the subclass gets to define.

In addition to this, the converter needs to stash an `IAsyncEnumerator` between invocations. In the case of reference types, it can store this directly into `WriteStackFrame` using type covariance. For value types, type covariance isn't an option. So, two specializations of the `IAsyncEnumerableOfTConverter` are provided, customizing how the `IAsyncEnumerator` is stashed, using a simple wrapper for value types.

When deserializing into a field whose type is `IAsyncEnumerable<T>`, some class that implements the interface is needed, and I'm not aware of one built into the framework, so a simple `AsyncEnumerableList` that subclasses `List<T>` and adds an implementation of `IAsyncEnumerable<T>` (just synchronous pass-through, since the data is already there) is used.

I modeled the way converter objects get created after what I saw for `IEnumerableOfT`, with a factory that I register in sequence before the `IEnumerableConverterFactory`, on the assumption that if a class chooses to implement both, it probably would prefer that the async variant be used.

Finally, I added a handful of unit tests in new file `IAsyncEnumerableTests.cs` to capture the various wrinkles I could think of.