### PR TITLE
[Test] temporarily disable the reverse eventpipe test

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -2,6 +2,9 @@
 <Project DefaultTargets = "GetListOfTestCmds" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- All OS/Arch/Runtime excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverse/*">
+            <Issue>https://github.com/dotnet/runtime/issues/38156</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracecontrol/tracecontrol/*">
             <Issue>https://github.com/dotnet/runtime/issues/11204</Issue>
         </ExcludeList>


### PR DESCRIPTION
Temporarily disabling the reverse eventpipe tests until failure is solved.

#38156 tracks work for solution.

CC #38284 @jaredpar @jashook @sywhang