### PR TITLE
[wasm] Add assembly level skip for System.Net.Requests on Browser

### DIFF
--- a/src/libraries/System.Net.Requests/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Requests/tests/AssemblyInfo.cs
@@ -5,3 +5,4 @@
 using Xunit;
 
 [assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/38283", TestPlatforms.Browser)]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -26,13 +26,10 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http.Json\tests\FunctionalTests\System.Net.Http.Json.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Mail\tests\Functional\System.Net.Mail.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Requests\tests\System.Net.Requests.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets\tests\System.Net.WebSockets.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\tests\System.Net.WebSockets.WebSocketProtocol.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Dataflow\tests\System.Threading.Tasks.Dataflow.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Tasks.Extensions\tests\System.Threading.Tasks.Extensions.Tests.csproj" />
     <!-- Builds currently do not pass -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Common\tests\Common.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.FileExtensions\tests\Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj" />


### PR DESCRIPTION
When running the tests for `System.Net.Requests` on Browser, the tests that hang all have `async Task`. Until there is support for these tests, an assembly level skip will be added to skip the entire test suite. This PR looks to make the `System.Net.Requests.Tests` test suite pass on WebAssembly.
```Tests run: 0, Errors: 0, Failures: 0, Skipped: 0. Time: 0.003914s```

Contributes to #38422 

The following is the `git diff --stat` showing the corresponding changes if hanging tests were disabled instead of the entire suite.
``` 
src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs                      |  2 +-
src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs                      | 52 ++++++++++++++++++++++++++--------------------------
src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs               |  6 +++---
src/libraries/System.Net.Requests/tests/HttpWebResponseTest.cs                     | 12 ++++++------
src/libraries/System.Net.Requests/tests/RequestStreamTest.cs                       | 40 ++++++++++++++++++++--------------------
```