### PR TITLE
AdvSimd support for System.Text.Unicode.Utf8Utility.GetPointerToFirstInvalidByte

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -119,7 +119,7 @@ namespace System.Text.Unicode
                         // the alignment check consumes at most a single DWORD.)
 
                         byte* pInputBufferFinalPosAtWhichCanSafelyLoop = pFinalPosWhereCanReadDWordFromInputBuffer - 3 * sizeof(uint); // can safely read 4 DWORDs here
-                        uint mask;
+                        ulong mask;
 
                         Vector128<byte> initialMask = Vector128.Create((ushort)0x1001).AsByte();
                         Vector128<byte> mostSignficantBitMask = Vector128.Create((byte)0x80).AsByte();
@@ -133,7 +133,7 @@ namespace System.Text.Unicode
                             // within the all-ASCII vectorized code at the entry to this method).
                             if (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian)
                             {
-                                mask = (uint)Arm64MoveMask(AdvSimd.LoadVector128(pInputBuffer), initialMask, mostSignficantBitMask);
+                                mask = GetNonAsciiBytes(AdvSimd.LoadVector128(pInputBuffer), initialMask, mostSignficantBitMask);
                                 if (mask != 0)
                                 {
                                     goto LoopTerminatedEarlyDueToNonAsciiData;
@@ -141,7 +141,7 @@ namespace System.Text.Unicode
                             }
                             else if (Sse2.IsSupported)
                             {
-                                mask = (uint)Sse2.MoveMask(Sse2.LoadVector128(pInputBuffer));
+                                mask = (ulong)Sse2.MoveMask(Sse2.LoadVector128(pInputBuffer));
                                 if (mask != 0)
                                 {
                                     goto LoopTerminatedEarlyDueToNonAsciiData;
@@ -734,7 +734,7 @@ namespace System.Text.Unicode
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong Arm64MoveMask(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
+        private static ulong GetNonAsciiBytes(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -733,12 +733,16 @@ namespace System.Text.Unicode
             return pInputBuffer;
         }
 
+        // Passing the values of initialMask and mostSignificantBitMask is slightly more efficient than using static readonly fields as of right now.
+        // The expected values are:
+        // initialMask = 0x1001 = 0001 0000 0000 0001 (2 bytes)
+        // mostSignficantBitMask = 0x80 = 1000 0000 (1 byte)
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong GetNonAsciiBytes(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
+        private static ulong GetNonAsciiBytes(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignificantBitMask)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
-            Vector128<byte> mostSignificantBitIsSet = AdvSimd.CompareEqual(AdvSimd.And(value, mostSignficantBitMask), mostSignficantBitMask);
+            Vector128<byte> mostSignificantBitIsSet = AdvSimd.CompareEqual(AdvSimd.And(value, mostSignificantBitMask), mostSignificantBitMask);
             Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, initialMask);
             extractedBits = AdvSimd.Arm64.AddPairwise(extractedBits, extractedBits);
             return extractedBits.AsUInt64().ToScalar();

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -123,6 +123,11 @@ namespace System.Text.Unicode
 
                         do
                         {
+                            // pInputBuffer is 32-bit aligned but not necessary 128-bit aligned, so we're
+                            // going to perform an unaligned load. We don't necessarily care about aligning
+                            // this because we pessimistically assume we'll encounter non-ASCII data at some
+                            // point in the not-too-distant future (otherwise we would've stayed entirely
+                            // within the all-ASCII vectorized code at the entry to this method).
                             if (AdvSimd.Arm64.IsSupported)
                             {
                                 mask = AdvSimd.Arm64.MaxAcross(AdvSimd.LoadVector128(pInputBuffer)).ToScalar();
@@ -133,12 +138,6 @@ namespace System.Text.Unicode
                             }
                             else if (Sse2.IsSupported)
                             {
-                                // pInputBuffer is 32-bit aligned but not necessary 128-bit aligned, so we're
-                                // going to perform an unaligned load. We don't necessarily care about aligning
-                                // this because we pessimistically assume we'll encounter non-ASCII data at some
-                                // point in the not-too-distant future (otherwise we would've stayed entirely
-                                // within the all-ASCII vectorized code at the entry to this method).
-
                                 mask = (uint)Sse2.MoveMask(Sse2.LoadVector128(pInputBuffer));
                                 if (mask != 0)
                                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -128,7 +128,7 @@ namespace System.Text.Unicode
                             // this because we pessimistically assume we'll encounter non-ASCII data at some
                             // point in the not-too-distant future (otherwise we would've stayed entirely
                             // within the all-ASCII vectorized code at the entry to this method).
-                            if (AdvSimd.Arm64.IsSupported)
+                            if (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian)
                             {
                                 mask = AdvSimd.Arm64.MaxAcross(AdvSimd.LoadVector128(pInputBuffer)).ToScalar();
                                 if (mask != 0)
@@ -164,6 +164,8 @@ namespace System.Text.Unicode
 
                     LoopTerminatedEarlyDueToNonAsciiData:
 
+                        // x86 can only be little endian, while ARM can be big or little endian
+                        // so if we reached this label we need to check both combinations are supported
                         Debug.Assert(BitConverter.IsLittleEndian);
                         Debug.Assert(AdvSimd.Arm64.IsSupported || Sse2.IsSupported);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -119,7 +119,7 @@ namespace System.Text.Unicode
                         // the alignment check consumes at most a single DWORD.)
 
                         byte* pInputBufferFinalPosAtWhichCanSafelyLoop = pFinalPosWhereCanReadDWordFromInputBuffer - 3 * sizeof(uint); // can safely read 4 DWORDs here
-                        int trailingZeroCount;
+                        nuint trailingZeroCount;
 
                         Vector128<byte> bitMask128 = BitConverter.IsLittleEndian ?
                             Vector128.Create((ushort)0x1001).AsByte() :
@@ -137,7 +137,7 @@ namespace System.Text.Unicode
                                 ulong mask = GetNonAsciiBytes(AdvSimd.LoadVector128(pInputBuffer), bitMask128);
                                 if (mask != 0)
                                 {
-                                    trailingZeroCount = BitOperations.TrailingZeroCount(mask) >> 2;
+                                    trailingZeroCount = (nuint)BitOperations.TrailingZeroCount(mask) >> 2;
                                     goto LoopTerminatedEarlyDueToNonAsciiData;
                                 }
                             }
@@ -146,7 +146,7 @@ namespace System.Text.Unicode
                                 uint mask = (uint)Sse2.MoveMask(Sse2.LoadVector128(pInputBuffer));
                                 if (mask != 0)
                                 {
-                                    trailingZeroCount = BitOperations.TrailingZeroCount(mask);
+                                    trailingZeroCount = (nuint)BitOperations.TrailingZeroCount(mask);
                                     goto LoopTerminatedEarlyDueToNonAsciiData;
                                 }
                             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -133,7 +133,7 @@ namespace System.Text.Unicode
                             // within the all-ASCII vectorized code at the entry to this method).
                             if (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian)
                             {
-                                mask = Arm64MoveMask(AdvSimd.LoadVector128(pInputBuffer), initialMask, mostSignficantBitMask);
+                                mask = (uint)Arm64MoveMask(AdvSimd.LoadVector128(pInputBuffer), initialMask, mostSignficantBitMask);
                                 if (mask != 0)
                                 {
                                     goto LoopTerminatedEarlyDueToNonAsciiData;
@@ -734,14 +734,14 @@ namespace System.Text.Unicode
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint Arm64MoveMask(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
+        private static ulong Arm64MoveMask(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
             Vector128<byte> mostSignificantBitIsSet = AdvSimd.CompareEqual(AdvSimd.And(value, mostSignficantBitMask), mostSignficantBitMask);
             Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, initialMask);
             extractedBits = AdvSimd.Arm64.AddPairwise(extractedBits, extractedBits);
-            return extractedBits.AsUInt16().ToScalar();
+            return extractedBits.AsUInt64().ToScalar();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -134,12 +134,14 @@ namespace System.Text.Unicode
                                 if (mask != 0)
                                 {
                                     trailingZeroCount = BitOperations.TrailingZeroCount(mask);
+                                    Debug.Assert(trailingZeroCount < 16);
+
                                     goto LoopTerminatedEarlyDueToNonAsciiData;
                                 }
                             }
                             else if (Sse2.IsSupported)
                             {
-                                int mask = Sse2.MoveMask(Sse2.LoadVector128(pInputBuffer));
+                                uint mask = (uint)Sse2.MoveMask(Sse2.LoadVector128(pInputBuffer));
                                 if (mask != 0)
                                 {
                                     trailingZeroCount = BitOperations.TrailingZeroCount(mask);

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -16,11 +16,14 @@ namespace System.Runtime.Intrinsics
 
     internal static class Vector128
     {
+        public static Vector128<long> Create(long value) => throw new PlatformNotSupportedException();
         public static Vector128<short> Create(short value) => throw new PlatformNotSupportedException();
+        public static Vector128<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
         public static Vector128<ushort> Create(ushort value) => throw new PlatformNotSupportedException();
         public static Vector128<ulong> CreateScalarUnsafe(ulong value) => throw new PlatformNotSupportedException();
         public static Vector128<byte> AsByte<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<short> AsInt16<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
+        public static Vector128<sbyte> AsSByte<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<ushort> AsUInt16<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<uint> AsUInt32<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<ulong> AsUInt64<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Utf8String.Experimental/tests/System/Utf8SpanTests.cs
+++ b/src/libraries/System.Utf8String.Experimental/tests/System/Utf8SpanTests.cs
@@ -348,6 +348,7 @@ namespace System.Text.Tests
             yield return new object[] { "Hello" }; // simple ASCII
             yield return new object[] { "a\U00000123b\U00001234c\U00101234d" }; // with multi-byte sequences of varying lengths
             yield return new object[] { "\uF8FF\uE000\U000FFFFF" }; // with scalars from the private use areas
+            yield return new object[] { "\u00E921222324303132333435363738393A3B3C3D3E3F3031323334353637\u00E938393A3B3C3D3E3F" }; // reaches the intrinsics optimizations in System.Text.Unicode.Utf8Utility.GetPointerToFirstInvalidByte
         }
     }
 }

--- a/src/libraries/System.Utf8String.Experimental/tests/System/Utf8SpanTests.cs
+++ b/src/libraries/System.Utf8String.Experimental/tests/System/Utf8SpanTests.cs
@@ -348,7 +348,6 @@ namespace System.Text.Tests
             yield return new object[] { "Hello" }; // simple ASCII
             yield return new object[] { "a\U00000123b\U00001234c\U00101234d" }; // with multi-byte sequences of varying lengths
             yield return new object[] { "\uF8FF\uE000\U000FFFFF" }; // with scalars from the private use areas
-            yield return new object[] { "\u00E921222324303132333435363738393A3B3C3D3E3F3031323334353637\u00E938393A3B3C3D3E3F" }; // reaches the intrinsics optimizations in System.Text.Unicode.Utf8Utility.GetPointerToFirstInvalidByte
         }
     }
 }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/35035

Adds AdvSimd.Arm64 support for
`System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar()`
inside the file
`runtime\src\libraries\System.Private.CoreLib\src\System\Text\Unicode\Utf8Utility.Validation.cs`

The tests for this method live in:
`runtime\src\libraries\System.Runtime\tests\System\Text\Unicode\Utf8UtilityTests.ValidateBytes.cs`

I've been having difficulties testing this in my ARM device so I want to analyze the CI results.
I manually executed an additional "Libraries Test Run" pipeline to ensure arm64 is run in all platforms.