### PR TITLE
Move AdvSimd check from PAL to VM

### DIFF
--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -23,13 +23,6 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 
     CORJIT_FLAGS &CPUCompileFlags = *flags;
 
-#if defined(TARGET_ARM64)
-    // Enable ARM64 based flags by default so we always crossgen
-    // ARM64 intrinsics for Linux
-    CPUCompileFlags.Set(InstructionSet_ArmBase);
-    CPUCompileFlags.Set(InstructionSet_AdvSimd);
-#endif // defined(TARGET_ARM64)
-
 #if defined(HOST_ARM64)
 #if HAVE_AUXV_HWCAP_H
     unsigned long hwCap = getauxval(AT_HWCAP);
@@ -40,6 +33,7 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 // From a single binary distribution perspective, compiling with latest kernel asm/hwcap.h should
 // include all published flags.  Given flags are merged to kernel and published before silicon is
 // available, using the latest kernel for release should be sufficient.
+    CPUCompileFlags.Set(InstructionSet_ArmBase);
 #ifdef HWCAP_AES
     if (hwCap & HWCAP_AES)
         CPUCompileFlags.Set(InstructionSet_Aes);
@@ -101,11 +95,8 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 //        CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_SHA3);
 #endif
 #ifdef HWCAP_ASIMD
-    if ((hwCap & HWCAP_ASIMD) == 0)
-    {
-        fprintf(stderr, "AdvSimd is not supported on the processor.\n");
-        abort();
-    }
+    if (hwCap & HWCAP_ASIMD)
+        CPUCompileFlags.Set(InstructionSet_AdvSimd);
 #endif
 #ifdef HWCAP_ASIMDRDM
 //    if (hwCap & HWCAP_ASIMDRDM)
@@ -127,6 +118,20 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 //    if (hwCap & HWCAP_SVE)
 //        CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_SVE);
 #endif
+#else // !HAVE_AUXV_HWCAP_H
+    // CoreCLR SIMD and FP support is included in ARM64 baseline
+    // On exceptional basis platforms may leave out support, but CoreCLR does not
+    // yet support such platforms
+    // Set baseline flags if OS has not exposed mechanism for us to determine CPU capabilities
+    CPUCompileFlags.Set(InstructionSet_ArmBase);
+    CPUCompileFlags.Set(InstructionSet_AdvSimd);
+    //    CPUCompileFlags.Set(CORJIT_FLAGS::CORJIT_FLAG_HAS_ARM64_FP);
 #endif // HAVE_AUXV_HWCAP_H
+#elif defined(TARGET_ARM64)
+    // Enable ARM64 based flags by default so we always crossgen
+    // ARM64 intrinsics for Linux
+    CPUCompileFlags.Set(InstructionSet_ArmBase);
+    CPUCompileFlags.Set(InstructionSet_AdvSimd);
+#endif // defined(TARGET_ARM64)
 #endif // defined(HOST_ARM64)
 }

--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -132,6 +132,5 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
     // ARM64 intrinsics for Linux
     CPUCompileFlags.Set(InstructionSet_ArmBase);
     CPUCompileFlags.Set(InstructionSet_AdvSimd);
-#endif // defined(TARGET_ARM64)
 #endif // defined(HOST_ARM64)
 }

--- a/src/coreclr/src/pal/src/misc/jitsupport.cpp
+++ b/src/coreclr/src/pal/src/misc/jitsupport.cpp
@@ -129,6 +129,4 @@ PAL_GetJitCpuCapabilityFlags(CORJIT_FLAGS *flags)
 #endif
 #endif // HAVE_AUXV_HWCAP_H
 #endif // defined(HOST_ARM64)
-    CPUCompileFlags.Set64BitInstructionSetVariants();
-    CPUCompileFlags.EnsureValidInstructionSetSupport();
 }

--- a/src/coreclr/src/vm/codeman.cpp
+++ b/src/coreclr/src/vm/codeman.cpp
@@ -1483,6 +1483,15 @@ void EEJitManager::SetCpuInfo()
     }
 #if defined(TARGET_UNIX)
     PAL_GetJitCpuCapabilityFlags(&CPUCompileFlags);
+
+    // For HOST_ARM64, if OS has exposed mechanism to detect CPU capabilities, make sure it has AdvSimd capability.
+    // For other cases i.e. if !HOST_ARM64 but TARGET_ARM64 or HOST_ARM64 but OS doesn't expose way to detect
+    // CPU capabilities, we always enable AdvSimd flags by default.
+    //
+    if (!CPUCompileFlags.IsSet(InstructionSet_AdvSimd))
+    {
+        EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("AdvSimd is not supported on the processor."));
+    }
 #elif defined(HOST_64BIT)
     // FP and SIMD support are enabled by default
     CPUCompileFlags.Set(InstructionSet_ArmBase);

--- a/src/coreclr/src/vm/codeman.cpp
+++ b/src/coreclr/src/vm/codeman.cpp
@@ -1473,6 +1473,15 @@ void EEJitManager::SetCpuInfo()
             CPUCompileFlags.Set(InstructionSet_LZCNT);
         }
     }
+
+    if (!CPUCompileFlags.IsSet(InstructionSet_SSE))
+    {
+        EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("SSE is not supported on the processor."));
+    }
+    if (!CPUCompileFlags.IsSet(InstructionSet_SSE2))
+    {
+        EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE, W("SSE2 is not supported on the processor."));
+    }
 #endif // defined(TARGET_X86) || defined(TARGET_AMD64)
 
 #if defined(TARGET_ARM64)


### PR DESCRIPTION
As per discussion in https://github.com/dotnet/runtime/pull/38060#discussion_r444069585 , making following changes:
- Remove redundant for `Set64BitInstructionSetVariants()` and `CPUCompileFlags.EnsureValidInstructionSetSupport()` from PAL
- Reverted part of the changes I did in https://github.com/dotnet/runtime/pull/38060 and move the check of `AdvSimd` presence in case of `TARGET_UNIX` from PAL to `codeman.cpp` .