### PR TITLE
Disable 2 tracing tests under GCStress

### DIFF
--- a/src/coreclr/tests/src/tracing/eventpipe/pauseonstart/pauseonstart.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/pauseonstart/pauseonstart.csproj
@@ -7,6 +7,8 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/coreclr/tests/src/tracing/eventpipe/reverse/reverse.csproj
+++ b/src/coreclr/tests/src/tracing/eventpipe/reverse/reverse.csproj
@@ -7,6 +7,8 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Tracking: https://github.com/dotnet/runtime/issues/38524