### PR TITLE
ARM64: Eliminate redundant opposite mov

### DIFF
--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -14921,11 +14921,11 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
         }
     }
 
-    bool isFirstInstrInIG = (emitCurIGinsCnt == 0) && ((emitCurIG->igFlags & IGF_EXTEND) == 0);
+    bool isFirstInstrInBlock = (emitCurIGinsCnt == 0) && ((emitCurIG->igFlags & IGF_EXTEND) == 0);
 
-    if (!isFirstInstrInIG && // Don't optimize if instruction is not the first instruction in IG.
-        (emitLastIns != nullptr &&
-         emitLastIns->idIns() == INS_mov) && // Don't optimize if last instruction was not 'mov'.
+    if (!isFirstInstrInBlock && // Don't optimize if instruction is not the first instruction in IG.
+        (emitLastIns != nullptr) &&
+        (emitLastIns->idIns() == INS_mov) && // Don't optimize if last instruction was not 'mov'.
         (emitLastIns->idOpSize() == size))   // Don't optimize if operand size is different than previous instruction.
     {
         // Check if we did same move in prev instruction except dst/src were switched.

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -14926,7 +14926,8 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
         }
     }
 
-    if (emitLastIns != nullptr && emitLastIns->idIns() == INS_mov)
+    // Don't look back across IG boundary or if the last instruction was not mov
+    if (emitCurIGinsCnt > 0 && emitLastIns != nullptr && emitLastIns->idIns() == INS_mov)
     {
         // Check if we did same move in prev instruction except dst/src were switched.
         regNumber prevDst = emitLastIns->idReg1();

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -14894,9 +14894,10 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
 //         mov Ry, Rx  # <-- current instruction can be omitted.
 //
 // Arguments:
-//    ins - The current instruction
-//    dst - The current destination
-//    src - The current source
+//    ins  - The current instruction
+//    size - Operand size of current instruction
+//    dst  - The current destination
+//    src  - The current source
 //
 // Return Value:
 //    true if previous instruction moved from current dst to src.
@@ -14934,16 +14935,16 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
         regNumber prevSrc    = emitLastIns->idReg2();
         insFormat lastInsfmt = emitLastIns->idInsFmt();
 
-        // Sometimes emitLastIns can be a mov with single register e.g. "mov reg, #imm". So ensure to
-        // optimize formats that does vector-to-vector or scalar-to-scalar register movs.
-        bool isValidLastInsFormats = ((lastInsfmt == IF_DV_3C) || (lastInsfmt == IF_DR_2G) || (lastInsfmt == IF_DR_2E));
- 
         if ((prevDst == dst) && (prevSrc == src))
         {
             assert(emitLastIns->idOpSize() == size);
             JITDUMP("\n -- suppressing mov because previous instruction already moved from src to dst register.\n");
             return true;
         }
+
+        // Sometimes emitLastIns can be a mov with single register e.g. "mov reg, #imm". So ensure to
+        // optimize formats that does vector-to-vector or scalar-to-scalar register movs.
+        bool isValidLastInsFormats = ((lastInsfmt == IF_DV_3C) || (lastInsfmt == IF_DR_2G) || (lastInsfmt == IF_DR_2E));
 
         if ((prevDst == src) && (prevSrc == dst) && isValidLastInsFormats)
         {

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -14962,7 +14962,7 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
             else if (size == EA_16BYTE)
             {
                 assert(isVectorRegister(src) && isVectorRegister(dst));
-                assert(lastInsfmt == IF_DR_3C);
+                assert(lastInsfmt == IF_DV_3C);
 
                 JITDUMP("\n -- suppressing mov because previous instruction already did an opposite move from dst to "
                         "src register.\n");

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -14902,11 +14902,6 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
 
 bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src)
 {
-    bool isRedundant = false;
-#ifdef DEBUG
-    const char* reason = nullptr;
-#endif // DEBUG
-
     assert(ins == INS_mov);
 
     if (dst == src)
@@ -14916,13 +14911,13 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
         //
         if (isGeneralRegisterOrSP(dst) && (size == EA_8BYTE))
         {
-            reason      = "\n -- suppressing mov because src and dst is same 8-byte register.\n";
-            isRedundant = true;
+            JITDUMP("\n -- suppressing mov because src and dst is same 8-byte register.\n");
+            return true;
         }
         else if (isVectorRegister(dst) && (size == EA_16BYTE))
         {
-            reason      = "\n -- suppressing mov because src and dst is same 16-byte register.\n";
-            isRedundant = true;
+            JITDUMP("\n -- suppressing mov because src and dst is same 16-byte register.\n");
+            return true;
         }
     }
 
@@ -14935,8 +14930,8 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
 
         if ((prevDst == dst) && (prevSrc == src))
         {
-            reason      = "\n -- suppressing mov because previous instruction already moved from src to dst register.\n";
-            isRedundant = true;
+            JITDUMP("\n -- suppressing mov because previous instruction already moved from src to dst register.\n");
+            return true;
         }
 
         // A mov with a EA_4BYTE has the side-effect of clearing the upper bits
@@ -14944,16 +14939,12 @@ bool emitter::IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regN
         //
         if (((size == EA_8BYTE) || (size == EA_16BYTE)) && (prevDst == src) && (prevSrc == dst))
         {
-            JITDUMP("\n -- suppressing mov because previous instruction already did an opposite move from dst to src register.\n");
+            JITDUMP("\n -- suppressing mov because previous instruction already did an opposite move from dst to src "
+                    "register.\n");
             return true;
         }
     }
 
-    if (isRedundant)
-    {
-        JITDUMP(reason);
-    }
-
-    return isRedundant;
+    return false;
 }
 #endif // defined(TARGET_ARM64)

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -14879,6 +14879,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
 //    A `mov` is redundant in following 3 cases:
 //
 //    1. Move to same register
+//       (Except 4-byte movement like "mov w1, w1" which zeros out upper bits of x1 register)
 //
 //         mov Rx, Rx
 //

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -48,6 +48,8 @@ void emitDispExtendReg(regNumber reg, insOpts opt, ssize_t imm);
 void emitDispAddrRI(regNumber reg, insOpts opt, ssize_t imm);
 void emitDispAddrRRExt(regNumber reg1, regNumber reg2, insOpts opt, bool isScaled, emitAttr size);
 
+bool IsOppositeOfPrevMov(instruction ins, regNumber dst, regNumber src);
+
 void emitDispIns(instrDesc* id,
                  bool       isNew,
                  bool       doffs,

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -113,9 +113,9 @@ static UINT64 NOT_helper(UINT64 value, unsigned width);
 // A helper method to perform a bit Replicate operation
 static UINT64 Replicate_helper(UINT64 value, unsigned width, emitAttr size);
 
-// Method to do peephole optimization by checking if mov is redundant to
-// immediately preceding mov and if yes, omit current mov.
-bool IsMovRedundantToPrevMov(instruction ins, regNumber dst, regNumber src);
+// Method to do peephole optimization by checking if mov is redundant with
+// respect to the last instruction. If yes, then will omit current mov instruction.
+bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src);
 
 /************************************************************************
 *

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -113,8 +113,8 @@ static UINT64 NOT_helper(UINT64 value, unsigned width);
 // A helper method to perform a bit Replicate operation
 static UINT64 Replicate_helper(UINT64 value, unsigned width, emitAttr size);
 
-// Method to do peephole optimization by checking if mov is redundant with
-// respect to the last instruction. If yes, then will omit current mov instruction.
+// Method to do check if mov is redundant with respect to the last instruction.
+// If yes, the caller of this method can choose to omit current mov instruction.
 bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src);
 
 /************************************************************************

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -48,8 +48,6 @@ void emitDispExtendReg(regNumber reg, insOpts opt, ssize_t imm);
 void emitDispAddrRI(regNumber reg, insOpts opt, ssize_t imm);
 void emitDispAddrRRExt(regNumber reg1, regNumber reg2, insOpts opt, bool isScaled, emitAttr size);
 
-bool IsOppositeOfPrevMov(instruction ins, regNumber dst, regNumber src);
-
 void emitDispIns(instrDesc* id,
                  bool       isNew,
                  bool       doffs,
@@ -114,6 +112,10 @@ static UINT64 NOT_helper(UINT64 value, unsigned width);
 
 // A helper method to perform a bit Replicate operation
 static UINT64 Replicate_helper(UINT64 value, unsigned width, emitAttr size);
+
+// Method to do peephole optimization by checking if mov is redundant to
+// immediately preceding mov and if yes, omit current mov.
+bool IsMovRedundantToPrevMov(instruction ins, regNumber dst, regNumber src);
 
 /************************************************************************
 *


### PR DESCRIPTION
Perform peephole optimization to skip `mov` instruction if the previous instruction was the opposite mov.

Fixes: https://github.com/dotnet/runtime/issues/35252

Looking at the size improvement, it matches closely to what was originally estimated in #35252.
```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -140040 (-0.281% of base)
    diff is an improvement.
Top file improvements (bytes):
      -19140 : System.Linq.Expressions.dasm (-0.418% of base)
      -13420 : System.Private.Xml.dasm (-0.292% of base)
      -12204 : System.Private.CoreLib.dasm (-0.214% of base)
       -7676 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.239% of base)
       -7436 : System.Data.Common.dasm (-0.451% of base)
       -6944 : Microsoft.CodeAnalysis.CSharp.dasm (-0.233% of base)
       -3620 : System.Linq.Parallel.dasm (-0.422% of base)
       -3556 : System.Management.dasm (-0.712% of base)
       -3552 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.069% of base)
       -3268 : System.DirectoryServices.dasm (-0.560% of base)
       -2804 : System.Private.DataContractSerialization.dasm (-0.253% of base)
       -2704 : Microsoft.CodeAnalysis.dasm (-0.257% of base)
       -2432 : Newtonsoft.Json.dasm (-0.268% of base)
       -2340 : System.DirectoryServices.AccountManagement.dasm (-0.624% of base)
       -2032 : System.Data.OleDb.dasm (-0.502% of base)
       -1672 : Microsoft.CSharp.dasm (-0.340% of base)
       -1672 : xunit.execution.dotnet.dasm (-0.601% of base)
       -1584 : System.Data.Odbc.dasm (-0.573% of base)
       -1568 : System.Text.Json.dasm (-0.238% of base)
       -1548 : System.Configuration.ConfigurationManager.dasm (-0.330% of base)
179 total files with Code Size differences (179 improved, 0 regressed), 84 unchanged.
Top method improvements (bytes):
      -17288 (-5.860% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.CallInstruction:FastCreate(System.Reflection.MethodInfo,System.Reflection.ParameterInfo[]):System.Linq.Expressions.Interpreter.CallInstruction (241 methods)
        -428 (-1.599% of base) : System.Private.Xml.dasm - System.Xml.Schema.XsdBuilder:.cctor()
        -424 (-2.719% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.ADStoreCtx:.cctor()
        -348 (-2.282% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.SAMStoreCtx:.cctor()
        -288 (-1.953% of base) : System.DirectoryServices.AccountManagement.dasm - System.DirectoryServices.AccountManagement.ADAMStoreCtx:.cctor()
        -228 (-1.256% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateTypeConverterClass():System.CodeDom.CodeTypeDeclaration:this
        -200 (-4.230% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.MetadataWriter:.ctor(Microsoft.Cci.MetadataHeapsBuilder,Microsoft.Cci.MetadataHeapsBuilder,Microsoft.CodeAnalysis.Emit.EmitContext,Microsoft.CodeAnalysis.CommonMessageProvider,bool,bool,System.Threading.CancellationToken):this
        -184 (-2.028% of base) : System.Private.Xml.dasm - System.Xml.Schema.XdrBuilder:.cctor()
        -180 (-4.712% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.Ecma335.MetadataBuilder:.ctor(int,int,int,int):this
        -176 (-1.386% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateProperties():this
        -164 (-6.337% of base) : System.Data.Common.dasm - System.Data.Common.DataStorage:CreateStorage(System.Data.DataColumn,System.Type,int):System.Data.Common.DataStorage
        -144 (-1.139% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFDateTimeFunction():this
        -136 (-1.216% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDMTFTimeIntervalFunction():this
        -132 (-0.785% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:AddToDateTimeFunction():this
        -124 (-1.393% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntime:SetupCallbacks(Microsoft.Diagnostics.Tracing.TraceEventDispatcher)
        -124 (-2.093% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateIfClassvalidFunction():this
        -120 (-3.901% of base) : System.Private.Xml.dasm - MS.Internal.Xml.XPath.LogicalExpr:.cctor()
        -112 (-1.611% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:GenerateCollectionClass():this
        -108 (-3.151% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.ExpressionEvaluator:EvaluateUnaryExpression(Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.UnaryExpressionSyntax):Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax.CConst:this
        -104 (-1.261% of base) : Microsoft.CSharp.dasm - Microsoft.CSharp.RuntimeBinder.Semantics.ExpressionBinder:.cctor()
Top method improvements (percentages):
          -4 (-12.500% of base) : System.Reflection.MetadataLoadContext.dasm - System.Reflection.TypeLoading.Helpers:ConvertAssemblyFlagsToAssemblyNameFlags(int):int
          -4 (-11.111% of base) : Microsoft.VisualBasic.Core.dasm - Microsoft.VisualBasic.FileIO.FileSystem:GetOperationFlags(int):ushort
          -4 (-11.111% of base) : System.Private.CoreLib.dasm - System.Threading.Tasks.ConcurrentExclusiveSchedulerPair:GetCreationOptionsForTask(bool):int
          -4 (-11.111% of base) : System.Threading.Tasks.Dataflow.dasm - System.Threading.Tasks.Dataflow.Internal.Common:GetCreationOptionsForTask(bool):int
          -4 (-8.333% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:DefaultOptionsForSource(Microsoft.Diagnostics.Tracing.TraceEventSource):int
          -4 (-8.333% of base) : System.ComponentModel.Annotations.dasm - System.ComponentModel.DataAnnotations.ValidationResult:ToString():System.String:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:InternalGetAbbreviatedDayOfWeekNames():System.String[]:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:InternalGetSuperShortDayNames():System.String[]:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:InternalGetDayOfWeekNames():System.String[]:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:InternalGetAbbreviatedMonthNames():System.String[]:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Globalization.DateTimeFormatInfo:InternalGetMonthNames():System.String[]:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Runtime.CompilerServices.AsyncTaskMethodBuilder:get_Task():System.Threading.Tasks.Task:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Reflection.RtFieldInfo:get_FieldType():System.Type:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[Boolean][System.Boolean]:get_Task():System.Threading.Tasks.Task`1[Boolean]:this
          -4 (-8.333% of base) : System.Private.CoreLib.dasm - System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1[Int32][System.Int32]:get_Task():System.Threading.Tasks.Task`1[Int32]:this
          -8 (-7.692% of base) : System.ComponentModel.TypeConverter.dasm - System.ComponentModel.PropertyDescriptor:GetInvocationTarget(System.Type,System.Object):System.Object:this
          -4 (-7.692% of base) : System.Configuration.ConfigurationManager.dasm - System.Configuration.OverrideModeSetting:get_AllowOverride():bool:this
          -4 (-7.692% of base) : System.Management.dasm - System.Management.ManagementClassGenerator:IsPropertyValueType(int):bool
          -4 (-7.692% of base) : System.Private.CoreLib.dasm - CachedData:get_Local():System.TimeZoneInfo:this
          -4 (-7.143% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.SyntaxNode:get_SlotCount():int:this
20688 total methods with Code Size differences (20688 improved, 0 regressed), 200441 unchanged.
```
**Update**: JIT code size diff collected using PMI.

```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  default jit
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -113636 (-0.20% of base)
    diff is an improvement.
Top file improvements (bytes):
      -13728 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.22% of base)
      -11424 : System.Private.CoreLib.dasm (-0.19% of base)
       -9136 : System.Private.Xml.dasm (-0.22% of base)
       -8280 : Microsoft.CodeAnalysis.CSharp.dasm (-0.17% of base)
       -6232 : System.Linq.Parallel.dasm (-0.35% of base)
       -6056 : Microsoft.CodeAnalysis.dasm (-0.29% of base)
       -4464 : System.Collections.Immutable.dasm (-0.36% of base)
       -4380 : System.Data.Common.dasm (-0.25% of base)
       -2636 : System.DirectoryServices.dasm (-0.54% of base)
       -2352 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.07% of base)
       -2244 : Newtonsoft.Json.dasm (-0.23% of base)
       -1932 : System.Linq.Expressions.dasm (-0.21% of base)
       -1892 : System.Private.DataContractSerialization.dasm (-0.21% of base)
       -1604 : System.Linq.dasm (-0.14% of base)
       -1508 : System.Threading.Tasks.Dataflow.dasm (-0.14% of base)
       -1428 : System.DirectoryServices.AccountManagement.dasm (-0.34% of base)
       -1328 : xunit.execution.dotnet.dasm (-0.49% of base)
       -1200 : System.ComponentModel.Composition.dasm (-0.30% of base)
       -1132 : Microsoft.CSharp.dasm (-0.26% of base)
       -1132 : System.Management.dasm (-0.28% of base)
173 total files with Code Size differences (173 improved, 0 regressed), 90 unchanged.
Top method regressions (bytes):
           8 ( 7.14% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Byte][System.Byte]:.cctor()
           8 ( 6.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int16][System.Int16]:.cctor()
Top method improvements (bytes):
       -1004 (-6.21% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__0-0(Roslyn.Utilities.ObjectReader):System.Object:this (251 methods)
        -564 (-3.80% of base) : System.Linq.Expressions.dasm - System.Linq.Expressions.Interpreter.CallInstruction:FastCreate(System.Reflection.MethodInfo,System.Reflection.ParameterInfo[]):System.Linq.Expressions.Interpreter.CallInstruction (15 methods)
        -296 (-6.25% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__9-0(Roslyn.Utilities.ObjectReader):System.Object:this (74 methods)
        -272 (-6.25% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__10-0(Roslyn.Utilities.ObjectReader):System.Object:this (68 methods)
        -176 (-6.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:<GetReader>b__18_0(Roslyn.Utilities.ObjectReader):System.Object:this (44 methods)
        -168 (-6.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:<GetReader>b__21_0(Roslyn.Utilities.ObjectReader):System.Object:this (42 methods)
        -164 (-8.42% of base) : System.Data.Common.dasm - System.Data.Common.DataStorage:CreateStorage(System.Data.DataColumn,System.Type,int):System.Data.Common.DataStorage
        -156 (-6.25% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__8-0(Roslyn.Utilities.ObjectReader):System.Object:this (39 methods)
        -140 (-6.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:<GetReader>b__24_0(Roslyn.Utilities.ObjectReader):System.Object:this (35 methods)
        -124 (-2.10% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Analysis.TraceLoadedDotNetRuntime:SetupCallbacks(Microsoft.Diagnostics.Tracing.TraceEventDispatcher)
        -100 (-7.69% of base) : System.Reflection.Metadata.dasm - Enumerator:System.Collections.IEnumerator.Reset():this (25 methods)
         -96 (-5.80% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.FullMetadataWriter:.ctor(Microsoft.CodeAnalysis.Emit.EmitContext,Microsoft.Cci.MetadataHeapsBuilder,Microsoft.Cci.MetadataHeapsBuilder,Microsoft.CodeAnalysis.CommonMessageProvider,bool,bool,System.Threading.CancellationToken):this
         -96 (-6.25% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__11-0(Roslyn.Utilities.ObjectReader):System.Object:this (24 methods)
         -96 (-2.72% of base) : System.Text.Json.dasm - System.Text.Json.JsonSerializerOptions:GetDefaultSimpleConverters():System.Collections.Generic.Dictionary`2[[System.Type, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.Text.Json.Serialization.JsonConverter, System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51]]
         -88 (-1.65% of base) : System.Private.CoreLib.dasm - System.Diagnostics.Tracing.RuntimeEventSource:OnEventCommand(System.Diagnostics.Tracing.EventCommandEventArgs):this
         -84 (-1.37% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Etlx.TraceLog:SetupCallbacks(Microsoft.Diagnostics.Tracing.TraceEventDispatcher):this
         -80 (-6.25% of base) : Microsoft.CodeAnalysis.CSharp.dasm - <>c:<GetReader>b__27_0(Roslyn.Utilities.ObjectReader):System.Object:this (20 methods)
         -76 (-6.25% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - _Closure$__:_Lambda$__12-0(Roslyn.Utilities.ObjectReader):System.Object:this (19 methods)
         -72 (-1.74% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.BinderFactory:CreateBinderForNodeAndUsage(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,ubyte,Microsoft.CodeAnalysis.VisualBasic.Binder):Microsoft.CodeAnalysis.VisualBasic.Binder:this
         -72 (-2.03% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.ExpressionLambdaRewriter:CreateBuiltInConversion(Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.Symbols.TypeSymbol,Microsoft.CodeAnalysis.VisualBasic.BoundExpression,bool,bool,int,bool):Microsoft.CodeAnalysis.VisualBasic.BoundExpression:this
Top method regressions (percentages):
           8 ( 7.14% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Byte][System.Byte]:.cctor()
           8 ( 6.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int16][System.Int16]:.cctor()
Top method improvements (percentages):
          -4 (-16.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceConstructorSymbol:GetReturnTypeAttributeDeclarations():Roslyn.Utilities.OneOrMany`1[[Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -4 (-16.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceDestructorSymbol:GetReturnTypeAttributeDeclarations():Roslyn.Utilities.OneOrMany`1[[Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -4 (-16.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Microsoft.CodeAnalysis.CSharp.Symbols.SourceMethodSymbol:GetAttributeDeclarations():Roslyn.Utilities.OneOrMany`1[[Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -4 (-16.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - Constructor:GetReturnTypeAttributeDeclarations():Roslyn.Utilities.OneOrMany`1[[Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -4 (-16.67% of base) : Microsoft.CodeAnalysis.CSharp.dasm - BeginInvokeMethod:GetReturnTypeAttributeDeclarations():Roslyn.Utilities.OneOrMany`1[[Microsoft.CodeAnalysis.SyntaxList`1[[Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax, Microsoft.CodeAnalysis.CSharp, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]], Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]]:this
          -4 (-10.00% of base) : Microsoft.Extensions.DependencyInjection.dasm - Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteValidator:VisitRootCache(Microsoft.Extensions.DependencyInjection.ServiceLookup.ServiceCallSite,CallSiteValidatorState):System.Type:this
          -4 (-9.09% of base) : System.Private.DataContractSerialization.dasm - System.Runtime.Serialization.Json.DataContractJsonSerializer:GetDataContract(System.Runtime.Serialization.DataContract,System.Type,System.Type):System.Runtime.Serialization.DataContract
          -4 (-9.09% of base) : System.Private.DataContractSerialization.dasm - System.Runtime.Serialization.Json.DataContractJsonSerializerImpl:GetDataContract(System.Runtime.Serialization.DataContract,System.Type,System.Type):System.Runtime.Serialization.DataContract
          -4 (-9.09% of base) : System.Security.Cryptography.Csp.dasm - System.Security.Cryptography.DSACryptoServiceProvider:get_PersistKeyInCsp():bool:this
          -4 (-9.09% of base) : System.Security.Cryptography.Csp.dasm - System.Security.Cryptography.RSACryptoServiceProvider:get_PersistKeyInCsp():bool:this
          -4 (-9.09% of base) : System.Security.Cryptography.Pkcs.dasm - Internal.Cryptography.PkcsHelpers:ToSerialBytes(System.String):System.Byte[]
         -16 (-9.09% of base) : System.Security.Cryptography.Pkcs.dasm - System.Security.Cryptography.Pkcs.CmsSigner:.ctor(System.Security.Cryptography.CspParameters):this
        -164 (-8.42% of base) : System.Data.Common.dasm - System.Data.Common.DataStorage:CreateStorage(System.Data.DataColumn,System.Type,int):System.Data.Common.DataStorage
          -4 (-8.33% of base) : System.Linq.dasm - ReverseIterator`1[Byte][System.Byte]:ToArray():System.Byte[]:this
          -4 (-8.33% of base) : System.Linq.dasm - ReverseIterator`1[Int16][System.Int16]:ToArray():System.Int16[]:this
          -4 (-8.33% of base) : System.Linq.dasm - ReverseIterator`1[Int32][System.Int32]:ToArray():System.Int32[]:this
          -4 (-8.33% of base) : System.Linq.dasm - ReverseIterator`1[Double][System.Double]:ToArray():System.Double[]:this
          -4 (-8.33% of base) : System.Linq.dasm - ReverseIterator`1[Vector`1][System.Numerics.Vector`1[System.Single]]:ToArray():System.Numerics.Vector`1[System.Single][]:this
          -4 (-8.33% of base) : System.Linq.dasm - ReverseIterator`1[Int64][System.Int64]:ToArray():System.Int64[]:this
          -4 (-8.33% of base) : System.Private.CoreLib.dasm - System.StubHelpers.StubHelpers:GetHRExceptionObject(int):System.Exception
21301 total methods with Code Size differences (21299 improved, 2 regressed), 287163 unchanged.
```