### PR TITLE
Fix signing by moving ItemsToSign evaluation to be inside a target

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,114 +5,119 @@
       Windows arm/arm64 jobs don't have MSIs to sign. Keep it simple: allow not finding any matches
       here and rely on overall signing validation.
     -->
-    <AllowEmptySignList>true</AllowEmptySignList>
+    <AllowEmptySignList Condition="'$(SignFinalPackages)' != 'true'">true</AllowEmptySignList>
   </PropertyGroup>
 
   <!-- Get artifact locations to sign. -->
   <Import Project="$(RepositoryEngineeringDir)Configurations.props" />
   <Import Project="$(RepositoryEngineeringDir)liveBuilds.targets" />
 
-  <ItemGroup>
-    <!--
-      Replace the default items to sign with the specific set we want. This allows the build to call
-      Arcade's Sign.proj multiple times for different sets of files as the build progresses.
-    -->
-    <ItemsToSign Remove="@(ItemsToSign)" />
+  <!-- We need  this to be inside a target to workaround: https://github.com/microsoft/msbuild/issues/5445 -->
+  <Target Name="PrepareItemsToSign" BeforeTargets="Sign">
 
-    <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
-    <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
-    <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
+    <ItemGroup>
+      <!--
+        Replace the default items to sign with the specific set we want. This allows the build to call
+        Arcade's Sign.proj multiple times for different sets of files as the build progresses.
+      -->
+      <ItemsToSign Remove="@(ItemsToSign)" />
 
-    <!-- apphost and comhost template files are not signed, by design. -->
-    <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
-  </ItemGroup>
+      <!-- Find bundle artifacts, which need multiple stages to fully sign. -->
+      <BundleInstallerEngineArtifact Include="$(ArtifactsPackagesDir)**/*engine.exe" />
+      <BundleInstallerExeArtifact Include="$(ArtifactsPackagesDir)**/*.exe" />
 
-  <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
-    <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CrossTargetComponentFolder)/sharedFramework/*.dll" />
-    <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CrossTargetComponentFolder)/sharedFramework/*.exe" />
-  </ItemGroup>
+      <!-- apphost and comhost template files are not signed, by design. -->
+      <FileSignInfo Include="apphost.exe;singlefilehost.exe;comhost.dll" CertificateName="None" />
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(SignBinaries)' == 'true'">
-    <!-- Sign CoreCLR. -->
-    <ItemsToSign Include="$(CoreCLRSharedFrameworkDir)*.dll" />
-    <ItemsToSign Include="$(CoreCLRSharedFrameworkDir)*.exe" />
+    <ItemGroup Condition="'$(CrossTargetComponentFolder)' != ''">
+      <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CrossTargetComponentFolder)/sharedFramework/*.dll" />
+      <CoreCLRCrossTargetItemsToSign Include="$(CoreCLRArtifactsPath)$(CrossTargetComponentFolder)/sharedFramework/*.exe" />
+    </ItemGroup>
 
-    <ItemsToSign Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll" />
+    <ItemGroup Condition="'$(SignBinaries)' == 'true'">
+      <!-- Sign CoreCLR. -->
+      <ItemsToSign Include="$(CoreCLRSharedFrameworkDir)*.dll" />
+      <ItemsToSign Include="$(CoreCLRSharedFrameworkDir)*.exe" />
 
-    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)crossgen2.exe" />
-    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
-    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.DependencyAnalysisFramework.dll" />
-    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.ReadyToRun.dll" />
-    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.TypeSystem.ReadyToRun.dll" />
-    <ItemsToSign Include="$(CoreCLRCrossgen2Dir)jitinterface.dll" />
+      <ItemsToSign Include="$(CoreCLRArtifactsPath)System.Private.CoreLib.dll" />
 
-    <ItemsToSign Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(CoreCLRCrossgen2Dir)clrjit-win-$(TargetArchitecture).dll" />
-    <ItemsToSign Condition="'$(TargetOS)' != 'Windows_NT'" Include="$(CoreCLRCrossgen2Dir)clrjit-unix-$(TargetArchitecture).dll" />
+      <ItemsToSign Include="$(CoreCLRCrossgen2Dir)crossgen2.exe" />
+      <ItemsToSign Include="$(CoreCLRCrossgen2Dir)crossgen2.dll" />
+      <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.DependencyAnalysisFramework.dll" />
+      <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.ReadyToRun.dll" />
+      <ItemsToSign Include="$(CoreCLRCrossgen2Dir)ILCompiler.TypeSystem.ReadyToRun.dll" />
+      <ItemsToSign Include="$(CoreCLRCrossgen2Dir)jitinterface.dll" />
 
-    <ItemsToSign Include="@(CoreCLRCrossTargetItemsToSign)" />
+      <ItemsToSign Condition="'$(TargetOS)' == 'Windows_NT'" Include="$(CoreCLRCrossgen2Dir)clrjit-win-$(TargetArchitecture).dll" />
+      <ItemsToSign Condition="'$(TargetOS)' != 'Windows_NT'" Include="$(CoreCLRCrossgen2Dir)clrjit-unix-$(TargetArchitecture).dll" />
 
-    <FileSignInfo Include="mscordaccore.dll" CertificateName="MicrosoftSHA2" />
+      <ItemsToSign Include="@(CoreCLRCrossTargetItemsToSign)" />
 
-    <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
-    <ItemsToSign
-      Condition="'$(Configuration)' == 'Release' and '$(TargetArchitecture)' == 'x86'"
-      Include="$(CoreCLRArtifactsPath)Redist\ucrt\DLLs\$(TargetArchitecture)\api-ms-win-core-xstate-l2-1-0.dll" />
+      <FileSignInfo Include="mscordaccore.dll" CertificateName="MicrosoftSHA2" />
 
-    <!-- Sign libraries. -->
-    <ItemsToSign Include="$(LibrariesNativeArtifactsPath)*.dll" />
-    <ItemsToSign Include="$(LibrariesSharedFrameworkRefArtifactsPath)*.dll" />
-    <!-- Most runtime artifacts will be crossgenned, so sign them post-crossgen. mscorlib isn't. -->
-    <ItemsToSign Include="$(LibrariesSharedFrameworkBinArtifactsPath)mscorlib.dll" />
+      <!-- Sign api-ms-win-core-xstate-l2-1-0 binary as it is only catalog signed in the current SDK. -->
+      <ItemsToSign
+        Condition="'$(Configuration)' == 'Release' and '$(TargetArchitecture)' == 'x86'"
+        Include="$(CoreCLRArtifactsPath)Redist\ucrt\DLLs\$(TargetArchitecture)\api-ms-win-core-xstate-l2-1-0.dll" />
 
-    <!-- Sign the host. -->
-    <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/hostfxr.dll" />
-    <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/hostpolicy.dll" />
-    <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/dotnet.exe" />
-    <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/ijwhost.dll" />
-    <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/nethost.dll" />
+      <!-- Sign libraries. -->
+      <ItemsToSign Include="$(LibrariesNativeArtifactsPath)*.dll" />
+      <ItemsToSign Include="$(LibrariesSharedFrameworkRefArtifactsPath)*.dll" />
+      <!-- Most runtime artifacts will be crossgenned, so sign them post-crossgen. mscorlib isn't. -->
+      <ItemsToSign Include="$(LibrariesSharedFrameworkBinArtifactsPath)mscorlib.dll" />
 
-    <!-- Sign managed libraries in installer subset. -->
-    <ItemsToSign Include="$(ArtifactsBinDir)Microsoft.NET.HostModel/**/*.dll" />
-  </ItemGroup>
+      <!-- Sign the host. -->
+      <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/hostfxr.dll" />
+      <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/hostpolicy.dll" />
+      <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/dotnet.exe" />
+      <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/ijwhost.dll" />
+      <ItemsToSign Include="$(BaseOutputRootPath)corehost/**/nethost.dll" />
 
-  <!-- Sign ready-to-run binaries after crossgen is applied. -->
-  <ItemGroup Condition="'$(SignR2RBinaries)' == 'true'">
-    <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
-  </ItemGroup>
+      <!-- Sign managed libraries in installer subset. -->
+      <ItemsToSign Include="$(ArtifactsBinDir)Microsoft.NET.HostModel/**/*.dll" />
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
-    <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
-  </ItemGroup>
+    <!-- Sign ready-to-run binaries after crossgen is applied. -->
+    <ItemGroup Condition="'$(SignR2RBinaries)' == 'true'">
+      <ItemsToSign Include="$(CrossGenRootPath)**/*.dll" />
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
-    <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(SignMsiFiles)' == 'true'">
+      <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.msi" />
+      <ItemsToSign Include="$(ArtifactsPackagesDir)**/*.cab" />
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
-    <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
-    <ItemsToSign
-      Include="@(BundleInstallerExeArtifact)"
-      Exclude="@(BundleInstallerEngineArtifact)" />
-    <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
-  </ItemGroup>
+    <ItemGroup Condition="'$(SignBurnEngineFiles)' == 'true'">
+      <ItemsToSign Include="@(BundleInstallerEngineArtifact)" />
+    </ItemGroup>
 
-  <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
-    <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
-    <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
+    <ItemGroup Condition="'$(SignBurnBundleFiles)' == 'true'">
+      <!-- Sign the bundles, now that the engine is reattached. Avoid re-signing the engine. -->
+      <ItemsToSign
+        Include="@(BundleInstallerExeArtifact)"
+        Exclude="@(BundleInstallerEngineArtifact)" />
+      <!-- Note: wixstdba is internal to the engine bundle and does not get signed. -->
+    </ItemGroup>
 
-    <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
-    <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
-  </ItemGroup>
+    <ItemGroup Condition="'$(SignFinalPackages)' == 'true'">
+      <DownloadedSymbolPackages Include="$(DownloadDirectory)**\*.symbols.nupkg" />
+      <ItemsToSign Include="$(DownloadDirectory)**\*.nupkg" Exclude="@(DownloadedSymbolPackages)" />
 
-  <ItemGroup>
-    <!-- External files -->
-    <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
-  </ItemGroup>
+      <ItemsToSign Include="$(DownloadDirectory)**\*.deb" />
+      <ItemsToSign Include="$(DownloadDirectory)**\*.rpm" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
-  </ItemGroup>
+    <ItemGroup>
+      <!-- External files -->
+      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ItemsToSign Update="@(ItemsToSign)" Authenticode="$(CertificateId)" />
+    </ItemGroup>
+
+  </Target>
 
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="Microsoft400" />


### PR DESCRIPTION
MSBuild had a regresion: https://github.com/microsoft/msbuild/issues/5445 which is causing:

```xml
    <ItemGroup>
      <!-- External files -->
      <ItemsToSign Remove="@(ItemsToSign->WithMetadataValue('Filename', 'Newtonsoft.Json'))" />
    </ItemGroup>
```
To remove all items from the itemgroup, hence not signing anything.

Also, just set allow empty sign list to true if SignFinalPackages != true to catch this earlier, not until signing validation which was moved out of the build already.

Test official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=694513&view=results

cc: @rainersigwald @mmitche 
