### PR TITLE
Align some Console properties on iOS/Android/WASM with other Unix implementations

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Android.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Android.cs
@@ -134,7 +134,7 @@ namespace System
 
         public static int WindowTop
         {
-            get => throw new PlatformNotSupportedException();
+            get => 0;
             set => throw new PlatformNotSupportedException();
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Android.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Android.cs
@@ -47,9 +47,9 @@ namespace System
 
         internal static TextReader GetOrCreateReader() => throw new PlatformNotSupportedException();
 
-        public static bool NumberLock => false;
+        public static bool NumberLock => throw new PlatformNotSupportedException();
 
-        public static bool CapsLock => false;
+        public static bool CapsLock => throw new PlatformNotSupportedException();
 
         public static bool KeyAvailable => false;
 
@@ -128,7 +128,7 @@ namespace System
 
         public static int WindowLeft
         {
-            get => throw new PlatformNotSupportedException();
+            get => 0;
             set => throw new PlatformNotSupportedException();
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
@@ -105,9 +105,9 @@ namespace System
 
         internal static TextReader GetOrCreateReader() => throw new PlatformNotSupportedException();
 
-        public static bool NumberLock => false;
+        public static bool NumberLock => throw new PlatformNotSupportedException();
 
-        public static bool CapsLock => false;
+        public static bool CapsLock => throw new PlatformNotSupportedException();
 
         public static bool KeyAvailable => false;
 
@@ -186,7 +186,7 @@ namespace System
 
         public static int WindowLeft
         {
-            get => throw new PlatformNotSupportedException();
+            get => 0;
             set => throw new PlatformNotSupportedException();
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.WebAssembly.cs
@@ -192,7 +192,7 @@ namespace System
 
         public static int WindowTop
         {
-            get => throw new PlatformNotSupportedException();
+            get => 0;
             set => throw new PlatformNotSupportedException();
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -52,9 +52,9 @@ namespace System
 
         internal static TextReader GetOrCreateReader() => throw new PlatformNotSupportedException();
 
-        public static bool NumberLock => false;
+        public static bool NumberLock => throw new PlatformNotSupportedException();
 
-        public static bool CapsLock => false;
+        public static bool CapsLock => throw new PlatformNotSupportedException();
 
         public static bool KeyAvailable => false;
 
@@ -133,7 +133,7 @@ namespace System
 
         public static int WindowLeft
         {
-            get => throw new PlatformNotSupportedException();
+            get => 0;
             set => throw new PlatformNotSupportedException();
         }
 

--- a/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.iOS.cs
@@ -139,7 +139,7 @@ namespace System
 
         public static int WindowTop
         {
-            get => throw new PlatformNotSupportedException();
+            get => 0;
             set => throw new PlatformNotSupportedException();
         }
 

--- a/src/libraries/System.Console/tests/ReadKey.cs
+++ b/src/libraries/System.Console/tests/ReadKey.cs
@@ -39,31 +39,17 @@ public class ReadKey
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
     public void NumberLock_GetUnix_ThrowsPlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.NumberLock);
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.Browser)]
-    public void NumberLock_Getter_Returns_False()
-    {
-        Assert.False(Console.NumberLock);
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
+    [PlatformSpecific(TestPlatforms.AnyUnix)]
     public void CapsLock_GetUnix_ThrowsPlatformNotSupportedException()
     {
         Assert.Throws<PlatformNotSupportedException>(() => Console.CapsLock);
-    }
-
-    [Fact]
-    [PlatformSpecific(TestPlatforms.Browser)]
-    public void CapsLock_Getter_Returns_False()
-    {
-        Assert.False(Console.CapsLock);
     }
 
     private static void RunRemote(Func<int> func, ProcessStartInfo psi = null)

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -156,7 +156,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
     public static void WindowTop_GetUnix_ReturnsZero()
     {
         Assert.Equal(0, Console.WindowTop);

--- a/src/libraries/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/libraries/System.Console/tests/WindowAndCursorProps.cs
@@ -142,7 +142,7 @@ public class WindowAndCursorProps
     }
 
     [Fact]
-    [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]  // Expected behavior specific to Unix
+    [PlatformSpecific(TestPlatforms.AnyUnix)]  // Expected behavior specific to Unix
     public static void WindowLeft_GetUnix_ReturnsZero()
     {
         Assert.Equal(0, Console.WindowLeft);


### PR DESCRIPTION
This is a follow-up for https://github.com/dotnet/runtime/pull/37975#pullrequestreview-433194817