### PR TITLE
Fix multi-reg temporary copy

### DIFF
--- a/src/coreclr/src/jit/lsra.cpp
+++ b/src/coreclr/src/jit/lsra.cpp
@@ -6790,8 +6790,8 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned m
         if (refPosition->copyReg)
         {
             // This is a TEMPORARY copy
-            assert(isCandidateLocalRef(tree));
-            newNode->gtFlags |= GTF_VAR_DEATH;
+            assert(isCandidateLocalRef(tree) || tree->IsMultiRegLclVar());
+            newNode->SetLastUse(multiRegIdx);
         }
 
         // Insert the copy/reload after the spilled node and replace the use of the original node with a use


### PR DESCRIPTION
If we need to insert a COPY node to signify a temporary copy of field of a multi-reg lclVar, we need to set the appropriate last use bit.

Fix #37830