### PR TITLE
[5.0-preview7] Bring back IO.AccessControl ref assemblies & expose 5.0 ref assemblies

### DIFF
--- a/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -1,14 +1,15 @@
 <Project DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
   <ItemGroup>
-    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj">
+    <ProjectReference Include="..\ref\System.IO.Pipes.AccessControl.csproj">
       <SupportedFramework>$(NetCoreAppCurrent)</SupportedFramework>
     </ProjectReference>
-    <HarvestIncludePaths Include="lib/net46;runtimes/win/lib/net46" />
-    <HarvestIncludePaths Include="lib/net461;runtimes/win/lib/net461" />
-    <HarvestIncludePaths Include="lib/netstandard1.3" />
-    <HarvestIncludePaths Include="lib/netstandard2.0" />
+    <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
+    <HarvestIncludePaths Include="ref/net461;lib/net461;runtimes/win/lib/net461" />
+    <HarvestIncludePaths Include="ref/netstandard1.3;lib/netstandard1.3" />
+    <HarvestIncludePaths Include="ref/netstandard2.0;lib/netstandard2.0" />
     <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.1" />
+    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/pkg/System.IO.Pipes.AccessControl.pkgproj
@@ -4,12 +4,12 @@
     <ProjectReference Include="..\ref\System.IO.Pipes.AccessControl.csproj">
       <SupportedFramework>$(NetCoreAppCurrent)</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
     <HarvestIncludePaths Include="ref/net46;lib/net46;runtimes/win/lib/net46" />
     <HarvestIncludePaths Include="ref/net461;lib/net461;runtimes/win/lib/net461" />
     <HarvestIncludePaths Include="ref/netstandard1.3;lib/netstandard1.3" />
     <HarvestIncludePaths Include="ref/netstandard2.0;lib/netstandard2.0" />
     <HarvestIncludePaths Include="runtimes/win/lib/netcoreapp2.1" />
-    <ProjectReference Include="..\src\System.IO.Pipes.AccessControl.csproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/ref/System.IO.Pipes.AccessControl.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
@@ -9,5 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\System.Security.AccessControl\ref\System.Security.AccessControl.csproj" />
     <ProjectReference Include="..\..\System.Security.Principal.Windows\ref\System.Security.Principal.Windows.csproj" />
+    <ProjectReference Include="..\..\System.IO.Pipes\ref\System.IO.Pipes.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
+++ b/src/libraries/System.IO.Pipes.AccessControl/src/System.IO.Pipes.AccessControl.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>System.IO.Pipes.AccessControl</AssemblyName>
+    <IncludeDefaultReferences>false</IncludeDefaultReferences>
     <IsPartialFacadeAssembly Condition="'$(TargetsWindows)' == 'true'">true</IsPartialFacadeAssembly>
     <OmitResources Condition="'$(TargetsWindows)' == 'true'">true</OmitResources>
     <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsWindows)' != 'true'">SR.PlatformNotSupported_AccessControl</GeneratePlatformNotSupportedAssemblyMessage>
-    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;netcoreapp2.1;$(NetCoreAppCurrent)</TargetFrameworks>
+    <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludeDefaultReferences Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">false</IncludeDefaultReferences>
-    <AssemblyVersion Condition="'$(TargetFramework)' == 'netcoreapp2.1'">4.0.3.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.Runtime" />
@@ -17,9 +16,6 @@
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <ProjectReference Include="..\..\System.IO.Pipes\src\System.IO.Pipes.csproj" />
     <ProjectReference Include="..\..\System.Security.AccessControl\src\System.Security.AccessControl.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <Reference Include="System.Resources.ResourceManager" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' != 'true'">
     <Reference Include="System.IO.Pipes" />


### PR DESCRIPTION
Backporting this change that is already in master: https://github.com/dotnet/runtime/pull/38252

cc @ericstj @safern @joperezr @Anipik 
