### PR TITLE
Fix MemoryCache Trim test

### DIFF
--- a/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
+++ b/src/libraries/System.Runtime.Caching/tests/System.Runtime.Caching/MemoryCacheTest.cs
@@ -988,8 +988,8 @@ namespace MonoTests.System.Runtime.Caching
 
             Assert.Equal(numItems, mc.GetCount());
 
-            // Trimming 75% for such a small number of items (supposedly each in its cache store) will end up trimming all of them
-            long trimmed = mc.Trim(75);
+            // Trimming 76% for such a small number of items (supposedly each in its cache store) will end up trimming all of them
+            long trimmed = mc.Trim(76);
             Assert.Equal(numItems, trimmed);
             Assert.Equal(0, mc.GetCount());
 


### PR DESCRIPTION
Based on conversation here: https://github.com/dotnet/runtime/issues/36488#issuecomment-629040035

I ran the test with the fix (changing to 76%) in a loop 50 times and it didn't fail

Run without the fix: https://helix.dot.net/api/2019-06-17/jobs/b7f84fb0-3804-49f6-97dc-d09fc2180585/workitems/NoFix/console

Run with the fix: https://helix.dot.net/api/2019-06-17/jobs/bc764363-3621-4740-a24c-d336546cb6c2/workitems/Fix/console

Fixes: https://github.com/dotnet/runtime/issues/36488