### PR TITLE
Remove defensive OID copies

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/ECCurve.cs
@@ -70,14 +70,9 @@ namespace System.Security.Cryptography
         /// <summary>
         /// The Oid representing the named curve. Applies only to Named curves.
         /// </summary>
-        /// <remarks>A clone is returned, not the current instance.</remarks>
         public Oid Oid
         {
-            get
-            {
-                // Ensure _oid remains immutable
-                return new Oid(_oid.Value, _oid.FriendlyName);
-            }
+            get => _oid;
             private set
             {
                 if (value == null)
@@ -91,25 +86,16 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
-        /// Create a curve without having to make a copy of the Oid
-        /// </summary>
-        private static ECCurve Create(Oid oid)
-        {
-            ECCurve curve = default;
-            curve.CurveType = ECCurveType.Named;
-            curve.Oid = oid;
-            return curve;
-        }
-
-        /// <summary>
         /// Create a curve from the given cref="Oid".
         /// </summary>
         /// <param name="curveOid">The Oid to use.</param>
         /// <returns>An ECCurve representing a named curve.</returns>
         public static ECCurve CreateFromOid(Oid curveOid)
         {
-            // Make a copy since Oid is mutable
-            return Create(new Oid(curveOid.Value, curveOid.FriendlyName));
+            ECCurve curve = default;
+            curve.CurveType = ECCurveType.Named;
+            curve.Oid = curveOid;
+            return curve;
         }
 
         /// <summary>
@@ -156,7 +142,7 @@ namespace System.Security.Cryptography
             }
 
             oid ??= new Oid(oidValue, oidFriendlyName);
-            return ECCurve.Create(oid);
+            return ECCurve.CreateFromOid(oid);
         }
 
         public bool IsPrime

--- a/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedData.cs
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System/Security/Cryptography/AsnEncodedData.cs
@@ -43,15 +43,8 @@ namespace System.Security.Cryptography
 
         public Oid? Oid
         {
-            get
-            {
-                return _oid;
-            }
-
-            set
-            {
-                _oid = (value == null) ? null : new Oid(value);
-            }
+            get => _oid;
+            set => _oid = value;
         }
 
         public byte[] RawData

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/PkcsHelpers.cs
@@ -690,5 +690,17 @@ namespace Internal.Cryptography
                 return false;
             }
         }
+
+        // Creates a defensive copy of an OID on platforms where OID
+        // is mutable. On platforms where OID is immutable, return the OID as-is.
+        [return: NotNullIfNotNull("oid")]
+        public static Oid? CopyOid(this Oid? oid)
+        {
+#if NETCOREAPP
+            return oid;
+#else
+            return oid is null ? null : new Oid(oid);
+#endif
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/CryptographicAttributeObject.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography;
 using System;
 using System.Diagnostics;
 
@@ -19,7 +20,8 @@ namespace System.Security.Cryptography
 
         public CryptographicAttributeObject(Oid oid, AsnEncodedDataCollection? values)
         {
-            _oid = new Oid(oid);
+            _oid = oid.CopyOid();
+
             if (values == null)
             {
                 Values = new AsnEncodedDataCollection();
@@ -39,13 +41,7 @@ namespace System.Security.Cryptography
         // Public properties.
         //
 
-        public Oid Oid
-        {
-            get
-            {
-                return new Oid(_oid);
-            }
-        }
+        public Oid Oid => _oid.CopyOid();
 
         public AsnEncodedDataCollection Values { get; }
         private readonly Oid _oid;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSigner.cs
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography.Pkcs
             }
 
             Certificate = certificate;
-            DigestAlgorithm = new Oid(s_defaultAlgorithm);
+            DigestAlgorithm = s_defaultAlgorithm.CopyOid();
             PrivateKey = privateKey;
         }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12CertBag.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12CertBag.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography.Pkcs
                 EncodeBagValue(certificateType, encodedCertificate),
                 skipCopy: true)
         {
-            _certTypeOid = new Oid(certificateType);
+            _certTypeOid = certificateType.CopyOid();
 
             _decoded = CertBagAsn.Decode(EncodedBagValue, AsnEncodingRules.BER);
 
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography.Pkcs
                 _certTypeOid = new Oid(_decoded.CertId);
             }
 
-            return new Oid(_certTypeOid);
+            return _certTypeOid.CopyOid();
         }
 
         public ReadOnlyMemory<byte> EncodedCertificate => _decoded.CertValue;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12SafeBag.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12SafeBag.cs
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.Pkcs
                 _bagOid = new Oid(_bagIdValue);
             }
 
-            return new Oid(_bagOid);
+            return _bagOid.CopyOid();
         }
 
         public bool TryEncode(Span<byte> destination, out int bytesWritten)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12SecretBag.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Pkcs12SecretBag.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Internal.Cryptography;
 using System.Diagnostics;
 using System.Formats.Asn1;
 using System.Security.Cryptography.Pkcs.Asn1;
@@ -41,7 +42,7 @@ namespace System.Security.Cryptography.Pkcs
                 _secretTypeOid = new Oid(_decoded.SecretTypeId);
             }
 
-            return new Oid(_secretTypeOid);
+            return _secretTypeOid.CopyOid();
         }
 
         private static byte[] EncodeBagValue(Oid secretTypeOid, in ReadOnlyMemory<byte> secretValue)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.CtorOverloads.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.CtorOverloads.cs
@@ -12,7 +12,7 @@ namespace System.Security.Cryptography.Pkcs
         private static readonly Oid s_cmsDataOid = Oid.FromOidValue(Oids.Pkcs7Data, OidGroup.ExtensionOrAttribute);
 
         private static ContentInfo MakeEmptyContentInfo() =>
-            new ContentInfo(new Oid(s_cmsDataOid), Array.Empty<byte>());
+            new ContentInfo(s_cmsDataOid.CopyOid(), Array.Empty<byte>());
 
         public SignedCms()
             : this(SubjectIdentifierType.IssuerAndSerialNumber, MakeEmptyContentInfo(), false)

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/CertBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/CertBagTests.cs
@@ -48,9 +48,11 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
             Oid firstCall = certBag.GetCertificateType();
             Oid secondCall = certBag.GetCertificateType();
 
+#if !NETCOREAPP
             Assert.NotSame(oid, firstCall);
             Assert.NotSame(oid, secondCall);
             Assert.NotSame(firstCall, secondCall);
+#endif
             Assert.Equal(oid.Value, firstCall.Value);
             Assert.Equal(oid.Value, secondCall.Value);
             Assert.Equal("Hello", firstCall.FriendlyName);

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12SafeBagTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/Pkcs12/Pkcs12SafeBagTests.cs
@@ -64,9 +64,12 @@ namespace System.Security.Cryptography.Pkcs.Tests.Pkcs12
             Pkcs12SafeBag safeBag = new TestSafeBag(Oids.Aes192);
             Oid firstCall = safeBag.GetBagId();
             Oid secondCall = safeBag.GetBagId();
-            Assert.NotSame(firstCall, secondCall);
+
             Assert.Equal(Oids.Aes192, firstCall.Value);
             Assert.Equal(firstCall.Value, secondCall.Value);
+#if !NETCOREAPP
+            Assert.NotSame(firstCall, secondCall);
+#endif
         }
 
         [Fact]

--- a/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsWholeDocumentTests.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/tests/SignedCms/SignedCmsWholeDocumentTests.cs
@@ -76,7 +76,9 @@ namespace System.Security.Cryptography.Pkcs.Tests
                 messageDigestAttr.MessageDigest.ByteArrayToHex());
 
             Assert.IsType<Pkcs9AttributeObject>(signedAttrs[3].Values[0]);
+#if !NETCOREAPP
             Assert.NotSame(signedAttrs[3].Oid, signedAttrs[3].Values[0].Oid);
+#endif
             Assert.Equal(
                 "306A300B060960864801650304012A300B0609608648016503040116300B0609" +
                     "608648016503040102300A06082A864886F70D0307300E06082A864886F70D03" +

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -14,7 +14,7 @@ namespace System.Security.Cryptography.X509Certificates
 
         public PublicKey(Oid oid, AsnEncodedData parameters, AsnEncodedData keyValue)
         {
-            _oid = new Oid(oid);
+            _oid = oid;
             EncodedParameters = new AsnEncodedData(parameters);
             EncodedKeyValue = new AsnEncodedData(keyValue);
         }
@@ -49,12 +49,6 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        public Oid Oid
-        {
-            get
-            {
-                return new Oid(_oid);
-            }
-        }
+        public Oid Oid => _oid;
     }
 }


### PR DESCRIPTION
Since OID is init-only, this removes defensive copies. This only addresses Oid to Oid copies. Next step is to provide shared instances of OIDs where possible instead of constructing a new ones from strings every time.

Contributes to #2043 