### PR TITLE
[wasm] Disable problematic threading tests in System.Threading.Tasks.Tests

### DIFF
--- a/src/libraries/System.Threading.Tasks/tests/CESchedulerPairTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/CESchedulerPairTests.cs
@@ -88,7 +88,7 @@ namespace System.Threading.Tasks.Tests
         /// and those parameters are respected when tasks are executed
         /// </summary>
         /// <remarks>maxItemsPerTask and which scheduler is used are verified in other testcases</remarks>
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData("default")]
         [InlineData("scheduler")]
         [InlineData("maxconcurrent")]
@@ -184,7 +184,7 @@ namespace System.Threading.Tasks.Tests
         /// is that each time ConcurrentExclusiveScheduler is called QueueTasK a counter (which acts as scheduler's Task id) is incremented.
         /// When a task executes, it observes the parent Task Id and if it matches the one its local cache, it increments its local counter (which tracks
         /// the items executed by a ConcurrentExclusiveScheduler Task). At any given time the Task's local counter cant exceed maxItemsPerTask</remarks>
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(4, 1, true)]
         [InlineData(1, 4, true)]
         [InlineData(4, 1, false)]
@@ -259,7 +259,7 @@ namespace System.Threading.Tasks.Tests
         /// When user specifies a concurrency level above the level allowed by the task scheduler, the concurrency level should be set
         /// to the concurrencylevel specified in the taskscheduler. Also tests that the maxConcurrencyLevel specified was respected
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestLowerConcurrencyLevel()
         {
             //a custom scheduler with maxConcurrencyLevel of one
@@ -296,7 +296,7 @@ namespace System.Threading.Tasks.Tests
             Task.WaitAll(taskList.ToArray());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestConcurrentBlockage()
         {
             ConcurrentExclusiveSchedulerPair schedPair = new ConcurrentExclusiveSchedulerPair();
@@ -329,7 +329,7 @@ namespace System.Threading.Tasks.Tests
             Task.WaitAll(taskList.ToArray());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(ApiType))]
         public static void TestIntegration(string apiType, bool useReader)
         {
@@ -363,7 +363,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test to ensure completion task works successfully
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestCompletionTask()
         {
             // Completion tasks is valid after initialization
@@ -416,7 +416,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Ensure that CESPs can be layered on other CESPs.
         /// </summary
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestSchedulerNesting()
         {
             // Create a hierarchical set of scheduler pairs
@@ -495,7 +495,7 @@ namespace System.Threading.Tasks.Tests
         /// Ensure that continuations and parent/children which hop between concurrent and exclusive work correctly.
         /// EH
         /// </summary>
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true)]
         [InlineData(false)]
         public static void TestConcurrentExclusiveChain(bool syncContinuations)

--- a/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/CancellationTokenTests.cs
@@ -323,7 +323,7 @@ namespace System.Threading.Tasks.Tests
         /// The signal occurs on a separate thread, and should happen after the wait begins.
         /// </summary>
         /// <returns></returns>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationTokenWaitHandle_SignalAfterWait()
         {
             CancellationTokenSource tokenSource = new CancellationTokenSource();
@@ -525,7 +525,7 @@ namespace System.Threading.Tasks.Tests
         /// This test from donnya. Thanks Donny.
         /// </summary>
         /// <returns></returns>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void WaitAll()
         {
             Debug.WriteLine("WaitAll:  Testing CancellationTokenTests.WaitAll, If Join does not work, then a deadlock will occur.");
@@ -561,7 +561,7 @@ namespace System.Threading.Tasks.Tests
             tokenSource.Cancel();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Cancel_ThrowOnFirstException()
         {
             ManualResetEvent mre_CancelHasBeenEnacted = new ManualResetEvent(false);
@@ -603,7 +603,7 @@ namespace System.Threading.Tasks.Tests
             Assert.NotNull(caughtException);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Cancel_DontThrowOnFirstException()
         {
             ManualResetEvent mre_CancelHasBeenEnacted = new ManualResetEvent(false);
@@ -868,7 +868,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Several tests for deriving custom user types from CancellationTokenSource
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void DerivedCancellationTokenSource()
         {
             // Verify that a derived CTS is functional
@@ -986,7 +986,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationTokenSourceWithTimer()
         {
             TimeSpan bigTimeSpan = new TimeSpan(2000, 0, 0, 0, 0);
@@ -1070,7 +1070,7 @@ namespace System.Threading.Tasks.Tests
                () => { cts.CancelAfter(reasonableTimeSpan); });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void EnlistWithSyncContext_BeforeCancel()
         {
             ManualResetEvent mre_CancelHasBeenEnacted = new ManualResetEvent(false); //synchronization helper
@@ -1106,7 +1106,7 @@ namespace System.Threading.Tasks.Tests
             SetSynchronizationContext(prevailingSyncCtx);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void EnlistWithSyncContext_BeforeCancel_ThrowingExceptionInSyncContextDelegate()
         {
             ManualResetEvent mre_CancelHasBeenEnacted = new ManualResetEvent(false); //synchronization helper
@@ -1153,7 +1153,7 @@ namespace System.Threading.Tasks.Tests
             //Cleanup.
             SetSynchronizationContext(prevailingSyncCtx);
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void EnlistWithSyncContext_BeforeCancel_ThrowingExceptionInSyncContextDelegate_ThrowOnFirst()
         {
             ManualResetEvent mre_CancelHasBeenEnacted = new ManualResetEvent(false); //synchronization helper
@@ -1200,7 +1200,7 @@ namespace System.Threading.Tasks.Tests
 
         // Test that we marshal exceptions back if we run callbacks on a sync context.
         // (This assumes that a syncContext.Send() may not be doing the marshalling itself).
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void SyncContextWithExceptionThrowingCallback()
         {
             Exception caughtEx1 = null;
@@ -1246,7 +1246,7 @@ namespace System.Threading.Tasks.Tests
             SetSynchronizationContext(prevailingSyncCtx);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Bug720327_DeregisterFromWithinACallbackIsSafe_SyncContextTest()
         {
             Debug.WriteLine("* CancellationTokenTests.Bug720327_DeregisterFromWithinACallbackIsSafe_SyncContextTest()");
@@ -1277,7 +1277,7 @@ namespace System.Threading.Tasks.Tests
             SetSynchronizationContext(prevailingSyncCtx);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationTokenRegistration_DisposeDuringCancellation_SuccessfullyRemovedIfNotYetInvoked()
         {
             var ctr0running = new ManualResetEventSlim();
@@ -1357,7 +1357,7 @@ namespace System.Threading.Tasks.Tests
             Assert.False(invoked);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationTokenRegistration_UnregisterWhileCallbackRunning_UnregisterDoesntWaitForCallbackToComplete()
         {
             using (var barrier = new Barrier(2))
@@ -1379,7 +1379,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationTokenRegistration_UnregisterDuringCancellation_SuccessfullyRemovedIfNotYetInvoked()
         {
             var ctr0running = new ManualResetEventSlim();
@@ -1414,7 +1414,7 @@ namespace System.Threading.Tasks.Tests
             Assert.False(ctr1Invoked);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task CancellationTokenRegistration_ConcurrentUnregisterWithCancel_ReturnsFalseOrCallbackInvoked()
         {
             using (Barrier barrier = new Barrier(2))
@@ -1559,7 +1559,7 @@ namespace System.Threading.Tasks.Tests
             Assert.False(invoked);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task CancellationTokenRegistration_DisposeAsyncWhileCallbackRunning_WaitsForCallbackToComplete()
         {
             using (var barrier = new Barrier(2))
@@ -1583,7 +1583,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task CancellationTokenRegistration_DisposeAsyncDuringCancellation_SuccessfullyRemovedIfNotYetInvoked()
         {
             var ctr0running = new ManualResetEventSlim();

--- a/src/libraries/System.Threading.Tasks/tests/MethodCoverage.cs
+++ b/src/libraries/System.Threading.Tasks/tests/MethodCoverage.cs
@@ -14,7 +14,7 @@ namespace TaskCoverage
     public class Coverage
     {
         // Regression test: Validates that tasks can wait on int.MaxValue without assertion.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWait_MaxInt32()
         {
             Task t = Task.Delay(1);
@@ -90,7 +90,7 @@ namespace TaskCoverage
         /// <summary>
         /// Test various Task.WhenAll and Wait overloads - EH
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitWithCTS()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -139,7 +139,7 @@ namespace TaskCoverage
         /// <summary>
         /// test WaitAny and when Any overloads
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAny_WhenAny()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -265,7 +265,7 @@ namespace TaskCoverage
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationTokenRegitration()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -282,7 +282,7 @@ namespace TaskCoverage
         /// <summary>
         /// verify that the taskawaiter.UnsafeOnCompleted is invoked
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskAwaiter()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -302,7 +302,7 @@ namespace TaskCoverage
         /// <summary>
         /// verify that the taskawaiter.UnsafeOnCompleted is invoked
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskConfigurableAwaiter()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -322,7 +322,7 @@ namespace TaskCoverage
         /// <summary>
         /// FromAsync testing: Not supported in .NET Native
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void FromAsync()
         {
             Task emptyTask = new Task(() => { });

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/AsyncTaskMethodBuilderTests.cs
@@ -454,7 +454,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Running tasks with exceptions.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void FaultedTaskExceptions()
         {
             var twa1 = Task.Run(() => { throw new Exception("uh oh"); });
@@ -487,7 +487,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test that OCEs don't result in the unobserved event firing
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CancellationDoesntResultInEventFiring()
         {
             var cts = new CancellationTokenSource();

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/ConfiguredCancelableAsyncEnumerableTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/ConfiguredCancelableAsyncEnumerableTests.cs
@@ -99,7 +99,7 @@ namespace System.Runtime.CompilerServices.Tests
                 enumerable.Flags);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task CanBeEnumeratedWithStandardPattern()
         {
             IAsyncEnumerable<int> asyncEnumerable = new EnumerableWithDelayToAsyncEnumerable<int>(Enumerable.Range(1, 10), 1);

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/TaskAwaiterTests.cs
@@ -11,7 +11,7 @@ namespace System.Threading.Tasks.Tests
 {
     public class TaskAwaiterTests
     {
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false, false)]
         [InlineData(false, true)]
         [InlineData(false, null)]
@@ -67,7 +67,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false, false)]
         [InlineData(false, true)]
         [InlineData(false, null)]
@@ -124,7 +124,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task Await_TaskCompletesOnNonDefaultSyncCtx_ContinuesOnDefaultSyncCtx()
         {
             await Task.Run(async delegate // escape xunit's sync context
@@ -154,7 +154,7 @@ namespace System.Threading.Tasks.Tests
             });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task Await_TaskCompletesOnNonDefaultScheduler_ContinuesOnDefaultScheduler()
         {
             await Task.Run(async delegate // escape xunit's sync context
@@ -180,7 +180,7 @@ namespace System.Threading.Tasks.Tests
                             yield return new object[] { numContinuations, runContinuationsAsynchronously, valueTask, scheduler };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(Await_MultipleAwaits_FirstCompletesAccordingToOptions_RestCompleteAsynchronously_MemberData))]
         public async Task Await_MultipleAwaits_FirstCompletesAccordingToOptions_RestCompleteAsynchronously(
             int numContinuations, bool runContinuationsAsynchronously, bool valueTask, object scheduler)
@@ -365,7 +365,7 @@ namespace System.Threading.Tasks.Tests
             Assert.NotEqual(task.ConfigureAwait(true).GetAwaiter(), task.ConfigureAwait(false).GetAwaiter());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void BaseSynchronizationContext_SameAsNoSynchronizationContext()
         {
             var quwi = new QUWITaskScheduler();
@@ -402,7 +402,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(CanceledTasksAndExpectedCancellationExceptions))]
         public static void OperationCanceledException_PropagatesThroughCanceledTask(int lineNumber, Task task, OperationCanceledException expected)
         {

--- a/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/YieldAwaitableTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/System.Runtime.CompilerServices/YieldAwaitableTests.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks.Tests
     public class YieldAwaitableTests
     {
         // awaiting Task.Yield
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunAsyncYieldAwaiterTests()
         {
             // Test direct usage works even though it's not encouraged
@@ -146,14 +146,14 @@ namespace System.Threading.Tasks.Tests
             SynchronizationContext.SetSynchronizationContext(null);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task AsyncMethod_Yields_ReturnsToDefaultTaskScheduler()
         {
             await Task.Yield();
             Assert.Same(TaskScheduler.Default, TaskScheduler.Current);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task AsyncMethod_Yields_ReturnsToCorrectTaskScheduler()
         {
             QUWITaskScheduler ts = new QUWITaskScheduler();
@@ -167,7 +167,7 @@ namespace System.Threading.Tasks.Tests
             Assert.NotSame(ts, TaskScheduler.Current);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static async Task AsyncMethod_Yields_ReturnsToCorrectSynchronizationContext()
         {
             var sc = new ValidateCorrectContextSynchronizationContext ();

--- a/src/libraries/System.Threading.Tasks/tests/Task/RunContinuationsAsynchronouslyTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/RunContinuationsAsynchronouslyTests.cs
@@ -8,7 +8,7 @@ namespace System.Threading.Tasks.Tests
 {
     public class RunContinuationsAsynchronouslyTests
     {
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void Direct(bool useRunContinuationsAsynchronously)
@@ -16,7 +16,7 @@ namespace System.Threading.Tasks.Tests
             Run(useRunContinuationsAsynchronously, t => t);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void ViaUnwrap(bool useRunContinuationsAsynchronously)
@@ -24,7 +24,7 @@ namespace System.Threading.Tasks.Tests
             Run(useRunContinuationsAsynchronously, t => ((Task<Task>)t).Unwrap());
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void ViaWhenAll(bool useRunContinuationsAsynchronously)
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks.Tests
             Run(useRunContinuationsAsynchronously, t => Task.WhenAll(t));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void ViaWhenAny(bool useRunContinuationsAsynchronously)

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskCancelWaitTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskCancelWaitTests.cs
@@ -11,7 +11,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
     {
         #region Test Methods
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait1()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Heavy, string.Empty, true);
@@ -24,7 +24,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait2()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Light, "AttachedToParent");
@@ -39,7 +39,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait3()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.VeryHeavy, "LongRunning, AttachedToParent");
@@ -60,7 +60,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait4()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Light, "AttachedToParent");
@@ -85,7 +85,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait6()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Medium, "RespectParentCancellation");
@@ -131,7 +131,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait8()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Heavy, "LongRunning, RespectParentCancellation");
@@ -157,7 +157,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait9()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Heavy, "None");
@@ -171,7 +171,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait10()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.VeryHeavy, "RespectParentCancellation");
@@ -211,7 +211,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait12()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Medium, "AttachedToParent");
@@ -253,7 +253,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait14()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.VeryLight, "AttachedToParent");
@@ -285,7 +285,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait16()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Heavy, "LongRunning, AttachedToParent");
@@ -295,7 +295,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait17()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Light, "LongRunning, AttachedToParent");
@@ -343,7 +343,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait19()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Medium, "LongRunning, AttachedToParent");
@@ -376,7 +376,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait21()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Heavy, "LongRunning");
@@ -401,7 +401,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait22()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Light, "RespectParentCancellation");
@@ -415,7 +415,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait23()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.VeryHeavy, "LongRunning, RespectParentCancellation");
@@ -428,7 +428,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait24()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Medium, "LongRunning");
@@ -443,7 +443,7 @@ namespace System.Threading.Tasks.Tests.CancelWait
             TaskCancelWaitTest test = new TaskCancelWaitTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCancelWait25()
         {
             TaskInfo node = new TaskInfo(null, "node", WorkloadType.Heavy, "RespectParentCancellation");

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWhenAllTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWhenAllTests.cs
@@ -16,7 +16,7 @@ namespace System.Threading.Tasks.Tests
         #region Test Methods
 
         // Test functionality of "bare" ContinueWhenAll overloads
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestContinueWhenAll_bare()
         {
             int smallSize = 2;
@@ -147,7 +147,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test functionality of ContinueWhenAll overloads w/ CancellationToken
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestContinueWhenAll_CancellationToken()
         {
             int smallSize = 2;
@@ -316,7 +316,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test functionality of ContinueWhenAll overloads w/ TaskContinuationOptions
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestContinueWhenAll_TaskContinuationOptions()
         {
             int smallSize = 2;
@@ -457,7 +457,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test functionality of "full up" ContinueWhenAll overloads
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestCWAll_CancellationToken_TaskContinuation_TaskScheduler()
         {
             int smallSize = 2;
@@ -628,7 +628,7 @@ namespace System.Threading.Tasks.Tests
             }// end i-loop (antecedents are futures or tasks)
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWhenAllTests_Exceptions()
         {
             int smallSize = 2;

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWhenAnyTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWhenAnyTests.cs
@@ -11,7 +11,7 @@ namespace System.Threading.Tasks.Tests
     {
         #region TaskFactory.ContinueWhenAny tests
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWhenAnyTests()
         {
             TaskCompletionSource<int> tcs = null;

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithAllAnyTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithAllAnyTests.cs
@@ -778,7 +778,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
 
     public sealed class TaskContinueWithAllAnyTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest0()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -789,7 +789,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest1()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -832,7 +832,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest4()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -857,7 +857,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest6()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -888,7 +888,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest8()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Cancelled);
@@ -946,7 +946,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest12()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -956,7 +956,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest13()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -985,7 +985,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest15()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -997,7 +997,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest16()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1023,7 +1023,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest18()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -1038,7 +1038,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest19()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryLight);
@@ -1051,7 +1051,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest20()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -1062,7 +1062,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest21()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Cancelled);
@@ -1087,7 +1087,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest23()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryLight);
@@ -1116,7 +1116,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest25()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -1148,7 +1148,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest27()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1227,7 +1227,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest31()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1239,7 +1239,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest32()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1251,7 +1251,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest33()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1263,7 +1263,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest34()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Cancelled);
@@ -1274,7 +1274,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest35()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1285,7 +1285,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             TaskContinueWithAllAnyTest test = new TaskContinueWithAllAnyTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest36()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);
@@ -1298,7 +1298,7 @@ namespace System.Threading.Tasks.Tests.ContinueWithAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskContinueWithAllAnyTest37()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Exceptional);

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWithTests.cs
@@ -18,7 +18,7 @@ namespace System.Threading.Tasks.Tests
     {
         #region ContinueWith Tests
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithAsyncStateCheckTests()
         {
             Task t = new Task(() => { });
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Stresses on multiple continuations from a single antecedent
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [SkipOnCoreClr("Test timing out: https://github.com/dotnet/runtime/issues/2271", RuntimeConfiguration.Checked)]
         public static void RunContinueWithStressTestsNoState()
         {
@@ -72,7 +72,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithPreCancelTests()
         {
             Action<Task, bool, string> EnsureCompletionStatus = delegate (Task task, bool shouldBeCompleted, string message)
@@ -131,7 +131,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinuationChainingTest()
         {
             int x = 0;
@@ -173,7 +173,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithParamsTest_Cancellation()
         {
             //
@@ -221,7 +221,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithParamsTest_IllegalArgs()
         {
             Task t1 = new Task(delegate { });
@@ -256,7 +256,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test what happens when you cancel a task in the middle of a continuation chain.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinuationCancelTest()
         {
             bool t1Ran = false;
@@ -295,7 +295,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithExceptionTestsNoState()
         {
             //
@@ -346,7 +346,7 @@ namespace System.Threading.Tasks.Tests
                () => { f1.ContinueWith(_ => 5, CancellationToken.None, TaskContinuationOptions.None, (TaskScheduler)null); });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithAllParamsTestsNoState()
         {
             for (int i = 0; i < 2; i++)
@@ -602,7 +602,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Make sure that cancellation works for monadic versions of ContinueWith()
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunUnwrapTests()
         {
             Task taskRoot = null;
@@ -773,7 +773,7 @@ namespace System.Threading.Tasks.Tests
             //catch (Exception e) {  }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunUnwrapTests_ExceptionTests()
         {
             Task taskRoot = null;
@@ -872,7 +872,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunUnwrapTests_CancellationTests()
         {
             Task taskRoot = null;
@@ -1024,7 +1024,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test what happens when you cancel a task in the middle of a continuation chain.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinuationCancelTest_State()
         {
             bool t1Ran = false;
@@ -1064,7 +1064,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestNoDeadlockOnContinueWith()
         {
             Debug.WriteLine("TestNoDeadlockOnContinueWith:  shouldn't deadlock if it passes.");
@@ -1081,7 +1081,7 @@ namespace System.Threading.Tasks.Tests
             Debug.WriteLine("Success!");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunLazyCancellationTests()
         {
             for (int i = 0; i < 2; i++)
@@ -1137,7 +1137,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunLazyCancellationTests_Negative()
         {
             for (int i = 0; i < 2; i++)
@@ -1227,7 +1227,7 @@ namespace System.Threading.Tasks.Tests
             t.Wait();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void LongContinuationChain_Unwrap_DoesNotStackOverflow()
         {
             const int DiveDepth = 12_000;
@@ -1243,7 +1243,7 @@ namespace System.Threading.Tasks.Tests
             func(DiveDepth).Wait();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void LongContinuationChain_Await_DoesNotStackOverflow()
         {
             const int DiveDepth = 12_000;
@@ -1258,7 +1258,7 @@ namespace System.Threading.Tasks.Tests
             func(0).Wait();
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public static void TestNoDeadlockOnContinueWithExecuteSynchronously(bool useWaitAll)

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionTests.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks.Tests
 
         #region Test Methods
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTestsNoState_NoneCompleted()
         {
             RunContinueWithTaskTask(TaskContinuationOptions.None);
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_NoneCompleted()
         {
             RunContinueWithTaskFuture(TaskContinuationOptions.None);
@@ -42,7 +42,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_NoneCompleted()
         {
             RunContinueWithFutureTask(TaskContinuationOptions.None);
@@ -52,7 +52,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_NoneCompleted()
         {
             RunContinueWithFutureFuture(TaskContinuationOptions.None);
@@ -62,7 +62,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureFuture(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTestsNoState_FaultedCanceled()
         {
             RunContinueWithTaskTask(s_onlyOnCanceled);
@@ -72,7 +72,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_FaultedCanceled()
         {
             RunContinueWithTaskFuture(s_onlyOnCanceled);
@@ -82,7 +82,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_FaultedCanceled()
         {
             RunContinueWithFutureTask(s_onlyOnCanceled);
@@ -92,7 +92,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_FaultedCanceled()
         {
             RunContinueWithFutureFuture(s_onlyOnCanceled);
@@ -103,7 +103,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Exception tests.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTestsNoState_NoneCompleted_OnException()
         {
             RunContinueWithTaskTask(TaskContinuationOptions.None, true);
@@ -113,7 +113,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_NoneCompleted_OnException()
         {
             RunContinueWithTaskFuture(TaskContinuationOptions.None, true);
@@ -123,7 +123,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_NoneCompleted_OnException()
         {
             RunContinueWithFutureTask(TaskContinuationOptions.None, true);
@@ -133,7 +133,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_NoneCompleted_OnException()
         {
             RunContinueWithFutureFuture(TaskContinuationOptions.None, true);
@@ -143,7 +143,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureFuture(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTestsNoState_FaultedCanceled_OnException()
         {
             RunContinueWithTaskTask(s_onlyOnCanceled, true);
@@ -152,7 +152,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask(s_onlyOnCanceled | TaskContinuationOptions.ExecuteSynchronously, true);
             RunContinueWithTaskTask(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_FaultedCanceled_OnException()
         {
             RunContinueWithTaskFuture(s_onlyOnCanceled, true);
@@ -162,7 +162,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_FaultedCanceled_OnException()
         {
             RunContinueWithFutureTask(s_onlyOnCanceled, true);
@@ -172,7 +172,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_FaultedCanceled_OnException()
         {
             RunContinueWithFutureFuture(s_onlyOnCanceled, true);

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionWithArgsTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskContinueWith_ContFuncAndActionWithArgsTests.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks.Tests
 
         #region Test Methods
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskTask_State()
         {
             RunContinueWithTaskTask_State_Helper(TaskContinuationOptions.None);
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_State()
         {
             RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions.None);
@@ -42,7 +42,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_State()
         {
             RunContinueWithFutureTask_State_Helper(TaskContinuationOptions.None);
@@ -52,7 +52,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_State()
         {
             RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions.None);
@@ -62,7 +62,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskTask_State_FaultedCanceled()
         {
             RunContinueWithTaskTask_State_Helper(s_onlyOnCanceled);
@@ -72,7 +72,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_State_FaultedCanceled()
         {
             RunContinueWithTaskFuture_State_Helper(s_onlyOnCanceled);
@@ -82,7 +82,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_State_FaultedCanceled()
         {
             RunContinueWithFutureTask_State_Helper(s_onlyOnCanceled);
@@ -92,7 +92,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_State_FaultedCanceled()
         {
             RunContinueWithFutureFuture_State_Helper(s_onlyOnCanceled);
@@ -102,7 +102,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskTask_State_OnException()
         {
             RunContinueWithTaskTask_State_Helper(TaskContinuationOptions.None, true);
@@ -112,7 +112,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_State_OnException()
         {
             RunContinueWithTaskFuture_State_Helper(TaskContinuationOptions.None, true);
@@ -122,7 +122,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_State_OnException()
         {
             RunContinueWithFutureTask_State_Helper(TaskContinuationOptions.None, true);
@@ -132,7 +132,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_State_OnException()
         {
             RunContinueWithFutureFuture_State_Helper(TaskContinuationOptions.None, true);
@@ -142,7 +142,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureFuture_State_Helper(s_onlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskTask_State_FaultedCanceled_OnException()
         {
             RunContinueWithTaskTask_State_Helper(s_onlyOnCanceled, true);
@@ -152,7 +152,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithTaskFuture_State_FaultedCanceled_OnException()
         {
             RunContinueWithTaskFuture_State_Helper(s_onlyOnCanceled, true);
@@ -162,7 +162,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithTaskFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureTask_State_FaultedCanceled_OnException()
         {
             RunContinueWithFutureTask_State_Helper(s_onlyOnCanceled, true);
@@ -172,7 +172,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureTask_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithFutureFuture_State_FaultedCanceled_OnException()
         {
             RunContinueWithFutureFuture_State_Helper(s_onlyOnCanceled, true);
@@ -182,7 +182,7 @@ namespace System.Threading.Tasks.Tests
             RunContinueWithFutureFuture_State_Helper(s_onlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously, true);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithPreCancelTests_State()
         {
             Action<Task, bool, string> EnsureCompletionStatus = delegate (Task task, bool shouldBeCompleted, string message)
@@ -262,7 +262,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinuationChainingTest_State()
         {
             int x = 0;
@@ -305,7 +305,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithOnDisposedTaskTest_State()
         {
             Task t1 = Task.Factory.StartNew(delegate { });
@@ -323,7 +323,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithParamsTest_State_Cancellation()
         {
             string stateParam = "test"; //used as a state parameter for the continuation if the useStateParam is true
@@ -373,7 +373,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunContinueWithParamsTest_State_IllegalParameters()
         {
             Task t1 = new Task(delegate { });

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskCreateTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskCreateTest.cs
@@ -21,7 +21,7 @@ namespace System.Threading.Tasks.Tests
     {
         #region Test Methods
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest0()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -36,7 +36,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest1()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -51,7 +51,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest2()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -66,7 +66,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest3()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -81,7 +81,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest4()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -95,7 +95,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.CreateTask();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest5()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -109,7 +109,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest6()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -123,7 +123,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest7()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -138,7 +138,7 @@ namespace System.Threading.Tasks.Tests
             test.ExceptionTests();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest8()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -153,7 +153,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest9()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -168,7 +168,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest10()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -183,7 +183,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest11()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -198,7 +198,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest12()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -213,7 +213,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest13()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -228,7 +228,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest14()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -243,7 +243,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest15()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -258,7 +258,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest16()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -273,7 +273,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest17()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -288,7 +288,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest18()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -303,7 +303,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest19()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -318,7 +318,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest20()
         {
             TestParameters parameters = new TestParameters(TaskType.FutureT)
@@ -332,7 +332,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.StartTask();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest21()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -346,7 +346,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest22()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -360,7 +360,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest23()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -375,7 +375,7 @@ namespace System.Threading.Tasks.Tests
             test.ExceptionTests();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest24()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -390,7 +390,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest25()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -405,7 +405,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest26()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -420,7 +420,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest27()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -435,7 +435,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest28()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -450,7 +450,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest29()
         {
             TestParameters parameters = new TestParameters(TaskType.Future)
@@ -465,7 +465,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest30()
         {
             TestParameters parameters = new TestParameters(TaskType.Promise)
@@ -480,7 +480,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest31()
         {
             TestParameters parameters = new TestParameters(TaskType.Promise)
@@ -495,7 +495,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest32()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -510,7 +510,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest33()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -525,7 +525,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest34()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -540,7 +540,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest35()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -555,7 +555,7 @@ namespace System.Threading.Tasks.Tests
             test.CreateTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest36()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -569,7 +569,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.CreateTask();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest37()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -583,7 +583,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest38()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -597,7 +597,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest39()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -611,7 +611,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest40()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -625,7 +625,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest41()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -639,7 +639,7 @@ namespace System.Threading.Tasks.Tests
             TaskCreateTest test = new TaskCreateTest(parameters);
             test.ExceptionTests();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest42()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -654,7 +654,7 @@ namespace System.Threading.Tasks.Tests
             test.ExceptionTests();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest43()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -669,7 +669,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest44()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -684,7 +684,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest45()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -699,7 +699,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest46()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -714,7 +714,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest47()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -729,7 +729,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest48()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -744,7 +744,7 @@ namespace System.Threading.Tasks.Tests
             test.StartNewTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest49()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -759,7 +759,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest50()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -774,7 +774,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest51()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -789,7 +789,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest52()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -804,7 +804,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest53()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)
@@ -819,7 +819,7 @@ namespace System.Threading.Tasks.Tests
             test.StartTask();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskCreateTest54()
         {
             TestParameters parameters = new TestParameters(TaskType.Task)

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskDisposeTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskDisposeTests.cs
@@ -11,7 +11,7 @@ namespace System.Threading.Tasks.Tests
 {
     public static class TaskDisposeTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Dispose_BeforeComplete()
         {
             // Verify that a task can only be disposed after it has completed
@@ -33,7 +33,7 @@ namespace System.Threading.Tasks.Tests
             task.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Dispose_InContinuation()
         {
             // Verify that a task can be disposed by a continuation
@@ -51,7 +51,7 @@ namespace System.Threading.Tasks.Tests
             task2.Dispose();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void Dispose_ThenAddContinuation()
         {
             // Verify that a continuation can be added after a task is completed and disposed

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskFromAsyncTest2.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskFromAsyncTest2.cs
@@ -23,7 +23,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
     {
         #region Test Methods
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest0()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
@@ -31,7 +31,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest3()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -39,7 +39,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest4()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
@@ -47,7 +47,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest7()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -55,7 +55,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest8()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.TaskT, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -63,7 +63,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest9()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
@@ -71,7 +71,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest12()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -79,7 +79,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest13()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.TaskT, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -87,7 +87,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest14()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
@@ -95,7 +95,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest17()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -103,7 +103,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest18()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.TaskT, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -111,7 +111,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest19()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.TaskT, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -119,7 +119,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest20()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
@@ -127,14 +127,14 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest22()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.NullEnd);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest23()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.TaskT, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -142,7 +142,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest25()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.TaskT, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -150,7 +150,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest27()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
@@ -159,35 +159,35 @@ namespace System.Threading.Tasks.Tests.FromAsync
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest30()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest33()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest34()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.Task, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest35()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest38()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -195,7 +195,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest39()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.Task, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -203,14 +203,14 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest40()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.None);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest43()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -218,7 +218,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest44()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.Task, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -226,7 +226,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest45()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.Task, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -235,14 +235,14 @@ namespace System.Threading.Tasks.Tests.FromAsync
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest47()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.NullEnd);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest48()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.TaskT, OverloadChoice.None, ErrorCase.Throwing);
@@ -250,7 +250,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest50()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.TaskT, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -258,14 +258,14 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest52()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.None);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest55()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.Throwing);
@@ -273,7 +273,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest56()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.None);
@@ -282,7 +282,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest59()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.Throwing);
@@ -290,7 +290,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest60()
         {
             TestParameters parameters = new TestParameters(API.APM_T2, TaskType.Task, TaskType.Task, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -298,7 +298,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest61()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.None);
@@ -307,7 +307,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest64()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.Throwing);
@@ -315,7 +315,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest65()
         {
             TestParameters parameters = new TestParameters(API.APM_T3, TaskType.Task, TaskType.Task, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -323,7 +323,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest66()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.None);
@@ -332,7 +332,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest69()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.Throwing);
@@ -340,7 +340,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest70()
         {
             TestParameters parameters = new TestParameters(API.APM_T, TaskType.Task, TaskType.Task, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -348,7 +348,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest71()
         {
             TestParameters parameters = new TestParameters(API.APM, TaskType.Task, TaskType.Task, OverloadChoice.WithTaskOption, ErrorCase.None);
@@ -356,7 +356,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest72()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.None);
@@ -365,14 +365,14 @@ namespace System.Threading.Tasks.Tests.FromAsync
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest74()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.NullEnd);
             TaskFromAsyncTest test = new TaskFromAsyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest75()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.Task, OverloadChoice.None, ErrorCase.Throwing);
@@ -380,7 +380,7 @@ namespace System.Threading.Tasks.Tests.FromAsync
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskFromAsyncTest77()
         {
             TestParameters parameters = new TestParameters(API.IAsyncResult, TaskType.Task, TaskType.Task, OverloadChoice.WithTaskOption, ErrorCase.None);

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskPropertiesTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskPropertiesTests.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test to ensure that the task and task scheduler IDs are unique when tasks are started
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskIDTest()
         {
             // Read Parameters
@@ -57,7 +57,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         //Use the Start method to start the task
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskOptionsTestAsync()
         {
             TaskOptionTest(false);

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -169,7 +169,7 @@ namespace System.Threading.Tasks.Tests
             Assert.True(future3.IsCanceled, "    > FAILED.  Future(unwrapped) w/ canceled token should have ended in Canceled state");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunRunTests_FastPathTests()
         {
             CancellationTokenSource cts = new CancellationTokenSource();
@@ -255,7 +255,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunRunTests_Unwrap_NegativeCases()
         {
             //
@@ -533,7 +533,7 @@ namespace System.Threading.Tasks.Tests
             Assert.False(task7.IsCompleted, "RunDelayTests:    > FAILED.  Delay(10000) appears to have completed too soon(2).");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunDelayTests_NegativeCases()
         {
             CancellationTokenSource disposedCTS = new CancellationTokenSource();
@@ -600,7 +600,7 @@ namespace System.Threading.Tasks.Tests
 
         // Test that exceptions are properly wrapped when thrown in various scenarios.
         // Make sure that "indirect" logic does not add superfluous exception wrapping.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunExceptionWrappingTest()
         {
             Action throwException = delegate { throw new InvalidOperationException(); };
@@ -748,7 +748,7 @@ namespace System.Threading.Tasks.Tests
             AsyncExceptionChecker(asyncFuture, "Future-based FromAsync(beginMethod, ...)");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunHideSchedulerTests()
         {
             TaskScheduler[] schedules = new TaskScheduler[2];
@@ -818,7 +818,7 @@ namespace System.Threading.Tasks.Tests
                () => { new TaskCompletionSource<int>(TaskCreationOptions.HideScheduler); });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunDenyChildAttachTests()
         {
             // StartNew, Task and Future

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests_Core.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRtTests_Core.cs
@@ -15,7 +15,7 @@ namespace System.Threading.Tasks.Tests
 {
     public static class TaskRtTests_Core
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTCSCompletionStateTests()
         {
             TaskCompletionSource<int> tcs = null;
@@ -71,7 +71,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTCSCompletionStateTests_SetCancel()
         {
             // Testing competing SetCancels
@@ -125,7 +125,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTCSCompletionStateTests_SetException()
         {
             TaskCompletionSource<int> tcs = null;
@@ -482,7 +482,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test "bare" overloads for Task<T> ctor, Task<T>.Factory.StartNew
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestTaskTConstruction_bare()
         {
             for (int i = 0; i < 2; i++)
@@ -544,7 +544,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test overloads for Task<T> ctor, Task<T>.Factory.StartNew that accept a CancellationToken
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestTaskTConstruction_ct()
         {
             for (int i = 0; i < 2; i++)
@@ -626,7 +626,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test overloads for Task<T> ctor, Task<T>.Factory.StartNew that accept a TaskCreationOptions param
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestTaskTConstruction_tco()
         {
             for (int i = 0; i < 2; i++)
@@ -690,7 +690,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test overloads for Task<T> ctor, Task<T>.Factory.StartNew that accept a CancellationToken and TaskCreationOptions
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TestTaskTConstruction_ct_tco()
         {
             for (int i = 0; i < 2; i++)
@@ -830,7 +830,7 @@ namespace System.Threading.Tasks.Tests
                () => { Task<int>.Factory.StartNew((obj) => 42, new object(), CancellationToken.None, TaskCreationOptions.None, (TaskScheduler)null); });
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBasicFutureTest_PromiseTestsAndCancellation()
         {
             //
@@ -902,7 +902,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test the Task.RunSynchronously() API on external and internal threads
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunSynchronouslyTest()
         {
             Task.Factory.StartNew(delegate { CoreRunSynchronouslyTest(); }).Wait();
@@ -1004,7 +1004,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void CoreRunSynchronouslyTest_NegativeTests()
         {
             //Executing RunSynchronously() validations on external thread
@@ -1058,7 +1058,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Simply throws an exception from the task and ensures it is propagated.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskExceptionTest()
         {
             Task t = Task.Factory.StartNew(delegate { });
@@ -1132,7 +1132,7 @@ namespace System.Threading.Tasks.Tests
             return levels;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskWaitAnyTests()
         {
             int numCores = Environment.ProcessorCount;
@@ -1172,7 +1172,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskWaitAnyTests_Negative()
         {
             // test exceptions
@@ -1249,7 +1249,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // basic WaitAny validations with Cancellation token
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskWaitAnyTests_WithCancellationTokenTests()
         {
             //Test stuck tasks + a cancellation token
@@ -1586,7 +1586,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunLongRunningTaskTests()
         {
             TaskScheduler tm = TaskScheduler.Default;
@@ -1626,7 +1626,7 @@ namespace System.Threading.Tasks.Tests
         // Various tests to exercise the refactored Task class.
         // Create()==>Factory.StartNew(), Task and Future ctors have been added,
         // and Task.Start() has been added.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunRefactoringTests()
         {
             int temp = 0;
@@ -1902,7 +1902,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunRefactoringTests_NegativeTests()
         {
             TaskCompletionSource<int> tr = new TaskCompletionSource<int>();
@@ -2021,7 +2021,7 @@ namespace System.Threading.Tasks.Tests
 
         // Test that TaskStatus values returned from Task.Status are what they should be.
         // TODO: Test WaitingToRun, Blocked.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskStatusTests()
         {
             Task t;
@@ -2203,7 +2203,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Test that TaskStatus values returned from Task.Status are what they should be.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskStatusTests_NegativeTests()
         {
             Task t;
@@ -2389,7 +2389,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Just runs a task and waits on it.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskWaitTest()
         {
             // wait on non-exceptional task
@@ -2437,7 +2437,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Just runs a task and waits on it.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskWaitTest_NegativeTests()
         {
             string exceptionMsg = "myexception";
@@ -2531,7 +2531,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Just runs a task and waits on it.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskRecursiveWaitTest()
         {
             Task t2 = null;
@@ -2574,7 +2574,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Just runs a task and waits on it, using a timeout.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskWaitTimeoutTest()
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -2596,7 +2596,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Just runs a task and waits on it, using a timeout.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskRecursiveWaitTimeoutTest()
         {
             ManualResetEvent taskStartedMRE = new ManualResetEvent(false);
@@ -2680,7 +2680,7 @@ namespace System.Threading.Tasks.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskCanceledExceptionTests()
         {
             TaskCanceledException tce = null;
@@ -2730,7 +2730,7 @@ namespace System.Threading.Tasks.Tests
             Assert.True(tse.Message.Equals(message), "RunTaskSchedulerExceptionTests:  Expected Message = message passed to ctor(string, ex)");
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunAsyncWaitHandleTests()
         {
             // Start a task, but make sure that it does not complete

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskRunSyncTests.cs
@@ -412,21 +412,21 @@ namespace System.Threading.Tasks.Tests
 
         #region Test methods
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest0()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Canceled, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest1()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Canceled, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithoutInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest2()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Canceled, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.Default);
@@ -441,35 +441,35 @@ namespace System.Threading.Tasks.Tests
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest4()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Completed, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithoutInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest5()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Completed, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.Default);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest6()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Continued, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest7()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Continued, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithoutInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest8()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Continued, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.Default);
@@ -477,7 +477,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest9()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Cancel, WorkloadType.ContinueInside, TaskCreationOptions.LongRunning, TaskSchedulerType.Default);
@@ -485,7 +485,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest10()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Cancel, WorkloadType.CreateChildTask, TaskCreationOptions.LongRunning, TaskSchedulerType.CustomWithoutInlineExecution);
@@ -493,7 +493,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest11()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Cancel, WorkloadType.CreateDetachedChildTask, TaskCreationOptions.AttachedToParent, TaskSchedulerType.CustomWithoutInlineExecution);
@@ -501,7 +501,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest12()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Cancel, WorkloadType.CreateDetachedChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithInlineExecution);
@@ -509,14 +509,14 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest13()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Cancel, WorkloadType.RunWithUserScheduler, TaskCreationOptions.None, TaskSchedulerType.Default);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest14()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Cancel, WorkloadType.ThrowException, TaskCreationOptions.AttachedToParent, TaskSchedulerType.CustomWithInlineExecution);
@@ -533,7 +533,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest16()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.ContinueWith, WorkloadType.CreateChildTask, TaskCreationOptions.AttachedToParent, TaskSchedulerType.Default);
@@ -575,7 +575,7 @@ namespace System.Threading.Tasks.Tests
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest21()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.Null);
@@ -583,7 +583,7 @@ namespace System.Threading.Tasks.Tests
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest22()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Created, PostRunSyncAction.Wait, WorkloadType.CreateDetachedChildTask, TaskCreationOptions.LongRunning, TaskSchedulerType.Default);
@@ -607,21 +607,21 @@ namespace System.Threading.Tasks.Tests
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest28()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Running, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest29()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Running, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.CustomWithoutInlineExecution);
             TaskRunSyncTest test = new TaskRunSyncTest(parameters);
             test.RealRun();
         }
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskRunSyncTest30()
         {
             TestParameters_RunSync parameters = new TestParameters_RunSync(PreTaskStatus.Running, PostRunSyncAction.Wait, WorkloadType.CreateChildTask, TaskCreationOptions.None, TaskSchedulerType.Default);

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskStatusTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskStatusTest.cs
@@ -531,7 +531,7 @@ namespace System.Threading.Tasks.Tests.Status
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskStatus10()
         {
             TestParameters parameters = new TestParameters(TestAction.CancelTask)
@@ -545,7 +545,7 @@ namespace System.Threading.Tasks.Tests.Status
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskStatus11()
         {
             TestParameters parameters = new TestParameters(TestAction.FailedTask)
@@ -585,7 +585,7 @@ namespace System.Threading.Tasks.Tests.Status
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskStatus14()
         {
             TestParameters parameters = new TestParameters(TestAction.FailedChildTask)
@@ -599,7 +599,7 @@ namespace System.Threading.Tasks.Tests.Status
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskStatus15()
         {
             TestParameters parameters = new TestParameters(TestAction.FailedChildTask)
@@ -627,7 +627,7 @@ namespace System.Threading.Tasks.Tests.Status
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskStatus17()
         {
             TestParameters parameters = new TestParameters(TestAction.CancelTaskAndAcknowledge)
@@ -641,7 +641,7 @@ namespace System.Threading.Tasks.Tests.Status
             test.RealRun();
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(Status_IsProperties_Match_MemberData))]
         public void Status_IsProperties_Match(StrongBox<Task> taskBox)
         {

--- a/src/libraries/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
+++ b/src/libraries/System.Threading.Tasks/tests/Task/TaskWaitAllAnyTest.cs
@@ -484,7 +484,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny3()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -494,7 +494,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny4()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -522,7 +522,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny6()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Light);
@@ -558,7 +558,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny9()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -569,7 +569,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny10()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -579,7 +579,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny11()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -595,7 +595,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny12()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryHeavy);
@@ -606,7 +606,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny13()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -631,7 +631,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny15()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -641,7 +641,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny16()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -652,7 +652,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny17()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryHeavy);
@@ -671,7 +671,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny19()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -682,7 +682,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny20()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -716,7 +716,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny23()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -726,7 +726,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny24()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryLight);
@@ -737,7 +737,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny25()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -762,7 +762,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny27()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Light);
@@ -772,7 +772,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny28()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -783,7 +783,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny29()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -925,7 +925,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny36()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -953,7 +953,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny38()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -963,7 +963,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny39()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -988,7 +988,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny41()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryLight);
@@ -1008,7 +1008,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny43()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -1018,7 +1018,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny44()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -1117,7 +1117,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny47()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.VeryHeavy);
@@ -1128,7 +1128,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny48()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -1144,7 +1144,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny49()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -1154,7 +1154,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny50()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Light);
@@ -1164,7 +1164,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny51()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Light);
@@ -1175,7 +1175,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny52()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);
@@ -1200,7 +1200,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny54()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -1211,7 +1211,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny55()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Light);
@@ -1221,7 +1221,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny56()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Heavy);
@@ -1232,7 +1232,7 @@ namespace System.Threading.Tasks.Tests.WaitAllAny
             test.RealRun();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void TaskWaitAllAny57()
         {
             TaskInfo node1 = new TaskInfo(WorkloadType.Medium);

--- a/src/libraries/System.Threading.Tasks/tests/TaskFactory/TaskFactoryTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/TaskFactory/TaskFactoryTests.cs
@@ -13,7 +13,7 @@ namespace System.Threading.Tasks.Tests
         #region Test Methods
 
         // Exercise functionality of TaskFactory and TaskFactory<TResult>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskFactoryTests()
         {
             TaskScheduler tm = TaskScheduler.Default;
@@ -69,7 +69,7 @@ namespace System.Threading.Tasks.Tests
         }
 
         // Exercise functionality of TaskFactory and TaskFactory<TResult>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunTaskFactoryTests_Cancellation_Negative()
         {
             CancellationTokenSource cancellationSrc = new CancellationTokenSource();

--- a/src/libraries/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
@@ -12,7 +12,7 @@ namespace System.Threading.Tasks.Tests
     public class TaskFactory_FromAsyncTests
     {
         // Exercise the FromAsync() methods in Task and Task<TResult>.
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunAPMFactoryTests()
         {
             FakeAsyncClass fac = new FakeAsyncClass();

--- a/src/libraries/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/TaskScheduler/TaskSchedulerTests.cs
@@ -51,7 +51,7 @@ namespace System.Threading.Tasks.Tests
             Task.WaitAll(tasks);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public static void RunBuggySchedulerTests()
         {
             Debug.WriteLine("* RunBuggySchedulerTests()");

--- a/src/libraries/System.Threading.Tasks/tests/UnwrapTests.cs
+++ b/src/libraries/System.Threading.Tasks/tests/UnwrapTests.cs
@@ -384,7 +384,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test Unwrap when the outer task for a non-generic inner task is marked as AttachedToParent.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void NonGeneric_AttachedToParent()
         {
             Exception error = new InvalidTimeZoneException();
@@ -409,7 +409,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test Unwrap when the outer task for a generic inner task is marked as AttachedToParent.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Generic_AttachedToParent()
         {
             Exception error = new InvalidTimeZoneException();
@@ -434,7 +434,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test that Unwrap with a non-generic task doesn't use TaskScheduler.Current.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void NonGeneric_DefaultSchedulerUsed()
         {
             var scheduler = new CountingScheduler();
@@ -454,7 +454,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test that Unwrap with a generic task doesn't use TaskScheduler.Current.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Generic_DefaultSchedulerUsed()
         {
             var scheduler = new CountingScheduler();
@@ -474,7 +474,7 @@ namespace System.Threading.Tasks.Tests
         /// <summary>
         /// Test that a long chain of Unwraps can execute without overflowing the stack.
         /// </summary>
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void RunStackGuardTests()
         {
             const int DiveDepth = 12000;


### PR DESCRIPTION
This PR looks to make the System.Threading.Tasks test suite pass on WebAssembly.
```Tests run: 624, Errors: 0, Failures: 0, Skipped: 364. Time: 0.777649s```