### PR TITLE
Fix comment

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Extensions.Logging.Console
         private LogMessageEntry CreateDefaultLogMessage(StringBuilder logBuilder, LogLevel logLevel, string logName, int eventId, string message, Exception exception)
         {
             // Example:
-            // INFO: ConsoleApp.Program[10]
+            // info: ConsoleApp.Program[10]
             //       Request received
 
             ConsoleColors logLevelColors = GetLogLevelConsoleColors(logLevel);


### PR DESCRIPTION
We use lowercase words, see https://github.com/dotnet/runtime/blob/d908270add914db0e9fb3ce72e93c410e8f0f95a/src/libraries/Microsoft.Extensions.Logging.Console/src/ConsoleLogger.cs#L234-L235