### PR TITLE
[wasm] Disable threading tests in System.IO.Pipelines

### DIFF
--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -33,7 +33,7 @@ namespace System.IO.Pipelines.Tests
             await Assert.ThrowsAsync<TaskCanceledException>(() => pipe.Reader.CopyToAsync(new MemoryStream(), new CancellationToken(true)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CopyToAsyncStreamWorks()
         {
             var messages = new List<byte[]>()
@@ -169,7 +169,7 @@ namespace System.IO.Pipelines.Tests
             await Assert.ThrowsAsync<OperationCanceledException>(() => task);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingBetweenReadsThrowsOperationCancelledException()
         {
             var pipe = new Pipe(s_testOptions);
@@ -194,7 +194,7 @@ namespace System.IO.Pipelines.Tests
             await Assert.ThrowsAsync<OperationCanceledException>(() => task);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingPipeWriterViaCancellationTokenThrowsOperationCancelledException()
         {
             var pipe = new Pipe(s_testOptions);
@@ -209,7 +209,7 @@ namespace System.IO.Pipelines.Tests
             await Assert.ThrowsAsync<OperationCanceledException>(() => task);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingPipeWriterViaPendingFlushThrowsOperationCancelledException()
         {
             var pipe = new Pipe(s_testOptions);
@@ -223,7 +223,7 @@ namespace System.IO.Pipelines.Tests
             await Assert.ThrowsAsync<OperationCanceledException>(() => task);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingStreamViaCancellationTokenThrowsOperationCancelledException()
         {
             var pipe = new Pipe(s_testOptions);
@@ -266,7 +266,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(0)]
         [InlineData(1)]
         public async Task ThrowingFromStreamCallsAdvanceToWithStartOfLastReadResult(int throwAfterNWrites)

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderStreamTests.nonnetstandard.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderStreamTests.nonnetstandard.cs
@@ -16,7 +16,7 @@ namespace System.IO.Pipelines.Tests
     {
         public delegate Task<int> ReadAsyncDelegate(Stream stream, byte[] data);
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task DisposingPipeReaderStreamCompletesPipeReader(bool dataInPipe)
@@ -171,7 +171,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancellingPendingReadThrowsOperationCancelledException()
         {
             var pipe = new Pipe();
@@ -187,7 +187,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanReadAfterCancellingPendingRead()
         {
             var pipe = new Pipe();
@@ -245,7 +245,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Same(stream, pipeReader.AsStream());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task PipeWriterStreamProducesToConsumingPipeReaderStream()
         {
             var pipe = new Pipe();
@@ -403,7 +403,10 @@ namespace System.IO.Pipelines.Tests
 
                 yield return new object[] { readArrayAsync };
                 yield return new object[] { readMemoryAsync };
-                yield return new object[] { readMemoryAsyncWithThreadHop };
+                if (PlatformDetection.IsThreadingSupported)
+                {
+                    yield return new object[] { readMemoryAsyncWithThreadHop };
+                }
                 yield return new object[] { readArraySync };
                 yield return new object[] { readSpanSync };
             }

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderWriterFacts.cs
@@ -368,7 +368,7 @@ namespace System.IO.Pipelines.Tests
             _pipe.Reader.AdvanceTo(reader.Start, reader.Start);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true)]
         [InlineData(false)]
         public async Task ReadAsyncOnCompletedCapturesTheExecutionContext(bool useSynchronizationContext)
@@ -421,7 +421,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true)]
         [InlineData(false)]
         public async Task FlushAsyncOnCompletedCapturesTheExecutionContextAndSyncContext(bool useSynchronizationContext)
@@ -475,7 +475,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ReadingCanBeCanceled()
         {
             var cts = new CancellationTokenSource();

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterCopyToAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterCopyToAsyncTests.cs
@@ -94,7 +94,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingViaCancelPendingFlushThrows()
         {
             var helloBytes = Encoding.UTF8.GetBytes("Hello World");
@@ -113,7 +113,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingViaCancellationTokenThrows()
         {
             var helloBytes = Encoding.UTF8.GetBytes("Hello World");
@@ -133,7 +133,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancelingStreamViaCancellationTokenThrows()
         {
             var pipe = new Pipe();

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterStreamTests.nonnetstandard.cs
@@ -16,7 +16,7 @@ namespace System.IO.Pipelines.Tests
     {
         public delegate Task WriteAsyncDelegate(Stream stream, byte[] data);
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task DisposingPipeWriterStreamCompletesPipeWriter()
         {
             var pipe = new Pipe();
@@ -119,7 +119,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancellingPendingFlushThrowsOperationCancelledException()
         {
             var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 10, resumeWriterThreshold: 0));
@@ -136,7 +136,7 @@ namespace System.IO.Pipelines.Tests
             pipe.Reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CancellationTokenFlowsToUnderlyingPipeWriter()
         {
             var pipe = new Pipe(new PipeOptions(pauseWriterThreshold: 10, resumeWriterThreshold: 0));

--- a/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeWriterTests.cs
@@ -230,6 +230,7 @@ namespace System.IO.Pipelines.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // allocates too much memory
         public async Task CompleteWithLargeWriteThrows()
         {
             var pipe = new Pipe();

--- a/src/libraries/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/ReadAsyncCancellationTests.cs
@@ -135,7 +135,7 @@ namespace System.IO.Pipelines.Tests
             Pipe.Reader.AdvanceTo(buffer.Start, buffer.Start);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void ReadAsyncCancellationDeadlock()
         {
             var cts = new CancellationTokenSource();
@@ -388,7 +388,7 @@ namespace System.IO.Pipelines.Tests
             Pipe.Reader.AdvanceTo(result.Buffer.Start);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ReadingCanBeCanceled()
         {
             var cts = new CancellationTokenSource();

--- a/src/libraries/System.IO.Pipelines/tests/SchedulerFacts.cs
+++ b/src/libraries/System.IO.Pipelines/tests/SchedulerFacts.cs
@@ -89,7 +89,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task DefaultReaderSchedulerRunsOnSynchronizationContext()
         {
             SynchronizationContext previous = SynchronizationContext.Current;
@@ -133,7 +133,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task DefaultReaderSchedulerIgnoresSyncContextIfConfigureAwaitFalse()
         {
             // Get off the xunit sync context
@@ -181,7 +181,7 @@ namespace System.IO.Pipelines.Tests
 
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task DefaultReaderSchedulerRunsOnThreadPool()
         {
             var pipe = new Pipe(new PipeOptions(useSynchronizationContext: false));
@@ -210,7 +210,7 @@ namespace System.IO.Pipelines.Tests
             await reading;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task DefaultWriterSchedulerRunsOnThreadPool()
         {
             using (var pool = new TestMemoryPool())
@@ -251,7 +251,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task UseSynchronizationContextFalseIgnoresSyncContextForWriterScheduler()
         {
             SynchronizationContext previous = SynchronizationContext.Current;
@@ -358,7 +358,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task DefaultWriterSchedulerIgnoresSynchronizationContext()
         {
             SynchronizationContext previous = SynchronizationContext.Current;
@@ -411,7 +411,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task FlushCallbackRunsOnWriterScheduler()
         {
             using (var pool = new TestMemoryPool())
@@ -456,7 +456,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ReadAsyncCallbackRunsOnReaderScheduler()
         {
             using (var pool = new TestMemoryPool())
@@ -489,7 +489,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ThreadPoolScheduler_SchedulesOnThreadPool()
         {
             var pipe = new Pipe(new PipeOptions(readerScheduler: PipeScheduler.ThreadPool, writerScheduler: PipeScheduler.Inline, useSynchronizationContext: false));

--- a/src/libraries/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/StreamPipeReaderTests.cs
@@ -64,7 +64,7 @@ namespace System.IO.Pipelines.Tests
             reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanReadMultipleTimes()
         {
             // This needs to run inline to synchronize the reader and writer
@@ -243,7 +243,7 @@ namespace System.IO.Pipelines.Tests
             reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ReadCanBeCancelledViaProvidedCancellationToken()
         {
             var stream = new CancelledReadsStream();
@@ -262,7 +262,7 @@ namespace System.IO.Pipelines.Tests
             reader.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ReadCanBeCanceledViaCancelPendingReadWhenReadIsAsync()
         {
             var stream = new CancelledReadsStream();

--- a/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/StreamPipeWriterTests.cs
@@ -180,7 +180,7 @@ namespace System.IO.Pipelines.Tests
             writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanDoMultipleAsyncWritesToStream()
         {
             var pipe = new Pipe();
@@ -236,7 +236,7 @@ namespace System.IO.Pipelines.Tests
             await readsTask;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanCancelFlushAsyncWithCancellationTokenStreamFlushAsyncThrows()
         {
             var stream = new CancelledWritesStream();
@@ -257,7 +257,7 @@ namespace System.IO.Pipelines.Tests
             writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanCancelFlushAsyncWithCancellationTokenWhenStreamWriteAsyncThrows()
         {
             var stream = new CancelledWritesStream();
@@ -278,7 +278,7 @@ namespace System.IO.Pipelines.Tests
             writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanCancelFlushAsyncWithCancelPendingFlushStreamFlushAsyncThrows()
         {
             var stream = new CancelledWritesStream();
@@ -299,7 +299,7 @@ namespace System.IO.Pipelines.Tests
             writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanCancelFlushAsyncWithCancelPendingFlushStreamWriteAsyncThrows()
         {
             var stream = new CancelledWritesStream();
@@ -320,7 +320,7 @@ namespace System.IO.Pipelines.Tests
             writer.Complete();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task StreamWriteAsyncThrowingDoesNotReturnMemoryToPool()
         {
             using (var pool = new DisposeTrackingBufferPool())
@@ -346,7 +346,7 @@ namespace System.IO.Pipelines.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task StreamFlushAsyncThrowingDoesReturnMemoryToPool()
         {
             using (var pool = new DisposeTrackingBufferPool())


### PR DESCRIPTION
Makes this testsuite pass on WebAssembly: `Tests run: 337, Errors: 0, Failures: 0, Skipped: 43. Time: 42.74615s`