### PR TITLE
[libraries] Add IsThreadingSupported for System.Threading.Timer

### DIFF
--- a/src/libraries/System.Threading.Timer/tests/TimerChangeTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerChangeTests.cs
@@ -49,7 +49,7 @@ namespace System.Threading.Tests
             Assert.Throws<ObjectDisposedException>(() => t.Change(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(1)));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(2)]

--- a/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
+++ b/src/libraries/System.Threading.Timer/tests/TimerFiringTests.cs
@@ -17,7 +17,7 @@ namespace System.Threading.Tests
     {
         internal const int MaxPositiveTimeoutInMs = 30000;
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Timer_Fires_After_DueTime_Ellapses()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -31,7 +31,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Timer_Fires_AndPassesStateThroughCallback()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -47,7 +47,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Timer_Fires_AndPassesNullStateThroughCallback()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -122,7 +122,7 @@ namespace System.Threading.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Timer_CanDisposeSelfInCallback()
         {
             Timer t = null;
@@ -149,7 +149,7 @@ namespace System.Threading.Tests
                 t.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void NonRepeatingTimer_ThatHasAlreadyFired_CanChangeAndFireAgain()
         {
             AutoResetEvent are = new AutoResetEvent(false);
@@ -163,7 +163,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void MultpleTimers_PeriodicTimerIsntBlockedByBlockedCallback()
         {
             int callbacks = 2;
@@ -183,7 +183,7 @@ namespace System.Threading.Tests
             GC.KeepAlive(t);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void ManyTimers_EachTimerDoesFire()
         {
             int maxTimers = 10000;
@@ -200,7 +200,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Timer_Constructor_CallbackOnly_Change()
         {
             var e = new ManualResetEvent(false);
@@ -217,7 +217,7 @@ namespace System.Threading.Tests
             Assert.Throws<ArgumentNullException>(() => new Timer(s => { }).Dispose(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Timer_Dispose_WaitHandle()
         {
             int tickCount = 0;


### PR DESCRIPTION
There were several threading related test failures when running library tests for wasm on helix [here](https://helix.dot.net/api/2019-06-17/jobs/2319ad98-f1d9-421d-acb6-14fb3dc2d6bd/workitems/System.Threading.Timer.Tests/console) that were missed. 
This PR looks to skip these tests by making changes similar to #38089 and #37822