### PR TITLE
moving cursor left/right in console on all plats.

### DIFF
--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -30,7 +30,7 @@ namespace System.IO
         private int _startIndex; // First unprocessed index in the buffer;
         private int _endIndex; // Index after last unprocessed index in the buffer;
 
-        private ConsoleKey[] denyList = new ConsoleKey[]
+        private readonly ConsoleKey[] denyList = new ConsoleKey[]
         {
             ConsoleKey.Backspace,
             ConsoleKey.LeftArrow,

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -16,7 +16,7 @@ namespace System.IO
     internal sealed class StdInReader : TextReader
     {
 
-        private static int _readLineIndex; // int that keeps track of current index in string oof _readLineSB
+        private static int _readLineIndex; // int that keeps track of current index in string of _readLineSB
         private static int _linesFromTop; // int that tells us how far from the top we are so we don't overwrite console text when home is pressed
         private static int _linesFromLeft;
         private readonly StringBuilder _readLineSB; // SB that holds readLine output.  This is a field simply to enable reuse; it's only used in ReadLine.

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -190,7 +190,7 @@ namespace System.IO
                         return false;
                     }
                     // Alt + B/F is what macOS will send in place of Alt + Left/Right
-                    else if (keyInfo.Modifiers == ConsoleModifiers.Alt && (OperatingSystem.IsMacOS() ? keyInfo.Key == ConsoleKey.B : keyInfo.Key == ConsoleKey.LeftArrow))
+                    else if ((OperatingSystem.IsMacOS() ? (keyInfo.Modifiers == ConsoleModifiers.Alt  && keyInfo.Key == ConsoleKey.B) :  (keyInfo.Modifiers == ConsoleModifiers.Control  && keyInfo.Key == ConsoleKey.LeftArrow)))
                     {
                         if (_readLineIndex == 0)
                             continue;
@@ -208,7 +208,7 @@ namespace System.IO
                         ConsolePal.SetCursorPosition(leftover, lines);
 
                     }
-                    else if (keyInfo.Modifiers == ConsoleModifiers.Alt && (OperatingSystem.IsMacOS() ? keyInfo.Key == ConsoleKey.F : keyInfo.Key == ConsoleKey.RightArrow))
+                    else if ((OperatingSystem.IsMacOS() ? (keyInfo.Modifiers == ConsoleModifiers.Alt  && keyInfo.Key == ConsoleKey.F) :  (keyInfo.Modifiers == ConsoleModifiers.Control  && keyInfo.Key == ConsoleKey.RightArrow)))
                     {
                         if (_readLineIndex == _readLineSB.Length)
                              continue;

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -251,6 +251,16 @@ namespace System
             AssertUserExpectedResults("Pi and Segma or question marks");
         }
 
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void CursorMovementTest()
+        {
+            Console.WriteLine("Write some text then use left/right arrow keys, Ctrl + Left/Right (Cmd + Left/Right on MacOS), and Home/End and make edits to the text.");
+            string input = Console.ReadLine();
+            Console.WriteLine(input);
+            AssertUserExpectedResults("What you typed as it appeared in the preview");
+        }
+
         private static void AssertUserExpectedResults(string expected)
         {
             Console.Write($"Did you see {expected}? [y/n] ");


### PR DESCRIPTION
Fixing issue mentioned in #38051 and #15711 to allow left/right arrow keys to move the cursor in text on Console.ReadLine on all platforms. Previously this only worked on Windows.