### PR TITLE
Add ExcludeFromCodeCoverageAttribute.Justification property

### DIFF
--- a/src/libraries/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
+++ b/src/libraries/Common/src/System/Diagnostics/CodeAnalysis/ExcludeFromCodeCoverageAttribute.cs
@@ -12,7 +12,9 @@ namespace System.Diagnostics.CodeAnalysis
 #endif
     sealed class ExcludeFromCodeCoverageAttribute : Attribute
     {
-        public ExcludeFromCodeCoverageAttribute()
-        { }
+        public ExcludeFromCodeCoverageAttribute() { }
+
+        /// <summary>Gets or sets the justification for excluding the member from code coverage.</summary>
+        public string? Justification { get; set; }
     }
 }

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpBinaryOperationBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpBinaryOperationBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     /// </summary>
     internal sealed class CSharpBinaryOperationBinder : BinaryOperationBinder, ICSharpBinder
     {
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Name should not be called for this binder")]
         public string Name
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpConvertBinder.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     /// </summary>
     internal sealed class CSharpConvertBinder : ConvertBinder, ICSharpBinder
     {
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Name should not be called for this binder")]
         public string Name
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpUnaryOperationBinder.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/CSharpUnaryOperationBinder.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CSharp.RuntimeBinder
     /// </summary>
     internal sealed class CSharpUnaryOperationBinder : UnaryOperationBinder, ICSharpBinder
     {
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Name should not be called for this binder")]
         public string Name
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolStore.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolStore.cs
@@ -90,7 +90,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             public bool Equals(Key other) => _name == other._name && _parent == other._parent;
 
 #if  DEBUG
-            [ExcludeFromCodeCoverage] // Typed overload should always be the method called.
+            [ExcludeFromCodeCoverage(Justification = "Typed overload should always be the method called")]
 #endif
             public override bool Equals(object obj)
             {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Tree/EXPR.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             protected set { _type = value; }
         }
 
-        [ExcludeFromCodeCoverage] // Should only be called through override.
+        [ExcludeFromCodeCoverage(Justification = "Should only be called through override")]
         public virtual object Object
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/NullableType.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public override FUNDTYPE FundamentalType => FUNDTYPE.FT_STRUCT;
 
-        [ExcludeFromCodeCoverage] // Should be unreachable. Overload exists just to catch it being hit during debug.
+        [ExcludeFromCodeCoverage(Justification = "Should be unreachable. Overload exists just to catch it being hit during debug.")]
         public override ConstValKind ConstValKind
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PointerType.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PointerType.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public override FUNDTYPE FundamentalType => FUNDTYPE.FT_PTR;
 
-        [ExcludeFromCodeCoverage(Justification = "Constant of pointer in dynamic code")]
+        [ExcludeFromCodeCoverage(Justification = "Dynamic code can't contain constant pointers")]
         public override ConstValKind ConstValKind
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PointerType.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PointerType.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public override FUNDTYPE FundamentalType => FUNDTYPE.FT_PTR;
 
-        [ExcludeFromCodeCoverage] // Technically correct, but we can't have constant pointers in dynamically dispatched code.
+        [ExcludeFromCodeCoverage(Justification = "Constant of pointer in dynamic code")]
         public override ConstValKind ConstValKind
         {
             get

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/Type.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             TypeKind = kind;
         }
 
-        [ExcludeFromCodeCoverage] // Should only be called through override.
+        [ExcludeFromCodeCoverage(Justification = "Should only be called through override")]
         public virtual Type AssociatedSystemType => throw Error.InternalCompilerError();
 
         public TypeKind TypeKind { get; }
@@ -99,7 +99,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public virtual bool IsClassType => false;
 
-        [ExcludeFromCodeCoverage] // Should only be called through override.
+        [ExcludeFromCodeCoverage(Justification = "Should only be called through override")]
         public virtual AggregateType UnderlyingEnumType => throw Error.InternalCompilerError();
 
         // Pointer types (or arrays of them) are the only unsafe types.
@@ -110,7 +110,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public virtual bool IsPredefined => false;
 
-        [ExcludeFromCodeCoverage] // Should only be called through override.
+        [ExcludeFromCodeCoverage(Justification = "Should only be called through override")]
         public virtual PredefinedType PredefinedType => throw Error.InternalCompilerError();
 
         public virtual bool IsStaticClass => false;
@@ -122,7 +122,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public virtual bool IsReferenceType => false;
 
-        [ExcludeFromCodeCoverage] // Should only be called through override.
+        [ExcludeFromCodeCoverage(Justification = "Should only be called through override")]
         public virtual AggregateType GetAts()
         {
             Debug.Fail("Bad type for AsAggregateType");

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeArray.cs
@@ -68,7 +68,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 return true;
             }
 
-            [ExcludeFromCodeCoverage] // Typed overload should always be the method called.
+            [ExcludeFromCodeCoverage(Justification = "Typed overload should always be the method called")]
             public override bool Equals(object obj)
             {
                 Debug.Fail("Sub-optimal overload called. Check if this can be avoided.");

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/TypeTable.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
                 && EqualityComparer<TKey2>.Default.Equals(_pKey2, other._pKey2);
 
 #if DEBUG
-            [ExcludeFromCodeCoverage] // Typed overload should always be the method called.
+            [ExcludeFromCodeCoverage(Justification = "Typed overload should always be the method called")]
 #endif
             public override bool Equals(object obj)
             {

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/WithType.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
 
         public static bool operator !=(SymWithType swt1, SymWithType swt2) => !(swt1 == swt2);
 
-        [ExcludeFromCodeCoverage] // == overload should always be the method called.
+        [ExcludeFromCodeCoverage(Justification = "== overload should always be the method called")]
         public override bool Equals(object obj)
         {
             Debug.Fail("Sub-optimal equality called. Check if this is correct.");
@@ -86,7 +86,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             return Sym == other.Sym && Ats == other.Ats;
         }
 
-        [ExcludeFromCodeCoverage] // Never used as a key.
+        [ExcludeFromCodeCoverage(Justification = "Never used as a key")]
         public override int GetHashCode()
         {
             Debug.Fail("If using this as a key, implement IEquatable<SymWithType>");

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/SymbolTable.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CSharp.RuntimeBinder
             public bool Equals(NameHashKey other) => Type.Equals(other.Type) && Name.Equals(other.Name);
 
 #if  DEBUG
-            [ExcludeFromCodeCoverage] // Typed overload should always be the method called.
+            [ExcludeFromCodeCoverage(Justification = "Typed overload should always be the method called")]
 #endif
             public override bool Equals(object obj)
             {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -823,7 +823,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Clear()
         {
             var self = this;
@@ -834,7 +833,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Add(T value)
         {
             var self = this;
@@ -845,7 +843,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items)
         {
             var self = this;
@@ -856,7 +853,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Insert(int index, T element)
         {
             var self = this;
@@ -867,7 +863,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.InsertRange(int index, IEnumerable<T> items)
         {
             var self = this;
@@ -878,7 +873,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T>? equalityComparer)
         {
             var self = this;
@@ -889,7 +883,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match)
         {
             var self = this;
@@ -900,7 +893,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer)
         {
             var self = this;
@@ -911,7 +903,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count)
         {
             var self = this;
@@ -922,7 +913,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveAt(int index)
         {
             var self = this;
@@ -933,7 +923,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See <see cref="IImmutableList{T}"/>
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.SetItem(int index, T value)
         {
             var self = this;
@@ -959,7 +948,6 @@ namespace System.Collections.Immutable
         /// The position into which the new element was inserted, or -1 to indicate that the item was not inserted into the collection,
         /// </returns>
         /// <exception cref="System.NotSupportedException"></exception>
-        [ExcludeFromCodeCoverage]
         int IList.Add(object? value)
         {
             throw new NotSupportedException();
@@ -969,7 +957,6 @@ namespace System.Collections.Immutable
         /// Removes all items from the <see cref="ICollection{T}"/>.
         /// </summary>
         /// <exception cref="System.NotSupportedException"></exception>
-        [ExcludeFromCodeCoverage]
         void IList.Clear()
         {
             throw new NotSupportedException();
@@ -982,7 +969,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// true if the <see cref="object"/> is found in the <see cref="IList"/>; otherwise, false.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         bool IList.Contains(object? value)
         {
             var self = this;
@@ -997,7 +983,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// The index of <paramref name="value"/> if found in the list; otherwise, -1.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         int IList.IndexOf(object? value)
         {
             var self = this;
@@ -1011,7 +996,6 @@ namespace System.Collections.Immutable
         /// <param name="index">The zero-based index at which <paramref name="value"/> should be inserted.</param>
         /// <param name="value">The object to insert into the <see cref="IList"/>.</param>
         /// <exception cref="System.NotSupportedException"></exception>
-        [ExcludeFromCodeCoverage]
         void IList.Insert(int index, object? value)
         {
             throw new NotSupportedException();
@@ -1023,7 +1007,6 @@ namespace System.Collections.Immutable
         /// <value>
         /// <c>true</c> if this instance is fixed size; otherwise, <c>false</c>.
         /// </value>
-        [ExcludeFromCodeCoverage]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         bool IList.IsFixedSize
         {
@@ -1036,7 +1019,6 @@ namespace System.Collections.Immutable
         /// <value>
         /// <c>true</c> if this instance is read only; otherwise, <c>false</c>.
         /// </value>
-        [ExcludeFromCodeCoverage]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         bool IList.IsReadOnly
         {
@@ -1047,7 +1029,6 @@ namespace System.Collections.Immutable
         /// Gets the size of the array.
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="IsDefault"/> property returns true.</exception>
-        [ExcludeFromCodeCoverage]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         int ICollection.Count
         {
@@ -1062,7 +1043,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="ICollection"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         bool ICollection.IsSynchronized
         {
@@ -1076,7 +1056,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Gets the sync root.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         object ICollection.SyncRoot
         {
@@ -1088,7 +1067,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="value">The object to remove from the <see cref="IList"/>.</param>
         /// <exception cref="System.NotSupportedException"></exception>
-        [ExcludeFromCodeCoverage]
         void IList.Remove(object? value)
         {
             throw new NotSupportedException();
@@ -1099,7 +1077,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The zero-based index of the item to remove.</param>
         /// <exception cref="System.NotSupportedException"></exception>
-        [ExcludeFromCodeCoverage]
         void IList.RemoveAt(int index)
         {
             throw new NotSupportedException();
@@ -1115,7 +1092,6 @@ namespace System.Collections.Immutable
         /// <returns></returns>
         /// <exception cref="NotSupportedException">Always thrown from the setter.</exception>
         /// <exception cref="InvalidOperationException">Thrown if the <see cref="IsDefault"/> property returns true.</exception>
-        [ExcludeFromCodeCoverage]
         object? IList.this[int index]
         {
             get
@@ -1132,7 +1108,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="array">The one-dimensional <see cref="Array"/> that is the destination of the elements copied from <see cref="ICollection"/>. The <see cref="Array"/> must have zero-based indexing.</param>
         /// <param name="index">The zero-based index in <paramref name="array"/> at which copying begins.</param>
-        [ExcludeFromCodeCoverage]
         void ICollection.CopyTo(Array array, int index)
         {
             var self = this;

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary_2.cs
@@ -202,7 +202,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// Gets the empty instance.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Clear()
         {
             return this.Clear();
@@ -510,7 +509,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value)
         {
             return this.Add(key, value);
@@ -519,7 +517,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value)
         {
             return this.SetItem(key, value);
@@ -538,7 +535,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
             return this.AddRange(pairs);
@@ -547,7 +543,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(IEnumerable<TKey> keys)
         {
             return this.RemoveRange(keys);
@@ -556,7 +551,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key)
         {
             return this.Remove(key);
@@ -827,7 +821,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// An <see cref="IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -371,7 +371,6 @@ namespace System.Collections.Immutable
             /// <returns>
             /// An <see cref="IEnumerator"/> object that can be used to iterate through the collection.
             /// </returns>
-            [ExcludeFromCodeCoverage]
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return this.GetEnumerator();

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
@@ -119,7 +119,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Clear()
         {
             return this.Clear();
@@ -360,7 +359,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Add(T item)
         {
             return this.Add(item);
@@ -369,7 +367,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Remove(T item)
         {
             return this.Remove(item);
@@ -378,7 +375,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Union(IEnumerable<T> other)
         {
             return this.Union(other);
@@ -387,7 +383,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Intersect(IEnumerable<T> other)
         {
             return this.Intersect(other);
@@ -396,7 +391,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Except(IEnumerable<T> other)
         {
             return this.Except(other);
@@ -407,7 +401,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="other">The other sequence of items.</param>
         /// <returns>The new set.</returns>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(IEnumerable<T> other)
         {
             return this.SymmetricExcept(other);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList_1.cs
@@ -799,13 +799,11 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Add(T value) => this.Add(value);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.AddRange(IEnumerable<T> items) => this.AddRange(items);
 
         /// <summary>
@@ -814,7 +812,6 @@ namespace System.Collections.Immutable
         /// <param name="index">The index at which to insert the value.</param>
         /// <param name="item">The element to add.</param>
         /// <returns>The new immutable list.</returns>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Insert(int index, T item) => this.Insert(index, item);
 
         /// <summary>
@@ -823,7 +820,6 @@ namespace System.Collections.Immutable
         /// <param name="index">The index at which to insert the value.</param>
         /// <param name="items">The elements to add.</param>
         /// <returns>The new immutable list.</returns>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.InsertRange(int index, IEnumerable<T> items)
         {
             return this.InsertRange(index, items);
@@ -832,25 +828,21 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.Remove(T value, IEqualityComparer<T>? equalityComparer) => this.Remove(value, equalityComparer);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveAll(Predicate<T> match) => this.RemoveAll(match);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveRange(IEnumerable<T> items, IEqualityComparer<T>? equalityComparer) => this.RemoveRange(items, equalityComparer);
 
         /// <summary>
         /// See the <see cref="IImmutableList{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveRange(int index, int count) => this.RemoveRange(index, count);
 
         /// <summary>
@@ -858,7 +850,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="index">The index.</param>
         /// <returns>A new list with the elements removed.</returns>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.RemoveAt(int index) => this.RemoveAt(index);
 
         /// <summary>
@@ -867,7 +858,6 @@ namespace System.Collections.Immutable
         /// <param name="index">The position in the list of the element to replace.</param>
         /// <param name="value">The element to replace the old element with.</param>
         /// <returns>The new list.</returns>
-        [ExcludeFromCodeCoverage]
         IImmutableList<T> IImmutableList<T>.SetItem(int index, T value) => this.SetItem(index, value);
 
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary_2.cs
@@ -398,7 +398,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Add(TKey key, TValue value)
         {
             return this.Add(key, value);
@@ -407,7 +406,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.SetItem(TKey key, TValue value)
         {
             return this.SetItem(key, value);
@@ -426,7 +424,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
             return this.AddRange(pairs);
@@ -435,7 +432,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.RemoveRange(IEnumerable<TKey> keys)
         {
             return this.RemoveRange(keys);
@@ -444,7 +440,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableDictionary{TKey, TValue}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableDictionary<TKey, TValue> IImmutableDictionary<TKey, TValue>.Remove(TKey key)
         {
             return this.Remove(key);
@@ -718,7 +713,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
         {
             return this.IsEmpty ?
@@ -736,7 +730,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// An <see cref="IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet_1.cs
@@ -607,7 +607,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Clear()
         {
             return this.Clear();
@@ -616,7 +615,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Add(T value)
         {
             return this.Add(value);
@@ -625,7 +623,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Remove(T value)
         {
             return this.Remove(value);
@@ -634,7 +631,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Intersect(IEnumerable<T> other)
         {
             return this.Intersect(other);
@@ -643,7 +639,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Except(IEnumerable<T> other)
         {
             return this.Except(other);
@@ -654,7 +649,6 @@ namespace System.Collections.Immutable
         /// </summary>
         /// <param name="other">The other sequence of items.</param>
         /// <returns>The new set.</returns>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.SymmetricExcept(IEnumerable<T> other)
         {
             return this.SymmetricExcept(other);
@@ -663,7 +657,6 @@ namespace System.Collections.Immutable
         /// <summary>
         /// See the <see cref="IImmutableSet{T}"/> interface.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         IImmutableSet<T> IImmutableSet<T>.Union(IEnumerable<T> other)
         {
             return this.Union(other);
@@ -954,7 +947,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// A <see cref="IEnumerator{T}"/> that can be used to iterate through the collection.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         IEnumerator<T> IEnumerable<T>.GetEnumerator()
         {
             return this.IsEmpty ?
@@ -972,7 +964,6 @@ namespace System.Collections.Immutable
         /// <returns>
         /// An <see cref="IEnumerator"/> object that can be used to iterate through the collection.
         /// </returns>
-        [ExcludeFromCodeCoverage]
         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/ContractUtils.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/ContractUtils.cs
@@ -15,7 +15,7 @@ namespace System.Dynamic.Utils
         /// <summary>
         /// Returns an exception object to be thrown when code is supposed to be unreachable.
         /// </summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public static Exception Unreachable
         {
             get

--- a/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/ListArgumentProvider.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Dynamic/Utils/ListArgumentProvider.cs
@@ -38,13 +38,13 @@ namespace System.Dynamic.Utils
             return -1;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void Insert(int index, T item)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void RemoveAt(int index)
         {
             throw ContractUtils.Unreachable;
@@ -61,7 +61,7 @@ namespace System.Dynamic.Utils
 
                 return GetElement(index);
             }
-            [ExcludeFromCodeCoverage] // Unreachable
+            [ExcludeFromCodeCoverage(Justification = "Unreachable")]
             set
             {
                 throw ContractUtils.Unreachable;
@@ -72,13 +72,13 @@ namespace System.Dynamic.Utils
 
         #region ICollection<T> Members
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void Add(T item)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void Clear()
         {
             throw ContractUtils.Unreachable;
@@ -110,10 +110,10 @@ namespace System.Dynamic.Utils
 
         public int Count => ElementCount;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public bool IsReadOnly => true;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public bool Remove(T item)
         {
             throw ContractUtils.Unreachable;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -107,19 +107,19 @@ namespace System.Linq.Expressions
         internal virtual bool SameVariables(ICollection<ParameterExpression>? variables) =>
             variables == null || variables.Count == 0;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual bool SameExpressions(ICollection<Expression> expressions)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual Expression GetExpression(int index)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual int ExpressionCount
         {
             get
@@ -128,7 +128,7 @@ namespace System.Linq.Expressions
             }
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual ReadOnlyCollection<Expression> GetOrMakeExpressions()
         {
             throw ContractUtils.Unreachable;
@@ -149,7 +149,7 @@ namespace System.Linq.Expressions
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
         /// subclass of BlockExpression which is being used.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression>? variables, Expression[] args)
         {
             throw ContractUtils.Unreachable;
@@ -708,13 +708,13 @@ namespace System.Linq.Expressions
             return -1;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void Insert(int index, Expression item)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void RemoveAt(int index)
         {
             throw ContractUtils.Unreachable;
@@ -731,7 +731,7 @@ namespace System.Linq.Expressions
 
                 return _block.GetExpression(index);
             }
-            [ExcludeFromCodeCoverage] // Unreachable
+            [ExcludeFromCodeCoverage(Justification = "Unreachable")]
             set
             {
                 throw ContractUtils.Unreachable;
@@ -742,13 +742,13 @@ namespace System.Linq.Expressions
 
         #region ICollection<Expression> Members
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void Add(Expression item)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public void Clear()
         {
             throw ContractUtils.Unreachable;
@@ -783,7 +783,7 @@ namespace System.Linq.Expressions
 
         public int Count => _block.ExpressionCount;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public bool IsReadOnly
         {
             get
@@ -792,7 +792,7 @@ namespace System.Linq.Expressions
             }
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public bool Remove(Expression item)
         {
             throw ContractUtils.Unreachable;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.SpilledExpressionBlock.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.SpilledExpressionBlock.cs
@@ -53,7 +53,7 @@ namespace System.Linq.Expressions.Compiler
         {
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression>? variables, Expression[] args)
         {
             throw ContractUtils.Unreachable;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
@@ -37,7 +37,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the start line of this <see cref="DebugInfoExpression"/>.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual int StartLine
         {
             get { throw ContractUtils.Unreachable; }
@@ -46,7 +46,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the start column of this <see cref="DebugInfoExpression"/>.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual int StartColumn
         {
             get { throw ContractUtils.Unreachable; }
@@ -55,7 +55,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the end line of this <see cref="DebugInfoExpression"/>.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual int EndLine
         {
             get { throw ContractUtils.Unreachable; }
@@ -64,7 +64,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the end column of this <see cref="DebugInfoExpression"/>.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual int EndColumn
         {
             get { throw ContractUtils.Unreachable; }
@@ -78,7 +78,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the value to indicate if the <see cref="DebugInfoExpression"/> is for clearing a sequence point.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual bool IsClear
         {
             get { throw ContractUtils.Unreachable; }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/DynamicExpression.cs
@@ -135,7 +135,7 @@ namespace System.Linq.Expressions
         /// </summary>
         public ReadOnlyCollection<Expression> Arguments => GetOrMakeArguments();
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             throw ContractUtils.Unreachable;
@@ -161,7 +161,7 @@ namespace System.Linq.Expressions
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
         /// subclass of DynamicExpression which is being used.
         /// </summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual DynamicExpression Rewrite(Expression[] args)
         {
             throw ContractUtils.Unreachable;
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions
             return ExpressionExtension.MakeDynamic(DelegateType, Binder, arguments);
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual bool SameArguments(ICollection<Expression>? arguments)
         {
             throw ContractUtils.Unreachable;
@@ -206,13 +206,13 @@ namespace System.Linq.Expressions
 
         #region IArgumentProvider Members
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         Expression IArgumentProvider.GetArgument(int index)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         int IArgumentProvider.ArgumentCount
         {
             get { throw ContractUtils.Unreachable; }

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/ControlFlowInstructions.cs
@@ -640,7 +640,7 @@ namespace System.Linq.Expressions.Interpreter
         // The exception is pushed onto the stack in the filter runner.
         public override int ProducedStack => 1;
 
-        [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
+        [ExcludeFromCodeCoverage(Justification = "Known to be a no-op, this instruction is skipped on execution")]
         public override int Run(InterpretedFrame frame) => 1;
     }
 
@@ -656,7 +656,7 @@ namespace System.Linq.Expressions.Interpreter
         // The exception and the boolean result are popped from the stack in the filter runner.
         public override int ConsumedStack => 2;
 
-        [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
+        [ExcludeFromCodeCoverage(Justification = "Known to be a no-op, this instruction is skipped on execution")]
         public override int Run(InterpretedFrame frame) => 1;
     }
 
@@ -687,7 +687,7 @@ namespace System.Linq.Expressions.Interpreter
         // Catch handlers: The value is immediately popped and stored into a local.
         public override int ProducedStack => 1;
 
-        [ExcludeFromCodeCoverage] // Known to be a no-op, this instruction is skipped on execution.
+        [ExcludeFromCodeCoverage(Justification = "Known to be a no-op, this instruction is skipped on execution")]
         public override int Run(InterpretedFrame frame)
         {
             // nop (the exception value is pushed by the interpreter in HandleCatch)

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -67,7 +67,7 @@ namespace System.Linq.Expressions
             return Invoke(expression, arguments);
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             throw ContractUtils.Unreachable;
@@ -78,7 +78,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="index">The index of the argument expression to get.</param>
         /// <returns>The expression representing the argument at the specified <paramref name="index"/>.</returns>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual Expression GetArgument(int index)
         {
             throw ContractUtils.Unreachable;
@@ -87,7 +87,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the number of argument expressions of the node.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual int ArgumentCount
         {
             get
@@ -104,7 +104,7 @@ namespace System.Linq.Expressions
             return visitor.VisitInvocation(this);
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual InvocationExpression Rewrite(Expression lambda, Expression[]? arguments)
         {
             throw ContractUtils.Unreachable;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -76,25 +76,25 @@ namespace System.Linq.Expressions
 
         internal virtual bool TailCallCore => false;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual ReadOnlyCollection<ParameterExpression> GetOrMakeParameters()
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         ParameterExpression IParameterProvider.GetParameter(int index) => GetParameter(index);
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual ParameterExpression GetParameter(int index)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         int IParameterProvider.ParameterCount => ParameterCount;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual int ParameterCount
         {
             get
@@ -249,13 +249,13 @@ namespace System.Linq.Expressions
             return Lambda<TDelegate>(body, Name, TailCall, parameters);
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual bool SameParameters(ICollection<ParameterExpression>? parameters)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual Expression<TDelegate> Rewrite(Expression body, ParameterExpression[]? parameters)
         {
             throw ContractUtils.Unreachable;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -55,7 +55,7 @@ namespace System.Linq.Expressions
         /// <returns>The <see cref="ExpressionType"/> that represents this expression.</returns>
         public sealed override ExpressionType NodeType => ExpressionType.MemberAccess;
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual MemberInfo GetMember()
         {
             throw ContractUtils.Unreachable;

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -89,13 +89,13 @@ namespace System.Linq.Expressions
             return Call(@object, Method, arguments);
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual bool SameArguments(ICollection<Expression>? arguments)
         {
             throw ContractUtils.Unreachable;
         }
 
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual ReadOnlyCollection<Expression> GetOrMakeArguments()
         {
             throw ContractUtils.Unreachable;
@@ -117,7 +117,7 @@ namespace System.Linq.Expressions
         /// This helper is provided to allow re-writing of nodes to not depend on the specific optimized
         /// subclass of MethodCallExpression which is being used.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         internal virtual MethodCallExpression Rewrite(Expression instance, IReadOnlyList<Expression>? args)
         {
             throw ContractUtils.Unreachable;
@@ -130,7 +130,7 @@ namespace System.Linq.Expressions
         /// </summary>
         /// <param name="index">The index of the argument expression to get.</param>
         /// <returns>The expression representing the argument at the specified <paramref name="index"/>.</returns>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual Expression GetArgument(int index)
         {
             throw ContractUtils.Unreachable;
@@ -139,7 +139,7 @@ namespace System.Linq.Expressions
         /// <summary>
         /// Gets the number of argument expressions of the node.
         /// </summary>
-        [ExcludeFromCodeCoverage] // Unreachable
+        [ExcludeFromCodeCoverage(Justification = "Unreachable")]
         public virtual int ArgumentCount
         {
             get { throw ContractUtils.Unreachable; }

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/ParallelQuery.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/ParallelQuery.cs
@@ -47,7 +47,7 @@ namespace System.Linq
         // is thrown.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "The derived class must override this method")]
         internal virtual ParallelQuery<TCastTo> Cast<TCastTo>()
         {
             Debug.Fail("The derived class must override this method.");
@@ -60,7 +60,7 @@ namespace System.Linq
         // the results.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "The derived class must override this method")]
         internal virtual ParallelQuery<TCastTo> OfType<TCastTo>()
         {
             Debug.Fail("The derived class must override this method.");
@@ -73,7 +73,7 @@ namespace System.Linq
         // IEnumerable<T>.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "The derived class must override this method")]
         internal virtual IEnumerator GetEnumeratorUntyped()
         {
             Debug.Fail("The derived class must override this method.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/ArrayMergeHelper.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/ArrayMergeHelper.cs
@@ -71,7 +71,7 @@ namespace System.Linq.Parallel
         /// We never expect this method to be called. ArrayMergeHelper is intended to be used when we want
         /// to consume the results using GetResultsAsArray().
         /// </summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "ArrayMergeHelper<>.GetEnumerator() is not intended to be used")]
         public IEnumerator<TInputOutput> GetEnumerator()
         {
             Debug.Fail("ArrayMergeHelper<>.GetEnumerator() is not intended to be used. Call GetResultsAsArray() instead.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
@@ -167,7 +167,7 @@ namespace System.Linq.Parallel
         // Returns the results as an array.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "An ordered pipelining merge is not intended to be used this way")]
         public TOutput[] GetResultsAsArray()
         {
             Debug.Fail("An ordered pipelining merge is not intended to be used this way.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/AssociativeAggregationOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/AssociativeAggregationOperator.cs
@@ -213,7 +213,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called. Associative aggregation can always be parallelized")]
         internal override IEnumerable<TIntermediate> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called. Associative aggregation can always be parallelized.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/InlinedAggregationOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Inlined/InlinedAggregationOperator.cs
@@ -142,7 +142,7 @@ namespace System.Linq.Parallel
         protected abstract QueryOperatorEnumerator<TIntermediate, int> CreateEnumerator<TKey>(
             int index, int count, QueryOperatorEnumerator<TSource, TKey> source, object? sharedData, CancellationToken cancellationToken);
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called. Associative aggregation can always be parallelized")]
         internal override IEnumerable<TIntermediate> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called. Associative aggregation can always be parallelized.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/AnyAllSearchOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/AnyAllSearchOperator.cs
@@ -124,7 +124,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called as it is an ending operator with LimitsParallelism=false")]
         internal override IEnumerable<bool> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as it is an ending operator with LimitsParallelism=false.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ContainsSearchOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ContainsSearchOperator.cs
@@ -110,7 +110,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called as it is an ending operator with LimitsParallelism=false")]
         internal override IEnumerable<bool> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as it is an ending operator with LimitsParallelism=false.");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ElementAtQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ElementAtQueryOperator.cs
@@ -98,7 +98,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called as fallback to sequential is handled in Aggregate()")]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as fallback to sequential is handled in Aggregate().");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/FirstQueryOperator.cs
@@ -96,7 +96,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called as fallback to sequential is handled in ParallelEnumerable.First()")]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as fallback to sequential is handled in ParallelEnumerable.First().");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ForAllOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/ForAllOperator.cs
@@ -100,7 +100,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "AsSequentialQuery is not supported on ForAllOperator")]
         internal override IEnumerable<TInput> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("AsSequentialQuery is not supported on ForAllOperator");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/LastQueryOperator.cs
@@ -92,7 +92,7 @@ namespace System.Linq.Parallel
         //---------------------------------------------------------------------------------------
         // Returns an enumerable that represents the query executing sequentially.
         //
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called as fallback to sequential is handled in ParallelEnumerable.First()")]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as fallback to sequential is handled in ParallelEnumerable.First().");

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SingleQueryOperator.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SingleQueryOperator.cs
@@ -73,7 +73,7 @@ namespace System.Linq.Parallel
         // Returns an enumerable that represents the query executing sequentially.
         //
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "This method should never be called as it is an ending operator with LimitsParallelism=false")]
         internal override IEnumerable<TSource> AsSequentialQuery(CancellationToken token)
         {
             Debug.Fail("This method should never be called as it is an ending operator with LimitsParallelism=false.");

--- a/src/libraries/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Partition.SpeedOpt.cs
@@ -35,10 +35,10 @@ namespace System.Linq
 
         public bool MoveNext() => false;
 
-        [ExcludeFromCodeCoverage] // Shouldn't be called, and as undefined can return or throw anything anyway.
+        [ExcludeFromCodeCoverage(Justification = "Shouldn't be called, and as undefined can return or throw anything anyway")]
         public TElement Current => default!;
 
-        [ExcludeFromCodeCoverage] // Shouldn't be called, and as undefined can return or throw anything anyway.
+        [ExcludeFromCodeCoverage(Justification = "Shouldn't be called, and as undefined can return or throw anything anyway")]
         [MaybeNull]
         object IEnumerator.Current => default!;
 

--- a/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System/Runtime/InteropServices/ComAwareEventInfoTests.cs
@@ -102,7 +102,6 @@ namespace System.Runtime.InteropServices.Tests
 
         internal class NonComObject
         {
-            [ExcludeFromCodeCoverage]
             public event EventHandler Event;
 
             public void Raise(object sender) => Event.Invoke(1, null);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5820,6 +5820,7 @@ namespace System.Diagnostics.CodeAnalysis
     public sealed partial class ExcludeFromCodeCoverageAttribute : System.Attribute
     {
         public ExcludeFromCodeCoverageAttribute() { }
+        public string? Justification { get; set; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property | System.AttributeTargets.ReturnValue, Inherited=false)]
     public sealed partial class MaybeNullAttribute : System.Attribute

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -335,7 +335,7 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal bool IsDebug => _regex != null && _regex.IsDebug;
 
         internal virtual void Dump()
@@ -377,7 +377,7 @@ namespace System.Text.RegularExpressions
         public override GroupCollection Groups => _groupcoll ??= new GroupCollection(this, _caps);
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal override void Dump()
         {
             if (_caps != null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -440,7 +440,7 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         /// <summary>True if the regex has debugging enabled.</summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal bool IsDebug => (roptions & RegexOptions.Debug) != 0;
 #endif
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexBoyerMoore.cs
@@ -360,10 +360,10 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         /// <summary>Used when dumping for debugging.</summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public override string ToString() => Dump(string.Empty);
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public string Dump(string indent)
         {
             var sb = new StringBuilder();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1536,7 +1536,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Produces a human-readable description for a set string.
         /// </summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public static string SetDescription(string set)
         {
             int setLength = set[SetLengthIndex];
@@ -1635,7 +1635,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Produces a human-readable description for a single character.
         /// </summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public static string CharDescription(char ch)
         {
             if (ch == '\\')
@@ -1671,7 +1671,7 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         private static string CategoryDescription(char ch)
         {
             if (ch == SpaceConst)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCode.cs
@@ -225,7 +225,7 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         private static string OperatorDescription(int Opcode)
         {
             string codeStr = (Opcode & Mask) switch
@@ -287,7 +287,7 @@ namespace System.Text.RegularExpressions
                 ((Opcode & Back2) != 0 ? "-Back2" : "");
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public string OpcodeDescription(int offset)
         {
             var sb = new StringBuilder();
@@ -396,10 +396,10 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public void Dump() => Debug.WriteLine(ToString());
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public override string ToString()
         {
             var sb = new StringBuilder();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -5354,7 +5354,7 @@ namespace System.Text.RegularExpressions
 
 #if DEBUG
         /// <summary>Emit code to print out the current state of the runner.</summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         private void DumpBacktracking()
         {
             Mvlocfld(_runtextposLocal!, s_runtextposField);

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -1364,7 +1364,7 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal override void DumpState()
         {
             base.DumpState();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1858,7 +1858,7 @@ namespace System.Text.RegularExpressions
                 _ => $"(unknown {Type})"
             };
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public string Description()
         {
             var sb = new StringBuilder(TypeName);
@@ -1930,10 +1930,10 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public void Dump() => Debug.WriteLine(ToString());
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public override string ToString()
         {
             RegexNode? curNode = this;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexPrefixAnalyzer.cs
@@ -357,7 +357,7 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public static string AnchorDescription(int anchors)
         {
             var sb = new StringBuilder();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -675,7 +675,7 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Dump the current state
         /// </summary>
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal virtual void DumpState()
         {
             Debug.WriteLine($"Text:  {TextposDescription()}");
@@ -683,7 +683,7 @@ namespace System.Text.RegularExpressions
             Debug.WriteLine($"Stack: {StackDescription(runstack!, runstackpos)}");
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         private static string StackDescription(int[] a, int index)
         {
             var sb = new StringBuilder();
@@ -713,7 +713,7 @@ namespace System.Text.RegularExpressions
             return sb.ToString();
         }
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal virtual string TextposDescription()
         {
             var sb = new StringBuilder();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexTree.cs
@@ -34,13 +34,13 @@ namespace System.Text.RegularExpressions
         }
 
 #if DEBUG
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public void Dump() => Root.Dump();
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public override string ToString() => Root.ToString();
 
-        [ExcludeFromCodeCoverage]
+        [ExcludeFromCodeCoverage(Justification = "Debug only")]
         public bool Debug => (Options & RegexOptions.Debug) != 0;
 #endif
     }


### PR DESCRIPTION
Delete some ExcludeFromCodeCoverages that aren't warranted, and add justifications almost everywhere else (only not doing so where a project builds for targets without the member).

Fixes https://github.com/dotnet/runtime/issues/29185