### PR TITLE
Disable Bundle_can_be_renamed_while_running test

### DIFF
--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleRename.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleRename.cs
@@ -23,6 +23,7 @@ namespace AppHost.Bundle.Tests
         }
 
         [Theory]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/38013")]
         [InlineData(true)]  // Test renaming the single-exe when contents are extracted
         [InlineData(false)] // Test renaming the single-exe when contents are not extracted 
         private void Bundle_can_be_renamed_while_running(bool testExtraction)


### PR DESCRIPTION
Disable the test due to non-deterministic failure in the CI.
Enabling tracked by: #38013

Fixes: #35068