### PR TITLE
[Wasm] Skip Microsoft.Extensions.FileProviders.Physical tests

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/AssemblyInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+[assembly: SkipOnMono("Microsoft.Extensions.FileProviders.Physical is not supported on wasm", TestPlatforms.Browser)]


### PR DESCRIPTION
FSW is not supported on wasm.