### PR TITLE
System.Text.Json: don't use reflection for looking up Stack/Queue types in enumerable helper

### DIFF
--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -227,6 +227,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)' or '$(TargetFramework)' == 'netcoreapp3.0'">
     <Reference Include="System.Collections" />
+    <Reference Include="System.Collections.NonGeneric" />
     <Reference Include="System.Diagnostics.Debug" />
     <Reference Include="System.Reflection.Primitives" />
     <Reference Include="System.Reflection.Emit.ILGeneration" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -254,8 +254,13 @@ namespace System.Text.Json.Serialization
 
         public static bool IsNonGenericStackOrQueue(this Type type)
         {
+#if NETCOREAPP
+            Type? typeOfStack = typeof(System.Collections.Stack);
+            Type? typeOfQueue = typeof(System.Collections.Queue);
+#else
             Type? typeOfStack = Type.GetType("System.Collections.Stack, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
             Type? typeOfQueue = Type.GetType("System.Collections.Queue, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+#endif
 
             Debug.Assert(typeOfStack != null);
             Debug.Assert(typeOfQueue != null);


### PR DESCRIPTION
On NETCOREAPP we'll just add a direct assembly reference to System.Collections.NonGeneric.dll instead.