### PR TITLE
Disable reverse eventpipe test

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -2,7 +2,7 @@
 <Project DefaultTargets = "GetListOfTestCmds" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <!-- All OS/Arch/Runtime excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverse/*">
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/reverse/reverse/*">
             <Issue>https://github.com/dotnet/runtime/issues/38156</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracecontrol/tracecontrol/*">


### PR DESCRIPTION
The exclude list entry path was incorrect in https://github.com/dotnet/runtime/pull/38293 and it was still running and failing in a PR today: https://dev.azure.com/dnceng/public/_build/results?buildId=709860&view=ms.vss-test-web.build-test-results-tab&runId=22002742&resultId=102535&paneView=debug