### PR TITLE
Improve performance of DateTime.Kind property.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1047,7 +1047,6 @@ namespace System
         internal bool IsAmbiguousDaylightSavingTime() =>
             InternalKind == KindLocalAmbiguousDst;
 
-
         public DateTimeKind Kind
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -111,8 +111,7 @@ namespace System
         private const ulong TicksMask = 0x3FFFFFFFFFFFFFFF;
         private const ulong FlagsMask = 0xC000000000000000;
         private const ulong LocalMask = 0x8000000000000000;
-        private const long TicksCeiling = 0x4000000000000000;
-        private const ulong KindUnspecified = 0x0000000000000000;
+        private const long TicksCeiling = 0x4000000000000000;        
         private const ulong KindUtc = 0x4000000000000000;
         private const ulong KindLocal = 0x8000000000000000;
         private const ulong KindLocalAmbiguousDst = 0xC000000000000000;

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1047,14 +1047,17 @@ namespace System
         internal bool IsAmbiguousDaylightSavingTime() =>
             InternalKind == KindLocalAmbiguousDst;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public DateTimeKind Kind =>
-            InternalKind switch
+
+        public DateTimeKind Kind
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => InternalKind switch
             {
                 KindUnspecified => DateTimeKind.Unspecified,
                 KindUtc => DateTimeKind.Utc,
                 _ => DateTimeKind.Local,
             };
+        }
 
         // Returns the millisecond part of this DateTime. The returned value
         // is an integer between 0 and 999.

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -111,7 +111,7 @@ namespace System
         private const ulong TicksMask = 0x3FFFFFFFFFFFFFFF;
         private const ulong FlagsMask = 0xC000000000000000;
         private const ulong LocalMask = 0x8000000000000000;
-        private const long TicksCeiling = 0x4000000000000000;        
+        private const long TicksCeiling = 0x4000000000000000;
         private const ulong KindUtc = 0x4000000000000000;
         private const ulong KindLocal = 0x8000000000000000;
         private const ulong KindLocalAmbiguousDst = 0xC000000000000000;

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -112,6 +112,7 @@ namespace System
         private const ulong FlagsMask = 0xC000000000000000;
         private const ulong LocalMask = 0x8000000000000000;
         private const long TicksCeiling = 0x4000000000000000;
+        private const ulong KindUnspecified = 0x0000000000000000;
         private const ulong KindUtc = 0x4000000000000000;
         private const ulong KindLocal = 0x8000000000000000;
         private const ulong KindLocalAmbiguousDst = 0xC000000000000000;
@@ -1046,25 +1047,14 @@ namespace System
         internal bool IsAmbiguousDaylightSavingTime() =>
             InternalKind == KindLocalAmbiguousDst;
 
-        public DateTimeKind Kind
-        {
-            get
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public DateTimeKind Kind =>
+            InternalKind switch
             {
-                //This algorithm works because values defined in DateTimeKind
-                //correspond to the internal represenation
-                //stored in the most significant bits of _dateData.
-                //The exception is the 4th kind
-                //which we need to coerce to DateTimeKind.Local.
-                var kind = (DateTimeKind)(_dateData >> KindShift);
-                var isAmbiguousLocalDst = kind > DateTimeKind.Local;
-                if (isAmbiguousLocalDst)
-                {
-                    kind = DateTimeKind.Local;
-                }
-
-                return kind;
-            }
-        }
+                KindUnspecified => DateTimeKind.Unspecified,
+                KindUtc => DateTimeKind.Utc,
+                _ => DateTimeKind.Local,
+            };
 
         // Returns the millisecond part of this DateTime. The returned value
         // is an integer between 0 and 999.

--- a/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/DateTime.cs
@@ -1047,13 +1047,25 @@ namespace System
         internal bool IsAmbiguousDaylightSavingTime() =>
             InternalKind == KindLocalAmbiguousDst;
 
-        public DateTimeKind Kind =>
-            InternalKind switch
+        public DateTimeKind Kind
+        {
+            get
             {
-                KindUnspecified => DateTimeKind.Unspecified,
-                KindUtc => DateTimeKind.Utc,
-                _ => DateTimeKind.Local,
-            };
+                //This algorithm works because values defined in DateTimeKind
+                //correspond to the internal represenation
+                //stored in the most significant bits of _dateData.
+                //The exception is the 4th kind
+                //which we need to coerce to DateTimeKind.Local.
+                var kind = (DateTimeKind)(_dateData >> KindShift);
+                var isAmbiguousLocalDst = kind > DateTimeKind.Local;
+                if (isAmbiguousLocalDst)
+                {
+                    kind = DateTimeKind.Local;
+                }
+
+                return kind;
+            }
+        }
 
         // Returns the millisecond part of this DateTime. The returned value
         // is an integer between 0 and 999.


### PR DESCRIPTION
Yesterday, I stumbled upon the fact that `DateTime.Kind` does not get inlined and generally produces unexpectedly large code footprint when used. I thus had to basically "manually inline" it in my library, which is not ideal. 

This PR focuses on bringing some improvements to `DateTime.Kind` with the aim of reducing the machine code size and time it takes to calculate the property. This comes with a drawback: the new algorithm is not as readable as the one used before and also depends on the definition of `DateTimeKind` members. To that end, I placed a large comment explaining what is going on in the getter. 

[Here](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgDkBXfGKASzFwBuGjWIBmBrgxQOYDAwAi2DDBoBvGgy0MADnwBuymA1jYAJhAB2AGwCeDDtasBzBgH0zy7MOraGm7UhLKQcnS1cAaV5LMwBVYJ0YMF4AM14YMwYAXgY6BDoCwqLiuh8/IJDHFwYomNiMMGzchBQStoKfAEgK+SrwhgAxa2xnXABZPABrJryAYXa2su09XkMVUOqASUsVKEtsa1rMrIA+d08MbAYAMkHh0YncSaWtAK1xGujMo+yz7d39ocvpIAO68BoACzeDA0vj82iO8VwiWSaQyv0+MRYSJRqXSZjQ0L8iIaGKO2IahLh8PcZK+LAAMhAwAdoQBfF7+alMCQ/AZ4DBHAAUAEpobDOp1DFAGJNgTkhUcRUKPF4GCczkhSCKulLsDLeLgmSzrE05TF1ZizIzmQddakGELDcaDmLqJK1PCaJLOubjlabSbdWzvd7OsQAOyOpV+zkh6jxvyiCQwSxcK3qaE4pJ49E5OhUvz1Ro5ciF7Qu005Ug0NlAA), I recreated the "before" and "after" state on Sharplab: the code is 3 times smaller and has one less branch.

Edit: the original benchmark was severely flawed. See the discussion below for accurate numbers.