### PR TITLE
Extend redundant zero init optimization to recognize assignments to `GT_OBJ(lcl_addr)`

### DIFF
--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9279,12 +9279,28 @@ void Compiler::optRemoveRedundantZeroInits()
                     case GT_ASG:
                     {
                         GenTreeOp* treeOp = tree->AsOp();
-                        if (!treeOp->gtOp1->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+
+                        unsigned lclNum = BAD_VAR_NUM;
+
+                        if (treeOp->gtOp1->OperIs(GT_LCL_VAR, GT_LCL_FLD))
+                        {
+                            lclNum = treeOp->gtOp1->AsLclVarCommon()->GetLclNum();
+                        }
+                        else if (treeOp->gtOp1->OperIs(GT_OBJ, GT_BLK))
+                        {
+                            GenTreeLclVarCommon* lcl = treeOp->gtOp1->gtGetOp1()->IsLocalAddrExpr();
+
+                            if (lcl != nullptr)
+                            {
+                                lclNum = lcl->GetLclNum();
+                            }
+                        }
+
+                        if (lclNum == BAD_VAR_NUM)
                         {
                             break;
                         }
 
-                        unsigned         lclNum    = treeOp->gtOp1->AsLclVarCommon()->GetLclNum();
                         LclVarDsc* const lclDsc    = lvaGetDesc(lclNum);
                         unsigned*        pRefCount = refCounts.LookupPointer(lclNum);
 


### PR DESCRIPTION
Fixes #38070.

No diffs in frameworks and benchmarks. Diffs are expected once we start using Roslyn that includes @BenAdams's change https://github.com/dotnet/roslyn/pull/45262