### PR TITLE
[Wasm]Adjust AppContext.BaseDirectory and enable Microsoft.Extensions tests 

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/tests/XmlConfigurationTest.cs
@@ -432,7 +432,8 @@ namespace Microsoft.Extensions.Configuration.Xml.Test
             var config = new ConfigurationBuilder().AddXmlFile("NotExistingConfig.xml", optional: true).Build();
         }
 
-        [ConditionalFact]
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]
         [FrameworkSkipCondition(RuntimeFrameworks.Mono)]
         public void LoadKeyValuePairsFromValidEncryptedXml()
         {

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -902,6 +902,7 @@ IniKey1=IniValue2");
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34580", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+        [SkipOnMono("System.IO.FileSystem.Watcher is not supported on wasm", TestPlatforms.Browser)]
         public void CanEnumerateProviders()
         {
             var config = CreateBuilder()

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/AssemblyInfo.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/AssemblyInfo.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/37669", TestPlatforms.Browser)]

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -45,7 +45,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\AggregateException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'" />
-    <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.UnixOrWindows.cs" Condition="'$(TargetsBrowser)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.AnyOS.cs" Condition="'$(TargetsBrowser)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomainSetup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomainUnloadedException.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -44,6 +44,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Activator.RuntimeType.cs" Condition="'$(TargetsCoreRT)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AggregateException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.Browser.cs" Condition="'$(TargetsBrowser)' == 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\AppContext.UnixOrWindows.cs" Condition="'$(TargetsBrowser)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomain.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomainSetup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\AppDomainUnloadedException.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs
@@ -13,9 +13,14 @@ namespace System
         {
             // Fallback path for hosts that do not set APP_CONTEXT_BASE_DIRECTORY explicitly
             string? directory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location);
-            if (directory != null && !Path.EndsInDirectorySeparator(directory))
+
+            if (directory == null)
+                return string.Empty;
+            
+            if (!Path.EndsInDirectorySeparator(directory))
                 directory += PathInternal.DirectorySeparatorCharAsString;
-            return directory ?? string.Empty;
+
+            return directory;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.AnyOS.cs
@@ -16,7 +16,7 @@ namespace System
 
             if (directory == null)
                 return string.Empty;
-            
+
             if (!Path.EndsInDirectorySeparator(directory))
                 directory += PathInternal.DirectorySeparatorCharAsString;
 

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.Browser.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System
+{
+    public static partial class AppContext
+    {
+        private static string GetBaseDirectoryCore()
+        {
+            // GetEntryAssembly().Location returns an empty string for wasm
+            // Until that can be easily changed, work around the problem here.
+            return "/";
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.UnixOrWindows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.UnixOrWindows.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Reflection;
+
+namespace System
+{
+    public static partial class AppContext
+    {
+        private static string GetBaseDirectoryCore()
+        {
+            // Fallback path for hosts that do not set APP_CONTEXT_BASE_DIRECTORY explicitly
+            string? directory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location);
+            if (directory != null && !Path.EndsInDirectorySeparator(directory))
+                directory += PathInternal.DirectorySeparatorCharAsString;
+            return directory ?? string.Empty;
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -36,9 +36,7 @@ namespace System
                 throw new ArgumentNullException(nameof(name));
 
             if (s_dataStore == null)
-            {
                 return null;
-            }
 
             object? data;
             lock (s_dataStore)

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -36,7 +36,9 @@ namespace System
                 throw new ArgumentNullException(nameof(name));
 
             if (s_dataStore == null)
+            {
                 return null;
+            }
 
             object? data;
             lock (s_dataStore)
@@ -141,15 +143,6 @@ namespace System
             {
                 s_dataStore.Add(new string(pNames[i]), new string(pValues[i]));
             }
-        }
-
-        private static string GetBaseDirectoryCore()
-        {
-            // Fallback path for hosts that do not set APP_CONTEXT_BASE_DIRECTORY explicitly
-            string? directory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location);
-            if (directory != null && !Path.EndsInDirectorySeparator(directory))
-                directory += PathInternal.DirectorySeparatorCharAsString;
-            return directory ?? string.Empty;
         }
 #endif
     }

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -31,14 +31,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\tests\System.Net.WebSockets.WebSocketProtocol.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
     <!-- Builds currently do not pass -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.FileExtensions\tests\Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Ini\tests\Microsoft.Extensions.Configuration.Ini.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Json\tests\Microsoft.Extensions.Configuration.Json.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.UserSecrets\tests\Microsoft.Extensions.Configuration.UserSecrets.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.Xml\tests\Microsoft.Extensions.Configuration.Xml.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration\tests\FunctionalTests\Microsoft.Extensions.Configuration.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyModel\tests\Microsoft.Extensions.DependencyModel.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Hosting\tests\UnitTests\Microsoft.Extensions.Hosting.Unit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.CodeDom\tests\System.CodeDom.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.NonGeneric\tests\System.Collections.NonGeneric.Tests.csproj" />


### PR DESCRIPTION
Adjust AppContext.BaseDirectory to return "/" for wasm because GetEntryAssembly().Location returns an empty string.

This change also enables most of the Microsoft.Extensions.* tests with the exception of DependencyModel and Hosting.