### PR TITLE
Fix packaging of PDBs for host binaries

### DIFF
--- a/src/installer/pkg/projects/Directory.Build.targets
+++ b/src/installer/pkg/projects/Directory.Build.targets
@@ -158,6 +158,15 @@
       <File Include="@(SiblingSymbolFile)" />
     </ItemGroup>
 
+    <!-- On Windows, native symbols are installed to a PDB subdirectory -->
+    <ItemGroup>
+      <WindowsSymbolFileInSubdirectory Include="@(WindowsSymbolFile -> '%(RootDir)%(Directory)PDB\%(Filename)%(Extension)')" />
+      <ExistingWindowsSymbolFileInSubdirectory Include="@(WindowsSymbolFileInSubdirectory)" Condition="Exists('%(Identity)')" />
+      <File Include="@(ExistingWindowsSymbolFileInSubdirectory)">
+        <IsSymbolFile>true</IsSymbolFile>
+      </File>
+    </ItemGroup>
+
     <PropertyGroup>
       <NeedsPlaceholderPdb Condition="'@(ExistingNonWindowsSymbolFile)' != '' and '@(ExistingWindowsSymbolFile)' == ''">true</NeedsPlaceholderPdb>
     </PropertyGroup>


### PR DESCRIPTION
Resolves #38587

After #33716, the PDBs for host binaries are installed to subdirectory instead of right next to the binaries themselves. As a result, they were no longer being put into the symbols packages.