### PR TITLE
Fix Diagnostics.Tracing ILLinkTrim entries

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -5,5 +5,9 @@
       <method name="_RegisterFrozenSegment" />
       <method name="_UnregisterFrozenSegment" />
     </type>
+    <!-- Accessed via private reflection by an external tracing controller. -->
+    <type fullname="System.Diagnostics.Tracing.EventPipe*" />
+    <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->
+    <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
   </assembly>
 </linker>

--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourcePropertyValueTest.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/EventSourcePropertyValueTest.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.Tracing;
+
+/// <summary>
+/// Tests that using EventSource with a reference type EventData works on a
+/// trimmed application.
+/// See System.Diagnostics.Tracing.PropertyValue.GetReferenceTypePropertyGetter.
+/// </summary>
+internal class Program
+{
+    [EventData]
+    private class TestData
+    {
+        public int TestInt { get; set; }
+        public TestSubData SubData { get; set; }
+    }
+
+    [EventData]
+    private class TestSubData
+    {
+        public int SubInt { get; set; }
+    }
+
+    [EventSource(Name = EventSourceName)]
+    private class TestEventSource : EventSource
+    {
+        public const string EventSourceName = "MyTest";
+        public static TestEventSource Log = new TestEventSource();
+
+        public TestEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat) { }
+
+        [Event(1)]
+        public void LogData(TestData data)
+        {
+            Write("LogData", data);
+        }
+    }
+
+    private class TestEventListener : EventListener
+    {
+        public ReadOnlyCollection<object> LogDataPayload { get; set; }
+
+        protected override void OnEventSourceCreated(EventSource eventSource)
+        {
+            if (eventSource.Name == TestEventSource.EventSourceName)
+            {
+                EnableEvents(eventSource, EventLevel.Verbose);
+            }
+
+            base.OnEventSourceCreated(eventSource);
+        }
+
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            if (eventData.EventName == "LogData")
+            {
+                LogDataPayload = eventData.Payload;
+            }
+
+            base.OnEventWritten(eventData);
+        }
+    }
+
+    public static int Main()
+    {
+        using (var listener = new TestEventListener())
+        {
+            var testData = new TestData()
+            {
+                TestInt = 5,
+                SubData = new TestSubData()
+                {
+                    SubInt = 6
+                }
+            };
+            TestEventSource.Log.LogData(testData);
+
+            if (listener.LogDataPayload?.Count == 2 &&
+                (int)listener.LogDataPayload[0] == testData.TestInt &&
+                (int)((IDictionary<string, object>)listener.LogDataPayload[1])["SubInt"] == testData.SubData.SubInt)
+            {
+                return 100;
+            }
+
+            return -1;
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/TrimmingTests/System.Diagnostics.Tracing.TrimmingTests.proj
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -37,15 +37,6 @@
       <!-- Methods is used by VS Tasks Window. -->
       <method name="GetActiveTaskFromId" />
     </type>
-    <!-- Accessed via private reflection by tracing controller. -->
-    <type fullname="System.Diagnostics.Tracing.EventPipe*" />
-    <!-- Accessed via private reflection and by native code. -->
-    <type fullname="System.Diagnostics.Tracing.RuntimeEventSource" />
-    <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
-    <type fullname="System.Diagnostics.Tracing.PropertyValue/ReferenceTypeHelper`1">
-      <!-- Instantiated via reflection -->
-      <method name=".ctor" />
-    </type>
     <!-- Accessed via native code. -->
     <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
     <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerator" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Diagnostics;
 #endif
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -197,7 +196,6 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="property"></param>
         /// <returns></returns>
-        [DynamicDependency("#ctor", typeof(ReferenceTypeHelper<>))]
         private static Func<PropertyValue, PropertyValue> GetReferenceTypePropertyGetter(PropertyInfo property)
         {
             var helper = (TypeHelper)Activator.CreateInstance(typeof(ReferenceTypeHelper<>).MakeGenericType(property.DeclaringType!))!;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Diagnostics;
 #endif
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -196,6 +197,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         /// <param name="property"></param>
         /// <returns></returns>
+        [DynamicDependency("#ctor", typeof(ReferenceTypeHelper<>))]
         private static Func<PropertyValue, PropertyValue> GetReferenceTypePropertyGetter(PropertyInfo property)
         {
             var helper = (TypeHelper)Activator.CreateInstance(typeof(ReferenceTypeHelper<>).MakeGenericType(property.DeclaringType!))!;


### PR DESCRIPTION
- PropertyValue/ReferenceTypeHelper's pattern is recognized by the ILLinker. Protected it with a new trimming test.
- RuntimeEventSource doesn't need to be rooted. This class is used by IL and doesn't get trimmed.
- EventPipe* and NativeRuntimeEventSource only need to be rooted in CoreCLR, since they aren't used in Mono. So they are moved to just CoreCLR's ILLinkTrim file.

Contributes to #35199

cc @marek-safar 