### PR TITLE
Fix "Bad IL format" bug for IL interpreter

### DIFF
--- a/src/coreclr/src/vm/interpreter.cpp
+++ b/src/coreclr/src/vm/interpreter.cpp
@@ -6410,8 +6410,10 @@ void Interpreter::LdVirtFtn()
         GCX_PREEMP();
         ResolveToken(&tok, tokVal, CORINFO_TOKENKIND_Method InterpTracingArg(RTK_LdVirtFtn));
         m_interpCeeInfo.getCallInfo(&tok, NULL, m_methInfo->m_method,
-                                  combine(CORINFO_CALLINFO_SECURITYCHECKS,CORINFO_CALLINFO_LDFTN),
-                                  &callInfo);
+                                    combine(CORINFO_CALLINFO_CALLVIRT,
+                                            combine(CORINFO_CALLINFO_SECURITYCHECKS,
+                                                    CORINFO_CALLINFO_LDFTN)),
+                                    &callInfo);
 
 
         classHnd = tok.hClass;


### PR DESCRIPTION
Bug fix: When `FEATURE_INTERPRETER` is set to 1, some of the tests fail and throw a `System.BadImageFormatException` with the message `Bad IL format`. For instance, `JIT.Performance\CodeQuality\Serialization\Deserialize` has the following output with the interpreter turned on:
```
JIT\Performance\CodeQuality\Serialization\Deserialize\Deserialize.cmd [FAIL]
        Unhandled exception. System.BadImageFormatException: Bad IL format.
           at Serialization.JsonBenchmarks.Main()
        
        Return code:      1
        Raw output file:      C:\Users\t-yucpan\GitHub\runtime\artifacts\tests\coreclr\Windows_NT.x64.Checked\Reports\JIT.Performance\CodeQuality\Serialization\Deserialize\Deserialize.output.txt
        Raw output:
        BEGIN EXECUTION
         "C:\Users\t-yucpan\GitHub\runtime\artifacts\tests\coreclr\Windows_NT.x64.Checked\Tests\Core_Root\corerun.exe" Deserialize.dll 
        Expected: 100
        Actual: -532462766
        END EXECUTION - FAILED
        FAILED
        Test Harness Exitcode is : 1
```
The bug causing this issue is that the interpreter does not mark a virtual call when obtaining the pointer to a callable stub for the `ldvirtftn <method>` instruction. The fix is hence straightforward.