### PR TITLE
[wasm] Remove WASM prefix from stdout in runtime-test.js

### DIFF
--- a/src/mono/wasm/runtime-test.js
+++ b/src/mono/wasm/runtime-test.js
@@ -152,7 +152,7 @@ if (typeof window == "undefined")
 var Module = { 
 	mainScriptUrlOrBlob: "dotnet.js",
 
-	print: function(x) { print ("WASM: " + x) },
+	print: print,
 	printErr: function(x) { print ("WASM-ERR: " + x) },
 
 	onAbort: function(x) {


### PR DESCRIPTION
Tools like xharness or BenchmarkDotNet want to parse the output unmodified and the prefix makes that harder.
It's enough if we only prefix stderr.