### PR TITLE
Update comment in Http2Stream

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1069,12 +1069,11 @@ namespace System.Net.Http
             {
                 Debug.Assert(_requestBodyCancellationSource != null);
 
-                // Deal with [ActiveIssue("https://github.com/dotnet/runtime/issues/17492")]
-                // Custom HttpContent classes do not get passed the cancellationToken.
-                // So, inject the expected CancellationToken here, to ensure we can cancel the request body send if needed.
+                // Cancel the request body sending if cancellation is requested on the supplied cancellation token.
                 CancellationTokenRegistration linkedRegistration = cancellationToken.CanBeCanceled && cancellationToken != _requestBodyCancellationSource.Token ?
                     RegisterRequestBodyCancellation(cancellationToken) :
                     default;
+
                 try
                 {
                     while (buffer.Length > 0)


### PR DESCRIPTION
Closes #17492 (this comment is the only place referring to the issue after the cancellable APIs have been implemented)

This logic is there to ensure that if the user-provided CT is not the same as the one passed to internal operations (`_requestBodyCancellationSource.Token`), we create a link so that cancelling the user-provided CT cancels the request.

While the comment refers to CTs not being flowed through custom HttpContents before new overloads were introduced, the user is always free to pass any cancellation token - not necessarily the one we gave it.
The necessity for linking the CTs therefore exists regardless of the existence of new CT overloads on HttpContent.

