### PR TITLE
[Prev6] Update MicrosoftPrivateIntellisensePackage and XmlDocFileRoot

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -113,7 +113,7 @@
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>3.1.0-preview-20200129.1</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>3.0.0-preview-20200602.3</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>5.0.0-preview.3.20301.1</MicrosoftNETILLinkTasksVersion>
     <!-- Mono LLVM -->
@@ -138,6 +138,7 @@
     <MicrosoftDotNetBuildTasksFeedPackage>Microsoft.DotNet.Build.Tasks.Feed</MicrosoftDotNetBuildTasksFeedPackage>
     <MicrosoftNETCoreTargetsPackage>Microsoft.NETCore.Targets</MicrosoftNETCoreTargetsPackage>
     <MicrosoftNETCoreRuntimeCoreCLRPackage>Microsoft.NETCore.Runtime.CoreCLR</MicrosoftNETCoreRuntimeCoreCLRPackage>
+    <XmlDocFileRoot>$([MSBuild]::NormalizeDirectory('$(NuGetPackageRoot)', '$(MicrosoftPrivateIntellisensePackage)', '$(MicrosoftPrivateIntellisenseVersion)', 'IntellisenseFiles', 'net'))</XmlDocFileRoot>
   </PropertyGroup>
   <!-- Override isolated build dependency versions with versions from Repo API. -->
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition="'$(DotNetPackageVersionPropsPath)' != ''" />

--- a/eng/packaging.props
+++ b/eng/packaging.props
@@ -12,9 +12,6 @@
     <PackagePlatform Condition="'$(PackagePlatform)' == ''">$(Platform)</PackagePlatform>
     <PackagePlatform Condition="'$(PackagePlatform)' == 'amd64'">x64</PackagePlatform>
 
-    <!-- Used by PackageLibs.targets -->
-    <XmlDocFileRoot>$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/IntellisenseFiles/netcoreapp</XmlDocFileRoot>
-
     <!-- By default the packaging targets will package desktop facades as ref,
          but we don't use this as we now build partial-reference-facades. -->
     <PackageDesktopAsRef>false</PackageDesktopAsRef>

--- a/eng/restore/docs.targets
+++ b/eng/restore/docs.targets
@@ -9,7 +9,7 @@
           AfterTargets="Restore">
 
     <ItemGroup>
-      <DocFile Include="$(NuGetPackageRoot)$(MicrosoftPrivateIntellisensePackage)/$(MicrosoftPrivateIntellisenseVersion)/IntellisenseFiles/netcoreapp/**/*.xml"/>
+      <DocFile Include="$(XmlDocFileDoot)**\*.xml"/>
       <DocFile>
         <!-- trim off slash since it differs by platform and we need to do a string compare -->
         <LCID>$([System.String]::new('%(RecursiveDir)').TrimEnd('\/'))</LCID>


### PR DESCRIPTION
PR for master: https://github.com/dotnet/runtime/pull/38109

This PR will update the Intellisense from Preview6 with what was generated from Preview5.

`XmlDocFileRoot` was defined in two places: `packaging.props` and `docs.targets`.
Moved it to a higher level to ensure it's only defined once, in `Directory.Build.props`. Made sure to define it after `NuGetPackageRoot` is defined.
Also made sure the folder it reads is `net` instead of `netcoreapp`, because the Docs build saves the .NET 5.0 intellisense files in the `net` folder, and the .NET 3.1 intellisense files in the `netcoreapp` folder.
Updated the nupkg to consume to the latest available version in the feed `20200602.3`, which contains the Preview5 APIs.

Note: The version is not being downgraded from 3.1 to 3.0. The Docs build uploads the nupkg to the feed with that name. We will ask them to rename it to avoid confusion.
