### PR TITLE
fixes genapi for project with corelib reference

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -165,7 +165,7 @@
       <GenAPIAdditionalParameters Condition="Exists('$(_ExcludeAPIList)')">$(GenAPIAdditionalParameters) --exclude-api-list "$(_ExcludeAPIList)"</GenAPIAdditionalParameters>
       <GenAPIAdditionalParameters>$(GenAPIAdditionalParameters) --header-file "$(_LicenseHeaderTxtPath)"</GenAPIAdditionalParameters>
       <GenAPIAdditionalParameters Condition="'$(LangVersion)' != ''">$(GenAPIAdditionalParameters) --lang-version "$(LangVersion)"</GenAPIAdditionalParameters>  
-      <GenAPIAdditionalParameters Condition="'@(ReferenceFromRuntime)' != ''">$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
+      <GenAPIAdditionalParameters Condition="'%(ProjectReference.Identity)' == '$(CoreLibProject)'">$(GenAPIAdditionalParameters) --follow-type-forwards</GenAPIAdditionalParameters>
     </PropertyGroup>
   </Target>
 


### PR DESCRIPTION
Currently if we try to run this on system.Runtime, the genapi produces an empty file. After the change it will produce the correct source file.
This was a side effect of our using project reference for corelib change