### PR TITLE
Adding default string for stacktrace Word_At

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -201,7 +201,9 @@ namespace System.Diagnostics
 
         internal void ToString(TraceFormat traceFormat, StringBuilder sb)
         {
-            string word_At = SR.Word_At;
+            // Adding a default string for "at" in case we are using Resource Keys instead of resources
+            // as this is a special case and we don't want to have "Word_At" on stack traces.
+            string word_At = SR.GetResourceString(nameof(SR.Word_At), defaultString: "at");
             string inFileLineNum = SR.StackTrace_InFileLineNumber;
             bool fFirstFrame = true;
             for (int iFrameIndex = 0; iFrameIndex < _numOfFrames; iFrameIndex++)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -201,10 +201,11 @@ namespace System.Diagnostics
 
         internal void ToString(TraceFormat traceFormat, StringBuilder sb)
         {
-            // Adding a default string for "at" in case we are using Resource Keys instead of resources
+            // Passing a default string for "at" in case we are using Resource Keys instead of resources
             // as this is a special case and we don't want to have "Word_At" on stack traces.
             string word_At = SR.GetResourceString(nameof(SR.Word_At), defaultString: "at");
-            string inFileLineNum = SR.StackTrace_InFileLineNumber;
+            // We also want to pass in a default for inFileLineNumber.
+            string inFileLineNum = SR.GetResourceString(nameof(SR.StackTrace_InFileLineNumber), defaultString: "in {0}:line {1}");
             bool fFirstFrame = true;
             for (int iFrameIndex = 0; iFrameIndex < _numOfFrames; iFrameIndex++)
             {
@@ -328,7 +329,9 @@ namespace System.Diagnostics
                     if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
                     {
                         sb.AppendLine();
-                        sb.Append(SR.Exception_EndStackTraceFromPreviousThrow);
+                        // Passing default for Exception_EndStackTraceFromPreviousThrow in case UsingResourceKeys is set.
+                        sb.Append(SR.GetResourceString(nameof(SR.Exception_EndStackTraceFromPreviousThrow),
+                            defaultString: "--- End of stack trace from previous location ---"));
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -201,7 +201,7 @@ namespace System.Diagnostics
 
         internal void ToString(TraceFormat traceFormat, StringBuilder sb)
         {
-            // Passing a default string for "at" in case we are using Resource Keys instead of resources
+            // Passing a default string for "at" in case SR.UsingResourceKeys() is true
             // as this is a special case and we don't want to have "Word_At" on stack traces.
             string word_At = SR.GetResourceString(nameof(SR.Word_At), defaultString: "at");
             // We also want to pass in a default for inFileLineNumber.
@@ -329,7 +329,7 @@ namespace System.Diagnostics
                     if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
                     {
                         sb.AppendLine();
-                        // Passing default for Exception_EndStackTraceFromPreviousThrow in case UsingResourceKeys is set.
+                        // Passing default for Exception_EndStackTraceFromPreviousThrow in case SR.UsingResourceKeys is set.
                         sb.Append(SR.GetResourceString(nameof(SR.Exception_EndStackTraceFromPreviousThrow),
                             defaultString: "--- End of stack trace from previous location ---"));
                     }


### PR DESCRIPTION
This is based on the discussion we had here: https://github.com/dotnet/runtime/pull/38397#discussion_r446291894 as @eerhardt did go and check and looks like StackTrace isn't using a default value for the word "at" in case resourceKeys are used.

I decided to send this out as a separate PR in order to not reset CI on the Resources PR which has finished and is ready to merge.