### PR TITLE
[mono] Add Apple Silicon support

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -449,6 +449,9 @@ case "$host" in
 				platform_ios=yes
 				has_dtrace=no
 				;;
+			aarch64*-darwinmacos*)
+				support_boehm=no
+				;;
 			aarch64*-darwin*)
 				platform_ios=yes
 				;;
@@ -4657,6 +4660,16 @@ case "$host" in
 		# assuming no other target other than watchOS is using aarch64*darwin triple
 		TARGET_SYS=WATCHOS
 		;;
+	aarch64-*-darwinmacos*)
+		TARGET_SYS=MACOS
+		TARGET=ARM64
+		arch_target=arm64
+		boehm_supported=false
+		AOT_SUPPORTED="yes"
+		BTLS_SUPPORTED=yes
+		BTLS_PLATFORM=aarch64
+		AC_CHECK_HEADER(stdalign.h,[],[BTLS_SUPPORTED=no])
+		;;
 	aarch64-*)
 		# https://lkml.org/lkml/2012/7/15/133
 		TARGET=ARM64
@@ -4984,7 +4997,7 @@ if test "x$target_mach" = "xyes"; then
 	  CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_WATCHOS"
 	  CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_WATCHOS"
 	  BTLS_SUPPORTED=no
-   elif test "x$TARGET" = "xARM" -o "x$TARGET" = "xARM64" -o "x$TARGET" = "xARM6432"; then
+   elif test "x$TARGET" = "xARM" -o "x$TARGET" = "xARM6432"; then
    	  AC_DEFINE(TARGET_IOS,1,[The JIT/AOT targets iOS])
 	  CPPFLAGS_FOR_LIBGC="$CPPFLAGS_FOR_LIBGC -DTARGET_IOS"
 	  CFLAGS_FOR_LIBGC="$CFLAGS_FOR_LIBGC -DTARGET_IOS"

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -329,7 +329,10 @@ mono_gc_run_finalize (void *obj, void *data)
 		mono_runtime_try_invoke (finalizer, o, params, &exc, error);
 	}
 #else
-	runtime_invoke (o, NULL, &exc, NULL);
+	{
+		MONO_SCOPE_ENABLE_JIT_EXEC ();
+		runtime_invoke (o, NULL, &exc, NULL);
+	}
 #endif
 
 	MONO_PROFILER_RAISE (gc_finalized_object, (o));

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -12293,7 +12293,7 @@ compile_asm (MonoAotCompile *acfg)
 #elif defined(__ppc__) && defined(TARGET_MACH)
 #define LD_NAME "gcc"
 #define LD_OPTIONS "-dynamiclib -Wl,-Bsymbolic"
-#elif defined(TARGET_AMD64) && defined(TARGET_MACH)
+#elif (defined(TARGET_AMD64) || (defined(TARGET_ARM64) && defined(TARGET_OSX))) && defined(TARGET_MACH)
 #define LD_NAME "clang"
 #define LD_OPTIONS "--shared"
 #elif defined(TARGET_WIN32_MSVC)

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -4741,7 +4741,10 @@ init_method (MonoAotModule *amodule, gpointer info, guint32 method_index, MonoMe
 				if (ji->type == MONO_PATCH_INFO_METHOD_JUMP)
 					addr = mono_create_ftnptr (domain, addr);
 				mono_memory_barrier ();
-				got [got_slots [pindex]] = addr;
+				{
+					MONO_SCOPE_ENABLE_JIT_WRITE ();
+					got [got_slots [pindex]] = addr;
+				}
 				if (ji->type == MONO_PATCH_INFO_METHOD_JUMP)
 					register_jump_target_got_slot (domain, ji->data.method, &(got [got_slots [pindex]]));
 

--- a/src/mono/mono/mini/exceptions-arm64.c
+++ b/src/mono/mono/mini/exceptions-arm64.c
@@ -35,6 +35,7 @@ mono_arch_get_restore_context (MonoTrampInfo **info, gboolean aot)
 
 	size = 256;
 	code = start = mono_global_codeman_reserve (size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	arm_movx (code, ARMREG_IP0, ARMREG_R0);
 	ctx_reg = ARMREG_IP0;
@@ -84,6 +85,7 @@ mono_arch_get_call_filter (MonoTrampInfo **info, gboolean aot)
 
 	size = 512;
 	start = code = mono_global_codeman_reserve (size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* Compute stack frame size and offsets */
 	offset = 0;
@@ -170,6 +172,7 @@ get_throw_trampoline (int size, gboolean corlib, gboolean rethrow, gboolean llvm
 	int i, offset, gregs_offset, fregs_offset, frame_size, num_fregs;
 
 	code = start = mono_global_codeman_reserve (size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* We are being called by JITted code, the exception object/type token is in R0 */
 

--- a/src/mono/mono/mini/mini-arm64.c
+++ b/src/mono/mono/mini/mini-arm64.c
@@ -114,6 +114,8 @@ get_delegate_invoke_impl (gboolean has_target, gboolean param_count, guint32 *co
 {
 	guint8 *code, *start;
 
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	if (has_target) {
 		start = code = mono_global_codeman_reserve (12);
 
@@ -5349,6 +5351,7 @@ mono_arch_build_imt_trampoline (MonoVTable *vtable, MonoDomain *domain, MonoIMTC
 	else
 		buf = mono_domain_code_reserve (domain, buf_len);
 	code = buf;
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/*
 	 * We are called by JITted code, which passes in the IMT argument in

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1460,8 +1460,11 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 			}
 		}
 
-		for (i = 0; i < patch_info->data.table->table_size; i++) {
-			jump_table [i] = code + GPOINTER_TO_INT (patch_info->data.table->table [i]);
+		{
+			MONO_SCOPE_ENABLE_JIT_WRITE ();
+			for (i = 0; i < patch_info->data.table->table_size; i++) {
+				jump_table [i] = code + GPOINTER_TO_INT (patch_info->data.table->table [i]);
+			}
 		}
 
 		target = jump_table;
@@ -2692,6 +2695,8 @@ lookup_start:
 gpointer
 mono_jit_compile_method (MonoMethod *method, MonoError *error)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	gpointer code;
 
 	code = mono_jit_compile_method_with_opt (method, mono_get_optimizations_for_method (method, default_opt), FALSE, error);
@@ -3384,6 +3389,7 @@ mono_jit_runtime_invoke (MonoMethod *method, void *obj, void **params, MonoObjec
 		if (!is_ok (error))
 			return NULL;
 	} else {
+		MONO_SCOPE_ENABLE_JIT_EXEC();
 		runtime_invoke = (MonoObject *(*)(MonoObject *, void **, MonoObject **, void *))info->runtime_invoke;
 
 		result = runtime_invoke ((MonoObject *)obj, params, exc, info->compiled_method);

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -2158,6 +2158,8 @@ mono_codegen (MonoCompile *cfg)
 	MonoDomain *code_domain;
 	guint unwindlen = 0;
 
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	if (mono_using_xdebug)
 		/*
 		 * Recent gdb versions have trouble processing symbol files containing
@@ -3077,6 +3079,8 @@ is_simd_supported (MonoCompile *cfg)
 MonoCompile*
 mini_method_compile (MonoMethod *method, guint32 opts, MonoDomain *domain, JitFlags flags, int parts, int aot_method_index)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	MonoMethodHeader *header;
 	MonoMethodSignature *sig;
 	MonoCompile *cfg;

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -3016,4 +3016,5 @@ mono_arch_load_function (MonoJitICallId jit_icall_id);
 MonoGenericContext
 mono_get_generic_context_from_stack_frame (MonoJitInfo *ji, gpointer generic_info);
 
+
 #endif /* __MONO_MINI_H__ */

--- a/src/mono/mono/mini/tramp-arm64.c
+++ b/src/mono/mono/mini/tramp-arm64.c
@@ -30,6 +30,8 @@
 void
 mono_arch_patch_callsite (guint8 *method_start, guint8 *code_ptr, guint8 *addr)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	mono_arm_patch (code_ptr - 4, addr, MONO_R_ARM64_BL);
 	mono_arch_flush_icache (code_ptr - 4, 4);
 }
@@ -103,6 +105,7 @@ mono_arch_create_generic_trampoline (MonoTrampolineType tramp_type, MonoTrampInf
 
 	buf_len = 768;
 	buf = code = mono_global_codeman_reserve (buf_len);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/*
 	 * We are getting called by a specific trampoline, ip1 contains the trampoline argument.
@@ -325,6 +328,7 @@ mono_arch_create_specific_trampoline (gpointer arg1, MonoTrampolineType tramp_ty
 	 * Pass the argument in ip1, clobbering ip0.
 	 */
 	tramp = mono_get_trampoline_code (tramp_type);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	buf = code = mono_domain_code_reserve (domain, buf_len);
 
@@ -351,6 +355,8 @@ mono_arch_get_unbox_trampoline (MonoMethod *m, gpointer addr)
 	MonoDomain *domain = mono_domain_get ();
 
 	start = code = mono_domain_code_reserve (domain, size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_addx_imm (code, ARMREG_R0, ARMREG_R0, MONO_ABI_SIZEOF (MonoObject));
 	arm_brx (code, ARMREG_IP0);
@@ -369,6 +375,8 @@ mono_arch_get_static_rgctx_trampoline (gpointer arg, gpointer addr)
 	MonoDomain *domain = mono_domain_get ();
 
 	start = code = mono_domain_code_reserve (domain, buf_len);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	code = mono_arm_emit_imm64 (code, MONO_ARCH_RGCTX_REG, (guint64)arg);
 	code = mono_arm_emit_imm64 (code, ARMREG_IP0, (guint64)addr);
 	arm_brx (code, ARMREG_IP0);
@@ -408,6 +416,7 @@ mono_arch_create_rgctx_lazy_fetch_trampoline (guint32 slot, MonoTrampInfo **info
 
 	buf_size = 64 + 16 * depth;
 	code = buf = mono_global_codeman_reserve (buf_size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	rgctx_null_jumps = g_malloc0 (sizeof (guint8*) * (depth + 2));
 	njumps = 0;
@@ -495,6 +504,7 @@ mono_arch_create_general_rgctx_lazy_fetch_trampoline (MonoTrampInfo **info, gboo
 	tramp_size = 32;
 
 	code = buf = mono_global_codeman_reserve (tramp_size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	mono_add_unwind_op_def_cfa (unwind_ops, code, buf, ARMREG_SP, 0);
 
@@ -534,6 +544,7 @@ mono_arch_create_sdb_trampoline (gboolean single_step, MonoTrampInfo **info, gbo
 	MonoJumpInfo *ji = NULL;
 
 	code = buf = mono_global_codeman_reserve (tramp_size);
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* Compute stack frame size and offsets */
 	offset = 0;
@@ -632,6 +643,8 @@ mono_arch_get_interp_to_native_trampoline (MonoTrampInfo **info)
 
 	buf_len = 512 + 1024;
 	start = code = (guint8 *) mono_global_codeman_reserve (buf_len);
+	
+	MONO_SCOPE_ENABLE_JIT_WRITE();
 
 	/* allocate frame */
 	framesize += 2 * sizeof (host_mgreg_t);

--- a/src/mono/mono/mini/unwind.c
+++ b/src/mono/mono/mini/unwind.c
@@ -551,6 +551,8 @@ mono_unwind_frame (guint8 *unwind_info, guint32 unwind_info_len,
 				   host_mgreg_t **save_locations, int save_locations_len,
 				   guint8 **out_cfa)
 {
+	MONO_SCOPE_ENABLE_JIT_WRITE();
+
 	Loc locations [NUM_HW_REGS];
 	guint8 reg_saved [NUM_HW_REGS];
 	int pos, reg, hwreg, cfa_reg = -1, cfa_offset = 0, offset;

--- a/src/mono/mono/utils/mono-codeman.c
+++ b/src/mono/mono/utils/mono-codeman.c
@@ -29,6 +29,11 @@ static void* mono_code_manager_heap;
 #include <mono/utils/mono-os-mutex.h>
 
 
+#if defined(__APPLE__) && defined(__arm64__)
+__thread jit_protect_mode arm_current_jit_protect_mode = JPM_NONE;
+#endif
+
+
 static uintptr_t code_memory_used = 0;
 static size_t dynamic_code_alloc_count;
 static size_t dynamic_code_bytes_count;

--- a/src/mono/mono/utils/mono-codeman.h
+++ b/src/mono/mono/utils/mono-codeman.h
@@ -7,6 +7,73 @@
 
 #include <mono/utils/mono-publib.h>
 
+#if defined(__APPLE__) && defined(__arm64__)
+
+#include <pthread.h>
+
+typedef enum {
+	JPM_NONE,
+	JPM_ENABLED,
+	JPM_DISABLED,
+} jit_protect_mode;
+
+extern __thread jit_protect_mode arm_current_jit_protect_mode;
+
+static void mono_arm_jit_write_protect_enable()
+{
+	if (__builtin_available(macOS 11, *)) {
+		if (arm_current_jit_protect_mode != JPM_ENABLED) {
+			pthread_jit_write_protect_np(1);
+			arm_current_jit_protect_mode = JPM_ENABLED;
+		}
+	}
+}
+
+static void mono_arm_jit_write_protect_disable()
+{
+	if (__builtin_available(macOS 11, *)) {
+		if (arm_current_jit_protect_mode != JPM_DISABLED) {
+			pthread_jit_write_protect_np(0);
+			arm_current_jit_protect_mode = JPM_DISABLED;
+		}
+	}
+}
+
+#define MONO_SCOPE_ENABLE_JIT_WRITE()					\
+	__attribute__((unused, cleanup(mono_arm_restore_jit_protect_mode))) \
+	jit_protect_mode scope_restrict_mode = arm_current_jit_protect_mode; \
+        mono_arm_jit_write_protect_disable();					\
+
+#define MONO_SCOPE_ENABLE_JIT_EXEC()					\
+	__attribute__((unused, cleanup(mono_arm_restore_jit_protect_mode))) \
+	jit_protect_mode scope_restrict_mode = arm_current_jit_protect_mode; \
+	mono_arm_jit_write_protect_enable();				\
+
+static void mono_arm_restore_jit_protect_mode(jit_protect_mode* previous_jit_protect_mode)
+{
+	if (*previous_jit_protect_mode == arm_current_jit_protect_mode)
+		return;
+
+	switch (*previous_jit_protect_mode)
+	{
+	case JPM_ENABLED:
+		mono_arm_jit_write_protect_enable();
+		break;
+	case JPM_DISABLED:
+	case JPM_NONE:
+	default:
+		mono_arm_jit_write_protect_disable();
+	}
+}
+
+#else
+#define MONO_SCOPE_ENABLE_JIT_WRITE()
+#define MONO_SCOPE_ENABLE_JIT_EXEC()
+
+static void mono_arm_jit_write_protect_enable() {}
+static void mono_arm_jit_write_protect_disable() {}
+#endif
+
 typedef struct _MonoCodeManager MonoCodeManager;
 
 #define MONO_CODE_MANAGER_CALLBACKS \

--- a/src/mono/mono/utils/mono-dl.h
+++ b/src/mono/mono/utils/mono-dl.h
@@ -15,7 +15,7 @@
 #define MONO_SOLIB_EXT ".dylib"
 #elif defined(TARGET_MACH) && defined(TARGET_X86)
 #define MONO_SOLIB_EXT ".dylib"
-#elif defined(TARGET_MACH) && defined(TARGET_AMD64)
+#elif defined(TARGET_MACH) && (defined(TARGET_AMD64) || (defined(TARGET_AMD64) && defined(TARGET_OSX)))
 #define MONO_SOLIB_EXT ".dylib"
 #else
 #define MONO_SOLIB_EXT ".so"


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20014,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Contributed by Apple

The original contributed patch was against a relatively old version of Mono.

In particular, mono_arch_get_enter_icall_trampoline was renamed to mono_arch_get_interp_to_native_trampoline in
mono/mono@60b180d24f32b0879d729bc47a3cf92d5a0ba25e

Also the original patch contained subsets of mono/mono@bc787a8a0105e96630597dda72fbbe4df4a3c71c and mono/mono@a86062cef0e0c9c0109dd6f376f5458d4870aa33 which are already in mono master.


---

I haven't tried compiling or running this code yet.  Need to get Xcode 12 set up for the latter, and get some hardware for the former.  But we can at least start discussing the design.

---

TODO:
- [ ] Audit all uses of `mono_global_codeman_reserve` to make sure that `MONO_SCOPE_ENABLE_JIT_WRITE();` is called
