### PR TITLE
Add threadpool support for webassembly.

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -303,6 +303,7 @@
   <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
       <Compile Include="$(BclSourcesRoot)\System\Threading\TimerQueue.Browser.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Threading\ThreadPool.Browser.Mono.cs" />
+      <Compile Include="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System\Threading\ThreadPoolBoundHandle.PlatformNotSupported.cs" />
   </ItemGroup>
   <ItemGroup>
       <Compile Include="$(BclSourcesRoot)\Mono\RuntimeStructs.cs" />

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -123,7 +123,7 @@
     <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
     <FeatureManagedEtw>true</FeatureManagedEtw>
     <FeaturePortableTimer Condition="'$(TargetsBrowser)' != 'true'">true</FeaturePortableTimer>
-    <FeaturePortableThreadPool>true</FeaturePortableThreadPool>
+    <FeaturePortableThreadPool Condition="'$(TargetsBrowser)' != 'true'">true</FeaturePortableThreadPool>
     <FeaturePerfTracing>true</FeaturePerfTracing>
     <FeatureDefaultInterfaces>true</FeatureDefaultInterfaces>
   </PropertyGroup>
@@ -302,6 +302,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
       <Compile Include="$(BclSourcesRoot)\System\Threading\TimerQueue.Browser.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\ThreadPool.Browser.Mono.cs" />
   </ItemGroup>
   <ItemGroup>
       <Compile Include="$(BclSourcesRoot)\Mono\RuntimeStructs.cs" />

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -82,12 +82,11 @@ namespace System.Threading
 
         internal static void NotifyWorkItemProgress()
         {
-            throw new PlatformNotSupportedException();
         }
 
         internal static bool NotifyWorkItemComplete()
         {
-            return false;
+            return true;
         }
 
         private static RegisteredWaitHandle RegisterWaitForSingleObject(

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -12,6 +12,15 @@ namespace System.Threading
 {
     public sealed class RegisteredWaitHandle : MarshalByRefObject
     {
+        internal RegisteredWaitHandle(WaitHandle waitHandle, _ThreadPoolWaitOrTimerCallback callbackHelper,
+            int millisecondsTimeout, bool repeating)
+        {
+        }
+
+        public bool Unregister(WaitHandle? waitObject)
+        {
+            throw new PlatformNotSupportedException();
+        }
     }
 
     public static partial class ThreadPool
@@ -24,6 +33,8 @@ namespace System.Threading
 
         public static bool SetMaxThreads(int workerThreads, int completionPortThreads)
         {
+            if (workerThreads == 1 || completionPortThreads == 1)
+                return true;
             return false;
         }
 
@@ -35,6 +46,8 @@ namespace System.Threading
 
         public static bool SetMinThreads(int workerThreads, int completionPortThreads)
         {
+            if (workerThreads == 1 || completionPortThreads == 1)
+                return true;
             return false;
         }
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -33,7 +33,7 @@ namespace System.Threading
 
         public static bool SetMaxThreads(int workerThreads, int completionPortThreads)
         {
-            if (workerThreads == 1 || completionPortThreads == 1)
+            if (workerThreads == 1 && completionPortThreads == 1)
                 return true;
             return false;
         }
@@ -46,7 +46,7 @@ namespace System.Threading
 
         public static bool SetMinThreads(int workerThreads, int completionPortThreads)
         {
-            if (workerThreads == 1 || completionPortThreads == 1)
+            if (workerThreads == 1 && completionPortThreads == 1)
                 return true;
             return false;
         }
@@ -54,13 +54,13 @@ namespace System.Threading
         public static void GetMinThreads(out int workerThreads, out int completionPortThreads)
         {
             workerThreads = 1;
-            completionPortThreads = 0;
+            completionPortThreads = 1;
         }
 
         public static void GetAvailableThreads(out int workerThreads, out int completionPortThreads)
         {
             workerThreads = 1;
-            completionPortThreads = 0;
+            completionPortThreads = 1;
         }
 
         public static int ThreadCount => 1;

--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -337,6 +337,20 @@ var App = {
 				test_exit (1);
 			}
 
+/*
+			// For testing tp/timers etc.
+			while (true) {
+				// Sleep by busy waiting
+				var start = performance.now ();
+				useconds = 1e6 / 10;
+				while (performance.now() - start < useconds / 1000) {
+					// Do nothing.
+				}
+
+				Module.pump_message ();
+			}
+*/
+
 			if (is_browser)
 				test_exit (0);
 


### PR DESCRIPTION
Register a JS callback when a work item is queued, the callback will call into the runtime/bcl to execute the work item.