### PR TITLE
Enable warning 5038 on VS.

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -454,7 +454,8 @@ if (MSVC)
   # 4132: Const object should be initialized.
   # 4212: Function declaration used ellipsis.
   # 4530: C++ exception handler used, but unwind semantics are not enabled. Specify -GX.
-  add_compile_options(/w34092 /w34121 /w34125 /w34130 /w34132 /w34212 /w34530)
+  # 35038: data member 'member1' will be initialized after data member 'member2'.
+  add_compile_options(/w34092 /w34121 /w34125 /w34130 /w34132 /w34212 /w34530 /w35038)
 
   # Set Warning Level 4:
   # 4177: Pragma data_seg s/b at global scope.

--- a/src/coreclr/src/debug/di/rsthread.cpp
+++ b/src/coreclr/src/debug/di/rsthread.cpp
@@ -2779,6 +2779,8 @@ bool CordbThread::CreateEventWasQueued()
 
 CordbUnmanagedThread::CordbUnmanagedThread(CordbProcess *pProcess, DWORD dwThreadId, HANDLE hThread, void *lpThreadLocalBase)
   : CordbBase(pProcess, dwThreadId, enumCordbUnmanagedThread),
+    m_stackBase(0),
+    m_stackLimit(0),
     m_handle(hThread),
     m_threadLocalBase(lpThreadLocalBase),
     m_pTLSArray(NULL),
@@ -2788,8 +2790,6 @@ CordbUnmanagedThread::CordbUnmanagedThread(CordbProcess *pProcess, DWORD dwThrea
 #ifdef TARGET_X86
     m_pSavedLeafSeh(NULL),
 #endif
-    m_stackBase(0),
-    m_stackLimit(0),
     m_continueCountCached(0)
 {
     m_pLeftSideContext.Set(NULL);

--- a/src/coreclr/src/debug/ee/controller.cpp
+++ b/src/coreclr/src/debug/ee/controller.cpp
@@ -8670,8 +8670,8 @@ DebuggerEnCBreakpoint::DebuggerEnCBreakpoint(SIZE_T offset,
                                              DebuggerEnCBreakpoint::TriggerType fTriggerType,
                                              AppDomain *pAppDomain)
   : DebuggerController(NULL, pAppDomain),
-    m_fTriggerType(fTriggerType),
-    m_jitInfo(jitInfo)
+    m_jitInfo(jitInfo),
+    m_fTriggerType(fTriggerType)
 {
     _ASSERTE( jitInfo != NULL );
     // Add and activate the specified patch

--- a/src/coreclr/src/debug/ee/debugger.cpp
+++ b/src/coreclr/src/debug/ee/debugger.cpp
@@ -12896,8 +12896,8 @@ private:
 // is a valid Remap Breakpoint location (not in a special offset, must be empty stack, and not in a handler.
 //
 EnCSequencePointHelper::EnCSequencePointHelper(DebuggerJitInfo *pJitInfo)
-    : m_pOffsetToHandlerInfo(NULL),
-      m_pJitInfo(pJitInfo)
+    : m_pJitInfo(pJitInfo),
+    m_pOffsetToHandlerInfo(NULL)      
 {
     CONTRACTL
     {

--- a/src/coreclr/src/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/src/hosts/coreconsole/coreconsole.cpp
@@ -27,7 +27,7 @@ class StringBuffer {
     StringBuffer& operator =(const StringBuffer&);
 
 public:
-    StringBuffer() : m_capacity(0), m_buffer(nullptr), m_length(0) {
+    StringBuffer() : m_buffer(nullptr), m_capacity(0), m_length(0) {
     }
 
     ~StringBuffer() {
@@ -116,7 +116,7 @@ public:
     wchar_t m_coreCLRDirectoryPath[MAX_LONGPATH];
 
     HostEnvironment(Logger *logger)
-        : m_log(logger), m_CLRRuntimeHost(nullptr) {
+        : m_CLRRuntimeHost(nullptr), m_log(logger) {
 
             // Discover the path to this exe's module. All other files are expected to be in the same directory.
             DWORD thisModuleLength = ::GetModuleFileNameW(::GetModuleHandleW(nullptr), m_hostPath, MAX_LONGPATH);

--- a/src/coreclr/src/hosts/corerun/corerun.cpp
+++ b/src/coreclr/src/hosts/corerun/corerun.cpp
@@ -95,10 +95,10 @@ public:
     PathString m_coreCLRDirectoryPath;
 
     HostEnvironment(Logger *logger)
-        : m_log(logger)
-        , m_CLRRuntimeHostInitialize(nullptr)
+        : m_CLRRuntimeHostInitialize(nullptr)
         , m_CLRRuntimeHostExecute(nullptr)
-        , m_CLRRuntimeHostShutdown(nullptr) {
+        , m_CLRRuntimeHostShutdown(nullptr)
+        , m_log(logger) {
 
             // Discover the path to this exe's module. All other files are expected to be in the same directory.
             WszGetModuleFileName(::GetModuleHandleW(nullptr), m_hostPath);
@@ -414,9 +414,9 @@ public:
     //       logger - Logger to record errors
     // assemblyPath - Assembly containing activation context manifest
     ActivationContext(Logger &logger, _In_z_ const WCHAR *assemblyPath)
-        : _actCookie{}
+        : _logger{ logger }
         , _actCxt{ INVALID_HANDLE_VALUE }
-        , _logger{ logger }
+        , _actCookie{} 
     {
         ACTCTX cxt{};
         cxt.cbSize = sizeof(cxt);

--- a/src/coreclr/src/inc/contract.h
+++ b/src/coreclr/src/inc/contract.h
@@ -986,7 +986,7 @@ class BaseContract
     };
 
 
-    NOTHROW_DECL BaseContract() : m_pClrDebugState(NULL),  m_testmask(0)
+    NOTHROW_DECL BaseContract() : m_testmask(0), m_pClrDebugState(NULL)
     {
     }
     NOTHROW_DECL void Restore()

--- a/src/coreclr/src/interop/comwrappers.hpp
+++ b/src/coreclr/src/interop/comwrappers.hpp
@@ -125,14 +125,13 @@ ABI_ASSERT(offsetof(ManagedObjectWrapper, Target) == 0);
 // Class for connecting a native COM object to a managed object instance
 class NativeObjectWrapperContext
 {
-#ifdef _DEBUG
-    size_t _sentinel;
-#endif
-
     IReferenceTracker* _trackerObject;
     void* _runtimeContext;
     Volatile<BOOL> _isValidTracker;
 
+#ifdef _DEBUG
+    size_t _sentinel;
+#endif
 public: // static
     // Convert a context pointer into a NativeObjectWrapperContext.
     static NativeObjectWrapperContext* MapFromRuntimeContext(_In_ void* cxt);

--- a/src/coreclr/src/vm/assembly.cpp
+++ b/src/coreclr/src/vm/assembly.cpp
@@ -119,13 +119,13 @@ Assembly::Assembly(BaseDomain *pDomain, PEAssembly* pFile, DebuggerAssemblyContr
 #ifdef FEATURE_COMINTEROP
     m_pITypeLib(NULL),
 #endif // FEATURE_COMINTEROP
-    m_debuggerFlags(debuggerFlags),
-    m_fTerminated(FALSE)
 #ifdef FEATURE_COMINTEROP
-    , m_InteropAttributeStatus(INTEROP_ATTRIBUTE_UNSET)
+    m_InteropAttributeStatus(INTEROP_ATTRIBUTE_UNSET),
 #endif
+    m_debuggerFlags(debuggerFlags),
+    m_fTerminated(FALSE),
 #if defined(FEATURE_PREJIT) || defined(FEATURE_READYTORUN)
-    , m_isInstrumentedStatus(IS_INSTRUMENTED_UNSET)
+    m_isInstrumentedStatus(IS_INSTRUMENTED_UNSET)
 #endif
 {
     STANDARD_VM_CONTRACT;

--- a/src/coreclr/src/vm/comcallablewrapper.cpp
+++ b/src/coreclr/src/vm/comcallablewrapper.cpp
@@ -3172,10 +3172,10 @@ IDispatch* ComCallWrapper::GetIDispatchIP()
 // constructor
 //--------------------------------------------------------------------------
 ComCallWrapperCache::ComCallWrapperCache() :
-    m_lock(CrstCOMWrapperCache),
     m_cbRef(0),
     m_pCacheLineAllocator(NULL),
-    m_pLoaderAllocator(NULL)
+    m_pLoaderAllocator(NULL),
+    m_lock(CrstCOMWrapperCache)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/src/coreclr/src/vm/comconnectionpoints.cpp
+++ b/src/coreclr/src/vm/comconnectionpoints.cpp
@@ -24,9 +24,9 @@ ConnectionPoint::ConnectionPoint(ComCallWrapper *pWrap, MethodTable *pEventMT)
 , m_pTCEProviderMT(pWrap->GetSimpleWrapper()->GetMethodTable())
 , m_pEventItfMT(pEventMT)
 , m_Lock(CrstInterop)
-, m_cbRefCount(0)
 , m_apEventMethods(NULL)
 , m_NumEventMethods(0)
+, m_cbRefCount(0)
 , m_pLastInserted(NULL)
 {
     CONTRACTL

--- a/src/coreclr/src/vm/dispatchinfo.cpp
+++ b/src/coreclr/src/vm/dispatchinfo.cpp
@@ -72,8 +72,8 @@ DispatchMemberInfo::DispatchMemberInfo(DispatchInfo *pDispInfo, DISPID DispID, S
 , m_hndMemberInfo(NULL)
 , m_apParamMarshaler(NULL)
 , m_pParamInOnly(NULL)
-, m_strName(strName)
 , m_pNext(NULL)
+, m_strName(strName)
 , m_enumType (Uninitted)
 , m_iNumParams(-1)
 , m_CultureAwareState(Unknown)
@@ -1035,8 +1035,8 @@ DispatchInfo::DispatchInfo(MethodTable *pMT)
 , m_pFirstMemberInfo(NULL)
 , m_lock(CrstInterop, (CrstFlags)(CRST_HOST_BREAKABLE | CRST_REENTRANCY))
 , m_CurrentDispID(0x10000)
-, m_bInvokeUsingInvokeMember(FALSE)
 , m_bAllowMembersNotInComMTMemberMap(FALSE)
+, m_bInvokeUsingInvokeMember(FALSE)
 {
     CONTRACTL
     {

--- a/src/coreclr/src/vm/dispparammarshaler.h
+++ b/src/coreclr/src/vm/dispparammarshaler.h
@@ -102,9 +102,9 @@ class DispParamInterfaceMarshaler : public DispParamMarshaler
 {
 public:
     DispParamInterfaceMarshaler(BOOL bDispatch, MethodTable* pIntfMT, MethodTable *pClassMT, BOOL bClassIsHint) :
-    m_bDispatch(bDispatch),
     m_pIntfMT(pIntfMT),
     m_pClassMT(pClassMT),
+    m_bDispatch(bDispatch),
     m_bClassIsHint(bClassIsHint)
     {
         WRAPPER_NO_CONTRACT;

--- a/src/coreclr/src/vm/dwbucketmanager.hpp
+++ b/src/coreclr/src/vm/dwbucketmanager.hpp
@@ -336,7 +336,7 @@ public:
 };
 
 BaseBucketParamsManager::BaseBucketParamsManager(GenericModeBlock* pGenericModeBlock, TypeOfReportedError typeOfError, PCODE initialFaultingPc, Thread* pFaultingThread, OBJECTREF* pThrownException)
-    : m_pFaultingMD(NULL), m_faultingPc(initialFaultingPc), m_pGmb(pGenericModeBlock), m_tore(typeOfError), m_pThread(pFaultingThread), m_pException(pThrownException)
+    : m_pGmb(pGenericModeBlock), m_tore(typeOfError), m_pThread(pFaultingThread), m_pException(pThrownException), m_pFaultingMD(NULL), m_faultingPc(initialFaultingPc)
 {
     CONTRACTL
     {

--- a/src/coreclr/src/vm/runtimecallablewrapper.h
+++ b/src/coreclr/src/vm/runtimecallablewrapper.h
@@ -1370,9 +1370,8 @@ class RCWCleanupList
 
 public:
     RCWCleanupList()
-        : m_lock(CrstRCWCleanupList, CRST_UNSAFE_ANYMODE),
-          m_pCurCleanupThread(NULL), m_doCleanupInContexts(FALSE),
-          m_pFirstBucket(NULL)
+        : m_pFirstBucket(NULL), m_lock(CrstRCWCleanupList, CRST_UNSAFE_ANYMODE),
+          m_pCurCleanupThread(NULL), m_doCleanupInContexts(FALSE)         
     {
         WRAPPER_NO_CONTRACT;
     }

--- a/src/coreclr/src/vm/stacksampler.cpp
+++ b/src/coreclr/src/vm/stacksampler.cpp
@@ -106,10 +106,10 @@ DWORD __stdcall StackSampler::SamplingThreadProc(void* arg)
 
 // Constructor
 StackSampler::StackSampler()
-    : m_nSampleAfter(0)
+    : m_crstJitInfo(CrstStackSampler, (CrstFlags)(CRST_UNSAFE_ANYMODE))
     , m_nSampleEvery(s_knDefaultSamplingIntervalMsec)
+    , m_nSampleAfter(0)
     , m_nNumMethods(s_knDefaultNumMethods)
-    , m_crstJitInfo(CrstStackSampler, (CrstFlags) (CRST_UNSAFE_ANYMODE))
 {
     // When to start sampling after the thread launch.
     int nSampleAfter = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_StackSamplingAfter);

--- a/src/coreclr/src/vm/stacksampler.h
+++ b/src/coreclr/src/vm/stacksampler.h
@@ -62,7 +62,7 @@ private:
     {
         unsigned uCount;
         bool fJitted;
-        CountInfo() : fJitted(false), uCount(0) {}
+        CountInfo() : uCount(0), fJitted(false) {}
     };
 
     // Fields

--- a/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives/ArrayTests.cpp
+++ b/src/coreclr/tests/src/Interop/COM/NativeClients/Primitives/ArrayTests.cpp
@@ -54,8 +54,8 @@ namespace
     {
     public:
         SafeArraySmartPtr(_In_ const std::vector<T> &in)
-            : _safeArray{}
-            , _elementCount{ static_cast<int>(in.size()) }
+            : _elementCount{ static_cast<int>(in.size())}
+              ,_safeArray{}
         {
             SAFEARRAYBOUND saBound;
             saBound.lLbound = 0;


### PR DESCRIPTION
[Warning](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5038?view=vs-2019): data member 'member1' will be initialized after data member 'member2'

It is enabled on clang as error. Often when doing development on Windows you could pass window build and get CI failures on Linux because of that.

Clang error example:
```
/__w/1/s/src/coreclr/src/jit/gentree.h:4787:11: error: field 'gtHWIntrinsicId' will be initialized after field 'm_layout' [-Werror,-Wreorder]
        , gtHWIntrinsicId(NI_Illegal)
```
