### PR TITLE
[Crossgen2] Remove legacy behavior around non-virtual interface calls

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1278,11 +1278,6 @@ namespace Internal.JitInterface
             {
                 directCall = true;
             }
-            else if (targetMethod.OwningType.IsInterface && targetMethod.IsAbstract)
-            {
-                // Backwards compat: calls to abstract interface methods are treated as callvirt
-                directCall = false;
-            }
             else
             {
                 bool devirt;


### PR DESCRIPTION
Resolves https://github.com/dotnet/runtime/issues/37400

The regression test was not failing in Crossgen2 because somewhere along the way when we eyeball ported `getCallInfo` the ordering of these two if block was switched, so Crossgen2 was always treating such calls as non-virtual.

```
if ((flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_CALLVIRT) == 0 || resolvedConstraint)
{
    directCall = true;
}
else if (targetMethod.OwningType.IsInterface && targetMethod.IsAbstract)
{
    // Backwards compat: calls to abstract interface methods are treated as callvirt
    directCall = false;
}
```
/cc @dotnet/crossgen-contrib 