### PR TITLE
Add type layout stress mode to crossgen2/runtime

### DIFF
--- a/src/coreclr/src/inc/corcompile.h
+++ b/src/coreclr/src/inc/corcompile.h
@@ -693,6 +693,9 @@ enum CORCOMPILE_FIXUP_BLOB_KIND
 
     ENCODE_CHECK_INSTRUCTION_SET_SUPPORT,           /* Define the set of instruction sets that must be supported/unsupported to use the fixup */
 
+    ENCODE_VERIFY_FIELD_OFFSET,                     /* Used for the R2R compiler can generate a check against the real field offset used at runtime */
+    ENCODE_VERIFY_TYPE_LAYOUT,                      /* Used for the R2R compiler can generate a check against the real type layout used at runtime */
+
     ENCODE_MODULE_HANDLE                = 0x50,     /* Module token */
     ENCODE_STATIC_FIELD_ADDRESS,                    /* For accessing a static field */
     ENCODE_MODULE_ID_FOR_STATICS,                   /* For accessing static fields */

--- a/src/coreclr/src/inc/readytorun.h
+++ b/src/coreclr/src/inc/readytorun.h
@@ -204,6 +204,9 @@ enum ReadyToRunFixupKind
     READYTORUN_FIXUP_PInvokeTarget              = 0x2F, /* Target of an inlined pinvoke */
 
     READYTORUN_FIXUP_Check_InstructionSetSupport= 0x30, /* Define the set of instruction sets that must be supported/unsupported to use the fixup */
+
+    READYTORUN_FIXUP_Verify_FieldOffset         = 0x31, /* Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike Check_FieldOffset, this will generate a runtime failure instead of silently dropping the method */
+    READYTORUN_FIXUP_Verify_TypeLayout          = 0x32, /* Generate a runtime check to ensure that the type layout (size, alignment, HFA, reference map) matches between compile and runtime. Unlike Check_TypeLayout, this will generate a runtime failure instead of silently dropping the method */
 };
 
 //

--- a/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/src/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -118,6 +118,9 @@ namespace Internal.ReadyToRunConstants
 
         Check_InstructionSetSupport = 0x30, // Define the set of instruction sets that must be supported/unsupported to use the fixup 
 
+        Verify_FieldOffset = 0x31,  // Generate a runtime check to ensure that the field offset matches between compile and runtime. Unlike CheckFieldOffset, this will generate a runtime exception on failure instead of silently dropping the method
+        Verify_TypeLayout = 0x32,  // Generate a runtime check to ensure that the type layout (size, alignment, HFA, reference map) matches between compile and runtime. Unlike Check_TypeLayout, this will generate a runtime failure instead of silently dropping the method
+
         ModuleOverride = 0x80,
         // followed by sig-encoded UInt with assemblyref index into either the assemblyref
         // table of the MSIL metadata of the master context module for the signature or

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/FieldFixupSignature.cs
@@ -40,9 +40,19 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 EcmaModule targetModule = factory.SignatureContext.GetTargetModule(_fieldDesc);
                 SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, factory.SignatureContext);
 
-                if (_fixupKind == ReadyToRunFixupKind.Check_FieldOffset)
+                if (_fixupKind == ReadyToRunFixupKind.Verify_FieldOffset)
                 {
-                    dataBuilder.EmitInt(_fieldDesc.Offset.AsInt);
+                    TypeDesc baseType = _fieldDesc.OwningType.BaseType;
+                    if ((_fieldDesc.OwningType.BaseType != null) && !_fieldDesc.IsStatic && !_fieldDesc.OwningType.IsValueType)
+                        dataBuilder.EmitUInt((uint)_fieldDesc.OwningType.BaseType.InstanceByteCount.AsInt);
+                    else
+                        dataBuilder.EmitUInt(0);
+                }
+
+                if ((_fixupKind == ReadyToRunFixupKind.Check_FieldOffset) ||
+                    (_fixupKind == ReadyToRunFixupKind.Verify_FieldOffset))
+                {
+                    dataBuilder.EmitUInt((uint)_fieldDesc.Offset.AsInt);
                 }
 
                 dataBuilder.EmitFieldSignature(_fieldDesc, innerContext);

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -43,7 +43,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 SignatureContext innerContext = dataBuilder.EmitFixup(factory, _fixupKind, targetModule, factory.SignatureContext);
                 dataBuilder.EmitTypeSignature(_typeDesc, innerContext);
 
-                if (_fixupKind == ReadyToRunFixupKind.Check_TypeLayout)
+                if ((_fixupKind == ReadyToRunFixupKind.Check_TypeLayout) ||
+                    (_fixupKind == ReadyToRunFixupKind.Verify_TypeLayout))
                 {
                     EncodeTypeLayout(dataBuilder, _typeDesc);
                 }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunSymbolNodeFactory.cs
@@ -38,10 +38,14 @@ namespace ILCompiler.DependencyAnalysis
     public sealed class ReadyToRunSymbolNodeFactory
     {
         private readonly NodeFactory _codegenNodeFactory;
+        private readonly bool _verifyTypeAndFieldLayout;
 
-        public ReadyToRunSymbolNodeFactory(NodeFactory codegenNodeFactory)
+        public bool VerifyTypeAndFieldLayout => _verifyTypeAndFieldLayout;
+
+        public ReadyToRunSymbolNodeFactory(NodeFactory codegenNodeFactory, bool verifyTypeAndFieldLayout)
         {
             _codegenNodeFactory = codegenNodeFactory;
+            _verifyTypeAndFieldLayout = verifyTypeAndFieldLayout;
             CreateNodeCaches();
         }
 
@@ -91,7 +95,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 return new PrecodeHelperImport(
                     _codegenNodeFactory,
-                    new FieldFixupSignature(ReadyToRunFixupKind.Check_FieldOffset, key)
+                    new FieldFixupSignature(_verifyTypeAndFieldLayout ? ReadyToRunFixupKind.Verify_FieldOffset : ReadyToRunFixupKind.Check_FieldOffset, key)
                 );
             });
 
@@ -129,7 +133,7 @@ namespace ILCompiler.DependencyAnalysis
             {
                 return new PrecodeHelperImport(
                     _codegenNodeFactory,
-                    _codegenNodeFactory.TypeSignature(ReadyToRunFixupKind.Check_TypeLayout, key)
+                    _codegenNodeFactory.TypeSignature(_verifyTypeAndFieldLayout ? ReadyToRunFixupKind.Verify_TypeLayout: ReadyToRunFixupKind.Check_TypeLayout, key)
                 );
             });
 

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -253,7 +253,8 @@ namespace ILCompiler
             ProfileDataManager profileData,
             ReadyToRunMethodLayoutAlgorithm methodLayoutAlgorithm,
             ReadyToRunFileLayoutAlgorithm fileLayoutAlgorithm,
-            int? customPESectionAlignment)
+            int? customPESectionAlignment,
+            bool verifyTypeAndFieldLayout)
             : base(
                   dependencyGraph,
                   nodeFactory,
@@ -268,7 +269,7 @@ namespace ILCompiler
             _parallelism = parallelism;
             _generateMapFile = generateMapFile;
             _customPESectionAlignment = customPESectionAlignment;
-            SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory);
+            SymbolNodeFactory = new ReadyToRunSymbolNodeFactory(nodeFactory, verifyTypeAndFieldLayout);
             _corInfoImpls = new ConditionalWeakTable<Thread, CorInfoImpl>();
             _inputFiles = inputFiles;
             _compositeRootPath = compositeRootPath;

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -30,6 +30,7 @@ namespace ILCompiler
         private ReadyToRunMethodLayoutAlgorithm _r2rMethodLayoutAlgorithm;
         private ReadyToRunFileLayoutAlgorithm _r2rFileLayoutAlgorithm;
         private int? _customPESectionAlignment;
+        private bool _verifyTypeAndFieldLayout;
 
         private string _jitPath;
         private string _outputFile;
@@ -150,6 +151,12 @@ namespace ILCompiler
             return this;
         }
 
+        public ReadyToRunCodegenCompilationBuilder UseVerifyTypeAndFieldLayout(bool verifyTypeAndFieldLayout)
+        {
+            _verifyTypeAndFieldLayout = verifyTypeAndFieldLayout;
+            return this;
+        }
+
         public override ICompilation ToCompilation()
         {
             // TODO: only copy COR headers for single-assembly build and for composite build with embedded MSIL
@@ -238,7 +245,8 @@ namespace ILCompiler
                 _profileData,
                 _r2rMethodLayoutAlgorithm,
                 _r2rFileLayoutAlgorithm,
-                _customPESectionAlignment);
+                _customPESectionAlignment,
+                _verifyTypeAndFieldLayout);
         }
     }
 }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1069,7 +1069,6 @@ namespace Internal.JitInterface
                     if (helperId != ReadyToRunHelperId.Invalid)
                     {
                         if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
-                        if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
                         {
                             // ENCODE_CHECK_FIELD_OFFSET
                             _methodCodeNode.Fixups.Add(_compilation.SymbolNodeFactory.CheckFieldOffset(field));

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -994,6 +994,12 @@ namespace Internal.JitInterface
                             CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_GCSTATIC_BASE :
                             CorInfoHelpFunc.CORINFO_HELP_GETGENERICS_NONGCSTATIC_BASE);
                     }
+
+                    if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+                    {
+                        // ENCODE_CHECK_FIELD_OFFSET
+                        _methodCodeNode.Fixups.Add(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                    }
                 }
                 else
                 {
@@ -1062,6 +1068,13 @@ namespace Internal.JitInterface
                     else
                     if (helperId != ReadyToRunHelperId.Invalid)
                     {
+                        if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+                        if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+                        {
+                            // ENCODE_CHECK_FIELD_OFFSET
+                            _methodCodeNode.Fixups.Add(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                        }
+
                         pResult->fieldLookup = CreateConstLookupToSymbol(
                             _compilation.SymbolNodeFactory.CreateReadyToRunHelper(helperId, field.OwningType)
                             );
@@ -1916,7 +1929,7 @@ namespace Internal.JitInterface
             if (!type.IsValueType)
                 return false;
 
-            return !_compilation.IsLayoutFixedInCurrentVersionBubble(type);
+            return !_compilation.IsLayoutFixedInCurrentVersionBubble(type) || _compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout;
         }
 
         private bool HasLayoutMetadata(TypeDesc type)
@@ -1972,10 +1985,20 @@ namespace Internal.JitInterface
             }
             else if (pMT.IsValueType)
             {
+                if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+                {
+                    // ENCODE_CHECK_FIELD_OFFSET
+                    _methodCodeNode.Fixups.Add(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                }
                 // ENCODE_NONE
             }
             else if (_compilation.IsInheritanceChainLayoutFixedInCurrentVersionBubble(pMT.BaseType))
             {
+                if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+                {
+                    // ENCODE_CHECK_FIELD_OFFSET
+                    _methodCodeNode.Fixups.Add(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                }
                 // ENCODE_NONE
             }
             else if (HasLayoutMetadata(pMT))
@@ -1992,6 +2015,12 @@ namespace Internal.JitInterface
             else
             {
                 PreventRecursiveFieldInlinesOutsideVersionBubble(field, callerMethod);
+
+                if (_compilation.SymbolNodeFactory.VerifyTypeAndFieldLayout)
+                {
+                    // ENCODE_CHECK_FIELD_OFFSET
+                    _methodCodeNode.Fixups.Add(_compilation.SymbolNodeFactory.CheckFieldOffset(field));
+                }
 
                 // ENCODE_FIELD_BASE_OFFSET
                 Debug.Assert(pResult->offset >= (uint)pMT.BaseType.InstanceByteCount.AsInt);

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1255,6 +1255,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
 
                 case ReadyToRunFixupKind.Check_TypeLayout:
+                case ReadyToRunFixupKind.Verify_TypeLayout:
                     ParseType(builder);
                     ReadyToRunTypeLayoutFlags layoutFlags = (ReadyToRunTypeLayoutFlags)ReadUInt();
                     builder.Append($" Flags {layoutFlags}");
@@ -1287,13 +1288,22 @@ namespace ILCompiler.Reflection.ReadyToRun
                         }
                     }
 
-                    builder.Append(" (CHECK_TYPE_LAYOUT)");
+                    if (fixupType == ReadyToRunFixupKind.Check_TypeLayout)
+                        builder.Append(" (CHECK_TYPE_LAYOUT)");
+                    else
+                        builder.Append(" (VERIFY_TYPE_LAYOUT)");
                     break;
 
                 case ReadyToRunFixupKind.Check_FieldOffset:
                     builder.Append($"{ReadUInt()} ");
                     ParseField(builder);
                     builder.Append(" (CHECK_FIELD_OFFSET)");
+                    break;
+
+                case ReadyToRunFixupKind.Verify_FieldOffset:
+                    builder.Append($"{ReadUInt()} ");
+                    ParseField(builder);
+                    builder.Append(" (VERIFY_FIELD_OFFSET)");
                     break;
 
                 case ReadyToRunFixupKind.Check_InstructionSetSupport:

--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunSignature.cs
@@ -1302,6 +1302,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
                 case ReadyToRunFixupKind.Verify_FieldOffset:
                     builder.Append($"{ReadUInt()} ");
+                    builder.Append($"{ReadUInt()} ");
                     ParseField(builder);
                     builder.Append(" (VERIFY_FIELD_OFFSET)");
                     break;

--- a/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
@@ -43,6 +43,7 @@ namespace ILCompiler
         public ReadyToRunMethodLayoutAlgorithm MethodLayout { get; set; }
         public ReadyToRunFileLayoutAlgorithm FileLayout { get; set; }
         public int? CustomPESectionAlignment { get; set; }
+        public bool VerifyTypeAndFieldLayout { get; set; }
 
         public string SingleMethodTypeName { get; set; }
         public string SingleMethodName { get; set; }
@@ -198,6 +199,10 @@ namespace ILCompiler
                 {
                     Argument = new Argument<ReadyToRunFileLayoutAlgorithm>()
                 },
+                new Option(new[] { "--verify-type-and-field-layout" }, SR.VerifyTypeAndFieldLayoutOption)
+                {
+                    Argument = new Argument<bool>()
+                }
             };
         }
     }

--- a/src/coreclr/src/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/Program.cs
@@ -524,6 +524,7 @@ namespace ILCompiler
                         .UseJitPath(_commandLineOptions.JitPath)
                         .UseInstructionSetSupport(instructionSetSupport)
                         .UseCustomPESectionAlignment(_commandLineOptions.CustomPESectionAlignment)
+                        .UseVerifyTypeAndFieldLayout(_commandLineOptions.VerifyTypeAndFieldLayout)
                         .GenerateOutputFile(_commandLineOptions.OutputFilePath.FullName)
                         .UseILProvider(ilProvider)
                         .UseBackendOptions(_commandLineOptions.CodegenOptions)

--- a/src/coreclr/src/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/src/tools/aot/crossgen2/Properties/Resources.resx
@@ -279,4 +279,7 @@
   <data name="ManagedCppNotSupported" xml:space="preserve">
     <value>Error: managed C++ is not supported: '{0}'</value>
   </data>
+  <data name="VerifyTypeAndFieldLayoutOption" xml:space="preserve">
+    <value>Verify that struct type layout and field offsets match between compile time and runtime. Use only for diagnostic purposes.</value>
+  </data>
 </root>

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -13753,13 +13753,30 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
         break;
 
     case ENCODE_CHECK_TYPE_LAYOUT:
+    case ENCODE_VERIFY_TYPE_LAYOUT:
         {
             TypeHandle th = ZapSig::DecodeType(currentModule, pInfoModule, pBlob);
             MethodTable * pMT = th.AsMethodTable();
             _ASSERTE(pMT->IsValueType());
 
             if (!TypeLayoutCheck(pMT, pBlob))
-                return FALSE;
+            {
+                if (kind == ENCODE_CHECK_TYPE_LAYOUT)
+                {
+                    return FALSE;
+                }
+                else
+                {
+                    // Verification failures are failfast events
+                    DefineFullyQualifiedNameForClassW();
+                    SString fatalErrorString;
+                    fatalErrorString.Printf(W("Verify_TypeLayout '%s' failed to verify type layout"), 
+                        GetFullyQualifiedNameForClassW(pMT));
+
+                    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(-1, fatalErrorString.GetUnicode());
+                    return FALSE;
+                }
+            }
 
             result = 1;
         }
@@ -13782,6 +13799,49 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             result = 1;
         }
         break;
+
+    case ENCODE_VERIFY_FIELD_OFFSET:
+        {
+            DWORD baseOffset = CorSigUncompressData(pBlob);
+            DWORD fieldOffset = CorSigUncompressData(pBlob);
+            FieldDesc* pField = ZapSig::DecodeField(currentModule, pInfoModule, pBlob);
+            pField->GetEnclosingMethodTable()->CheckRestore();
+            DWORD actualFieldOffset = pField->GetOffset();
+            if (!pField->IsStatic() && !pField->IsFieldOfValueType())
+            {
+                actualFieldOffset += sizeof(Object);
+            }
+
+            DWORD actualBaseOffset = 0;
+            if (!pField->IsStatic() && 
+                pField->GetEnclosingMethodTable()->GetParentMethodTable() != NULL &&
+                !pField->GetEnclosingMethodTable()->IsValueType())
+            {
+                actualBaseOffset = ReadyToRunInfo::GetFieldBaseOffset(pField->GetEnclosingMethodTable());
+            }
+
+            if ((fieldOffset != actualFieldOffset) || (baseOffset != actualBaseOffset))
+            {
+                // Verification failures are failfast events
+                DefineFullyQualifiedNameForClassW();
+                SString ssFieldName(SString::Utf8, pField->GetName());
+
+                SString fatalErrorString;
+                fatalErrorString.Printf(W("Verify_FieldOffset '%s.%s' %d!=%d || %d!=%d"), 
+                    GetFullyQualifiedNameForClassW(pField->GetEnclosingMethodTable()),
+                    ssFieldName.GetUnicode(),
+                    fieldOffset,
+                    actualFieldOffset,
+                    baseOffset,
+                    actualBaseOffset);
+
+                EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(-1, fatalErrorString.GetUnicode());
+                return FALSE;
+            }
+            result = 1;
+        }
+        break;
+
 
     case ENCODE_CHECK_INSTRUCTION_SET_SUPPORT:
         {

--- a/src/coreclr/src/zap/zapreadytorun.cpp
+++ b/src/coreclr/src/zap/zapreadytorun.cpp
@@ -844,6 +844,9 @@ static_assert_no_msg((int)READYTORUN_FIXUP_PInvokeTarget             == (int)ENC
 
 static_assert_no_msg((int)READYTORUN_FIXUP_Check_InstructionSetSupport== (int)ENCODE_CHECK_INSTRUCTION_SET_SUPPORT);
 
+static_assert_no_msg((int)READYTORUN_FIXUP_Verify_FieldOffset         == (int)ENCODE_VERIFY_FIELD_OFFSET);
+static_assert_no_msg((int)READYTORUN_FIXUP_Verify_TypeLayout          == (int)ENCODE_VERIFY_TYPE_LAYOUT);
+
 //
 // READYTORUN_EXCEPTION
 //

--- a/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/coreclr/tests/src/readytorun/crossgen2/crossgen2smoke.csproj
@@ -25,14 +25,14 @@
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 copy helperildll.dll helperildll.ildll
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
-%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll -r:%Core_Root%\*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
+%Core_Root%\CoreRun.exe %Core_Root%\crossgen2\crossgen2.dll --verify-type-and-field-layout -r:%Core_Root%\*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></CLRTestBatchPreCommands>
     <BashCLRTestPreCommands><![CDATA[
 $(BashCLRTestPreCommands)
 cp helperildll.dll helperildll.ildll
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll -r:$CORE_ROOT/*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
-$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll -r:$CORE_ROOT/*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -o:helperildll.dll helperildll.ildll
+$CORE_ROOT/corerun $CORE_ROOT/crossgen2/crossgen2.dll --verify-type-and-field-layout -r:$CORE_ROOT/*.dll -r:helperdll.dll -r:helperildll.dll -o:crossgen2smoke.dll crossgen2smoke.ildll
 ]]></BashCLRTestPreCommands>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- New command line parameter --verify-type-and-field-layout
  - Intended for use diagnosing bugs in crossgen2 only, not for general
  production use
- New r2r precode fixups Verify_TypeLayout and Verify_FieldOffset
  - These allows the compiler to specify that a particular type/field
  layout must match with the runtime calculation.
  - If there is a mismatch, the runtime will failfast, even on release
  builds
- Add use of new switch to crossgen2smoke test
- Fix encoding bug in FieldFixupSignature. Check_FieldOffset and
Verify_FieldOffset use unsigned offsets, not signed offsets