### PR TITLE
Disable native varargs for Windows arm

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -25,7 +25,7 @@ namespace System
         private IntPtr ArgPtr;                  // Pointer to remaining args.
         private int RemainingArgs;           // # of remaining args.
 
-#if TARGET_WINDOWS // Native Varargs are not supported on Unix
+#if (TARGET_WINDOWS && !TARGET_ARM)   // Native Varargs are not supported on Unix / Windows ARM
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern ArgIterator(IntPtr arglist);
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -25,7 +25,7 @@ namespace System
         private IntPtr ArgPtr;                  // Pointer to remaining args.
         private int RemainingArgs;           // # of remaining args.
 
-#if (TARGET_WINDOWS && !TARGET_ARM)   // Native Varargs are not supported on Unix / Windows ARM
+#if (TARGET_WINDOWS && !TARGET_ARM)   // Native Varargs are not supported on Unix (all architectures) and Windows ARM
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern ArgIterator(IntPtr arglist);
 

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -6,7 +6,7 @@
 #ifndef TARGET_H_
 #define TARGET_H_
 
- // Native Varargs are not supported on Unix (all architectures) and Windows ARM
+// Native Varargs are not supported on Unix (all architectures) and Windows ARM
 #if defined(TARGET_WINDOWS) && !defined(TARGET_ARM)
 #define FEATURE_VARARG 1
 #else

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -7,7 +7,7 @@
 #define TARGET_H_
 
  // Native Varargs are not supported on Unix (all architectures) and Windows ARM
-#if (TARGET_WINDOWS && !TARGET_ARM)
+#if defined(TARGET_WINDOWS) && !defined(TARGET_ARM)
 #define FEATURE_VARARG 1
 #else
 #define FEATURE_VARARG 0

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -6,7 +6,7 @@
 #ifndef TARGET_H_
 #define TARGET_H_
 
-#if defined(TARGET_UNIX)
+#if defined(TARGET_UNIX) || defined(TARGET_ARM)
 #define FEATURE_VARARG 0
 #else
 #define FEATURE_VARARG 1

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -6,10 +6,11 @@
 #ifndef TARGET_H_
 #define TARGET_H_
 
-#if defined(TARGET_UNIX) || defined(TARGET_ARM)
-#define FEATURE_VARARG 0
-#else
+ // Native Varargs are not supported on Unix (all architectures) and Windows ARM
+#if (TARGET_WINDOWS && !TARGET_ARM)
 #define FEATURE_VARARG 1
+#else
+#define FEATURE_VARARG 0
 #endif
 
 /*****************************************************************************/

--- a/src/libraries/System.Runtime/tests/System/ArgIteratorTests.cs
+++ b/src/libraries/System.Runtime/tests/System/ArgIteratorTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using Microsoft.DotNet.XUnitExtensions;
 using System.Globalization;
 using System.Reflection;
 using Xunit;
@@ -91,12 +90,6 @@ namespace System.Tests
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsArgIteratorNotSupported))]
         public static unsafe void ArgIterator_Throws_PlatformNotSupportedException()
         {
-            if (PlatformDetection.IsWindows && PlatformDetection.IsArmProcess)
-            {
-                // Active Issue: https://github.com/dotnet/runtime/issues/35754
-                throw new SkipTestException("ArgIterator doesn't throw not supported in ArmProcess");
-            }
-
             Assert.Throws<PlatformNotSupportedException>(() => new ArgIterator(new RuntimeArgumentHandle()));
             Assert.Throws<PlatformNotSupportedException>(() => {
                 fixed (void* p = "test")


### PR DESCRIPTION
Disable native varargs for Windows arm so `ArgsIterator` throws `PlatformNotSupported` exception. Also re-enable the test that was disabled in https://github.com/dotnet/runtime/pull/35690.

Fixes: https://github.com/dotnet/runtime/issues/35754