### PR TITLE
Update xharness to latest version with WASM fixes

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.dotnet.xharness.cli": {
-      "version": "1.0.0-prerelease.20303.2",
+      "version": "1.0.0-prerelease.20329.4",
       "commands": [
         "xharness"
       ]

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -174,13 +174,13 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>b0b5143ee2a59517df69d38cb6c363cdd17177a8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20322.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20329.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>19aa97963aa11b4818f3e3487b913244efa4ff0f</Sha>
+      <Sha>36f9e13084868949278edc7153866cc1173931d2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20322.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="1.0.0-prerelease.20329.4">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>19aa97963aa11b4818f3e3487b913244efa4ff0f</Sha>
+      <Sha>36f9e13084868949278edc7153866cc1173931d2</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,8 +105,8 @@
     <SystemDataSqlClientVersion>4.8.0</SystemDataSqlClientVersion>
     <!-- Testing -->
     <MicrosoftNETTestSdkVersion>16.7.0-release-20200612-02</MicrosoftNETTestSdkVersion>
-    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
-    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20322.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessTestRunnersXunitVersion>1.0.0-prerelease.20329.4</MicrosoftDotNetXHarnessTestRunnersXunitVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>1.0.0-prerelease.20329.4</MicrosoftDotNetXHarnessCLIVersion>
     <XUnitVersion>2.4.1</XUnitVersion>
     <XUnitRunnerVisualStudioVersion>2.4.2</XUnitRunnerVisualStudioVersion>
     <CoverletCollectorVersion>1.3.0</CoverletCollectorVersion>

--- a/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.cs
+++ b/src/libraries/Common/tests/WasmTestRunner/WasmTestRunner.cs
@@ -9,13 +9,14 @@ using Microsoft.DotNet.XHarness.TestRunners.Xunit;
 
 public class SimpleWasmTestRunner : WasmApplicationEntryPoint
 {
-    protected override string TestAssembly { get; set; } = "";
-    protected override IEnumerable<string> ExcludedTraits { get; set; } = new List<string>();
-
     public static int Main(string[] args)
     {
         var testAssembly = args[0];
         var excludedTraits = new List<string>();
+        var includedTraits = new List<string>();
+        var includedNamespaces = new List<string>();
+        var includedClasses = new List<string>();
+        var includedMethods = new List<string>();
 
         for (int i = 1; i < args.Length; i++)
         {
@@ -26,6 +27,22 @@ public class SimpleWasmTestRunner : WasmApplicationEntryPoint
                     excludedTraits.Add (args[i + 1]);
                     i++;
                     break;
+                case "-trait":
+                    includedTraits.Add (args[i + 1]);
+                    i++;
+                    break;
+                case "-namespace":
+                    includedNamespaces.Add (args[i + 1]);
+                    i++;
+                    break;
+                case "-class":
+                    includedClasses.Add (args[i + 1]);
+                    i++;
+                    break;
+                case "-method":
+                    includedMethods.Add (args[i + 1]);
+                    i++;
+                    break;
                 default:
                     throw new ArgumentException($"Invalid argument '{option}'.");
             }
@@ -34,7 +51,11 @@ public class SimpleWasmTestRunner : WasmApplicationEntryPoint
         var runner = new SimpleWasmTestRunner()
         {
             TestAssembly = testAssembly,
-            ExcludedTraits = excludedTraits
+            ExcludedTraits = excludedTraits,
+            IncludedTraits = includedTraits,
+            IncludedNamespaces = includedNamespaces,
+            IncludedClasses = includedClasses,
+            IncludedMethods = includedMethods
         };
 
         return runner.Run();


### PR DESCRIPTION
Addresses an issue that caused the testResult.xml to be empty on Helix runs.

Adds options to only execute a specific class/method to the WASM runner.