### PR TITLE
Increase partition size to 30

### DIFF
--- a/eng/common/performance/perfhelixpublish.proj
+++ b/eng/common/performance/perfhelixpublish.proj
@@ -71,7 +71,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <PartitionCount>5</PartitionCount>
+    <PartitionCount>30</PartitionCount>
   </PropertyGroup>
   <ItemGroup>
     <Partition Include="$(BuildConfig).Partition0" Index="0" />
@@ -79,6 +79,31 @@
     <Partition Include="$(BuildConfig).Partition2" Index="2" />
     <Partition Include="$(BuildConfig).Partition3" Index="3" />
     <Partition Include="$(BuildConfig).Partition4" Index="4" />
+    <Partition Include="$(BuildConfig).Partition5" Index="5" />
+    <Partition Include="$(BuildConfig).Partition6" Index="6" />
+    <Partition Include="$(BuildConfig).Partition7" Index="7" />
+    <Partition Include="$(BuildConfig).Partition8" Index="8" />
+    <Partition Include="$(BuildConfig).Partition9" Index="9" />
+    <Partition Include="$(BuildConfig).Partition10" Index="10" />
+    <Partition Include="$(BuildConfig).Partition11" Index="11" />
+    <Partition Include="$(BuildConfig).Partition12" Index="12" />
+    <Partition Include="$(BuildConfig).Partition13" Index="13" />
+    <Partition Include="$(BuildConfig).Partition14" Index="14" />
+    <Partition Include="$(BuildConfig).Partition15" Index="15" />
+    <Partition Include="$(BuildConfig).Partition16" Index="16" />
+    <Partition Include="$(BuildConfig).Partition17" Index="17" />
+    <Partition Include="$(BuildConfig).Partition18" Index="18" />
+    <Partition Include="$(BuildConfig).Partition19" Index="19" />
+    <Partition Include="$(BuildConfig).Partition20" Index="20" />
+    <Partition Include="$(BuildConfig).Partition21" Index="21" />
+    <Partition Include="$(BuildConfig).Partition22" Index="22" />
+    <Partition Include="$(BuildConfig).Partition23" Index="23" />
+    <Partition Include="$(BuildConfig).Partition24" Index="24" />
+    <Partition Include="$(BuildConfig).Partition25" Index="25" />
+    <Partition Include="$(BuildConfig).Partition26" Index="26" />
+    <Partition Include="$(BuildConfig).Partition27" Index="27" />
+    <Partition Include="$(BuildConfig).Partition28" Index="28" />
+    <Partition Include="$(BuildConfig).Partition29" Index="29" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Compare)' == 'true'">


### PR DESCRIPTION
The mono interpreter tests take a very long time to finish. In order
to mitigate this we are going to split the workitems up further and
have each machine do less work. Since we have a large pool of empty
machines this should be fine.