### PR TITLE
Move Mono Linux_arm64 build to run when runtime tests change

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -401,7 +401,6 @@ jobs:
     buildConfig: release
     platforms:
     - Linux_x64
-    - Linux_arm64
     # - Linux_musl_arm64
     - Windows_NT_x64
     # - Windows_NT_x86
@@ -425,6 +424,7 @@ jobs:
     buildConfig: release
     platforms:
     - OSX_x64
+    - Linux_arm64
     jobParameters:
       condition: >-
         or(


### PR DESCRIPTION
PR: https://github.com/dotnet/runtime/pull/37859 changed the way hardware intrinsic tests were built but the Linux_arm64 Mono Runtime tests didn't run because the Mono Linux_arm64 product build was in the wrong template expansion which didn't run that leg if runtimetests subset was changed, causing the Linux_arm64 Mono runtime test to not run because it depends on the Mono product build, since the latter was skipped, the former didn't run.

With this change, both OSX and Linux_arm64 Mono runtime tests will be run when runtimetests subset is changed.

cc: @naricc @tannergooding 