### PR TITLE
Small performance improvment

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.cs
@@ -108,12 +108,7 @@ namespace System.Numerics
         /// <returns>A translation matrix.</returns>
         public static Matrix3x2 CreateTranslation(Vector2 position)
         {
-            Matrix3x2 result;
-
-            result.M11 = 1.0f;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
-            result.M22 = 1.0f;
+            Matrix3x2 result = _identity;
 
             result.M31 = position.X;
             result.M32 = position.Y;
@@ -129,12 +124,7 @@ namespace System.Numerics
         /// <returns>A translation matrix.</returns>
         public static Matrix3x2 CreateTranslation(float xPosition, float yPosition)
         {
-            Matrix3x2 result;
-
-            result.M11 = 1.0f;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
-            result.M22 = 1.0f;
+            Matrix3x2 result = _identity;
 
             result.M31 = xPosition;
             result.M32 = yPosition;
@@ -150,14 +140,10 @@ namespace System.Numerics
         /// <returns>A scaling matrix.</returns>
         public static Matrix3x2 CreateScale(float xScale, float yScale)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             result.M11 = xScale;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = yScale;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
 
             return result;
         }
@@ -171,14 +157,12 @@ namespace System.Numerics
         /// <returns>A scaling matrix.</returns>
         public static Matrix3x2 CreateScale(float xScale, float yScale, Vector2 centerPoint)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             float tx = centerPoint.X * (1 - xScale);
             float ty = centerPoint.Y * (1 - yScale);
 
             result.M11 = xScale;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = yScale;
             result.M31 = tx;
             result.M32 = ty;
@@ -193,14 +177,10 @@ namespace System.Numerics
         /// <returns>A scaling matrix.</returns>
         public static Matrix3x2 CreateScale(Vector2 scales)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             result.M11 = scales.X;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scales.Y;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
 
             return result;
         }
@@ -213,14 +193,12 @@ namespace System.Numerics
         /// <returns>A scaling matrix.</returns>
         public static Matrix3x2 CreateScale(Vector2 scales, Vector2 centerPoint)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             float tx = centerPoint.X * (1 - scales.X);
             float ty = centerPoint.Y * (1 - scales.Y);
 
             result.M11 = scales.X;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scales.Y;
             result.M31 = tx;
             result.M32 = ty;
@@ -235,14 +213,10 @@ namespace System.Numerics
         /// <returns>A scaling matrix.</returns>
         public static Matrix3x2 CreateScale(float scale)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             result.M11 = scale;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scale;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
 
             return result;
         }
@@ -255,14 +229,12 @@ namespace System.Numerics
         /// <returns>A scaling matrix.</returns>
         public static Matrix3x2 CreateScale(float scale, Vector2 centerPoint)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             float tx = centerPoint.X * (1 - scale);
             float ty = centerPoint.Y * (1 - scale);
 
             result.M11 = scale;
-            result.M12 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scale;
             result.M31 = tx;
             result.M32 = ty;
@@ -278,17 +250,13 @@ namespace System.Numerics
         /// <returns>A skew matrix.</returns>
         public static Matrix3x2 CreateSkew(float radiansX, float radiansY)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             float xTan = MathF.Tan(radiansX);
             float yTan = MathF.Tan(radiansY);
 
-            result.M11 = 1.0f;
             result.M12 = yTan;
             result.M21 = xTan;
-            result.M22 = 1.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
 
             return result;
         }
@@ -302,7 +270,7 @@ namespace System.Numerics
         /// <returns>A skew matrix.</returns>
         public static Matrix3x2 CreateSkew(float radiansX, float radiansY, Vector2 centerPoint)
         {
-            Matrix3x2 result;
+            Matrix3x2 result = _identity;
 
             float xTan = MathF.Tan(radiansX);
             float yTan = MathF.Tan(radiansY);
@@ -310,10 +278,9 @@ namespace System.Numerics
             float tx = -centerPoint.Y * xTan;
             float ty = -centerPoint.X * yTan;
 
-            result.M11 = 1.0f;
             result.M12 = yTan;
             result.M21 = xTan;
-            result.M22 = 1.0f;
+
             result.M31 = tx;
             result.M32 = ty;
 
@@ -327,8 +294,6 @@ namespace System.Numerics
         /// <returns>A rotation matrix.</returns>
         public static Matrix3x2 CreateRotation(float radians)
         {
-            Matrix3x2 result;
-
             radians = MathF.IEEERemainder(radians, MathF.PI * 2);
 
             float c, s;
@@ -367,12 +332,11 @@ namespace System.Numerics
             // [  c  s ]
             // [ -s  c ]
             // [  0  0 ]
+            Matrix3x2 result = _identity;
             result.M11 = c;
             result.M12 = s;
             result.M21 = -s;
             result.M22 = c;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
 
             return result;
         }
@@ -773,9 +737,9 @@ namespace System.Numerics
         /// <returns>True if the Object is equal to this matrix; False otherwise.</returns>
         public override readonly bool Equals(object? obj)
         {
-            if (obj is Matrix3x2)
+            if (obj is Matrix3x2 m)
             {
-                return Equals((Matrix3x2)obj);
+                return Equals(m);
             }
 
             return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -331,26 +331,10 @@ namespace System.Numerics
         /// <returns>The translation matrix.</returns>
         public static Matrix4x4 CreateTranslation(Vector3 position)
         {
-            Matrix4x4 result;
-
-            result.M11 = 1.0f;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
-            result.M22 = 1.0f;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
-            result.M33 = 1.0f;
-            result.M34 = 0.0f;
-
+            Matrix4x4 result = _identity;
             result.M41 = position.X;
             result.M42 = position.Y;
             result.M43 = position.Z;
-            result.M44 = 1.0f;
-
             return result;
         }
 
@@ -363,26 +347,10 @@ namespace System.Numerics
         /// <returns>The translation matrix.</returns>
         public static Matrix4x4 CreateTranslation(float xPosition, float yPosition, float zPosition)
         {
-            Matrix4x4 result;
-
-            result.M11 = 1.0f;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
-            result.M22 = 1.0f;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
-            result.M33 = 1.0f;
-            result.M34 = 0.0f;
-
+            Matrix4x4 result = _identity;
             result.M41 = xPosition;
             result.M42 = yPosition;
             result.M43 = zPosition;
-            result.M44 = 1.0f;
-
             return result;
         }
 
@@ -395,25 +363,10 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale)
         {
-            Matrix4x4 result;
-
+            Matrix4x4 result = _identity;
             result.M11 = xScale;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = yScale;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
             result.M33 = zScale;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
-
             return result;
         }
 
@@ -427,29 +380,18 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float xScale, float yScale, float zScale, Vector3 centerPoint)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float tx = centerPoint.X * (1 - xScale);
             float ty = centerPoint.Y * (1 - yScale);
             float tz = centerPoint.Z * (1 - zScale);
 
             result.M11 = xScale;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = yScale;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
             result.M33 = zScale;
-            result.M34 = 0.0f;
             result.M41 = tx;
             result.M42 = ty;
             result.M43 = tz;
-            result.M44 = 1.0f;
-
             return result;
         }
 
@@ -460,25 +402,10 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(Vector3 scales)
         {
-            Matrix4x4 result;
-
+            Matrix4x4 result = _identity;
             result.M11 = scales.X;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scales.Y;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
             result.M33 = scales.Z;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
-
             return result;
         }
 
@@ -490,29 +417,18 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(Vector3 scales, Vector3 centerPoint)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float tx = centerPoint.X * (1 - scales.X);
             float ty = centerPoint.Y * (1 - scales.Y);
             float tz = centerPoint.Z * (1 - scales.Z);
 
             result.M11 = scales.X;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scales.Y;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
             result.M33 = scales.Z;
-            result.M34 = 0.0f;
             result.M41 = tx;
             result.M42 = ty;
             result.M43 = tz;
-            result.M44 = 1.0f;
-
             return result;
         }
 
@@ -523,24 +439,11 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float scale)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = scale;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scale;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
             result.M33 = scale;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -553,28 +456,19 @@ namespace System.Numerics
         /// <returns>The scaling matrix.</returns>
         public static Matrix4x4 CreateScale(float scale, Vector3 centerPoint)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float tx = centerPoint.X * (1 - scale);
             float ty = centerPoint.Y * (1 - scale);
             float tz = centerPoint.Z * (1 - scale);
 
             result.M11 = scale;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
             result.M22 = scale;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
             result.M33 = scale;
-            result.M34 = 0.0f;
+
             result.M41 = tx;
             result.M42 = ty;
             result.M43 = tz;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -586,7 +480,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateRotationX(float radians)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float c = MathF.Cos(radians);
             float s = MathF.Sin(radians);
@@ -595,22 +489,11 @@ namespace System.Numerics
             // [  0  c  s  0 ]
             // [  0 -s  c  0 ]
             // [  0  0  0  1 ]
-            result.M11 = 1.0f;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
+
             result.M22 = c;
             result.M23 = s;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
             result.M32 = -s;
             result.M33 = c;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -623,7 +506,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateRotationX(float radians, Vector3 centerPoint)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float c = MathF.Cos(radians);
             float s = MathF.Sin(radians);
@@ -635,22 +518,13 @@ namespace System.Numerics
             // [  0  c  s  0 ]
             // [  0 -s  c  0 ]
             // [  0  y  z  1 ]
-            result.M11 = 1.0f;
-            result.M12 = 0.0f;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
+
             result.M22 = c;
             result.M23 = s;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
             result.M32 = -s;
             result.M33 = c;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
             result.M42 = y;
             result.M43 = z;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -662,7 +536,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateRotationY(float radians)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float c = MathF.Cos(radians);
             float s = MathF.Sin(radians);
@@ -672,21 +546,9 @@ namespace System.Numerics
             // [  s  0  c  0 ]
             // [  0  0  0  1 ]
             result.M11 = c;
-            result.M12 = 0.0f;
             result.M13 = -s;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
-            result.M22 = 1.0f;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
             result.M31 = s;
-            result.M32 = 0.0f;
             result.M33 = c;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -699,7 +561,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateRotationY(float radians, Vector3 centerPoint)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float c = MathF.Cos(radians);
             float s = MathF.Sin(radians);
@@ -712,21 +574,11 @@ namespace System.Numerics
             // [  s  0  c  0 ]
             // [  x  0  z  1 ]
             result.M11 = c;
-            result.M12 = 0.0f;
             result.M13 = -s;
-            result.M14 = 0.0f;
-            result.M21 = 0.0f;
-            result.M22 = 1.0f;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
             result.M31 = s;
-            result.M32 = 0.0f;
             result.M33 = c;
-            result.M34 = 0.0f;
             result.M41 = x;
-            result.M42 = 0.0f;
             result.M43 = z;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -738,7 +590,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateRotationZ(float radians)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float c = MathF.Cos(radians);
             float s = MathF.Sin(radians);
@@ -749,20 +601,8 @@ namespace System.Numerics
             // [  0  0  0  1 ]
             result.M11 = c;
             result.M12 = s;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
             result.M21 = -s;
             result.M22 = c;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
-            result.M33 = 1.0f;
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -775,7 +615,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateRotationZ(float radians, Vector3 centerPoint)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float c = MathF.Cos(radians);
             float s = MathF.Sin(radians);
@@ -789,20 +629,10 @@ namespace System.Numerics
             // [  x  y  0  1 ]
             result.M11 = c;
             result.M12 = s;
-            result.M13 = 0.0f;
-            result.M14 = 0.0f;
             result.M21 = -s;
             result.M22 = c;
-            result.M23 = 0.0f;
-            result.M24 = 0.0f;
-            result.M31 = 0.0f;
-            result.M32 = 0.0f;
-            result.M33 = 1.0f;
-            result.M34 = 0.0f;
             result.M41 = x;
             result.M42 = y;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -845,24 +675,19 @@ namespace System.Numerics
             float xx = x * x, yy = y * y, zz = z * z;
             float xy = x * y, xz = x * z, yz = y * z;
 
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = xx + ca * (1.0f - xx);
             result.M12 = xy - ca * xy + sa * z;
             result.M13 = xz - ca * xz - sa * y;
-            result.M14 = 0.0f;
+
             result.M21 = xy - ca * xy - sa * z;
             result.M22 = yy + ca * (1.0f - yy);
             result.M23 = yz - ca * yz + sa * x;
-            result.M24 = 0.0f;
+
             result.M31 = xz - ca * xz + sa * y;
             result.M32 = yz - ca * yz - sa * x;
             result.M33 = zz + ca * (1.0f - zz);
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -1000,20 +825,12 @@ namespace System.Numerics
         /// <returns>The orthographic projection matrix.</returns>
         public static Matrix4x4 CreateOrthographic(float width, float height, float zNearPlane, float zFarPlane)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = 2.0f / width;
-            result.M12 = result.M13 = result.M14 = 0.0f;
-
             result.M22 = 2.0f / height;
-            result.M21 = result.M23 = result.M24 = 0.0f;
-
             result.M33 = 1.0f / (zNearPlane - zFarPlane);
-            result.M31 = result.M32 = result.M34 = 0.0f;
-
-            result.M41 = result.M42 = 0.0f;
             result.M43 = zNearPlane / (zNearPlane - zFarPlane);
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -1030,21 +847,17 @@ namespace System.Numerics
         /// <returns>The orthographic projection matrix.</returns>
         public static Matrix4x4 CreateOrthographicOffCenter(float left, float right, float bottom, float top, float zNearPlane, float zFarPlane)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = 2.0f / (right - left);
-            result.M12 = result.M13 = result.M14 = 0.0f;
 
             result.M22 = 2.0f / (top - bottom);
-            result.M21 = result.M23 = result.M24 = 0.0f;
 
             result.M33 = 1.0f / (zNearPlane - zFarPlane);
-            result.M31 = result.M32 = result.M34 = 0.0f;
 
             result.M41 = (left + right) / (left - right);
             result.M42 = (top + bottom) / (bottom - top);
             result.M43 = zNearPlane / (zNearPlane - zFarPlane);
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -1062,24 +875,23 @@ namespace System.Numerics
             Vector3 xaxis = Vector3.Normalize(Vector3.Cross(cameraUpVector, zaxis));
             Vector3 yaxis = Vector3.Cross(zaxis, xaxis);
 
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = xaxis.X;
             result.M12 = yaxis.X;
             result.M13 = zaxis.X;
-            result.M14 = 0.0f;
+
             result.M21 = xaxis.Y;
             result.M22 = yaxis.Y;
             result.M23 = zaxis.Y;
-            result.M24 = 0.0f;
+
             result.M31 = xaxis.Z;
             result.M32 = yaxis.Z;
             result.M33 = zaxis.Z;
-            result.M34 = 0.0f;
+
             result.M41 = -Vector3.Dot(xaxis, cameraPosition);
             result.M42 = -Vector3.Dot(yaxis, cameraPosition);
             result.M43 = -Vector3.Dot(zaxis, cameraPosition);
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -1097,24 +909,23 @@ namespace System.Numerics
             Vector3 xaxis = Vector3.Normalize(Vector3.Cross(up, zaxis));
             Vector3 yaxis = Vector3.Cross(zaxis, xaxis);
 
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = xaxis.X;
             result.M12 = xaxis.Y;
             result.M13 = xaxis.Z;
-            result.M14 = 0.0f;
+
             result.M21 = yaxis.X;
             result.M22 = yaxis.Y;
             result.M23 = yaxis.Z;
-            result.M24 = 0.0f;
+
             result.M31 = zaxis.X;
             result.M32 = zaxis.Y;
             result.M33 = zaxis.Z;
-            result.M34 = 0.0f;
+
             result.M41 = position.X;
             result.M42 = position.Y;
             result.M43 = position.Z;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -1126,7 +937,7 @@ namespace System.Numerics
         /// <returns>The rotation matrix.</returns>
         public static Matrix4x4 CreateFromQuaternion(Quaternion quaternion)
         {
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             float xx = quaternion.X * quaternion.X;
             float yy = quaternion.Y * quaternion.Y;
@@ -1142,19 +953,14 @@ namespace System.Numerics
             result.M11 = 1.0f - 2.0f * (yy + zz);
             result.M12 = 2.0f * (xy + wz);
             result.M13 = 2.0f * (xz - wy);
-            result.M14 = 0.0f;
+
             result.M21 = 2.0f * (xy - wz);
             result.M22 = 1.0f - 2.0f * (zz + xx);
             result.M23 = 2.0f * (yz + wx);
-            result.M24 = 0.0f;
+
             result.M31 = 2.0f * (xz + wy);
             result.M32 = 2.0f * (yz - wx);
             result.M33 = 1.0f - 2.0f * (yy + xx);
-            result.M34 = 0.0f;
-            result.M41 = 0.0f;
-            result.M42 = 0.0f;
-            result.M43 = 0.0f;
-            result.M44 = 1.0f;
 
             return result;
         }
@@ -1189,7 +995,7 @@ namespace System.Numerics
             float c = -p.Normal.Z;
             float d = -p.D;
 
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = a * lightDirection.X + dot;
             result.M21 = b * lightDirection.X;
@@ -1206,9 +1012,6 @@ namespace System.Numerics
             result.M33 = c * lightDirection.Z + dot;
             result.M43 = d * lightDirection.Z;
 
-            result.M14 = 0.0f;
-            result.M24 = 0.0f;
-            result.M34 = 0.0f;
             result.M44 = dot;
 
             return result;
@@ -1231,27 +1034,23 @@ namespace System.Numerics
             float fb = -2.0f * b;
             float fc = -2.0f * c;
 
-            Matrix4x4 result;
+            Matrix4x4 result = _identity;
 
             result.M11 = fa * a + 1.0f;
             result.M12 = fb * a;
             result.M13 = fc * a;
-            result.M14 = 0.0f;
 
             result.M21 = fa * b;
             result.M22 = fb * b + 1.0f;
             result.M23 = fc * b;
-            result.M24 = 0.0f;
 
             result.M31 = fa * c;
             result.M32 = fb * c;
             result.M33 = fc * c + 1.0f;
-            result.M34 = 0.0f;
 
             result.M41 = fa * value.D;
             result.M42 = fb * value.D;
             result.M43 = fc * value.D;
-            result.M44 = 1.0f;
 
             return result;
         }


### PR DESCRIPTION
In the methods I modified, the return value has fields in common with the already-declared `_identity` static field.
So, instead of assigning field by field, I assign `_identity` directly then modify the different values.

Benchmarks code:

```csharp
    [Benchmark]
    public Matrix4x4[] OldImpl()
    {
        var arr = new Matrix4x4[2];
        for (int i = 0; i < 2; i++)
            arr[i] = Matrix4x4.CreateTranslation(1 + i, 2 + i, 3 + i);
        return arr;
    }

    [Benchmark]
    public Matrix4x4[] NewImpl()
    {
        var arr = new Matrix4x4[2];
        for (int i = 0; i < 2; i++)
            arr[i] = Matrix4x4.CreateTranslationOptimized(1 + i, 2 + i, 3 + i);
        return arr;
    }
```

Benchmark results:

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18362.900 (1903/May2019Update/19H1)
Intel Core i5-8250U CPU 1.60GHz (Kaby Lake R), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=3.1.300
  [Host]     : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
  DefaultJob : .NET Core 3.1.4 (CoreCLR 4.700.20.20201, CoreFX 4.700.20.22101), X64 RyuJIT
```

|  Method |     Mean |    Error |   StdDev |   Median |
|-------- |---------:|---------:|---------:|---------:|
| OldImpl | 67.72 ns | 8.491 ns | 25.04 ns | 56.45 ns |
| NewImpl | 63.37 ns | 8.067 ns | 23.79 ns | 56.39 ns |