### PR TITLE
Fixing an issue in DateTime.cs where adding milliseconds with decimal values get truncated to an integer addition.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -443,7 +443,7 @@ namespace System
             if (millis_double <= (double)-MaxMillis || millis_double >= (double)MaxMillis)
                 throw new ArgumentOutOfRangeException(nameof(value), SR.ArgumentOutOfRange_AddValue);
 
-            return AddTicks((long)millis_double * TicksPerMillisecond);
+            return AddTicks((long)(millis_double * (double)TicksPerMillisecond));
         }
 
         // Returns the DateTime resulting from adding a fractional number of


### PR DESCRIPTION
Fixing an issue in DateTime.cs where adding milliseconds with decimal values get truncated to an integer addition.

See issue #38412 for details. 