### PR TITLE
Bump Helix SDK with breaking change in XHarness SDK

### DIFF
--- a/eng/testing/WasmRunnerTemplate.sh
+++ b/eng/testing/WasmRunnerTemplate.sh
@@ -6,8 +6,12 @@ cd $EXECUTION_DIR
 
 XHARNESS_OUT="$EXECUTION_DIR/xharness-output"
 
-if [ ! -x "$(command -v xharness)" ]; then
-	HARNESS_RUNNER="dotnet"
+if [ ! -z "$XHARNESS_CLI_PATH" ]; then
+	# When running in CI, we only have the .NET runtime available
+	# We need to call the XHarness CLI DLL directly via dotnet exec
+	HARNESS_RUNNER="dotnet exec $XHARNESS_CLI_PATH"
+else
+	HARNESS_RUNNER="dotnet xharness"
 fi
 
 # RunCommands defined in tests.mobile.targets
@@ -15,6 +19,6 @@ fi
 
 _exitCode=$?
 
-echo "Xharness artifacts: $XHARNESS_OUT"
+echo "XHarness artifacts: $XHARNESS_OUT"
 
 exit $_exitCode

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -14,7 +14,7 @@
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
     <!-- We need to set this in order to get extensibility on xunit category traits and other arguments we pass down to xunit via MSBuild properties -->
-    <RunScriptCommand>$HARNESS_RUNNER xharness wasm test --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js -v --output-directory=$XHARNESS_OUT -- --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
+    <RunScriptCommand>$HARNESS_RUNNER wasm test --engine=$(JSEngine) $(JSEngineArgs) --js-file=runtime.js -v --output-directory=$XHARNESS_OUT -- --run WasmTestRunner.dll $(AssemblyName).dll</RunScriptCommand>
   </PropertyGroup>
 
   <!-- Generate a self-contained app bundle for Android with tests. -->

--- a/global.json
+++ b/global.json
@@ -15,7 +15,7 @@
     "Microsoft.DotNet.Build.Tasks.TargetFramework.Sdk": "5.0.0-beta.20316.1",
     "Microsoft.DotNet.Arcade.Sdk": "5.0.0-beta.20316.1",
     "Microsoft.DotNet.Build.Tasks.SharedFramework.Sdk": "5.0.0-beta.20316.1",
-    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20316.1",
+    "Microsoft.DotNet.Helix.Sdk": "5.0.0-beta.20330.3",
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.7.20316.4",
     "Microsoft.Build.NoTargets": "1.0.53",

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -20,11 +20,11 @@
     <TimeoutInSeconds Condition="'$(Scenario)' == '' and '$(TimeoutInSeconds)' == ''">900</TimeoutInSeconds>
     <TimeoutInSeconds Condition="'$(Scenario)' != '' and '$(TimeoutInSeconds)' == ''">1800</TimeoutInSeconds>
     <_timeoutSpan>$([System.TimeSpan]::FromSeconds($(TimeoutInSeconds)))</_timeoutSpan>
-    
+
     <!-- We need to enable xunit reporter so that it parses test results
          Package testing doesn't run on xunit. -->
     <EnableXunitReporter Condition="'$(BuildAllConfigurations)' != 'true'">true</EnableXunitReporter>
-    
+
     <!-- The Helix runtime payload and the tests to run -->
     <!-- TestArchiveRuntimeFile will be passed as a property by the calling project -->
     <HelixCorrelationPayload Condition="'$(HelixCorrelationPayload)' == ''">$(TestArchiveRuntimeFile)</HelixCorrelationPayload>
@@ -63,7 +63,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
-    <IncludeDotNetCli>true</IncludeDotNetCli>
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
   </PropertyGroup>
 
@@ -118,7 +117,7 @@
   <PropertyGroup>
     <HelixPreCommands>@(HelixPreCommand)</HelixPreCommands>
   </PropertyGroup>
-    
+
   <PropertyGroup Condition="'$(HelixCommand)' == ''">
     <!--
       For Windows we need to use "call", since the command is going to be called from a batch script created by Helix.


### PR DESCRIPTION
There is a small breaking change in the SDK about how we run the XHarness tool - we are no longer installing the full .NET SDK to install the tool on every agent but rather installing it on the build machine and then shipping it as-is as Helix correlation payload. We then only need the .NET runtime to be installed on the Helix agents saving us bandwidth and cycles

