### PR TITLE
Issue 38160 - MidpointRounding is buggy

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Math.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Math.cs
@@ -1019,7 +1019,7 @@ namespace System
         
         public static unsafe double Round(double value, int digits, RoundingMode rounding) 
         { 
-	        if ((digits < 0) || (digits > kMaxDoubleDigits))
+	        if ((digits < 0) || (digits > maxRoundingDigits))
 	        {
 		        throw new ArgumentOutOfRangeException(nameof(digits), SR.ArgumentOutOfRange_RoundingDigits);
 	        }
@@ -1039,37 +1039,37 @@ namespace System
 	        {
 		        throw new ArgumentException(SR.Format(SR.Argument_InvalidEnumValue, mode, nameof(RoundingMode)), nameof(mode));
 	        }
-	        if (System.Math.Abs(value) < kRoundDoubleLimit)
+	        if (Abs(value) < doubleRoundLimit)
 	        {
 		        if (rounding == RoundingMode.Down)
 		        {
-			        return System.Math.Floor(value);
+			        return Floor(value);
 		        }
 		        else if (rounding == RoundingMode.Up)
 		        {
-			        return System.Math.Ceiling(value);
+			        return Ceiling(value);
 		        }
 		        else if (rounding == RoundingMode.TowardsZero)
 		        {
-			        return System.Math.Truncate(value);
+			        return Truncate(value);
 		        }
         		else if (rounding == RoundingMode.AwayZero)
 		        {
-			        return System.Math.Sign(value) < 0 ? System.Math.Floor(value) : System.Math.Ceiling(value);
+			        return Sign(value) < 0 ? Floor(value) : Ceiling(value);
 		        }
         		else if (rounding == RoundingMode.HalfToEven)
 		        {
-			        return System.Math.Round(value);
+			        return Round(value);
 		        }
         		else
 		        {
 			        double fraction = ModF(value, &value);
-			        double absoluteFrac = System.Math.Abs(fraction);
+			        double absoluteFrac = Abs(fraction);
 			        if (absoluteFrac < 0.5D)
 			        {
 				        return value;
 			        }
-			        int signFrac = System.Math.Sign(fraction);
+			        int signFrac = Sign(fraction);
 			        switch (rounding)
 			        {
 				        case RoundingMode.HalfAwayZero:

--- a/src/libraries/System.Private.CoreLib/src/System/RoundingMode
+++ b/src/libraries/System.Private.CoreLib/src/System/RoundingMode
@@ -1,0 +1,126 @@
+namespace System
+{
+  public enum RoundingMode
+	{
+	  	/// <summary>
+		  /// Directed round down (same as Floor).
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.8D);</code>
+		  /// </remarks>
+		  Down = 3,
+
+		  /// <summary>
+		  /// Directed round up (same as Ceiling).
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-1D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+		  /// </remarks>
+		  Up = 4,
+
+		  /// <summary>
+		  /// Directed round towards zero (same as Truncate).
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-1D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.8D);</code>
+		  /// </remarks>
+		  TowardsZero = 2,
+
+		  /// <summary>
+		  /// Directed round away from zero
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+		  /// </remarks>
+		  AwayZero = 5,
+
+		  /// <summary>
+		  /// Round to nearest integer and down when the number is halfway between two others.
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+      /// <code>Assert.AreEqual(4503599627370496D, 4503599627370496D);
+		  /// </remarks>
+		  HalfDown = 6,
+
+		  /// <summary>
+		  /// Round to nearest integer and up when the number is halfway between two others.
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+      /// <code>Assert.AreEqual(4503599627370496D, 4503599627370496D);
+		  /// </remarks>
+		  HalfUp = 7,
+
+		  /// <summary>
+		  /// Round to nearest integer and towards zero when the number is halfway between two others.
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+		  /// </remarks>
+		  HalfTowardsZero = 8,
+
+		  /// <summary>
+		  /// Round to nearest integer and away from zero when the number is halfway between two others.
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+		  /// </remarks>
+		  HalfAwayZero = 1,
+
+		  /// <summary>
+		  /// Round to nearest integer and to nearest even integer when the number is halfway between two others.
+		  /// </summary>
+		  /// <remarks>
+		  /// <code>Assert.AreEqual(-2D, -1.8D);</code>
+		  /// <code>Assert.AreEqual(-2D, -1.5D);</code>
+		  /// <code>Assert.AreEqual(-1D, -1.2D);</code>
+		  /// <code>Assert.AreEqual(0D, -0.5D);</code>
+		  /// <code>Assert.AreEqual(0D, +0.5D);</code>
+		  /// <code>Assert.AreEqual(1D, +1.2D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.5D);</code>
+		  /// <code>Assert.AreEqual(2D, +1.8D);</code>
+		  /// </remarks>
+		  HalfToEven = 0
+	}
+}


### PR DESCRIPTION
**From** the [https://github.com/dotnet/runtime/issues/38160] issue

**USAGE**
The System.Math.Round and System.MathF.Round is buggy when using MidpointRounding and the algorithm may overflow when using digits.
The MidpointRounding counts some directed round (and not rounding to nearest integer), for example : the MidpointRounding.ToZero description says : "when a number is halfway between two others......." but in reality is a directed rounding (and not HALF).

**Proposed API**
To avoid breaking changes, a new enum for the rounding mode is proposed, the rounding functions using MidpointRounding are marked as obsolete (except for MidpointRounding.ToEven that is correct), and an implementation with the new enum is proposed.
```
public enum RoundingMode
{
	/// <summary>
	/// Directed round down (same as Floor).
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-2D, -1.5D);</code>
	/// <code>Assert.AreEqual(-2D, -1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.5D);</code>
	/// <code>Assert.AreEqual(1D, +1.8D);</code>
	/// </remarks>
	Down = 3,

	/// <summary>
	/// Directed round up (same as Ceiling).
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-1D, -1.8D);</code>
	/// <code>Assert.AreEqual(-1D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	Up = 4,

	/// <summary>
	/// Directed round towards zero (same as Truncate).
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-1D, -1.8D);</code>
	/// <code>Assert.AreEqual(-1D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.5D);</code>
	/// <code>Assert.AreEqual(1D, +1.8D);</code>
	/// </remarks>
	TowardsZero = 2,

	/// <summary>
	/// Directed round away from zero
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-2D, -1.5D);</code>
	/// <code>Assert.AreEqual(-2D, -1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	AwayZero = 5,

	/// <summary>
	/// Round to nearest integer and down when the number is halfway between two others.
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-2D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	HalfDown = 6,

	/// <summary>
	/// Round to nearest integer and up when the number is halfway between two others.
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-1D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	HalfUp = 7,

	/// <summary>
	/// Round to nearest integer and towards zero when the number is halfway between two others.
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-1D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	HalfTowardsZero = 8,

	/// <summary>
	/// Round to nearest integer and away from zero when the number is halfway between two others.
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-2D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	HalfAwayZero = 1,

	/// <summary>
	/// Round to nearest integer and to nearest even integer when the number is halfway between two others.
	/// </summary>
	/// <remarks>
	/// <code>Assert.AreEqual(-2D, -1.8D);</code>
	/// <code>Assert.AreEqual(-2D, -1.5D);</code>
	/// <code>Assert.AreEqual(-1D, -1.2D);</code>
	/// <code>Assert.AreEqual(0D, -0.5D);</code>
	/// <code>Assert.AreEqual(0D, +0.5D);</code>
	/// <code>Assert.AreEqual(1D, +1.2D);</code>
	/// <code>Assert.AreEqual(2D, +1.5D);</code>
	/// <code>Assert.AreEqual(2D, +1.8D);</code>
	/// </remarks>
	HalfToEven = 0
}```

To avoid an overflow, just the fractional part of the value (double or float) is powered by 10^digits and not the entire value.
