### PR TITLE
Improve correctness of SslStream.IsEncrypted

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -476,7 +476,7 @@ namespace System.Net.Security
             }
         }
 
-        public override bool IsEncrypted => IsAuthenticated;
+        public override bool IsEncrypted => IsAuthenticated && CipherAlgorithm != CipherAlgorithmType.Null;
 
         public override bool IsSigned => IsAuthenticated;
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -68,6 +68,7 @@ namespace System.Net.Security.Tests
                     CipherAlgorithmType expected = CipherAlgorithmType.Null;
                     Assert.Equal(expected, sslStream.CipherAlgorithm);
                     Assert.Equal(0, sslStream.CipherStrength);
+                    Assert.False(sslStream.IsEncrypted);
                 }
             }
         }
@@ -93,6 +94,7 @@ namespace System.Net.Security.Tests
                         CipherAlgorithmType expected = CipherAlgorithmType.Null;
                         Assert.Equal(expected, sslStream.CipherAlgorithm);
                         Assert.Equal(0, sslStream.CipherStrength);
+                        Assert.False(sslStream.IsEncrypted);
                     }
                     else
                     {


### PR DESCRIPTION
I bump to this while looking at some other issues. [Documention](https://docs.microsoft.com/en-us/dotnet/api/system.net.security.sslstream.isencrypted?view=net-5.0) claim this returns true if data are encrypted before transmission.

Currently, this returns true if handshake was completed. Hover that does not ensures encryption. Encryption can be explicitly disabled using `EncryptionPolicy.NoEncryption` or it can be negotiated if null encryption is allowed. In such case, data are segmented into TLS frames but data are transmitted in clear text without encryption. 

This may be technically breaking change and we may mark it as such.
Alternatively we should document that IsEncrypted can return true in some cases when data are not encrypted. 
