### PR TITLE
Fix SOS test failures on latest runtime

### DIFF
--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -2290,11 +2290,9 @@ private:
     // by one. For it to hit zero an explicit close must have happened.
     LONG        m_cRef;                    // Ref count.
 
-#ifndef DACCESS_COMPILE
     // Map of loaded composite native images indexed by base load addresses
     CrstExplicitInit m_nativeImageLoadCrst;
     MapSHash<LPCUTF8, PTR_NativeImage, NativeImageIndexTraits> m_nativeImageMap;
-#endif
 
 #ifdef FEATURE_COMINTEROP
     // this cache stores the RCWs in this domain


### PR DESCRIPTION
#ifndef DACCESS_COMPILE variables in the AppDomain causes the DAC/runtime layout to be different thus breaking our diagnostics repo's SOS tests.  

/cc: @dotnet/dotnet-diag 