### PR TITLE
[wasm] Disable problematic threading tests in System.Threading.Tests

### DIFF
--- a/src/libraries/System.Threading/tests/AsyncLocalTests.cs
+++ b/src/libraries/System.Threading/tests/AsyncLocalTests.cs
@@ -352,7 +352,7 @@ namespace System.Threading.Tests
             return func();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task AsyncMethodNotifications()
         {
             //

--- a/src/libraries/System.Threading/tests/AutoResetEventTests.cs
+++ b/src/libraries/System.Threading/tests/AutoResetEventTests.cs
@@ -44,7 +44,7 @@ namespace System.Threading.Tests
             Assert.Throws<ArgumentNullException>(() => WaitHandle.WaitAll(null, TimeSpan.Zero));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void WaitHandleWaitAll()
         {
             AutoResetEvent[] handles = new AutoResetEvent[10];
@@ -62,7 +62,7 @@ namespace System.Threading.Tests
             Assert.False(Task.Run(() => WaitHandle.WaitAll(handles, 0)).Result); // Task.Run used to ensure MTA thread (necessary for desktop)
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void WaitHandleWaitAny()
         {
             AutoResetEvent[] handles = new AutoResetEvent[10];
@@ -76,7 +76,7 @@ namespace System.Threading.Tests
             Assert.Equal(WaitHandle.WaitTimeout, WaitHandle.WaitAny(handles, 0));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void PingPong()
         {
             using (AutoResetEvent are1 = new AutoResetEvent(true), are2 = new AutoResetEvent(false))

--- a/src/libraries/System.Threading/tests/BarrierCancellationTests.cs
+++ b/src/libraries/System.Threading/tests/BarrierCancellationTests.cs
@@ -31,7 +31,7 @@ namespace System.Threading.Tests
             barrier.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void BarrierCancellationTestsCancelAfterWait_Negative()
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -51,7 +51,7 @@ namespace System.Threading.Tests
             // currently we don't expose this.. but it was verified manually
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void BarrierCancellationTestsCancelAfterWait()
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();

--- a/src/libraries/System.Threading/tests/BarrierTests.cs
+++ b/src/libraries/System.Threading/tests/BarrierTests.cs
@@ -51,7 +51,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBarrierSignalAndWaitTests()
         {
             RunBarrierTest2_SignalAndWait(1, new TimeSpan(0, 0, 0, 0, -1), true, null);
@@ -151,7 +151,7 @@ namespace System.Threading.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => b.RemoveParticipants(2));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task RemovingWaitingParticipants()
         {
             Barrier b = new Barrier(4);
@@ -261,7 +261,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBarrierTest7a()
         {
             for (int j = 0; j < 100; j++)
@@ -292,7 +292,7 @@ namespace System.Threading.Tests
         /// Test the case when the post phase action throws an exception
         /// </summary>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBarrierTest8_PostPhaseException()
         {
             bool shouldThrow = true;
@@ -400,7 +400,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBarrierTest10b()
         {
             // Regression test for Barrier race condition
@@ -421,7 +421,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBarrierTest10c()
         {
             for (int j = 0; j < 10; j++)

--- a/src/libraries/System.Threading/tests/CountdownEventCancellationTests.cs
+++ b/src/libraries/System.Threading/tests/CountdownEventCancellationTests.cs
@@ -26,7 +26,7 @@ namespace System.Threading.Tests
             countdownEvent.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancelAfterWait()
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();

--- a/src/libraries/System.Threading/tests/ExecutionContextTests.cs
+++ b/src/libraries/System.Threading/tests/ExecutionContextTests.cs
@@ -11,7 +11,7 @@ namespace System.Threading.Tests
 {
     public static class ExecutionContextTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CreateCopyTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>
@@ -39,7 +39,7 @@ namespace System.Threading.Tests
             executionContext.CreateCopy().Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void FlowTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>
@@ -146,7 +146,7 @@ namespace System.Threading.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CaptureThenSuppressThenRunFlowTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>
@@ -227,7 +227,7 @@ namespace System.Threading.Tests
             Assert.Equal(expectedValue, asyncLocalValue);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void AsyncFlowControlTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/HostExecutionContextManagerTests.cs
+++ b/src/libraries/System.Threading/tests/HostExecutionContextManagerTests.cs
@@ -8,7 +8,7 @@ namespace System.Threading.Tests
 {
     public static class HostExecutionContextManagerTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void BasicTest()
         {
             ThreadTestHelpers.RunTestInBackgroundThread(() =>

--- a/src/libraries/System.Threading/tests/InterlockedTests.cs
+++ b/src/libraries/System.Threading/tests/InterlockedTests.cs
@@ -92,7 +92,7 @@ namespace System.Threading.Tests
             Assert.Equal(43u, value);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void InterlockedDecrement_Int32()
         {
             int value = 42;
@@ -118,7 +118,7 @@ namespace System.Threading.Tests
             Assert.Equal(41u, value);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void InterlockedDecrement_Int64()
         {
             long value = 42;
@@ -302,7 +302,7 @@ namespace System.Threading.Tests
             Assert.Equal(0x17755771u, value);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/11177")]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotArm64Process), nameof(PlatformDetection.IsThreadingSupported))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/11177")]
         public void MemoryBarrierProcessWide()
         {
             // Stress MemoryBarrierProcessWide correctness using a simple AsymmetricLock

--- a/src/libraries/System.Threading/tests/ManualResetEventSlimCancellationTests.cs
+++ b/src/libraries/System.Threading/tests/ManualResetEventSlimCancellationTests.cs
@@ -26,7 +26,7 @@ namespace System.Threading.Tests
             mres.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancelAfterWait()
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();

--- a/src/libraries/System.Threading/tests/ManualResetEventSlimTests.cs
+++ b/src/libraries/System.Threading/tests/ManualResetEventSlimTests.cs
@@ -30,7 +30,7 @@ namespace System.Threading.Tests
         }
 
         // Uses 3 events to coordinate between two threads. Very little validation.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunManualResetEventSlimTest1_SimpleWait()
         {
             ManualResetEventSlim ev1 = new ManualResetEventSlim(false);

--- a/src/libraries/System.Threading/tests/ManualResetEventTests.cs
+++ b/src/libraries/System.Threading/tests/ManualResetEventTests.cs
@@ -37,7 +37,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void WaitHandleWaitAll()
         {
             ManualResetEvent[] handles = new ManualResetEvent[10];
@@ -55,7 +55,7 @@ namespace System.Threading.Tests
             Assert.True(Task.Run(() => WaitHandle.WaitAll(handles, 0)).Result); // Task.Run used to ensure MTA thread (necessary for desktop)
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void WaitHandleWaitAny()
         {
             ManualResetEvent[] handles = new ManualResetEvent[10];
@@ -69,7 +69,7 @@ namespace System.Threading.Tests
             Assert.Equal(5, WaitHandle.WaitAny(handles, 0));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void PingPong()
         {
             using (ManualResetEvent mre1 = new ManualResetEvent(true), mre2 = new ManualResetEvent(false))

--- a/src/libraries/System.Threading/tests/MonitorTests.cs
+++ b/src/libraries/System.Threading/tests/MonitorTests.cs
@@ -65,7 +65,7 @@ namespace System.Threading.Tests
             Assert.False(Monitor.IsEntered(obj));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void IsEntered_WhenHeldBySomeoneElse_ThrowsSynchronizationLockException()
         {
             var obj = new object();
@@ -127,7 +127,7 @@ namespace System.Threading.Tests
             Assert.Throws<SynchronizationLockException>(() => Monitor.Exit(valueType));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Exit_WhenHeldBySomeoneElse_ThrowsSynchronizationLockException()
         {
             var obj = new object();
@@ -208,7 +208,7 @@ namespace System.Threading.Tests
             AssertExtensions.Throws<ArgumentException>("lockTaken", () => Monitor.TryEnter(obj, TimeSpan.Zero, ref lockTaken));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Enter_HasToWait()
         {
             var thinLock = new object();
@@ -401,7 +401,7 @@ namespace System.Threading.Tests
             AssertExtensions.Throws<ArgumentOutOfRangeException>("timeout", () => Monitor.Wait(obj, TimeSpan.FromMilliseconds(-2)));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WaitTest()
         {
             var obj = new object();
@@ -437,7 +437,7 @@ namespace System.Threading.Tests
             Monitor.Exit(obj);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Enter_HasToWait_LockContentionCountTest()
         {
             long initialLockContentionCount = Monitor.LockContentionCount;

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -96,7 +96,7 @@ namespace System.Threading.Tests
                 Assert.Throws<UnauthorizedAccessException>(() => new Mutex(false, "Global\\" + Guid.NewGuid().ToString("N"))));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(GetValidNames))]
         public void OpenExisting(string name)
         {
@@ -225,7 +225,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(AbandonExisting_MemberData))]
         public void AbandonExisting(
             string name,
@@ -465,7 +465,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void NamedMutex_ThreadExitDisposeRaceTest()
         {
             var mutexName = Guid.NewGuid().ToString("N");
@@ -525,7 +525,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void NamedMutex_DisposeWhenLockedRaceTest()
         {
             var mutexName = Guid.NewGuid().ToString("N");

--- a/src/libraries/System.Threading/tests/ReaderWriterLockSlimTests.cs
+++ b/src/libraries/System.Threading/tests/ReaderWriterLockSlimTests.cs
@@ -177,7 +177,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(LockRecursionPolicy.NoRecursion)]
         [InlineData(LockRecursionPolicy.SupportsRecursion)]
         public static void InvalidExits(LockRecursionPolicy policy)
@@ -237,7 +237,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WritersAreMutuallyExclusiveFromReaders()
         {
             using (Barrier barrier = new Barrier(2))
@@ -262,7 +262,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WritersAreMutuallyExclusiveFromWriters()
         {
             using (Barrier barrier = new Barrier(2))
@@ -287,7 +287,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void ReadersMayBeConcurrent()
         {
             using (Barrier barrier = new Barrier(2))
@@ -321,7 +321,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WriterToWriterChain()
         {
             using (AutoResetEvent are = new AutoResetEvent(false))
@@ -341,7 +341,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WriterToReaderChain()
         {
             using (AutoResetEvent are = new AutoResetEvent(false))
@@ -361,7 +361,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WriterToUpgradeableReaderChain()
         {
             using (AutoResetEvent are = new AutoResetEvent(false))

--- a/src/libraries/System.Threading/tests/ReaderWriterLockTests.cs
+++ b/src/libraries/System.Threading/tests/ReaderWriterLockTests.cs
@@ -87,7 +87,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void InvalidLockCookieTest()
         {
             // Invalid lock cookie created by using one up with Upgrade/Downgrade
@@ -122,7 +122,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void BasicLockTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -480,7 +480,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WaitingReadersTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -510,7 +510,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WaitingWritersTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -541,7 +541,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void ReadersWaitingOnWaitingWriterTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -591,7 +591,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void ReadersWaitingOnWaitingUpgraderTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -644,7 +644,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WaitingUpgradersTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -689,7 +689,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void AtomicRecursiveReaderTest()
         {
             var trwl = new TestReaderWriterLock();
@@ -715,7 +715,7 @@ namespace System.Threading.Tests
             trwl.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void AtomicDowngradeTest()
         {
             var trwl = new TestReaderWriterLock();

--- a/src/libraries/System.Threading/tests/SemaphoreSlimCancellationTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimCancellationTests.cs
@@ -26,7 +26,7 @@ namespace System.Threading.Tests
             semaphoreSlim.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancelAfterWait()
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
@@ -50,7 +50,7 @@ namespace System.Threading.Tests
             // currently we don't expose this.. but it was verified manually
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task Cancel_WaitAsync_ContinuationInvokedAsynchronously()
         {
             await Task.Run(async () => // escape xunit's SynchronizationContext

--- a/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreSlimTests.cs
@@ -70,7 +70,7 @@ namespace System.Threading.Tests
                (10, 10, new TimeSpan(0, 0, int.MaxValue), true, typeof(ArgumentOutOfRangeException));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunSemaphoreSlimTest1_WaitAsync()
         {
             // Infinite timeout
@@ -88,7 +88,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest1_WaitAsync_Helper(0, 10, 10, false, null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunSemaphoreSlimTest1_WaitAsync_NegativeCases()
         {
             // Invalid timeout
@@ -460,7 +460,7 @@ namespace System.Threading.Tests
         /// <param name="failedWait">Number of failed wait threads</param>
         /// <param name="finalCount">The final semaphore count</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(5, 1000, 50, 50, 50, 0, 5, 1000)]
         [InlineData(0, 1000, 50, 25, 25, 25, 0, 500)]
         [InlineData(0, 1000, 50, 0, 0, 50, 0, 100)]
@@ -526,7 +526,7 @@ namespace System.Threading.Tests
         /// <param name="failedWait">Number of failed wait threads</param>
         /// <param name="finalCount">The final semaphore count</param>
         /// <returns>True if the test succeeded, false otherwise</returns>
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(5, 1000, 50, 50, 50, 0, 5, 500)]
         [InlineData(0, 1000, 50, 25, 25, 25, 0, 500)]
         [InlineData(0, 1000, 50, 0, 0, 50, 0, 100)]
@@ -575,7 +575,7 @@ namespace System.Threading.Tests
             Assert.Equal(finalCount, semaphore.CurrentCount);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(10, 10)]
         [InlineData(1, 10)]
         [InlineData(10, 1)]

--- a/src/libraries/System.Threading/tests/SemaphoreTests.cs
+++ b/src/libraries/System.Threading/tests/SemaphoreTests.cs
@@ -139,7 +139,7 @@ namespace System.Threading.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void AnonymousProducerConsumer()
         {
             using (Semaphore s = new Semaphore(0, int.MaxValue))

--- a/src/libraries/System.Threading/tests/SpinLockTests.cs
+++ b/src/libraries/System.Threading/tests/SpinLockTests.cs
@@ -13,7 +13,7 @@ namespace System.Threading.Tests
     /// </summary>
     public class SpinLockTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void EnterExit()
         {
             var sl = new SpinLock();

--- a/src/libraries/System.Threading/tests/SynchronizationContextTests.cs
+++ b/src/libraries/System.Threading/tests/SynchronizationContextTests.cs
@@ -9,7 +9,7 @@ namespace System.Threading.Tests
 {
     public static class SynchronizationContextTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WaitTest()
         {
             var tsc = new TestSynchronizationContext();

--- a/src/libraries/System.Threading/tests/ThreadLocalTests.cs
+++ b/src/libraries/System.Threading/tests/ThreadLocalTests.cs
@@ -60,7 +60,7 @@ namespace System.Threading.Tests
             Assert.True(tlocal.IsValueCreated);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunThreadLocalTest4_Value()
         {
             ThreadLocal<string> tlocal = null;
@@ -109,7 +109,7 @@ namespace System.Threading.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunThreadLocalTest5_Dispose()
         {
             // test recycling the combination index;
@@ -224,7 +224,7 @@ namespace System.Threading.Tests
             threadLocalWeakReferenceTest.Run();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunThreadLocalTest8_Values()
         {
             // Test adding values and updating values


### PR DESCRIPTION
This PR looks to make the System.Threading test suite pass on WebAssembly.

```
Tests run: 420, Errors: 0, Failures: 0, Skipped: 67. Time: 23.2063199s
```