### PR TITLE
JsonSerializer - Prevent Stack and Queue types from being pulled in if not used in calling app

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -254,13 +254,22 @@ namespace System.Text.Json.Serialization
 
         public static bool IsNonGenericStackOrQueue(this Type type)
         {
-            Type? stackType = GetTypeIfExists("System.Collections.Stack, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+#if BUILDING_INBOX_LIBRARY
+            // Optimize for linking scenarios where mscorlib is trimmed out.
+            const string stackTypeName = "System.Collections.Stack, System.Collections.NonGeneric";
+            const string queueTypeName = "System.Collections.Queue, System.Collections.NonGeneric";
+#else
+            const string stackTypeName = "System.Collections.Stack, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+            const string queueTypeName = "System.Collections.Queue, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+#endif
+
+            Type? stackType = GetTypeIfExists(stackTypeName);
             if (stackType?.IsAssignableFrom(type) == true)
             {
                 return true;
             }
 
-            Type? queueType = GetTypeIfExists("System.Collections.Queue, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+            Type? queueType = GetTypeIfExists(queueTypeName);
             if (queueType?.IsAssignableFrom(type) == true)
             {
                 return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -254,13 +254,21 @@ namespace System.Text.Json.Serialization
 
         public static bool IsNonGenericStackOrQueue(this Type type)
         {
-            Type? typeOfStack = Type.GetType("System.Collections.Stack, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
-            Type? typeOfQueue = Type.GetType("System.Collections.Queue, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+            Type? stackType = GetTypeIfExists("System.Collections.Stack, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+            if (stackType?.IsAssignableFrom(type) == true)
+            {
+                return true;
+            }
 
-            Debug.Assert(typeOfStack != null);
-            Debug.Assert(typeOfQueue != null);
+            Type? queueType = GetTypeIfExists("System.Collections.Queue, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+            if (queueType?.IsAssignableFrom(type) == true)
+            {
+                return true;
+            }
 
-            return typeOfStack.IsAssignableFrom(type) || typeOfQueue.IsAssignableFrom(type);
+            return false;
         }
+
+        private static Type? GetTypeIfExists(string name) => Type.GetType(name, false);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableConverterFactoryHelpers.cs
@@ -269,6 +269,8 @@ namespace System.Text.Json.Serialization
             return false;
         }
 
+        // This method takes an unannotated string which makes linker reflection analysis lose track of the type we are
+        // looking for. This indirection allows the removal of the type if it is not used in the calling application.
         private static Type? GetTypeIfExists(string name) => Type.GetType(name, false);
     }
 }

--- a/src/libraries/System.Text.Json/tests/TrimmingTests/StackOrQueueNotRootedTest.cs
+++ b/src/libraries/System.Text.Json/tests/TrimmingTests/StackOrQueueNotRootedTest.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Text.Json;
+
+/// <summary>
+/// Tests that the System.Collections.NonGeneric dll is not dragged into a user's app
+/// when excercising a code path that would check if an input type to JsonSerializer is
+/// or derives from System.Collections.[Stack|Queue].
+/// The reason ConcurrentStack/Queue are chosen is that the checks for assigning their
+/// converters in the IEnumerableConverterFactory occurs after checks for Stack and Queue.
+/// </summary>
+class Program
+{
+    static int Main(string[] args)
+    {
+        // Test serialization.
+        var stack = new ConcurrentStack<int>();
+        string json = JsonSerializer.Serialize(stack); // "[]"
+        if (json != "[]")
+        {
+            return -1;
+        }
+
+        // Test deserialization.
+        ConcurrentQueue<int> queue = JsonSerializer.Deserialize<ConcurrentQueue<int>>(json);
+        if (!queue.IsEmpty)
+        {
+            return -1;
+        }
+
+        Type stackOrQueueType = GetTypeIfExists("System.Collections.Stack, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089") ??
+            GetTypeIfExists("System.Collections.Queue, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089");
+
+        return stackOrQueueType == null ? 100 : -1;
+    }
+
+    private static Type GetTypeIfExists(string name) => Type.GetType(name, false);
+}
+

--- a/src/libraries/System.Text.Json/tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
+++ b/src/libraries/System.Text.Json/tests/TrimmingTests/System.Text.Json.TrimmingTests.proj
@@ -1,0 +1,5 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>


### PR DESCRIPTION
Addresses discussion in https://github.com/dotnet/runtime/pull/38148#discussion_r442889830.

Holding off on adding a `[UnconditionalSuppressMessage(...)]` on the `IEnumerableConverterFactoryHelpers.GetTypeIfExists` till I work on https://github.com/dotnet/runtime/issues/38033.