### PR TITLE
Fix 'varDsc->lvExactSize == 12' assert.

### DIFF
--- a/src/coreclr/src/jit/hwintrinsic.cpp
+++ b/src/coreclr/src/jit/hwintrinsic.cpp
@@ -91,6 +91,10 @@ var_types Compiler::getBaseTypeFromArgIfNeeded(NamedIntrinsic       intrinsic,
 
 CORINFO_CLASS_HANDLE Compiler::gtGetStructHandleForHWSIMD(var_types simdType, var_types simdBaseType)
 {
+    if (m_simdHandleCache == nullptr)
+    {
+        return NO_CLASS_HANDLE;
+    }
     if (simdType == TYP_SIMD16)
     {
         switch (simdBaseType)

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -3212,8 +3212,8 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
         return false;
     }
 
-    // If this is a struct type, we can only consider it for CSE-ing if we can get at
-    // its handle, so that we can create a temp.
+    // If this is a struct type (including SIMD*), we can only consider it for CSE-ing
+    // if we can get its handle, so that we can create a temp.
     if (varTypeIsStruct(type) && (gtGetStructHandleIfPresent(tree) == NO_CLASS_HANDLE))
     {
         return false;

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -2638,17 +2638,15 @@ public:
             // If all occurances were in GT_IND nodes it could still be NO_CLASS_HANDLE
             //
             CORINFO_CLASS_HANDLE structHnd = successfulCandidate->CseDsc()->csdStructHnd;
-            assert((structHnd != NO_CLASS_HANDLE) || (cseLclVarTyp != TYP_STRUCT));
-            if (structHnd != NO_CLASS_HANDLE)
+            if (structHnd == NO_CLASS_HANDLE)
             {
-                m_pCompiler->lvaSetStruct(cseLclVarNum, structHnd, false);
+                assert(varTypeIsSIMD(cseLclVarTyp));
+                // We are not setting it for `SIMD* indir` during the first path
+                // because it is not precise, see `optValnumCSE_Index`.
+                structHnd = m_pCompiler->gtGetStructHandle(successfulCandidate->CseDsc()->csdTree);
             }
-#ifdef FEATURE_SIMD
-            else if (varTypeIsSIMD(cseLclVarTyp))
-            {
-                m_pCompiler->lvaGetDesc(cseLclVarNum)->lvSIMDType = true;
-            }
-#endif // FEATURE_SIMD
+            assert(structHnd != NO_CLASS_HANDLE);
+            m_pCompiler->lvaSetStruct(cseLclVarNum, structHnd, false);
         }
         m_pCompiler->lvaTable[cseLclVarNum].lvType  = cseLclVarTyp;
         m_pCompiler->lvaTable[cseLclVarNum].lvIsCSE = true;
@@ -3216,7 +3214,7 @@ bool Compiler::optIsCSEcandidate(GenTree* tree)
 
     // If this is a struct type, we can only consider it for CSE-ing if we can get at
     // its handle, so that we can create a temp.
-    if ((type == TYP_STRUCT) && (gtGetStructHandleIfPresent(tree) == NO_CLASS_HANDLE))
+    if (varTypeIsStruct(type) && (gtGetStructHandleIfPresent(tree) == NO_CLASS_HANDLE))
     {
         return false;
     }

--- a/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
+++ b/src/libraries/System.Numerics.Vectors/tests/Matrix4x4Tests.cs
@@ -500,7 +500,6 @@ namespace System.Numerics.Tests
 
         // A test for CreateFromAxisAngle(Vector3f,float)
         [Fact]
-        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/36586", RuntimeTestModes.JitStress)]
         public void Matrix4x4CreateFromAxisAngleTest()
         {
             float radians = MathHelper.ToRadians(-30.0f);


### PR DESCRIPTION
It is a small pessimization, but no diffs(benchmarks/libraries),

I had a more ambitious [change ](https://github.com/dotnet/runtime/compare/master...sandreenko:makeLayourAvailableForEachSIMDNode) (based on Tanner's suggestion and ClassLayout added to JitIntrinsic by Carol recently) that required layout for each Intrinsic (SIMD and HW) node to be initialized and it was passing tests. However:

-  I feel like it was too dangerous for the current moment in the release cycle;
-  would require more time to prepare for review;
- the most important, we have an issue with `LCL_FLD` for structs with overlapping fields when we drop `FldSeq` and can't restore `CLASS_HANDLE` after, so it was not clear for me how to keep struct handle in this case.

Fixes #36586.