### PR TITLE
Markdown: remove unused definitions

### DIFF
--- a/docs/design/features/source-generator-pinvokes.md
+++ b/docs/design/features/source-generator-pinvokes.md
@@ -214,7 +214,6 @@ namespace System.Runtime.InteropServices
 [IL Stubs description][il_stub_link]
 
 <!-- Common links -->
-[dotnet_link]: https://docs.microsoft.com/dotnet/core/tools/dotnet
 [typemarshal_link]: https://docs.microsoft.com/dotnet/standard/native-interop/type-marshaling
 [pinvoke_link]: https://docs.microsoft.com/dotnet/standard/native-interop/pinvoke
 [comwrappers_link]: https://github.com/dotnet/runtime/issues/1845

--- a/docs/project/glossary.md
+++ b/docs/project/glossary.md
@@ -350,8 +350,6 @@ and enabling support for running WPF on .NET Core (Windows Only).
 [corefx]: http://github.com/dotnet/corefx
 [referencesource]: https://github.com/microsoft/referencesource
 [mono-supported-platforms]: http://www.mono-project.com/docs/about-mono/supported-platforms/
-[JamesNK]: https://twitter.com/JamesNK
-[Newtonsoft.Json]: https://github.com/JamesNK/Newtonsoft.Json
 [mono-winforms]: http://www.mono-project.com/docs/gui/winforms/
 [xunit]: https://github.com/xunit
 [mc.dot.net]: https://mc.dot.net/


### PR DESCRIPTION
Fix #38549