### PR TITLE
Optimize WithUpper/WithLower with InsertSelectedScalar, SpanHelpers.Sequence APIs

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -1682,12 +1682,9 @@ namespace System.Runtime.Intrinsics
         public static Vector128<T> WithLower<T>(this Vector128<T> vector, Vector64<T> value)
             where T : struct
         {
-            if (AdvSimd.IsSupported)
+            if (AdvSimd.Arm64.IsSupported)
             {
-                // Note: The 3rd operand GetElement() should be the argument to Insert(). Storing the
-                // result of GetElement() in a local variable and then passing local variable to Insert()
-                // would not merge insert/getelement in a single instruction.
-                return AdvSimd.Insert(vector.AsUInt64(), 0, value.AsUInt64().GetElement(0)).As<ulong, T>();
+                return AdvSimd.Arm64.InsertSelectedScalar(vector.AsUInt64(), 0, value.ToVector128Unsafe().AsUInt64(), 0).As<ulong, T>();
             }
 
             return SoftwareFallback(vector, value);
@@ -1727,12 +1724,9 @@ namespace System.Runtime.Intrinsics
         public static Vector128<T> WithUpper<T>(this Vector128<T> vector, Vector64<T> value)
             where T : struct
         {
-            if (AdvSimd.IsSupported)
+            if (AdvSimd.Arm64.IsSupported)
             {
-                // Note: The 3rd operand GetElement() should be the argument to Insert(). Storing the
-                // result of GetElement() in a local variable and then passing local variable to Insert()
-                // would not merge insert/getelement in a single instruction.
-                return AdvSimd.Insert(vector.AsUInt64(), 1, value.AsUInt64().GetElement(0)).As<ulong, T>();
+                return AdvSimd.Arm64.InsertSelectedScalar(vector.AsUInt64(), 1, value.ToVector128Unsafe().AsUInt64(), 0).As<ulong, T>();
             }
 
             return SoftwareFallback(vector, value);

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -1552,6 +1552,13 @@ namespace System
                     goto NotEqual;
                 }
             }
+            //else if (AdvSimd.Arm64.IsSupported)
+            //{
+            //    // This API is not optimized with ARM64 intrinsics because there is not much performance win seen
+            //    // when compared to the vectorized implementation below. In addition to comparing the bytes in chunks of
+            //    // 16-bytes, the only check that is done is if there is a mismatch and if yes, return false. This check
+            //    // done with Vector<T> will generate same code by JIT as that if used ARM64 intrinsic instead.
+            //}
             else if (Vector.IsHardwareAccelerated && length >= (nuint)Vector<byte>.Count)
             {
                 nuint offset = 0;
@@ -1787,6 +1794,15 @@ namespace System
                     return result;
                 }
             }
+            //else if (AdvSimd.Arm64.IsSupported)
+            //{
+            //    // This API is not optimized with ARM64 intrinsics because there is not much performance win seen
+            //    // when compared to the vectorized implementation below. There were some wins if the mismatch happen
+            //    // after 8th index of the chunk because with ARM64 intrinsic, using fewer instructions the first mismatched
+            //    // index can be retrieved. In case of vectorization, sequential scan has to be done instead. However, at the
+            //    // same time, there are losses if the mismatch index is less than 7~8. So the overall benefit doesn't justify
+            //    // to optimize this method with ARM64 hardware intrinsics.
+            //}
             else if (Vector.IsHardwareAccelerated)
             {
                 if (lengthToExamine > (nuint)Vector<byte>.Count)


### PR DESCRIPTION
As mentioned in https://github.com/dotnet/runtime/pull/37139 , use `AdvSimd.Arm64.InsertSelectedScalar()` to better optimize `WithUpper()`, `WithLower()` and hence `Vector28.Create(Vector64, Vector64)`.

* [withupper.txt](https://github.com/dotnet/runtime/files/4797512/withupper.txt)
* [withlower.txt](https://github.com/dotnet/runtime/files/4797513/withlower.txt)
* [create.txt](https://github.com/dotnet/runtime/files/4797514/create.txt)

Also, added a note in `SpanHelpers.SequenceEqual()` and `SpanHelpers.SequenceCompareTo()` that we are not optimizing it currently with ARM64 intrinsics because it gives similar (sometimes less) wins than the vectorized version.