### PR TITLE
Disable TermInfo library tests on WASM

### DIFF
--- a/src/libraries/System.Console/tests/TermInfo.cs
+++ b/src/libraries/System.Console/tests/TermInfo.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using Xunit;
 
+[PlatformSpecific(~TestPlatforms.Browser)]
 public class TermInfo
 {
     // Names of internal members accessed via reflection


### PR DESCRIPTION
We disable TermInfo library tests because the respective functionality doesn't make sense on WASM.