### PR TITLE
Disable two more tests that use RemoteExecutor on platforms where it's not supported

### DIFF
--- a/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.netcoreapp.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/tests/EncodingCodePages.netcoreapp.cs
@@ -35,7 +35,7 @@ namespace System.Text.Tests
             new EncodingInformation(65001, "utf-8")
         };
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestGetEncodings()
         {
             RemoteExecutor.Invoke(() => {
@@ -48,7 +48,7 @@ namespace System.Text.Tests
             }).Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void TestGetEncodingsWithProvider()
         {
             RemoteExecutor.Invoke(() => {


### PR DESCRIPTION
Those sneaked in with https://github.com/dotnet/runtime/pull/37528 which was merged at the same time as my PR https://github.com/dotnet/runtime/pull/37479.