### PR TITLE
Adding Trimming tests for StackFrameHelper and AppDomain

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.props
+++ b/eng/testing/linker/SupportFiles/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <PublishTrimmed>true</PublishTrimmed>
     <_TrimmerDefaultAction>link</_TrimmerDefaultAction>
+    <_TrimmerLinkSymbols>true</_TrimmerLinkSymbols>
     <SelfContained>true</SelfContained>
     <EnableTargetingPackDownload>false</EnableTargetingPackDownload>
     <PlatformManifestFile />

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <TestConsoleAppSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    <TestConsoleAppSourceFiles Condition="'@(TestConsoleAppSourceFiles)' == ''" Include="$(MSBuildProjectDirectory)\*.cs" />
 
     <TestSupportFiles Include="$(MSBuildThisFileDirectory)SupportFiles\Directory.Build.*">
       <DestinationFolder>$(TrimmingTestDir)</DestinationFolder>
@@ -41,7 +41,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <TestConsoleApps Include="@(TestConsoleAppSourceFiles->'%(ProjectFile)')">
+      <TestConsoleApps Include="@(TestConsoleAppSourceFiles->'%(ProjectFile)')" Condition="!$([System.String]::Copy('%(TestConsoleAppSourceFiles.SkipOnTestRuntimes)').Contains('$(PackageRID)'))">
         <ProjectCompileItems>%(Identity)</ProjectCompileItems>
       </TestConsoleApps>
     </ItemGroup>
@@ -81,7 +81,7 @@
       <TestPublishTrimmedCommand>$(TestPublishTrimmedCommand) -p:configuration=$(Configuration)</TestPublishTrimmedCommand>
     </PropertyGroup>
 
-    <Exec Command="$(TestPublishTrimmedCommand)" EnvironmentVariables="@(CliEnvironment)" StandardOutputImportance="Low" WorkingDirectory="%(TestConsoleApps.ProjectDir)" />
+    <Exec Command="$(TestPublishTrimmedCommand) %(TestConsoleApps.AdditionalArgs)" EnvironmentVariables="@(CliEnvironment)" StandardOutputImportance="Low" WorkingDirectory="%(TestConsoleApps.ProjectDir)" />
   </Target>
 
   <Target Name="ExecuteApplications"

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadGenericPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadGenericPrincipalTest.cs
@@ -12,6 +12,10 @@ class Program
         // after setting UnauthenticatedPrincipal as the PrincipalPolicy
         AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.UnauthenticatedPrincipal);
         IPrincipal genericPrincipal = Thread.CurrentPrincipal;
+        if (genericPrincipal.GetType().Name != "GenericPrincipal")
+        {
+            return -1;
+        }
 
         return 100;
     }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadGenericPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadGenericPrincipalTest.cs
@@ -7,7 +7,7 @@ class Program
 {
     static int Main(string[] args)
     {
-    	// Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
+        // Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
         // contains annotation attributes and will require GenericPrincipal.GetDefaultInstance
         // after setting UnauthenticatedPrincipal as the PrincipalPolicy
         AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.UnauthenticatedPrincipal);

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadGenericPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadGenericPrincipalTest.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Security.Principal;
+using System.Threading;
+using System.Diagnostics;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+    	// Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
+        // contains annotation attributes and will require GenericPrincipal.GetDefaultInstance
+        // after setting UnauthenticatedPrincipal as the PrincipalPolicy
+        AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.UnauthenticatedPrincipal);
+        IPrincipal genericPrincipal = Thread.CurrentPrincipal;
+
+        return 100;
+    }
+}

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadPrincipalTest.cs
@@ -8,6 +8,7 @@ class Program
         // Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
         // contains annotation attributes and will require WindowsPrincipal.GetDefaultInstance
         // and GenericPrincipal.GetDefaultInstance
+        AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
         IPrincipal principal = Thread.CurrentPrincipal;
         return 100;
     }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadPrincipalTest.cs
@@ -1,0 +1,14 @@
+using System.Security.Principal;
+using System.Threading;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        // Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
+        // contains annotation attributes and will require WindowsPrincipal.GetDefaultInstance
+        // and GenericPrincipal.GetDefaultInstance
+        IPrincipal principal = Thread.CurrentPrincipal;
+        return 100;
+    }
+}

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadWindowsPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadWindowsPrincipalTest.cs
@@ -1,15 +1,18 @@
+using System;
 using System.Security.Principal;
 using System.Threading;
+using System.Diagnostics;
 
 class Program
 {
     static int Main(string[] args)
     {
-        // Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
+    	// Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
         // contains annotation attributes and will require WindowsPrincipal.GetDefaultInstance
-        // and GenericPrincipal.GetDefaultInstance
+        // after setting that as the PrincipalPolicy
         AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
         IPrincipal principal = Thread.CurrentPrincipal;
+
         return 100;
     }
 }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadWindowsPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadWindowsPrincipalTest.cs
@@ -12,6 +12,10 @@ class Program
         // after setting that as the PrincipalPolicy
         AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
         IPrincipal principal = Thread.CurrentPrincipal;
+        if (principal.GetType().Name != "WindowsPrincipal")
+        {
+            return -1;
+        }
 
         return 100;
     }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadWindowsPrincipalTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/AppDomainGetThreadWindowsPrincipalTest.cs
@@ -7,7 +7,7 @@ class Program
 {
     static int Main(string[] args)
     {
-    	// Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
+        // Thread.CurrentPrincipal calls AppDomain.CurrentDomain.GetThreadPrincipal() which
         // contains annotation attributes and will require WindowsPrincipal.GetDefaultInstance
         // after setting that as the PrincipalPolicy
         AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);

--- a/src/libraries/System.Runtime/tests/TrimmingTests/StackFrameHelperTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/StackFrameHelperTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics;
 
 class Program
@@ -8,7 +7,13 @@ class Program
         // StackTrace constructor calls CaptureStackTrace method which in turn will call
         // StackFrameHelper.InitializeSourceInfo which has annotations as it will require
         // StackTraceSymbols.ctor and StackTraceSymbols.GetSourceLineInfo
-        StackTrace thisTrace = new StackTrace();
+        StackTrace thisTrace = new StackTrace(true);
+        // Validate that the stackTrace indeed contains source line info
+        // If something failed in GetSourceLineInfo, then GetFileLineNumber
+        // will return 0
+        int lineNumber = thisTrace.GetFrame(0).GetFileLineNumber();
+        if (lineNumber == 0)
+            return -1;
         return 100;
     }
 }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/StackFrameHelperTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/StackFrameHelperTest.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Diagnostics;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        // StackTrace constructor calls CaptureStackTrace method which in turn will call
+        // StackFrameHelper.InitializeSourceInfo which has annotations as it will require
+        // StackTraceSymbols.ctor and StackTraceSymbols.GetSourceLineInfo
+        StackTrace thisTrace = new StackTrace();
+        return 100;
+    }
+}

--- a/src/libraries/System.Runtime/tests/TrimmingTests/StackFrameHelperTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/StackFrameHelperTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 
 class Program
@@ -7,11 +8,11 @@ class Program
         // StackTrace constructor calls CaptureStackTrace method which in turn will call
         // StackFrameHelper.InitializeSourceInfo which has annotations as it will require
         // StackTraceSymbols.ctor and StackTraceSymbols.GetSourceLineInfo
-        StackTrace thisTrace = new StackTrace(true);
-        // Validate that the stackTrace indeed contains source line info
+        StackTrace thisTrace = new StackTrace(fNeedFileInfo: true);
+        // Validate that the stackTrace indeed contains source line info for the last frame of the stack.
         // If something failed in GetSourceLineInfo, then GetFileLineNumber
         // will return 0
-        int lineNumber = thisTrace.GetFrame(0).GetFileLineNumber();
+        int lineNumber = thisTrace.GetFrame(thisTrace.FrameCount - 1).GetFileLineNumber();
         if (lineNumber == 0)
             return -1;
         return 100;

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -1,5 +1,20 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="AppDomainGetThreadGenericPrincipalTest.cs" />
+    <TestConsoleAppSourceFiles Include="AppDomainGetThreadWindowsPrincipalTest.cs">
+      <SkipOnTestRuntimes>osx-x64;linux-x64</SkipOnTestRuntimes>
+    </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="GenericArraySortHelperTest.cs" />
+    <TestConsoleAppSourceFiles Include="StackFrameHelperTest.cs">
+      <!-- There is a bug with the linker where it is corrupting the pdbs while trimming
+      causing the framework to not be able to get source line info any longer. This
+      specific test depends on being able to do that, so we use DebugType as Embedded
+      as a workaround while the linker bug is fixed. -->
+      <AdditionalArgs>/p:DebugType=Embedded</AdditionalArgs>
+    </TestConsoleAppSourceFiles>
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -11,7 +11,8 @@
       <!-- There is a bug with the linker where it is corrupting the pdbs while trimming
       causing the framework to not be able to get source line info any longer. This
       specific test depends on being able to do that, so we use DebugType as Embedded
-      as a workaround while the linker bug is fixed. -->
+      as a workaround while the linker bug is fixed. This bug has been logged in the
+      linker repo here: https://github.com/mono/linker/issues/1285 -->
       <AdditionalArgs>/p:DebugType=Embedded</AdditionalArgs>
     </TestConsoleAppSourceFiles>
   </ItemGroup>

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -97,6 +97,8 @@
         <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
         <IsNative>true</IsNative>
       </_runtimePackNativeFiles>
+      <!-- Clear the IsNative flag on System.PrivateCoreLib given that it is present in native dir but it is actually managed -->
+      <_runtimePackNativeFiles Update="@(_runtimePackNativeFiles)" Condition="'%(FileName)%(Extension)' == 'System.Private.CoreLib.dll'" IsNative="" />
 
       <FrameworkListRootAttributes Include="Name" Value="$(NetCoreAppCurrentBrandName)" />
       <FrameworkListRootAttributes Include="TargetFrameworkIdentifier" Value="$(NetCoreAppCurrentIdentifier)" />

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -69,7 +69,6 @@
       <BinPlaceItem Include="@(MonoIncludeFiles)">
         <DestinationSubDirectory>include/%(RecursiveDir)</DestinationSubDirectory>
       </BinPlaceItem>
-      <BinPlaceItem Remove="@(BinPlaceItem)" Condition="'$(RuntimeFlavor)' != 'Mono' and '%(BinPlaceItem.Filename)' == 'System.Private.CoreLib'" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
       <TestHostBinPlaceItem Include="@(RuntimeFiles)" />


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/37677

cc: @layomia @eerhardt 

These two tests are the ones needed to cover the first half of the list on @layomia's issue. Once this is merged I'll check the corresponding checkboxes on that.