### PR TITLE
Exclude failing JIT/Methodical/xxobj/sizeof tests.

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -118,6 +118,24 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
             <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32_Target_32Bit/*">
+            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64/*">
+            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof_Target_32Bit/*">
+            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_relsizeof32_Target_32Bit/*">
+            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_relsizeof64_Target_32Bit/*">
+            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_relsizeof_Target_32Bit/*">
+            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->


### PR DESCRIPTION
Revert when #37470 is fixed.

Note: it looks we have [a new constant failure](https://dev.azure.com/dnceng/public/_build/results?buildId=696964&view=ms.vss-test-web.build-test-results-tab&runId=21605364&paneView=debug&resultId=100069) on OSX:
Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest/UnmanagedCallersOnlyTest.sh
so we won't get clean outerloop after this.

PTAL @dotnet/jit-contrib 
