### PR TITLE
Disable mono interpreter perf jobs

### DIFF
--- a/eng/pipelines/coreclr/perf.yml
+++ b/eng/pipelines/coreclr/perf.yml
@@ -74,18 +74,19 @@ jobs:
       liveLibrariesBuildConfig: Release
       runtimeType: mono
 
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
-    buildConfig: release
-    runtimeFlavor: mono
-    platforms:
-    - Linux_x64
-    jobParameters:
-      testGroup: perf
-      liveLibrariesBuildConfig: Release
-      runtimeType: mono
-      codeGenType: 'Interpreter'
+# Drains the pool: https://github.com/dotnet/core-eng/issues/10070
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/coreclr/templates/perf-job.yml
+#     buildConfig: release
+#     runtimeFlavor: mono
+#     platforms:
+#     - Linux_x64
+#     jobParameters:
+#       testGroup: perf
+#       liveLibrariesBuildConfig: Release
+#       runtimeType: mono
+#       codeGenType: 'Interpreter'
 
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:


### PR DESCRIPTION
The change is causing others legs to timeout as the pool is drained: https://github.com/dotnet/core-eng/issues/10070. Presumably this is because the interpreter mono perf runs take _very long_.

Disabling the mono interpreter perf jobs meanwhile.