### PR TITLE
Fix Assertion failed 'rhs != UninitVal()'

### DIFF
--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -7369,6 +7369,12 @@ void Compiler::fgCreateLoopPreHeader(unsigned lnum)
     preHead->inheritWeight(head);
     preHead->bbFlags &= ~BBF_PROF_WEIGHT;
 
+    // Copy the bbReach set from head for the new preHead block
+    preHead->bbReach = BlockSetOps::MakeEmpty(this);
+    BlockSetOps::Assign(this, preHead->bbReach, head->bbReach);
+    // Also include 'head' in the preHead bbReach set
+    BlockSetOps::AddElemD(this, preHead->bbReach, head->bbNum);
+
 #ifdef DEBUG
     if (verbose)
     {

--- a/src/coreclr/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b539509/b539509.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b539509/b539509.csproj
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
-    <JitOptimizationSensitive>True</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Issue was a preHeader block that was inserted and later compacted with the previous block
and we had a null value for bbReach during compaction.

Fixes #35413