### PR TITLE
JIT: fix inline policy handling of call site depth

### DIFF
--- a/src/coreclr/src/jit/inlinepolicy.cpp
+++ b/src/coreclr/src/jit/inlinepolicy.cpp
@@ -1129,7 +1129,6 @@ void RandomPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
 // clang-format off
 DiscretionaryPolicy::DiscretionaryPolicy(Compiler* compiler, bool isPrejitRoot)
     : DefaultPolicy(compiler, isPrejitRoot)
-    , m_Depth(0)
     , m_BlockCount(0)
     , m_Maxstack(0)
     , m_ArgCount(0)
@@ -1270,10 +1269,6 @@ void DiscretionaryPolicy::NoteInt(InlineObservation obs, int value)
 
         case InlineObservation::CALLEE_NUMBER_OF_BASIC_BLOCKS:
             m_BlockCount = value;
-            break;
-
-        case InlineObservation::CALLSITE_DEPTH:
-            m_Depth = value;
             break;
 
         case InlineObservation::CALLSITE_WEIGHT:
@@ -1810,7 +1805,6 @@ void DiscretionaryPolicy::DumpSchema(FILE* file) const
     fprintf(file, ",CallsiteFrequency");
     fprintf(file, ",InstructionCount");
     fprintf(file, ",LoadStoreCount");
-    fprintf(file, ",Depth");
     fprintf(file, ",BlockCount");
     fprintf(file, ",Maxstack");
     fprintf(file, ",ArgCount");
@@ -1893,7 +1887,6 @@ void DiscretionaryPolicy::DumpData(FILE* file) const
     fprintf(file, ",%u", m_CallsiteFrequency);
     fprintf(file, ",%u", m_InstructionCount);
     fprintf(file, ",%u", m_LoadStoreCount);
-    fprintf(file, ",%u", m_Depth);
     fprintf(file, ",%u", m_BlockCount);
     fprintf(file, ",%u", m_Maxstack);
     fprintf(file, ",%u", m_ArgCount);
@@ -2034,7 +2027,7 @@ void ModelPolicy::NoteInt(InlineObservation obs, int value)
     {
         unsigned depthLimit = m_RootCompiler->m_inlineStrategy->GetMaxInlineDepth();
 
-        if (m_Depth > depthLimit)
+        if (m_CallsiteDepth > depthLimit)
         {
             SetFailure(InlineObservation::CALLSITE_IS_TOO_DEEP);
             return;
@@ -2199,7 +2192,7 @@ void FullPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
 
     unsigned depthLimit = m_RootCompiler->m_inlineStrategy->GetMaxInlineDepth();
 
-    if (m_Depth > depthLimit)
+    if (m_CallsiteDepth > depthLimit)
     {
         SetFailure(InlineObservation::CALLSITE_IS_TOO_DEEP);
         return;

--- a/src/coreclr/src/jit/inlinepolicy.h
+++ b/src/coreclr/src/jit/inlinepolicy.h
@@ -227,7 +227,6 @@ protected:
         MAX_ARGS = 6
     };
 
-    unsigned    m_Depth;
     unsigned    m_BlockCount;
     unsigned    m_Maxstack;
     unsigned    m_ArgCount;


### PR DESCRIPTION
In #38163 I added a depth field to one of the inline policy base classes.
A derived class already had a similar field. Unify in favor of the base class
field.

The inline policies implemented by these derived policy classes are sometimes
used during jit stress (eg for random inlining).

Fixes #38374.