### PR TITLE
Remove Opcode Validation When Specifying a RelatedActivityId

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/EventSourceTestParser.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/EventSourceTestParser.cs
@@ -328,17 +328,6 @@ using Address = System.UInt64;
 //                source.UnregisterEventTemplate(value, 30, ProviderGuid);
 //            }
 //        }
-//        public event Action<EmptyTraceData> LogTransferNoOpcode
-//        {
-//            add
-//            {
-//                source.RegisterEventTemplate(LogTransferNoOpcodeTemplate(value));
-//            }
-//            remove
-//            {
-//                source.UnregisterEventTemplate(value, 28, ProviderGuid);
-//            }
-//        }
 //        public event Action<MessageArgs> Message
 //        {
 //            add
@@ -535,10 +524,6 @@ using Address = System.UInt64;
 //        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
 //            return new EventWithWeirdArgsArgs(action, 30, 65504, "EventWithWeirdArgs", Guid.Empty, 0, "", ProviderGuid, ProviderName);
 //        }
-//        private static EmptyTraceData LogTransferNoOpcodeTemplate(Action<EmptyTraceData> action)
-//        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
-//            return new EmptyTraceData(action, 28, 65506, "LogTransferNoOpcode", Guid.Empty, 0, "", ProviderGuid, ProviderName);
-//        }
 //        private static MessageArgs MessageTemplate(Action<MessageArgs> action)
 //        {                  // action, eventid, taskid, taskName, taskGuid, opcode, opcodeName, providerGuid, providerName
 //            return new MessageArgs(action, 14, 65520, "Message", Guid.Empty, 0, "", ProviderGuid, ProviderName);
@@ -577,7 +562,7 @@ using Address = System.UInt64;
 //        {
 //            if (s_templates == null)
 //            {
-//                var templates = new TraceEvent[35];
+//                var templates = new TraceEvent[34];
 //                templates[0] = Event0Template(null);
 //                templates[1] = EventITemplate(null);
 //                templates[2] = EventIITemplate(null);
@@ -605,14 +590,13 @@ using Address = System.UInt64;
 //                templates[24] = EventWithManyTypeArgsTemplate(null);
 //                templates[25] = EventWith7StringsTemplate(null);
 //                templates[26] = EventWith9StringsTemplate(null);
-//                templates[27] = LogTransferNoOpcodeTemplate(null);
-//                templates[28] = WorkManyArgsSendTemplate(null);
-//                templates[29] = EventWithWeirdArgsTemplate(null);
-//                templates[30] = WorkWeirdArgsSendTemplate(null);
-//                templates[31] = EventWithEscapingMessageTemplate(null);
-//                templates[32] = EventWithMoreEscapingMessageTemplate(null);
-//                templates[33] = EventWithByteArrArgTemplate(null);
-//                templates[34] = EventWithBytePtrArgTemplate(null);
+//                templates[27] = WorkManyArgsSendTemplate(null);
+//                templates[28] = EventWithWeirdArgsTemplate(null);
+//                templates[29] = WorkWeirdArgsSendTemplate(null);
+//                templates[30] = EventWithEscapingMessageTemplate(null);
+//                templates[31] = EventWithMoreEscapingMessageTemplate(null);
+//                templates[32] = EventWithByteArrArgTemplate(null);
+//                templates[33] = EventWithBytePtrArgTemplate(null);
 //                s_templates = templates;
 //            }
 //            foreach (var template in s_templates)

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.Etw.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEventToListener.Etw.cs
@@ -68,9 +68,6 @@ namespace BasicEventSourceTests
                     Assert.True((bool)LoudListener.LastEvent.Payload[1]);
                     Assert.Equal(MyLongEnum.LongVal1, (MyLongEnum)LoudListener.LastEvent.Payload[2]);
                     // Assert.Equal(9999999999999999999999999999m, (decimal)LoudListener.LastEvent.Payload[3]);
-
-                    actid = Guid.NewGuid();
-                    Assert.Throws<EventSourceException>(() => log.LogTransferNoOpcode(actid));
                 }
             }
             TestUtilities.CheckNoEventSourcesRunning("Stop");

--- a/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/EventSourceTest.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/CustomEventSources/EventSourceTest.cs
@@ -156,15 +156,6 @@ namespace SdtEventSources
         public void EventWith9Strings(string s0, string s1, string s2, string s3, string s4, string s5, string s6, string s7, string s8)
         { WriteEvent(27, s0, s1, s2, s3, s4, s5, s6, s7, s8); }
 
-        [Event(28, Keywords = Keywords.Transfer | Keywords.HasNoArgs)]
-        public void LogTransferNoOpcode(Guid RelatedActivityId)
-        {
-            unsafe
-            {
-                WriteEventWithRelatedActivityIdCore(28, &RelatedActivityId, 0, null);
-            }
-        }
-
         [Event(29, Keywords = Keywords.Transfer | Keywords.HasNoArgs, Level = EventLevel.Informational, Opcode = EventOpcode.Send, Task = Tasks.WorkManyArgs)]
         public void EventWithXferManyTypeArgs(Guid RelatedActivityId, long l, uint ui, ulong ui64, char ch,
                                           byte b, sbyte sb, short sh, ushort ush,

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1184,9 +1184,6 @@ namespace System.Diagnostics.Tracing
                 Debug.Assert(m_eventData != null);  // You must have initialized this if you enabled the source.
                 try
                 {
-                    if (relatedActivityId != null)
-                        ValidateEventOpcodeForTransfer(ref m_eventData[eventId], m_eventData[eventId].Name);
-
                     EventOpcode opcode = (EventOpcode)m_eventData[eventId].Descriptor.Opcode;
                     EventActivityOptions activityOptions = m_eventData[eventId].ActivityOptions;
                     Guid* pActivityId = null;
@@ -1869,8 +1866,6 @@ namespace System.Diagnostics.Tracing
                 {
                     if (childActivityID != null)
                     {
-                        ValidateEventOpcodeForTransfer(ref m_eventData[eventId], m_eventData[eventId].Name);
-
                         // If you use WriteEventWithRelatedActivityID you MUST declare the first argument to be a GUID
                         // with the name 'relatedActivityID, and NOT pass this argument to the WriteEvent method.
                         // During manifest creation we modify the ParameterInfo[] that we store to strip out any
@@ -2379,16 +2374,6 @@ namespace System.Diagnostics.Tracing
             finally
             {
                 m_EventSourceExceptionRecurenceCount--;
-            }
-        }
-
-        private void ValidateEventOpcodeForTransfer(ref EventMetadata eventData, string? eventName)
-        {
-            if ((EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Send &&
-                (EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Receive &&
-                (EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Start)
-            {
-                ThrowEventSourceException(eventName);
             }
         }
 


### PR DESCRIPTION
Fixes #38223.

The existing Opcode validation is overly strict, and isn't required by any of the logging systems that we support.  There are some semantics defined on the consumption side for particular opcodes, but that doesn't preclude use of additional opcodes.

Right now, WCF client events are broken because they use a wider set of opcodes when specifying a RelatedActivityID.

cc: @mconnew 