### PR TITLE
Port signature type system unit test

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="ILDisassemblerTests.cs" />
     <Compile Include="InterfacesTests.cs" />
     <Compile Include="RuntimeDeterminedTypesTests.cs" />
+    <Compile Include="SignatureTests.cs" />
     <Compile Include="SyntheticVirtualOverrideTests.cs" />
     <Compile Include="TestMetadataFieldLayoutAlgorithm.cs" />
     <Compile Include="TypeNameParsingTests.cs" />

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/ILTestAssembly.ilproj
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/ILTestAssembly.ilproj
@@ -16,6 +16,7 @@
     <Compile Include="InstanceFieldLayout.il" />
     <Compile Include="StaticFieldLayout.il" />
     <Compile Include="VirtualFunctionOverride.il" />
+    <Compile Include="Signature.il" />
   </ItemGroup>
 
 </Project>

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/Signature.il
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/Signature.il
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.class private auto ansi beforefieldinit Atom
+       extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method I::.ctor
+
+} // end of class Atom
+
+.class private auto ansi beforefieldinit A`1<U>
+       extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method A`1::.ctor
+
+} // end of class A`1
+
+.class private auto ansi beforefieldinit BaseClass`2<U,T>
+       extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig newslot virtual 
+          instance void  Method(!U u,
+                                !T modopt (FooModifier) t) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method BaseClass`2::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method BaseClass`2::.ctor
+
+} // end of class BaseClass`2
+
+.class private auto ansi beforefieldinit DerivedClass
+       extends class BaseClass`2<class A`1<class Atom>,class Atom>
+{
+  .method public hidebysig virtual instance void 
+          Method(class A`1<class Atom> u,
+                 class Atom modopt (FooModifier) t) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method DerivedClass::Method
+
+  .method public hidebysig virtual instance void 
+          Method(class A`1<class Atom> u,
+                 class Atom t) cil managed
+  {
+    // Code size       2 (0x2)
+    .maxstack  8
+    IL_0000:  nop
+    IL_0001:  ret
+  } // end of method DerivedClass::Method
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void class BaseClass`2<class A`1<class Atom>,class Atom>::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method DerivedClass::.ctor
+
+} // end of DerivedClass
+
+.class public FooModifier { }
+.class public BarModifier { }

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Internal.IL;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public class SignatureTests
+    {
+        private TestTypeSystemContext _context;
+        private ModuleDesc _testModule;
+
+        public SignatureTests()
+        {
+            _context = new TestTypeSystemContext(TargetArchitecture.X64);
+            var systemModule = _context.CreateModuleForSimpleName("CoreTestAssembly");
+            _context.SetSystemModule(systemModule);
+
+            _testModule = _context.GetModuleForSimpleName("ILTestAssembly");
+        }
+
+        [Fact]
+        public void TestSignatureMatches()
+        {
+            MetadataType atomType = _testModule.GetType("", "Atom");
+            MetadataType aType = _testModule.GetType("", "A`1");
+            MetadataType aOfAtomType = aType.MakeInstantiatedType(new Instantiation(atomType));
+
+
+            MetadataType baseClassType = _testModule.GetType("", "BaseClass`2");
+            MethodDesc baseClassMethod = baseClassType.GetMethods().Single(m => string.Equals(m.Name, "Method"));
+            MethodSignature baseClassMethodSignature = baseClassMethod.Signature;
+            MethodSignatureBuilder matchingSignatureBuilder = new MethodSignatureBuilder(baseClassMethodSignature);
+            matchingSignatureBuilder[0] = aOfAtomType;
+            matchingSignatureBuilder[1] = atomType;
+            MethodSignature matchingSignature = matchingSignatureBuilder.ToSignature();
+
+            MetadataType derivedClassType = _testModule.GetType("", "DerivedClass");
+            IEnumerable<MethodDesc> derivedClassMethods = derivedClassType.GetMethods().Where(m => string.Equals(m.Name, "Method"));
+            IEnumerable<bool> matches = derivedClassMethods.Select(m => matchingSignature.Equals(m.Signature));
+            int matchCount = matches.Select(b => b ? 1 : 0).Sum();
+            Assert.Equal(1, matchCount);
+        }
+    }
+}


### PR DESCRIPTION
Restore and port Andrew's signature tests that had been reverted last year, originally from https://github.com/dotnet/corert/commit/5575cc060201ad462809f48db25a56c35e4eaca0