### PR TITLE
Make parts of ResourceManager trimming safe

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceManager.cs
@@ -105,7 +105,10 @@ namespace System.Resources
         private Dictionary<string, ResourceSet>? _resourceSets;
         private readonly string? _moduleDir;          // For assembly-ignorant directory location
         private readonly Type? _locationInfo;         // For Assembly or type-based directory layout
+
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         private readonly Type? _userResourceSet;      // Which ResourceSet instance to create
+
         private CultureInfo? _neutralResourcesCulture;  // For perf optimizations.
 
         private CultureNameResourceSetPair? _lastUsedResourceCache;
@@ -166,7 +169,9 @@ namespace System.Resources
         //
         // Note: System.Windows.Forms uses this method at design time.
         //
-        private ResourceManager(string baseName, string resourceDir, Type? userResourceSet)
+        private ResourceManager(string baseName, string resourceDir,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+            Type? userResourceSet)
         {
             if (null == baseName)
                 throw new ArgumentNullException(nameof(baseName));
@@ -200,7 +205,9 @@ namespace System.Resources
             CommonAssemblyInit();
         }
 
-        public ResourceManager(string baseName, Assembly assembly, Type? usingResourceSet)
+        public ResourceManager(string baseName, Assembly assembly,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        Type? usingResourceSet)
         {
             if (null == baseName)
                 throw new ArgumentNullException(nameof(baseName));
@@ -264,6 +271,7 @@ namespace System.Resources
 
         // Returns the Type of the ResourceSet the ResourceManager uses
         // to construct ResourceSets.
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
         public virtual Type ResourceSetType => _userResourceSet ?? typeof(RuntimeResourceSet);
 
         protected UltimateResourceFallbackLocation FallbackLocation
@@ -754,6 +762,7 @@ namespace System.Resources
             // NEEDED BOTH BY FILE-BASED  AND ASSEMBLY-BASED
             internal Type? LocationInfo => _rm._locationInfo;
 
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
             internal Type? UserResourceSet => _rm._userResourceSet;
 
             internal string? BaseNameField => _rm.BaseNameField;

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Text;
@@ -20,7 +19,6 @@ namespace System.Resources
         // statics used to dynamically call into BinaryFormatter
         // When successfully located s_binaryFormatterType will point to the BinaryFormatter type
         // and s_deserializeMethod will point to an unbound delegate to the deserialize method.
-        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
         private static Type? s_binaryFormatterType;
         private static Func<object?, Stream, object>? s_deserializeMethod;
 
@@ -67,47 +65,24 @@ namespace System.Resources
             return graph;
         }
 
-        // TODO: Remove this DynamicDependencyAttributes when https://github.com/mono/linker/issues/943 is fixed.
-        [DynamicDependency("Deserialize", "System.Runtime.Serialization.Formatters.Binary.BinaryFormatter", "System.Runtime.Serialization.Formatters")]
         private void InitializeBinaryFormatter()
         {
-            if (s_binaryFormatterType == null || s_deserializeMethod == null)
+            LazyInitializer.EnsureInitialized(ref s_binaryFormatterType, () =>
+                Type.GetType("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter, System.Runtime.Serialization.Formatters, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
+                throwOnError: true)!);
+
+            LazyInitializer.EnsureInitialized(ref s_deserializeMethod, () =>
             {
-                // Important: keep this as a local that is populated by a Type.GetType call so that the dataflow
-                // analysis in IL Linker can reason about the subsequent GetMethod call.
-                // Accessing the type from the s_binaryFormatterType field would make IL Linker lose track of the value
-                // (the value could be overwritten from another thread, so IL Linker can't make assumptions about it).
-                Type binaryFormatterType =
-                    Type.GetType("System.Runtime.Serialization.Formatters.Binary.BinaryFormatter, System.Runtime.Serialization.Formatters, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a",
-                    throwOnError: true)!;
+                MethodInfo binaryFormatterDeserialize = s_binaryFormatterType!.GetMethod("Deserialize", new Type[] { typeof(Stream) })!;
 
-                if (s_binaryFormatterType == null)
-                {
-                    s_binaryFormatterType = binaryFormatterType;
-                }
-
-                if (s_deserializeMethod == null)
-                {
-                    MethodInfo binaryFormatterDeserialize = binaryFormatterType.GetMethod("Deserialize", new Type[] { typeof(Stream) })!;
-
-                    // create an unbound delegate that can accept a BinaryFormatter instance as object
-                    s_deserializeMethod = (Func<object?, Stream, object>)CreateUntypedDelegateMethodInfo()
-                            .Invoke(null, new object[] { binaryFormatterDeserialize })!;
-                }
-            }
+                // create an unbound delegate that can accept a BinaryFormatter instance as object
+                return (Func<object?, Stream, object>)typeof(ResourceReader)
+                        .GetMethod(nameof(CreateUntypedDelegate), BindingFlags.NonPublic | BindingFlags.Static)!
+                        .MakeGenericMethod(s_binaryFormatterType)
+                        .Invoke(null, new object[] { binaryFormatterDeserialize })!;
+            });
 
             _binaryFormatter = Activator.CreateInstance(s_binaryFormatterType!)!;
-
-            // This is split off into a separate method only because we need a IL Linker suppression and the
-            // containing method is doing a lot of reflection we do want to get warnings for.
-            [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
-                Justification = "CreateUntypedDelegate doesn't have annotated generic parameters and this is safe")]
-            static MethodInfo CreateUntypedDelegateMethodInfo()
-            {
-                return typeof(ResourceReader)
-                    .GetMethod(nameof(CreateUntypedDelegate), BindingFlags.NonPublic | BindingFlags.Static)!
-                    .MakeGenericMethod(s_binaryFormatterType!);
-            }
         }
 
         // generic method that we specialize at runtime once we've loaded the BinaryFormatter type


### PR DESCRIPTION
We'll need a feature switch to turn off support for the parts that read text strings out of resources to make this fully safe.

I got rid of the LazyInitializer because it's just extra overhead that is not buying anything, except making things impossible to statically analyze. There won't be races when it comes to reflection object...