### PR TITLE
Adjust stack level while calculating offset for Vector.getElement

### DIFF
--- a/src/coreclr/src/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/src/jit/simdcodegenxarch.cpp
@@ -2151,11 +2151,9 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
                 // Adjust the offset by the amount currently pushed on the CPU stack
                 offset += genStackLevel;
             }
-            else
+#else
+            assert(genStackLevel == 0);
 #endif // !FEATURE_FIXED_OUT_ARGS
-            {
-                assert(genStackLevel == 0);
-            }
 
             if (op1->OperGet() == GT_LCL_FLD)
             {
@@ -2214,11 +2212,9 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
             // Adjust the offset by the amount currently pushed on the CPU stack
             offs += genStackLevel;
         }
-        else
+#else
+        assert(genStackLevel == 0);
 #endif // !FEATURE_FIXED_OUT_ARGS
-        {
-            assert(genStackLevel == 0);
-        }
 
         regNumber indexReg = op2->GetRegNum();
 

--- a/src/coreclr/src/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/src/jit/simdcodegenxarch.cpp
@@ -2144,6 +2144,19 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
             bool     isEBPbased;
             unsigned varNum = op1->AsLclVarCommon()->GetLclNum();
             offset += compiler->lvaFrameAddress(varNum, &isEBPbased);
+
+#if !FEATURE_FIXED_OUT_ARGS
+            if (!isEBPbased)
+            {
+                // Adjust the offset by the amount currently pushed on the CPU stack
+                offset += genStackLevel;
+            }
+            else
+#endif // !FEATURE_FIXED_OUT_ARGS
+            {
+                assert(genStackLevel == 0);
+            }
+
             if (op1->OperGet() == GT_LCL_FLD)
             {
                 offset += op1->AsLclFld()->GetLclOffs();
@@ -2195,8 +2208,17 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
         bool     isEBPbased;
         unsigned offs = compiler->lvaFrameAddress(simdInitTempVarNum, &isEBPbased);
 
-        // Adjust the offset with stack level, if any.
-        offs += genStackLevel;
+#if !FEATURE_FIXED_OUT_ARGS
+        if (!isEBPbased)
+        {
+            // Adjust the offset by the amount currently pushed on the CPU stack
+            offs += genStackLevel;
+        }
+        else
+#endif // !FEATURE_FIXED_OUT_ARGS
+        {
+            assert(genStackLevel == 0);
+        }
 
         regNumber indexReg = op2->GetRegNum();
 

--- a/src/coreclr/src/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/src/jit/simdcodegenxarch.cpp
@@ -2194,6 +2194,10 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
         noway_assert(simdInitTempVarNum != BAD_VAR_NUM);
         bool      isEBPbased;
         unsigned  offs     = compiler->lvaFrameAddress(simdInitTempVarNum, &isEBPbased);
+
+        // Adjust the offset with stack level, if any.
+        offs += genStackLevel;
+
         regNumber indexReg = op2->GetRegNum();
 
         // Store the vector to the temp location.

--- a/src/coreclr/src/jit/simdcodegenxarch.cpp
+++ b/src/coreclr/src/jit/simdcodegenxarch.cpp
@@ -2192,8 +2192,8 @@ void CodeGen::genSIMDIntrinsicGetItem(GenTreeSIMD* simdNode)
     {
         unsigned simdInitTempVarNum = compiler->lvaSIMDInitTempVarNum;
         noway_assert(simdInitTempVarNum != BAD_VAR_NUM);
-        bool      isEBPbased;
-        unsigned  offs     = compiler->lvaFrameAddress(simdInitTempVarNum, &isEBPbased);
+        bool     isEBPbased;
+        unsigned offs = compiler->lvaFrameAddress(simdInitTempVarNum, &isEBPbased);
 
         // Adjust the offset with stack level, if any.
         offs += genStackLevel;

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace projs
+{
+    public class Program
+    {
+        public static int Main(string[] args)
+        {
+            Program p = new Program();
+            p.NarrowDouble();
+            Console.WriteLine("Passed.");
+            return 100;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void NarrowDouble()
+        {
+            // GenerateSource1 and GenerateSource2 methods are needed to exercise the bug code path.
+            double[] source1 = GenerateSource1();
+            double[] source2 = GenerateSource2();
+            Vector<double> sourceVec1 = new Vector<double>(source1);
+            Vector<double> sourceVec2 = new Vector<double>(source2);
+            Vector<float> dest = Vector.Narrow(sourceVec1, sourceVec2);
+
+            for (int i = 0; i < Vector<double>.Count; i++)
+            {
+                Assert.Equal(unchecked((float)source1[i]), dest[i]);
+            }
+            for (int i = 0; i < Vector<double>.Count; i++)
+            {
+                // The test represents a problem where stack level is not adjusted in the offset while trying to
+                // fetch the element of dest.
+                Assert.Equal(unchecked((float)source2[i]), dest[i + Vector<double>.Count]);
+            }
+        }
+
+        internal static double[] GenerateSource1()
+        {
+            return new double[4] { 5.1, 5.2, 5.3, 5.4 };
+        }
+        internal static double[] GenerateSource2()
+        {
+            return new double[4] { 6.1, 6.2, 6.3, 6.4 };
+        }
+    }
+}

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.cs
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.cs
@@ -36,8 +36,9 @@ namespace projs
             }
             for (int i = 0; i < Vector<double>.Count; i++)
             {
-                // The test represents a problem where stack level is not adjusted in the offset while trying to
-                // fetch the element of dest.
+                // The test represents a problem on x86 when double-alignment causes access to stack local.
+                // At that time, the stack level was not included in the offset while trying to fetch the element
+                // of dest present on stack.
                 Assert.Equal(unchecked((float)source2[i]), dest[i + Vector<double>.Count]);
             }
         }

--- a/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
+++ b/src/coreclr/tests/src/JIT/Regression/JitBlue/GitHub_36614/GitHub_36614.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set JitStreess variables, Linux requires them to be properly capitalized. -->
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitStressModeNames=STRESS_RANDOM_INLINE STRESS_DBL_ALN
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitStressModeNames=STRESS_RANDOM_INLINE STRESS_DBL_ALN
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+</Project>

--- a/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -3031,7 +3031,6 @@ namespace System.Numerics.Tests
         }
 
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/36614", RuntimeTestModes.JitStress)]
         public void NarrowDouble()
         {
             double[] source1 = GenerateRandomValuesForVector<double>();


### PR DESCRIPTION
Include stack level while calculating the offset from stack pointer when emitting `vmovss`  for getting element of SIMD intrinsic.

```asm
       3B7704       cmp      esi, dword ptr [edi+4]
       7339         jae      SHORT G_M33220_IG10
       C5FB5A44F708 vcvtsd2ss xmm0, dword ptr [edi+8*esi+8]
       83EC04       sub      esp, 4                            ; <--- stack adjustment
       C5FA110424   vmovss   dword ptr [esp], xmm0
       8D4604       lea      eax, [esi+4]
       C5FD10442430 vmovupd  ymm0, ymmword ptr[esp+2CH+04H]
       C5FD11442408 vmovupd  ymmword ptr[esp+04H+04H], ymm0
       C5FA104C8404 vmovss   xmm1, dword ptr [esp+4*eax+04H]   ; <--- doesn't include +0x4 because of stack adjustment above
       83EC04       sub      esp, 4
       C5FA110C24   vmovss   dword ptr [esp], xmm1
       E86DFAFFFF   call     Xunit.Assert:Equal(float,float)
       46           inc      esi
       EBA5         jmp      SHORT G_M33220_IG05
```

This started showing up in stress run because `STRESS_DBL_ALN` was set for the method which was forcing the stack to be stack pointer based rather than frame pointer.

Fixes: https://github.com/dotnet/runtime/issues/36614