### PR TITLE
Crossgen method bodies having ARM64 intrinsic

### DIFF
--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -121,6 +121,7 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 #ifdef HWCAP_SVE
 //    if (hwCap & HWCAP_SVE)
 //        CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_SVE);
+#endif
 #endif // HAVE_AUXV_HWCAP_H
 #endif // defined(HOST_ARM64)
     CPUCompileFlags.Set64BitInstructionSetVariants();

--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -23,12 +23,14 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 
     CORJIT_FLAGS &CPUCompileFlags = *flags;
 
+
+#if defined(HOST_ARM64)
+
     // Enable ARM64 based flags by default so we always crossgen
     // ARM64 intrinsics for Linux
     CPUCompileFlags.Set(InstructionSet_ArmBase);
     CPUCompileFlags.Set(InstructionSet_AdvSimd);
 
-#if defined(HOST_ARM64)
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
 

--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -23,14 +23,14 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 
     CORJIT_FLAGS &CPUCompileFlags = *flags;
 
-
-#if defined(HOST_ARM64)
-
+#if defined(TARGET_ARM64)
     // Enable ARM64 based flags by default so we always crossgen
     // ARM64 intrinsics for Linux
     CPUCompileFlags.Set(InstructionSet_ArmBase);
     CPUCompileFlags.Set(InstructionSet_AdvSimd);
+#endif // defined(TARGET_ARM64)
 
+#if defined(HOST_ARM64)
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
 
@@ -101,8 +101,11 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 //        CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_SHA3);
 #endif
 #ifdef HWCAP_ASIMD
-    if (hwCap & HWCAP_ASIMD)
-        CPUCompileFlags.Set(InstructionSet_AdvSimd);
+    if ((hwCap & HWCAP_ASIMD) == 0)
+    {
+        fprintf(stderr, "AdvSimd is not supported on the processor.\n");
+        abort();
+    }
 #endif
 #ifdef HWCAP_ASIMDRDM
 //    if (hwCap & HWCAP_ASIMDRDM)

--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -22,6 +22,12 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
     _ASSERTE(flags);
 
     CORJIT_FLAGS &CPUCompileFlags = *flags;
+
+    // Enable ARM64 based flags by default so we always crossgen
+    // ARM64 intrinsics for Linux
+    CPUCompileFlags.Set(InstructionSet_ArmBase);
+    CPUCompileFlags.Set(InstructionSet_AdvSimd);
+
 #if defined(HOST_ARM64)
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
@@ -32,7 +38,6 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 // From a single binary distribution perspective, compiling with latest kernel asm/hwcap.h should
 // include all published flags.  Given flags are merged to kernel and published before silicon is
 // available, using the latest kernel for release should be sufficient.
-    CPUCompileFlags.Set(InstructionSet_ArmBase);
 #ifdef HWCAP_AES
     if (hwCap & HWCAP_AES)
         CPUCompileFlags.Set(InstructionSet_Aes);
@@ -116,14 +121,6 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 #ifdef HWCAP_SVE
 //    if (hwCap & HWCAP_SVE)
 //        CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_SVE);
-#endif
-#else // !HAVE_AUXV_HWCAP_H
-    // CoreCLR SIMD and FP support is included in ARM64 baseline
-    // On exceptional basis platforms may leave out support, but CoreCLR does not
-    // yet support such platforms
-    // Set baseline flags if OS has not exposed mechanism for us to determine CPU capabilities
-    CPUCompileFlags.Set(InstructionSet_AdvSimd);
-//    CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_FP);
 #endif // HAVE_AUXV_HWCAP_H
 #endif // defined(HOST_ARM64)
     CPUCompileFlags.Set64BitInstructionSetVariants();

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -1481,10 +1481,10 @@ MethodTableBuilder::BuildMethodTableThrowing(
 #endif
         {
 #if defined(CROSSGEN_COMPILE)
-#if defined(TARGET_X86) || defined(TARGET_AMD64)
+#if defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_ARM64)
             if ((!IsNgenPDBCompilationProcess()
                 && GetAppDomain()->ToCompilationDomain()->GetTargetModule() != g_pObjectClass->GetModule()))
-#endif // defined(TARGET_X86) || defined(TARGET_AMD64)
+#endif // defined(TARGET_X86) || defined(TARGET_AMD64) || defined(TARGET_ARM64)
             {
                 // Disable AOT compiling for managed implementation of hardware intrinsics.
                 // We specially treat them here to ensure correct ISA features are set during compilation

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2150,7 +2150,12 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
         // Additionally, we make sure none of the hardware intrinsic method bodies get pregenerated in crossgen
         // (see ZapInfo::CompileMethod) but get JITted instead. The JITted method will have the correct
         // answer for the CPU the code is running on.
+#if defined(TARGET_ARM64)
+        fTreatAsRegularMethodCall = (fIsGetIsSupportedMethod && fIsPlatformHWIntrinsic);
+#else
         fTreatAsRegularMethodCall = (fIsGetIsSupportedMethod && fIsPlatformHWIntrinsic) || (!fIsPlatformHWIntrinsic && fIsHWIntrinsic);
+#endif 
+
 
         if (fIsPlatformHWIntrinsic)
         {

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2152,12 +2152,11 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
         // answer for the CPU the code is running on.
 
         // For Arm64, AdvSimd/ArmBase is the baseline that is suported and hence we do pregenerate the method bodies
-        // of ARM4 harware intrinsic.
+        // of ARM64 harware intrinsic.
         fTreatAsRegularMethodCall = (fIsGetIsSupportedMethod && fIsPlatformHWIntrinsic);
 #if !defined(TARGET_ARM64)
         fTreatAsRegularMethodCall |= (!fIsPlatformHWIntrinsic && fIsHWIntrinsic);
 #endif 
-
 
         if (fIsPlatformHWIntrinsic)
         {

--- a/src/coreclr/src/zap/zapinfo.cpp
+++ b/src/coreclr/src/zap/zapinfo.cpp
@@ -2147,13 +2147,15 @@ DWORD FilterNamedIntrinsicMethodAttribs(ZapInfo* pZapInfo, DWORD attribs, CORINF
         // is because they often change the code they emit based on what ISAs are supported by the compiler,
         // but we don't know what the target machine will support.
         //
-        // Additionally, we make sure none of the hardware intrinsic method bodies get pregenerated in crossgen
+        // Additionally, we make sure none of the hardware intrinsic method bodies (except ARM64) get pregenerated in crossgen
         // (see ZapInfo::CompileMethod) but get JITted instead. The JITted method will have the correct
         // answer for the CPU the code is running on.
-#if defined(TARGET_ARM64)
+
+        // For Arm64, AdvSimd/ArmBase is the baseline that is suported and hence we do pregenerate the method bodies
+        // of ARM4 harware intrinsic.
         fTreatAsRegularMethodCall = (fIsGetIsSupportedMethod && fIsPlatformHWIntrinsic);
-#else
-        fTreatAsRegularMethodCall = (fIsGetIsSupportedMethod && fIsPlatformHWIntrinsic) || (!fIsPlatformHWIntrinsic && fIsHWIntrinsic);
+#if !defined(TARGET_ARM64)
+        fTreatAsRegularMethodCall |= (!fIsPlatformHWIntrinsic && fIsHWIntrinsic);
 #endif 
 
 


### PR DESCRIPTION
Today, method bodies containing ARM64 intrinsics are not crossgened. Currently there are not many methods that uses ARM64 intrinsics, but gradually once all the APIs #33308 are intrinsified , it will impact startup time of those methods because they would get JITted first before executing. This PR makes such methods bodies to get crossgened for faster startup time. Additionally, methods of `Vector64` and `Vector128` were being treated as method calls but since they are intrinsified already (again as part of #33308), it is safe to just crossgen their method bodies. 

Below is the code size difference. There seems to be regression of 1% but it will still give us good startup time benefits.

```

Summary of Code Size diffs:
(Lower is better)

Total bytes of diff: 53216 (0.935% of base)
    diff is a regression.

Total byte diff includes 59916 bytes from reconciling methods
        Base had    0 unique methods,        0 unique bytes
        Diff had 1477 unique methods,    59916 unique bytes

Top file regressions (bytes):
       53216 : System.Private.CoreLib.dasm (0.935% of base)

1 total files with Code Size differences (0 improved, 1 regressed), 0 unchanged.

Top method regressions (bytes):
         500 (10.113% of base) : System.Private.CoreLib.dasm - Internal.Runtime.CompilerServices.Unsafe:As(byref):byref (292 base, 323 diff methods)
         220 (117.021% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:GetHashCode():int:this
         208 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithLower(System.Runtime.Intrinsics.Vector128`1[__Canon],System.Runtime.Intrinsics.Vector64`1[__Canon]):System.Runtime.Intrinsics.Vector128`1[__Canon] (0 base, 1 diff methods)
         208 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:WithUpper(System.Runtime.Intrinsics.Vector128`1[__Canon],System.Runtime.Intrinsics.Vector64`1[__Canon]):System.Runtime.Intrinsics.Vector128`1[__Canon] (0 base, 1 diff methods)
         180 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte,ubyte):System.Runtime.Intrinsics.Vector128`1[Byte] (0 base, 1 diff methods)
         180 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte,byte):System.Runtime.Intrinsics.Vector128`1[SByte] (0 base, 1 diff methods)
         136 (75.556% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[UInt32]):bool
         136 (75.556% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:<Equals>g__SoftwareFallback|12_0(byref,System.Runtime.Intrinsics.Vector128`1[Int32]):bool
         112 (70.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int16][System.Int16]:GetHashCode():int:this
         112 (70.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:GetHashCode():int:this
         112 (70.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int32][System.Int32]:GetHashCode():int:this
         112 (70.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt16][System.UInt16]:GetHashCode():int:this
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Byte],ubyte,System.Runtime.Intrinsics.Vector64`1[Byte],ubyte):System.Runtime.Intrinsics.Vector128`1[Byte] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Byte],ubyte,System.Runtime.Intrinsics.Vector128`1[Byte],ubyte):System.Runtime.Intrinsics.Vector128`1[Byte] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Double],ubyte,System.Runtime.Intrinsics.Vector128`1[Double],ubyte):System.Runtime.Intrinsics.Vector128`1[Double] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Int16],ubyte,System.Runtime.Intrinsics.Vector64`1[Int16],ubyte):System.Runtime.Intrinsics.Vector128`1[Int16] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Int16],ubyte,System.Runtime.Intrinsics.Vector128`1[Int16],ubyte):System.Runtime.Intrinsics.Vector128`1[Int16] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Int32],ubyte,System.Runtime.Intrinsics.Vector64`1[Int32],ubyte):System.Runtime.Intrinsics.Vector128`1[Int32] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Int32],ubyte,System.Runtime.Intrinsics.Vector128`1[Int32],ubyte):System.Runtime.Intrinsics.Vector128`1[Int32] (0 base, 1 diff methods)
         108 (     ∞ of base) : System.Private.CoreLib.dasm - Arm64:InsertSelectedScalar(System.Runtime.Intrinsics.Vector128`1[Int64],ubyte,System.Runtime.Intrinsics.Vector128`1[Int64],ubyte):System.Runtime.Intrinsics.Vector128`1[Int64] (0 base, 1 diff methods)

Top method improvements (bytes):
        -236 (-19.601% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:ToString():System.String:this
        -232 (-21.561% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Double][System.Double]:ToString():System.String:this
        -212 (-20.623% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt64][System.UInt64]:ToString():System.String:this
        -176 (-3.392% of base) : System.Private.CoreLib.dasm - System.Numerics.Matrix4x4:<Invert>g__SseImpl|59_0(System.Numerics.Matrix4x4,byref):bool
        -156 (-9.466% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:GetIndexOfFirstNonAsciiChar_Sse2(long,long):long
        -148 (-8.959% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:GetIndexOfFirstNonLatin1Char_Sse2(long,long):long
        -104 (-54.167% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:UnalignedCountVector128(byref):long (2 methods)
        -104 (-57.778% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:Equals(System.Runtime.Intrinsics.Vector64`1[Int64]):bool:this
        -104 (-57.778% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt64][System.UInt64]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt64]):bool:this
         -88 (-44.898% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Double][System.Double]:Equals(System.Runtime.Intrinsics.Vector64`1[Double]):bool:this
         -84 (-21.429% of base) : System.Private.CoreLib.dasm - System.Text.ASCIIUtility:NarrowUtf16ToAscii_Sse2(long,long,long):long
         -84 (-20.588% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:NarrowUtf16ToLatin1_Sse2(long,long,long):long
         -76 (-14.179% of base) : System.Private.CoreLib.dasm - System.Text.Latin1Utility:WidenLatin1ToUtf16_Sse2(long,long,long)
         -76 (-38.776% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Double][System.Double]:GetHashCode():int:this
         -76 (-46.341% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:GetHashCode():int:this
         -76 (-46.341% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt64][System.UInt64]:GetHashCode():int:this
         -68 (-30.909% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[SByte][System.SByte]:<Equals>g__SoftwareFallback|14_0(byref,System.Runtime.Intrinsics.Vector256`1[SByte]):bool
         -68 (-30.909% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[Byte][System.Byte]:<Equals>g__SoftwareFallback|14_0(byref,System.Runtime.Intrinsics.Vector256`1[Byte]):bool
         -64 (-29.091% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[UInt16][System.UInt16]:<Equals>g__SoftwareFallback|14_0(byref,System.Runtime.Intrinsics.Vector256`1[UInt16]):bool
         -64 (-29.091% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector256`1[Int16][System.Int16]:<Equals>g__SoftwareFallback|14_0(byref,System.Runtime.Intrinsics.Vector256`1[Int16]):bool

Top method regressions (percentages):
          40 (     ∞ of base) : System.Private.CoreLib.dasm - System.Math:CopySign(double,double):double (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.MathF:CopySign(float,float):float (0 base, 1 diff methods)
          80 (     ∞ of base) : System.Private.CoreLib.dasm - System.SpanHelpers:TryFindFirstMatchedLane(System.Runtime.Intrinsics.Vector128`1[Byte],System.Runtime.Intrinsics.Vector128`1[Byte],byref):bool (0 base, 1 diff methods)
          72 (     ∞ of base) : System.Private.CoreLib.dasm - System.SpanHelpers:TryFindFirstMatchedLane(System.Runtime.Intrinsics.Vector128`1[UInt16],byref):bool (0 base, 1 diff methods)
          20 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.BitOperations:LeadingZeroCount(int):int (0 base, 1 diff methods)
          20 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.BitOperations:LeadingZeroCount(long):int (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.BitOperations:Log2(int):int (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.BitOperations:Log2(long):int (0 base, 1 diff methods)
          36 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.BitOperations:PopCount(int):int (0 base, 1 diff methods)
          32 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.BitOperations:PopCount(long):int (0 base, 1 diff methods)
          48 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.VectorMath:ConditionalSelectBitwise(System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single],System.Runtime.Intrinsics.Vector128`1[Single]):System.Runtime.Intrinsics.Vector128`1[Single] (0 base, 1 diff methods)
          48 (     ∞ of base) : System.Private.CoreLib.dasm - System.Numerics.VectorMath:ConditionalSelectBitwise(System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double],System.Runtime.Intrinsics.Vector128`1[Double]):System.Runtime.Intrinsics.Vector128`1[Double] (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(ubyte):System.Runtime.Intrinsics.Vector128`1[Byte] (0 base, 1 diff methods)
          24 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(double):System.Runtime.Intrinsics.Vector128`1[Double] (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(short):System.Runtime.Intrinsics.Vector128`1[Int16] (0 base, 1 diff methods)
          24 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(int):System.Runtime.Intrinsics.Vector128`1[Int32] (0 base, 1 diff methods)
          24 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(long):System.Runtime.Intrinsics.Vector128`1[Int64] (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(byte):System.Runtime.Intrinsics.Vector128`1[SByte] (0 base, 1 diff methods)
          24 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(float):System.Runtime.Intrinsics.Vector128`1[Single] (0 base, 1 diff methods)
          28 (     ∞ of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:Create(ushort):System.Runtime.Intrinsics.Vector128`1[UInt16] (0 base, 1 diff methods)

Top method improvements (percentages):
         -44 (-64.706% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetCharVector128SpanLength(long,long):long
         -44 (-64.706% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetCharVector256SpanLength(long,long):long
         -40 (-58.824% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetByteVector128SpanLength(long,int):long
         -40 (-58.824% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:GetByteVector256SpanLength(long,int):long
        -104 (-57.778% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:Equals(System.Runtime.Intrinsics.Vector64`1[Int64]):bool:this
        -104 (-57.778% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[UInt64][System.UInt64]:Equals(System.Runtime.Intrinsics.Vector64`1[UInt64]):bool:this
        -104 (-54.167% of base) : System.Private.CoreLib.dasm - System.SpanHelpers:UnalignedCountVector128(byref):long (2 methods)
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Byte][System.Byte]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[Byte]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Double][System.Double]:get_AllBitsSet():System.Runtime.Intrinsics.Vector64`1[Double]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int16][System.Int16]:get_AllBitsSet():System.Runtime.Intrinsics.Vector64`1[Int16]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int64][System.Int64]:get_AllBitsSet():System.Runtime.Intrinsics.Vector64`1[Int64]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector64`1[Int32][System.Int32]:get_AllBitsSet():System.Runtime.Intrinsics.Vector64`1[Int32]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt16][System.UInt16]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[UInt16]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[SByte][System.SByte]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[SByte]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Single][System.Single]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[Single]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt64][System.UInt64]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[UInt64]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[UInt32][System.UInt32]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[UInt32]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Double][System.Double]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[Double]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int16][System.Int16]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[Int16]
         -28 (-53.846% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128`1[Int64][System.Int64]:get_AllBitsSet():System.Runtime.Intrinsics.Vector128`1[Int64]

1825 total methods with Code Size differences (314 improved, 1511 regressed), 26424 unchanged.
```