### PR TITLE
Fix infinite loop for UOH allocations with hardlimit in Server GC

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -13069,14 +13069,12 @@ bool gc_heap::should_retry_other_heap (int gen_number, size_t size)
 #ifdef MULTIPLE_HEAPS
     if (heap_hard_limit)
     {
-        size_t total_heap_committed_recorded =
-            current_total_committed - current_total_committed_bookkeeping;
         size_t min_size = dd_min_size (g_heaps[0]->dynamic_data_of (gen_number));
         size_t slack_space = max (commit_min_th, min_size);
-        bool retry_p = ((total_heap_committed_recorded + size) < (heap_hard_limit - slack_space));
+        bool retry_p = ((current_total_committed + size) < (heap_hard_limit - slack_space));
         dprintf (1, ("%Id - %Id - total committed %Id - size %Id = %Id, %s",
-            heap_hard_limit, slack_space, total_heap_committed_recorded, size,
-            (heap_hard_limit - slack_space - total_heap_committed_recorded - size),
+            heap_hard_limit, slack_space, current_total_committed, size,
+            (heap_hard_limit - slack_space - current_total_committed - size),
             (retry_p ? "retry" : "no retry")));
         return retry_p;
     }


### PR DESCRIPTION
In Server GC when we allocate UOH objects and decide whether we should retry
when hardlimit is in effect we have an inconsistency between `should_retry_other_heap`
and `virtual_commit`. The former uses
`current_total_committed - current_total_committed_bookkeeping`
while the latter uses `current_total_committed`.
This causes us to be in a situation where we may have an infinite loop
since the `allocate_uoh` says to retry but `virtual_commit` fails.

this is to fix [issue #37410](https://github.com/dotnet/runtime/issues/37410)