### PR TITLE
Use key services and data keys where possible for faster EC operations.

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Ansi.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/AsymmetricAlgorithmHelpers.Ansi.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal static partial class AsymmetricAlgorithmHelpers
+    {
+        // Encodes a EC key as an uncompressed set of concatenated scalars,
+        // optionally including the private key. To omit the private parameter,
+        // "d" must have a length of zero.
+        public static (Range PublicKey, Range? PrivateKey) EncodeToUncompressedAnsiX963Key(
+            ReadOnlySpan<byte> x,
+            ReadOnlySpan<byte> y,
+            ReadOnlySpan<byte> d,
+            Span<byte> destination)
+        {
+            const byte UncompressedKeyPrefix = 0x04;
+            if (x.Length != y.Length || (d.Length > 0 && d.Length != y.Length))
+                throw new CryptographicException(SR.Cryptography_NotValidPublicOrPrivateKey);
+
+            int size = 1 + x.Length + y.Length + d.Length; // 0x04 || X || Y { || D }
+
+            if (destination.Length < size)
+            {
+                Debug.Fail("destination.Length < size");
+                throw new CryptographicException();
+            }
+
+            destination[0] = UncompressedKeyPrefix;
+            x.CopyTo(destination.Slice(1));
+            y.CopyTo(destination.Slice(1 + x.Length));
+            Range publicKey = 0..(1 + x.Length + y.Length);
+            Range? privateKey;
+
+            if (d.Length > 0)
+            {
+                d.CopyTo(destination[publicKey.End..]);
+                privateKey = 0..size;
+            }
+            else
+            {
+                privateKey = null;
+            }
+
+            return (publicKey, privateKey);
+        }
+    }
+}

--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.KeyServices.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.KeyServices.cs
@@ -1,0 +1,210 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#nullable enable
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.Apple;
+
+internal static partial class Interop
+{
+    internal static partial class AppleCrypto
+    {
+        internal enum PAL_KeyAlgorithm : uint
+        {
+            Unknown = 0,
+            EC = 1,
+            RSA = 2,
+        }
+
+        internal enum PAL_SignatureAlgorithm : uint
+        {
+            Unknown = 0,
+            RsaPkcs1 = 1,
+            EC = 2,
+            DSA = 3
+        }
+
+        internal static unsafe SafeSecKeyRefHandle CreateDataKey(
+            ReadOnlySpan<byte> keyData,
+            int keySizeInBits,
+            PAL_KeyAlgorithm keyAlgorithm,
+            bool isPublic)
+        {
+            fixed (byte* pKey = keyData)
+            {
+                int result = AppleCryptoNative_CreateDataKey(
+                    pKey,
+                    keyData.Length,
+                    keySizeInBits,
+                    keyAlgorithm,
+                    isPublic ? 1 : 0,
+                    out SafeSecKeyRefHandle dataKey,
+                    out SafeCFErrorHandle errorHandle);
+
+                using (errorHandle)
+                {
+                    const int Success = 1;
+                    const int kErrorSeeError = -2;
+
+                    return result switch
+                    {
+                        Success => dataKey,
+                        kErrorSeeError => throw CreateExceptionForCFError(errorHandle),
+                        _ => throw new CryptographicException { HResult = result }
+                    };
+                }
+            }
+        }
+
+        internal static bool KeyServicesVerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            ReadOnlySpan<byte> dataHash,
+            ReadOnlySpan<byte> signature,
+            PAL_HashAlgorithm hashAlgorithm,
+            PAL_SignatureAlgorithm signatureAlgorithm,
+            bool digest)
+        {
+            const int Valid = 1;
+            const int Invalid = 0;
+            const int kErrorSeeError = -2;
+
+            int result = AppleCryptoNative_SecKeyVerifySignature(
+                publicKey,
+                dataHash,
+                signature,
+                hashAlgorithm,
+                signatureAlgorithm,
+                digest,
+                out SafeCFErrorHandle errorHandle);
+
+            using (errorHandle)
+            {
+                return result switch
+                {
+                    Valid => true,
+                    Invalid => false,
+                    kErrorSeeError => throw CreateExceptionForCFError(errorHandle),
+                    _ => throw new CryptographicException { HResult = result }
+                };
+            }
+        }
+
+        internal static byte[] KeyServicesCreateSignature(
+            SafeSecKeyRefHandle privateKey,
+            ReadOnlySpan<byte> dataHash,
+            PAL_HashAlgorithm hashAlgorithm,
+            PAL_SignatureAlgorithm signatureAlgorithm,
+            bool digest)
+        {
+            const int Success = 1;
+            const int kErrorSeeError = -2;
+
+            int result = AppleCryptoNative_SecKeyCreateSignature(
+                privateKey,
+                dataHash,
+                hashAlgorithm,
+                signatureAlgorithm,
+                digest,
+                out SafeCFDataHandle signature,
+                out SafeCFErrorHandle errorHandle);
+
+            using (errorHandle)
+            using (signature)
+            {
+                return result switch
+                {
+                    Success => CoreFoundation.CFGetData(signature),
+                    kErrorSeeError => throw CreateExceptionForCFError(errorHandle),
+                    _ => throw new CryptographicException { HResult = result }
+                };
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static unsafe extern int AppleCryptoNative_CreateDataKey(
+            byte* pKey,
+            int cbKey,
+            int keySizeInBits,
+            PAL_KeyAlgorithm keyAlgorithm,
+            int isPublic,
+            out SafeSecKeyRefHandle pDataKey,
+            out SafeCFErrorHandle pErrorOut);
+
+        private static unsafe int AppleCryptoNative_SecKeyVerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            ReadOnlySpan<byte> dataHash,
+            ReadOnlySpan<byte> signature,
+            PAL_HashAlgorithm hashAlgorithm,
+            PAL_SignatureAlgorithm signatureAlgorithm,
+            bool digest,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pDataHash = dataHash)
+            fixed (byte* pSignature = signature)
+            {
+                return AppleCryptoNative_SecKeyVerifySignature(
+                    publicKey,
+                    pDataHash,
+                    dataHash.Length,
+                    pSignature,
+                    signature.Length,
+                    hashAlgorithm,
+                    signatureAlgorithm,
+                    digest ? 1 : 0,
+                    out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static unsafe extern int AppleCryptoNative_SecKeyVerifySignature(
+            SafeSecKeyRefHandle publicKey,
+            byte* pbDataHash,
+            int cbDataHash,
+            byte* pbSignature,
+            int cbSignature,
+            PAL_HashAlgorithm hashAlgorithm,
+            PAL_SignatureAlgorithm signatureAlgorithm,
+            int digest,
+            out SafeCFErrorHandle pErrorOut);
+
+        private static unsafe int AppleCryptoNative_SecKeyCreateSignature(
+            SafeSecKeyRefHandle privateKey,
+            ReadOnlySpan<byte> dataHash,
+            PAL_HashAlgorithm hashAlgorithm,
+            PAL_SignatureAlgorithm signatureAlgorithm,
+            bool digest,
+            out SafeCFDataHandle pSignatureOut,
+            out SafeCFErrorHandle pErrorOut)
+        {
+            fixed (byte* pDataHash = dataHash)
+            {
+                return AppleCryptoNative_SecKeyCreateSignature(
+                    privateKey,
+                    pDataHash,
+                    dataHash.Length,
+                    hashAlgorithm,
+                    signatureAlgorithm,
+                    digest ? 1 : 0,
+                    out pSignatureOut,
+                    out pErrorOut);
+            }
+        }
+
+        [DllImport(Libraries.AppleCryptoNative)]
+        private static unsafe extern int AppleCryptoNative_SecKeyCreateSignature(
+            SafeSecKeyRefHandle privateKey,
+            byte* pbDataHash,
+            int cbDataHash,
+            PAL_HashAlgorithm hashAlgorithm,
+            PAL_SignatureAlgorithm signatureAlgorithm,
+            int digest,
+            out SafeCFDataHandle pSignatureOut,
+            out SafeCFErrorHandle pErrorOut);
+    }
+}

--- a/src/libraries/Common/src/System/Security/Cryptography/SecKeyPair.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SecKeyPair.cs
@@ -11,11 +11,15 @@ namespace System.Security.Cryptography
     {
         internal SafeSecKeyRefHandle PublicKey { get; private set; }
         internal SafeSecKeyRefHandle? PrivateKey { get; private set; }
+        internal SafeSecKeyRefHandle? PublicDataKey { get; private set; }
+        internal SafeSecKeyRefHandle? PrivateDataKey { get; private set; }
 
-        private SecKeyPair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle? privateKey)
+        private SecKeyPair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle? privateKey, SafeSecKeyRefHandle? publicDataKey, SafeSecKeyRefHandle? privateDataKey)
         {
             PublicKey = publicKey;
             PrivateKey = privateKey;
+            PublicDataKey = publicDataKey;
+            PrivateDataKey = privateDataKey;
         }
 
         public void Dispose()
@@ -24,6 +28,10 @@ namespace System.Security.Cryptography
             PrivateKey = null;
             PublicKey?.Dispose();
             PublicKey = null!;
+            PublicDataKey?.Dispose();
+            PublicDataKey = null!;
+            PrivateDataKey?.Dispose();
+            PrivateDataKey = null!;
         }
 
         internal static SecKeyPair PublicPrivatePair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey)
@@ -33,15 +41,31 @@ namespace System.Security.Cryptography
             if (privateKey == null || privateKey.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(privateKey));
 
-            return new SecKeyPair(publicKey, privateKey);
+            return new SecKeyPair(publicKey, privateKey, null, null);
         }
 
-        internal static SecKeyPair PublicOnly(SafeSecKeyRefHandle publicKey)
+        internal static SecKeyPair PublicPrivatePair(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle privateKey, SafeSecKeyRefHandle publicDataKey, SafeSecKeyRefHandle privateDataKey)
         {
             if (publicKey == null || publicKey.IsInvalid)
                 throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicKey));
+            if (privateKey == null || privateKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(privateKey));
+            if (publicDataKey == null || publicDataKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicDataKey));
+            if (privateDataKey == null || privateDataKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(privateDataKey));
 
-            return new SecKeyPair(publicKey, null);
+            return new SecKeyPair(publicKey, privateKey, publicDataKey, privateDataKey);
+        }
+
+        internal static SecKeyPair PublicOnly(SafeSecKeyRefHandle publicKey, SafeSecKeyRefHandle? publicDataKey = null)
+        {
+            if (publicKey == null || publicKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicKey));
+            if (publicDataKey != null && publicDataKey.IsInvalid)
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(publicDataKey));
+
+            return new SecKeyPair(publicKey, null, publicDataKey, null);
         }
     }
 }

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/CMakeLists.txt
@@ -9,6 +9,7 @@ set(NATIVECRYPTO_SOURCES
     pal_hmac.c
     pal_keyagree.c
     pal_keychain.c
+    pal_keyservices.c
     pal_random.c
     pal_rsa.c
     pal_sec.c

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keyservices.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keyservices.c
@@ -1,0 +1,219 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_keyservices.h"
+#include "pal_ecc.h"
+
+#if !defined(TARGET_IOS) && !defined(TARGET_TVOS)
+
+static CFStringRef GetSignatureAlgorithmIdentifier(PAL_HashAlgorithm hashAlgorithm, PAL_SignatureAlgorithm signatureAlgorithm, bool digest)
+{
+    if (signatureAlgorithm == PAL_SignatureAlgorithm_EC)
+    {
+        // ECDSA signatures are always based on digests. The managed implementation
+        // will always pre-hash data before getting here.
+        assert(digest);
+        return kSecKeyAlgorithmECDSASignatureDigestX962;
+    }
+    if (signatureAlgorithm == PAL_SignatureAlgorithm_RSA_Pkcs1)
+    {
+        if (digest)
+        {
+            switch (hashAlgorithm)
+            {
+                case PAL_SHA1: return kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1;
+                case PAL_SHA256: return kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256;
+                case PAL_SHA384: return kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384;
+                case PAL_SHA512: return kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512;
+            }
+
+        }
+        else
+        {
+            switch (hashAlgorithm)
+            {
+                case PAL_SHA1: return kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA1;
+                case PAL_SHA256: return kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA256;
+                case PAL_SHA384: return kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA384;
+                case PAL_SHA512: return kSecKeyAlgorithmRSASignatureMessagePKCS1v15SHA512;
+            }
+        }
+    }
+
+    assert(false);
+    return NULL;
+}
+
+static CFStringRef GetKeyAlgorithmIdentifier(PAL_KeyAlgorithm keyAlgorithm)
+{
+    if (keyAlgorithm == PAL_KeyAlgorithm_EC)
+        return kSecAttrKeyTypeECSECPrimeRandom;
+    if (keyAlgorithm == PAL_KeyAlgorithm_RSA)
+        return kSecAttrKeyTypeRSA;
+
+    return NULL;
+}
+
+int32_t AppleCryptoNative_CreateDataKey(uint8_t* pKey,
+                                        int32_t cbKey,
+                                        int32_t keySizeInBits,
+                                        PAL_KeyAlgorithm keyAlgorithm,
+                                        int32_t isPublic,
+                                        SecKeyRef* pKeyOut,
+                                        CFErrorRef* pErrorOut)
+{
+    if (pErrorOut != NULL)
+        *pErrorOut = NULL;
+
+    if (pKeyOut != NULL)
+        *pKeyOut = NULL;
+
+    if (pKeyOut == NULL || pErrorOut == NULL || cbKey <= 0 || pKey == NULL)
+        return kErrorBadInput;
+
+    CFMutableDictionaryRef dataAttributes = CFDictionaryCreateMutable(
+        kCFAllocatorDefault, 3, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+    if (dataAttributes == NULL)
+    {
+        return kErrorUnknownState;
+    }
+
+    CFNumberRef cfKeySizeInBits = CFNumberCreate(NULL, kCFNumberIntType, &keySizeInBits);
+
+    if (cfKeySizeInBits == NULL)
+    {
+        CFRelease(dataAttributes);
+        return kErrorUnknownState;
+    }
+
+    CFStringRef keyClass = isPublic == 0 ? kSecAttrKeyClassPrivate : kSecAttrKeyClassPublic;
+    CFStringRef keyType = GetKeyAlgorithmIdentifier(keyAlgorithm);
+
+    if (keyType == NULL)
+    {
+        CFRelease(dataAttributes);
+        CFRelease(cfKeySizeInBits);
+        return kErrorBadInput;
+    }
+
+    CFDictionarySetValue(dataAttributes, kSecAttrKeySizeInBits, cfKeySizeInBits);
+    CFDictionarySetValue(dataAttributes, kSecAttrKeyType, keyType);
+    CFDictionarySetValue(dataAttributes, kSecAttrKeyClass, keyClass);
+    CFDataRef cfData = CFDataCreateWithBytesNoCopy(NULL, pKey, cbKey, kCFAllocatorNull);
+
+    *pKeyOut = SecKeyCreateWithData(cfData, dataAttributes, pErrorOut);
+    int32_t ret = kErrorSeeError;
+
+    if (*pKeyOut != NULL)
+    {
+        ret = 1;
+    }
+
+    CFRelease(cfData);
+    CFRelease(cfKeySizeInBits);
+    CFRelease(dataAttributes);
+    return ret;
+}
+
+int32_t AppleCryptoNative_SecKeyCreateSignature(SecKeyRef privateKey,
+                                                uint8_t* pbDataHash,
+                                                int32_t cbDataHash,
+                                                PAL_HashAlgorithm hashAlgorithm,
+                                                PAL_SignatureAlgorithm signatureAlgorithm,
+                                                int32_t digest,
+                                                CFDataRef* pSignatureOut,
+                                                CFErrorRef* pErrorOut)
+{
+    if (pErrorOut != NULL)
+        *pErrorOut = NULL;
+
+    if (pSignatureOut != NULL)
+        *pSignatureOut = NULL;
+
+    if (privateKey == NULL || pbDataHash == NULL || cbDataHash < 0 ||
+        pErrorOut == NULL || pSignatureOut == NULL)
+        return kErrorBadInput;
+
+    bool useDigest = digest != 0;
+    CFStringRef algorithm = GetSignatureAlgorithmIdentifier(hashAlgorithm, signatureAlgorithm, useDigest);
+
+    if (algorithm == NULL)
+        return kErrorBadInput;
+
+    CFDataRef dataHash = CFDataCreateWithBytesNoCopy(NULL, pbDataHash, cbDataHash, kCFAllocatorNull);
+
+    if (dataHash == NULL)
+    {
+        return kErrorUnknownState;
+    }
+
+    int32_t ret = kErrorSeeError;
+
+    CFDataRef sig = SecKeyCreateSignature(privateKey, algorithm, dataHash, pErrorOut);
+
+    if (sig != NULL)
+    {
+        CFRetain(sig);
+        *pSignatureOut = sig;
+        ret = 1;
+    }
+
+    CFRelease(dataHash);
+    return ret;
+}
+
+int32_t AppleCryptoNative_SecKeyVerifySignature(SecKeyRef publicKey,
+                                                uint8_t* pbDataHash,
+                                                int32_t cbDataHash,
+                                                uint8_t* pbSignature,
+                                                int32_t cbSignature,
+                                                PAL_HashAlgorithm hashAlgorithm,
+                                                PAL_SignatureAlgorithm signatureAlgorithm,
+                                                int digest,
+                                                CFErrorRef* pErrorOut)
+{
+    if (pErrorOut != NULL)
+        *pErrorOut = NULL;
+
+    if (publicKey == NULL || pbDataHash == NULL || cbDataHash < 0 || pbSignature == NULL || cbSignature < 0 ||
+        pErrorOut == NULL)
+        return kErrorBadInput;
+
+    bool useDigest = digest != 0;
+    CFStringRef algorithm = GetSignatureAlgorithmIdentifier(hashAlgorithm, signatureAlgorithm, useDigest);
+
+    if (algorithm == NULL)
+        return kErrorBadInput;
+
+    CFDataRef dataHash = CFDataCreateWithBytesNoCopy(NULL, pbDataHash, cbDataHash, kCFAllocatorNull);
+
+    if (dataHash == NULL)
+        return kErrorUnknownState;
+
+    CFDataRef signature = CFDataCreateWithBytesNoCopy(NULL, pbSignature, cbSignature, kCFAllocatorNull);
+
+    if (signature == NULL)
+    {
+        CFRelease(dataHash);
+        return kErrorUnknownState;
+    }
+
+    int32_t ret = kErrorSeeError;
+
+    if (SecKeyVerifySignature(publicKey, algorithm, dataHash, signature, pErrorOut))
+    {
+        ret = 1;
+    }
+    else if (CFErrorGetCode(*pErrorOut) == errSecVerifyFailed)
+    {
+        ret = 0;
+    }
+
+    CFRelease(dataHash);
+    CFRelease(signature);
+
+    return ret;
+}
+#endif

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keyservices.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native.Apple/pal_keyservices.h
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include "pal_digest.h"
+#include "pal_seckey.h"
+#include "pal_compiler.h"
+
+#include <Security/Security.h>
+
+#if !defined(TARGET_IOS) && !defined(TARGET_TVOS)
+enum
+{
+    PAL_SignatureAlgorithm_Unknown = 0,
+    PAL_SignatureAlgorithm_RSA_Pkcs1 = 1,
+    PAL_SignatureAlgorithm_EC = 2,
+    PAL_SignatureAlgorithm_DSA = 3,
+};
+typedef uint32_t PAL_SignatureAlgorithm;
+
+enum
+{
+    PAL_KeyAlgorithm_Unknown = 0,
+    PAL_KeyAlgorithm_EC = 1,
+    PAL_KeyAlgorithm_RSA = 2,
+};
+typedef uint32_t PAL_KeyAlgorithm;
+
+PALEXPORT int32_t AppleCryptoNative_CreateDataKey(uint8_t* pKey,
+                                                  int32_t cbKey,
+                                                  int32_t keySizeInBits,
+                                                  PAL_KeyAlgorithm keyAlgorithm,
+                                                  int32_t isPublic,
+                                                  SecKeyRef* pKeyOut,
+                                                  CFErrorRef* pErrorOut);
+
+PALEXPORT int32_t AppleCryptoNative_SecKeyCreateSignature(SecKeyRef privateKey,
+                                                          uint8_t* pbDataHash,
+                                                          int32_t cbDataHash,
+                                                          PAL_HashAlgorithm hashAlgorithm,
+                                                          PAL_SignatureAlgorithm signatureAlgorithm,
+                                                          int32_t digest,
+                                                          CFDataRef* pSignatureOut,
+                                                          CFErrorRef* pErrorOut);
+
+PALEXPORT int32_t AppleCryptoNative_SecKeyVerifySignature(SecKeyRef publicKey,
+                                                          uint8_t* pbDataHash,
+                                                          int32_t cbDataHash,
+                                                          uint8_t* pbSignature,
+                                                          int32_t cbSignature,
+                                                          PAL_HashAlgorithm hashAlgorithm,
+                                                          PAL_SignatureAlgorithm signatureAlgorithm,
+                                                          int digest,
+                                                          CFErrorRef* pErrorOut);
+#endif

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -86,6 +86,8 @@
     <Compile Include="System\Security\Cryptography\SignatureDescription.cs" />
     <Compile Include="System\Security\Cryptography\TripleDES.cs" />
     <Compile Include="System\Security\Cryptography\XmlKeyHelper.cs" />
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Ansi.cs"
+             Link="Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Ansi.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs"
              Link="Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\BasicSymmetricCipher.cs"
@@ -511,6 +513,8 @@
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyAgree.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyServices.cs"
+             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyServices.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Random.cs"

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -99,6 +99,8 @@
       <Link>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.manual.cs</Link>
       <DependentUpon>Common\System\Security\Cryptography\Asn1\X509ExtensionAsn.xml</DependentUpon>
     </Compile>
+    <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Ansi.cs"
+             Link="Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Ansi.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs"
              Link="Common\Internal\Cryptography\AsymmetricAlgorithmHelpers.Der.cs" />
     <Compile Include="$(CommonPath)Internal\Cryptography\Helpers.cs"
@@ -410,6 +412,8 @@
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Err.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.Keychain.cs" />
+    <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyServices.cs"
+             Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.KeyServices.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs"
              Link="Common\Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.PAL_HashAlgorithm.cs" />
     <Compile Include="$(CommonPath)Interop\OSX\System.Security.Cryptography.Native.Apple\Interop.RSA.cs"
@@ -679,6 +683,6 @@
     <Reference Include="System.Console" Condition="'$(Configuration)' == 'Debug'" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="@(AsnXml)" /> 
+    <None Include="@(AsnXml)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is an attempt at improving asymmetric cryptographic operations on macOS, starting with ECDSA.

The makes use of Apple's newer Trust / Key Services APIs instead of using security transforms. In order to gain performance increases, two things needed to happen. One, the key needed to be a "data" key, not attached to any keychain, not even an ephemeral one. Second, use the `SecKey*` APIs.

Though the APIs still work off of `SecKeyRef`s, many of the legacy APIs cannot operate on keys that are not in a keychain, ephemeral or not. An example of this is `SecItemExport` for ECDSA data keys. To keep the existing code paths working and the changes more minimal, and allow for more gradual adoption of key services where possible, both key handle types are used. When data keys are present, those are preferred for signing and verification operations.

In this PR data keys exist in two scenarios. The first is `Create` or `GenerateKey`. The second is `ImportParameters` and any other import methods that defer to it. Other means of obtaining a key, like from a certificate in a keychain or importing a PFX, will not have data keys and will use security transforms.

The data keys are obtained by exporting the keys to `ECParameters` and importing them again through keychain services APIs. This means that although signing and verifying ECDSA operations are much faster, importing and key generation take a performance hit since they have more work to do.

Some native support for RSA exists here. Though none of the managed implementation uses it yet, as this is solely for ECDSA so far. 

Contributes to #36107

Benchmarks:

All sign / verify benches use a generated key.

|     Method |        Job |  Toolchain |           Config |        Mean |     Error |    StdDev | Ratio |
|----------- |----------- |----------- |----------------- |------------:|----------:|----------:|------:|
|   **SignHash** | **Job-FCMYUV** | **fast-ecdsa** | **nistP256, SHA256** |    **283.1 μs** |   **3.70 μs** |   **3.46 μs** |  **0.05** |
|   SignHash | Job-CJQWDK |     master | nistP256, SHA256 |  5,303.6 μs |  22.00 μs |  19.50 μs |  1.00 |
|            |            |            |                  |             |           |           |       |
| VerifyHash | Job-FCMYUV | fast-ecdsa | nistP256, SHA256 |    235.1 μs |   3.09 μs |   2.89 μs |  0.02 |
| VerifyHash | Job-CJQWDK |     master | nistP256, SHA256 | 10,176.4 μs |  42.18 μs |  37.40 μs |  1.00 |
|            |            |            |                  |             |           |           |       |
|   **SignHash** | **Job-FCMYUV** | **fast-ecdsa** | **nistP384, SHA384** |    **784.0 μs** |   **9.87 μs** |   **9.23 μs** |  **0.08** |
|   SignHash | Job-CJQWDK |     master | nistP384, SHA384 |  9,659.1 μs |  30.62 μs |  28.65 μs |  1.00 |
|            |            |            |                  |             |           |           |       |
| VerifyHash | Job-FCMYUV | fast-ecdsa | nistP384, SHA384 |    643.1 μs |   8.74 μs |   8.18 μs |  0.03 |
| VerifyHash | Job-CJQWDK |     master | nistP384, SHA384 | 18,932.7 μs |  39.28 μs |  32.80 μs |  1.00 |
|            |            |            |                  |             |           |           |       |
|   **SignHash** | **Job-FCMYUV** | **fast-ecdsa** | **nistP521, SHA512** |  **1,104.3 μs** |  **13.61 μs** |  **12.73 μs** |  **0.06** |
|   SignHash | Job-CJQWDK |     master | nistP521, SHA512 | 17,658.8 μs |  59.31 μs |  55.48 μs |  1.00 |
|            |            |            |                  |             |           |           |       |
| VerifyHash | Job-FCMYUV | fast-ecdsa | nistP521, SHA512 |    841.2 μs |   5.21 μs |   4.35 μs |  0.02 |
| VerifyHash | Job-CJQWDK |     master | nistP521, SHA512 | 34,376.4 μs | 113.74 μs | 106.40 μs |  1.00 |


| Method |        Job |  Toolchain |    curve |      Mean |    Error |   StdDev | Ratio |
|------- |----------- |----------- |--------- |----------:|---------:|---------:|------:|
| **KeyGen** | **Job-FCMYUV** | **fast-ecdsa** | **nistP256** |  **65.20 ms** | **0.528 ms** | **0.494 ms** |  **1.09** |
| KeyGen | Job-CJQWDK |     master | nistP256 |  60.09 ms | 0.368 ms | 0.326 ms |  1.00 |
|        |            |            |          |           |          |          |       |
| **KeyGen** | **Job-FCMYUV** | **fast-ecdsa** | **nistP384** |  **96.29 ms** | **0.595 ms** | **0.557 ms** |  **1.04** |
| KeyGen | Job-CJQWDK |     master | nistP384 |  92.89 ms | 0.737 ms | 0.689 ms |  1.00 |
|        |            |            |          |           |          |          |       |
| **KeyGen** | **Job-FCMYUV** | **fast-ecdsa** | **nistP521** | **151.86 ms** | **0.676 ms** | **0.632 ms** |  **1.04** |
| KeyGen | Job-CJQWDK |     master | nistP521 | 146.65 ms | 0.874 ms | 0.817 ms |  1.00 |


|                  Method |        Job |  Toolchain |    curve |         Mean |      Error |     StdDev | Ratio | RatioSD |
|------------------------ |----------- |----------- |--------- |-------------:|-----------:|-----------:|------:|--------:|
| **ImportPrivateParameters** | **Job-FCMYUV** | **fast-ecdsa** | **nistP256** | **24,156.73 μs** | **208.931 μs** | **195.434 μs** |  **1.32** |    **0.01** |
| ImportPrivateParameters | Job-CJQWDK |     master | nistP256 | 18,260.68 μs | 126.533 μs | 118.359 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
|  ImportPublicParameters | Job-FCMYUV | fast-ecdsa | nistP256 |    500.94 μs |   6.068 μs |   5.676 μs |  2.36 |    0.03 |
|  ImportPublicParameters | Job-CJQWDK |     master | nistP256 |    212.29 μs |   0.567 μs |   0.503 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
| ExportPrivateParameters | Job-FCMYUV | fast-ecdsa | nistP256 |  4,785.72 μs |  20.711 μs |  19.373 μs |  0.99 |    0.00 |
| ExportPrivateParameters | Job-CJQWDK |     master | nistP256 |  4,813.65 μs |  19.685 μs |  17.450 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
|  ExportPublicParameters | Job-FCMYUV | fast-ecdsa | nistP256 |     63.79 μs |   0.260 μs |   0.243 μs |  1.02 |    0.01 |
|  ExportPublicParameters | Job-CJQWDK |     master | nistP256 |     62.81 μs |   0.387 μs |   0.362 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
| **ImportPrivateParameters** | **Job-FCMYUV** | **fast-ecdsa** | **nistP384** | **40,911.78 μs** | **189.020 μs** | **157.841 μs** |  **1.12** |    **0.01** |
| ImportPrivateParameters | Job-CJQWDK |     master | nistP384 | 36,636.35 μs | 334.361 μs | 296.402 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
|  ImportPublicParameters | Job-FCMYUV | fast-ecdsa | nistP384 |    494.84 μs |   1.100 μs |   0.859 μs |  2.35 |    0.01 |
|  ImportPublicParameters | Job-CJQWDK |     master | nistP384 |    210.55 μs |   0.663 μs |   0.620 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
| ExportPrivateParameters | Job-FCMYUV | fast-ecdsa | nistP384 |  4,793.74 μs |  17.751 μs |  13.859 μs |  0.99 |    0.01 |
| ExportPrivateParameters | Job-CJQWDK |     master | nistP384 |  4,820.73 μs |  26.000 μs |  23.049 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
|  ExportPublicParameters | Job-FCMYUV | fast-ecdsa | nistP384 |     62.36 μs |   0.344 μs |   0.322 μs |  0.98 |    0.01 |
|  ExportPublicParameters | Job-CJQWDK |     master | nistP384 |     63.75 μs |   0.275 μs |   0.215 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
| **ImportPrivateParameters** | **Job-FCMYUV** | **fast-ecdsa** | **nistP521** | **73,257.64 μs** | **930.959 μs** | **870.820 μs** |  **1.07** |    **0.02** |
| ImportPrivateParameters | Job-CJQWDK |     master | nistP521 | 68,366.20 μs | 874.672 μs | 818.169 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
|  ImportPublicParameters | Job-FCMYUV | fast-ecdsa | nistP521 |    504.41 μs |   1.454 μs |   1.360 μs |  2.26 |    0.10 |
|  ImportPublicParameters | Job-CJQWDK |     master | nistP521 |    220.97 μs |   4.129 μs |   7.551 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
| ExportPrivateParameters | Job-FCMYUV | fast-ecdsa | nistP521 |  4,808.95 μs |  18.758 μs |  16.628 μs |  0.96 |    0.01 |
| ExportPrivateParameters | Job-CJQWDK |     master | nistP521 |  5,005.39 μs |  37.495 μs |  35.073 μs |  1.00 |    0.00 |
|                         |            |            |          |              |            |            |       |         |
|  ExportPublicParameters | Job-FCMYUV | fast-ecdsa | nistP521 |     63.73 μs |   0.298 μs |   0.279 μs |  0.97 |    0.02 |
|  ExportPublicParameters | Job-CJQWDK |     master | nistP521 |     65.62 μs |   1.293 μs |   1.681 μs |  1.00 |    0.00 |

Code is here: https://github.com/vcsjones/DotNetCryptoBenches