### PR TITLE
fix for cg2 + sealed default interface methods

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1291,8 +1291,7 @@ namespace Internal.JitInterface
                 // CG2 checks a method cache that it builds with a bunch of new code.
                 if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(callerMethod) ||
                     // check the Typical TargetMethod, not the Instantiation
-                    !_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(targetMethod.IsTypicalMethodDefinition ?
-                                                                                            targetMethod: targetMethod.GetTypicalMethodDefinition()))
+                    !_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(targetMethod.GetTypicalMethodDefinition()))
                 {
                     // For version resiliency we won't de-virtualize all final/sealed method calls.  Because during a 
                     // servicing event it is legal to unseal a method or type.

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1280,21 +1280,16 @@ namespace Internal.JitInterface
             {
                 bool devirt;
 
-                // Check For interfaces before the bubble check
-                // since interface methods 
-                if (targetMethod.OwningType.IsInterface)
-                {
-                    // Handle interface methods specially because the Sealed bit has no meaning on interfaces.
-                    devirt = !targetMethod.IsVirtual;
-                }
                 // if we are generating version resilient code
                 // AND
                 //    caller/callee are in different version bubbles
                 // we have to apply more restrictive rules
                 // These rules are related to the "inlining rules" as far as the
                 // boundaries of a version bubble are concerned.
-                else if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(callerMethod) ||
-                    !_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(targetMethod))
+                if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(callerMethod) ||
+                    // check the Typical TargetMethod, not the Instantiation
+                    !_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(targetMethod.IsTypicalMethodDefinition ?
+                                                                                            targetMethod: targetMethod.GetTypicalMethodDefinition()))
                 {
                     // For version resiliency we won't de-virtualize all final/sealed method calls.  Because during a 
                     // servicing event it is legal to unseal a method or type.
@@ -1308,6 +1303,11 @@ namespace Internal.JitInterface
                         (targetMethod.IsIntrinsic && getIntrinsicID(targetMethod, null) != CorInfoIntrinsics.CORINFO_INTRINSIC_Illegal);
 
                     callVirtCrossingVersionBubble = true;
+                }
+                else if (targetMethod.OwningType.IsInterface)
+                {
+                    // Handle interface methods specially because the Sealed bit has no meaning on interfaces.
+                    devirt = !targetMethod.IsVirtual;
                 }
                 else
                 {

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1280,13 +1280,20 @@ namespace Internal.JitInterface
             {
                 bool devirt;
 
+                // Check For interfaces before the bubble check
+                // since interface methods 
+                if (targetMethod.OwningType.IsInterface)
+                {
+                    // Handle interface methods specially because the Sealed bit has no meaning on interfaces.
+                    devirt = !targetMethod.IsVirtual;
+                }
                 // if we are generating version resilient code
                 // AND
                 //    caller/callee are in different version bubbles
                 // we have to apply more restrictive rules
                 // These rules are related to the "inlining rules" as far as the
                 // boundaries of a version bubble are concerned.
-                if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(callerMethod) ||
+                else if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(callerMethod) ||
                     !_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(targetMethod))
                 {
                     // For version resiliency we won't de-virtualize all final/sealed method calls.  Because during a 
@@ -1301,11 +1308,6 @@ namespace Internal.JitInterface
                         (targetMethod.IsIntrinsic && getIntrinsicID(targetMethod, null) != CorInfoIntrinsics.CORINFO_INTRINSIC_Illegal);
 
                     callVirtCrossingVersionBubble = true;
-                }
-                else if (targetMethod.OwningType.IsInterface)
-                {
-                    // Handle interface methods specially because the Sealed bit has no meaning on interfaces.
-                    devirt = !targetMethod.IsVirtual;
                 }
                 else
                 {

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1286,6 +1286,9 @@ namespace Internal.JitInterface
                 // we have to apply more restrictive rules
                 // These rules are related to the "inlining rules" as far as the
                 // boundaries of a version bubble are concerned.
+                // This check is different between CG1 and CG2. CG1 considers two types in the same version bubble
+                // if their assemblies are in the same bubble, or if the NonVersionableTypeAttribute is present on the type.
+                // CG2 checks a method cache that it builds with a bunch of new code.
                 if (!_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(callerMethod) ||
                     // check the Typical TargetMethod, not the Instantiation
                     !_compilation.NodeFactory.CompilationModuleGroup.VersionsWithMethodBody(targetMethod.IsTypicalMethodDefinition ?

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -1023,8 +1023,12 @@ internal class Program
 
     class ImplementGenericWithSealedDefaultMethod: IGenericWithSealedDefaultMethod<string>
     {
-
     }
+
+    class ImplementGenericWithSealedDefaultMethodAcrossModule : IGenericWithSealedDefaultMethodAcrossModule<string>
+    {
+    }
+
 
     class MyGen<T>
     {
@@ -1281,6 +1285,15 @@ internal class Program
             return false;
         if (!igsdf.GenericMethod<bool>().Equals("System.Boolean"))
             return false;
+
+
+        // Test a similar case across modules
+        IGenericWithSealedDefaultMethodAcrossModule<string> igsdf2 = new ImplementGenericWithSealedDefaultMethodAcrossModule();
+        if (!igsdf2.Method().Equals("System.String"))
+            return false;
+        if (!igsdf2.GenericMethod<bool>().Equals("System.Boolean"))
+            return false;
+
         return true;
     }
 

--- a/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/Program.cs
@@ -1000,7 +1000,32 @@ internal class Program
 
         return true;
     }
-    
+
+    interface IGenericWithSealedDefaultMethod<T>
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        sealed
+        string Method()
+        {
+            Type t = typeof(T);
+            return t.FullName;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        sealed
+        string GenericMethod<V>()
+        {
+            Type t = typeof(V);
+            return t.FullName;
+        }
+
+    }
+
+    class ImplementGenericWithSealedDefaultMethod: IGenericWithSealedDefaultMethod<string>
+    {
+
+    }
+
     class MyGen<T>
     {
         public static string GcValue;
@@ -1249,6 +1274,16 @@ internal class Program
             return true;
     }
 
+    private static bool SealedDefaultInterfaceMethodTest()
+    {
+        IGenericWithSealedDefaultMethod<string> igsdf = new ImplementGenericWithSealedDefaultMethod();
+        if (!igsdf.Method().Equals("System.String"))
+            return false;
+        if (!igsdf.GenericMethod<bool>().Equals("System.Boolean"))
+            return false;
+        return true;
+    }
+
     private static bool FunctionPointerFromAnotherModuleTest()
     {
         // This test tests referencing a method from another module while creating a function pointer.
@@ -1322,6 +1357,7 @@ internal class Program
         RunTest("ObjectToStringOnGenericParamTestVersionBubbleLocalStruct", ObjectToStringOnGenericParamTestVersionBubbleLocalStruct());
         RunTest("EnumValuesToStringTest", EnumValuesToStringTest());
         RunTest("DelegateFromAnotherModuleTest", DelegateFromAnotherModuleTest());
+        RunTest("SealedDefaultInterfaceMethodTest", SealedDefaultInterfaceMethodTest());
         RunTest("FunctionPointerFromAnotherModuleTest", FunctionPointerFromAnotherModuleTest());
 
         File.Delete(TextFileName);

--- a/src/coreclr/tests/src/readytorun/crossgen2/helperdll.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/helperdll.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class HelperClass
 {
@@ -19,4 +20,27 @@ public class HelperClass
     {
         Console.WriteLine("In function pointer method");
     }
+}
+
+//
+// This is a test case for cross module sealed default method invocation
+//
+public interface IGenericWithSealedDefaultMethodAcrossModule<T>
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    sealed
+    string Method()
+    {
+        Type t = typeof(T);
+        return t.FullName;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    sealed
+    string GenericMethod<V>()
+    {
+        Type t = typeof(V);
+        return t.FullName;
+    }
+
 }


### PR DESCRIPTION
Fix for issue: https://github.com/dotnet/runtime/issues/37344

was (moving the interface check to be before the versionbubble check. Validated that the repro works with this. )

updated fix to use TypicalMethod for target to lookup within VersionsWithMethodBody