### PR TITLE
Experimental changes to try and capture dumps from CI

### DIFF
--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -619,6 +619,11 @@ CONFIG_DWORD_INFO(INTERNAL_OSR_HighId, W("OSR_HighId"), 10000000, "High end of e
 #endif
 
 ///
+/// Hack
+///
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_ExpectedExitCode, W("ExpectedExitCode"), 0, "expected process exit code");
+
+///
 /// Profile Guided Opts
 ///
 #ifdef FEATURE_PGO

--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -389,6 +389,19 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
             }
         }
 
+#if _DEBUG
+        if (pReturnValue)
+        {
+            // Hack, reusing existing config value
+            DWORD expectedValue = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_ExpectedExitCode);
+
+            if (expectedValue != 16)
+            {
+                _ASSERTE(*pReturnValue == expectedValue);
+            }
+        }
+#endif
+
         GCPROTECT_END();
     }
 

--- a/src/coreclr/src/vm/corhost.cpp
+++ b/src/coreclr/src/vm/corhost.cpp
@@ -395,7 +395,7 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
             // Hack, reusing existing config value
             DWORD expectedValue = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_ExpectedExitCode);
 
-            if (expectedValue != 16)
+            if (expectedValue != 0)
             {
                 _ASSERTE(*pReturnValue == expectedValue);
             }

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -118,24 +118,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/mono/runningmono/*">
             <Issue>This test is to verify we are running mono, and therefore only makes sense on mono.</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32_Target_32Bit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64/*">
-            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof_Target_32Bit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_relsizeof32_Target_32Bit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_relsizeof64_Target_32Bit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/xxobj/sizeof/_il_relsizeof_Target_32Bit/*">
-            <Issue>https://github.com/dotnet/runtime/issues/37470</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All Unix targets on all runtimes -->

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32_Target_32Bit.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32_Target_32Bit.ilproj
@@ -10,4 +10,14 @@
   <ItemGroup>
     <Compile Include="sizeof32.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_ExpectedExitCode=64
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_ExpectedExitCode=64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64.ilproj
@@ -11,4 +11,14 @@
     <Compile Condition="'$(TargetArchitecture)' == 'x86'" Include="sizeof64.il" />
     <Compile Condition="'$(TargetArchitecture)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_ExpectedExitCode=64
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_ExpectedExitCode=64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof_Target_32Bit.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof_Target_32Bit.ilproj
@@ -10,4 +10,14 @@
   <ItemGroup>
     <Compile Include="sizeof.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_ExpectedExitCode=64
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_ExpectedExitCode=64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32_Target_32Bit.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32_Target_32Bit.ilproj
@@ -10,4 +10,14 @@
   <ItemGroup>
     <Compile Include="sizeof32.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_ExpectedExitCode=64
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_ExpectedExitCode=64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
 </Project>

--- a/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof_Target_32Bit.ilproj
+++ b/src/coreclr/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof_Target_32Bit.ilproj
@@ -10,4 +10,14 @@
   <ItemGroup>
     <Compile Include="sizeof.il" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_ExpectedExitCode=64
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_ExpectedExitCode=64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
These tests don't fail outside of CI and don't crash. So I'm adding the
ability to assert that we see a particular exit code.