### PR TITLE
Fix TPA map hash calculation.

### DIFF
--- a/src/coreclr/src/binder/inc/applicationcontext.hpp
+++ b/src/coreclr/src/binder/inc/applicationcontext.hpp
@@ -46,8 +46,12 @@ namespace BINDER_SPACE
             key = e.m_wszSimpleName;
             return key;
         }
-        static count_t Hash(const key_t &str) { return HashiString(str); }
-        static BOOL Equals(const key_t &lhs, const key_t &rhs) { LIMITED_METHOD_CONTRACT; return (_wcsicmp(lhs, rhs) == 0); }
+        static count_t Hash(const key_t &str)
+        {
+            SString ssKey(SString::Literal, str);
+            return ssKey.HashCaseInsensitive();
+        }
+        static BOOL Equals(const key_t &lhs, const key_t &rhs) { LIMITED_METHOD_CONTRACT; return (SString::_wcsicmp(lhs, rhs) == 0); }
 
         void OnDestructPerEntryCleanupAction(const SimpleNameToFileNameMapEntry & e)
         {

--- a/src/coreclr/tests/src/Loader/binding/assemblies/assemblybugs/37910/Ii.cs
+++ b/src/coreclr/tests/src/Loader/binding/assemblies/assemblybugs/37910/Ii.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+public class Program
+{
+    [DllImport("libc", EntryPoint = "setlocale")]
+    public static extern IntPtr setlocale(int category, [MarshalAs(UnmanagedType.LPStr)] string locale);
+
+    public static int Main()
+    {
+        Assembly a1 = Assembly.GetExecutingAssembly();
+
+        // In case of Turkish locale:
+        // towupper 'i' -> \x0130 (instead of 'I')
+        // towlower 'I' -> \x0131 (instead of 'i')
+        const string TRLocale = "tr_TR.UTF-8";
+        IntPtr res = setlocale(6 /*LC_ALL*/, TRLocale);
+        if (TRLocale != Marshal.PtrToStringAnsi(res))
+        {
+            Console.WriteLine("Failed! " + TRLocale + " locale was not found in system!");
+            return -1;
+        }
+
+        Assembly a2 = Assembly.Load("Ii");
+
+        if (a1 != a2)
+        {
+            Console.WriteLine("Failed!");
+            return -2;
+        }
+
+        Console.WriteLine("Passed!");
+        return 100;
+    }
+}

--- a/src/coreclr/tests/src/Loader/binding/assemblies/assemblybugs/37910/Ii.csproj
+++ b/src/coreclr/tests/src/Loader/binding/assemblies/assemblybugs/37910/Ii.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test unsupported outside of linux -->
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'Linux'">true</CLRTestTargetUnsupported>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Ii.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The point of issue is "the Turkish-I Problem". After locale changed, towupper() provide another result for "i" and different hash are calculated in case if file name have "i" letter.

Fix https://github.com/dotnet/runtime/issues/37910

CC @alpencolt @jkotas @HJLeee