### PR TITLE
Fix solution restore in libraries

### DIFF
--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- For solution restore, msbuild doesn't honor the property set in Directory.Build.props. -->
+    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37358

VS doesn't honor the `RestoreUseStaticGraphEvaluation` set in a Directory.Build.props import as that file isn't imported in a solution. Specifying the property in a `Directory.Solution.props` file which is imported in a solution uses static graph restore and fixes the restore issue.