### PR TITLE
StoreIND/Store_BLK/Store_OBJ improvements.

### DIFF
--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12946,7 +12946,7 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
 
     if (addr->isContained())
     {
-        assert(addr->OperGet() == GT_CLS_VAR_ADDR || addr->OperGet() == GT_LCL_VAR_ADDR || addr->OperGet() == GT_LEA);
+        assert(addr->OperIs(GT_CLS_VAR_ADDR, GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR, GT_LEA));
 
         int   offset = 0;
         DWORD lsl    = 0;
@@ -13028,6 +13028,24 @@ void emitter::emitInsLoadStoreOp(instruction ins, emitAttr attr, regNumber dataR
                 // Get a temp integer register to compute long address.
                 regNumber addrReg = indir->GetSingleTempReg();
                 emitIns_R_C(ins, attr, dataReg, addrReg, addr->AsClsVar()->gtClsVarHnd, 0);
+            }
+            else if (addr->OperIs(GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR))
+            {
+                GenTreeLclVarCommon* varNode = addr->AsLclVarCommon();
+                unsigned             lclNum  = varNode->GetLclNum();
+                unsigned             offset  = 0;
+                if (addr->OperIs(GT_LCL_FLD_ADDR))
+                {
+                    offset = varNode->AsLclFld()->GetLclOffs();
+                }
+                if (emitInsIsStore(ins))
+                {
+                    emitIns_S_R(ins, attr, dataReg, lclNum, offset);
+                }
+                else
+                {
+                    emitIns_R_S(ins, attr, dataReg, lclNum, offset);
+                }
             }
             else if (emitIns_valid_imm_for_ldst_offset(offset, emitTypeSize(indir->TypeGet())))
             {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6392,8 +6392,8 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
     }
     else
     {
-        // if `ADDR` node under `IND(struct(ADDR))` under `STORE_OBJ`
-        // is a complex one it could benefit from a not contained `LEA`.
+        // If the `ADDR` node under `STORE_OBJ(dstAddr, IND(struct(ADDR))` 
+        // is a complex one it could benefit from an `LEA` that is not contained.
         TryCreateAddrMode(ind->Addr(), false);
     }
 }

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6394,7 +6394,8 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
     {
         // If the `ADDR` node under `STORE_OBJ(dstAddr, IND(struct(ADDR))`
         // is a complex one it could benefit from an `LEA` that is not contained.
-        TryCreateAddrMode(ind->Addr(), false);
+        const bool isContainable = false;
+        TryCreateAddrMode(ind->Addr(), isContainable);
     }
 }
 
@@ -6425,7 +6426,7 @@ void Lowering::LowerBlockStoreCommon(GenTreeBlk* blkNode)
 //    true if the replacement was made, false otherwise.
 //
 // Notes:
-//    TODO-CQ: that method should do the transformation when possible
+//    TODO-CQ: this method should do the transformation when possible
 //    and STOREIND should always generate better or the same code as
 //    STORE_OBJ/BLK for the same copy.
 //

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -250,7 +250,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
             }
             __fallthrough;
         case GT_STORE_DYN_BLK:
-            LowerBlockStore(node->AsBlk());
+            LowerBlockStoreCommon(node->AsBlk());
             break;
 
         case GT_LCLHEAP:
@@ -3115,7 +3115,7 @@ void Lowering::LowerStoreLocCommon(GenTreeLclVarCommon* lclStore)
             objStore->SetAddr(addr);
             objStore->SetData(src);
             BlockRange().InsertBefore(objStore, addr);
-            LowerBlockStore(objStore);
+            LowerBlockStoreCommon(objStore);
             return;
         }
     }
@@ -3441,7 +3441,7 @@ void Lowering::LowerStoreCallStruct(GenTreeBlk* store)
 
         GenTreeLclVar* spilledCall = SpillStructCallResult(call);
         store->SetData(spilledCall);
-        LowerBlockStore(store);
+        LowerBlockStoreCommon(store);
 #endif // WINDOWS_AMD64_ABI
     }
 }
@@ -6396,4 +6396,16 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
         // is a complex one it could benefit from a not contained `LEA`.
         TryCreateAddrMode(ind->Addr(), false);
     }
+}
+
+//------------------------------------------------------------------------
+// LowerBlockStoreCommon: a common logic to lower STORE_OBJ/BLK/DYN_BLK.
+//
+// Arguments:
+//    blkNode - the store blk/obj node we are lowering.
+//
+void Lowering::LowerBlockStoreCommon(GenTreeBlk* blkNode)
+{
+    assert(blkNode->OperIs(GT_STORE_BLK, GT_STORE_DYN_BLK, GT_STORE_OBJ));
+    LowerBlockStore(blkNode);
 }

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3192,6 +3192,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
             __fallthrough;
         case GT_IND:
             retVal->ChangeType(nativeReturnType);
+            LowerIndir(retVal->AsIndir());
             break;
 
         case GT_LCL_VAR:
@@ -3422,7 +3423,8 @@ void Lowering::LowerStoreCallStruct(GenTreeBlk* store)
     {
         store->ChangeType(regType);
         store->SetOper(GT_STOREIND);
-        LowerStoreIndir(store->AsIndir());
+        LowerStoreIndirCommon(store);
+        return;
     }
     else
     {
@@ -6334,7 +6336,7 @@ void Lowering::LowerStoreIndirCommon(GenTreeIndir* ind)
 // LowerIndir: a common logic to lower IND load or NullCheck.
 //
 // Arguments:
-//    node - the ind node we are lowering.
+//    ind - the ind node we are lowering.
 //
 void Lowering::LowerIndir(GenTreeIndir* ind)
 {

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6392,7 +6392,7 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
     }
     else
     {
-        // If the `ADDR` node under `STORE_OBJ(dstAddr, IND(struct(ADDR))` 
+        // If the `ADDR` node under `STORE_OBJ(dstAddr, IND(struct(ADDR))`
         // is a complex one it could benefit from an `LEA` that is not contained.
         TryCreateAddrMode(ind->Addr(), false);
     }
@@ -6425,7 +6425,7 @@ void Lowering::LowerBlockStoreCommon(GenTreeBlk* blkNode)
 //    true if the replacement was made, false otherwise.
 //
 // Notes:
-//    TODO: that method should do the transformation when possible
+//    TODO-CQ: that method should do the transformation when possible
 //    and STOREIND should always generate better or the same code as
 //    STORE_OBJ/BLK for the same copy.
 //
@@ -6450,13 +6450,13 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     }
     if (varTypeIsSIMD(regType))
     {
-        // TODO: support STORE_IND SIMD16(SIMD16, CNT_INT 0).
+        // TODO-CQ: support STORE_IND SIMD16(SIMD16, CNT_INT 0).
         return false;
     }
 
     if (varTypeIsGC(regType))
     {
-        // TODO: STOREIND does not try to contain src if we need a barrier,
+        // TODO-CQ: STOREIND does not try to contain src if we need a barrier,
         // STORE_OBJ generates better code currently.
         return false;
     }

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6390,4 +6390,10 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
             }
         }
     }
+    else
+    {
+        // if `ADDR` node under `IND(struct(ADDR))` under `STORE_OBJ`
+        // is a complex one it could benefit from a not contained `LEA`.
+        TryCreateAddrMode(ind->Addr(), false);
+    }
 }

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -113,64 +113,11 @@ GenTree* Lowering::LowerNode(GenTree* node)
     {
         case GT_NULLCHECK:
         case GT_IND:
-            // Process struct typed indirs separately unless they are unused;
-            // they only appear as the source of a block copy operation or a return node.
-            if (!node->TypeIs(TYP_STRUCT) || node->IsUnusedValue())
-            {
-                // TODO-Cleanup: We're passing isContainable = true but ContainCheckIndir rejects
-                // address containment in some cases so we end up creating trivial (reg + offfset)
-                // or (reg + reg) LEAs that are not necessary.
-                TryCreateAddrMode(node->AsIndir()->Addr(), true);
-                ContainCheckIndir(node->AsIndir());
-
-                if (node->OperIs(GT_NULLCHECK) || node->IsUnusedValue())
-                {
-                    // A nullcheck is essentially the same as an indirection with no use.
-                    // The difference lies in whether a target register must be allocated.
-                    // On XARCH we can generate a compare with no target register as long as the addresss
-                    // is not contained.
-                    // On ARM64 we can generate a load to REG_ZR in all cases.
-                    // However, on ARM we must always generate a load to a register.
-                    // In the case where we require a target register, it is better to use GT_IND, since
-                    // GT_NULLCHECK is a non-value node and would therefore require an internal register
-                    // to use as the target. That is non-optimal because it will be modeled as conflicting
-                    // with the source register(s).
-                    // So, to summarize:
-                    // - On ARM64, always use GT_NULLCHECK for a dead indirection.
-                    // - On ARM, always use GT_IND.
-                    // - On XARCH, use GT_IND if we have a contained address, and GT_NULLCHECK otherwise.
-                    // In all cases, change the type to TYP_INT.
-                    //
-                    node->gtType = TYP_INT;
-#ifdef TARGET_ARM64
-                    bool useNullCheck = true;
-#elif TARGET_ARM
-                    bool useNullCheck = false;
-#else  // TARGET_XARCH
-                    bool useNullCheck = !node->AsIndir()->Addr()->isContained();
-#endif // !TARGET_XARCH
-
-                    if (useNullCheck && node->OperIs(GT_IND))
-                    {
-                        node->ChangeOper(GT_NULLCHECK);
-                        node->ClearUnusedValue();
-                    }
-                    else if (!useNullCheck && node->OperIs(GT_NULLCHECK))
-                    {
-                        node->ChangeOper(GT_IND);
-                        node->SetUnusedValue();
-                    }
-                }
-            }
+            LowerIndir(node->AsIndir());
             break;
 
         case GT_STOREIND:
-            assert(node->TypeGet() != TYP_STRUCT);
-            TryCreateAddrMode(node->AsIndir()->Addr(), true);
-            if (!comp->codeGen->gcInfo.gcIsWriteBarrierStoreIndNode(node))
-            {
-                LowerStoreIndir(node->AsIndir());
-            }
+            LowerStoreIndirCommon(node->AsIndir());
             break;
 
         case GT_ADD:
@@ -6363,5 +6310,82 @@ void Lowering::ContainCheckBitCast(GenTree* node)
     else if (op1->IsLocal())
     {
         op1->SetContained();
+    }
+}
+
+//------------------------------------------------------------------------
+// LowerStoreIndirCommon: a common logic to lower StoreIndir.
+//
+// Arguments:
+//    ind - the store indirection node we are lowering.
+//
+void Lowering::LowerStoreIndirCommon(GenTreeIndir* ind)
+{
+    assert(ind->OperIs(GT_STOREIND));
+    assert(ind->TypeGet() != TYP_STRUCT);
+    TryCreateAddrMode(ind->Addr(), true);
+    if (!comp->codeGen->gcInfo.gcIsWriteBarrierStoreIndNode(ind))
+    {
+        LowerStoreIndir(ind);
+    }
+}
+
+//------------------------------------------------------------------------
+// LowerIndir: a common logic to lower IND load or NullCheck.
+//
+// Arguments:
+//    node - the ind node we are lowering.
+//
+void Lowering::LowerIndir(GenTreeIndir* ind)
+{
+    assert(ind->OperIs(GT_IND, GT_NULLCHECK));
+    // Process struct typed indirs separately unless they are unused;
+    // they only appear as the source of a block copy operation or a return node.
+    if (!ind->TypeIs(TYP_STRUCT) || ind->IsUnusedValue())
+    {
+        // TODO-Cleanup: We're passing isContainable = true but ContainCheckIndir rejects
+        // address containment in some cases so we end up creating trivial (reg + offfset)
+        // or (reg + reg) LEAs that are not necessary.
+        TryCreateAddrMode(ind->Addr(), true);
+        ContainCheckIndir(ind);
+
+        if (ind->OperIs(GT_NULLCHECK) || ind->IsUnusedValue())
+        {
+            // A nullcheck is essentially the same as an indirection with no use.
+            // The difference lies in whether a target register must be allocated.
+            // On XARCH we can generate a compare with no target register as long as the addresss
+            // is not contained.
+            // On ARM64 we can generate a load to REG_ZR in all cases.
+            // However, on ARM we must always generate a load to a register.
+            // In the case where we require a target register, it is better to use GT_IND, since
+            // GT_NULLCHECK is a non-value node and would therefore require an internal register
+            // to use as the target. That is non-optimal because it will be modeled as conflicting
+            // with the source register(s).
+            // So, to summarize:
+            // - On ARM64, always use GT_NULLCHECK for a dead indirection.
+            // - On ARM, always use GT_IND.
+            // - On XARCH, use GT_IND if we have a contained address, and GT_NULLCHECK otherwise.
+            // In all cases, change the type to TYP_INT.
+            //
+            ind->gtType = TYP_INT;
+#ifdef TARGET_ARM64
+            bool useNullCheck = true;
+#elif TARGET_ARM
+            bool useNullCheck = false;
+#else  // TARGET_XARCH
+            bool useNullCheck = !ind->Addr()->isContained();
+#endif // !TARGET_XARCH
+
+            if (useNullCheck && ind->OperIs(GT_IND))
+            {
+                ind->ChangeOper(GT_NULLCHECK);
+                ind->ClearUnusedValue();
+            }
+            else if (!useNullCheck && ind->OperIs(GT_NULLCHECK))
+            {
+                ind->ChangeOper(GT_IND);
+                ind->SetUnusedValue();
+            }
+        }
     }
 }

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -291,6 +291,7 @@ private:
     GenTree* LowerConstIntDivOrMod(GenTree* node);
     GenTree* LowerSignedDivOrMod(GenTree* node);
     void LowerBlockStore(GenTreeBlk* blkNode);
+    void LowerBlockStoreCommon(GenTreeBlk* blkNode);
     void ContainBlockStoreAddress(GenTreeBlk* blkNode, unsigned size, GenTree* addr);
     void LowerPutArgStk(GenTreePutArgStk* tree);
 

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -283,6 +283,8 @@ private:
 #endif // defined(TARGET_XARCH)
 
     // Per tree node member functions
+    void LowerStoreIndirCommon(GenTreeIndir* ind);
+    void LowerIndir(GenTreeIndir* ind);
     void LowerStoreIndir(GenTreeIndir* node);
     GenTree* LowerAdd(GenTreeOp* node);
     bool LowerUnsignedDivOrMod(GenTreeOp* divMod);

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -297,6 +297,8 @@ private:
 
     bool TryCreateAddrMode(GenTree* addr, bool isContainable);
 
+    bool TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode);
+
     GenTree* LowerSwitch(GenTree* node);
     bool TryLowerSwitchToBitTest(
         BasicBlock* jumpTable[], unsigned jumpCount, unsigned targetCount, BasicBlock* bbSwitch, GenTree* switchValue);

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -1123,10 +1123,11 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
         }
     }
 #ifdef TARGET_ARM64
-    else if (addr->OperGet() == GT_CLS_VAR_ADDR)
+    else if (addr->OperIs(GT_CLS_VAR_ADDR, GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR))
     {
         // These nodes go into an addr mode:
         // - GT_CLS_VAR_ADDR turns into a constant.
+        // - GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR is a stack addr mode.
 
         // make this contained, it turns into a constant that goes into an addr mode
         MakeSrcContained(indirNode, addr);

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -3047,11 +3047,11 @@ void Lowering::ContainCheckIndir(GenTreeIndir* node)
         // The address of an indirection that requires its address in a reg.
         // Skip any further processing that might otherwise make it contained.
     }
-    else if ((addr->OperGet() == GT_CLS_VAR_ADDR) || (addr->OperGet() == GT_LCL_VAR_ADDR))
+    else if (addr->OperIs(GT_CLS_VAR_ADDR, GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR))
     {
         // These nodes go into an addr mode:
         // - GT_CLS_VAR_ADDR turns into a constant.
-        // - GT_LCL_VAR_ADDR is a stack addr mode.
+        // - GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR is a stack addr mode.
 
         // make this contained, it turns into a constant that goes into an addr mode
         MakeSrcContained(node, addr);

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -44,6 +44,72 @@ void copyFlags(GenTree* dst, GenTree* src, unsigned mask)
     dst->gtFlags |= (src->gtFlags & mask);
 }
 
+// RewriteIndir: Rewrite an indirection and clear the flags that should not be set after rationalize.
+//
+// Arguments:
+//    use - A use of an indirection node.
+//
+void Rationalizer::RewriteIndir(LIR::Use& use)
+{
+    GenTreeIndir* indir = use.Def()->AsIndir();
+    assert(indir->OperIs(GT_IND, GT_BLK, GT_OBJ));
+
+    // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
+    indir->gtFlags &= ~GTF_IND_ASG_LHS;
+
+    if (indir->OperIs(GT_IND))
+    {
+        if (varTypeIsSIMD(indir))
+        {
+            RewriteSIMDIndir(use);
+        }
+        else
+        {
+            // Due to promotion of structs containing fields of type struct with a
+            // single scalar type field, we could potentially see IR nodes of the
+            // form GT_IND(GT_ADD(lclvarAddr, 0)) where 0 is an offset representing
+            // a field-seq. These get folded here.
+            //
+            // TODO: This code can be removed once JIT implements recursive struct
+            // promotion instead of lying about the type of struct field as the type
+            // of its single scalar field.
+            GenTree* addr = indir->Addr();
+            if (addr->OperGet() == GT_ADD && addr->gtGetOp1()->OperGet() == GT_LCL_VAR_ADDR &&
+                addr->gtGetOp2()->IsIntegralConst(0))
+            {
+                GenTreeLclVarCommon* lclVarNode = addr->gtGetOp1()->AsLclVarCommon();
+                unsigned             lclNum     = lclVarNode->GetLclNum();
+                LclVarDsc*           varDsc     = comp->lvaTable + lclNum;
+                if (indir->TypeGet() == varDsc->TypeGet())
+                {
+                    JITDUMP("Rewriting GT_IND(GT_ADD(LCL_VAR_ADDR,0)) to LCL_VAR\n");
+                    lclVarNode->SetOper(GT_LCL_VAR);
+                    lclVarNode->gtType = indir->TypeGet();
+                    use.ReplaceWith(comp, lclVarNode);
+                    BlockRange().Remove(addr);
+                    BlockRange().Remove(addr->gtGetOp2());
+                    BlockRange().Remove(indir);
+                }
+            }
+        }
+    }
+    else if (indir->OperIs(GT_OBJ))
+    {
+        assert((indir->TypeGet() == TYP_STRUCT) || !use.User()->OperIsInitBlkOp());
+        if (varTypeIsSIMD(indir->TypeGet()))
+        {
+            indir->SetOper(GT_IND);
+            RewriteSIMDIndir(use);
+        }
+    }
+    else
+    {
+        assert(indir->OperIs(GT_BLK));
+        // We should only see GT_BLK for TYP_STRUCT or for InitBlocks.
+        assert((indir->TypeGet() == TYP_STRUCT) || use.User()->OperIsInitBlkOp());
+    }
+}
+
 // RewriteSIMDIndir: Rewrite a SIMD indirection as a simple lclVar if possible.
 //
 // Arguments:
@@ -557,42 +623,9 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
             break;
 
         case GT_IND:
-            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
-            node->gtFlags &= ~GTF_IND_ASG_LHS;
-
-            if (varTypeIsSIMD(node))
-            {
-                RewriteSIMDIndir(use);
-            }
-            else
-            {
-                // Due to promotion of structs containing fields of type struct with a
-                // single scalar type field, we could potentially see IR nodes of the
-                // form GT_IND(GT_ADD(lclvarAddr, 0)) where 0 is an offset representing
-                // a field-seq. These get folded here.
-                //
-                // TODO: This code can be removed once JIT implements recursive struct
-                // promotion instead of lying about the type of struct field as the type
-                // of its single scalar field.
-                GenTree* addr = node->AsIndir()->Addr();
-                if (addr->OperGet() == GT_ADD && addr->gtGetOp1()->OperGet() == GT_LCL_VAR_ADDR &&
-                    addr->gtGetOp2()->IsIntegralConst(0))
-                {
-                    GenTreeLclVarCommon* lclVarNode = addr->gtGetOp1()->AsLclVarCommon();
-                    unsigned             lclNum     = lclVarNode->GetLclNum();
-                    LclVarDsc*           varDsc     = comp->lvaTable + lclNum;
-                    if (node->TypeGet() == varDsc->TypeGet())
-                    {
-                        JITDUMP("Rewriting GT_IND(GT_ADD(LCL_VAR_ADDR,0)) to LCL_VAR\n");
-                        lclVarNode->SetOper(GT_LCL_VAR);
-                        lclVarNode->gtType = node->TypeGet();
-                        use.ReplaceWith(comp, lclVarNode);
-                        BlockRange().Remove(addr);
-                        BlockRange().Remove(addr->gtGetOp2());
-                        BlockRange().Remove(node);
-                    }
-                }
-            }
+        case GT_BLK:
+        case GT_OBJ:
+            RewriteIndir(use);
             break;
 
         case GT_NOP:
@@ -695,24 +728,6 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
         case GT_INTRINSIC:
             // Non-target intrinsics should have already been rewritten back into user calls.
             assert(comp->IsTargetIntrinsic(node->AsIntrinsic()->gtIntrinsicId));
-            break;
-
-        case GT_BLK:
-            // We should only see GT_BLK for TYP_STRUCT or for InitBlocks.
-            assert((node->TypeGet() == TYP_STRUCT) || use.User()->OperIsInitBlkOp());
-            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
-            node->gtFlags &= ~GTF_IND_ASG_LHS;
-            break;
-
-        case GT_OBJ:
-            assert((node->TypeGet() == TYP_STRUCT) || !use.User()->OperIsInitBlkOp());
-            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
-            node->gtFlags &= ~GTF_IND_ASG_LHS;
-            if (varTypeIsSIMD(node->TypeGet()))
-            {
-                node->SetOper(GT_IND);
-                RewriteSIMDIndir(use);
-            }
             break;
 
 #ifdef FEATURE_SIMD

--- a/src/coreclr/src/jit/rationalize.cpp
+++ b/src/coreclr/src/jit/rationalize.cpp
@@ -700,10 +700,14 @@ Compiler::fgWalkResult Rationalizer::RewriteNode(GenTree** useEdge, Compiler::Ge
         case GT_BLK:
             // We should only see GT_BLK for TYP_STRUCT or for InitBlocks.
             assert((node->TypeGet() == TYP_STRUCT) || use.User()->OperIsInitBlkOp());
+            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
+            node->gtFlags &= ~GTF_IND_ASG_LHS;
             break;
 
         case GT_OBJ:
             assert((node->TypeGet() == TYP_STRUCT) || !use.User()->OperIsInitBlkOp());
+            // Clear the `GTF_IND_ASG_LHS` flag, which overlaps with `GTF_IND_REQ_ADDR_IN_REG`.
+            node->gtFlags &= ~GTF_IND_ASG_LHS;
             if (varTypeIsSIMD(node->TypeGet()))
             {
                 node->SetOper(GT_IND);

--- a/src/coreclr/src/jit/rationalize.h
+++ b/src/coreclr/src/jit/rationalize.h
@@ -35,6 +35,8 @@ private:
         return LIR::AsRange(m_block);
     }
 
+    void RewriteIndir(LIR::Use& use);
+
     // SIMD related
     void RewriteSIMDIndir(LIR::Use& use);
 


### PR DESCRIPTION
<h3>This is a two parts change:</h3>
As usual, I recommend reviewing by commits, because there are several extracting/refactoring changes.

<h4>First part:</h4>

https://github.com/dotnet/runtime/pull/38316/commits/ceec9c8fd43d5b938f5bc5ad610075aa44498b44: Arm64: Support contained `GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR` under `IND, STOREIND`.

https://github.com/dotnet/runtime/pull/38316/commits/eefeb7e7b1485f48c2c3d65d119c7fa7693b0943: XARCH: Support contained `GT_LCL_FLD_ADDR` under `GT_STORE_IND, GT_IND`.

https://github.com/dotnet/runtime/pull/38316/commits/ef2709d3e108220108bd590ca129d34e1e768679: Clear `GTF_IND_ASG_LHS` after Rationalize for STORE_OBJ/BLK.
We were doing this for `STOREIND`, but forgetting for `STORE_OBJ/BLK`.

https://github.com/dotnet/runtime/pull/38316/commits/eecb41af88a9830627608acd9dc8e78da01ec27d: Extract `LowerStoreIndirCommon`, `LowerIndir`.
Extract without changes, I will need to add additional calls to them later.

https://github.com/dotnet/runtime/pull/38316/commits/6f8575ec4972ff4db7d38cbb50d75f5d2588f5e7: Call the extracted funtions.
Fix a few regressions with `NoRetyping`.

<h4>Second part:</h4>

https://github.com/dotnet/runtime/pull/38316/commits/d8821cc79a3440382e94e0c9577e9af3f4e83a00: Create `LEA` of comples addr expr.
Gives a few improvements when addr has an index.

https://github.com/dotnet/runtime/pull/38316/commits/f642505758846f67cdfc4911a00d5b7525cec773: Extract `LowerBlockStoreCommon`.

https://github.com/dotnet/runtime/pull/38316/commits/0624264b1fdb9498aa11946d1fbe6f5bfc49b0b7: Tranform STORE_BLK/OBJ into STOREIND.
When it is possible and profitable.

https://github.com/dotnet/runtime/pull/38316/commits/428a86b9eb3ddb6776fcd53fa189153390a8cf9a: Don't tranform for GC and small types.
For GC types we were not trying to contain addr(why?) when needed a barrier and it looked dangerous for me to do such a change(for 5.0). @erozenfeld helped me to pass tests with GC types transformation, but I still was not confident enough and saw strange asm diffs like byref copy replaced by ref copy in some cases.

For small types we were generating `movzx rax` for `IND byte` instead of `mov ax` .

<h3>Diffs (sorry markdown doesn't understand merged word cells, so I have pasted it as an image)</h3>

![image](https://user-images.githubusercontent.com/22642771/85806003-ba33dc80-b702-11ea-9e15-2d9eacd84dd7.png)


I am planning to open two follow up issues if this goes in:
1. combine reuse reg and containment analysis, there are many methods that decide to mark `CNT_INT int 0` as contained, but have a `0` available for reuse already (contained happens in lowering, reusing happens after in LSRA, a simple fix is to check reuse possibility even for contained, will fix `xor rax, rax; mov byte  ptr [esi], 0;`, but not `mov byte  ptr [esi], 0; xor rax, rax;`
2. `STOREIND` should always generate code not worse than `STOREOBJ` for the same copy block, right now it doesn't hold for GCRefs and small types.


I need these changes for `NoRetyping`, because there we have move structs and for `STORE_LCL_VAR(src)` when `src` is not 
 a `LCL_VAR` we are generating `STORE_OBJ` and it caused many regressions.
