### PR TITLE
Enable ilasm/ildasm round trip testing in new AzDO pipeline

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -103,6 +103,9 @@ jobs:
     # the __TestTimeout variable, which is later read by the coreclr xunit test wrapper code (the code in the
     # xunit test dlls that invokes the actual tests).
     #
+    # Note that "timeoutInMinutes" is an Azure DevOps Pipelines parameter for a "job" that specifies the
+    # total time allowed for a job, and is specified lower down. Make sure you set it properly for any new testGroup.
+    #
     # Please note that for Crossgen / Crossgen2 R2R runs, the "test running time" also includes the
     # time needed to compile the test into native code with the Crossgen compiler.
 
@@ -139,6 +142,12 @@ jobs:
         value: 300
       - name: timeoutPerTestInMinutes
         value: 90
+    - ${{ if eq(parameters.testGroup, 'ilasm') }}:
+      # ilasm-ildasm round trip testing runs every test twice, plus runs ilasm and ildasm, so double the 'outerloop' timeout numbers.
+      - name: timeoutPerTestInMinutes
+        value: 20
+      - name: timeoutPerTestCollectionInMinutes
+        value: 240
 
     - ${{ if eq(parameters.compositeBuildMode, true) }}:
       - name: crossgenArg
@@ -156,7 +165,7 @@ jobs:
       timeoutInMinutes: 270
     ${{ if in(parameters.testGroup, 'gc-longrunning', 'gc-simulator') }}:
       timeoutInMinutes: 480
-    ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc') }}:
+    ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc', 'ilasm') }}:
       timeoutInMinutes: 390
     ${{ if in(parameters.testGroup, 'jitstress-isas-x86', 'gcstress-extra', 'r2r-extra') }}:
       timeoutInMinutes: 510
@@ -427,6 +436,9 @@ jobs:
           - jitehwritethru
           - jitobjectstackallocation
           - jitpgo
+        ${{ if in(parameters.testGroup, 'ilasm') }}:
+          scenarios:
+          - ilasmroundtrip
 
     # Publish Logs
     - task: PublishPipelineArtifact@1

--- a/eng/pipelines/coreclr/ilasm.yml
+++ b/eng/pipelines/coreclr/ilasm.yml
@@ -1,0 +1,48 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 19 * * 6"
+  displayName: Sat at 11:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+#
+# Checkout repository
+#
+- template: /eng/pipelines/common/checkout-job.yml
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platformGroup: all
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: ilasm
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: ilasm
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: checked
+    platformGroup: all
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: ilasm
+      liveLibrariesBuildConfig: Release

--- a/src/coreclr/tests/src/CLRTest.Execute.Bash.targets
+++ b/src/coreclr/tests/src/CLRTest.Execute.Bash.targets
@@ -69,14 +69,14 @@ WARNING:   When setting properties based on their current state (for example:
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
     <PropertyGroup>
-      <GCBashScriptExitCode>0</GCBashScriptExitCode>
+      <IncompatibleTestBashScriptExitCode>0</IncompatibleTestBashScriptExitCode>
 
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(GCStressIncompatible)' == 'true'"><![CDATA[
 $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$COMPlus_GCStress" ]
 then
   echo SKIPPING EXECUTION BECAUSE COMPlus_GCStress IS SET
-  exit $(GCBashScriptExitCode)
+  exit $(IncompatibleTestBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(UnloadabilityIncompatible)' == 'true'"><![CDATA[
@@ -84,7 +84,7 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$RunInUnloadableContext" ]
 then
   echo SKIPPING EXECUTION BECAUSE the test is incompatible with unloadability
-  exit $(GCBashScriptExitCode)
+  exit $(IncompatibleTestBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'">
@@ -93,12 +93,12 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [[ ( ! -z "$COMPlus_JitStress" ) || ( ! -z "$COMPlus_JitStressRegs" ) || ( ! -z "$COMPlus_JITMinOpts" ) || ( ! -z "$COMPlus_TailcallStress" ) ]]
 then
   echo "SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts, COMPlus_TailcallStress) IS SET"
-  exit $(GCBashScriptExitCode)
+  exit $(IncompatibleTestBashScriptExitCode)
 fi
 if [[ "$COMPlus_TieredCompilation" != "0" ]]
 then
   echo "SKIPPING EXECUTION BECAUSE COMPlus_TieredCompilation has not been disabled and this test is marked JitOptimizationSensitive"
-  exit $(GCBashScriptExitCode)
+  exit $(IncompatibleTestBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(HeapVerifyIncompatible)' == 'true'"><![CDATA[
@@ -106,7 +106,15 @@ $(BashCLRTestEnvironmentCompatibilityCheck)
 if [ ! -z "$COMPlus_HeapVerify" ]
 then
   echo SKIPPING EXECUTION BECAUSE COMPlus_HeapVerify IS SET
-  exit $(GCBashScriptExitCode)
+  exit $(IncompatibleTestBashScriptExitCode)
+fi
+      ]]></BashCLRTestEnvironmentCompatibilityCheck>
+      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(IlasmRoundTripIncompatible)' == 'true'"><![CDATA[
+$(BashCLRTestEnvironmentCompatibilityCheck)
+if [ ! -z "$RunningIlasmRoundTrip" ]
+then
+  echo SKIPPING EXECUTION BECAUSE RunningIlasmRoundTrip IS SET
+  exit $(IncompatibleTestBashScriptExitCode)
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
 
@@ -248,15 +256,10 @@ fi
       </PropertyGroup>
       <PropertyGroup>
       <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun"</_CLRTestRunFile>
-      <BashCLRTestLaunchCmds>$(BashIlrtTestLaunchCmds)</BashCLRTestLaunchCmds>
 
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'">
     <![CDATA[
 $(BashLinkerTestLaunchCmds)
-$(BashCLRTestLaunchCmds)
-if [ ! -z ${RunCrossGen+x} ]%3B then
-  TakeLock
-fi
 
 if [ ! -z "$CLRCustomTestLauncher" ];
 then
@@ -265,17 +268,23 @@ else
     LAUNCHER="$_DebuggerFullPath $(_CLRTestRunFile)"
 fi
 
+$(BashIlrtTestLaunchCmds)
+
+if [ ! -z ${RunCrossGen+x} ]%3B then
+  TakeLock
+fi
+
 echo $LAUNCHER $ExePath %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
 $LAUNCHER $ExePath "${CLRTestExecutionArguments[@]}"
-
 CLRTestExitCode=$?
+
 if [ ! -z ${RunCrossGen+x} ]%3B then
   ReleaseLock
 fi
+
 $(BashLinkerTestCleanupCmds)
       ]]></BashCLRTestLaunchCmds>
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
-$(BashCLRTestLaunchCmds)
 echo export CDPATH="$%28dirname "${BASH_SOURCE[0]}")"
 export CDPATH="$%28dirname "${BASH_SOURCE[0]}")"
 echo /usr/bin/env bash $(InputAssemblyName) %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")

--- a/src/coreclr/tests/src/CLRTest.Execute.Batch.targets
+++ b/src/coreclr/tests/src/CLRTest.Execute.Batch.targets
@@ -118,6 +118,14 @@ IF NOT "%COMPlus_HeapVerify%"=="" (
   Exit /b 0
 )
       ]]></BatchCLRTestEnvironmentCompatibilityCheck>
+      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(IlasmRoundTripIncompatible)' == 'true'"><![CDATA[
+$(BatchCLRTestEnvironmentCompatibilityCheck)
+IF NOT "%RunningIlasmRoundTrip%"=="" (
+  ECHO SKIPPING EXECUTION BECAUSE RunningIlasmRoundTrip IS SET
+  popd
+  Exit /b 0
+)
+      ]]></BatchCLRTestEnvironmentCompatibilityCheck>
       
       <BatchCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
         <![CDATA[
@@ -279,19 +287,18 @@ REM Local CoreShim requested - see MSBuild property 'CLRTestScriptLocalCoreShim'
 ECHO Copying '%CORE_ROOT%\CoreShim.dll'...
 COPY /y %CORE_ROOT%\CoreShim.dll .
       ]]></BatchCopyCoreShimLocalCmds>
-      <BatchCLRTestLaunchCmds><![CDATA[
+      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'">
+    <![CDATA[
+$(BatchLinkerTestLaunchCmds)
+$(BatchCopyCoreShimLocalCmds)
+
 IF NOT "%CLRCustomTestLauncher%"=="" (
   set LAUNCHER=call %CLRCustomTestLauncher% %scriptPath%
 ) ELSE (
   set LAUNCHER=%_DebuggerFullPath% $(_CLRTestRunFile)
 )
+
 $(BatchIlrtTestLaunchCmds)
-$(BatchCopyCoreShimLocalCmds)
-      ]]></BatchCLRTestLaunchCmds>
-      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'">
-    <![CDATA[
-$(BatchLinkerTestLaunchCmds)
-$(BatchCLRTestLaunchCmds)
 
 if defined RunCrossGen (
   call :TakeLock
@@ -306,11 +313,11 @@ $(BatchLinkerTestCleanupCmds)
       ]]></BatchCLRTestLaunchCmds>
 
       <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
-$(BatchCLRTestLaunchCmds)
+$(BatchCopyCoreShimLocalCmds)
 ECHO  cmd /c $(InputAssemblyName)
 cmd /c $(InputAssemblyName)
-set CLRTestExpectedExitCode=0
 set CLRTestExitCode=!ERRORLEVEL!
+set CLRTestExpectedExitCode=0
       ]]></BatchCLRTestLaunchCmds>
     </PropertyGroup>
     <PropertyGroup>

--- a/src/coreclr/tests/src/CLRTest.Jit.targets
+++ b/src/coreclr/tests/src/CLRTest.Jit.targets
@@ -68,63 +68,72 @@ if defined RunningJitDisasm (
     </PropertyGroup>
   </Target>
 
-  <PropertyGroup>
-    <IlrtTestKind Condition="'$(IlrtTestKind)' == ''">$(CLRTestKind)</IlrtTestKind>
-  </PropertyGroup>
+  <!--
+  ***********************************************************************************************
+  ildasm / ilasm round trip testing
 
-  <Target
-      Name="GetIlasmRoundTripBashScript"
-      Returns="$(IlasmRoundTripBashScript);$(BashIlrtTestLaunchCmds)">
+  Note: https://github.com/dotnet/runtime/issues/4873 describes an issue with ildasm that requires
+  us to use the "/raweh" argument.
+  ***********************************************************************************************
+  -->
+
+  <Target Name="GetIlasmRoundTripBashScript"
+          Returns="$(IlasmRoundTripBashScript);$(BashIlrtTestLaunchCmds)">
     <PropertyGroup>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)).Replace("\","/"))</InputAssemblyName>
       <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).dll</InputAssemblyName>
       <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
       <TargetAssemblyName>$(MSBuildProjectName).asm.dll</TargetAssemblyName>
 
-      <IlasmRoundTripBashScript>
-        <![CDATA[
+      <IlasmRoundTripBashScript Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
 # IlasmRoundTrip Script
+# For CLRTestKind==RunOnly, we don't do any ilasm round-trip testing. We also need to disable
+# ilasm round-trip testing for the project we call, as there might be multiple RunOnly tests
+# concurrently invoking the same project, which can lead to race conditions on the ilasm/ildasm commands.
+export RunningIlasmRoundTrip=
+]]>
+      </IlasmRoundTripBashScript>
 
+      <IlasmRoundTripBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
+# IlasmRoundTrip Script
 # Disable Ilasm round-tripping for Linker tests.
 # Todo: Ilasm round-trip on linked binaries.
 
 if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
 then
-    echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-    "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
-    ERRORLEVEL=$?
-    if [ $ERRORLEVEL -ne 0 ]
-    then
-      echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
-      exit 1
-    fi
-
-    echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-    "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
-    ERRORLEVEL=$?
-    if [ $ERRORLEVEL -ne 0 ]
-    then
-      echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
-      exit 1
-    fi
-fi
-        ]]>
-      </IlasmRoundTripBashScript>
-      
-      <BashIlrtTestLaunchCmds Condition="'$(IlrtTestKind)' != 'BuildOnly'">
-        <![CDATA[
-if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
-then
-  echo $(_CLRTestRunFile) $(TargetAssemblyName) %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
-  $(_CLRTestRunFile) $(TargetAssemblyName) "${CLRTestExecutionArguments[@]}"
-  if [  $? -ne $CLRTestExpectedExitCode ]
+  echo "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+  "$CORE_ROOT/ildasm" -raweh -out=$(DisassemblyName) $(InputAssemblyName)
+  ERRORLEVEL=$?
+  if [ $ERRORLEVEL -ne 0 ]
   then
-    echo END EXECUTION OF IL{D}ASM BINARY - FAILED $? vs $CLRTestExpectedExitCode
-    echo FAILED
+    echo EXECUTION OF ILDASM - FAILED $ERRORLEVEL
+    exit 1
+  fi
+
+  echo "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+  "$CORE_ROOT/ilasm" -output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+  ERRORLEVEL=$?
+  if [ $ERRORLEVEL -ne 0 ]
+  then
+    echo EXECUTION OF ILASM - FAILED $ERRORLEVEL
     exit 1
   fi
 fi
-        ]]>
+]]>
+      </IlasmRoundTripBashScript>
+      <BashIlrtTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
+if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
+then
+  echo $LAUNCHER $(TargetAssemblyName) %24(printf "'%s' " "${CLRTestExecutionArguments[@]}")
+  $LAUNCHER $(TargetAssemblyName) "${CLRTestExecutionArguments[@]}"
+  ERRORLEVEL=$?
+  if [ $ERRORLEVEL -ne $CLRTestExpectedExitCode ]
+  then
+    echo END EXECUTION OF IL{D}ASM BINARY - FAILED $ERRORLEVEL vs $CLRTestExpectedExitCode
+    exit 1
+  fi
+fi
+]]>
       </BashIlrtTestLaunchCmds>
     </PropertyGroup>
   </Target>
@@ -137,16 +146,22 @@ fi
       <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
       <TargetAssemblyName>$(MSBuildProjectName).asm.dll</TargetAssemblyName>
 
-      <!-- https://github.com/dotnet/coreclr/issues/2481. Delete /raweh to ildasm once it is resolved.-->
-      <IlasmRoundTripBatchScript>
-        <![CDATA[
+      <IlasmRoundTripBatchScript Condition="'$(CLRTestKind)' == 'RunOnly'"><![CDATA[
 REM IlasmRoundTrip Script
+REM For CLRTestKind==RunOnly, we don't do any ilasm round-trip testing. We also need to disable
+REM ilasm round-trip testing for the project we call, as there might be multiple RunOnly tests
+REM concurrently invoking the same project, which can lead to race conditions on the ilasm/ildasm commands.
+set RunningIlasmRoundTrip=
+]]>
+      </IlasmRoundTripBatchScript>
 
+      <IlasmRoundTripBatchScript Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
+REM IlasmRoundTrip Script
 REM Disable Ilasm round-tripping for Linker tests.
 REM Todo: Ilasm round-trip on linked binaries.
 IF NOT DEFINED DoLink (
   IF DEFINED RunningIlasmRoundTrip (
-    echo %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+    ECHO %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
     %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
     IF NOT "!ERRORLEVEL!"=="0" (
       ECHO EXECUTION OF ILDASM - FAILED !ERRORLEVEL!
@@ -160,17 +175,15 @@ IF NOT DEFINED DoLink (
     )
   )
 )
-        ]]>
+]]>
       </IlasmRoundTripBatchScript>
-      <BatchIlrtTestLaunchCmds Condition="'$(IlrtTestKind)' != 'BuildOnly'"><![CDATA[
+      <BatchIlrtTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
 IF NOT DEFINED DoLink (
   if defined RunningIlasmRoundTrip (
-    ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
-    %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
-
+    ECHO %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments%
+    %LAUNCHER% $(TargetAssemblyName) %CLRTestExecutionArguments%
     IF NOT "!ERRORLEVEL!"=="%CLRTestExpectedExitCode%" (
       ECHO END EXECUTION OF IL{D}ASM BINARY - FAILED !ERRORLEVEL! vs %CLRTestExpectedExitCode%
-      ECHO FAILED
       Exit /b 1
     )
   )

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceMarshallingTests.csproj
@@ -4,8 +4,8 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests.csproj
+++ b/src/coreclr/tests/src/Interop/COM/ComWrappers/GlobalInstance/GlobalInstanceTrackerSupportTests.csproj
@@ -4,8 +4,8 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/Dynamic/Dynamic.csproj
+++ b/src/coreclr/tests/src/Interop/COM/Dynamic/Dynamic.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Aggregation/NETClientAggregation.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/ConsumeNETServer/ConsumeNETServer.csproj
@@ -4,8 +4,8 @@
     <ApplicationManifest>App.manifest</ApplicationManifest>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Events/NETClientEvents.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Events/NETClientEvents.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/IDispatch/NETClientIDispatch.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Licensing/NETClientLicense.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitives.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <!-- Test unsupported outside of windows -->

--- a/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NETClients/Primitives/NETClientPrimitivesInALC.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <ApplicationManifest>App.manifest</ApplicationManifest>
-    <!-- Blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/coreclr/issues/20819 -->
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <!-- ilasm round-trip testing blocked on ILAsm supporting embedding resources. See https://github.com/dotnet/runtime/issues/11412 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- This test would require the runincontext.exe to include App.manifest describing the COM interfaces -->

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/DefaultInterfaces.csproj
@@ -4,7 +4,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Dispatch.csproj
@@ -4,7 +4,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Events.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Events.csproj
@@ -4,7 +4,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Licensing.csproj
@@ -4,7 +4,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives.csproj
@@ -4,7 +4,7 @@
     <IgnoreCoreCLRTestLibraryDependency>true</IgnoreCoreCLRTestLibraryDependency>
     <CLRTestScriptLocalCoreShim>true</CLRTestScriptLocalCoreShim>
     <RequiresMockHostPolicy>true</RequiresMockHostPolicy>
-    <IlrtTestKind>BuildOnly</IlrtTestKind>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <DefineConstants>BLOCK_WINDOWS_NANO</DefineConstants>
   </PropertyGroup>

--- a/src/coreclr/tests/src/JIT/jit64/opt/cse/HugeField2.csproj
+++ b/src/coreclr/tests/src/JIT/jit64/opt/cse/HugeField2.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- ilasm round-trip test failure, see https://github.com/dotnet/runtime/issues/38529 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/coreclr/tests/src/JIT/jit64/opt/cse/hugeexpr1.csproj
+++ b/src/coreclr/tests/src/JIT/jit64/opt/cse/hugeexpr1.csproj
@@ -3,12 +3,14 @@
     <OutputType>Exe</OutputType>
     <GCStressIncompatible>true</GCStressIncompatible>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- ilasm round-trip testing test failure: https://github.com/dotnet/runtime/issues/38515 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
     <!-- This test is very resource heavy and doesn't play well with some JitStress modes, especially when memory is limited  (x86),
-         on arm the test fails to crossgen with stress mode because of an relocation offset size limit, see #16587 -->
+         on arm the test fails to crossgen with stress mode because of an relocation offset size limit, see https://github.com/dotnet/runtime/issues/9821 -->
     <JitOptimizationSensitive Condition="'$(TargetArchitecture)' == 'x86' Or '$(TargetArchitecture)' == 'arm'">true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>

--- a/src/coreclr/tests/src/JIT/jit64/verif/sniff/fg/ver_fg_13.ilproj
+++ b/src/coreclr/tests/src/JIT/jit64/verif/sniff/fg/ver_fg_13.ilproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
+    <!-- Disable for ilasm round-trip test failure: https://github.com/dotnet/runtime/issues/38506 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ver_fg_13.il" />

--- a/src/coreclr/tests/src/JIT/opt/Inline/regression/badcallee/badcallee.ilproj
+++ b/src/coreclr/tests/src/JIT/opt/Inline/regression/badcallee/badcallee.ilproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- Test is not expected to work with ilasm round-tripping due to invalid IL: https://github.com/dotnet/runtime/issues/38507 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/coreclr/tests/src/JIT/superpmi/superpmicollect.csproj
+++ b/src/coreclr/tests/src/JIT/superpmi/superpmicollect.csproj
@@ -1,6 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <!-- ilasm round-trip testing works, but is not interesting for this test:
+         we already get round-trip testing for the referenced projects, so doing
+         it here only adds round-trip testing of the harness, as well as doing
+         SuperPMI collections of both the normal and round-tripped tests, which
+         seems more costly than it's worth.
+    -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <GCStressIncompatible>true</GCStressIncompatible>
     <!-- This test takes a long time to complete -->
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>

--- a/src/coreclr/tests/src/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest.ilproj
+++ b/src/coreclr/tests/src/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/CompatibleWithTest.ilproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- Disable for ilasm round-trip test failure: https://github.com/dotnet/runtime/issues/38508 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CompatibleWithTest.il" />

--- a/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -5,6 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
 
+    <!-- ilasm round-trip testing doesn't make sense for this test -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+    
     <!-- Crossgen2 currently targets x64 and ARM64 only -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64'">true</CLRTestTargetUnsupported>
 

--- a/src/coreclr/tests/testenvironment.proj
+++ b/src/coreclr/tests/testenvironment.proj
@@ -7,6 +7,10 @@
 
 
   <!-- COMPlus_* variables that can be specified for a test scenario -->
+  <!-- There is a non-COMPlus variable here: RunningIlasmRoundTrip. When set to 1, this triggers CoreCLR round-trip testing.
+       The value is read in the test wrapper scripts. When set in a __TestEnv script, it is set before it is read.
+       The COMPlus_ processing handling below allows for variables not prefixed by 'COMPlus_'.
+  -->
   <PropertyGroup>
     <COMPlusVariables>
       COMPlus_TieredCompilation;
@@ -48,7 +52,8 @@
       COMPlus_TieredPGO;
       COMPlus_JitEnableGuardedDevirtualization;
       COMPlus_EnableEHWriteThru;
-      COMPlus_JitObjectStackAllocation
+      COMPlus_JitObjectStackAllocation;
+      RunningIlasmRoundTrip
     </COMPlusVariables>
   </PropertyGroup>
   <ItemGroup>
@@ -140,6 +145,7 @@
     <TestEnvironment Include="jitguardeddevirtualization" JitEnableGuardedDevirtualization="1" TieredCompilation="0" />
     <TestEnvironment Include="jitehwritethru" EnableEhWriteThru="1" TieredCompilation="0" />
     <TestEnvironment Include="jitobjectstackallocation" JitObjectStackAllocation="1" TieredCompilation="0" />
+    <TestEnvironment Include="ilasmroundtrip" RunningIlasmRoundTrip="1" />
   </ItemGroup>
 
   <!-- We use target batching on the COMPlusVariable items to iterate over the all COMPlus_* environment variables


### PR DESCRIPTION
Pipeline is `runtime-coreclr ilasm`.