### PR TITLE
Fix link to corehost build requirements on Windows

### DIFF
--- a/src/coreclr/setup_vs_tools.cmd
+++ b/src/coreclr/setup_vs_tools.cmd
@@ -21,16 +21,16 @@ if defined VisualStudioVersion (
     goto skip_setup
 )
 
-echo %__MsgPrefix%Searching ^for Visual Studio 2017 or later installation
+echo %__MsgPrefix%Searching ^for Visual Studio installation
 set _VSWHERE="%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
 if exist %_VSWHERE% (
     for /f "usebackq tokens=*" %%i in (`%_VSWHERE% -latest -prerelease -property installationPath`) do set _VSCOMNTOOLS=%%i\Common7\Tools
     goto call_vs
 )
-echo Visual Studio 2017 or later not found
+
 :call_vs
 if not exist "%_VSCOMNTOOLS%" (
-    echo %__MsgPrefix%Error: Visual Studio 2017 or 2019 required.
+    echo %__MsgPrefix%Error: Visual Studio 2019 required.
     echo        Please see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/windows-requirements.md for build instructions.
     exit /b 1
 )

--- a/src/installer/corehost/build.cmd
+++ b/src/installer/corehost/build.cmd
@@ -64,8 +64,8 @@ if "%VisualStudioVersion%"=="16.0" (
 )
 
 :MissingVersion
-:: Can't find VS 2017, 2019
-echo Error: Visual Studio 2017 or 2019 required
+:: Can't find required VS install
+echo Error: Visual Studio 2019 required
 echo        Please see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/windows-requirements.md for build requirements.
 exit /b 1
 

--- a/src/installer/corehost/build.cmd
+++ b/src/installer/corehost/build.cmd
@@ -66,7 +66,7 @@ if "%VisualStudioVersion%"=="16.0" (
 :MissingVersion
 :: Can't find VS 2017, 2019
 echo Error: Visual Studio 2017 or 2019 required
-echo        Please see https://github.com/dotnet/runtime/tree/master/docs/installer/building/windows-instructions.md for build instructions.
+echo        Please see https://github.com/dotnet/runtime/blob/master/docs/workflow/requirements/windows-requirements.md for build requirements.
 exit /b 1
 
 :VS2019

--- a/src/libraries/Native/build-native.cmd
+++ b/src/libraries/Native/build-native.cmd
@@ -67,8 +67,8 @@ if "%VisualStudioVersion%"=="16.0" (
 )
 
 :MissingVersion
-:: Can't find VS 2017, 2019
-echo Error: Visual Studio 2017 or 2019 required
+:: Can't find appropriate VS install
+echo Error: Visual Studio 2019 required
 echo        Please see https://github.com/dotnet/runtime/tree/master/docs/workflow/building/libraries for build instructions.
 exit /b 1
 


### PR DESCRIPTION
The error is shown on VS not being installed. Make the link point to the doc for installation requirements for building.

Resolves #34116