### PR TITLE
Align native SpecializeComparer with managed ComparerHelpers

### DIFF
--- a/src/coreclr/src/vm/compile.cpp
+++ b/src/coreclr/src/vm/compile.cpp
@@ -4803,7 +4803,7 @@ static BOOL CanSatisfyConstraints(Instantiation typicalInst, Instantiation candi
 
 
 //
-// This method has duplicated logic from bcl\system\collections\generic\comparer.cs
+// This method has duplicated logic from coreclr\src\System.Private.CoreLib\src\System\Collections\Generic\ComparerHelpers.cs
 //
 static void SpecializeComparer(SString& ss, Instantiation& inst)
 {
@@ -4843,26 +4843,14 @@ static void SpecializeComparer(SString& ss, Instantiation& inst)
         CorElementType et = elemTypeHnd.GetVerifierCorElementType();
         if (et == ELEMENT_TYPE_I1 ||
             et == ELEMENT_TYPE_I2 ||
-            et == ELEMENT_TYPE_I4)
-        {
-            ss.Set(W("System.Collections.Generic.Int32EnumComparer`1"));
-            return;
-        }
-        if (et == ELEMENT_TYPE_U1 ||
+            et == ELEMENT_TYPE_I4 ||
+            et == ELEMENT_TYPE_I8 ||
+            et == ELEMENT_TYPE_U1 ||
             et == ELEMENT_TYPE_U2 ||
-            et == ELEMENT_TYPE_U4)
+            et == ELEMENT_TYPE_U4 ||
+            et == ELEMENT_TYPE_U8)
         {
-            ss.Set(W("System.Collections.Generic.UInt32EnumComparer`1"));
-            return;
-        }
-        if (et == ELEMENT_TYPE_I8)
-        {
-            ss.Set(W("System.Collections.Generic.Int64EnumComparer`1"));
-            return;
-        }
-        if (et == ELEMENT_TYPE_U8)
-        {
-            ss.Set(W("System.Collections.Generic.UInt64EnumComparer`1"));
+            ss.Set(W("System.Collections.Generic.EnumComparer`1"));
             return;
         }
     }

--- a/src/coreclr/src/vm/compile.cpp
+++ b/src/coreclr/src/vm/compile.cpp
@@ -4857,7 +4857,7 @@ static void SpecializeComparer(SString& ss, Instantiation& inst)
 }
 
 //
-// This method has duplicated logic from bcl\system\collections\generic\equalitycomparer.cs
+// This method has duplicated logic from coreclr\src\System.Private.CoreLib\src\System\Collections\Generic\ComparerHelpers.cs
 // and matching logic in jitinterface.cpp
 //
 static void SpecializeEqualityComparer(SString& ss, Instantiation& inst)
@@ -4895,23 +4895,17 @@ static void SpecializeEqualityComparer(SString& ss, Instantiation& inst)
 
     if (elemTypeHnd.IsEnum())
     {
-        // Note: We have different comparers for Short and SByte because for those types we need to make sure we call GetHashCode on the actual underlying type as the
-        // implementation of GetHashCode is more complex than for the other types.
         CorElementType et = elemTypeHnd.GetVerifierCorElementType();
-        if (et == ELEMENT_TYPE_I4 ||
-            et == ELEMENT_TYPE_U4 ||
-            et == ELEMENT_TYPE_U2 ||
+        if (et == ELEMENT_TYPE_I1 ||
             et == ELEMENT_TYPE_I2 ||
+            et == ELEMENT_TYPE_I4 ||
+            et == ELEMENT_TYPE_I8 ||
             et == ELEMENT_TYPE_U1 ||
-            et == ELEMENT_TYPE_I1)
+            et == ELEMENT_TYPE_U2 ||
+            et == ELEMENT_TYPE_U4 ||
+            et == ELEMENT_TYPE_U8)
         {
             ss.Set(W("System.Collections.Generic.EnumEqualityComparer`1"));
-            return;
-        }
-        else if (et == ELEMENT_TYPE_I8 ||
-                 et == ELEMENT_TYPE_U8)
-        {
-            ss.Set(W("System.Collections.Generic.LongEnumEqualityComparer`1"));
             return;
         }
     }


### PR DESCRIPTION
The various `EnumComparer`s have been streamlined in https://github.com/dotnet/coreclr/commit/82e02f37564f83c3a7c90e5e28a652a39017701a two years ago.
This PR reflects those changes in the duplicate native code.

This inconsistency is currently blocking #37546.

/cc @nattress, @jkotas