### PR TITLE
[Small] 2 one-line changes.

### DIFF
--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -746,7 +746,6 @@ regMaskTP GenTree::gtGetRegMask() const
 
     if (IsMultiRegCall())
     {
-        // temporarily cast away const-ness as AsCall() method is not declared const
         resultMask = genRegMask(GetRegNum());
         resultMask |= AsCall()->GetOtherRegMask();
     }

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -7078,9 +7078,7 @@ inline bool GenTree::IsMultiRegCall() const
 {
     if (this->IsCall())
     {
-        // We cannot use AsCall() as it is not declared const
-        const GenTreeCall* call = reinterpret_cast<const GenTreeCall*>(this);
-        return call->HasMultiRegRetVal();
+        return AsCall()->HasMultiRegRetVal();
     }
 
     return false;

--- a/src/coreclr/src/jit/rangecheck.cpp
+++ b/src/coreclr/src/jit/rangecheck.cpp
@@ -461,6 +461,7 @@ LclSsaVarDsc* RangeCheck::GetSsaDefAsg(GenTreeLclVarCommon* lclUse)
 
 #ifdef DEBUG
     Location* loc = GetDef(lclUse);
+    assert(loc != nullptr);
     assert(loc->parent == ssaDef->GetAssignment());
     assert(loc->block == ssaDef->GetBlock());
 #endif


### PR DESCRIPTION
These are 2 one-line changes extracted from another PR, @dotnet/jit-contrib 