### PR TITLE
[wasm] Disable test on browser

### DIFF
--- a/src/libraries/System.Runtime.Numerics/tests/BigInteger/GetBitLengthTests.cs
+++ b/src/libraries/System.Runtime.Numerics/tests/BigInteger/GetBitLengthTests.cs
@@ -37,7 +37,12 @@ namespace System.Numerics.Tests
             // Random cases
             VerifyLoopGetBitLength(random, true);
             VerifyLoopGetBitLength(random, false);
+        }
 
+        [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // OOM on browser due to large array allocations
+        public static void RunGetBitLengthTestsLarge()
+        {
             // Very large cases
             VerifyGetBitLength(BigInteger.One << 32 << int.MaxValue, int.MaxValue + 32L + 1, 1);
             VerifyGetBitLength(BigInteger.One << 64 << int.MaxValue, int.MaxValue + 64L + 1, 1);


### PR DESCRIPTION
It OOMs due to excessive allocations.

Fixes #38605