### PR TITLE
[wasm] Disable threading tests in System.IO

### DIFF
--- a/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
+++ b/src/libraries/System.IO/tests/BufferedStream/BufferedStreamTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.IO.Tests
@@ -17,7 +18,7 @@ namespace System.IO.Tests
             return new BufferedStream(new MemoryStream());
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ConcurrentOperationsAreSerialized()
         {
             byte[] data = Enumerable.Range(0, 1000).Select(i => unchecked((byte)i)).ToArray();
@@ -54,11 +55,16 @@ namespace System.IO.Tests
             Assert.Equal(TaskStatus.Faulted, stream.FlushAsync().Status);
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task CopyToTest_RequiresFlushingOfWrites(bool copyAsynchronously)
         {
+            if (copyAsynchronously && !PlatformDetection.IsThreadingSupported)
+            {
+                throw new SkipTestException(nameof(PlatformDetection.IsThreadingSupported));
+            }
+
             byte[] data = Enumerable.Range(0, 1000).Select(i => (byte)(i % 256)).ToArray();
 
             var manualReleaseStream = new ManuallyReleaseAsyncOperationsStream();

--- a/src/libraries/System.IO/tests/Stream/Stream.CopyToTests.cs
+++ b/src/libraries/System.IO/tests/Stream/Stream.CopyToTests.cs
@@ -81,7 +81,7 @@ namespace System.IO.Tests
             Assert.InRange(trackingStream.TimesCalled(nameof(trackingStream.Position)), 0, 1);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task AsyncIfCanSeekIsTrueLengthAndPositionShouldOnlyBeCalledOnce()
         {
             var baseStream = new DelegateStream(

--- a/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
+++ b/src/libraries/System.IO/tests/StreamReader/StreamReaderTests.cs
@@ -513,6 +513,7 @@ namespace System.IO.Tests
         [InlineData(0, true)]
         [InlineData(1, false)]
         [InlineData(1, true)]
+        [PlatformSpecific(~TestPlatforms.Browser)]
         public async Task ReadAsync_Canceled_ThrowsException(int method, bool precanceled)
         {
             Func<StreamReader, CancellationToken, Task<int>> func = method switch

--- a/src/libraries/System.IO/tests/TextWriter/TextWriterTests.cs
+++ b/src/libraries/System.IO/tests/TextWriter/TextWriterTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.IO.Tests
@@ -463,7 +464,7 @@ namespace System.IO.Tests
 
         #region Write Async Overloads
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteAsyncCharTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -484,7 +485,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteAsyncCharArrayIndexCountTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -498,7 +499,7 @@ namespace System.IO.Tests
 
         #region WriteLineAsync Overloads
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteLineAsyncTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -508,7 +509,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteLineAsyncCharTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -518,7 +519,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteLineAsyncStringTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -529,7 +530,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteLineAsyncCharArrayIndexCount()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -563,7 +564,7 @@ namespace System.IO.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task WriteCharMemoryTest()
         {
             using (CharArrayTextWriter tw = NewTextWriter)
@@ -611,10 +612,15 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(GetStringBuilderTestData))]
         public async Task WriteAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
+            if (!isSynchronized && !PlatformDetection.IsThreadingSupported)
+            {
+                throw new SkipTestException(nameof(PlatformDetection.IsThreadingSupported));
+            }
+
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;
@@ -624,10 +630,15 @@ namespace System.IO.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [MemberData(nameof(GetStringBuilderTestData))]
         public async Task WriteLineAsyncStringBuilderTest(bool isSynchronized, StringBuilder testData)
         {
+            if (!isSynchronized && !PlatformDetection.IsThreadingSupported)
+            {
+                throw new SkipTestException(nameof(PlatformDetection.IsThreadingSupported));
+            }
+
             using (CharArrayTextWriter ctw = NewTextWriter)
             {
                 TextWriter tw = isSynchronized ? TextWriter.Synchronized(ctw) : ctw;


### PR DESCRIPTION
This allows the test suite to finish on WASM: `Tests run: 883, Errors: 0, Failures: 0, Skipped: 30. Time: 58.57082s`