### PR TITLE
Add trimming tests for System.Private.Xml changes

### DIFF
--- a/src/libraries/System.Data.Common/tests/TrimmingTests/CreateSqlXmlReader.cs
+++ b/src/libraries/System.Data.Common/tests/TrimmingTests/CreateSqlXmlReader.cs
@@ -1,3 +1,7 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 using System.Data.SqlTypes;
 using System.IO;
 
@@ -8,6 +12,6 @@ class Program
         MemoryStream ms = new MemoryStream();
         var sqlXml = new SqlXml(ms);
         var xmlReader = sqlXml.CreateReader();
-        return 100;
+        return xmlReader != null ? 100 : -1;
     }
 }

--- a/src/libraries/System.Data.Common/tests/TrimmingTests/CreateSqlXmlReader.cs
+++ b/src/libraries/System.Data.Common/tests/TrimmingTests/CreateSqlXmlReader.cs
@@ -1,0 +1,13 @@
+using System.Data.SqlTypes;
+using System.IO;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        MemoryStream ms = new MemoryStream();
+        var sqlXml = new SqlXml(ms);
+        var xmlReader = sqlXml.CreateReader();
+        return 100;
+    }
+}

--- a/src/libraries/System.Data.Common/tests/TrimmingTests/System.Data.Common.TrimmingTests.proj
+++ b/src/libraries/System.Data.Common/tests/TrimmingTests/System.Data.Common.TrimmingTests.proj
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/37677 (Strip the ILLinkTrim.xml file from System.Private.Xml - #35547)