### PR TITLE
Synchronize CI trigger exclusion paths between runtime-linker-tests.yml and runtime.yml

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -12,7 +12,6 @@ trigger:
   paths:
     include:
     - '*'
-    - docs/manpages/*
     exclude:
     - eng/Version.Details.xml
     - .github/*
@@ -34,7 +33,6 @@ pr:
   paths:
     include:
     - '*'
-    - docs/manpages/*
     exclude:
     - eng/Version.Details.xml
     - .github/*

--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -7,13 +7,45 @@ trigger:
   branches:
     include:
     - master
+    - dev/infrastructure
     - release/*.*
+  paths:
+    include:
+    - '*'
+    - docs/manpages/*
+    exclude:
+    - eng/Version.Details.xml
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 
 pr:
   branches:
     include:
     - master
+    - dev/infrastructure
     - release/*.*
+  paths:
+    include:
+    - '*'
+    - docs/manpages/*
+    exclude:
+    - eng/Version.Details.xml
+    - .github/*
+    - docs/*
+    - CODE-OF-CONDUCT.md
+    - CONTRIBUTING.md
+    - LICENSE.TXT
+    - PATENTS.TXT
+    - README.md
+    - SECURITY.md
+    - THIRD-PARTY-NOTICES.TXT
 
 jobs:
 #


### PR DESCRIPTION
The linker-tests pipeline didn't have path exclusions set up like the main pipeline so it was triggered even for documentation-only PRs like https://github.com/dotnet/runtime/pull/38149.