### PR TITLE
Increase delays in flaky tests

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -2271,7 +2271,7 @@ namespace System.Net.Http.Functional.Tests
                     cancellationTokenSource.Cancel();
 
                     // Cancellation may not propagate immediately. So wait a brief time to try to ensure it propagates.
-                    await Task.Delay(500);
+                    await Task.Delay(3000);
 
                     // Attempting to write on the request body should now fail with OperationCanceledException.
                     Exception e = await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => { await SendAndReceiveRequestDataAsync(contentBytes, requestStream, connection, streamId); });

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -199,7 +199,7 @@ namespace System.Net.Http.Functional.Tests
 
                             // Wait a small amount of time before sending the first response, so the connection lifetime will expire.
                             Debug.Assert(lifetimeMilliseconds < 100);
-                            await Task.Delay(100);
+                            await Task.Delay(1000);
 
                             // Second request should not have completed yet, as we haven't completed the first yet.
                             Assert.False(request2.IsCompleted);


### PR DESCRIPTION
Two tests are failing due to delays being too small for background actions completion when test VM perf degrades. PR increases those delays.