### PR TITLE
Introduce EventSource.IsSupported feature switch

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,9 +46,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>71b580038fb704df63e03c6b7ae7d2c6a4fdd71d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20316.1">
+    <Dependency Name="Microsoft.DotNet.RemoteExecutor" Version="5.0.0-beta.20325.16">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>71b580038fb704df63e03c6b7ae7d2c6a4fdd71d</Sha>
+      <Sha>b91c34a908efe4d95ac487a33b88521c76c6c3cf</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="5.0.0-beta.20316.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,7 +59,7 @@
     <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20316.1</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20316.1</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20316.1</MicrosoftDotNetBuildTasksPackagingVersion>
-    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20316.1</MicrosoftDotNetRemoteExecutorVersion>
+    <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20325.16</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20316.1</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->
     <MicrosoftNETCoreAppVersion>5.0.0-preview.4.20202.18</MicrosoftNETCoreAppVersion>

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestNotSupported.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestNotSupported.cs
@@ -21,12 +21,10 @@ namespace BasicEventSourceTests
         /// feature switch is set to disable all EventSource operations.
         /// </summary>
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [ActiveIssue("https://github.com/dotnet/arcade/pull/5698", TargetFrameworkMonikers.Any)]
         public void TestBasicOperations_IsSupported_False()
         {
             RemoteInvokeOptions options = new RemoteInvokeOptions();
-            // Requires https://github.com/dotnet/arcade/pull/5698 to be merged into dotnet/runtime
-            // options.RuntimeConfigurationOptions.Add("System.Diagnostics.Tracing.EventSource.IsSupported", "false");
+            options.RuntimeConfigurationOptions.Add("System.Diagnostics.Tracing.EventSource.IsSupported", false);
 
             RemoteExecutor.Invoke(() =>
             {

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestNotSupported.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestNotSupported.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Xunit;
+using SdtEventSources;
+using Microsoft.DotNet.RemoteExecutor;
+#if USE_MDT_EVENTSOURCE
+using Microsoft.Diagnostics.Tracing;
+#else
+using System.Diagnostics.Tracing;
+#endif
+
+namespace BasicEventSourceTests
+{
+    public class TestNotSupported
+    {
+        /// <summary>
+        /// Tests using EventSource when the System.Diagnostics.Tracing.EventSource.IsSupported
+        /// feature switch is set to disable all EventSource operations.
+        /// </summary>
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [ActiveIssue("https://github.com/dotnet/arcade/pull/5698", TargetFrameworkMonikers.Any)]
+        public void TestBasicOperations_IsSupported_False()
+        {
+            RemoteInvokeOptions options = new RemoteInvokeOptions();
+            // Requires https://github.com/dotnet/arcade/pull/5698 to be merged into dotnet/runtime
+            // options.RuntimeConfigurationOptions.Add("System.Diagnostics.Tracing.EventSource.IsSupported", "false");
+
+            RemoteExecutor.Invoke(() =>
+            {
+                using (var log = new EventSourceTest())
+                {
+                    using (var listener = new LoudListener(log))
+                    {
+                        IEnumerable<EventSource> sources = EventSource.GetSources();
+                        Assert.Empty(sources);
+
+                        Assert.Null(EventSource.GenerateManifest(typeof(SimpleEventSource), string.Empty, EventManifestOptions.OnlyIfNeededForRegistration));
+                        Assert.Null(EventSource.GenerateManifest(typeof(EventSourceTest), string.Empty, EventManifestOptions.AllCultures));
+
+                        log.Event0();
+                        Assert.Null(LoudListener.LastEvent);
+
+                        EventSource.SendCommand(log, EventCommand.Enable, commandArguments: null);
+                        Assert.False(log.IsEnabled());
+                    }
+                }
+            }, options).Dispose();
+        }
+    }
+}

--- a/src/libraries/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="BasicEventSourceTest\Harness\Listeners.cs" />
     <Compile Include="BasicEventSourceTest\TestEventCounter.cs" />
     <Compile Include="BasicEventSourceTest\TestFilter.cs" />
+    <Compile Include="BasicEventSourceTest\TestNotSupported.cs" />
     <Compile Include="BasicEventSourceTest\TestShutdown.cs" />
     <Compile Include="BasicEventSourceTest\TestsEventSourceLifetime.cs" />
     <Compile Include="BasicEventSourceTest\TestsManifestGeneration.cs" />

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -1,5 +1,9 @@
 <linker>
   <assembly fullname="System.Private.CoreLib">
+    <type fullname="System.Diagnostics.Tracing.EventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
+      <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
+      <method signature="System.Boolean IsEnabled()" body="stub" value="false" />
+    </type>
     <type fullname="System.Globalization.GlobalizationMode">
       <method signature="System.Boolean get_Invariant()" body="stub" value="true" feature="System.Globalization.Invariant" featurevalue="true" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.Shared.xml
@@ -3,6 +3,8 @@
     <type fullname="System.Diagnostics.Tracing.EventSource" feature="System.Diagnostics.Tracing.EventSource.IsSupported" featurevalue="false">
       <method signature="System.Boolean get_IsSupported()" body="stub" value="false" />
       <method signature="System.Boolean IsEnabled()" body="stub" value="false" />
+      <method signature="System.Boolean IsEnabled(System.Diagnostics.Tracing.EventLevel,System.Diagnostics.Tracing.EventKeywords)" body="stub" value="false" />
+      <method signature="System.Boolean IsEnabled(System.Diagnostics.Tracing.EventLevel,System.Diagnostics.Tracing.EventKeywords,System.Diagnostics.Tracing.EventChannel)" body="stub" value="false" />
     </type>
     <type fullname="System.Globalization.GlobalizationMode">
       <method signature="System.Boolean get_Invariant()" body="stub" value="true" feature="System.Globalization.Invariant" featurevalue="true" />

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -405,7 +405,7 @@ namespace System.Diagnostics.Tracing
         /// <returns></returns>
         public static IEnumerable<EventSource> GetSources()
         {
-            if (IsSupported)
+            if (!IsSupported)
             {
                 return Array.Empty<EventSource>();
             }
@@ -1779,7 +1779,7 @@ namespace System.Diagnostics.Tracing
             Debug.Assert(m_eventData != null);
             Type dataType = GetDataType(m_eventData[eventId], parameterId);
 
-        Again:
+            Again:
             if (dataType == typeof(IntPtr))
             {
                 return *((IntPtr*)dataPointer);
@@ -2903,7 +2903,7 @@ namespace System.Diagnostics.Tracing
                 dataDescrs[1].Reserved = 0;
 
                 int chunkSize = ManifestEnvelope.MaxChunkSize;
-            TRY_AGAIN_WITH_SMALLER_CHUNK_SIZE:
+                TRY_AGAIN_WITH_SMALLER_CHUNK_SIZE:
                 envelope.TotalChunks = (ushort)((dataLeft + (chunkSize - 1)) / chunkSize);
                 while (dataLeft > 0)
                 {
@@ -3442,7 +3442,7 @@ namespace System.Diagnostics.Tracing
             }
 #endif
             return;
-        Error:
+            Error:
             manifest.ManifestError(SR.Format(SR.EventSource_EnumKindMismatch, staticField.Name, staticField.FieldType.Name, providerEnumKind));
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -38,7 +38,7 @@ namespace System.Diagnostics.Tracing
 #endif
 
 #if FEATURE_PERFTRACING
-        private readonly TraceLoggingEventHandleTable m_eventHandleTable = new TraceLoggingEventHandleTable();
+        private readonly TraceLoggingEventHandleTable m_eventHandleTable = null!;
 #endif
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -269,7 +269,7 @@ namespace System.Threading.Tasks
             int OriginatingTaskSchedulerID, int OriginatingTaskID,  // PFX_COMMON_EVENT_HEADER
             int TaskID, bool IsExceptional)
         {
-            if (IsEnabled(EventLevel.Informational, Keywords.Tasks))
+            if (IsEnabled() && IsEnabled(EventLevel.Informational, Keywords.Tasks))
             {
                 unsafe
                 {
@@ -538,7 +538,7 @@ namespace System.Threading.Tasks
         public void IncompleteAsyncMethod(IAsyncStateMachineBox stateMachineBox)
         {
             System.Diagnostics.Debug.Assert(stateMachineBox != null);
-            if (IsEnabled(EventLevel.Warning, Keywords.AsyncMethod))
+            if (IsEnabled() && IsEnabled(EventLevel.Warning, Keywords.AsyncMethod))
             {
                 IAsyncStateMachine stateMachine = stateMachineBox.GetStateMachineObject();
                 if (stateMachine != null)


### PR DESCRIPTION
This allows for all of the EventSource logic to be trimmed by the ILLinker when the feature switch is set to false.

Fix #37414

On the default Blazor template, this change along with #38125 allows for ~160 KB of savings.

| Build          | Size     |
|----------------|----------|
| master         | 3,804,748 bytes |
| PR + #38125     | 3,641,932 bytes |

cc @marek-safar 