### PR TITLE
[CBOR] Use System.Half for encoding and decoding half-precision data items

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/Resources/Strings.resx
+++ b/src/libraries/System.Formats.Cbor/src/Resources/Strings.resx
@@ -177,8 +177,8 @@
   <data name="Cbor_Reader_NotAFloatEncoding" xml:space="preserve">
     <value>Data item does not encode a floating point number.</value>
   </data>
-  <data name="Cbor_Reader_ReadingDoubleAsSingle" xml:space="preserve">
-    <value>Attempting to read double-precision floating point encoding as a single-precision value.</value>
+  <data name="Cbor_Reader_ReadingAsLowerPrecision" xml:space="preserve">
+    <value>Attempting to read floating point encoding as a lower-precision value.</value>
   </data>
   <data name="Cbor_Reader_NotABooleanEncoding" xml:space="preserve">
     <value>CBOR simple value does not encode a boolean value.</value>

--- a/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
+++ b/src/libraries/System.Formats.Cbor/src/System.Formats.Cbor.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="$(CommonPath)System\Marvin.cs" Link="Common\System\Marvin.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs" Link="Common\System\Memory\PointerMemoryManager.cs" />
+    <Compile Include="System\Formats\Cbor\HalfHelpers.cs" />
     <Compile Include="System\Formats\Cbor\Reader\CborReaderState.cs" />
     <Compile Include="System\Formats\Cbor\Reader\CborReader.PeekState.cs" />
     <Compile Include="System\Formats\Cbor\Reader\CborReader.SkipValue.cs" />

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/CborConformanceLevel.cs
@@ -84,6 +84,23 @@ namespace System.Formats.Cbor
             };
         }
 
+        public static bool RequiresPreservingFloatPrecision(CborConformanceMode conformanceMode)
+        {
+            switch (conformanceMode)
+            {
+                case CborConformanceMode.Lax:
+                case CborConformanceMode.Strict:
+                case CborConformanceMode.Canonical:
+                    return false;
+
+                case CborConformanceMode.Ctap2Canonical:
+                    return true;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(conformanceMode));
+            };
+        }
+
         public static bool RequiresUtf8Validation(CborConformanceMode conformanceMode)
         {
             switch (conformanceMode)

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/HalfHelpers.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/HalfHelpers.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.using System;
+
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System.Formats.Cbor
+{
+    // Temporarily implements missing APIs for System.Half
+    // Remove class once https://github.com/dotnet/runtime/issues/38288 has been addressed
+    internal static class HalfHelpers
+    {
+        public const int SizeOfHalf = sizeof(short);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Half ReadHalfBigEndian(ReadOnlySpan<byte> source)
+        {
+            return BitConverter.IsLittleEndian ?
+                Int16BitsToHalf(BinaryPrimitives.ReverseEndianness(MemoryMarshal.Read<short>(source))) :
+                MemoryMarshal.Read<Half>(source);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void WriteHalfBigEndian(Span<byte> destination, Half value)
+        {
+            if (BitConverter.IsLittleEndian)
+            {
+                short tmp = BinaryPrimitives.ReverseEndianness(HalfToInt16Bits(value));
+                MemoryMarshal.Write(destination, ref tmp);
+            }
+            else
+            {
+                MemoryMarshal.Write(destination, ref value);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe short HalfToInt16Bits(Half value)
+        {
+            return *((short*)&value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Half Int16BitsToHalf(short value)
+        {
+            return *(Half*)&value;
+        }
+    }
+}

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
@@ -8,7 +8,42 @@ namespace System.Formats.Cbor
 {
     public partial class CborReader
     {
-        private const int SizeOfHalf = 2; // the size in bytes of an IEEE 754 Half-Precision float
+        /// <summary>
+        ///   Reads the next data item as a half-precision floating point number (major type 7).
+        /// </summary>
+        /// <returns>The decoded value.</returns>
+        /// <exception cref="InvalidOperationException">
+        ///   the next data item does not have the correct major type. -or-
+        ///   the next simple value is not a floating-point number encoding. -or-
+        ///   the encoded value is a double-precision float
+        /// </exception>
+        /// <exception cref="CborContentException">
+        ///   the next value has an invalid CBOR encoding. -or-
+        ///   there was an unexpected end of CBOR encoding data. -or-
+        ///   the next value uses a CBOR encoding that is not valid under the current conformance mode.
+        /// </exception>
+        internal Half ReadHalf()
+        {
+            CborInitialByte header = PeekInitialByte(expectedType: CborMajorType.Simple);
+            ReadOnlySpan<byte> buffer = GetRemainingBytes();
+            Half result;
+
+            switch (header.AdditionalInfo)
+            {
+                case CborAdditionalInfo.Additional16BitData:
+                    EnsureReadCapacity(buffer, 1 + HalfHelpers.SizeOfHalf);
+                    result = HalfHelpers.ReadHalfBigEndian(buffer.Slice(1));
+                    AdvanceBuffer(1 + HalfHelpers.SizeOfHalf);
+                    AdvanceDataItemCounters();
+                    return result;
+
+                case CborAdditionalInfo.Additional64BitData:
+                    throw new InvalidOperationException(SR.Cbor_Reader_ReadingAsLowerPrecision);
+
+                default:
+                    throw new InvalidOperationException(SR.Cbor_Reader_NotAFloatEncoding);
+            }
+        }
 
         /// <summary>
         ///   Reads the next data item as a single-precision floating point number (major type 7).
@@ -33,9 +68,9 @@ namespace System.Formats.Cbor
             switch (header.AdditionalInfo)
             {
                 case CborAdditionalInfo.Additional16BitData:
-                    EnsureReadCapacity(buffer, 1 + SizeOfHalf);
-                    result = (float)ReadHalfBigEndian(buffer.Slice(1));
-                    AdvanceBuffer(1 + SizeOfHalf);
+                    EnsureReadCapacity(buffer, 1 + HalfHelpers.SizeOfHalf);
+                    result = (float)HalfHelpers.ReadHalfBigEndian(buffer.Slice(1));
+                    AdvanceBuffer(1 + HalfHelpers.SizeOfHalf);
                     AdvanceDataItemCounters();
                     return result;
 
@@ -47,7 +82,7 @@ namespace System.Formats.Cbor
                     return result;
 
                 case CborAdditionalInfo.Additional64BitData:
-                    throw new InvalidOperationException(SR.Cbor_Reader_ReadingDoubleAsSingle);
+                    throw new InvalidOperationException(SR.Cbor_Reader_ReadingAsLowerPrecision);
 
                 default:
                     throw new InvalidOperationException(SR.Cbor_Reader_NotAFloatEncoding);
@@ -77,9 +112,9 @@ namespace System.Formats.Cbor
             switch (header.AdditionalInfo)
             {
                 case CborAdditionalInfo.Additional16BitData:
-                    EnsureReadCapacity(buffer, 1 + SizeOfHalf);
-                    result = ReadHalfBigEndian(buffer.Slice(1));
-                    AdvanceBuffer(1 + SizeOfHalf);
+                    EnsureReadCapacity(buffer, 1 + HalfHelpers.SizeOfHalf);
+                    result = (double)HalfHelpers.ReadHalfBigEndian(buffer.Slice(1));
+                    AdvanceBuffer(1 + HalfHelpers.SizeOfHalf);
                     AdvanceDataItemCounters();
                     return result;
 
@@ -198,31 +233,6 @@ namespace System.Formats.Cbor
                 default:
                     throw new InvalidOperationException(SR.Cbor_Reader_NotASimpleValueEncoding);
             }
-        }
-
-        // half-precision float decoder adapted from https://tools.ietf.org/html/rfc7049#appendix-D
-        private static double ReadHalfBigEndian(ReadOnlySpan<byte> buffer)
-        {
-            int half = (buffer[0] << 8) + buffer[1];
-            bool isNegative = (half >> 15) != 0;
-            int exp = (half >> 10) & 0x1f;
-            int mant = half & 0x3ff;
-            double value;
-
-            if (exp == 0)
-            {
-                value = Math.ScaleB(mant, -24);
-            }
-            else if (exp != 31)
-            {
-                value = Math.ScaleB(mant + 1024, exp - 25);
-            }
-            else
-            {
-                value = (mant == 0) ? double.PositiveInfinity : double.NaN;
-            }
-
-            return isNegative ? -value : value;
         }
     }
 }

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Reader/CborReader.Simple.cs
@@ -37,6 +37,7 @@ namespace System.Formats.Cbor
                     AdvanceDataItemCounters();
                     return result;
 
+                case CborAdditionalInfo.Additional32BitData:
                 case CborAdditionalInfo.Additional64BitData:
                     throw new InvalidOperationException(SR.Cbor_Reader_ReadingAsLowerPrecision);
 

--- a/src/libraries/System.Formats.Cbor/tests/CborRoundtripTests.cs
+++ b/src/libraries/System.Formats.Cbor/tests/CborRoundtripTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System;
 using System.Linq;
 using Test.Cryptography;

--- a/src/libraries/System.Formats.Cbor/tests/CoseKeyHelpers.cs
+++ b/src/libraries/System.Formats.Cbor/tests/CoseKeyHelpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Diagnostics;
 using System.Security.Cryptography;
 

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Array.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Array.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.ByteString.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.ByteString.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Linq;
 using Test.Cryptography;
 using Xunit;

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Helpers.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Helpers.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Linq;
 using System.Numerics;
 using Test.Cryptography;

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Integer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Map.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Map.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using System.Linq;
 using Test.Cryptography;
 using Xunit;

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Simple.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Simple.cs
@@ -235,6 +235,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData("f6")] // null
         [InlineData("f4")] // false
         [InlineData("c202")] // tagged value
+        [InlineData("fb7ff0000000000000")] // double-precision float encoding
         public static void ReadSingle_InvalidTypes_ShouldThrowInvalidOperationException(string hexEncoding)
         {
             byte[] encoding = hexEncoding.HexToByteArray();

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.SkipValue.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.SkipValue.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.Tag.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.TextString.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.TextString.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Text;
 using Test.Cryptography;
 using Xunit;

--- a/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Reader/CborReaderTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Array.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Array.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Array.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Array.cs
@@ -19,7 +19,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }, "98190102030405060708090a0b0c0d0e0f101112131415161718181819")]
         [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "840120604107")]
         [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "83656c6f72656d65697073756d65646f6c6f72")]
-        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "84f4f6faffc00000fb7ff0000000000000")]
+        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "84f4f6f9fe00f97c00")]
         public static void WriteArray_SimpleValues_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
@@ -49,7 +49,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }, "9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff")]
         [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "9f0120604107ff")]
         [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "9f656c6f72656d65697073756d65646f6c6f72ff")]
-        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "9ff4f6faffc00000fb7ff0000000000000ff")]
+        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "9ff4f6f9fe00f97c00ff")]
         public static void WriteArray_IndefiniteLength_NoPatching_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();
@@ -83,7 +83,7 @@ namespace System.Formats.Cbor.Tests
         [InlineData(new object[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25 }, "98190102030405060708090a0b0c0d0e0f101112131415161718181819")]
         [InlineData(new object[] { 1, -1, "", new byte[] { 7 } }, "840120604107")]
         [InlineData(new object[] { "lorem", "ipsum", "dolor" }, "83656c6f72656d65697073756d65646f6c6f72")]
-        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "84f4f6faffc00000fb7ff0000000000000")]
+        [InlineData(new object?[] { false, null, float.NaN, double.PositiveInfinity }, "84f4f6f9fe00f97c00")]
         public static void WriteArray_IndefiniteLength_WithPatching_HappyPath(object[] values, string expectedHexEncoding)
         {
             byte[] expectedEncoding = expectedHexEncoding.HexToByteArray();

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.ByteString.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.ByteString.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using System.Linq;
 using Test.Cryptography;
 using Xunit;

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Helpers.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Helpers.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-
 using System.Linq;
 using System.Numerics;
 using Test.Cryptography;
-using Xunit;
 
 namespace System.Formats.Cbor.Tests
 {

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Integer.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Integer.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Map.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Map.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
-//using static W = System.Formats.Cbor.Tests.CborWriterHelpers;
 
 namespace System.Formats.Cbor.Tests
 {

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Simple.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Simple.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Simple.cs
@@ -15,14 +15,71 @@ namespace System.Formats.Cbor.Tests
         [Theory]
         [InlineData(100000.0, "fa47c35000")]
         [InlineData(3.4028234663852886e+38, "fa7f7fffff")]
-        [InlineData(float.PositiveInfinity, "fa7f800000")]
-        [InlineData(float.NegativeInfinity, "faff800000")]
-        [InlineData(float.NaN, "faffc00000")]
+        [InlineData(float.PositiveInfinity, "f97c00")]
+        [InlineData(float.NegativeInfinity, "f9fc00")]
+        [InlineData(float.NaN, "f9fe00")]
         public static void WriteSingle_SingleValue_HappyPath(float input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
             var writer = new CborWriter();
             writer.WriteSingle(input);
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
+        }
+
+        [Theory]
+        [InlineData(float.NaN, "f9fe00", CborConformanceMode.Lax)]
+        [InlineData(float.NaN, "f9fe00", CborConformanceMode.Strict)]
+        [InlineData(float.NaN, "f9fe00", CborConformanceMode.Canonical)]
+        public static void WriteSingle_NonCtapConformance_ShouldMinimizePrecision(float input, string hexExpectedEncoding, CborConformanceMode mode)
+        {
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+            var writer = new CborWriter(mode);
+            writer.WriteSingle(input);
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
+        }
+
+        [Theory]
+        [InlineData(100000.0, "fa47c35000")]
+        [InlineData(3.4028234663852886e+38, "fa7f7fffff")]
+        [InlineData(float.PositiveInfinity, "fa7f800000")]
+        [InlineData(float.NegativeInfinity, "faff800000")]
+        [InlineData(float.NaN, "faffc00000")]
+        public static void WriteSingle_Ctap2Conformance_ShouldPreservePrecision(float input, string hexExpectedEncoding)
+        {
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+            var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+            writer.WriteSingle(input);
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
+        }
+
+        [Theory]
+        [InlineData(1.1, "fb3ff199999999999a")]
+        [InlineData(1.0e+300, "fb7e37e43c8800759c")]
+        [InlineData(-4.1, "fbc010666666666666")]
+        [InlineData(3.1415926, "fb400921fb4d12d84a")]
+        [InlineData(double.PositiveInfinity, "f97c00")]
+        [InlineData(double.NegativeInfinity, "f9fc00")]
+        [InlineData(double.NaN, "f9fe00")]
+        public static void WriteDouble_SingleValue_HappyPath(double input, string hexExpectedEncoding)
+        {
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+            var writer = new CborWriter();
+            writer.WriteDouble(input);
+            AssertHelper.HexEqual(expectedEncoding, writer.Encode());
+        }
+
+        [Theory]
+        [InlineData(double.NaN, "f9fe00", CborConformanceMode.Lax)]
+        [InlineData(double.NaN, "f9fe00", CborConformanceMode.Strict)]
+        [InlineData(double.NaN, "f9fe00", CborConformanceMode.Canonical)]
+        [InlineData(65505, "fa477fe100", CborConformanceMode.Lax)]
+        [InlineData(65505, "fa477fe100", CborConformanceMode.Strict)]
+        [InlineData(65505, "fa477fe100", CborConformanceMode.Canonical)]
+        public static void WriteDouble_NonCtapConformance_ShouldMinimizePrecision(double input, string hexExpectedEncoding, CborConformanceMode mode)
+        {
+            byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
+            var writer = new CborWriter(mode);
+            writer.WriteDouble(input);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }
 
@@ -34,10 +91,10 @@ namespace System.Formats.Cbor.Tests
         [InlineData(double.PositiveInfinity, "fb7ff0000000000000")]
         [InlineData(double.NegativeInfinity, "fbfff0000000000000")]
         [InlineData(double.NaN, "fbfff8000000000000")]
-        public static void WriteDouble_SingleValue_HappyPath(double input, string hexExpectedEncoding)
+        public static void WriteDouble_Ctap2Conformance_ShouldPreservePrecision(double input, string hexExpectedEncoding)
         {
             byte[] expectedEncoding = hexExpectedEncoding.HexToByteArray();
-            var writer = new CborWriter();
+            var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
             writer.WriteDouble(input);
             AssertHelper.HexEqual(expectedEncoding, writer.Encode());
         }

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Tag.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.Tag.cs
@@ -107,9 +107,9 @@ namespace System.Formats.Cbor.Tests
         [Theory]
         [InlineData(1363896240, "c1fb41d452d9ec000000")]
         [InlineData(1586439081, "c1fb41d7a3c8ea400000")]
-        [InlineData(0, "c1fb0000000000000000")]
-        [InlineData(-1, "c1fbbff0000000000000")]
-        [InlineData(-315619200, "c1fbc1b2cff780000000")]
+        [InlineData(0, "c1f90000")]
+        [InlineData(-1, "c1f9bc00")]
+        [InlineData(-315619200, "c1facd967fbc")]
         [InlineData(1363896240.5, "c1fb41d452d9ec200000")]
         [InlineData(15870467036.15, "c1fb420d8fa0dee13333")]
         public static void WriteUnixTimeSeconds_Double_SingleValue_HappyPath(double value, string expectedHexEncoding)

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.TextString.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.TextString.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
 using Test.Cryptography;
 using Xunit;
 

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#nullable enable
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;


### PR DESCRIPTION
* Replaces the bespoke half-precision decoding implementation with System.Half.
* For non CTAP2 conformance modes, support lowering precision of encoded floats.
* Removes `#nullable` directives which are no longer required.

The implementation also adds a reader and writer method for System.Half which are currently marked internal. I will follow up with an API proposal for these.