### PR TITLE
SmtpClient: enable failing TestZeroTimeout test to get CI coredump

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/SmtpClientTest.cs
@@ -309,7 +309,7 @@ namespace System.Net.Mail.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31719")]
+        // [ActiveIssue("https://github.com/dotnet/runtime/issues/31719")]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, ".NET Framework has a bug and may not time out for low values")]
         [PlatformSpecific(~TestPlatforms.OSX)] // on OSX, not all synchronous operations (e.g. connect) can be aborted by closing the socket.
         public void TestZeroTimeout()


### PR DESCRIPTION
For debugging https://github.com/dotnet/runtime/issues/31719.

The attribute can be added back when we have a fresh coredump.

cc @stephentoub 