### PR TITLE
Initial support for SslStreamCertificateContext

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.OpenSsl.cs
@@ -199,53 +199,11 @@ internal static partial class Interop
                         }
                     }
 
-                    if (hasCertificateAndKey)
+                    if (sslAuthenticationOptions.CertificateContext != null && sslAuthenticationOptions.CertificateContext.IntermediateCertificates.Length > 0)
                     {
-                        bool hasCertReference = false;
-                        if (sslAuthenticationOptions.CertificateContext != null && sslAuthenticationOptions.CertificateContext.IntermediateCertificates != null)
+                        if (!Ssl.AddExtraChainCertificates(context, sslAuthenticationOptions.CertificateContext!.IntermediateCertificates))
                         {
-                            // We got chain already built. Use it instead of building one here.
-                            if (!Ssl.AddExtraChainCertificates(context, sslAuthenticationOptions.CertificateContext.IntermediateCertificates))
-                            {
-                                throw CreateSslException(SR.net_ssl_use_cert_failed);
-                            }
-                        }
-                        else
-                        {
-                            try
-                            {
-                                certHandle!.DangerousAddRef(ref hasCertReference);
-                                using (X509Certificate2 cert = new X509Certificate2(certHandle.DangerousGetHandle()))
-                                {
-                                    X509Chain? chain = null;
-                                    try
-                                    {
-                                        chain = TLSCertificateExtensions.BuildNewChain(cert, includeClientApplicationPolicy: false);
-                                        if (chain != null && !Ssl.AddExtraChainCertificates(context, chain))
-                                        {
-                                            throw CreateSslException(SR.net_ssl_use_cert_failed);
-                                        }
-                                    }
-                                    finally
-                                    {
-                                        if (chain != null)
-                                        {
-                                            int elementsCount = chain.ChainElements.Count;
-                                            for (int i = 0; i < elementsCount; i++)
-                                            {
-                                             chain.ChainElements[i].Certificate!.Dispose();
-                                            }
-
-                                            chain.Dispose();
-                                        }
-                                    }
-                                }
-                            }
-                            finally
-                            {
-                                if (hasCertReference)
-                                    certHandle!.DangerousRelease();
-                            }
+                            throw CreateSslException(SR.net_ssl_use_cert_failed);
                         }
                     }
 

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -193,6 +193,25 @@ internal static partial class Interop
             return true;
         }
 
+        internal static bool AddExtraChainCertificates(SafeSslHandle sslContext, X509Certificate2[] chain)
+        {
+            // send pre-computed list of intermediates.
+            for (int i = 0; i < chain.Length; i++)
+            {
+                SafeX509Handle dupCertHandle = Crypto.X509UpRef(chain[i].Handle);
+                Crypto.CheckValidOpenSslHandle(dupCertHandle);
+                if (!SslAddExtraChainCert(sslContext, dupCertHandle))
+                {
+                    Crypto.ErrClearError();
+                    dupCertHandle.Dispose(); // we still own the safe handle; clean it up
+                    return false;
+                }
+                dupCertHandle.SetHandleAsInvalid(); // ownership has been transferred to sslHandle; do not free via this safe handle
+            }
+
+            return true;
+        }
+
         internal static class SslMethods
         {
             internal static readonly IntPtr SSLv23_method = SslV2_3Method();

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -126,7 +126,7 @@ namespace System.Net.Security
     }
     public sealed partial class SslStreamCertificateContext
     {
-        internal SslStreamCertificateContext(System.Security.Cryptography.X509Certificates.X509Certificate2 target, System.Security.Cryptography.X509Certificates.X509Certificate2[]? intermediates = null) { throw null; }
+        internal SslStreamCertificateContext() { throw null; }
         public static SslStreamCertificateContext Create(System.Security.Cryptography.X509Certificates.X509Certificate2 target, System.Security.Cryptography.X509Certificates.X509Certificate2Collection? additionalCertificates, bool offline = false) { throw null; }
     }
     public partial class SslClientAuthenticationOptions

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -124,6 +124,11 @@ namespace System.Net.Security
         public static bool operator !=(System.Net.Security.SslApplicationProtocol left, System.Net.Security.SslApplicationProtocol right) { throw null; }
         public override string ToString() { throw null; }
     }
+    public sealed partial class SslStreamCertificateContext
+    {
+        internal SslStreamCertificateContext(System.Security.Cryptography.X509Certificates.X509Certificate2 target, System.Security.Cryptography.X509Certificates.X509Certificate2[]? intermediates = null) { throw null; }
+        public static SslStreamCertificateContext Create(System.Security.Cryptography.X509Certificates.X509Certificate2 target, System.Security.Cryptography.X509Certificates.X509Certificate2Collection? additionalCertificates, bool offline = false) { throw null; }
+    }
     public partial class SslClientAuthenticationOptions
     {
         public SslClientAuthenticationOptions() { }
@@ -150,6 +155,7 @@ namespace System.Net.Security
         public System.Net.Security.EncryptionPolicy EncryptionPolicy { get { throw null; } set { } }
         public System.Net.Security.RemoteCertificateValidationCallback? RemoteCertificateValidationCallback { get { throw null; } set { } }
         public System.Security.Cryptography.X509Certificates.X509Certificate? ServerCertificate { get { throw null; } set { } }
+        public System.Net.Security.SslStreamCertificateContext? ServerCertificateContext { get { throw null; } set { } }
         public System.Net.Security.ServerCertificateSelectionCallback? ServerCertificateSelectionCallback { get { throw null; } set { } }
     }
     public partial class SslStream : System.Net.Security.AuthenticatedStream

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -28,6 +28,7 @@
     <Compile Include="System\Net\Security\SslSessionsCache.cs" />
     <Compile Include="System\Net\Security\SslStream.cs" />
     <Compile Include="System\Net\Security\SslStream.Implementation.cs" />
+    <Compile Include="System\Net\Security\SslStreamCertificateContext.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.cs" />
     <Compile Include="System\Net\Security\StreamSizes.cs" />
     <Compile Include="System\Net\Security\TlsAlertType.cs" />

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -248,6 +248,7 @@
     <Compile Include="System\Net\Security\CipherSuitesPolicyPal.Linux.cs" />
     <Compile Include="System\Net\Security\SslStreamPal.Unix.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.Linux.cs" />
+    <Compile Include="System\Net\Security\SslStreamCertificateContext.Linux.cs" />
     <Compile Include="System\Net\Security\StreamSizes.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\Security\CertificateValidation.Unix.cs"
              Link="Common\System\Net\Security\CertificateValidation.Unix.cs" />

--- a/src/libraries/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/libraries/System.Net.Security/src/System.Net.Security.csproj
@@ -126,6 +126,7 @@
     <Compile Include="System\Net\Security\CipherSuitesPolicyPal.Windows.cs" />
     <Compile Include="System\Net\Security\NegotiateStreamPal.Windows.cs" />
     <Compile Include="System\Net\Security\NetEventSource.Security.Windows.cs" />
+    <Compile Include="System\Net\Security\SslStreamCertificateContext.Windows.cs" />
     <Compile Include="System\Net\Security\SslStreamPal.Windows.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.Windows.cs" />
     <Compile Include="System\Net\Security\StreamSizes.Windows.cs" />
@@ -330,6 +331,7 @@
     <Compile Include="System\Net\Security\Pal.OSX\SafeDeleteSslContext.cs" />
     <Compile Include="System\Net\Security\Pal.OSX\SafeFreeSslCredentials.cs" />
     <Compile Include="System\Net\Security\SslConnectionInfo.OSX.cs" />
+    <Compile Include="System\Net\Security\SslStreamCertificateContext.OSX.cs" />
     <Compile Include="System\Net\Security\SslStreamPal.OSX.cs" />
     <Compile Include="System\Net\Security\StreamSizes.OSX.cs" />
     <Compile Include="System\Net\Security\CipherSuitesPolicyPal.OSX.cs" />

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -105,11 +105,11 @@ namespace System.Net
             WriteEvent(SecureChannelCtorId, sslStream, hostname, secureChannelHash, clientCertificatesCount, (int)encryptionPolicy);
 
         [NonEvent]
-        public void LocatingPrivateKey(X509Certificate x509Certificate, SecureChannel secureChannel)
+        public void LocatingPrivateKey(X509Certificate x509Certificate, object instance)
         {
             if (IsEnabled())
             {
-                LocatingPrivateKey(x509Certificate.ToString(true), GetHashCode(secureChannel));
+                LocatingPrivateKey(x509Certificate.ToString(true), GetHashCode(instance));
             }
         }
         [Event(LocatingPrivateKeyId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
@@ -117,11 +117,11 @@ namespace System.Net
             WriteEvent(LocatingPrivateKeyId, x509Certificate, secureChannelHash);
 
         [NonEvent]
-        public void CertIsType2(SecureChannel secureChannel)
+        public void CertIsType2(object instance)
         {
             if (IsEnabled())
             {
-                CertIsType2(GetHashCode(secureChannel));
+                CertIsType2(GetHashCode(instance));
             }
         }
         [Event(CertIsType2Id, Keywords = Keywords.Default, Level = EventLevel.Informational)]
@@ -129,11 +129,11 @@ namespace System.Net
             WriteEvent(CertIsType2Id, secureChannelHash);
 
         [NonEvent]
-        public void FoundCertInStore(bool serverMode, SecureChannel secureChannel)
+        public void FoundCertInStore(bool serverMode, object instance)
         {
             if (IsEnabled())
             {
-                FoundCertInStore(serverMode ? "LocalMachine" : "CurrentUser", GetHashCode(secureChannel));
+                FoundCertInStore(serverMode ? "LocalMachine" : "CurrentUser", GetHashCode(instance));
             }
         }
         [Event(FoundCertInStoreId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
@@ -141,11 +141,11 @@ namespace System.Net
             WriteEvent(FoundCertInStoreId, store, secureChannelHash);
 
         [NonEvent]
-        public void NotFoundCertInStore(SecureChannel secureChannel)
+        public void NotFoundCertInStore(object instance)
         {
             if (IsEnabled())
             {
-                NotFoundCertInStore(GetHashCode(secureChannel));
+                NotFoundCertInStore(GetHashCode(instance));
             }
         }
         [Event(NotFoundCertInStoreId, Keywords = Keywords.Default, Level = EventLevel.Informational)]

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -531,7 +531,7 @@ namespace System.Net.Security
             //
             // SECURITY: Accessing X509 cert Credential is disabled for semitrust.
             // We no longer need to demand for unmanaged code permissions.
-            // EnsurePrivateKey should do the right demand for us.
+            // FindCertificateWithPrivateKey should do the right demand for us.
             if (filteredCerts != null)
             {
                 for (int i = 0; i < filteredCerts.Count; ++i)
@@ -608,10 +608,9 @@ namespace System.Net.Security
             }
             finally
             {
-                // An extra cert could have been created, dispose it now.
-                if (selectedCert != null && (object?)clientCertificate != (object?)selectedCert)
+                if (selectedCert != null)
                 {
-                    selectedCert.Dispose();
+                    _sslAuthenticationOptions.CertificateContext = SslStreamCertificateContext.Create(selectedCert);
                 }
             }
 
@@ -698,7 +697,7 @@ namespace System.Net.Security
                     NetEventSource.Fail(this, "'selectedCert' does not match 'localCertificate'.");
                 }
 
-                _sslAuthenticationOptions.CertificateContext = new SslStreamCertificateContext(selectedCert);
+                _sslAuthenticationOptions.CertificateContext = SslStreamCertificateContext.Create(selectedCert);
             }
 
             //

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -77,7 +77,7 @@ namespace System.Net.Security
         {
             get
             {
-                return _sslAuthenticationOptions.ServerCertificate;
+                return _sslAuthenticationOptions.CertificateContext?.Certificate;
             }
         }
 
@@ -186,7 +186,7 @@ namespace System.Net.Security
         // SECURITY: we open a private key container on behalf of the caller
         // and we require the caller to have permission associated with that operation.
         //
-        private X509Certificate2? EnsurePrivateKey(X509Certificate certificate)
+        internal static X509Certificate2? FindCertificateWithPrivateKey(object instance, bool isServer, X509Certificate certificate)
         {
             if (certificate == null)
             {
@@ -194,7 +194,7 @@ namespace System.Net.Security
             }
 
             if (NetEventSource.IsEnabled)
-                NetEventSource.Log.LocatingPrivateKey(certificate, this);
+                NetEventSource.Log.LocatingPrivateKey(certificate, instance);
 
             try
             {
@@ -206,12 +206,12 @@ namespace System.Net.Security
                     if (certEx.HasPrivateKey)
                     {
                         if (NetEventSource.IsEnabled)
-                            NetEventSource.Log.CertIsType2(this);
+                            NetEventSource.Log.CertIsType2(instance);
 
                         return certEx;
                     }
 
-                    if ((object)certificate != (object)certEx)
+                    if (!object.ReferenceEquals(certificate, certEx))
                     {
                         certEx.Dispose();
                     }
@@ -222,26 +222,26 @@ namespace System.Net.Security
 
                 // ELSE Try the MY user and machine stores for private key check.
                 // For server side mode MY machine store takes priority.
-                X509Store? store = CertificateValidationPal.EnsureStoreOpened(_sslAuthenticationOptions.IsServer);
+                X509Store? store = CertificateValidationPal.EnsureStoreOpened(isServer);
                 if (store != null)
                 {
                     collectionEx = store.Certificates.Find(X509FindType.FindByThumbprint, certHash, false);
                     if (collectionEx.Count > 0 && collectionEx[0].HasPrivateKey)
                     {
                         if (NetEventSource.IsEnabled)
-                            NetEventSource.Log.FoundCertInStore(_sslAuthenticationOptions.IsServer, this);
+                            NetEventSource.Log.FoundCertInStore(isServer, instance);
                         return collectionEx[0];
                     }
                 }
 
-                store = CertificateValidationPal.EnsureStoreOpened(!_sslAuthenticationOptions.IsServer);
+                store = CertificateValidationPal.EnsureStoreOpened(!isServer);
                 if (store != null)
                 {
                     collectionEx = store.Certificates.Find(X509FindType.FindByThumbprint, certHash, false);
                     if (collectionEx.Count > 0 && collectionEx[0].HasPrivateKey)
                     {
                         if (NetEventSource.IsEnabled)
-                            NetEventSource.Log.FoundCertInStore(_sslAuthenticationOptions.IsServer, this);
+                            NetEventSource.Log.FoundCertInStore(!isServer, instance);
                         return collectionEx[0];
                     }
                 }
@@ -251,7 +251,7 @@ namespace System.Net.Security
             }
 
             if (NetEventSource.IsEnabled)
-                NetEventSource.Log.NotFoundCertInStore(this);
+                NetEventSource.Log.NotFoundCertInStore(instance);
             return null;
         }
 
@@ -537,7 +537,7 @@ namespace System.Net.Security
                 for (int i = 0; i < filteredCerts.Count; ++i)
                 {
                     clientCertificate = filteredCerts[i];
-                    if ((selectedCert = EnsurePrivateKey(clientCertificate)) != null)
+                    if ((selectedCert = FindCertificateWithPrivateKey(this, _sslAuthenticationOptions.IsServer, clientCertificate)) != null)
                     {
                         break;
                     }
@@ -631,84 +631,91 @@ namespace System.Net.Security
                 NetEventSource.Enter(this);
 
             X509Certificate? localCertificate = null;
+            X509Certificate2? selectedCert = null;
             bool cachedCred = false;
 
             // There are three options for selecting the server certificate. When
             // selecting which to use, we prioritize the new ServerCertSelectionDelegate
             // API. If the new API isn't used we call LocalCertSelectionCallback (for compat
-            // with .NET Framework), and if neither is set we fall back to using ServerCertificate.
+            // with .NET Framework), and if neither is set we fall back to using CertificateContext.
             if (_sslAuthenticationOptions.ServerCertSelectionDelegate != null)
             {
                 localCertificate = _sslAuthenticationOptions.ServerCertSelectionDelegate(_sslAuthenticationOptions.TargetHost);
                 if (localCertificate == null)
                 {
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Error(this, $"ServerCertSelectionDelegate returned no certificaete for '{_sslAuthenticationOptions.TargetHost}'.");
                     throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
                 }
+
                 if (NetEventSource.IsEnabled)
-                    NetEventSource.Info(this, "Use delegate selected Cert");
+                    NetEventSource.Info(this, "ServerCertSelectionDelegate selected Cert");
             }
             else if (_sslAuthenticationOptions.CertSelectionDelegate != null)
             {
                 X509CertificateCollection tempCollection = new X509CertificateCollection();
-                tempCollection.Add(_sslAuthenticationOptions.ServerCertificate!);
+                tempCollection.Add(_sslAuthenticationOptions.CertificateContext!.Certificate!);
                 // We pass string.Empty here to maintain strict compatability with .NET Framework.
                 localCertificate = _sslAuthenticationOptions.CertSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
+                if (localCertificate == null)
+                {
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Error(this, $"CertSelectionDelegate returned no certificaete for '{_sslAuthenticationOptions.TargetHost}'.");
+                    throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
+                }
+
                 if (NetEventSource.IsEnabled)
-                    NetEventSource.Info(this, "Use delegate selected Cert");
+                    NetEventSource.Info(this, "CertSelectionDelegate selected Cert");
             }
-            else
+            else if (_sslAuthenticationOptions.CertificateContext != null)
             {
-                localCertificate = _sslAuthenticationOptions.ServerCertificate;
+                selectedCert = _sslAuthenticationOptions.CertificateContext.Certificate;
             }
-
-            if (localCertificate == null)
-            {
-                throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
-            }
-
-            // SECURITY: Accessing X509 cert Credential is disabled for semitrust.
-            // We no longer need to demand for unmanaged code permissions.
-            // EnsurePrivateKey should do the right demand for us.
-            X509Certificate2? selectedCert = EnsurePrivateKey(localCertificate);
 
             if (selectedCert == null)
             {
-                throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
-            }
+                // We will get here if vertificate was slected via legacy callback using X509Certificate
+                // Fail immediately if no certificate was given.
+                if (localCertificate == null)
+                {
+                    if (NetEventSource.IsEnabled)
+                        NetEventSource.Error(this, "Certiticate callback returned no certificaete.");
+                    throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
+                }
 
-            if (!localCertificate.Equals(selectedCert))
-            {
-                NetEventSource.Fail(this, "'selectedCert' does not match 'localCertificate'.");
+                // SECURITY: Accessing X509 cert Credential is disabled for semitrust.
+                // We no longer need to demand for unmanaged code permissions.
+                // EnsurePrivateKey should do the right demand for us.
+                selectedCert = FindCertificateWithPrivateKey(this, _sslAuthenticationOptions.IsServer, localCertificate);
+
+                if (selectedCert == null)
+                {
+                    throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
+                }
+
+                if (!localCertificate.Equals(selectedCert))
+                {
+                    NetEventSource.Fail(this, "'selectedCert' does not match 'localCertificate'.");
+                }
+
+                _sslAuthenticationOptions.CertificateContext = new SslStreamCertificateContext(selectedCert);
             }
 
             //
             // Note selectedCert is a safe ref possibly cloned from the user passed Cert object
             //
             byte[] guessedThumbPrint = selectedCert.GetCertHash();
-            try
-            {
-                SafeFreeCredentials? cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
+            SafeFreeCredentials? cachedCredentialHandle = SslSessionsCache.TryCachedCredential(guessedThumbPrint, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.IsServer, _sslAuthenticationOptions.EncryptionPolicy);
 
-                if (cachedCredentialHandle != null)
-                {
-                    _credentialsHandle = cachedCredentialHandle;
-                    _sslAuthenticationOptions.ServerCertificate = localCertificate;
-                    cachedCred = true;
-                }
-                else
-                {
-                    _credentialsHandle = SslStreamPal.AcquireCredentialsHandle(selectedCert, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.EncryptionPolicy, _sslAuthenticationOptions.IsServer);
-                    thumbPrint = guessedThumbPrint;
-                    _sslAuthenticationOptions.ServerCertificate = localCertificate;
-                }
-            }
-            finally
+            if (cachedCredentialHandle != null)
             {
-                // An extra cert could have been created, dispose it now.
-                if ((object)localCertificate != (object)selectedCert)
-                {
-                    selectedCert.Dispose();
-                }
+                _credentialsHandle = cachedCredentialHandle;
+                cachedCred = true;
+            }
+            else
+            {
+                _credentialsHandle = SslStreamPal.AcquireCredentialsHandle(selectedCert, _sslAuthenticationOptions.EnabledSslProtocols, _sslAuthenticationOptions.EncryptionPolicy, _sslAuthenticationOptions.IsServer);
+                thumbPrint = guessedThumbPrint;
             }
 
             if (NetEventSource.IsEnabled)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -47,9 +47,35 @@ namespace System.Net.Security
             TargetHost = string.Empty;
 
             // Server specific options.
-            CertificateRevocationCheckMode = sslServerAuthenticationOptions.CertificateRevocationCheckMode;
-            ServerCertificate = sslServerAuthenticationOptions.ServerCertificate;
             CipherSuitesPolicy = sslServerAuthenticationOptions.CipherSuitesPolicy;
+            CertificateRevocationCheckMode = sslServerAuthenticationOptions.CertificateRevocationCheckMode;
+
+            if (sslServerAuthenticationOptions.ServerCertificateContext != null)
+            {
+                CertificateContext = sslServerAuthenticationOptions.ServerCertificateContext;
+            }
+            else if (sslServerAuthenticationOptions.ServerCertificate != null)
+            {
+                X509Certificate2? certificateWithKey = sslServerAuthenticationOptions.ServerCertificate as X509Certificate2;
+
+                if (certificateWithKey != null && certificateWithKey.HasPrivateKey)
+                {
+                    // given cert is X509Certificate2 with key. We can use it directly.
+                    CertificateContext = SslStreamCertificateContext.Create(certificateWithKey, null);
+                }
+                else
+                {
+                    // This is legacy fix-up. If the Certificate did not have key, we will search stores and we
+                    // will try to find one with matching hash.
+                    certificateWithKey = SecureChannel.FindCertificateWithPrivateKey(this, true, sslServerAuthenticationOptions.ServerCertificate);
+                    if (certificateWithKey == null)
+                    {
+                        throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
+                    }
+
+                    CertificateContext = new SslStreamCertificateContext(certificateWithKey);
+                }
+            }
         }
 
         private static SslProtocols FilterOutIncompatibleSslProtocols(SslProtocols protocols)
@@ -72,7 +98,7 @@ namespace System.Net.Security
         internal X509CertificateCollection? ClientCertificates { get; set; }
         internal List<SslApplicationProtocol>? ApplicationProtocols { get; }
         internal bool IsServer { get; set; }
-        internal X509Certificate? ServerCertificate { get; set; }
+        internal SslStreamCertificateContext? CertificateContext { get; set; }
         internal SslProtocols EnabledSslProtocols { get; set; }
         internal X509RevocationMode CertificateRevocationCheckMode { get; set; }
         internal EncryptionPolicy EncryptionPolicy { get; set; }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -73,7 +73,7 @@ namespace System.Net.Security
                         throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
                     }
 
-                    CertificateContext = new SslStreamCertificateContext(certificateWithKey);
+                    CertificateContext = SslStreamCertificateContext.Create(certificateWithKey);
                 }
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslServerAuthenticationOptions.cs
@@ -31,6 +31,8 @@ namespace System.Net.Security
 
         public X509Certificate? ServerCertificate { get; set; }
 
+        public SslStreamCertificateContext? ServerCertificateContext { get; set; }
+
         public SslProtocols EnabledSslProtocols
         {
             get => _enabledSslProtocols;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -177,12 +177,13 @@ namespace System.Net.Security
 
         private SslAuthenticationOptions CreateAuthenticationOptions(SslServerAuthenticationOptions sslServerAuthenticationOptions)
         {
-            if (sslServerAuthenticationOptions.ServerCertificate == null && sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null && _certSelectionDelegate == null)
+            if (sslServerAuthenticationOptions.ServerCertificate == null && sslServerAuthenticationOptions.ServerCertificateContext == null &&
+                    sslServerAuthenticationOptions.ServerCertificateSelectionCallback == null && _certSelectionDelegate == null)
             {
                 throw new ArgumentNullException(nameof(sslServerAuthenticationOptions.ServerCertificate));
             }
 
-            if ((sslServerAuthenticationOptions.ServerCertificate != null || _certSelectionDelegate != null) && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
+            if ((sslServerAuthenticationOptions.ServerCertificate != null || sslServerAuthenticationOptions.ServerCertificateContext != null || _certSelectionDelegate != null) && sslServerAuthenticationOptions.ServerCertificateSelectionCallback != null)
             {
                 throw new InvalidOperationException(SR.Format(SR.net_conflicting_options, nameof(ServerCertificateSelectionCallback)));
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Linux.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    public partial class SslStreamCertificateContext
+    {
+        internal static SslStreamCertificateContext Create(X509Certificate2 target) => Create(target, null);
+    }
+}

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
@@ -15,4 +15,3 @@ namespace System.Net.Security
         }
     }
 }
-

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
@@ -11,7 +11,7 @@ namespace System.Net.Security
         internal static SslStreamCertificateContext Create(X509Certificate2 target)
         {
             // On OSX we do not need to build chain unless we are asked for it.
-            return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>);
+            return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>());
         }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.OSX.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    public partial class SslStreamCertificateContext
+    {
+        internal static SslStreamCertificateContext Create(X509Certificate2 target)
+        {
+            // On OSX we do not need to build chain unless we are asked for it.
+            return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>);
+        }
+    }
+}
+

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
@@ -15,4 +15,3 @@ namespace System.Net.Security
         }
     }
 }
-

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
@@ -11,7 +11,7 @@ namespace System.Net.Security
         internal static SslStreamCertificateContext Create(X509Certificate2 target)
         {
             // On Windows we do not need to build chain unless we are asked for it.
-            return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>);
+            return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>());
         }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.Windows.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    public partial class SslStreamCertificateContext
+    {
+        internal static SslStreamCertificateContext Create(X509Certificate2 target)
+        {
+            // On Windows we do not need to build chain unless we are asked for it.
+            return new SslStreamCertificateContext(target, Array.Empty<X509Certificate2>);
+        }
+    }
+}
+

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -6,10 +6,10 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Net.Security
 {
-    public class SslStreamCertificateContext
+    public partial class SslStreamCertificateContext
     {
         internal readonly X509Certificate2 Certificate;
-        internal readonly X509Certificate2[]? IntermediateCertificates;
+        internal readonly X509Certificate2[] IntermediateCertificates;
 
         public static SslStreamCertificateContext Create(X509Certificate2 target, X509Certificate2Collection? additionalCertificates, bool offline = false)
         {
@@ -18,7 +18,7 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
             }
 
-            X509Certificate2[]? intermediates = null;
+            X509Certificate2[] intermediates = Array.Empty<X509Certificate2>();
 
             using (X509Chain chain = new X509Chain())
             {
@@ -35,21 +35,43 @@ namespace System.Net.Security
                 chain.ChainPolicy.DisableCertificateDownloads = offline;
                 chain.Build(target);
 
-                if (chain.ChainElements.Count > 2)
+                // No leaf, no root.
+                int count = chain.ChainElements.Count - 2;
+
+                foreach (X509ChainStatus status in chain.ChainStatus)
                 {
-                    int count = chain.ChainElements.Count;
+                    if (status.Status.HasFlag(X509ChainStatusFlags.PartialChain))
+                    {
+                        // The last cert isn't a root cert
+                        count++;
+                        break;
+                    }
+                }
+
+                // Count can be zero for a self-signed certificate, or a cert issued directly from a root.
+                if (count > 0)
+                {
                     intermediates = new X509Certificate2[count];
                     for (int i = 0; i < count; i++)
                     {
                         intermediates[i] = chain.ChainElements[i + 1].Certificate;
                     }
                 }
+
+                // Dispose the copy of the target cert.
+                chain.ChainElements[0].Certificate.Dispose();
+
+                // Dispose the last cert, if we didn't include it.
+                for (int i = count + 1; i < chain.ChainElements.Count; i++)
+                {
+                    chain.ChainElements[i].Certificate.Dispose();
+                }
             }
 
             return new SslStreamCertificateContext(target, intermediates);
         }
 
-        internal SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[]? intermediates = null)
+        private SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[] intermediates)
         {
             Certificate = target;
             IntermediateCertificates = intermediates;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamCertificateContext.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Security
+{
+    public class SslStreamCertificateContext
+    {
+        internal readonly X509Certificate2 Certificate;
+        internal readonly X509Certificate2[]? IntermediateCertificates;
+
+        public static SslStreamCertificateContext Create(X509Certificate2 target, X509Certificate2Collection? additionalCertificates, bool offline = false)
+        {
+            if (!target.HasPrivateKey)
+            {
+                throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
+            }
+
+            X509Certificate2[]? intermediates = null;
+
+            using (X509Chain chain = new X509Chain())
+            {
+                if (additionalCertificates != null)
+                {
+                    foreach (X509Certificate cert in additionalCertificates)
+                    {
+                        chain.ChainPolicy.ExtraStore.Add(cert);
+                    }
+                }
+
+                chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
+                chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                chain.ChainPolicy.DisableCertificateDownloads = offline;
+                chain.Build(target);
+
+                if (chain.ChainElements.Count > 2)
+                {
+                    int count = chain.ChainElements.Count;
+                    intermediates = new X509Certificate2[count];
+                    for (int i = 0; i < count; i++)
+                    {
+                        intermediates[i] = chain.ChainElements[i + 1].Certificate;
+                    }
+                }
+            }
+
+            return new SslStreamCertificateContext(target, intermediates);
+        }
+
+        internal SslStreamCertificateContext(X509Certificate2 target, X509Certificate2[]? intermediates = null)
+        {
+            Certificate = target;
+            IntermediateCertificates = intermediates;
+        }
+    }
+}

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslAuthenticationOptionsTest.cs
@@ -43,6 +43,7 @@ namespace System.Net.Security.Tests
                 SslProtocols serverSslProtocols = SslProtocols.Tls11 | SslProtocols.Tls12;
                 EncryptionPolicy serverEncryption = EncryptionPolicy.AllowNoEncryption;
                 RemoteCertificateValidationCallback serverRemoteCallback = new RemoteCertificateValidationCallback(delegate { return true; });
+                SslStreamCertificateContext certificateContext = SslStreamCertificateContext.Create(serverCert, null, false);
 
                 var network = new VirtualNetwork();
                 using (var client = new SslStream(new VirtualNetworkStream(network, isServer: false)))
@@ -72,7 +73,8 @@ namespace System.Net.Security.Tests
                         EnabledSslProtocols = serverSslProtocols,
                         EncryptionPolicy = serverEncryption,
                         RemoteCertificateValidationCallback = serverRemoteCallback,
-                        ServerCertificate = serverCert
+                        ServerCertificate = serverCert,
+                        ServerCertificateContext = certificateContext,
                     };
 
                     // Authenticate
@@ -103,6 +105,7 @@ namespace System.Net.Security.Tests
                     Assert.Equal(serverEncryption, serverOptions.EncryptionPolicy);
                     Assert.Same(serverRemoteCallback, serverOptions.RemoteCertificateValidationCallback);
                     Assert.Same(serverCert, serverOptions.ServerCertificate);
+                    Assert.Same(certificateContext, serverOptions.ServerCertificateContext);
                 }
             }
         }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -42,7 +42,7 @@ namespace System.Net.Security.Tests
             {
                 clientOptions.RemoteCertificateValidationCallback = AllowAnyServerCertificate;
                 clientOptions.TargetHost = certificate.GetNameInfo(X509NameType.SimpleName, false);
-                serverOptions.ServerCertificate = certificate;
+                serverOptions.ServerCertificateContext = SslStreamCertificateContext.Create(certificate, null);
 
                 Task t1 = clientSslStream.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions);
                 Task t2 = serverSslStream.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -87,6 +87,11 @@ namespace System.Net.Security
         internal X509Certificate LocalClientCertificate => default;
         internal X509RevocationMode CheckCertRevocationStatus => default;
         internal ProtocolToken CreateShutdownToken() => default;
+
+        internal static X509Certificate2? FindCertificateWithPrivateKey(object instance, bool isServer, X509Certificate certificate)
+        {
+            return certificate as X509Certificate2;
+        }
     }
 
     internal class ProtocolToken

--- a/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Security/tests/UnitTests/System.Net.Security.Unit.Tests.csproj
@@ -46,6 +46,10 @@
              Link="ProductionCode\System\Net\Security\SslApplicationProtocol.cs" />
     <Compile Include="..\..\src\System\Net\Security\SslConnectionInfo.cs"
              Link="ProductionCode\System\Net\Security\SslConnectionInfo.cs" />
+    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.cs"
+             Link="ProductionCode\System\Net\Security\SslStreamCertificateContext.cs" />
+    <Compile Include="..\..\src\System\Net\Security\SslStreamCertificateContext.Windows.cs"
+             Link="ProductionCode\System\Net\Security\SslStreamCertificateContext.Windows.cs" />
     <Compile Include="..\..\src\System\Net\Security\ReadWriteAdapter.cs"
              Link="ProductionCode\System\Net\Security\ReadWriteAdapter.cs" />
     <Compile Include="..\..\src\System\Net\SslStreamContext.cs"


### PR DESCRIPTION
This adds part of the new API surface approved in #37933. Internally, I switched SslStream to use CertificateContext instead of ServerCertificate  and I did minimal fixes in OpenSSL pal to get that through. MacOS and Windows will follow. 
So as more tests once #38182 is in. I will us that structure to create more test scenarios for partial chains.

contribues to #35844

SslStreamCertificateContext.Create() was approved with X509Certificate2Collection and I'm wondering if X509CertificateCollection would be sufficient @bartonjs since we do not need keys for the intermediate certificates. 

 