### PR TITLE
Add build instructions for pkg-config

### DIFF
--- a/docs/workflow/building/coreclr/osx-instructions.md
+++ b/docs/workflow/building/coreclr/osx-instructions.md
@@ -39,7 +39,7 @@ brew install icu4c
 
 pkg-config
 ----------
-pkg-config is also required to build and run. It can be obtained via [Homebrew](https://brew.sh/).
+pkg-config is also required to build. It can be obtained via [Homebrew](https://brew.sh/).
 
 ```sh
 brew install pkg-config

--- a/docs/workflow/building/coreclr/osx-instructions.md
+++ b/docs/workflow/building/coreclr/osx-instructions.md
@@ -37,6 +37,14 @@ ICU (International Components for Unicode) is also required to build and run. It
 brew install icu4c
 ```
 
+pkg-config
+----------
+pkg-config is also required to build and run. It can be obtained via [Homebrew](https://brew.sh/).
+
+```sh
+brew install pkg-config
+```
+
 Build the Runtime and System.Private.CoreLib
 ============================================
 


### PR DESCRIPTION
Building locally on fresh osx:
```
  Please install pkg-config before running this script, see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/macos-requirements.md
/Users/hugh/Documents/GitHub/runtime/src/coreclr/runtime.proj(31,5): error MSB3073: The command ""/Users/hugh/Documents/GitHub/runtime/src/coreclr/build-runtime.sh" -x64 -debug -os OSX" exited with code 1.

```