### PR TITLE
Enable the multifolder test on ARM64

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -618,9 +618,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/jit64/opt/rngchk/RngchkStress3/*">
             <Issue>Needs Triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/readytorun/multifolder/**">
-            <Issue>https://github.com/dotnet/runtime/issues/37990</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are x64 Unix failures on CoreCLR. -->


### PR DESCRIPTION
The PE issues that were causing issues in the multifolder test
on ARM64 have been fixed with

https://github.com/dotnet/runtime/pull/37518

so I'm reenabling the temporarily disabled test.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib 