### PR TITLE
Optimize memory allocations in ActivitySource

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -39,7 +39,6 @@ namespace System.Diagnostics
                     {
                         ((ActivitySource)source).AddListener(listener);
                     }
-
                 }, this);
             }
         }


### PR DESCRIPTION
We have many callbacks inside ActivitySource which were causing the compiler to create closure objects when invoking such callbacks. Also, we were using anonymous Func/Action methods implementation which was causing the compiler to create temporary objects of such Func or Action types. This change is to avoid having the compiler create such closure objects and converting the implementation of the anonymous method to static delegate objects.