### PR TITLE
Add method names next to reloc adrp/add in disasm

### DIFF
--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1488,7 +1488,7 @@ public:
     void instGen_Set_Reg_To_Imm(emitAttr  size,
                                 regNumber reg,
                                 ssize_t   imm,
-                                insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(size_t methodHandle = 0)
+                                insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(size_t targetHandle = 0)
                                     DEBUGARG(unsigned gtFlags = 0));
 
     void instGen_Compare_Reg_To_Zero(emitAttr size, regNumber reg);

--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1485,11 +1485,11 @@ public:
 
     void instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags flags = INS_FLAGS_DONT_CARE);
 
-    void instGen_Set_Reg_To_Imm(
-        emitAttr  size,
-        regNumber reg,
-        ssize_t   imm,
-        insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(CORINFO_METHOD_HANDLE methodHandle = nullptr));
+    void instGen_Set_Reg_To_Imm(emitAttr  size,
+                                regNumber reg,
+                                ssize_t   imm,
+                                insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(size_t methodHandle = 0)
+                                    DEBUGARG(unsigned gtFlags = 0));
 
     void instGen_Compare_Reg_To_Zero(emitAttr size, regNumber reg);
 

--- a/src/coreclr/src/jit/codegen.h
+++ b/src/coreclr/src/jit/codegen.h
@@ -1485,7 +1485,11 @@ public:
 
     void instGen_Set_Reg_To_Zero(emitAttr size, regNumber reg, insFlags flags = INS_FLAGS_DONT_CARE);
 
-    void instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, insFlags flags = INS_FLAGS_DONT_CARE);
+    void instGen_Set_Reg_To_Imm(
+        emitAttr  size,
+        regNumber reg,
+        ssize_t   imm,
+        insFlags flags = INS_FLAGS_DONT_CARE DEBUGARG(CORINFO_METHOD_HANDLE methodHandle = nullptr));
 
     void instGen_Compare_Reg_To_Zero(emitAttr size, regNumber reg);
 

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -156,7 +156,10 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 //------------------------------------------------------------------------
 // instGen_Set_Reg_To_Imm: Move an immediate value into an integer register.
 //
-void CodeGen::instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, insFlags flags)
+void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
+                                     regNumber reg,
+                                     ssize_t   imm,
+                                     insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -159,7 +159,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
+                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1687,7 +1687,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
             if (con->ImmedValNeedsReloc(compiler))
             {
                 instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, targetReg, cnsVal,
-                                       INS_FLAGS_DONT_CARE DEBUGARG(tree->AsIntCon()->gtMethodHandle)
+                                       INS_FLAGS_DONT_CARE DEBUGARG(tree->AsIntCon()->gtTargetHandle)
                                            DEBUGARG(tree->AsIntCon()->gtFlags));
                 regSet.verifyRegUsed(targetReg);
             }

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1574,7 +1574,10 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 
 //  move an immediate value into an integer register
 
-void CodeGen::instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
+void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
+                                     regNumber reg,
+                                     ssize_t   imm,
+                                     insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));
@@ -3776,7 +3779,8 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
         callTarget = callTargetReg;
 
         // adrp + add with relocations will be emitted
-        GetEmitter()->emitIns_R_AI(INS_adrp, EA_PTR_DSP_RELOC, callTarget, (ssize_t)pAddr DEBUGARG(compiler->eeFindHelper(helper)));
+        GetEmitter()->emitIns_R_AI(INS_adrp, EA_PTR_DSP_RELOC, callTarget,
+                                   (ssize_t)pAddr DEBUGARG(compiler->eeFindHelper(helper)));
         GetEmitter()->emitIns_R_R(INS_ldr, EA_PTRSIZE, callTarget, callTarget);
         callType = emitter::EC_INDIR_R;
     }
@@ -4934,7 +4938,8 @@ void CodeGen::genProfilingEnterCallback(regNumber initReg, bool* pInitRegModifie
 
     if (compiler->compProfilerMethHndIndirected)
     {
-        instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, REG_PROFILER_ENTER_ARG_FUNC_ID, (ssize_t)compiler->compProfilerMethHnd);
+        instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, REG_PROFILER_ENTER_ARG_FUNC_ID,
+                               (ssize_t)compiler->compProfilerMethHnd);
         GetEmitter()->emitIns_R_R(INS_ldr, EA_PTRSIZE, REG_PROFILER_ENTER_ARG_FUNC_ID, REG_PROFILER_ENTER_ARG_FUNC_ID);
     }
     else

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1577,7 +1577,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
+                                     insFlags flags DEBUGARG(size_t methodHandle) DEBUGARG(unsigned gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));
@@ -1589,7 +1589,7 @@ void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
     if (EA_IS_RELOC(size))
     {
         // This emits a pair of adrp/add (two instructions) with fix-ups.
-        GetEmitter()->emitIns_R_AI(INS_adrp, size, reg, imm DEBUGARG(methodHandle));
+        GetEmitter()->emitIns_R_AI(INS_adrp, size, reg, imm DEBUGARG(methodHandle) DEBUGARG(gtFlags));
     }
     else if (imm == 0)
     {
@@ -1687,7 +1687,8 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
             if (con->ImmedValNeedsReloc(compiler))
             {
                 instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, targetReg, cnsVal,
-                                       INS_FLAGS_DONT_CARE DEBUGARG(tree->AsIntCon()->gtMethodHandle));
+                                       INS_FLAGS_DONT_CARE DEBUGARG(tree->AsIntCon()->gtMethodHandle)
+                                           DEBUGARG(tree->AsIntCon()->gtFlags));
                 regSet.verifyRegUsed(targetReg);
             }
             else
@@ -3780,7 +3781,8 @@ void CodeGen::genEmitHelperCall(unsigned helper, int argSize, emitAttr retSize, 
 
         // adrp + add with relocations will be emitted
         GetEmitter()->emitIns_R_AI(INS_adrp, EA_PTR_DSP_RELOC, callTarget,
-                                   (ssize_t)pAddr DEBUGARG(compiler->eeFindHelper(helper)));
+                                   (ssize_t)pAddr DEBUGARG((size_t)compiler->eeFindHelper(helper))
+                                       DEBUGARG(GTF_ICON_METHOD_HDL));
         GetEmitter()->emitIns_R_R(INS_ldr, EA_PTRSIZE, callTarget, callTarget);
         callType = emitter::EC_INDIR_R;
     }

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -1577,7 +1577,7 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(size_t methodHandle) DEBUGARG(unsigned gtFlags))
+                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));
@@ -1589,7 +1589,7 @@ void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
     if (EA_IS_RELOC(size))
     {
         // This emits a pair of adrp/add (two instructions) with fix-ups.
-        GetEmitter()->emitIns_R_AI(INS_adrp, size, reg, imm DEBUGARG(methodHandle) DEBUGARG(gtFlags));
+        GetEmitter()->emitIns_R_AI(INS_adrp, size, reg, imm DEBUGARG(targetHandle) DEBUGARG(gtFlags));
     }
     else if (imm == 0)
     {

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -588,7 +588,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
     else
     {
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)TargetHandleType::SetGSCookie) DEBUGARG(0));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)THT_SetGSCookie) DEBUGARG(0));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -588,8 +588,8 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
     else
     {
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE,
-                               (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::SetGSCookie);
+                               INS_FLAGS_DONT_CARE DEBUGARG(
+                                   (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::SetGSCookie));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -589,7 +589,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
     {
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
                                INS_FLAGS_DONT_CARE,
-                               (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::SetGCCookie);
+                               (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::SetGSCookie);
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -588,7 +588,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
     else
     {
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)MethodHandleType::SetGSCookie) DEBUGARG(0));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)TargetHandleType::SetGSCookie) DEBUGARG(0));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -587,7 +587,9 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
     }
     else
     {
-        instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr);
+        instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
+                               INS_FLAGS_DONT_CARE,
+                               (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::SetGCCookie);
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -588,8 +588,7 @@ void CodeGen::genSetGSSecurityCookie(regNumber initReg, bool* pInitRegModified)
     else
     {
         instGen_Set_Reg_To_Imm(EA_PTR_DSP_RELOC, initReg, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG(
-                                   (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::SetGSCookie));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)MethodHandleType::SetGSCookie) DEBUGARG(0));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, initReg, initReg, 0);
         regSet.verifyRegUsed(initReg);
         GetEmitter()->emitIns_S_R(INS_str, EA_PTRSIZE, initReg, compiler->lvaGSSecurityCookie, 0);

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1753,7 +1753,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     {
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)TargetHandleType::GSCookieCheck) DEBUGARG(0));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)THT_GSCookieCheck) DEBUGARG(0));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1754,7 +1754,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
                                INS_FLAGS_DONT_CARE DEBUGARG(
-                                   (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::GCCookieCheck));
+                                   (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::GSCookieCheck));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1752,7 +1752,9 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     else
     {
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
-        instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr);
+        instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
+                               INS_FLAGS_DONT_CARE DEBUGARG(
+                                   (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::GCCookieCheck));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1753,8 +1753,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     {
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG(
-                                   (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::GSCookieCheck));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)MethodHandleType::GSCookieCheck) DEBUGARG(0));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -1753,7 +1753,7 @@ void CodeGen::genEmitGSCookieCheck(bool pushReg)
     {
         // Ngen case - GS cookie constant needs to be accessed through an indirection.
         instGen_Set_Reg_To_Imm(EA_HANDLE_CNS_RELOC, regGSConst, (ssize_t)compiler->gsGlobalSecurityCookieAddr,
-                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)MethodHandleType::GSCookieCheck) DEBUGARG(0));
+                               INS_FLAGS_DONT_CARE DEBUGARG((size_t)TargetHandleType::GSCookieCheck) DEBUGARG(0));
         GetEmitter()->emitIns_R_R_I(INS_ldr, EA_PTRSIZE, regGSConst, regGSConst, 0);
     }
     // Load this method's GS value from the stack frame

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -437,7 +437,7 @@ void CodeGen::genEHFinallyOrFilterRet(BasicBlock* block)
 
 //  Move an immediate value into an integer register
 
-void CodeGen::instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, insFlags flags)
+void CodeGen::instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -440,7 +440,7 @@ void CodeGen::genEHFinallyOrFilterRet(BasicBlock* block)
 void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
                                      regNumber reg,
                                      ssize_t   imm,
-                                     insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
+                                     insFlags flags DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -437,7 +437,10 @@ void CodeGen::genEHFinallyOrFilterRet(BasicBlock* block)
 
 //  Move an immediate value into an integer register
 
-void CodeGen::instGen_Set_Reg_To_Imm(emitAttr size, regNumber reg, ssize_t imm, insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
+void CodeGen::instGen_Set_Reg_To_Imm(emitAttr  size,
+                                     regNumber reg,
+                                     ssize_t   imm,
+                                     insFlags flags DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
 {
     // reg cannot be a FP register
     assert(!genIsValidFloatReg(reg));

--- a/src/coreclr/src/jit/emit.h
+++ b/src/coreclr/src/jit/emit.h
@@ -528,6 +528,7 @@ protected:
         size_t            idSize;        // size of the instruction descriptor
         unsigned          idVarRefOffs;  // IL offset for LclVar reference
         size_t            idMemCookie;   // for display of method name  (also used by switch table)
+        unsigned          idFlags;       // for determining type of handle in idMemCookie
         bool              idFinallyCall; // Branch instruction is a call to finally
         bool              idCatchRet;    // Instruction is for a catch 'return'
         CORINFO_SIG_INFO* idCallSig;     // Used to report native call site signatures to the EE

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12082,7 +12082,7 @@ void emitter::emitDispIns(
                 assert(imm == 0);
                 if (id->idIsReloc())
                 {
-                    printf("RELOC ");
+                    printf("HIGH RELOC ");
                     emitDispImm((ssize_t)id->idAddr()->iiaAddr, false);
                 }
                 else if (id->idIsBound())
@@ -12272,7 +12272,17 @@ void emitter::emitDispIns(
                 emitDispReg(id->idReg1(), size, true);
                 emitDispReg(id->idReg2(), size, true);
             }
-            emitDispImmOptsLSL12(emitGetInsSC(id), id->idInsOpt());
+            if (id->idIsReloc())
+            {
+                assert(ins == INS_add);
+                printf("[LOW RELOC ");
+                emitDispImm((ssize_t)id->idAddr()->iiaAddr, false);
+                printf("]");
+            }
+            else
+            {
+                emitDispImmOptsLSL12(emitGetInsSC(id), id->idInsOpt());
+            }
             break;
 
         case IF_DI_2B: // DI_2B   X........X.nnnnn ssssssnnnnnddddd      Rd Rn    imm(0-63)

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12115,6 +12115,9 @@ void emitter::emitDispIns(
                         case GenTreeIntCon::MethodHandleType::StaticFieldAccess:
                             targetName = "StaticFieldAccess";
                             break;
+                        case GenTreeIntCon::MethodHandleType::FieldAccess:
+                            targetName = "FieldAccess";
+                            break;
                         case GenTreeIntCon::MethodHandleType::GSCookieCheck:
                             targetName = "GlobalSecurityCookieCheck";
                             break;

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12133,6 +12133,10 @@ void emitter::emitDispIns(
                     {
                         targetName = "SetGlobalSecurityCookie";
                     }
+                    else if (targetHandle == TargetHandleType::StaticFieldAccess)
+                    {
+                        targetName = "StaticFieldAccess";
+                    }
                     else
                     {
                         targetName = "Unknown";

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12118,7 +12118,7 @@ void emitter::emitDispIns(
                         // future, once it is is implemented, no changes will be needed here.
                         if (stringLiteral == nullptr)
                         {
-                            stringLiteral = L"String handle";
+                            targetName = "String handle";
                         }
                     }
                     else if ((idFlags == GTF_ICON_FIELD_HDL) || (idFlags == GTF_ICON_STATIC_HDL))

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12098,7 +12098,19 @@ void emitter::emitDispIns(
                     size_t   targetHandle = id->idDebugOnlyInfo()->idMemCookie;
                     unsigned idFlags      = id->idDebugOnlyInfo()->idFlags & GTF_ICON_HDL_MASK;
 
-                    if ((idFlags == GTF_ICON_STR_HDL) || (idFlags == GTF_ICON_PSTR_HDL))
+                    if (targetHandle == THT_IntializeArrayIntrinsics)
+                    {
+                        targetName = "IntializeArrayIntrinsics";
+                    }
+                    else if (targetHandle == THT_GSCookieCheck)
+                    {
+                        targetName = "GlobalSecurityCookieCheck";
+                    }
+                    else if (targetHandle == THT_SetGSCookie)
+                    {
+                        targetName = "SetGlobalSecurityCookie";
+                    }
+                    else if ((idFlags == GTF_ICON_STR_HDL) || (idFlags == GTF_ICON_PSTR_HDL))
                     {
                         stringLiteral = emitComp->eeGetCPString(targetHandle);
                         // Note that eGetCPString isn't currently implemented on Linux/ARM
@@ -12109,7 +12121,7 @@ void emitter::emitDispIns(
                             stringLiteral = L"String handle";
                         }
                     }
-                    else if (idFlags == GTF_ICON_FIELD_HDL)
+                    else if ((idFlags == GTF_ICON_FIELD_HDL) || (idFlags == GTF_ICON_STATIC_HDL))
                     {
                         targetName = emitComp->eeGetFieldName((CORINFO_FIELD_HANDLE)targetHandle);
                     }
@@ -12121,21 +12133,9 @@ void emitter::emitDispIns(
                     {
                         targetName = emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)targetHandle);
                     }
-                    else if (targetHandle == TargetHandleType::IntializeArrayIntrinsics)
+                    else if (idFlags == GTF_ICON_TOKEN_HDL)
                     {
-                        targetName = "IntializeArrayIntrinsics";
-                    }
-                    else if (targetHandle == TargetHandleType::GSCookieCheck)
-                    {
-                        targetName = "GlobalSecurityCookieCheck";
-                    }
-                    else if (targetHandle == TargetHandleType::SetGSCookie)
-                    {
-                        targetName = "SetGlobalSecurityCookie";
-                    }
-                    else if (targetHandle == TargetHandleType::StaticFieldAccess)
-                    {
-                        targetName = "StaticFieldAccess";
+                        targetName = "Token handle";
                     }
                     else
                     {

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12115,10 +12115,10 @@ void emitter::emitDispIns(
                         case GenTreeIntCon::MethodHandleType::StaticFieldAccess:
                             targetName = "StaticFieldAccess";
                             break;
-                        case GenTreeIntCon::MethodHandleType::GCCookieCheck:
+                        case GenTreeIntCon::MethodHandleType::GSCookieCheck:
                             targetName = "GlobalSecurityCookieCheck";
                             break;
-                        case GenTreeIntCon::MethodHandleType::SetGCCookie:
+                        case GenTreeIntCon::MethodHandleType::SetGSCookie:
                             targetName = "SetGlobalSecurityCookie";
                             break;
                         default:

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -12101,6 +12101,9 @@ void emitter::emitDispIns(
                     if ((idFlags == GTF_ICON_STR_HDL) || (idFlags == GTF_ICON_PSTR_HDL))
                     {
                         stringLiteral = emitComp->eeGetCPString(targetHandle);
+                        // Note that eGetCPString isn't currently implemented on Linux/ARM
+                        // and instead always returns nullptr. However, use it here, so in
+                        // future, once it is is implemented, no changes will be needed here.
                         if (stringLiteral == nullptr)
                         {
                             stringLiteral = L"String handle";
@@ -12118,15 +12121,15 @@ void emitter::emitDispIns(
                     {
                         targetName = emitComp->eeGetClassName((CORINFO_CLASS_HANDLE)targetHandle);
                     }
-                    else if (targetHandle == MethodHandleType::IntializeArrayIntrinsics)
+                    else if (targetHandle == TargetHandleType::IntializeArrayIntrinsics)
                     {
                         targetName = "IntializeArrayIntrinsics";
                     }
-                    else if (targetHandle == MethodHandleType::GSCookieCheck)
+                    else if (targetHandle == TargetHandleType::GSCookieCheck)
                     {
                         targetName = "GlobalSecurityCookieCheck";
                     }
-                    else if (targetHandle == MethodHandleType::SetGSCookie)
+                    else if (targetHandle == TargetHandleType::SetGSCookie)
                     {
                         targetName = "SetGlobalSecurityCookie";
                     }

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -7807,7 +7807,10 @@ void emitter::emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNu
 }
 
 // This computes address from the immediate which is relocatable.
-void emitter::emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize_t addr DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
+void emitter::emitIns_R_AI(instruction ins,
+                           emitAttr    attr,
+                           regNumber   ireg,
+                           ssize_t addr DEBUGARG(CORINFO_METHOD_HANDLE methodHandle))
 {
     assert(EA_IS_RELOC(attr));
     emitAttr      size    = EA_SIZE(attr);
@@ -11949,7 +11952,7 @@ void emitter::emitDispIns(
         ssize_t      index;
         ssize_t      index2;
         unsigned     registerListSize;
-        const char* targetName;
+        const char*  targetName;
 
         case IF_BI_0A: // BI_0A   ......iiiiiiiiii iiiiiiiiiiiiiiii               simm26:00
         case IF_BI_0B: // BI_0B   ......iiiiiiiiii iiiiiiiiiii.....               simm19:00
@@ -12055,7 +12058,7 @@ void emitter::emitDispIns(
         case IF_LARGEADR:
             assert(insOptsNone(id->idInsOpt()));
             emitDispReg(id->idReg1(), size, true);
-            imm = emitGetInsSC(id);
+            imm        = emitGetInsSC(id);
             targetName = nullptr;
 
             /* Is this actually a reference to a data section? */
@@ -12092,7 +12095,8 @@ void emitter::emitDispIns(
                     emitDispImm((ssize_t)id->idAddr()->iiaAddr, false);
                     size_t methodHandle = id->idDebugOnlyInfo()->idMemCookie;
 
-                    switch (methodHandle) {
+                    switch (methodHandle)
+                    {
                         case GenTreeIntCon::MethodHandleType::Unknown:
                             targetName = "Unknown";
                             break;

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -7810,7 +7810,7 @@ void emitter::emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNu
 void emitter::emitIns_R_AI(instruction ins,
                            emitAttr    attr,
                            regNumber   ireg,
-                           ssize_t addr DEBUGARG(size_t methodHandle) DEBUGARG(unsigned gtFlags))
+                           ssize_t addr DEBUGARG(size_t targetHandle) DEBUGARG(unsigned gtFlags))
 {
     assert(EA_IS_RELOC(attr));
     emitAttr      size    = EA_SIZE(attr);
@@ -7839,7 +7839,7 @@ void emitter::emitIns_R_AI(instruction ins,
     id->idReg1(ireg);
     id->idSetIsDspReloc();
 #ifdef DEBUG
-    id->idDebugOnlyInfo()->idMemCookie = methodHandle;
+    id->idDebugOnlyInfo()->idMemCookie = targetHandle;
     id->idDebugOnlyInfo()->idFlags     = gtFlags;
 #endif
 

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -810,7 +810,7 @@ void emitIns_I_AR(instruction ins, emitAttr attr, int val, regNumber reg, int of
 
 void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 
-void emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize_t disp);
+void emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize_t disp DEBUGARG(CORINFO_METHOD_HANDLE methodHandle = nullptr));
 
 void emitIns_AR_R(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -813,7 +813,7 @@ void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg,
 void emitIns_R_AI(instruction ins,
                   emitAttr    attr,
                   regNumber   ireg,
-                  ssize_t disp DEBUGARG(CORINFO_METHOD_HANDLE methodHandle = nullptr));
+                  ssize_t disp DEBUGARG(size_t methodHandle = 0) DEBUGARG(unsigned gtFlags = 0));
 
 void emitIns_AR_R(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -810,7 +810,10 @@ void emitIns_I_AR(instruction ins, emitAttr attr, int val, regNumber reg, int of
 
 void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 
-void emitIns_R_AI(instruction ins, emitAttr attr, regNumber ireg, ssize_t disp DEBUGARG(CORINFO_METHOD_HANDLE methodHandle = nullptr));
+void emitIns_R_AI(instruction ins,
+                  emitAttr    attr,
+                  regNumber   ireg,
+                  ssize_t disp DEBUGARG(CORINFO_METHOD_HANDLE methodHandle = nullptr));
 
 void emitIns_AR_R(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -813,7 +813,7 @@ void emitIns_R_AR(instruction ins, emitAttr attr, regNumber ireg, regNumber reg,
 void emitIns_R_AI(instruction ins,
                   emitAttr    attr,
                   regNumber   ireg,
-                  ssize_t disp DEBUGARG(size_t methodHandle = 0) DEBUGARG(unsigned gtFlags = 0));
+                  ssize_t disp DEBUGARG(size_t targetHandle = 0) DEBUGARG(unsigned gtFlags = 0));
 
 void emitIns_AR_R(instruction ins, emitAttr attr, regNumber ireg, regNumber reg, int offs);
 

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -7196,7 +7196,7 @@ GenTree* Compiler::gtCloneExpr(
                 else
 #endif
                 {
-                    copy                                  = gtNewIconNode(tree->AsIntCon()->gtIconVal, tree->gtType);
+                    copy = gtNewIconNode(tree->AsIntCon()->gtIconVal, tree->gtType);
 #ifdef DEBUG
                     copy->AsIntCon()->gtMethodHandle = tree->AsIntCon()->gtMethodHandle;
 #endif

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -5928,11 +5928,19 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
         case IAT_PVALUE: // The value needs to be accessed via an indirection
             // Create an indirection
             tree = gtNewIndOfIconHandleNode(TYP_REF, (size_t)pValue, GTF_ICON_STR_HDL, false);
+#ifdef DEBUG
+            tree->gtGetOp1()->AsIntCon()->gtMethodHandle =
+                (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StringLiteralNode;
+#endif
             break;
 
         case IAT_PPVALUE: // The value needs to be accessed via a double indirection
             // Create the first indirection
             tree = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pValue, GTF_ICON_PSTR_HDL, true);
+#ifdef DEBUG
+            tree->gtGetOp1()->AsIntCon()->gtMethodHandle =
+                (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StringLiteralNode;
+#endif
 
             // Create the second indirection
             tree = gtNewOperNode(GT_IND, TYP_REF, tree);
@@ -7189,6 +7197,9 @@ GenTree* Compiler::gtCloneExpr(
 #endif
                 {
                     copy                                  = gtNewIconNode(tree->AsIntCon()->gtIconVal, tree->gtType);
+#ifdef DEBUG
+                    copy->AsIntCon()->gtMethodHandle = tree->AsIntCon()->gtMethodHandle;
+#endif
                     copy->AsIntCon()->gtCompileTimeHandle = tree->AsIntCon()->gtCompileTimeHandle;
                     copy->AsIntCon()->gtFieldSeq          = tree->AsIntCon()->gtFieldSeq;
                 }

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -5922,15 +5922,17 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
         case IAT_VALUE: // constructStringLiteral in CoreRT case can return IAT_VALUE
             tree         = gtNewIconEmbHndNode(pValue, nullptr, GTF_ICON_STR_HDL, nullptr);
             tree->gtType = TYP_REF;
-            tree         = gtNewOperNode(GT_NOP, TYP_REF, tree); // prevents constant folding
+#ifdef DEBUG
+            tree->AsIntCon()->gtMethodHandle = (size_t)pValue;
+#endif
+            tree = gtNewOperNode(GT_NOP, TYP_REF, tree); // prevents constant folding
             break;
 
         case IAT_PVALUE: // The value needs to be accessed via an indirection
             // Create an indirection
             tree = gtNewIndOfIconHandleNode(TYP_REF, (size_t)pValue, GTF_ICON_STR_HDL, false);
 #ifdef DEBUG
-            tree->gtGetOp1()->AsIntCon()->gtMethodHandle =
-                (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StringLiteralNode;
+            tree->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)pValue;
 #endif
             break;
 
@@ -5938,8 +5940,7 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
             // Create the first indirection
             tree = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pValue, GTF_ICON_PSTR_HDL, true);
 #ifdef DEBUG
-            tree->gtGetOp1()->AsIntCon()->gtMethodHandle =
-                (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StringLiteralNode;
+            tree->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)pValue;
 #endif
 
             // Create the second indirection

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -5923,7 +5923,7 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
             tree         = gtNewIconEmbHndNode(pValue, nullptr, GTF_ICON_STR_HDL, nullptr);
             tree->gtType = TYP_REF;
 #ifdef DEBUG
-            tree->AsIntCon()->gtMethodHandle = (size_t)pValue;
+            tree->AsIntCon()->gtTargetHandle = (size_t)pValue;
 #endif
             tree = gtNewOperNode(GT_NOP, TYP_REF, tree); // prevents constant folding
             break;
@@ -5932,7 +5932,7 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
             // Create an indirection
             tree = gtNewIndOfIconHandleNode(TYP_REF, (size_t)pValue, GTF_ICON_STR_HDL, false);
 #ifdef DEBUG
-            tree->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)pValue;
+            tree->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)pValue;
 #endif
             break;
 
@@ -5940,7 +5940,7 @@ GenTree* Compiler::gtNewStringLiteralNode(InfoAccessType iat, void* pValue)
             // Create the first indirection
             tree = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)pValue, GTF_ICON_PSTR_HDL, true);
 #ifdef DEBUG
-            tree->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)pValue;
+            tree->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)pValue;
 #endif
 
             // Create the second indirection
@@ -7199,7 +7199,7 @@ GenTree* Compiler::gtCloneExpr(
                 {
                     copy = gtNewIconNode(tree->AsIntCon()->gtIconVal, tree->gtType);
 #ifdef DEBUG
-                    copy->AsIntCon()->gtMethodHandle = tree->AsIntCon()->gtMethodHandle;
+                    copy->AsIntCon()->gtTargetHandle = tree->AsIntCon()->gtTargetHandle;
 #endif
                     copy->AsIntCon()->gtCompileTimeHandle = tree->AsIntCon()->gtCompileTimeHandle;
                     copy->AsIntCon()->gtFieldSeq          = tree->AsIntCon()->gtFieldSeq;

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2971,8 +2971,9 @@ struct GenTreeIntCon : public GenTreeIntConCommon
                           RuntimeLookupTree        = 8,
                           IntializeArrayIntrinsics = 10,
                           StaticFieldAccess        = 12,
-                          GSCookieCheck            = 14,
-                          SetGSCookie              = 16};
+                          FieldAccess              = 14,
+                          GSCookieCheck            = 16,
+                          SetGSCookie              = 18};
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -138,6 +138,20 @@ enum gtCallTypes : BYTE
     CT_COUNT // fake entry (must be last)
 };
 
+#ifdef DEBUG
+/*****************************************************************************
+*
+*  TargetHandleTypes are used to determine the type of handle present inside GenTreeIntCon node.
+*  The values are such that they don't overlap with helper's or user function's handle.
+*/
+enum MethodHandleType : byte
+{
+    Unknown                  = 2,
+    GSCookieCheck            = 4,
+    SetGSCookie              = 6,
+    IntializeArrayIntrinsics = 8
+};
+#endif
 /*****************************************************************************/
 
 struct BasicBlock;
@@ -2962,18 +2976,7 @@ struct GenTreeIntCon : public GenTreeIntConCommon
 #ifdef DEBUG
     // If the value represents target address, holds the method handle to that target which is used
     // to fetch target method name and display in the disassembled code.
-    CORINFO_METHOD_HANDLE gtMethodHandle = (CORINFO_METHOD_HANDLE)Unknown;
-
-    // Enum values are such that they don't overlap with helper's or user function's method handle.
-    enum MethodHandleType{Unknown                  = 2,
-                          StringLiteralNode        = 4,
-                          StaticLookupTree         = 6,
-                          RuntimeLookupTree        = 8,
-                          IntializeArrayIntrinsics = 10,
-                          StaticFieldAccess        = 12,
-                          FieldAccess              = 14,
-                          GSCookieCheck            = 16,
-                          SetGSCookie              = 18};
+    size_t gtMethodHandle = 0;
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2964,14 +2964,15 @@ struct GenTreeIntCon : public GenTreeIntConCommon
     // to fetch target method name and display in the disassembled code.
     CORINFO_METHOD_HANDLE gtMethodHandle = (CORINFO_METHOD_HANDLE)Unknown;
 
-    enum MethodHandleType{Unknown = 0,
-                          StringLiteralNode,
-                          StaticLookupTree,
-                          RuntimeLookupTree,
-                          IntializeArrayIntrinsics,
-                          StaticFieldAccess,
-                          GSCookieCheck,
-                          SetGSCookie};
+    // Enum values are such that they don't overlap with helper's or user function's method handle.
+    enum MethodHandleType{Unknown                  = 2,
+                          StringLiteralNode        = 4,
+                          StaticLookupTree         = 6,
+                          RuntimeLookupTree        = 8,
+                          IntializeArrayIntrinsics = 10,
+                          StaticFieldAccess        = 12,
+                          GSCookieCheck            = 14,
+                          SetGSCookie              = 16};
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -144,7 +144,7 @@ enum gtCallTypes : BYTE
 *  TargetHandleTypes are used to determine the type of handle present inside GenTreeIntCon node.
 *  The values are such that they don't overlap with helper's or user function's handle.
 */
-enum TargetHandleType : byte
+enum TargetHandleType : BYTE
 {
     THT_Unknown                  = 2,
     THT_GSCookieCheck            = 4,

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -146,11 +146,10 @@ enum gtCallTypes : BYTE
 */
 enum TargetHandleType : byte
 {
-    Unknown                  = 2,
-    GSCookieCheck            = 4,
-    SetGSCookie              = 6,
-    StaticFieldAccess        = 8,
-    IntializeArrayIntrinsics = 10
+    THT_Unknown                  = 2,
+    THT_GSCookieCheck            = 4,
+    THT_SetGSCookie              = 6,
+    THT_IntializeArrayIntrinsics = 8
 };
 #endif
 /*****************************************************************************/

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2962,19 +2962,16 @@ struct GenTreeIntCon : public GenTreeIntConCommon
 #ifdef DEBUG
     // If the value represents target address, holds the method handle to that target which is used
     // to fetch target method name and display in the disassembled code.
-    CORINFO_METHOD_HANDLE gtMethodHandle = (CORINFO_METHOD_HANDLE) Unknown;
+    CORINFO_METHOD_HANDLE gtMethodHandle = (CORINFO_METHOD_HANDLE)Unknown;
 
-    enum MethodHandleType
-    {
-        Unknown = 0,
-        StringLiteralNode,
-        StaticLookupTree,
-        RuntimeLookupTree,
-        IntializeArrayIntrinsics,
-        StaticFieldAccess,
-        GCCookieCheck,
-        SetGCCookie
-    };
+    enum MethodHandleType{Unknown = 0,
+                          StringLiteralNode,
+                          StaticLookupTree,
+                          RuntimeLookupTree,
+                          IntializeArrayIntrinsics,
+                          StaticFieldAccess,
+                          GCCookieCheck,
+                          SetGCCookie};
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2970,8 +2970,8 @@ struct GenTreeIntCon : public GenTreeIntConCommon
                           RuntimeLookupTree,
                           IntializeArrayIntrinsics,
                           StaticFieldAccess,
-                          GCCookieCheck,
-                          SetGCCookie};
+                          GSCookieCheck,
+                          SetGSCookie};
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -2959,6 +2959,24 @@ struct GenTreeIntCon : public GenTreeIntConCommon
     // sequence of fields.
     FieldSeqNode* gtFieldSeq;
 
+#ifdef DEBUG
+    // If the value represents target address, holds the method handle to that target which is used
+    // to fetch target method name and display in the disassembled code.
+    CORINFO_METHOD_HANDLE gtMethodHandle = (CORINFO_METHOD_HANDLE) Unknown;
+
+    enum MethodHandleType
+    {
+        Unknown = 0,
+        StringLiteralNode,
+        StaticLookupTree,
+        RuntimeLookupTree,
+        IntializeArrayIntrinsics,
+        StaticFieldAccess,
+        GCCookieCheck,
+        SetGCCookie
+    };
+#endif
+
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))
         : GenTreeIntConCommon(GT_CNS_INT, type DEBUGARG(largeNode))
         , gtIconVal(value)

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -149,7 +149,8 @@ enum TargetHandleType : byte
     Unknown                  = 2,
     GSCookieCheck            = 4,
     SetGSCookie              = 6,
-    IntializeArrayIntrinsics = 8
+    StaticFieldAccess        = 8,
+    IntializeArrayIntrinsics = 10
 };
 #endif
 /*****************************************************************************/

--- a/src/coreclr/src/jit/gentree.h
+++ b/src/coreclr/src/jit/gentree.h
@@ -144,7 +144,7 @@ enum gtCallTypes : BYTE
 *  TargetHandleTypes are used to determine the type of handle present inside GenTreeIntCon node.
 *  The values are such that they don't overlap with helper's or user function's handle.
 */
-enum MethodHandleType : byte
+enum TargetHandleType : byte
 {
     Unknown                  = 2,
     GSCookieCheck            = 4,
@@ -2976,7 +2976,7 @@ struct GenTreeIntCon : public GenTreeIntConCommon
 #ifdef DEBUG
     // If the value represents target address, holds the method handle to that target which is used
     // to fetch target method name and display in the disassembled code.
-    size_t gtMethodHandle = 0;
+    size_t gtTargetHandle = 0;
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value DEBUGARG(bool largeNode = false))

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -7186,7 +7186,7 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                 op1 = gtNewIconHandleNode(pFldAddr == nullptr ? (size_t)fldAddr : (size_t)pFldAddr, GTF_ICON_STATIC_HDL,
                                           fldSeq);
 #ifdef DEBUG
-                op1->AsIntCon()->gtTargetHandle = op1->AsIntCon()->gtIconVal;
+                op1->AsIntCon()->gtTargetHandle = TargetHandleType::StaticFieldAccess;
 #endif
 
                 if (pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_INITCLASS)

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -11030,6 +11030,7 @@ void Compiler::impImportBlockCode(BasicBlock* block)
 
         unsigned mflags   = 0;
         unsigned clsFlags = 0;
+
         switch (opcode)
         {
             unsigned  lclNum;

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1893,12 +1893,11 @@ GenTree* Compiler::impLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 #ifdef DEBUG
         if (handle != nullptr)
         {
-            addr->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticLookupTree;
+            addr->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
         }
         else
         {
-            addr->gtGetOp1()->AsIntCon()->gtMethodHandle =
-                (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticLookupTree;
+            addr->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
         }
 #endif
         return addr;
@@ -1940,12 +1939,11 @@ GenTree* Compiler::impReadyToRunLookupToTree(CORINFO_CONST_LOOKUP* pLookup,
 #ifdef DEBUG
     if (handle != nullptr)
     {
-        addr->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::RuntimeLookupTree;
+        addr->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
     }
     else
     {
-        addr->gtGetOp1()->AsIntCon()->gtMethodHandle =
-            (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::RuntimeLookupTree;
+        addr->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
     }
 #endif //  DEBUG
     return addr;
@@ -3433,8 +3431,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
     GenTree* dst     = new (this, GT_BLK) GenTreeBlk(GT_BLK, TYP_STRUCT, dstAddr, typGetBlkLayout(blkSize));
     GenTree* src     = gtNewIndOfIconHandleNode(TYP_STRUCT, (size_t)initData, GTF_ICON_STATIC_HDL, false);
 #ifdef DEBUG
-    src->gtGetOp1()->AsIntCon()->gtMethodHandle =
-        (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::IntializeArrayIntrinsics;
+    src->gtGetOp1()->AsIntCon()->gtMethodHandle = MethodHandleType::IntializeArrayIntrinsics;
 #endif
 
     return gtNewBlkOpNode(dst,   // dst
@@ -7189,8 +7186,7 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                 op1 = gtNewIconHandleNode(pFldAddr == nullptr ? (size_t)fldAddr : (size_t)pFldAddr, GTF_ICON_STATIC_HDL,
                                           fldSeq);
 #ifdef DEBUG
-                op1->AsIntCon()->gtMethodHandle =
-                    (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticFieldAccess;
+                op1->AsIntCon()->gtMethodHandle = op1->AsIntCon()->gtIconVal;
 #endif
 
                 if (pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_INITCLASS)

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1893,11 +1893,11 @@ GenTree* Compiler::impLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken,
 #ifdef DEBUG
         if (handle != nullptr)
         {
-            addr->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
+            addr->AsIntCon()->gtTargetHandle = (size_t)compileTimeHandle;
         }
         else
         {
-            addr->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
+            addr->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)compileTimeHandle;
         }
 #endif
         return addr;
@@ -1939,11 +1939,11 @@ GenTree* Compiler::impReadyToRunLookupToTree(CORINFO_CONST_LOOKUP* pLookup,
 #ifdef DEBUG
     if (handle != nullptr)
     {
-        addr->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
+        addr->AsIntCon()->gtTargetHandle = (size_t)compileTimeHandle;
     }
     else
     {
-        addr->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)compileTimeHandle;
+        addr->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)compileTimeHandle;
     }
 #endif //  DEBUG
     return addr;
@@ -3431,7 +3431,7 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
     GenTree* dst     = new (this, GT_BLK) GenTreeBlk(GT_BLK, TYP_STRUCT, dstAddr, typGetBlkLayout(blkSize));
     GenTree* src     = gtNewIndOfIconHandleNode(TYP_STRUCT, (size_t)initData, GTF_ICON_STATIC_HDL, false);
 #ifdef DEBUG
-    src->gtGetOp1()->AsIntCon()->gtMethodHandle = MethodHandleType::IntializeArrayIntrinsics;
+    src->gtGetOp1()->AsIntCon()->gtTargetHandle = TargetHandleType::IntializeArrayIntrinsics;
 #endif
 
     return gtNewBlkOpNode(dst,   // dst
@@ -7186,7 +7186,7 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                 op1 = gtNewIconHandleNode(pFldAddr == nullptr ? (size_t)fldAddr : (size_t)pFldAddr, GTF_ICON_STATIC_HDL,
                                           fldSeq);
 #ifdef DEBUG
-                op1->AsIntCon()->gtMethodHandle = op1->AsIntCon()->gtIconVal;
+                op1->AsIntCon()->gtTargetHandle = op1->AsIntCon()->gtIconVal;
 #endif
 
                 if (pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_INITCLASS)

--- a/src/coreclr/src/jit/importer.cpp
+++ b/src/coreclr/src/jit/importer.cpp
@@ -1888,16 +1888,17 @@ GenTree* Compiler::impLookupToTree(CORINFO_RESOLVED_TOKEN* pResolvedToken,
         {
             pIndirection = pLookup->constLookup.addr;
         }
-        GenTree* addr =  gtNewIconEmbHndNode(handle, pIndirection, handleFlags, compileTimeHandle);
+        GenTree* addr = gtNewIconEmbHndNode(handle, pIndirection, handleFlags, compileTimeHandle);
 
-#ifdef  DEBUG
+#ifdef DEBUG
         if (handle != nullptr)
         {
             addr->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticLookupTree;
         }
         else
         {
-            addr->gtGetOp1()->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticLookupTree;
+            addr->gtGetOp1()->AsIntCon()->gtMethodHandle =
+                (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticLookupTree;
         }
 #endif
         return addr;
@@ -1936,14 +1937,15 @@ GenTree* Compiler::impReadyToRunLookupToTree(CORINFO_CONST_LOOKUP* pLookup,
         pIndirection = pLookup->addr;
     }
     GenTree* addr = gtNewIconEmbHndNode(handle, pIndirection, handleFlags, compileTimeHandle);
-#ifdef  DEBUG
+#ifdef DEBUG
     if (handle != nullptr)
     {
         addr->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::RuntimeLookupTree;
     }
     else
     {
-        addr->gtGetOp1()->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::RuntimeLookupTree;
+        addr->gtGetOp1()->AsIntCon()->gtMethodHandle =
+            (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::RuntimeLookupTree;
     }
 #endif //  DEBUG
     return addr;
@@ -3431,7 +3433,8 @@ GenTree* Compiler::impInitializeArrayIntrinsic(CORINFO_SIG_INFO* sig)
     GenTree* dst     = new (this, GT_BLK) GenTreeBlk(GT_BLK, TYP_STRUCT, dstAddr, typGetBlkLayout(blkSize));
     GenTree* src     = gtNewIndOfIconHandleNode(TYP_STRUCT, (size_t)initData, GTF_ICON_STATIC_HDL, false);
 #ifdef DEBUG
-    src->gtGetOp1()->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::IntializeArrayIntrinsics;
+    src->gtGetOp1()->AsIntCon()->gtMethodHandle =
+        (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::IntializeArrayIntrinsics;
 #endif
 
     return gtNewBlkOpNode(dst,   // dst
@@ -7186,7 +7189,8 @@ GenTree* Compiler::impImportStaticFieldAccess(CORINFO_RESOLVED_TOKEN* pResolvedT
                 op1 = gtNewIconHandleNode(pFldAddr == nullptr ? (size_t)fldAddr : (size_t)pFldAddr, GTF_ICON_STATIC_HDL,
                                           fldSeq);
 #ifdef DEBUG
-                op1->AsIntCon()->gtMethodHandle = (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticFieldAccess;
+                op1->AsIntCon()->gtMethodHandle =
+                    (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::StaticFieldAccess;
 #endif
 
                 if (pFieldInfo->fieldFlags & CORINFO_FLG_FIELD_INITCLASS)

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3629,7 +3629,7 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
                 // a single indirection.
                 GenTree* cellAddr = AddrGen(addr);
 #ifdef DEBUG
-                cellAddr->AsIntCon()->gtMethodHandle = (size_t)call->gtCallMethHnd;
+                cellAddr->AsIntCon()->gtTargetHandle = (size_t)call->gtCallMethHnd;
 #endif
                 GenTree* indir = Ind(cellAddr);
                 result         = indir;
@@ -4446,7 +4446,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
             case IAT_PVALUE:
                 addrTree = AddrGen(addr);
 #ifdef DEBUG
-                addrTree->AsIntCon()->gtMethodHandle = (size_t)methHnd;
+                addrTree->AsIntCon()->gtTargetHandle = (size_t)methHnd;
 #endif
                 result = Ind(addrTree);
                 break;
@@ -4454,7 +4454,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
             case IAT_PPVALUE:
                 addrTree = AddrGen(addr);
 #ifdef DEBUG
-                addrTree->AsIntCon()->gtMethodHandle = (size_t)methHnd;
+                addrTree->AsIntCon()->gtTargetHandle = (size_t)methHnd;
 #endif
                 result = Ind(Ind(addrTree));
                 break;

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3628,6 +3628,9 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
                 // Non-virtual direct calls to addresses accessed by
                 // a single indirection.
                 GenTree* cellAddr = AddrGen(addr);
+#ifdef DEBUG
+                cellAddr->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
+#endif
                 GenTree* indir    = Ind(cellAddr);
                 result            = indir;
             }
@@ -4420,6 +4423,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
         comp->info.compCompHnd->getAddressOfPInvokeTarget(methHnd, &lookup);
 
         void* addr = lookup.addr;
+        GenTree* addrTree; 
         switch (lookup.accessType)
         {
             case IAT_VALUE:
@@ -4440,11 +4444,19 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
                 break;
 
             case IAT_PVALUE:
-                result = Ind(AddrGen(addr));
+                addrTree   = AddrGen(addr);
+#ifdef DEBUG
+                addrTree->AsIntCon()->gtMethodHandle = methHnd;
+#endif
+                result = Ind(addrTree);
                 break;
 
             case IAT_PPVALUE:
-                result = Ind(Ind(AddrGen(addr)));
+                addrTree                    = AddrGen(addr);
+#ifdef DEBUG
+                addrTree->AsIntCon()->gtMethodHandle = methHnd;
+#endif
+                result = Ind(Ind(addrTree));
                 break;
 
             case IAT_RELPVALUE:

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3629,7 +3629,7 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
                 // a single indirection.
                 GenTree* cellAddr = AddrGen(addr);
 #ifdef DEBUG
-                cellAddr->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
+                cellAddr->AsIntCon()->gtMethodHandle = (size_t)call->gtCallMethHnd;
 #endif
                 GenTree* indir = Ind(cellAddr);
                 result         = indir;
@@ -4446,7 +4446,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
             case IAT_PVALUE:
                 addrTree = AddrGen(addr);
 #ifdef DEBUG
-                addrTree->AsIntCon()->gtMethodHandle = methHnd;
+                addrTree->AsIntCon()->gtMethodHandle = (size_t)methHnd;
 #endif
                 result = Ind(addrTree);
                 break;
@@ -4454,7 +4454,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
             case IAT_PPVALUE:
                 addrTree = AddrGen(addr);
 #ifdef DEBUG
-                addrTree->AsIntCon()->gtMethodHandle = methHnd;
+                addrTree->AsIntCon()->gtMethodHandle = (size_t)methHnd;
 #endif
                 result = Ind(Ind(addrTree));
                 break;

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3631,8 +3631,8 @@ GenTree* Lowering::LowerDirectCall(GenTreeCall* call)
 #ifdef DEBUG
                 cellAddr->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
 #endif
-                GenTree* indir    = Ind(cellAddr);
-                result            = indir;
+                GenTree* indir = Ind(cellAddr);
+                result         = indir;
             }
             break;
         }
@@ -4422,8 +4422,8 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
         CORINFO_CONST_LOOKUP lookup;
         comp->info.compCompHnd->getAddressOfPInvokeTarget(methHnd, &lookup);
 
-        void* addr = lookup.addr;
-        GenTree* addrTree; 
+        void*    addr = lookup.addr;
+        GenTree* addrTree;
         switch (lookup.accessType)
         {
             case IAT_VALUE:
@@ -4444,7 +4444,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
                 break;
 
             case IAT_PVALUE:
-                addrTree   = AddrGen(addr);
+                addrTree = AddrGen(addr);
 #ifdef DEBUG
                 addrTree->AsIntCon()->gtMethodHandle = methHnd;
 #endif
@@ -4452,7 +4452,7 @@ GenTree* Lowering::LowerNonvirtPinvokeCall(GenTreeCall* call)
                 break;
 
             case IAT_PPVALUE:
-                addrTree                    = AddrGen(addr);
+                addrTree = AddrGen(addr);
 #ifdef DEBUG
                 addrTree->AsIntCon()->gtMethodHandle = methHnd;
 #endif

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6097,6 +6097,8 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             {
                 offsetNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)tree->AsField()->gtFieldLookup.addr,
                                                       GTF_ICON_FIELD_HDL, false);
+                offsetNode->gtGetOp1()->AsIntCon()->gtMethodHandle =
+                    (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::FieldAccess;
             }
             else
             {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -6097,8 +6097,10 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
             {
                 offsetNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)tree->AsField()->gtFieldLookup.addr,
                                                       GTF_ICON_FIELD_HDL, false);
+#ifdef DEBUG
                 offsetNode->gtGetOp1()->AsIntCon()->gtMethodHandle =
                     (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::FieldAccess;
+#endif
             }
             else
             {

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -2705,7 +2705,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         size_t   addrValue           = (size_t)call->gtEntryPoint.addr;
         GenTree* indirectCellAddress = gtNewIconHandleNode(addrValue, GTF_ICON_FTN_ADDR);
 #ifdef DEBUG
-        indirectCellAddress->AsIntCon()->gtMethodHandle = (size_t)call->gtCallMethHnd;
+        indirectCellAddress->AsIntCon()->gtTargetHandle = (size_t)call->gtCallMethHnd;
 #endif
         indirectCellAddress->SetRegNum(REG_R2R_INDIRECT_PARAM);
 
@@ -6098,7 +6098,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
                 offsetNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)tree->AsField()->gtFieldLookup.addr,
                                                       GTF_ICON_FIELD_HDL, false);
 #ifdef DEBUG
-                offsetNode->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)symHnd;
+                offsetNode->gtGetOp1()->AsIntCon()->gtTargetHandle = (size_t)symHnd;
 #endif
             }
             else
@@ -8398,7 +8398,7 @@ GenTree* Compiler::fgGetStubAddrArg(GenTreeCall* call)
         ssize_t addr = ssize_t(call->gtStubCallStubAddr);
         stubAddrArg  = gtNewIconHandleNode(addr, GTF_ICON_FTN_ADDR);
 #ifdef DEBUG
-        stubAddrArg->AsIntCon()->gtMethodHandle = (size_t)call->gtCallMethHnd;
+        stubAddrArg->AsIntCon()->gtTargetHandle = (size_t)call->gtCallMethHnd;
 #endif
     }
     assert(stubAddrArg != nullptr);

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -2704,6 +2704,9 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 
         size_t   addrValue           = (size_t)call->gtEntryPoint.addr;
         GenTree* indirectCellAddress = gtNewIconHandleNode(addrValue, GTF_ICON_FTN_ADDR);
+#ifdef DEBUG
+        indirectCellAddress->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
+#endif
         indirectCellAddress->SetRegNum(REG_R2R_INDIRECT_PARAM);
 
         // Push the stub address onto the list of arguments.
@@ -8391,6 +8394,9 @@ GenTree* Compiler::fgGetStubAddrArg(GenTreeCall* call)
         assert(call->gtCallMoreFlags & GTF_CALL_M_VIRTSTUB_REL_INDIRECT);
         ssize_t addr = ssize_t(call->gtStubCallStubAddr);
         stubAddrArg  = gtNewIconHandleNode(addr, GTF_ICON_FTN_ADDR);
+#ifdef DEBUG
+        stubAddrArg->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
+#endif
     }
     assert(stubAddrArg != nullptr);
     stubAddrArg->SetRegNum(virtualStubParamInfo->GetReg());

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -2705,7 +2705,7 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         size_t   addrValue           = (size_t)call->gtEntryPoint.addr;
         GenTree* indirectCellAddress = gtNewIconHandleNode(addrValue, GTF_ICON_FTN_ADDR);
 #ifdef DEBUG
-        indirectCellAddress->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
+        indirectCellAddress->AsIntCon()->gtMethodHandle = (size_t)call->gtCallMethHnd;
 #endif
         indirectCellAddress->SetRegNum(REG_R2R_INDIRECT_PARAM);
 
@@ -6098,8 +6098,7 @@ GenTree* Compiler::fgMorphField(GenTree* tree, MorphAddrContext* mac)
                 offsetNode = gtNewIndOfIconHandleNode(TYP_I_IMPL, (size_t)tree->AsField()->gtFieldLookup.addr,
                                                       GTF_ICON_FIELD_HDL, false);
 #ifdef DEBUG
-                offsetNode->gtGetOp1()->AsIntCon()->gtMethodHandle =
-                    (CORINFO_METHOD_HANDLE)GenTreeIntCon::MethodHandleType::FieldAccess;
+                offsetNode->gtGetOp1()->AsIntCon()->gtMethodHandle = (size_t)symHnd;
 #endif
             }
             else
@@ -8399,7 +8398,7 @@ GenTree* Compiler::fgGetStubAddrArg(GenTreeCall* call)
         ssize_t addr = ssize_t(call->gtStubCallStubAddr);
         stubAddrArg  = gtNewIconHandleNode(addr, GTF_ICON_FTN_ADDR);
 #ifdef DEBUG
-        stubAddrArg->AsIntCon()->gtMethodHandle = call->gtCallMethHnd;
+        stubAddrArg->AsIntCon()->gtMethodHandle = (size_t)call->gtCallMethHnd;
 #endif
     }
     assert(stubAddrArg != nullptr);


### PR DESCRIPTION
Added method names next to the disasm code of adrp/add to reflect the target method. I tried checking every possible code path that generated adrp/add for `System.Private.Corelib.dll` and passed `methodHandle` that can be queried during disassembly printing to get the target method name. For places where `methodHandle` was not available (or I was not sure what to use) added `MethodHandleType enum` to tell disassembler what type of target it is. I made sure that the values of these enum don't overlap with those of helper or user function. So for `System.Private.Corelib`, we should never see `Unknown` as the target method name. However just before sending out this PR, I ran crossgen over framework libraries and I see bunch of places where we are seeing `Unknown`. Finding those code path should be easy because in a separate branch I added logging at around 60 places to track those code path. 

~If I get time, I will try to fix those code path as well, but just wanted to send out PR.~ I added one last `FieldAccess` type after which we have valid target name for all generated crossgened code for framework libraries.

Below are type of target methods that are identified and printed in disassembly.


| Scenario                                       | Count |
|------------------------------------------------|-------|
| Helper call                                    | 10813 |
| Virtual stub address                           | 2730  |
| Indirect cell address                          | 80486 |
| GS cookie check                                | 521   |
| Setting GS cookie                              | 381   |
| Static field access                            | 101   |
| Direct call (indirection access)               | 5937  |
| Nonvirtual PInvoke (double indirection access) | 201   |
|  Nonvirtual PInvoke (indirection access)       | 4     |
| String literal lookup                          | 15984 |
| Static lookup tree                             | 2112  |
| Runtime lookup tree                            | 443   |
| Initialize array elements                      | 87    |

With this change, here is the sample asm:

```asm
        2A1403E2          mov     w2, w20
        B9008FA2          str     w2, [fp,#140]
        9000000B          adrp    x11, [HIGH RELOC #0x29747e95ca8]      // [BCrypt:BCryptGenRandom(long,long,int,int):int]
        9100016B          add     x11, x11, [LOW RELOC #0x29747e95ca8]
        F9003FAB          str     x11, [fp,#120]
        D2800000          mov     x0, #0
        F9003BA0          str     x0, [fp,#112]
        52800043          mov     w3, #2
        B9008BA3          str     w3, [fp,#136]
        910063A0          add     x0, fp, #24   // [V14 PInvokeFrame]
        90000004          adrp    x4, [HIGH RELOC #0x29747e96080]      // [CORINFO_HELP_JIT_PINVOKE_BEGIN]
        91000084          add     x4, x4, [LOW RELOC #0x29747e96080]
        F9400084          ldr     x4, [x4]
```

Fixes: https://github.com/dotnet/runtime/issues/35271