### PR TITLE
Add mono_exception_try_get_managed_backtrace().

### DIFF
--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -2046,6 +2046,9 @@ mono_exception_handle_get_native_backtrace (MonoExceptionHandle exc);
 char *
 mono_exception_get_managed_backtrace (MonoException *exc);
 
+gboolean
+mono_exception_try_get_managed_backtrace (MonoException *exc, const char *prefix, char **result);
+
 void
 mono_copy_value (MonoType *type, void *dest, void *value, int deref_pointer);
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20024,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This is an enhanced version of `mono_exception_get_managed_backtrace()` that takes an optional `const char *prefix` argument (to indent the stack-trace) and returns FALSE with a NULL backtrace on error.