### PR TITLE
JIT: allow inlinees with delegate invoke

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -7630,14 +7630,6 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
                 return TYP_UNDEF;
             }
 
-            /* For now ignore delegate invoke */
-
-            if (mflags & CORINFO_FLG_DELEGATE_INVOKE)
-            {
-                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_DELEGATE_INVOKE);
-                return TYP_UNDEF;
-            }
-
             /* For now ignore varargs */
             if ((sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_NATIVEVARARG)
             {
@@ -8004,7 +7996,6 @@ var_types Compiler::impImportCall(OPCODE                  opcode,
 
     if (mflags & CORINFO_FLG_DELEGATE_INVOKE)
     {
-        assert(!compIsForInlining());
         assert(!(mflags & CORINFO_FLG_STATIC)); // can't call a static method
         assert(mflags & CORINFO_FLG_FINAL);
 

--- a/src/coreclr/src/jit/inline.def
+++ b/src/coreclr/src/jit/inline.def
@@ -31,7 +31,6 @@ INLINE_OBSERVATION(BAD_LOCAL_NUMBER,          bool,   "invalid local number",   
 INLINE_OBSERVATION(CLASS_INIT_FAILURE,        bool,   "class init failed",                    FATAL,       CALLEE)
 INLINE_OBSERVATION(COMPILATION_ERROR,         bool,   "compilation error",                    FATAL,       CALLEE)
 INLINE_OBSERVATION(EXCEEDS_THRESHOLD,         bool,   "exceeds profit threshold",             FATAL,       CALLEE)
-INLINE_OBSERVATION(HAS_DELEGATE_INVOKE,       bool,   "delegate invoke",                      FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_EH,                    bool,   "has exception handling",               FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_ENDFILTER,             bool,   "has endfilter",                        FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_ENDFINALLY,            bool,   "has endfinally",                       FATAL,       CALLEE)


### PR DESCRIPTION
RyuJit would not inline methods that contained delegate invokes. Remove
this limitation.

Closes #10048. See also #37941.