### PR TITLE
Move COM ILLink.Descriptors entries to CoreCLR

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
+++ b/src/coreclr/src/System.Private.CoreLib/ILLinkTrim.xml
@@ -9,5 +9,13 @@
     <type fullname="System.Diagnostics.Tracing.EventPipe*" />
     <!-- The private Event methods are accessed by private reflection in the base EventSource class. -->
     <type fullname="System.Diagnostics.Tracing.NativeRuntimeEventSource" />
+    <!-- Accessed via native code. -->
+    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
+    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerator" />
+    <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
+    <!-- Workaround for https://github.com/mono/linker/issues/378 -->
+    <type fullname="System.Runtime.InteropServices.IDispatch" />
+    <type fullname="System.Runtime.InteropServices.IMarshal" />
+    <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
   </assembly>
 </linker>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -37,14 +37,6 @@
       <!-- Methods is used by VS Tasks Window. -->
       <method name="GetActiveTaskFromId" />
     </type>
-    <!-- Accessed via native code. -->
-    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerable" />
-    <type fullname="System.Runtime.InteropServices.ComTypes.IEnumerator" />
-    <type fullname="System.Runtime.InteropServices.CustomMarshalers.*" />
-    <!-- Workaround for https://github.com/mono/linker/issues/378 -->
-    <type fullname="System.Runtime.InteropServices.IDispatch" />
-    <type fullname="System.Runtime.InteropServices.IMarshal" />
-    <type fullname="Internal.Runtime.InteropServices.IClassFactory2" />
     <type fullname="System.Threading.ThreadPoolBoundHandle">
       <!-- Workaround to keep .interfaceimpl even though this type
              is not instantiated on unix:


### PR DESCRIPTION
These types only exist in CoreCLR, they don't exist in Mono.

Contributes to #36659

See https://github.com/dotnet/runtime/issues/36659#issuecomment-646460765