### PR TITLE
Remove BinaryFormatter from System.Transactions.Local

### DIFF
--- a/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.csproj
+++ b/src/libraries/System.Transactions.Local/ref/System.Transactions.Local.csproj
@@ -10,7 +10,5 @@
   <ItemGroup>
     <ProjectReference Include="..\..\System.Runtime\ref\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Runtime.InteropServices\ref\System.Runtime.InteropServices.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Serialization.Primitives\ref\System.Runtime.Serialization.Primitives.csproj" />
-    <ProjectReference Include="..\..\System.Runtime.Serialization.Formatters\ref\System.Runtime.Serialization.Formatters.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Transactions.Local/src/Resources/Strings.resx
+++ b/src/libraries/System.Transactions.Local/src/Resources/Strings.resx
@@ -62,7 +62,6 @@
   <data name="BadResourceManagerId" xml:space="preserve"><value>Resource Manager Identifiers cannot be Guid.Empty.</value></data>
   <data name="CannotPromoteSnapshot" xml:space="preserve"><value>Transactions with IsolationLevel Snapshot cannot be promoted.</value></data>
   <data name="CannotSetCurrent" xml:space="preserve"><value>Current cannot be set directly when Com+ Interop is enabled.</value></data>
-  <data name="ConfigInvalidTimeSpanValue" xml:space="preserve"><value>Valid TimeSpan values are greater than TimeSpan.Zero.</value></data>
   <data name="CurrentDelegateSet" xml:space="preserve"><value>The delegate for an external current can only be set once.</value></data>
   <data name="DisposeScope" xml:space="preserve"><value>The current TransactionScope is already complete. You should dispose the TransactionScope.</value></data>
   <data name="EnlistmentStateException" xml:space="preserve"><value>The operation is not valid for the current state of the enlistment.</value></data>

--- a/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
+++ b/src/libraries/System.Transactions.Local/src/System.Transactions.Local.csproj
@@ -46,7 +46,6 @@
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.Extensions" />
     <Reference Include="System.Runtime.InteropServices" />
-    <Reference Include="System.Runtime.Serialization.Formatters" />
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.Thread" />
     <Reference Include="System.Threading.ThreadPool" />

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/Configuration/DefaultSettingsSection.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/Configuration/DefaultSettingsSection.cs
@@ -16,14 +16,6 @@ namespace System.Transactions.Configuration
         public TimeSpan Timeout
         {
             get { return s_timeout; }
-            set
-            {
-                if (value < TimeSpan.Zero || value > TimeSpan.MaxValue)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(Timeout), SR.ConfigInvalidTimeSpanValue);
-                }
-                s_timeout = value;
-            }
         }
     }
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/Configuration/MachineSettingsSection.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/Configuration/MachineSettingsSection.cs
@@ -14,14 +14,6 @@ namespace System.Transactions.Configuration
         public TimeSpan MaxTimeout
         {
             get { return s_maxTimeout; }
-            set
-            {
-                if (value < TimeSpan.Zero || value > TimeSpan.MaxValue)
-                {
-                    throw new ArgumentOutOfRangeException(nameof(MaxTimeout), SR.ConfigInvalidTimeSpanValue);
-                }
-                s_maxTimeout = value;
-            }
         }
     }
 }

--- a/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
+++ b/src/libraries/System.Transactions.Local/src/System/Transactions/TransactionManager.cs
@@ -4,10 +4,7 @@
 
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.IO;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Threading;
 using System.Transactions.Configuration;
 using System.Transactions.Distributed;
@@ -22,7 +19,6 @@ namespace System.Transactions
     {
         // Revovery Information Version
         private const int RecoveryInformationVersion1 = 1;
-        private const int CurrentRecoveryVersion = RecoveryInformationVersion1;
 
         // Hashtable of promoted transactions, keyed by identifier guid.  This is used by
         // FindPromotedTransaction to support transaction equivalence when a transaction is
@@ -372,77 +368,6 @@ namespace System.Transactions
 
                 return s_maximumTimeout;
             }
-        }
-
-
-        // This routine writes the "header" for the recovery information, based on the
-        // type of the calling object and its provided parameter collection.  This information
-        // we be read back by the static Reenlist method to create the necessary transaction
-        // manager object with the right parameters in order to do a ReenlistTransaction call.
-        internal static byte[] GetRecoveryInformation(string? startupInfo, byte[] resourceManagerRecoveryInformation)
-        {
-            TransactionsEtwProvider etwLog = TransactionsEtwProvider.Log;
-            if (etwLog.IsEnabled())
-            {
-                etwLog.MethodEnter(TraceSourceType.TraceSourceBase, "TransactionManager.GetRecoveryInformation");
-            }
-
-            MemoryStream stream = new MemoryStream();
-            byte[]? returnValue = null;
-
-            try
-            {
-                // Manually write the recovery information
-                BinaryWriter writer = new BinaryWriter(stream);
-
-                writer.Write(TransactionManager.CurrentRecoveryVersion);
-                if (startupInfo != null)
-                {
-                    writer.Write(startupInfo);
-                }
-                else
-                {
-                    writer.Write("");
-                }
-                writer.Write(resourceManagerRecoveryInformation);
-                writer.Flush();
-                returnValue = stream.ToArray();
-            }
-            finally
-            {
-                stream.Dispose();
-            }
-
-            if (etwLog.IsEnabled())
-            {
-                etwLog.MethodExit(TraceSourceType.TraceSourceBase, "TransactionManager.GetRecoveryInformation");
-            }
-
-            return returnValue;
-        }
-
-        internal static byte[] ConvertToByteArray(object thingToConvert)
-        {
-            MemoryStream streamToWrite = new MemoryStream();
-            byte[]? returnValue = null;
-
-            try
-            {
-                // First seralize the type to the stream.
-                IFormatter formatter = new BinaryFormatter();
-                formatter.Serialize(streamToWrite, thingToConvert);
-
-                returnValue = new byte[streamToWrite.Length];
-
-                streamToWrite.Position = 0;
-                streamToWrite.Read(returnValue, 0, Convert.ToInt32(streamToWrite.Length, CultureInfo.InvariantCulture));
-            }
-            finally
-            {
-                streamToWrite.Dispose();
-            }
-
-            return returnValue;
         }
 
         /// <summary>


### PR DESCRIPTION
This was a dead code path that had no callers. I also removed some other low-hanging fruit call sites from `TransactionManager` and the _Configuration_ namespace, which further allowed removal of an unused resource string.

Contributes to https://github.com/dotnet/runtime/issues/38682.