### PR TITLE
Approximate the heap_hard_limit

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -35186,8 +35186,7 @@ HRESULT GCHeap::Initialize()
         {
             gc_heap::heap_hard_limit_oh[2] = min_segment_size_hard_limit;
         }
-        // This tells the system there is a hard limit, but otherwise we will not compare against this value.
-        gc_heap::heap_hard_limit = 1;
+        gc_heap::heap_hard_limit = gc_heap::heap_hard_limit_oh[0] + gc_heap::heap_hard_limit_oh[1] + gc_heap::heap_hard_limit_oh[2];
     }
     else
     {
@@ -35222,8 +35221,7 @@ HRESULT GCHeap::Initialize()
             {
                 gc_heap::heap_hard_limit_oh[2] = (size_t)(gc_heap::total_physical_mem * (uint64_t)percent_of_mem_poh / (uint64_t)100);
             }
-            // This tells the system there is a hard limit, but otherwise we will not compare against this value.
-            gc_heap::heap_hard_limit = 1;
+            gc_heap::heap_hard_limit = gc_heap::heap_hard_limit_oh[0] + gc_heap::heap_hard_limit_oh[1] + gc_heap::heap_hard_limit_oh[2];
         }
     }
 


### PR DESCRIPTION
It appears to me that the field `gc_heap::heap_hard_limit` is also used as a heuristic to determine generation to condemn. If we set it to 1, the heuristic would think we are going to run out of memory and keep triggering gen 2 GC.

This change approximates the `heap_hard_limit` value by adding the individual object heaps. This is an approximation because we discounted the memory that would be used for the auxiliary structures (such as the card table)

@dotnet/gc