### PR TITLE
Don't resolve direct methods outside of the version bubble

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 SignatureContext innerContext = builder.EmitFixup(factory, ReadyToRunFixupKind.DelegateCtor, _methodToken.Module, factory.SignatureContext);
 
                 builder.EmitMethodSignature(
-                    new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null, unboxing: false),
+                    new MethodWithToken(_targetMethod.Method, exactType: _targetMethod.Method.OwningType, _methodToken, constrainedType: null, unboxing: false),
                     enforceDefEncoding: false,
                     enforceOwningType: false,
                     innerContext,

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -116,6 +116,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             else if (_typeArgument != null)
             {
+                if (_fixupKind == ReadyToRunFixupKind.DeclaringTypeHandle)
+                {
+                    dataBuilder.EmitTypeSignature(_methodContext.ContextType, innerContext);
+                }
                 dataBuilder.EmitTypeSignature(_typeArgument, innerContext);
             }
             else if (_fieldArgument != null)

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -61,7 +61,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
                 signatureBuilder.EmitMethodSignature(
-                    new MethodWithToken(method.Method, moduleToken, constrainedType: null, unboxing: false),
+                    new MethodWithToken(method.Method, exactType: method.Method.OwningType, moduleToken, constrainedType: null, unboxing: false),
                     enforceDefEncoding: true,
                     enforceOwningType: _factory.CompilationModuleGroup.EnforceOwningType(moduleToken.Module),
                     factory.SignatureContext,

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -80,13 +80,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 if (method.Token.TokenType == CorTokenType.mdtMethodSpec)
                 {
-                    method = new MethodWithToken(method.Method, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType, unboxing: _method.Unboxing);
+                    method = new MethodWithToken(method.Method, method.ExactType, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType, unboxing: _method.Unboxing);
                 }
                 else if (!optimized && (method.Token.TokenType == CorTokenType.mdtMemberRef))
                 {
                     if (method.Method.OwningType.GetTypeDefinition() is EcmaType)
                     {
-                        method = new MethodWithToken(method.Method, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType, unboxing: _method.Unboxing);
+                        method = new MethodWithToken(method.Method, method.ExactType, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType, unboxing: _method.Unboxing);
                     }
                 }
             }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -530,7 +530,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             EmitUInt(flags);
             if ((flags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
             {
-                EmitTypeSignature(method.Method.OwningType, context);
+                EmitTypeSignature(method.ExactType, context);
             }
             EmitTokenRid(methodToken.Token);
             if ((flags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation) != 0)

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -395,7 +395,7 @@ namespace ILCompiler.DependencyAnalysis
                 EcmaModule module = ((EcmaMethod)method.GetTypicalMethodDefinition()).Module;
                 ModuleToken moduleToken = Resolver.GetModuleTokenForMethod(method, throwIfNotFound: true);
 
-                IMethodNode methodNodeDebug = MethodEntrypoint(new MethodWithToken(method, moduleToken, constrainedType: null, unboxing: false), false, false);
+                IMethodNode methodNodeDebug = MethodEntrypoint(new MethodWithToken(method, method.OwningType, moduleToken, constrainedType: null, unboxing: false), false, false, false);
                 MethodWithGCInfo methodCodeNodeDebug = methodNodeDebug as MethodWithGCInfo;
                 if (methodCodeNodeDebug == null && methodNodeDebug is DelayLoadMethodImport DelayLoadMethodImport)
                 {

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -537,6 +537,13 @@ namespace ILCompiler.DependencyAnalysis
                         helperArgument,
                         methodContext);
 
+                case ReadyToRunHelperId.DeclaringTypeHandle:
+                    return GenericLookupTypeHelper(
+                        runtimeLookupKind,
+                        ReadyToRunFixupKind.DeclaringTypeHandle,
+                        (MethodWithToken)helperArgument,
+                        methodContext);
+
                 case ReadyToRunHelperId.MethodHandle:
                     return GenericLookupMethodHelper(
                         runtimeLookupKind,

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1244,6 +1244,13 @@ namespace Internal.JitInterface
             //
 
             targetMethod = methodAfterConstraintResolution;
+            if (!_compilation.CompilationModuleGroup.VersionsWithMethodBody(targetMethod))
+            {
+                // This loosely corresponds to the bit around
+                // https://github.com/dotnet/runtime/blob/9380bbf37bb0ba19c7e2671359875c93686b400c/src/coreclr/src/vm/zapsig.cpp#L1278
+                // where we're resorting to use the original token for the sake of version resiliency.
+                targetMethod = originalMethod;
+            }
 
             if (targetMethod.HasInstantiation)
             {

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1107,6 +1107,13 @@ namespace ILCompiler.Reflection.ReadyToRun
                     builder.Append(" (TYPE_HANDLE)");
                     break;
 
+                case ReadyToRunFixupKind.DeclaringTypeHandle:
+                    ParseType(builder);
+                    builder.Append(" => ");
+                    ParseType(builder);
+                    builder.Append(" (DECLARING_TYPE_HANDLE)");
+                    break;
+
                 case ReadyToRunFixupKind.MethodHandle:
                     ParseMethod(builder);
                     builder.Append(" (METHOD_HANDLE)");
@@ -1323,11 +1330,6 @@ namespace ILCompiler.Reflection.ReadyToRun
                     builder.Append(" => ");
                     ParseType(builder);
                     builder.Append(" (DELEGATE_CTOR)");
-                    break;
-
-                case ReadyToRunFixupKind.DeclaringTypeHandle:
-                    ParseType(builder);
-                    builder.Append(" (DECLARING_TYPE_HANDLE)");
                     break;
 
                 case ReadyToRunFixupKind.IndirectPInvokeTarget:

--- a/src/coreclr/tests/src/readytorun/crossgen2/Generated1358.il
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Generated1358.il
@@ -1,0 +1,103 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { .publickeytoken = (B7 7A 5C 56 19 34 E0 89 ) .ver 4:0:0:0 }
+
+//TYPES IN FORWARDER ASSEMBLIES:
+
+//TEST ASSEMBLY:
+.assembly Generated1358 { .hash algorithm 0x00008004 }
+.module Generated1358.dll
+
+.class private BaseClass0 
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+.class private BaseClass1 
+        extends BaseClass0
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void BaseClass0::.ctor()
+        ret
+    }
+}
+.class private G3_C1830`1<T0> 
+        extends class G2_C774`2<!T0,class BaseClass0>
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void class G2_C774`2<!T0,class BaseClass0>::.ctor()
+        ret
+    }
+}
+.class private G2_C774`2<T0, T1> 
+        extends class G1_C14`2<!T0,class BaseClass0>
+{
+    .method public hidebysig newslot virtual instance string 'G1_C14<T0,class BaseClass0>.ClassMethod1350'<M0>() cil managed noinlining { 
+        .override method instance string class G1_C14`2<!T0,class BaseClass0>::ClassMethod1350<[1]>()
+        ldstr "G2_C774::ClassMethod1350.MI.12159<"
+        ldtoken !!M0
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        call string [mscorlib]System.String::Concat(object,object)
+        ldstr ">()"
+        call string [mscorlib]System.String::Concat(object,object)
+        ret
+    }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void class G1_C14`2<!T0,class BaseClass0>::.ctor()
+        ret
+    }
+}
+.class private G1_C14`2<T0, T1> 
+        implements class IBase2`2<!T1,class BaseClass1>, class IBase1`1<class BaseClass1> 
+{
+    .method public hidebysig newslot virtual instance string ClassMethod1350<M0>() cil managed noinlining { 
+        ldstr "G1_C14::ClassMethod1350.4883<"
+        ldtoken !!M0
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        call string [mscorlib]System.String::Concat(object,object)
+        ldstr ">()"
+        call string [mscorlib]System.String::Concat(object,object)
+        ret
+    }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+.class interface private abstract IBase2`2<+T0, -T1> 
+{
+}
+.class interface private abstract IBase1`1<+T0> 
+{
+}
+.class public auto ansi beforefieldinit TypeGeneratorTest1358 {
+    .method static bool M.G2_C774.T.T<T0,T1,(class G2_C774`2<!!T0,!!T1>)W>(!!W 'inst', string exp) cil managed {
+        .maxstack 14
+        ldarga.s     0
+        constrained. !!W
+        callvirt     instance string class G2_C774`2<!!T0,!!T1>::ClassMethod1350<object>()
+        ldarg.1
+        call         bool [mscorlib]System.String::Equals(string, string)
+        ret
+    }
+    .method public hidebysig static bool ConstrainedCallsTest() cil managed
+    {
+        .maxstack  10
+        .locals init (object V_0)
+        newobj instance void class G3_C1830`1<class BaseClass0>::.ctor()
+        stloc.0
+        ldloc.0
+        ldstr "G2_C774::ClassMethod1350.MI.12159<System.Object>()"
+        call bool TypeGeneratorTest1358::M.G2_C774.T.T<class BaseClass0,class BaseClass0,class G3_C1830`1<class BaseClass0>>(!!2,string)
+        ret
+    }
+}

--- a/src/coreclr/tests/src/readytorun/crossgen2/Generated1358.ilproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Generated1358.ilproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Generated1358.il" />
+  </ItemGroup>
+</Project>

--- a/src/coreclr/tests/src/readytorun/crossgen2/Generated612.il
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Generated612.il
@@ -1,0 +1,105 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+.assembly extern mscorlib { .publickeytoken = (B7 7A 5C 56 19 34 E0 89 ) .ver 4:0:0:0 }
+
+//TYPES IN FORWARDER ASSEMBLIES:
+
+//TEST ASSEMBLY:
+.assembly Generated612 { .hash algorithm 0x00008004 }
+.module Generated612.dll
+
+.class public BaseClass0 
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+.class public BaseClass1 
+        extends BaseClass0
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void BaseClass0::.ctor()
+        ret
+    }
+}
+.class public G3_C1084`1<T0> 
+        extends G2_C21
+        implements class IBase2`2<class BaseClass1,!T0> 
+{
+    .method public hidebysig newslot virtual instance string 'G2_C21.ClassMethod1356'<M0>() cil managed noinlining { 
+        .override method instance string G2_C21::ClassMethod1356<[1]>()
+        ldstr "G3_C1084::ClassMethod1356.MI.14216<"
+        ldtoken !!M0
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        call string [mscorlib]System.String::Concat(object,object)
+        ldstr ">()"
+        call string [mscorlib]System.String::Concat(object,object)
+        ret
+    }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void G2_C21::.ctor()
+        ret
+    }
+}
+.class public G2_C21 
+        extends class G1_C6`2<class BaseClass0,class BaseClass0>
+        implements class IBase2`2<class BaseClass0,class BaseClass1>, class IBase1`1<class BaseClass1> 
+{
+    .method public hidebysig newslot virtual instance string ClassMethod1356<M0>() cil managed noinlining { 
+        ldstr "G2_C21::ClassMethod1356.4932<"
+        ldtoken !!M0
+        call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+        call string [mscorlib]System.String::Concat(object,object)
+        ldstr ">()"
+        call string [mscorlib]System.String::Concat(object,object)
+        ret
+    }
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void class G1_C6`2<class BaseClass0,class BaseClass0>::.ctor()
+        ret
+    }
+}
+.class interface public abstract IBase2`2<+T0, -T1> 
+{
+}
+.class public G1_C6`2<T0, T1> 
+        implements class IBase2`2<class BaseClass1,!T0> 
+{
+    .method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
+        ldarg.0
+        call instance void [mscorlib]System.Object::.ctor()
+        ret
+    }
+}
+.class interface public abstract IBase1`1<+T0> 
+{
+}
+.class public auto ansi beforefieldinit TypeGeneratorTest612 {
+    .method static bool M.G3_C1084.T<T0,(class G3_C1084`1<!!T0>)W>(!!W 'inst', string exp) cil managed {
+        .maxstack 14
+        ldarga.s     0
+        constrained. !!W
+        callvirt     instance string class G3_C1084`1<!!T0>::ClassMethod1356<object>()
+        ldarg.1
+        call         bool [mscorlib]System.String::Equals(string, string)
+        ret
+    }
+    .method public hidebysig static bool ConstrainedCallsTest() cil managed
+    {
+        .maxstack  10
+        .locals init (object V_0)
+        newobj instance void class G3_C1084`1<class BaseClass0>::.ctor()
+        stloc.0
+        ldloc.0
+        ldstr "G3_C1084::ClassMethod1356.MI.14216<System.Object>()"
+        call bool TypeGeneratorTest612::M.G3_C1084.T<class BaseClass0,class G3_C1084`1<class BaseClass0>>(!!1,string)
+        ret
+    }
+}

--- a/src/coreclr/tests/src/readytorun/crossgen2/Generated612.ilproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Generated612.ilproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>SharedLibrary</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Generated612.il" />
+  </ItemGroup>
+</Project>

--- a/src/tests/readytorun/crossgen2/Program.cs
+++ b/src/tests/readytorun/crossgen2/Program.cs
@@ -1691,6 +1691,8 @@ internal class Program
         RunTest("ExplicitlySizedStructTest", ExplicitlySizedStructTest());
         RunTest("ExplicitlySizedClassTest", ExplicitlySizedClassTest());
         RunTest("GenericLdtokenTest", GenericLdtokenTest());
+        RunTest("ConstrainedCallTest612", TypeGeneratorTest612.ConstrainedCallsTest());
+        RunTest("ConstrainedCallTest1358", TypeGeneratorTest1358.ConstrainedCallsTest());
 
         File.Delete(TextFileName);
 

--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -20,6 +20,8 @@
   <ItemGroup>
     <ProjectReference Include=".\helperdll.csproj" />
     <ProjectReference Include=".\helperildll.ilproj" />
+    <ProjectReference Include=".\Generated612.ilproj" />
+    <ProjectReference Include=".\Generated1358.ilproj" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -28,14 +30,31 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 copy helperildll.dll helperildll.ildll
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+copy Generated612.dll Generated612.ildll
+copy Generated1358.dll Generated1358.ildll
+
+set CMD_HELPER=%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
+echo %CMD_HELPER%
+%CMD_HELPER%
+set CMD_612=%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -o:Generated612.dll Generated612.ildll
+echo %CMD_612%
+%CMD_612%
+set CMD_1358=%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -o:Generated1358.dll Generated1358.ildll
+echo %CMD_1358%
+%CMD_1358%
+set CMD_MAIN=%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -r:helperildll.dll -r:Generated612.dll -r:Generated1358.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+echo %CMD_MAIN%
+%CMD_MAIN%
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 cp helperildll.dll helperildll.ildll
+cp Generated612.dll Generated612.ildll
+cp Generated1358.dll Generated1358.ildll
 $CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -o:Generated612.dll Generated612.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -o:Generated1358.dll Generated1358.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -r:helperildll.dll -r:Generated612.dll -r:Generated1358.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This change fixes 66 TypeGeneratorTests that were previously failing due to inability to locate the associated MethodDesc.

/cc: @dotnet/crossgen-contrib 