### PR TITLE
WASM: Add an internal method to pump the threadpool

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -319,6 +319,8 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern DeserializationTracker GetThreadDeserializationTracker(ref StackCrawlMark stackMark);
 
+        internal const bool IsThreadStartSupported = true;
+
         /// <summary>Returns true if the thread has been started and is not dead.</summary>
         public extern bool IsAlive
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -372,13 +372,7 @@ namespace System.Threading
         [System.Diagnostics.Conditional("DEBUG")]
         internal static void CheckThreadPoolAndContextsAreDefault()
         {
-            if (Thread.IsThreadStartSupported)
-            {
-#pragma warning disable CS0162 // Unreachable code detected. Thread.IsThreadStartSupported is constant false in runtimes where we can't create threads.
-                Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
-#pragma warning restore CS0162
-            }
-
+            Debug.Assert(!Thread.IsThreadStartSupported || Thread.CurrentThread.IsThreadPoolThread); // there are no dedicated threadpool threads on runtimes where we can't start threads
             Debug.Assert(Thread.CurrentThread._executionContext == null, "ThreadPool thread not on Default ExecutionContext.");
             Debug.Assert(Thread.CurrentThread._synchronizationContext == null, "ThreadPool thread not on Default SynchronizationContext.");
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs
@@ -372,7 +372,13 @@ namespace System.Threading
         [System.Diagnostics.Conditional("DEBUG")]
         internal static void CheckThreadPoolAndContextsAreDefault()
         {
-            Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
+            if (Thread.IsThreadStartSupported)
+            {
+#pragma warning disable CS0162 // Unreachable code detected. Thread.IsThreadStartSupported is constant false in runtimes where we can't create threads.
+                Debug.Assert(Thread.CurrentThread.IsThreadPoolThread);
+#pragma warning restore CS0162
+            }
+
             Debug.Assert(Thread.CurrentThread._executionContext == null, "ThreadPool thread not on Default ExecutionContext.");
             Debug.Assert(Thread.CurrentThread._synchronizationContext == null, "ThreadPool thread not on Default SynchronizationContext.");
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ThreadPoolTaskScheduler.cs
@@ -43,7 +43,7 @@ namespace System.Threading.Tasks
         protected internal override void QueueTask(Task task)
         {
             TaskCreationOptions options = task.Options;
-            if ((options & TaskCreationOptions.LongRunning) != 0)
+            if (Thread.IsThreadStartSupported && (options & TaskCreationOptions.LongRunning) != 0)
             {
                 // Run LongRunning tasks on their own dedicated thread.
                 Thread thread = new Thread(s_longRunningThreadWork);

--- a/src/mono/mono/mini/mini-wasm.c
+++ b/src/mono/mono/mini/mini-wasm.c
@@ -395,6 +395,9 @@ extern void mono_set_timeout (int t, int d);
 extern void mono_wasm_queue_tp_cb (void);
 G_END_DECLS
 
+extern void mono_wasm_pump_threadpool (void);
+void mono_background_exec (void);
+
 #endif // HOST_WASM
 
 gpointer
@@ -621,11 +624,20 @@ mono_wasm_queue_tp_cb (void)
 }
 
 void
+mono_wasm_pump_threadpool (void)
+{
+#ifdef HOST_WASM
+	mono_background_exec ();
+#endif
+}
+
+void
 mono_arch_register_icall (void)
 {
 #ifdef ENABLE_NETCORE
 	mono_add_internal_call_internal ("System.Threading.TimerQueue::SetTimeout", mono_wasm_set_timeout);
 	mono_add_internal_call_internal ("System.Threading.ThreadPool::QueueCallback", mono_wasm_queue_tp_cb);
+	mono_add_internal_call_internal ("System.Threading.ThreadPool::PumpThreadPool", mono_wasm_pump_threadpool);
 #else
 	mono_add_internal_call_internal ("System.Threading.WasmRuntime::SetTimeout", mono_wasm_set_timeout);
 #endif

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -304,7 +304,11 @@
   <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
       <Compile Include="$(BclSourcesRoot)\System\Threading\TimerQueue.Browser.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Threading\ThreadPool.Browser.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Threading\Thread.Browser.Mono.cs" />
       <Compile Include="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System\Threading\ThreadPoolBoundHandle.PlatformNotSupported.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
+      <Compile Include="$(BclSourcesRoot)\System\Threading\Thread.UnixOrWindows.Mono.cs" />
   </ItemGroup>
   <ItemGroup>
       <Compile Include="$(BclSourcesRoot)\Mono\RuntimeStructs.cs" />

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.Browser.Mono.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading
+{
+    public partial class Thread
+    {
+        internal const bool IsThreadStartSupported = false;
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.UnixOrWindows.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/Thread.UnixOrWindows.Mono.cs
@@ -1,0 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Threading
+{
+    public partial class Thread
+    {
+        internal const bool IsThreadStartSupported = true;
+    }
+}

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Mono.cs
@@ -107,8 +107,12 @@ namespace System.Threading
         }
 
         [DynamicDependency("Callback")]
+        [DynamicDependency("PumpThreadPool")]
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void QueueCallback();
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern void PumpThreadPool(); // NOTE: this method is called via reflection by test code
 
         private static void Callback()
         {


### PR DESCRIPTION
This can by used by the xharness xunit runner to make sure async tasks are executed.

We also need to tweak how `ThreadPoolTaskScheduler` handles `TaskCreationOptions.LongRunning` since the usual mode of starting a new thread doesn't work, instead we treat it like the option wasn't set and queue the task on the threadpool.