### PR TITLE
Skip Bundle_can_be_renamed() installer test

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleRename.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleRename.cs
@@ -23,6 +23,7 @@ namespace AppHost.Bundle.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/38013")]
         [InlineData(true)]  // Test renaming the single-exe when contents are extracted
         [InlineData(false)] // Test renaming the single-exe when contents are not extracted 
         private void Bundle_can_be_renamed_while_running(bool testExtraction)


### PR DESCRIPTION
This test is randomly failing in the lab: #35068
Therefore skip this test until the underlying problem is resolved.
Enabling the test is tracked by #38013

Fixes #35068.