### PR TITLE
[wasm] Make Common.Tests pass

### DIFF
--- a/src/libraries/Common/tests/Tests/System/Security/IdentityHelperTests.cs
+++ b/src/libraries/Common/tests/Tests/System/Security/IdentityHelperTests.cs
@@ -29,6 +29,7 @@ namespace Tests.System.Security
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)]
         public void GetNormalizedStrongNameHash()
         {
             // Validating that we match the exact hash the .NET Framework IsolatedStorage implementation would create.
@@ -36,6 +37,7 @@ namespace Tests.System.Security
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)]
         public void GetNormalizedUrlHash()
         {
             // Validating that we match the exact hash the .NET Framework IsolatedStorage implementation would create.

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -34,7 +34,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Extensions\tests\System.Threading.Tasks.Extensions.Tests.csproj" />
     <!-- Builds currently do not pass -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Common\tests\Common.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.FileExtensions\tests\Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Ini\tests\Microsoft.Extensions.Configuration.Ini.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Json\tests\Microsoft.Extensions.Configuration.Json.Tests.csproj" />


### PR DESCRIPTION
Two test methods from IdentityHelperTests class (GetNormalizedStrongNameHash and GetNormalizedUrlHash) throw PNSE because the respective S.S.Cryptography functionality has been updated recently to produce PNSE at assembly level.
Disabling them makes Common.Tests pass with the following result: `Tests run: 2190, Errors: 0, Failures: 0, Skipped: 2`

Part of https://github.com/dotnet/runtime/issues/38422