### PR TITLE
Binder tracing tests: only track loads that tests are interested in

### DIFF
--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.Basic.cs
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.Basic.cs
@@ -98,7 +98,7 @@ namespace BinderTracingTests
             };
         }
 
-        [BinderTest(isolate: true)]
+        [BinderTest(isolate: true, additionalLoadsToTrack: new string[] { "System.Xml" })]
         public static BindOperation LoadFromAssemblyName()
         {
             AssemblyName assemblyName = new AssemblyName("System.Xml");
@@ -136,7 +136,7 @@ namespace BinderTracingTests
             };
         }
 
-        [BinderTest(isolate: true)]
+        [BinderTest(isolate: true, additionalLoadsToTrack: new string[] { "System.Xml" })]
         public static BindOperation PlatformAssembly()
         {
             var assemblyName = new AssemblyName("System.Xml");
@@ -164,7 +164,7 @@ namespace BinderTracingTests
             };
         }
 
-        [BinderTest(isolate: true, testSetup: nameof(PlatformAssembly))]
+        [BinderTest(isolate: true, testSetup: nameof(PlatformAssembly), additionalLoadsToTrack: new string[] { "System.Xml" })]
         public static BindOperation PlatformAssembly_Cached()
         {
             BindOperation bind = PlatformAssembly();

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.DefaultProbing.cs
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.DefaultProbing.cs
@@ -70,7 +70,7 @@ namespace BinderTracingTests
         //   KnownPathProbed : AppPaths             (EXE)   [COR_E_FILENOTFOUND]
         // Note: corerun always sets APP_PATH and APP_NI_PATH. In regular use cases,
         // the customer would have to explicitly configure the app to set those.
-        [BinderTest]
+        [BinderTest(additionalLoadsToTrack: new string[] { "DoesNotExist" })]
         public static BindOperation NonExistentAssembly()
         {
             string assemblyName = "DoesNotExist";

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.EventHandlers.cs
@@ -71,7 +71,7 @@ namespace BinderTracingTests
             }
         }
 
-        [BinderTest]
+        [BinderTest(additionalLoadsToTrack: new string[] { SubdirectoryAssemblyName + "Mismatch" })]
         public static BindOperation AssemblyLoadContextResolving_NameMismatch()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
@@ -98,7 +98,7 @@ namespace BinderTracingTests
         public static BindOperation AssemblyLoadContextResolving_MultipleHandlers()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
-            CustomALC alc = new CustomALC(nameof(AssemblyLoadContextResolving_NameMismatch));
+            CustomALC alc = new CustomALC(nameof(AssemblyLoadContextResolving_MultipleHandlers));
             using (var handlerNull = new Handlers(HandlerReturn.Null, alc))
             using (var handlerLoad = new Handlers(HandlerReturn.RequestedAssembly, alc))
             {
@@ -175,7 +175,7 @@ namespace BinderTracingTests
             }
         }
 
-        [BinderTest]
+        [BinderTest(additionalLoadsToTrack: new string[] { SubdirectoryAssemblyName + "Mismatch" })]
         public static BindOperation AppDomainAssemblyResolve_NameMismatch()
         {
             var assemblyName = new AssemblyName(SubdirectoryAssemblyName);
@@ -229,7 +229,7 @@ namespace BinderTracingTests
             }
         }
 
-        [BinderTest(isolate: true)]
+        [BinderTest(isolate: true, additionalLoadsToTrack: new string[] { "AssemblyToLoadDependency" })]
         public static BindOperation AssemblyLoadFromResolveHandler_LoadDependency()
         {
             string assemblyPath = Helpers.GetAssemblyInSubdirectoryPath(SubdirectoryAssemblyName);
@@ -268,7 +268,7 @@ namespace BinderTracingTests
             };
         }
 
-        [BinderTest(isolate: true)]
+        [BinderTest(isolate: true, additionalLoadsToTrack: new string[] { "AssemblyToLoadDependency" })]
         public static BindOperation AssemblyLoadFromResolveHandler_MissingDependency()
         {
             string appPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);

--- a/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.cs
+++ b/src/coreclr/tests/src/Loader/binding/tracing/BinderTracingTest.ResolutionFlow.cs
@@ -181,7 +181,7 @@ namespace BinderTracingTests
         //   ResolutionAttempted : ApplicationAssemblies                (DefaultALC)    [MismatchedAssemblyName]
         //   ResolutionAttempted : AssemblyLoadContextResolvingEvent    (DefaultALC)    [AssemblyNotFound]
         //   ResolutionAttempted : AppDomainAssemblyResolveEvent        (DefaultALC)    [AssemblyNotFound]
-        [BinderTest(isolate: true)]
+        [BinderTest(isolate: true, additionalLoadsToTrack: new string[] { DependentAssemblyName + "_Copy" } )]
         public static BindOperation ApplicationAssemblies_MismatchedAssemblyName()
         {
             var assemblyName = new AssemblyName($"{DependentAssemblyName}_Copy, Culture=neutral, PublicKeyToken=null");
@@ -273,7 +273,7 @@ namespace BinderTracingTests
         //   ResolutionAttempted : FindInLoadContext                    (DefaultALC)    [AssemblyNotFound]
         //   ResolutionAttempted : ApplicationAssemblies                (DefaultALC)    [Success]
         //   ResolutionAttempted : DefaultAssemblyLoadContextFallback   (CustomALC)     [Success]
-        [BinderTest(isolate: true)]
+        [BinderTest(isolate: true, additionalLoadsToTrack: new string[] { "System.Xml" })]
         public static BindOperation DefaultAssemblyLoadContextFallback()
         {
             var assemblyName = new AssemblyName("System.Xml");


### PR DESCRIPTION
The binder tracing tests run multiple tests and use separate event listeners for each test. It is possible for a listener to be created after a load (that is not one we are testing) has started. This change makes the listener only track tracing of the loads that are being tested.

Resolves #38121