### PR TITLE
add DebuggerDisplay attribute to ProcessStartInfo

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Win32.cs
@@ -47,17 +47,7 @@ namespace System.Diagnostics
             if (startInfo._environmentVariables != null)
                 throw new InvalidOperationException(SR.CantUseEnvVars);
 
-            string arguments;
-            if (startInfo.ArgumentList.Count > 0)
-            {
-                StringBuilder sb = new StringBuilder();
-                Process.AppendArguments(sb, startInfo.ArgumentList);
-                arguments = sb.ToString();
-            }
-            else
-            {
-                arguments = startInfo.Arguments;
-            }
+            string arguments = startInfo.BuildArguments();
 
             fixed (char* fileName = startInfo.FileName.Length > 0 ? startInfo.FileName : null)
             fixed (char* verb = startInfo.Verb.Length > 0 ? startInfo.Verb : null)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -460,8 +460,8 @@ namespace System.Diagnostics
             //    * CreateProcess allows you to redirect all or none of the standard IO handles, so we use
             //      GetStdHandle for the handles that are not being redirected
 
-            StringBuilder commandLine = BuildCommandLine(startInfo.FileName, StartInfo.Arguments);
-            Process.AppendArguments(commandLine, StartInfo.ArgumentList);
+            StringBuilder commandLine = BuildCommandLine(startInfo.FileName);
+            startInfo.AppendArguments(commandLine);
 
             Interop.Kernel32.STARTUPINFO startupInfo = default;
             Interop.Kernel32.PROCESS_INFORMATION processInfo = default;
@@ -668,7 +668,7 @@ namespace System.Diagnostics
 
         private bool _signaled;
 
-        private static StringBuilder BuildCommandLine(string executableFileName, string arguments)
+        private static StringBuilder BuildCommandLine(string executableFileName)
         {
             // Construct a StringBuilder with the appropriate command line
             // to pass to CreateProcess.  If the filename isn't already
@@ -677,7 +677,7 @@ namespace System.Diagnostics
             // is the file to execute).
             StringBuilder commandLine = new StringBuilder();
             string fileName = executableFileName.Trim();
-            bool fileNameIsQuoted = (fileName.StartsWith('\"') && fileName.EndsWith('\"'));
+            bool fileNameIsQuoted = fileName.StartsWith('\"') && fileName.EndsWith('\"');
             if (!fileNameIsQuoted)
             {
                 commandLine.Append('"');
@@ -688,12 +688,6 @@ namespace System.Diagnostics
             if (!fileNameIsQuoted)
             {
                 commandLine.Append('"');
-            }
-
-            if (!string.IsNullOrEmpty(arguments))
-            {
-                commandLine.Append(' ');
-                commandLine.Append(arguments);
             }
 
             return commandLine;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -460,8 +460,7 @@ namespace System.Diagnostics
             //    * CreateProcess allows you to redirect all or none of the standard IO handles, so we use
             //      GetStdHandle for the handles that are not being redirected
 
-            StringBuilder commandLine = BuildCommandLine(startInfo.FileName);
-            startInfo.AppendArguments(commandLine);
+            StringBuilder commandLine = BuildCommandLine(startInfo);
 
             Interop.Kernel32.STARTUPINFO startupInfo = default;
             Interop.Kernel32.PROCESS_INFORMATION processInfo = default;
@@ -668,7 +667,7 @@ namespace System.Diagnostics
 
         private bool _signaled;
 
-        private static StringBuilder BuildCommandLine(string executableFileName)
+        private static StringBuilder BuildCommandLine(ProcessStartInfo startInfo)
         {
             // Construct a StringBuilder with the appropriate command line
             // to pass to CreateProcess.  If the filename isn't already
@@ -676,7 +675,7 @@ namespace System.Diagnostics
             // problems (it specifies exactly which part of the string
             // is the file to execute).
             StringBuilder commandLine = new StringBuilder();
-            string fileName = executableFileName.Trim();
+            string fileName = startInfo.FileName.Trim();
             bool fileNameIsQuoted = fileName.StartsWith('\"') && fileName.EndsWith('\"');
             if (!fileNameIsQuoted)
             {
@@ -689,6 +688,8 @@ namespace System.Diagnostics
             {
                 commandLine.Append('"');
             }
+
+            startInfo.AppendArguments(commandLine);
 
             return commandLine;
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -689,7 +689,7 @@ namespace System.Diagnostics
                 commandLine.Append('"');
             }
 
-            startInfo.AppendArguments(commandLine);
+            startInfo.AppendArgumentsTo(commandLine);
 
             return commandLine;
         }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -675,8 +675,8 @@ namespace System.Diagnostics
             // problems (it specifies exactly which part of the string
             // is the file to execute).
             StringBuilder commandLine = new StringBuilder();
-            string fileName = startInfo.FileName.Trim();
-            bool fileNameIsQuoted = fileName.StartsWith('\"') && fileName.EndsWith('\"');
+            ReadOnlySpan<char> fileName = startInfo.FileName.AsSpan().Trim();
+            bool fileNameIsQuoted = fileName.Length > 0 && fileName[0] == '\"' && fileName[fileName.Length - 1] == '\"';
             if (!fileNameIsQuoted)
             {
                 commandLine.Append('"');

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1610,17 +1610,6 @@ namespace System.Diagnostics
             }
         }
 
-        private static void AppendArguments(StringBuilder stringBuilder, Collection<string> argumentList)
-        {
-            if (argumentList.Count > 0)
-            {
-                foreach (string argument in argumentList)
-                {
-                    PasteArguments.AppendArgument(stringBuilder, argument);
-                }
-            }
-        }
-
         /// <summary>
         /// This enum defines the operation mode for redirected process stream.
         /// We don't support switching between synchronous mode and asynchronous mode.

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -171,7 +171,7 @@ namespace System.Diagnostics
 
         internal string BuildArguments()
         {
-            if (_argumentList == null || ArgumentList.Count == 0)
+            if (_argumentList == null || _argumentList.Count == 0)
             {
                 return Arguments;
             }
@@ -185,9 +185,9 @@ namespace System.Diagnostics
 
         internal void AppendArgumentsTo(StringBuilder stringBuilder)
         {
-            if (_argumentList != null && ArgumentList.Count > 0)
+            if (_argumentList != null && _argumentList.Count > 0)
             {
-                foreach (string argument in ArgumentList)
+                foreach (string argument in _argumentList)
                 {
                     PasteArguments.AppendArgument(stringBuilder, argument);
                 }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -178,7 +178,7 @@ namespace System.Diagnostics
 
         internal void AppendArguments(StringBuilder stringBuilder)
         {
-            if (ArgumentList.Count > 0)
+            if (_argumentList != null && ArgumentList.Count > 0)
             {
                 foreach (string argument in ArgumentList)
                 {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -171,9 +171,16 @@ namespace System.Diagnostics
 
         internal string BuildArguments()
         {
-            var stringBuilder = new StringBuilder();
-            AppendArguments(stringBuilder);
-            return stringBuilder.ToString();
+            if (_argumentList == null || ArgumentList.Count == 0)
+            {
+                return Arguments;
+            }
+            else
+            {
+                var stringBuilder = new StringBuilder();
+                AppendArguments(stringBuilder);
+                return stringBuilder.ToString();
+            }
         }
 
         internal void AppendArguments(StringBuilder stringBuilder)

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics
     ///     used in conjunction with the <see cref='System.Diagnostics.Process'/>
     ///     component.
     /// </devdoc>
-    [DebuggerDisplay(@"FileName=""{FileName}"", Arguments=""{BuildArguments()}"", WorkingDirectory=""{WorkingDirectory}""")]
+    [DebuggerDisplay("FileName={FileName}, Arguments={BuildArguments()}, WorkingDirectory={WorkingDirectory}")]
     public sealed partial class ProcessStartInfo
     {
         private string? _fileName;

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -178,12 +178,12 @@ namespace System.Diagnostics
             else
             {
                 var stringBuilder = new StringBuilder();
-                AppendArguments(stringBuilder);
+                AppendArgumentsTo(stringBuilder);
                 return stringBuilder.ToString();
             }
         }
 
-        internal void AppendArguments(StringBuilder stringBuilder)
+        internal void AppendArgumentsTo(StringBuilder stringBuilder)
         {
             if (_argumentList != null && ArgumentList.Count > 0)
             {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -16,6 +16,7 @@ namespace System.Diagnostics
     ///     used in conjunction with the <see cref='System.Diagnostics.Process'/>
     ///     component.
     /// </devdoc>
+    [DebuggerDisplay("FileName={FileName}, Arguments={BuildArguments()}, WorkingDirectory={WorkingDirectory}")]
     public sealed partial class ProcessStartInfo
     {
         private string? _fileName;
@@ -165,6 +166,33 @@ namespace System.Diagnostics
                 }
 
                 _windowStyle = value;
+            }
+        }
+
+        internal string BuildArguments()
+        {
+            var stringBuilder = new StringBuilder();
+            AppendArguments(stringBuilder);
+            return stringBuilder.ToString();
+        }
+
+        internal void AppendArguments(StringBuilder stringBuilder)
+        {
+            if (ArgumentList.Count > 0)
+            {
+                foreach (string argument in ArgumentList)
+                {
+                    PasteArguments.AppendArgument(stringBuilder, argument);
+                }
+            }
+            else if (!string.IsNullOrEmpty(Arguments))
+            {
+                if (stringBuilder.Length > 0)
+                {
+                    stringBuilder.Append(' ');
+                }
+
+                stringBuilder.Append(Arguments);
             }
         }
     }

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics
     ///     used in conjunction with the <see cref='System.Diagnostics.Process'/>
     ///     component.
     /// </devdoc>
-    [DebuggerDisplay("FileName={FileName}, Arguments={BuildArguments()}, WorkingDirectory={WorkingDirectory}")]
+    [DebuggerDisplay(@"FileName=""{FileName}"", Arguments=""{BuildArguments()}"", WorkingDirectory=""{WorkingDirectory}""")]
     public sealed partial class ProcessStartInfo
     {
         private string? _fileName;


### PR DESCRIPTION
In #27251 @kichalla wrote:

> For diagnostic purposes, I was looking to print out the actual command that was used to create the process. i.e I would like to see the command after any of its arguments were escaped etc.

I've [asked](https://github.com/dotnet/runtime/issues/27251#issuecomment-648109937) whether this is needed for debugging or logging. The answer was both, but "DebuggerDisplay should be enough."

I don't think we are going to have time to discuss this new API for 5.0 (due to deadlines), so for now we can add `DebuggerDisplay` (I hope it's not a breaking change) and work on extending `Process` API with `CommandLine` property (https://github.com/dotnet/runtime/issues/21941) for 6.0

@eiriktsarpalis @kichalla what do you think?

Before:

![obraz](https://user-images.githubusercontent.com/6011991/85422803-4b297d00-b576-11ea-864b-aacec6ba33d7.png)

After:

![obraz](https://user-images.githubusercontent.com/6011991/85422895-63010100-b576-11ea-8ff6-8964f143bdbd.png)

<details>

```cs
using System.Diagnostics;

namespace NumaStart
{
    class Program
    {
        static void Main(string[] args)
        {
            if (!Debugger.IsAttached)
            {
                Debugger.Launch();
            }

            Process.Start(GetProcessStartInfo(@"C:\Windows\System32\notepad.exe", 0, 8, args));
        }

        static ProcessStartInfo GetProcessStartInfo(string fileName, uint group, uint mask, params string[] arguments)
        {
            var startInfo = new ProcessStartInfo("cmd.exe");

            startInfo.ArgumentList.Add("/c");
            startInfo.ArgumentList.Add("start");
            startInfo.ArgumentList.Add("/NODE");
            startInfo.ArgumentList.Add(group.ToString());
            startInfo.ArgumentList.Add("/AFFINITY");
            startInfo.ArgumentList.Add(mask.ToString("X2"));
            startInfo.ArgumentList.Add(fileName);

            foreach (var argument in arguments)
            {
                startInfo.ArgumentList.Add(argument);
            }

            return startInfo;
        }
    }
}
```

</details>