### PR TITLE
Add native runtime components to Crossgen2 package

### DIFF
--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -100,8 +100,17 @@
 
   <Target Name="GenerateDepsJsonFile" Returns="$(ProjectDepsFilePath)" DependsOnTargets="GenerateBuildDependencyFile" />
 
-  <Target Name="RemoveLongNameDacFromDepsJson" AfterTargets="ResolveRuntimePackAssets" BeforeTargets="GenerateBuildDependencyFile" Condition="'$(RemoveLongNameDac)' == 'true'">
+  <Target Name="RemoveUnusedFilesFromDepsJson" AfterTargets="ResolveRuntimePackAssets" BeforeTargets="GenerateBuildDependencyFile">
+    <PropertyGroup>
+      <StaticLibraryFileExtension>.a</StaticLibraryFileExtension>
+      <StaticLibraryFileExtension Condition="'$(TargetOS)' == 'Windows_NT'">.lib</StaticLibraryFileExtension>
+    </PropertyGroup>
+
     <ItemGroup>
+      <RuntimePackAsset Remove="@(RuntimePackAsset)" Condition="'%(Extension)' == '$(StaticLibraryFileExtension)'" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(RemoveLongNameDac)' == 'true'">
       <RuntimePackAsset Remove="@(RuntimePackAsset)" Condition="$([System.String]::new('%(FileName)').StartsWith('mscordaccore_'))" />
     </ItemGroup>
   </Target>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -59,9 +59,12 @@
       <!-- Include the native and managed files from the Microsoft.NETCore.App shared framework -->
       <Crossgen2File Include="@(RuntimeFile)" Condition="'%(RuntimeFile.TargetPath)' == 'runtimes/$(PackageRID)/native'" />
       <Crossgen2File Include="@(RuntimeFile)" Condition="'%(RuntimeFile.TargetPath)' == 'runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)'" />
-      <!-- Include the native hosting layer  -->
+      <!-- Include the native hosting layer -->
       <Crossgen2File Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostfxr$(LibraryFileExtension)" />
       <Crossgen2File Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostpolicy$(LibraryFileExtension)" />
+      <!-- Include native runtime components -->
+      <Crossgen2File Include="$(LibrariesNativeArtifactsPath)$(LibraryFilePrefix)*$(LibraryFileExtension)"
+        Exclude="$(LibrariesNativeArtifactsPath)$(LibraryFilePrefix)System.IO.Ports.Native$(LibraryFileExtension)" />
     </ItemGroup>
 
     <MSBuild Projects="$(CoreClrProjectRoot)src/tools/aot/crossgen2/crossgen2.csproj"


### PR DESCRIPTION
Fixes #37196.  For Windows, these changes add `clrcompression.dll` to the package.  For Linux, they add `libSystem.IO.Compression.Native.so`, `libSystem.Native.so`, `libSystem.Net.Security.Native.so`, and `libSystem.Security.Cryptography.Native.OpenSsl.so` to the package and also remove the corresponding files with the `.a` extension from `crossgen2.deps.json`.
