### PR TITLE
Share portions of CoreCLR and Mono CoreLib's ILLinkTrim.xml file

### DIFF
--- a/eng/illink.targets
+++ b/eng/illink.targets
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <PrepareResourcesDependsOn>
-      _EmbedILLinkSubstitutionsXmls;
+      _EmbedILLinkXmls;
       $(PrepareResourcesDependsOn)
     </PrepareResourcesDependsOn>
   </PropertyGroup>
@@ -38,18 +38,14 @@
     <ILLinkTrimXml Condition="'$(ILLinkTrimXml)' == '' and Exists('$(MSBuildProjectDirectory)/ILLinkTrim.xml')">$(MSBuildProjectDirectory)/ILLinkTrim.xml</ILLinkTrimXml>
     <!-- ILLinkTrim_LibraryBuild.xml files are only used during building the library, not an app. They shouldn't be embedded into the assembly. -->
     <ILLinkTrimXmlLibraryBuild Condition="'$(ILLinkTrimXmlLibraryBuild)' == '' and Exists('$(MSBuildProjectDirectory)/ILLinkTrim_LibraryBuild.xml')">$(MSBuildProjectDirectory)/ILLinkTrim_LibraryBuild.xml</ILLinkTrimXmlLibraryBuild>
+    <ILLinkDescriptorsXmlIntermediatePath>$(IntermediateOutputPath)ILLink.Descriptors.xml</ILLinkDescriptorsXmlIntermediatePath>
+
     <ILLinkSubstitutionsXml Condition="'$(ILLinkSubstitutionsXml)' == '' and Exists('$(MSBuildProjectDirectory)/ILLink.Substitutions.xml')">$(MSBuildProjectDirectory)/ILLink.Substitutions.xml</ILLinkSubstitutionsXml>
     <ILLinkSubstitutionsXmlIntermediatePath>$(IntermediateOutputPath)ILLink.Substitutions.xml</ILLinkSubstitutionsXmlIntermediatePath>
 
     <!-- if building a PDB, tell illink to rewrite the symbols file -->
     <ILLinkRewritePDBs Condition="'$(ILLinkRewritePDBs)' == '' and '$(DebugSymbols)' != 'false'">true</ILLinkRewritePDBs>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(ILLinkTrimXml)' != ''">
-    <EmbeddedResource Include="$(ILLinkTrimXml)">
-      <LogicalName>$(AssemblyName).xml</LogicalName>
-    </EmbeddedResource>
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="$(ILLinkTrimXmlLibraryBuild)" Condition="'$(ILLinkTrimXmlLibraryBuild)' != ''" />
@@ -75,9 +71,14 @@
     </BinPlaceTargetFramework>
   </ItemGroup>
 
-  <Target Name="_EmbedILLinkSubstitutionsXmls"
-          Condition="'$(ILLinkTrimAssembly)' == 'true'"
-          DependsOnTargets="_CombineILLinkSubstitutionsXmls">
+  <Target Name="_EmbedILLinkXmls"
+          DependsOnTargets="_CombineILLinkDescriptorsXmls;_CombineILLinkSubstitutionsXmls">
+
+    <ItemGroup Condition="'$(ILLinkTrimXml)' != ''">
+      <EmbeddedResource Include="$(ILLinkTrimXml)">
+        <LogicalName>$(AssemblyName).xml</LogicalName>
+      </EmbeddedResource>
+    </ItemGroup>
 
     <ItemGroup Condition="'$(ILLinkSubstitutionsXml)' != ''">
       <EmbeddedResource Include="$(ILLinkSubstitutionsXml)">
@@ -88,6 +89,22 @@
   </Target>
 
   <UsingTask TaskName="CombineLinkerXmlFiles" AssemblyFile="$(ILLinkTasksPath)" />
+  <Target Name="_CombineILLinkDescriptorsXmls"
+          Condition="'$(ILLinkTrimXml)' == '' and '@(ILLinkDescriptorsXmls)' != ''"
+          Inputs="@(ILLinkDescriptorsXmls)"
+          Outputs="$(ILLinkDescriptorsXmlIntermediatePath)">
+    <PropertyGroup>
+      <ILLinkTrimXml>$(ILLinkDescriptorsXmlIntermediatePath)</ILLinkTrimXml>
+    </PropertyGroup>
+
+    <CombineLinkerXmlFiles LinkerXmlFiles="@(ILLinkDescriptorsXmls)"
+                           CombinedLinkerXmlFile="$(ILLinkTrimXml)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(ILLinkTrimXml)" />
+    </ItemGroup>
+  </Target>
+
   <Target Name="_CombineILLinkSubstitutionsXmls"
           Condition="'$(ILLinkSubstitutionsXml)' == '' and '@(ILLinkSubstitutionsXmls)' != ''"
           Inputs="@(ILLinkSubstitutionsXmls)"
@@ -103,7 +120,7 @@
       <FileWrites Include="$(ILLinkSubstitutionsXml)" />
     </ItemGroup>
   </Target>
-  
+
   <Target Name="_SetILLinkTrimAssembly" 
           Condition="'$(ILLinkTrimAssembly)' == ''"
           DependsOnTargets="GetBinPlaceTargetFramework">

--- a/src/coreclr/src/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
+++ b/src/coreclr/src/System.Private.CoreLib/CreateRuntimeRootILLinkDescriptorFile.targets
@@ -10,11 +10,17 @@
     <_MscorlibFilePath Condition=" '$(_MscorlibFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\mscorlib.h</_MscorlibFilePath>
     <_CortypeFilePath Condition=" '$(_CortypeFilePath)' == '' ">$(MSBuildThisFileDirectory)..\inc\cortypeinfo.h</_CortypeFilePath>
     <_RexcepFilePath Condition=" '$(_RexcepFilePath)' == '' ">$(MSBuildThisFileDirectory)..\vm\rexcep.h</_RexcepFilePath>
-    <_ILLinkTrimXmlFilePath Condition=" '$(_ILLinkTrimXmlFilePath)' == '' ">$(MSBuildThisFileDirectory)ILLinkTrim.xml</_ILLinkTrimXmlFilePath>
+    <_ILLinkDescriptorsIntermediatePath>$(IntermediateOutputPath)ILLink.Descriptors.Combined.xml</_ILLinkDescriptorsIntermediatePath>
     <_ILLinkTasksToolsDir>$(PkgMicrosoft_NET_ILLink_Tasks)/tools</_ILLinkTasksToolsDir>
     <_ILLinkTasksDir>$(_ILLinkTasksToolsDir)/$(NetFrameworkCurrent)/</_ILLinkTasksDir>
     <_ILLinkTasksDir Condition="'$(MSBuildRuntimeType)' == 'Core'">$(_ILLinkTasksToolsDir)/netcoreapp3.0/</_ILLinkTasksDir>
+    <_ILLinkTasksPath>$(_ILLinkTasksDir)ILLink.Tasks.dll</_ILLinkTasksPath>
   </PropertyGroup>
+
+  <ItemGroup>
+    <_ILLinkDescriptorsFilePaths Include="$(MSBuildThisFileDirectory)ILLinkTrim.xml" />
+    <_ILLinkDescriptorsFilePaths Include="$(CoreLibSharedDir)ILLink\ILLink.Descriptors.Shared.xml" />
+  </ItemGroup>
 
   <!--
         Generates the xml root descriptor file for ILLink. The file contains roots required by the runtime.
@@ -24,16 +30,31 @@
         of child processes, and attach a debugger to msbuild. After that you can set a bp on the exception
         you are seeing.
   -->
-  <UsingTask TaskName="CreateRuntimeRootILLinkDescriptorFile" AssemblyFile="$(_ILLinkTasksDir)ILLink.Tasks.dll" />
+  <UsingTask TaskName="CreateRuntimeRootILLinkDescriptorFile" AssemblyFile="$(_ILLinkTasksPath)" />
   <Target Name="_CreateILLinkRuntimeRootDescriptorFile"
-          Inputs="$(_NamespaceFilePath);$(_MscorlibFilePath);$(_CortypeFilePath);$(_RexcepFilePath);$(_ILLinkTrimXmlFilePath)"
+          DependsOnTargets="_CombineILLinkTrimXmlFilePaths"
+          Inputs="$(_NamespaceFilePath);$(_MscorlibFilePath);$(_CortypeFilePath);$(_RexcepFilePath);$(_ILLinkDescriptorsIntermediatePath)"
           Outputs="$(_ILLinkRuntimeRootDescriptorFilePath)">
     <Message Text="Generating ILLink roots file: $(_ILLinkRuntimeRootDescriptorFilePath)" />
     <CreateRuntimeRootILLinkDescriptorFile NamespaceFilePath="$(_NamespaceFilePath)"
                                            MscorlibFilePath="$(_MscorlibFilePath)"
                                            CortypeFilePath="$(_CortypeFilePath)"
                                            RexcepFilePath="$(_RexcepFilePath)"
-                                           ILLinkTrimXmlFilePath="$(_ILLinkTrimXmlFilePath)"
+                                           ILLinkTrimXmlFilePath="$(_ILLinkDescriptorsIntermediatePath)"
                                            RuntimeRootDescriptorFilePath="$(_ILLinkRuntimeRootDescriptorFilePath)" />
   </Target>
+
+  <UsingTask TaskName="CombineLinkerXmlFiles" AssemblyFile="$(_ILLinkTasksPath)" />
+  <Target Name="_CombineILLinkTrimXmlFilePaths"
+          Inputs="@(_ILLinkDescriptorsFilePaths)"
+          Outputs="$(_ILLinkDescriptorsIntermediatePath)">
+
+    <CombineLinkerXmlFiles LinkerXmlFiles="@(_ILLinkDescriptorsFilePaths)"
+                           CombinedLinkerXmlFile="$(_ILLinkDescriptorsIntermediatePath)" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_ILLinkDescriptorsXmlIntermediatePath)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -1,68 +1,9 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
-    <type fullname="Interop/Globalization">
-      <!-- Internal API used by tests only. -->
-      <method name="GetICUVersion" />
-    </type>
     <type fullname="System.GC">
       <!-- Methods are used to register and unregister frozen segments. They are private and experimental. -->
       <method name="_RegisterFrozenSegment" />
       <method name="_UnregisterFrozenSegment" />
-    </type>
-    <!-- Properties and methods used by a debugger. -->
-    <type fullname="System.Threading.Tasks.Task">
-      <property name="ParentForDebugger" />
-      <property name="StateFlagsForDebugger" />
-      <method name="GetDelegateContinuationsForDebugger" />
-      <method name="SetNotificationForWaitCompletion" />
-    </type>
-    <type fullname="System.Threading.ThreadPool">
-      <method name="GetQueuedWorkItemsForDebugger" />
-      <method name="GetGloballyQueuedWorkItemsForDebugger" />
-      <method name="GetLocallyQueuedWorkItemsForDebugger" />
-    </type>
-    <type fullname="System.Threading.Tasks.TaskScheduler">
-      <method name="GetScheduledTasksForDebugger" />
-      <method name="GetTaskSchedulersForDebugger" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.AsyncMethodBuilderCore">
-      <method name="TryGetStateMachineForDebugger" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.AsyncIteratorMethodBuilder">
-      <property name="ObjectIdForDebugger" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder">
-      <property name="ObjectIdForDebugger" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder*">
-      <property name="ObjectIdForDebugger" />
-      <method name="SetNotificationForWaitCompletion" />
-    </type>
-    <type fullname="System.Threading.Tasks.Task">
-      <!-- Methods is used by VS Tasks Window. -->
-      <method name="GetActiveTaskFromId" />
-    </type>
-    <!-- Accessed via private reflection by tracing controller. -->
-    <type fullname="System.Diagnostics.Tracing.EventPipe*" />
-    <!-- Accessed via private reflection and by native code. -->
-    <type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
-    <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
-    <type fullname="System.Diagnostics.Tracing.PropertyValue/ReferenceTypeHelper`1">
-      <!-- Instantiated via reflection -->
-      <method name=".ctor" />
-    </type>
-    <!-- Accessed via native code. -->
-    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
-    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerator" />
-    <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
-    <!-- Workaround for https://github.com/mono/linker/issues/378 -->
-    <type fullname="System.Runtime.InteropServices.IDispatch" />
-    <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
-    <type fullname="System.Threading.ThreadPoolBoundHandle">
-        <!-- Workaround to keep .interfaceimpl even though this type
-             is not instantiated on unix:
-             https://github.com/mono/linker/pull/649 -->
-      <method name=".ctor" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -1,0 +1,63 @@
+<linker>
+  <assembly fullname="System.Private.CoreLib">
+    <type fullname="Interop/Globalization">
+      <!-- Internal API used by tests only. -->
+      <method name="GetICUVersion" />
+    </type>
+    <!-- Properties and methods used by a debugger. -->
+    <type fullname="System.Threading.Tasks.Task">
+      <property name="ParentForDebugger" />
+      <property name="StateFlagsForDebugger" />
+      <method name="GetDelegateContinuationsForDebugger" />
+      <method name="SetNotificationForWaitCompletion" />
+    </type>
+    <type fullname="System.Threading.ThreadPool">
+      <method name="GetQueuedWorkItemsForDebugger" />
+      <method name="GetGloballyQueuedWorkItemsForDebugger" />
+      <method name="GetLocallyQueuedWorkItemsForDebugger" />
+    </type>
+    <type fullname="System.Threading.Tasks.TaskScheduler">
+      <method name="GetScheduledTasksForDebugger" />
+      <method name="GetTaskSchedulersForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncMethodBuilderCore">
+      <method name="TryGetStateMachineForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncIteratorMethodBuilder">
+      <property name="ObjectIdForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder">
+      <property name="ObjectIdForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder*">
+      <property name="ObjectIdForDebugger" />
+      <method name="SetNotificationForWaitCompletion" />
+    </type>
+    <type fullname="System.Threading.Tasks.Task">
+      <!-- Methods is used by VS Tasks Window. -->
+      <method name="GetActiveTaskFromId" />
+    </type>
+    <!-- Accessed via private reflection by tracing controller. -->
+    <type fullname="System.Diagnostics.Tracing.EventPipe*" />
+    <!-- Accessed via private reflection and by native code. -->
+    <type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
+    <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
+    <type fullname="System.Diagnostics.Tracing.PropertyValue/ReferenceTypeHelper`1">
+      <!-- Instantiated via reflection -->
+      <method name=".ctor" />
+    </type>
+    <!-- Accessed via native code. -->
+    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
+    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerator" />
+    <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
+    <!-- Workaround for https://github.com/mono/linker/issues/378 -->
+    <type fullname="System.Runtime.InteropServices.IDispatch" />
+    <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
+    <type fullname="System.Threading.ThreadPoolBoundHandle">
+      <!-- Workaround to keep .interfaceimpl even though this type
+             is not instantiated on unix:
+             https://github.com/mono/linker/pull/649 -->
+      <method name=".ctor" />
+    </type>
+  </assembly>
+</linker>

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <!-- Generate Mono corelib version file -->
   <Import Project="GenerateMonoCoreLibVersionFile.targets" />
 
@@ -144,10 +144,12 @@
   <PropertyGroup>
     <ILLinkTrimAssembly>true</ILLinkTrimAssembly>
     <ILLinkDirectory>$(MSBuildThisFileDirectory)src\ILLink\</ILLinkDirectory>
-    <ILLinkTrimXml>$(ILLinkDirectory)System.Private.CoreLib.xml</ILLinkTrimXml>
   </PropertyGroup>
 
   <ItemGroup>
+    <ILLinkDescriptorsXmls Include="$(ILLinkDirectory)System.Private.CoreLib.xml" />
+    <ILLinkDescriptorsXmls Include="$(CoreLibSharedDir)ILLink\ILLink.Descriptors.Shared.xml" />
+    
     <ILLinkSubstitutionsXmls Include="$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml"
                              Condition="Exists('$(ILLinkDirectory)ILLink.Substitutions.$(Platform).xml')" />
   </ItemGroup>

--- a/src/mono/netcore/System.Private.CoreLib/src/ILLink/System.Private.CoreLib.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/ILLink/System.Private.CoreLib.xml
@@ -753,70 +753,9 @@
 			<method signature="System.Void .ctor()" />
 		</type>
 
-		<!-- From src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml -->
-		<!-- Properties and methods used by a debugger. -->
-		<type fullname="System.Threading.Tasks.Task">
-			<property name="ParentForDebugger" />
-			<property name="StateFlagsForDebugger" />
-			<method name="GetDelegateContinuationsForDebugger" />
-			<method name="SetNotificationForWaitCompletion" />
-		</type>
-		<type fullname="System.Threading.ThreadPool">
-			<method name="GetQueuedWorkItemsForDebugger" />
-			<method name="GetGloballyQueuedWorkItemsForDebugger" />
-			<method name="GetLocallyQueuedWorkItemsForDebugger" />
-		</type>
-		<type fullname="System.Threading.Tasks.TaskScheduler">
-			<method name="GetScheduledTasksForDebugger" />
-			<method name="GetTaskSchedulersForDebugger" />
-		</type>
-		<type fullname="System.Runtime.CompilerServices.AsyncMethodBuilderCore">
-			<method name="TryGetStateMachineForDebugger" />
-		</type>
-		<type fullname="System.Runtime.CompilerServices.AsyncIteratorMethodBuilder">
-			<property name="ObjectIdForDebugger" />
-		</type>
-		<type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder">
-			<property name="ObjectIdForDebugger" />
-		</type>
-		<type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder*">
-			<property name="ObjectIdForDebugger" />
-			<method name="SetNotificationForWaitCompletion" />
-		</type>
-		<type fullname="System.Threading.Tasks.Task">
-			<!-- Methods is used by VS Tasks Window. -->
-			<method name="GetActiveTaskFromId" />
-		</type>
-		<!-- Accessed via private reflection by tracing controller. -->
-		<type fullname="System.Diagnostics.Tracing.EventPipe*" />
-		<!-- Accessed via private reflection and by native code. -->
-		<type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
-		<type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
-		<type fullname="System.Diagnostics.Tracing.PropertyValue/ReferenceTypeHelper`1">
-			<!-- Instantiated via reflection -->
-			<method name=".ctor" />
-		</type>
-		<!-- Accessed via native code. -->
-		<type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
-		<type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
-		<!-- Workaround for https://github.com/mono/linker/issues/378 -->
-		<type fullname="System.Runtime.InteropServices.IDispatch" />
-		<type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
-		<type fullname="System.Threading.ThreadPoolBoundHandle">
-			<!-- Workaround to keep .interfaceimpl even though this type
-				is not instantiated on unix:
-				https://github.com/mono/linker/pull/649 -->
-			<method name=".ctor" />
-		</type>
-		<!-- end of src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml -->
-
 		<!-- Used by binary formatter tests -->
 		<type fullname="System.Threading.ThreadStartException">
 			<method name=".ctor" />
-		</type>
-		<!-- Internal API used by System.Globalization tests -->
-		<type fullname="Interop/Globalization">
-			<method name="GetICUVersion" />
 		</type>
 		<type fullname="System.Runtime.InteropServices.Marshal">
 			<!-- marshal-ilgen.c: emit_marshal_custom_get_instance -->


### PR DESCRIPTION
This reduces the duplication between these libraries, and allows for easier maintenance going forward.

Fix #37255