### PR TITLE
WASM: Ensure we rerun autogen.sh and configure with emconfigure set

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -40,7 +40,7 @@
   </PropertyGroup>
 
   <!-- OSX/iOS/tvOS/Android/Linux Mono runtime build -->
-  <Target Name="ConfigureMonoRuntimeUnix" Condition="'$(OS)' != 'Windows_NT'" Inputs="$(MonoProjectRoot)configure.ac" Outputs="$(MonoObjDir)config.h;$(CrossConfigH)">
+  <Target Name="ConfigureMonoRuntimeUnix" Condition="'$(OS)' != 'Windows_NT'" Inputs="$(MonoProjectRoot)configure.ac;$(MonoProjectRoot)configure" Outputs="$(MonoObjDir)config.h;$(CrossConfigH)">
 
     <!-- Sanity checks -->
     <Error Condition="'$(TargetstvOS)' == 'true' and '$(Platform)' != 'x64' and '$(Platform)' != 'arm64'" Text="Error: Invalid platform for $(TargetOS): $(Platform)." />


### PR DESCRIPTION
When the `configure` file is touched the autotools build will rerun it without the `emconfigure` wrapper like we do in mono.proj.
This means instead of emscripten's `ar` or `ranlib` we're getting the system tools instead, causing compilation errors like:

```
libmono-icall-table.a: archive is missing an index; Use emar when creating libraries to ensure an index is created
```

Fix this by adding a dependency on configure as well so we rerun the whole autogen.sh process.