### PR TITLE
Initialize arguments in ExternalMethodFixupStub

### DIFF
--- a/src/coreclr/src/vm/arm64/asmhelpers.S
+++ b/src/coreclr/src/vm/arm64/asmhelpers.S
@@ -545,6 +545,8 @@ NESTED_ENTRY ExternalMethodFixupStub, _TEXT, NoHandler
 
     add x0, sp, #__PWTB_TransitionBlock // pTransitionBlock
     mov x1, x12 // pThunk
+    mov x2, #0  // sectionIndex
+    mov x3, #0  // pModule
 
     bl C_FUNC(ExternalMethodFixupWorker)
 

--- a/src/coreclr/src/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/src/vm/arm64/asmhelpers.asm
@@ -612,6 +612,8 @@ Exit
 
     add         x0, sp, #__PWTB_TransitionBlock ; pTransitionBlock
     mov         x1, x12                         ; pThunk
+    mov         x2, #0                          ; sectionIndex
+    mov         x3, #0                          ; pModule
 
     bl          ExternalMethodFixupWorker
 


### PR DESCRIPTION
- Fix a crash in arm64 and NGen environment.
- Iniitialize sectionIndex and pModule values in ExternalMethodFixupStub
  to call ExternalMethodFixupWorker