### PR TITLE
Fix38455

### DIFF
--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -9237,7 +9237,8 @@ REDO_RETURN_NODE:
     {
         // It is possible that we now have a lclVar of scalar type.
         // If so, don't transform it to GT_LCL_FLD.
-        if (lvaTable[op->AsLclVar()->GetLclNum()].lvType != info.compRetNativeType)
+        LclVarDsc* varDsc = lvaGetDesc(op->AsLclVarCommon());
+        if (genActualType(varDsc->TypeGet()) != genActualType(info.compRetNativeType))
         {
             op->ChangeOper(GT_LCL_FLD);
         }

--- a/src/libraries/System.Runtime/tests/System/DoubleTests.cs
+++ b/src/libraries/System.Runtime/tests/System/DoubleTests.cs
@@ -551,7 +551,6 @@ namespace System.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/38455", TestRuntimes.CoreCLR)]
         [InlineData(double.NegativeInfinity, false)]    // Negative Infinity
         [InlineData(double.MinValue, false)]            // Min Negative Normal
         [InlineData(-2.2250738585072014E-308, false)]   // Max Negative Normal


### PR DESCRIPTION
Fix the scalar check with fixing up struct return - we don't need a precise type match.