### PR TITLE
Fixed outerloop tests for Sync HttpClient API

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -832,6 +832,7 @@ namespace System.Net.Http.Functional.Tests
                                 for (int i = 0; i < 100; ++i)
                                 {
                                     stream.Write(new byte[] { 0xff });
+                                    stream.Flush();
                                     Thread.Sleep(TimeSpan.FromSeconds(0.1));
                                 }
                             }))
@@ -874,6 +875,7 @@ namespace System.Net.Http.Functional.Tests
                                 for (int i = 0; i < 100; ++i)
                                 {
                                     stream.Write(new byte[] { 0xff });
+                                    stream.Flush();
                                     Thread.Sleep(TimeSpan.FromSeconds(0.1));
                                 }
                             }))
@@ -976,6 +978,7 @@ namespace System.Net.Http.Functional.Tests
                             for (int i = 0; i < 100; ++i)
                             {
                                 await connection.Writer.WriteLineAsync(content);
+                                await connection.Writer.FlushAsync();
                                 await Task.Delay(TimeSpan.FromSeconds(0.1));
                             }
                         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -824,6 +824,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     var sendTask = Task.Run(() => {
                         using HttpClient httpClient = CreateHttpClient();
+                        httpClient.Timeout = TimeSpan.FromMinutes(5);
 
                         HttpResponseMessage response = httpClient.Send(new HttpRequestMessage(HttpMethod.Get, uri) {
                             Content = new CustomContent(new Action<Stream>(stream =>
@@ -917,6 +918,7 @@ namespace System.Net.Http.Functional.Tests
                 {
                     var sendTask = Task.Run(() => {
                         using HttpClient httpClient = CreateHttpClient();
+                        httpClient.Timeout = TimeSpan.FromMinutes(5);
 
                         HttpResponseMessage response = httpClient.Send(new HttpRequestMessage(HttpMethod.Get, uri) {
                             Content = new CustomContent(stream =>

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -898,7 +898,7 @@ namespace System.Net.Http.Functional.Tests
                         try
                         {
                             await connection.ReadRequestHeaderAsync();
-                            mres.Wait();
+                            mres.Wait(TimeSpan.FromMinutes(5));
                         }
                         catch { }
                     });
@@ -987,7 +987,7 @@ namespace System.Net.Http.Functional.Tests
                             await connection.SendResponseAsync(headers: new List<HttpHeaderData>() {
                                 new HttpHeaderData("Content-Length", (content.Length * 2).ToString())
                             });
-                            mres.Wait();
+                            mres.Wait(TimeSpan.FromMinutes(5));
                             await connection.Writer.WriteLineAsync(content);
                         }
                         catch { }


### PR DESCRIPTION
Extended and added some timeouts to mitigate failing tests on slow infra.
Failures:
https://dev.azure.com/dnceng/public/_build/results?buildId=706219&view=results
https://dev.azure.com/dnceng/public/_build/results?buildId=706263&view=results

Fixes #38497