### PR TITLE
Add more System.Net.Http counters

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -19,8 +19,11 @@ namespace System.Net.Http
         private PollingCounter? _startedRequestsCounter;
         private PollingCounter? _currentRequestsCounter;
         private PollingCounter? _abortedRequestsCounter;
+
+#if !TARGETS_BROWSER
         private PollingCounter? _maxHttp11ConnectionsPerPoolCounter;
         private PollingCounter? _maxHttp20StreamsPerConnectionCounter;
+#endif
 
         private long _startedRequests;
         private long _stoppedRequests;
@@ -99,6 +102,7 @@ namespace System.Net.Http
                     DisplayName = "Current Requests"
                 };
 
+#if !TARGETS_BROWSER
                 _maxHttp11ConnectionsPerPoolCounter ??= new PollingCounter("http11-connections-single-pool-max", this, () => HttpConnectionPoolManager.GetMaxHttp11ConnectionsPerPool())
                 {
                     DisplayName = "Maximum Http 1.1 Connections per Connection Pool"
@@ -108,6 +112,7 @@ namespace System.Net.Http
                 {
                     DisplayName = "Maximum Http Streams per Http 2.0 Connection"
                 };
+#endif
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -19,6 +19,8 @@ namespace System.Net.Http
         private PollingCounter? _startedRequestsCounter;
         private PollingCounter? _currentRequestsCounter;
         private PollingCounter? _abortedRequestsCounter;
+        private PollingCounter? _maxHttp11ConnectionsPerPoolCounter;
+        private PollingCounter? _maxHttp20StreamsPerConnectionCounter;
 
         private long _startedRequests;
         private long _stoppedRequests;
@@ -95,6 +97,16 @@ namespace System.Net.Http
                 _currentRequestsCounter ??= new PollingCounter("current-requests", this, () => -Interlocked.Read(ref _stoppedRequests) + Interlocked.Read(ref _startedRequests))
                 {
                     DisplayName = "Current Requests"
+                };
+
+                _maxHttp11ConnectionsPerPoolCounter ??= new PollingCounter("http11-connections-single-pool-max", this, () => HttpConnectionPoolManager.GetMaxHttp11ConnectionsPerPool())
+                {
+                    DisplayName = "Maximum Http 1.1 Connections per Connection Pool"
+                };
+
+                _maxHttp20StreamsPerConnectionCounter ??= new PollingCounter("http20-streams-single-connection-max", this, () => HttpConnectionPoolManager.GetMaxHttp20StreamsPerConnection())
+                {
+                    DisplayName = "Maximum Http Streams per Http 2.0 Connection"
                 };
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1559,6 +1559,8 @@ namespace System.Net.Http
             }
         }
 
+        public int HttpStreamCount => _httpStreams.Count;
+
         private enum FrameType : byte
         {
             Data = 0,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -1553,6 +1553,10 @@ namespace System.Net.Http
                 memberName,                  // method name
                 message);                    // message
 
+        public int Http11ConnectionCount => _associatedConnectionCount;
+
+        public int Http20StreamCount => _http2Connection?.HttpStreamCount ?? 0;
+
         /// <summary>A cached idle connection and metadata about it.</summary>
         [StructLayout(LayoutKind.Auto)]
         private readonly struct CachedConnection : IEquatable<CachedConnection>


### PR DESCRIPTION
Add `http11-connections-single-pool-max` (HTTP 1.1 connections per pool)
The maximum number (high-water mark) of TCP connections across any HTTP 1.1 connection pool in SocketsHttpHandler.

Add `http20-streams-single-connection-max` (HTTP 2.0 streams per connection)
The maximum number (high-water mark) of HTTP/2 streams across any HTTP 2.0 connection in SocketsHttpHandler.

Contributes to #37428