### PR TITLE
Ensure Process.MainWindowTitle and Process.Responding is refreshed

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -119,6 +119,7 @@ namespace System.Diagnostics
         {
             _signaled = false;
             _haveMainWindow = false;
+            _mainWindowTitle = null;
         }
 
         /// <summary>Additional logic invoked when the Process is closed.</summary>

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -120,6 +120,7 @@ namespace System.Diagnostics
             _signaled = false;
             _haveMainWindow = false;
             _mainWindowTitle = null;
+            _haveResponding = false;
         }
 
         /// <summary>Additional logic invoked when the Process is closed.</summary>

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1622,7 +1622,7 @@ namespace System.Diagnostics.Tests
                         Thread.Sleep(100);
                     }
 
-                    Assert.NotEqual(string.Empty, process.MainWindowHandle);
+                    Assert.NotEqual(string.Empty, process.MainWindowTitle);
                 }
                 finally
                 {
@@ -1641,14 +1641,14 @@ namespace System.Diagnostics.Tests
             const string ExePath = @"C:\Program Files\Windows NT\Accessories\wordpad.exe";
             Assert.True(IsProgramInstalled(ExePath));
 
-            const string DummyFilePath = $@"{Path.GetTempPath()}dummy_file";
+            string dummyFilePath = $@"{Path.GetTempPath()}dummy_file";
 
-            var dummyFile = new FileStream(DummyFilePath, System.IO.FileMode.Create);
+            var dummyFile = new FileStream(dummyFilePath, System.IO.FileMode.Create);
             _ = dummyFile.Seek(2048L * 1024 * 1024, SeekOrigin.Begin);
             dummyFile.WriteByte(0);
             dummyFile.Close();
 
-            using (Process process = Process.Start(ExePath, DummyFilePath))
+            using (Process process = Process.Start(ExePath, dummyFilePath))
             {
                 try
                 {
@@ -1674,7 +1674,7 @@ namespace System.Diagnostics.Tests
                 }
             }
 
-            File.Delete(DummyFilePath);
+            File.Delete(dummyFilePath);
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1641,14 +1641,14 @@ namespace System.Diagnostics.Tests
             const string ExePath = @"C:\Program Files\Windows NT\Accessories\wordpad.exe";
             Assert.True(IsProgramInstalled(ExePath));
 
-            string dummyFilePath = $@"{Path.GetTempPath()}dummy_file";
+            const string DummyFilePath = $@"{Path.GetTempPath()}dummy_file";
 
-            var dummyFile = new FileStream(dummyFilePath, System.IO.FileMode.Create);
+            var dummyFile = new FileStream(DummyFilePath, System.IO.FileMode.Create);
             _ = dummyFile.Seek(2048L * 1024 * 1024, SeekOrigin.Begin);
             dummyFile.WriteByte(0);
             dummyFile.Close();
 
-            using (Process process = Process.Start(ExePath, dummyFilePath))
+            using (Process process = Process.Start(ExePath, DummyFilePath))
             {
                 try
                 {
@@ -1674,7 +1674,7 @@ namespace System.Diagnostics.Tests
                 }
             }
 
-            File.Delete(dummyFilePath);
+            File.Delete(DummyFilePath);
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1596,6 +1596,42 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Fact]
+        [OuterLoop]
+        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Pops UI
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void MainWindowTitle_GetWithGui_ShouldRefresh_Windows()
+        {
+            const string ExePath = "notepad.exe";
+            Assert.True(IsProgramInstalled(ExePath));
+
+            using (Process process = Process.Start(ExePath))
+            {
+                try
+                {
+                    Assert.Equal(string.Empty, process.MainWindowTitle);
+
+                    for (int attempt = 0; attempt < 50; ++attempt)
+                    {
+                        process.Refresh();
+                        if (process.MainWindowTitle != string.Empty)
+                        {
+                            break;
+                        }
+
+                        Thread.Sleep(100);
+                    }
+
+                    Assert.NotEqual(string.Empty, process.MainWindowHandle);
+                }
+                finally
+                {
+                    process.Kill();
+                    Assert.True(process.WaitForExit(WaitInMS));
+                }
+            }
+        }
+
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void MainWindowTitle_NoWindow_ReturnsEmpty()
         {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1632,51 +1632,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [Fact]
-        [OuterLoop]
-        [Trait(XunitConstants.Category, XunitConstants.IgnoreForCI)] // Pops UI
-        [PlatformSpecific(TestPlatforms.Windows)]
-        public void Responding_GetWithGui_ShouldRefresh_Windows()
-        {
-            const string ExePath = @"C:\Program Files\Windows NT\Accessories\wordpad.exe";
-            Assert.True(IsProgramInstalled(ExePath));
-
-            string dummyFilePath = $@"{Path.GetTempPath()}dummy_file";
-
-            var dummyFile = new FileStream(dummyFilePath, System.IO.FileMode.Create);
-            _ = dummyFile.Seek(2048L * 1024 * 1024, SeekOrigin.Begin);
-            dummyFile.WriteByte(0);
-            dummyFile.Close();
-
-            using (Process process = Process.Start(ExePath, dummyFilePath))
-            {
-                try
-                {
-                    Assert.True(process.Responding);
-
-                    for (int attempt = 0; attempt < 100; ++attempt)
-                    {
-                        process.Refresh();
-                        if (!process.Responding)
-                        {
-                            break;
-                        }
-
-                        Thread.Sleep(100);
-                    }
-
-                    Assert.False(process.Responding);
-                }
-                finally
-                {
-                    process.Kill();
-                    Assert.True(process.WaitForExit(WaitInMS));
-                }
-            }
-
-            File.Delete(dummyFilePath);
-        }
-
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public void MainWindowTitle_NoWindow_ReturnsEmpty()
         {


### PR DESCRIPTION
PR for issue #36768.

It should fix the issue, but I'm unable to run the tests because opening the solution leads to the following NuGet error:
```
Error occurred while restoring NuGet packages: Invalid restore input. Duplicate frameworks found: 'net5.0, net5.0, net5.0, net5.0, net5.0, net5.0'. Input files: E:\Repos\JeroenOortwijn\dotnet\runtime\src\libraries\System.Diagnostics.Process\src\System.Diagnostics.Process.csproj.
```
(Which, I think, is tracked in #34173.)