### PR TITLE
Fix error handling in SocketHttpHandler's ConnectHelper.Connect

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -101,13 +101,7 @@ namespace System.Net.Http
             catch (Exception e)
             {
                 socket.Dispose();
-
-                if (CancellationHelper.ShouldWrapInOperationCanceledException(e, cancellationToken))
-                {
-                    throw CancellationHelper.CreateOperationCanceledException(e, cancellationToken);
-                }
-
-                throw;
+                throw CreateWrappedException(e, cancellationToken);
             }
 
             return new NetworkStream(socket, ownsSocket: true);


### PR DESCRIPTION
It's failing to wrap exceptions in HttpRequestException.  This was found by an HttpWebRequest test when augmenting those tests to use Send.
cc: @ManickaP 