### PR TITLE
[wasm] Disable threading tests in System.Threading.Tasks.Extensions

### DIFF
--- a/src/libraries/System.Threading.Tasks.Extensions/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/38283", TestPlatforms.Browser)]

--- a/src/libraries/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Extensions/tests/System.Threading.Tasks.Extensions.Tests.csproj
@@ -5,6 +5,7 @@
     <TestRuntime>true</TestRuntime>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AsyncMethodBuilderAttributeTests.cs" />
     <Compile Include="AsyncValueTaskMethodBuilderTests.cs" />
     <Compile Include="ManualResetValueTaskSourceTests.cs" />


### PR DESCRIPTION
When disabling tests with `async Task`, about half the tests would be skipped. Instead of doing so, an assembly level skip will be added. This PR looks to make the System.Threading.Tasks.Extensions test suite pass on WebAssembly.
```Tests run: 0, Errors: 0, Failures: 0, Skipped: 0. Time: 0.004518s```

Contributes to #38422 