### PR TITLE
Fix #20022 - changing the signature of mono_handle_native_crash() for s390x

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -1124,7 +1124,10 @@ AC_ARG_WITH(csc, [  --with-csc=mcs,roslyn,default      Configures the CSharp com
 
 if test $csc_compiler = default; then
    if test $endian = big; then
-      csc_compiler=mcs
+      case "$host" in
+        s390x*) csc_compiler=roslyn ;;
+        *) csc_compiler=mcs
+      esac
    elif test $endian = little; then
       case "$host" in
         powerpc*) csc_compiler=mcs ;;


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20028,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>* Fix exception-s390x so mono_handle_native_crash() is called according to the changes made in mono/mono#19973 
* Make roslyn the default compiler for s390x