### PR TITLE
Changing RAX to none for consistency

### DIFF
--- a/src/coreclr/src/tools/r2rdump/Extensions.cs
+++ b/src/coreclr/src/tools/r2rdump/Extensions.cs
@@ -209,7 +209,7 @@ namespace R2RDump
                 writer.WriteLine($"Flags:              0x{amd64UnwindInfo.Flags:X2}{parsedFlags}");
                 writer.WriteLine($"SizeOfProlog:       0x{amd64UnwindInfo.SizeOfProlog:X4}");
                 writer.WriteLine($"CountOfUnwindCodes: {amd64UnwindInfo.CountOfUnwindCodes}");
-                writer.WriteLine($"FrameRegister:      {amd64UnwindInfo.FrameRegister}");
+                writer.WriteLine($"FrameRegister:      {((amd64UnwindInfo.FrameRegister == 0) ? "None" : amd64UnwindInfo.FrameRegister.ToString())}");
                 writer.WriteLine($"FrameOffset:        0x{amd64UnwindInfo.FrameOffset}");
                 if (!options.Naked)
                 {


### PR DESCRIPTION
In runtime/src/coreclr/src/jit/unwindamd64.cpp line 516
frame register is printed as none if it is RAX,
made a change in extensions.cs to reflect this