### PR TITLE
Fix PEFile::GetAssemblyLoadContext during early runtime stages

### DIFF
--- a/src/coreclr/src/vm/appdomain.cpp
+++ b/src/coreclr/src/vm/appdomain.cpp
@@ -4472,9 +4472,9 @@ AppDomain::RaiseUnhandledExceptionEvent(OBJECTREF *pThrowable, BOOL isTerminatin
 
 #endif // CROSSGEN_COMPILE
 
-IUnknown *AppDomain::CreateBinderContext()
+CLRPrivBinderCoreCLR *AppDomain::CreateBinderContext()
 {
-    CONTRACT(IUnknown *)
+    CONTRACT(CLRPrivBinderCoreCLR *)
     {
         GC_TRIGGERS;
         THROWS;
@@ -4492,11 +4492,6 @@ IUnknown *AppDomain::CreateBinderContext()
 
         // Initialize the assembly binder for the default context loads for CoreCLR.
         IfFailThrow(CCoreCLRBinderHelper::DefaultBinderSetupContext(DefaultADID, &m_pTPABinderContext));
-
-        // Since the PEAssembly for the System.Private.CoreLib.dll is created before the binder (the AssemblyLoadContext),
-        // we need to update the AssemblyLoadContext pointer in that PEAssembly now. For other assemblies, it is
-        // set in the PEFile constructor.
-        SystemDomain::SystemFile()->SetupAssemblyLoadContext();
     }
 
     RETURN m_pTPABinderContext;

--- a/src/coreclr/src/vm/appdomain.hpp
+++ b/src/coreclr/src/vm/appdomain.hpp
@@ -2036,7 +2036,7 @@ public:
         return m_tpIndex;
     }
 
-    IUnknown *CreateBinderContext();
+    CLRPrivBinderCoreCLR *CreateBinderContext();
 
     void SetIgnoreUnhandledExceptions()
     {

--- a/src/coreclr/src/vm/pefile.cpp
+++ b/src/coreclr/src/vm/pefile.cpp
@@ -2349,7 +2349,7 @@ void PEFile::SetupAssemblyLoadContext()
 
     m_pAssemblyLoadContext = (pOpaqueBinder != NULL) ?
         (AssemblyLoadContext*)pOpaqueBinder :
-        AppDomain::GetCurrentDomain()->GetTPABinderContext();
+        AppDomain::GetCurrentDomain()->CreateBinderContext();
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/src/vm/pefile.h
+++ b/src/coreclr/src/vm/pefile.h
@@ -581,11 +581,13 @@ public:
 
 #endif //!DACCESS_COMPILE
 
+    // Returns AssemblyLoadContext into which the current PEFile was loaded.
+    // It returns NULL for System.Private.CoreLib during early runtime initialization
+    // stage when the related AssemblyLoadContext does not exist yet.
     PTR_AssemblyLoadContext GetAssemblyLoadContext()
     {
         LIMITED_METHOD_CONTRACT;
 
-        _ASSERTE(m_pAssemblyLoadContext != NULL);
         return m_pAssemblyLoadContext;
     }
 

--- a/src/coreclr/src/vm/pefile.h
+++ b/src/coreclr/src/vm/pefile.h
@@ -582,12 +582,11 @@ public:
 #endif //!DACCESS_COMPILE
 
     // Returns AssemblyLoadContext into which the current PEFile was loaded.
-    // It returns NULL for System.Private.CoreLib during early runtime initialization
-    // stage when the related AssemblyLoadContext does not exist yet.
     PTR_AssemblyLoadContext GetAssemblyLoadContext()
     {
         LIMITED_METHOD_CONTRACT;
 
+        _ASSERTE(m_pAssemblyLoadContext != NULL);
         return m_pAssemblyLoadContext;
     }
 

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -504,10 +504,6 @@ static NativeImage *AcquireCompositeImage(Module * pModule, PEImageLayout * pLay
     if (ownerCompositeExecutableName != NULL)
     {
         AssemblyLoadContext *loadContext = pModule->GetFile()->GetAssemblyLoadContext();
-        if (loadContext == nullptr)
-        {
-            loadContext = (AssemblyLoadContext *)AppDomain::GetCurrentDomain()->CreateBinderContext();
-        }
         return loadContext->LoadNativeImage(pModule, ownerCompositeExecutableName);
     }
     


### PR DESCRIPTION
The PEFile::GetAssemblyLoadContext was asserting if it was called before
the m_pTPABinderContext was created in AppDomain::CreateBinderContext.
That turned out to be a problem for a check performed in
ReadyToRunInfo::Initialize.

This change calls AppDomain::CreateBinderContext from the
PEFile::SetupAssemblyLoadContext instead of calling
AppDomain::GetTPABinderContext. That ensures that the
PEFile::GetAssemblyLoadContext can always return valid
AssemblyLoadContext.