### PR TITLE
[wasm] Disable threading tests in System.Linq.Parallel

### DIFF
--- a/src/libraries/System.Linq.Parallel/tests/PlinqModesTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/PlinqModesTests.cs
@@ -136,7 +136,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         // Check that some queries run in parallel by default, and some require forcing.
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(WithExecutionModeQueryData), new[] { 1, 4 })] // DOP of 1 to verify sequential and 4 to verify parallel
         public static void WithExecutionMode(
             Labeled<ParallelQuery<int>> labeled,

--- a/src/libraries/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/libraries/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -516,7 +516,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         // Heavily exercises OrderBy, but only throws one user delegate exception to simulate an occasional failure.
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(OrderByThreadedData), new[] { 1, 2, 16, 128, 1024 }, new[] { 1, 2, 4, 7, 8, 31, 32 })]
         public static void OrderBy_ThreadedDeadlock_SingleException(Labeled<ParallelQuery<int>> labeled, int count, int degree)
         {


### PR DESCRIPTION
This allows the test suite to pass on WASM: `Tests run: 27708, Errors: 0, Failures: 0, Skipped: 107. Time: 159.380298s`