### PR TITLE
Use ProjectReference to build against System.Private.CoreLib

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/coreclr/src/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -6,7 +6,7 @@
     <GenerateResxSourceOmitGetResourceString>true</GenerateResxSourceOmitGetResourceString>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <EnsureRuntimePackageDependencies>false</EnsureRuntimePackageDependencies>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
 
     <!-- Ensure a portable PDB is emitted for the project. A PDB is needed for crossgen. -->
     <DebugType>Portable</DebugType>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -253,6 +253,10 @@
     <NetStandard21RefPath>$([MSBuild]::NormalizeDirectory('$(RefRootPath)', 'netstandard2.1'))</NetStandard21RefPath>
     <NetFxRefPath>$([MSBuild]::NormalizeDirectory('$(RefRootPath)', '$(NetFrameworkCurrent)'))</NetFxRefPath>
 
+    <!-- System.Private.CoreLib -->
+    <CoreLibProject Condition="'$(RuntimeFlavor)' == 'CoreCLR'">$([MSBuild]::NormalizePath('$(CoreClrProjectRoot)', 'src', 'System.Private.CoreLib', 'System.Private.CoreLib.csproj'))</CoreLibProject>
+    <CoreLibProject Condition="'$(RuntimeFlavor)' == 'Mono'">$([MSBuild]::NormalizePath('$(MonoProjectRoot)', 'netcore', 'System.Private.CoreLib', 'System.Private.CoreLib.csproj'))</CoreLibProject>
+
     <!-- Helix properties -->
     <OSPlatformConfig>$(TargetOS).$(Platform).$(Configuration)</OSPlatformConfig>
     <AnyOSPlatformConfig>AnyOS.AnyCPU.$(Configuration)</AnyOSPlatformConfig>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -1,4 +1,4 @@
-<Project InitialTargets="AddSkipGetTargetFrameworkToProjectReferences">
+<Project InitialTargets="UpdateProjectReferencesWithAttributes">
   <PropertyGroup>
     <RefPath>$([MSBuild]::NormalizeDirectory('$(RefRootPath)', '$(TargetFramework)'))</RefPath>  
   </PropertyGroup>
@@ -184,10 +184,12 @@
   <!-- Define this target to override the workaround in arcade as we don't need it for our pkgprojs -->
   <Target Name="InitializeStandardNuspecProperties" />
 
-  <Target Name="AddSkipGetTargetFrameworkToProjectReferences" Condition="'@(ProjectReference)' != ''">
+  <Target Name="UpdateProjectReferencesWithAttributes" Condition="'@(ProjectReference)' != ''">
     <ItemGroup>
       <ProjectReference>
         <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+        <AdditionalProperties Condition="'%(Filename)' == 'System.Private.CoreLib' and '$(RuntimeFlavor)' == 'CoreCLR'">Configuration=$(CoreCLRConfiguration);TargetFramework=$(NetCoreAppCurrent)</AdditionalProperties>
+        <AdditionalProperties Condition="'%(Filename)' == 'System.Private.CoreLib' and '$(RuntimeFlavor)' == 'Mono'">Configuration=$(MonoConfiguration);TargetFramework=$(NetCoreAppCurrent)</AdditionalProperties>
       </ProjectReference>
     </ItemGroup>
   </Target>

--- a/src/libraries/System.AppContext/src/System.AppContext.csproj
+++ b/src/libraries/System.AppContext/src/System.AppContext.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Buffers/src/System.Buffers.csproj
+++ b/src/libraries/System.Buffers/src/System.Buffers.csproj
@@ -7,6 +7,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/libraries/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -22,7 +22,7 @@
              Link="System\Collections\Concurrent\IProducerConsumerCollectionDebugView.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
     <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Tracing\src\System.Diagnostics.Tracing.csproj" />
     <ProjectReference Include="..\..\System.Threading\src\System.Threading.csproj" />

--- a/src/libraries/System.Collections/src/System.Collections.csproj
+++ b/src/libraries/System.Collections/src/System.Collections.csproj
@@ -33,6 +33,6 @@
              Link="Common\System\Collections\Generic\EnumerableHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Contracts/src/System.Diagnostics.Contracts.csproj
+++ b/src/libraries/System.Diagnostics.Contracts/src/System.Diagnostics.Contracts.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/libraries/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <DefaultReferenceExclusions Include="System.Diagnostics.Debug" />
     <DefaultReferenceExclusions Include="System.Runtime.Extensions" />
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" Private="false" />
     <ReferenceFromRuntime Include="System.Runtime" />
     <ReferenceFromRuntime Include="System.Threading" />
   </ItemGroup>

--- a/src/libraries/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
+++ b/src/libraries/System.Diagnostics.StackTrace/src/System.Diagnostics.StackTrace.csproj
@@ -34,6 +34,6 @@
     <ProjectReference Include="..\..\System.Collections.Immutable\src\System.Collections.Immutable.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
+++ b/src/libraries/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
+++ b/src/libraries/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.csproj
@@ -61,6 +61,6 @@
     <ProjectReference Include="..\..\System.Threading\src\System.Threading.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/libraries/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
+++ b/src/libraries/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Globalization/src/System.Globalization.csproj
+++ b/src/libraries/System.Globalization/src/System.Globalization.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/libraries/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Memory/src/System.Memory.csproj
+++ b/src/libraries/System.Memory/src/System.Memory.csproj
@@ -38,6 +38,6 @@
              Link="Common\System\Buffers\ArrayBufferWriter.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
+++ b/src/libraries/System.Numerics.Vectors/src/System.Numerics.Vectors.csproj
@@ -5,6 +5,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/libraries/System.Private.Uri/src/System.Private.Uri.csproj
@@ -43,6 +43,6 @@
     <Compile Include="System\Uri.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.Emit.ILGeneration/src/System.Reflection.Emit.ILGeneration.csproj
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/src/System.Reflection.Emit.ILGeneration.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.Emit.Lightweight/src/System.Reflection.Emit.Lightweight.csproj
+++ b/src/libraries/System.Reflection.Emit.Lightweight/src/System.Reflection.Emit.Lightweight.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
+++ b/src/libraries/System.Reflection.Emit/src/System.Reflection.Emit.csproj
@@ -5,6 +5,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.Primitives/src/System.Reflection.Primitives.csproj
+++ b/src/libraries/System.Reflection.Primitives/src/System.Reflection.Primitives.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.csproj
+++ b/src/libraries/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.csproj
@@ -11,6 +11,6 @@
     <Compile Include="System\Reflection\TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection/src/System.Reflection.csproj
+++ b/src/libraries/System.Reflection/src/System.Reflection.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
+++ b/src/libraries/System.Resources.ResourceManager/src/System.Resources.ResourceManager.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/libraries/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -11,6 +11,6 @@
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/libraries/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -50,6 +50,6 @@
     <Compile Include="System\Security\SecureStringMarshal.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Intrinsics/src/System.Runtime.Intrinsics.csproj
+++ b/src/libraries/System.Runtime.Intrinsics/src/System.Runtime.Intrinsics.csproj
@@ -5,6 +5,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Loader/src/System.Runtime.Loader.csproj
+++ b/src/libraries/System.Runtime.Loader/src/System.Runtime.Loader.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
@@ -58,7 +58,7 @@
              Link="Common\System\Collections\HashHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
     <ProjectReference Include="..\..\System.Runtime.CompilerServices.Unsafe\src\System.Runtime.CompilerServices.Unsafe.ilproj" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Collections\src\System.Collections.csproj" />

--- a/src/libraries/System.Runtime/src/System.Runtime.csproj
+++ b/src/libraries/System.Runtime/src/System.Runtime.csproj
@@ -16,6 +16,6 @@
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Security.Principal/src/System.Security.Principal.csproj
+++ b/src/libraries/System.Security.Principal/src/System.Security.Principal.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
+++ b/src/libraries/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Text.Encoding/src/System.Text.Encoding.csproj
+++ b/src/libraries/System.Text.Encoding/src/System.Text.Encoding.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
+++ b/src/libraries/System.Threading.Overlapped/src/System.Threading.Overlapped.csproj
@@ -7,6 +7,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/libraries/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -5,6 +5,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.Tasks/src/System.Threading.Tasks.csproj
+++ b/src/libraries/System.Threading.Tasks/src/System.Threading.Tasks.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.Thread/src/System.Threading.Thread.csproj
+++ b/src/libraries/System.Threading.Thread/src/System.Threading.Thread.csproj
@@ -7,6 +7,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
+++ b/src/libraries/System.Threading.ThreadPool/src/System.Threading.ThreadPool.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading.Timer/src/System.Threading.Timer.csproj
+++ b/src/libraries/System.Threading.Timer/src/System.Threading.Timer.csproj
@@ -6,6 +6,6 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Threading/src/System.Threading.csproj
+++ b/src/libraries/System.Threading/src/System.Threading.csproj
@@ -18,6 +18,6 @@
              Link="Common\System\HResults.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Utf8String.Experimental/src/System.Utf8String.Experimental.csproj
+++ b/src/libraries/System.Utf8String.Experimental/src/System.Utf8String.Experimental.csproj
@@ -132,7 +132,7 @@
     <Reference Include="System.Security.Cryptography.Algorithms" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
-    <ReferenceFromRuntime Include="System.Private.CoreLib" />
+    <ProjectReference Include="$(CoreLibProject)" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Primitives" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />

--- a/src/libraries/shims/manual/Directory.Build.props
+++ b/src/libraries/shims/manual/Directory.Build.props
@@ -17,14 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ReferencePath
-      Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.Win32.*.dll;$(RuntimePath)netstandard.dll"
-      Exclude="$(RuntimePath)$(MSBuildProjectName).dll" />
+    <ReferencePath Include="$(RuntimePath)System.*.dll;$(RuntimePath)Microsoft.Win32.*.dll;$(RuntimePath)netstandard.dll"
+                   Exclude="$(RuntimePath)$(MSBuildProjectName).dll" />
+    <ProjectReference Include="$(CoreLibProject)" />
   </ItemGroup>
-
-  <Target Name="AddSystemPrivateCoreLibReferencePath" DependsOnTargets="GetFilesFromRuntime" BeforeTargets="ResolveReferences">
-    <ItemGroup>
-      <ReferencePath Include="@(RuntimeFiles)" Condition="'%(FileName)%(Extension)' == 'System.Private.CoreLib.dll'" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -8,7 +8,7 @@
     <GenerateResxSourceOmitGetResourceString>true</GenerateResxSourceOmitGetResourceString>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
     <EnsureRuntimePackageDependencies>false</EnsureRuntimePackageDependencies>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <EnablePInvokeAnalyzer>false</EnablePInvokeAnalyzer>
 
     <!-- Ensure a portable PDB is emitted for the project. A PDB is needed for crossgen. -->


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/36464
Fixes https://github.com/dotnet/runtime/issues/37963

Validated System.Private.CoreLib's ability to build incrementally (fast).