### PR TITLE
[wasm]Don't assume SharedArrayBuffer exists.

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -36,7 +36,8 @@ var BindingSupportLib = {
 			DataView.prototype[Symbol.for("wasm type")] = 3;
 			Function.prototype[Symbol.for("wasm type")] =  4;
 			Map.prototype[Symbol.for("wasm type")] = 5;
-			SharedArrayBuffer.prototype[Symbol.for("wasm type")] =  6;
+			if (typeof SharedArrayBuffer !== "undefined")
+				SharedArrayBuffer.prototype[Symbol.for("wasm type")] =  6;
 			Int8Array.prototype[Symbol.for("wasm type")] = 10;
 			Uint8Array.prototype[Symbol.for("wasm type")] = 11;
 			Uint8ClampedArray.prototype[Symbol.for("wasm type")] = 12;


### PR DESCRIPTION
This is quick fix to avoid errors on js hosts where SharedArrayBuffer doesn't exist for the next preview.  A more extensive cleanup of registration will follow.