### PR TITLE
Do not override CoreCLRArtifactsPath if RuntimeIdentifier is empty

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -22,6 +22,7 @@
     but we need to point to the AllArtifacts locations when building the platform manifest.
   -->
   <PropertyGroup Condition="
+    '$(RuntimeIdentifier)' != '' and
     '$(RuntimeIdentifier)' != '$(OutputRid)' and
     '$(AllArtifactsDownloadPath)' != ''">
     <!-- Convert the OS component in the RID into names that match the job IDs. -->


### PR DESCRIPTION
Probably a fix for https://github.com/dotnet/runtime/issues/38590

In some builds (official builds?) we do not see `RuntimeIdentifier` set while `AllArtifactsDownloadPath` is set, which results in `CoreCLRArtifactsPath` override to a bogus path. 