### PR TITLE
Fix and cleanup dead indirections

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1191,7 +1191,7 @@ protected:
     void genCodeForCpBlkHelper(GenTreeBlk* cpBlkNode);
 #endif
     void genCodeForPhysReg(GenTreePhysReg* tree);
-    void genCodeForNullCheck(GenTreeOp* tree);
+    void genCodeForNullCheck(GenTreeIndir* tree);
     void genCodeForCmpXchg(GenTreeCmpXchg* tree);
 
     void genAlignStackBeforeCall(GenTreePutArgStk* putArgStk);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -457,7 +457,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             break;
 
         case GT_NULLCHECK:
-            genCodeForNullCheck(treeNode->AsOp());
+            genCodeForNullCheck(treeNode->AsIndir());
             break;
 
         case GT_CATCH_ARG:
@@ -1500,19 +1500,19 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 // Return value:
 //    None
 //
-void CodeGen::genCodeForNullCheck(GenTreeOp* tree)
+void CodeGen::genCodeForNullCheck(GenTreeIndir* tree)
 {
-    assert(tree->OperIs(GT_NULLCHECK));
-    assert(!tree->gtOp1->isContained());
-    regNumber addrReg = genConsumeReg(tree->gtOp1);
-
-#ifdef TARGET_ARM64
-    regNumber targetReg = REG_ZR;
+#ifdef TARGET_ARM
+    assert("GT_NULLCHECK isn't supported for Arm32; use GT_IND.");
 #else
-    regNumber targetReg = tree->GetSingleTempReg();
-#endif
+    assert(tree->OperIs(GT_NULLCHECK));
+    GenTree* op1 = tree->gtOp1;
 
-    GetEmitter()->emitIns_R_R_I(INS_ldr, EA_4BYTE, targetReg, addrReg, 0);
+    genConsumeRegs(op1);
+    regNumber targetReg = REG_ZR;
+
+    GetEmitter()->emitInsLoadStoreOp(INS_ldr, EA_4BYTE, targetReg, tree);
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -1503,7 +1503,7 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 void CodeGen::genCodeForNullCheck(GenTreeIndir* tree)
 {
 #ifdef TARGET_ARM
-    assert("GT_NULLCHECK isn't supported for Arm32; use GT_IND.");
+    assert(!"GT_NULLCHECK isn't supported for Arm32; use GT_IND.");
 #else
     assert(tree->OperIs(GT_NULLCHECK));
     GenTree* op1 = tree->gtOp1;

--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -1512,7 +1512,7 @@ void CodeGen::genConsumeRegs(GenTree* tree)
     }
     else if (tree->isContained())
     {
-        if (tree->isIndir())
+        if (tree->OperIsIndir())
         {
             genConsumeAddress(tree->AsIndir()->Addr());
         }

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -1747,7 +1747,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             break;
 
         case GT_NULLCHECK:
-            genCodeForNullCheck(treeNode->AsOp());
+            genCodeForNullCheck(treeNode->AsIndir());
             break;
 
         case GT_CATCH_ARG:
@@ -3795,7 +3795,7 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 // Return value:
 //    None
 //
-void CodeGen::genCodeForNullCheck(GenTreeOp* tree)
+void CodeGen::genCodeForNullCheck(GenTreeIndir* tree)
 {
     assert(tree->OperIs(GT_NULLCHECK));
 

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -2944,7 +2944,7 @@ void emitter::spillIntArgRegsToShadowSlots()
 //
 void emitter::emitInsLoadInd(instruction ins, emitAttr attr, regNumber dstReg, GenTreeIndir* mem)
 {
-    assert(mem->OperIs(GT_IND));
+    assert(mem->OperIs(GT_IND, GT_NULLCHECK));
 
     GenTree* addr = mem->Addr();
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -16555,12 +16555,12 @@ bool GenTree::isContained() const
 // return true if node is contained and an indir
 bool GenTree::isContainedIndir() const
 {
-    return isIndir() && isContained();
+    return OperIsIndir() && isContained();
 }
 
 bool GenTree::isIndirAddrMode()
 {
-    return isIndir() && AsIndir()->Addr()->OperIsAddrMode() && AsIndir()->Addr()->isContained();
+    return OperIsIndir() && AsIndir()->Addr()->OperIsAddrMode() && AsIndir()->Addr()->isContained();
 }
 
 bool GenTree::isIndir() const

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -550,6 +550,9 @@ public:
 
     bool isIndirAddrMode();
 
+    // This returns true only for GT_IND and GT_STOREIND, and is used in contexts where a "true"
+    // indirection is expected (i.e. either a load to or a store from a single register).
+    // OperIsIndir() returns true also for indirection nodes such as GT_BLK, etc. as well as GT_NULLCHECK.
     bool isIndir() const;
 
     bool isContainedIntOrIImmed() const
@@ -1465,6 +1468,9 @@ public:
         return OperMayOverflow(gtOper);
     }
 
+    // This returns true only for GT_IND and GT_STOREIND, and is used in contexts where a "true"
+    // indirection is expected (i.e. either a load to or a store from a single register).
+    // OperIsIndir() returns true also for indirection nodes such as GT_BLK, etc. as well as GT_NULLCHECK.
     static bool OperIsIndir(genTreeOps gtOper)
     {
         return gtOper == GT_IND || gtOper == GT_STOREIND || gtOper == GT_NULLCHECK || OperIsBlk(gtOper);

--- a/src/coreclr/src/jit/gtlist.h
+++ b/src/coreclr/src/jit/gtlist.h
@@ -283,7 +283,7 @@ GTNODE(SWITCH_TABLE     , GenTreeOp          ,0, (GTK_BINOP|GTK_NOVALUE))  // Ju
 GTNODE(CLS_VAR          , GenTreeClsVar      ,0,GTK_LEAF)                        // static data member
 GTNODE(CLS_VAR_ADDR     , GenTreeClsVar      ,0,GTK_LEAF)                        // static data member address
 GTNODE(ARGPLACE         , GenTreeArgPlace    ,0,GTK_LEAF|GTK_NOVALUE|GTK_NOTLIR) // placeholder for a register arg
-GTNODE(NULLCHECK        , GenTreeOp          ,0,GTK_UNOP|GTK_NOVALUE)            // null checks the source
+GTNODE(NULLCHECK        , GenTreeIndir       ,0,GTK_UNOP|GTK_NOVALUE)            // null checks the source
 GTNODE(PHYSREG          , GenTreePhysReg     ,0,GTK_LEAF)                        // read from a physical register
 GTNODE(EMITNOP          , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)            // emitter-placed nop
 GTNODE(PINVOKE_PROLOG   , GenTree            ,0,GTK_LEAF|GTK_NOVALUE)            // pinvoke prolog seq

--- a/src/coreclr/src/jit/lsraarm.cpp
+++ b/src/coreclr/src/jit/lsraarm.cpp
@@ -694,17 +694,15 @@ int LinearScan::BuildNode(GenTree* tree)
         break;
 
         case GT_NULLCHECK:
-            // It requires a internal register on ARM, as it is implemented as a load
-            assert(dstCount == 0);
-            assert(!tree->gtGetOp1()->isContained());
-            srcCount = 1;
-            buildInternalIntRegisterDefForNode(tree);
-            BuildUse(tree->gtGetOp1());
-            buildInternalRegisterUses();
-            break;
-
+#ifdef TARGET_ARM
+            // On Arm32 we never want to use GT_NULLCHECK, as we require a target register.
+            // Previously we used an internal register for this, but that results in a lifetime
+            // that overlaps with all the source registers.
+            assert(!"Should never see GT_NULLCHECK on Arm/32");
+#endif
+        // For Arm64 we simply fall through to the GT_IND case, and will use REG_ZR as the target.
         case GT_IND:
-            assert(dstCount == 1);
+            assert(dstCount == (tree->OperIs(GT_NULLCHECK) ? 0 : 1));
             srcCount = BuildIndir(tree->AsIndir());
             break;
 

--- a/src/coreclr/src/jit/lsraarm64.cpp
+++ b/src/coreclr/src/jit/lsraarm64.cpp
@@ -717,16 +717,8 @@ int LinearScan::BuildNode(GenTree* tree)
         break;
 
         case GT_NULLCHECK:
-            // Unlike ARM, ARM64 implements NULLCHECK as a load to REG_ZR, so no internal register
-            // is required, and it is not a localDefUse.
-            assert(dstCount == 0);
-            assert(!tree->gtGetOp1()->isContained());
-            BuildUse(tree->gtGetOp1());
-            srcCount = 1;
-            break;
-
         case GT_IND:
-            assert(dstCount == 1);
+            assert(dstCount == (tree->OperIs(GT_NULLCHECK) ? 0 : 1));
             srcCount = BuildIndir(tree->AsIndir());
             break;
 

--- a/src/coreclr/src/jit/lsraarmarch.cpp
+++ b/src/coreclr/src/jit/lsraarmarch.cpp
@@ -117,7 +117,7 @@ int LinearScan::BuildIndir(GenTreeIndir* indirTree)
     int srcCount = BuildIndirUses(indirTree);
     buildInternalRegisterUses();
 
-    if (indirTree->gtOper != GT_STOREIND)
+    if (!indirTree->OperIs(GT_STOREIND, GT_NULLCHECK))
     {
         BuildDef(indirTree);
     }

--- a/src/coreclr/src/jit/lsraxarch.cpp
+++ b/src/coreclr/src/jit/lsraxarch.cpp
@@ -620,8 +620,9 @@ int LinearScan::BuildNode(GenTree* tree)
         case GT_NULLCHECK:
         {
             assert(dstCount == 0);
-            regMaskTP indirCandidates = RBM_NONE;
-            BuildUse(tree->gtGetOp1(), indirCandidates);
+            // If we have a contained address on a nullcheck, we transform it to
+            // an unused GT_IND, since we require a target register.
+            BuildUse(tree->gtGetOp1());
             srcCount = 1;
             break;
         }


### PR DESCRIPTION
The backend doesn't support a dead `TYP_STRUCT` indirection. Also, if a target register is needed, a `GT_IND` is better.

Fix #36237