### PR TITLE
Bring back System.IO.Pipes.AccessControl package and make it available in .NET 5.0

### DIFF
--- a/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -1,0 +1,10 @@
+<Project DefaultTargets="Build">
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
+    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="lib/net461;runtimes/win/lib/net461" />
+    <HarvestIncludePaths Include="lib/netstandard1.3;runtimes/win/lib/netstandard1.3" />
+    <HarvestIncludePaths Include="lib/netstandard2.0;runtimes/win/lib/netstandard2.0" />
+    <HarvestIncludePaths Include="lib/netcoreapp2.1" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -1,10 +1,14 @@
 <Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
-    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
+    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj">
+      <SupportedFramework>$(NetCoreAppCurrent)</SupportedFramework>
+    </ProjectReference>
     <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="lib/net461;runtimes/win/lib/net461" />
-    <HarvestIncludePaths Include="lib/netstandard1.3;runtimes/win/lib/netstandard1.3" />
-    <HarvestIncludePaths Include="lib/netstandard2.0;runtimes/win/lib/netstandard2.0" />
-    <HarvestIncludePaths Include="lib/netcoreapp2.1" />
+    <HarvestIncludePaths Include="lib/netstandard1.3" />
+    <HarvestIncludePaths Include="lib/netstandard2.0" />
+    <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.1" />
   </ItemGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- We are no longer shipping this assembly and it is only used in desktop facades.
-        The reference assembly version needs to be frozen so that our desktop compat facades point to the version from the package. -->
-    <AssemblyVersion>4.0.3.0</AssemblyVersion>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
@@ -5,7 +5,7 @@
     <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(TargetsWindows)' == 'true'">true</OmitResources>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_AccessControl</GeneratePlatformNotSupportedAssemblyMessage>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
@@ -1,12 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>System.IO.Pipes.AccessControl</AssemblyName>
-    <IncludeDefaultReferences>false</IncludeDefaultReferences>
     <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(TargetsWindows)' == 'true'">true</OmitResources>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_AccessControl</GeneratePlatformNotSupportedAssemblyMessage>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;netcoreapp2.1;$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IncludeDefaultReferences Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">false</IncludeDefaultReferences>
+    <AssemblyVersion Condition="'$(TargetFramework)' == 'netcoreapp2.1'">4.0.3.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />
@@ -14,6 +17,9 @@
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <ProjectReference Include="..\..\System.IO.Pipes\src\System.IO.Pipes.csproj" />
     <ProjectReference Include="..\..\System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <Reference Include="System.Resources.ResourceManager" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
     <Reference Include="System.IO.Pipes" />

--- a/src/libraries/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
+++ b/src/libraries/pkg/Microsoft.Windows.Compatibility/Microsoft.Windows.Compatibility.pkgproj
@@ -30,6 +30,7 @@
     <PrereleaseLibraryPackage Include="System.DirectoryServices.Protocols" />
     <PrereleaseLibraryPackage Include="System.IO.FileSystem.AccessControl" />
     <PrereleaseLibraryPackage Include="System.IO.Packaging" />
+    <PrereleaseLibraryPackage Include="System.IO.Pipes.AccessControl" />
     <PrereleaseLibraryPackage Include="System.IO.Ports" />
     <PrereleaseLibraryPackage Include="System.Management" />
     <PrereleaseLibraryPackage Include="System.Runtime.Caching" />
@@ -49,9 +50,6 @@
     <NS21PrereleaseLibraryPackage Include="System.Reflection.Context" />
 
     <!-- Packages we don't build in master anymore -->
-    <LibraryPackage Include="System.IO.Pipes.AccessControl">
-      <Version>4.5.1</Version>
-    </LibraryPackage>
     <LibraryPackage Include="System.Data.DataSetExtensions">
       <Version>4.5.0</Version>
     </LibraryPackage>

--- a/src/libraries/pkg/baseline/packageIndex.json
+++ b/src/libraries/pkg/baseline/packageIndex.json
@@ -3376,12 +3376,13 @@
         "4.5.0",
         "4.5.1"
       ],
-      "BaselineVersion": "4.5.1",
+      "BaselineVersion": "5.0.0",
       "InboxOn": {},
       "AssemblyVersionInPackageVersion": {
         "4.0.1.0": "4.3.0",
         "4.0.2.0": "4.4.0",
-        "4.0.3.0": "4.5.0"
+        "4.0.3.0": "4.5.0",
+        "5.0.0.0": "5.0.0"
       }
     },
     "System.IO.Ports": {
@@ -7248,8 +7249,8 @@
     }
   },
   "ModulesToPackages": {
-    "sni.dll": "runtime.native.System.Data.SqlClient.sni",
-    "libSystem.IO.Ports.Native": "runtime.native.System.IO.Ports"
+    "libSystem.IO.Ports.Native": "runtime.native.System.IO.Ports",
+    "sni.dll": "runtime.native.System.Data.SqlClient.sni"
   },
   "MetaPackages": {
     "NETStandard.Library": [


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/38123

Pending making sure we don't regress this: https://github.com/dotnet/runtime/issues/30813

cc @joperezr @safern @ericstj @Jozkee 