### PR TITLE
Small Performance improvment for memory caching

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private void RemoveEntry(CacheEntry entry)
         {
-            if (EntriesCollection.Remove(new KeyValuePair<object, CacheEntry>(entry.Key, entry)))
+            if (_entries.TryRemove(entry.Key, out _))
             {
                 if (_options.SizeLimit.HasValue)
                 {


### PR DESCRIPTION
As we can see the `EntriesCollection` will return the `_entries` and why not we use the `_entries` to remove the value

https://github.com/dotnet/runtime/blob/d06f5b022d2e78c04194bb4edbc90ebc2a99c347/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs#L95