### PR TITLE
Span Symmetric ICryptoTransform

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/BasicSymmetricCipher.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/BasicSymmetricCipher.cs
@@ -29,7 +29,7 @@ namespace Internal.Cryptography
             BlockSizeInBytes = blockSizeInBytes;
         }
 
-        public abstract int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset);
+        public abstract int Transform(ReadOnlySpan<byte> input, Span<byte> output);
 
         public abstract int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output);
 

--- a/src/libraries/Common/src/Internal/Cryptography/BasicSymmetricCipher.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/BasicSymmetricCipher.cs
@@ -31,7 +31,7 @@ namespace Internal.Cryptography
 
         public abstract int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset);
 
-        public abstract byte[] TransformFinal(byte[] input, int inputOffset, int count);
+        public abstract int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output);
 
         public int BlockSizeInBytes { get; private set; }
 

--- a/src/libraries/Common/src/Internal/Cryptography/BasicSymmetricCipherBCrypt.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/BasicSymmetricCipherBCrypt.cs
@@ -61,28 +61,23 @@ namespace Internal.Cryptography
             base.Dispose(disposing);
         }
 
-        public override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        public override int Transform(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(count > 0);
-            Debug.Assert((count % BlockSizeInBytes) == 0);
-            Debug.Assert(input.Length - inputOffset >= count);
-            Debug.Assert(output != null);
-            Debug.Assert(outputOffset >= 0);
-            Debug.Assert(output.Length - outputOffset >= count);
+            Debug.Assert(input.Length > 0);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
             int numBytesWritten;
+
             if (_encrypting)
             {
-                numBytesWritten = Interop.BCrypt.BCryptEncrypt(_hKey, input, inputOffset, count, _currentIv, output, outputOffset, output.Length - outputOffset);
+                numBytesWritten = Interop.BCrypt.BCryptEncrypt(_hKey, input, _currentIv, output);
             }
             else
             {
-                numBytesWritten = Interop.BCrypt.BCryptDecrypt(_hKey, input, inputOffset, count, _currentIv, output, outputOffset, output.Length - outputOffset);
+                numBytesWritten = Interop.BCrypt.BCryptDecrypt(_hKey, input, _currentIv, output);
             }
 
-            if (numBytesWritten != count)
+            if (numBytesWritten != input.Length)
             {
                 // CNG gives us no way to tell BCryptDecrypt() that we're decrypting the final block, nor is it performing any
                 // padding /depadding for us. So there's no excuse for a provider to hold back output for "future calls." Though
@@ -93,23 +88,20 @@ namespace Internal.Cryptography
             return numBytesWritten;
         }
 
-        public override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        public override int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(count >= 0);
-            Debug.Assert((count % BlockSizeInBytes) == 0);
-            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
-            byte[] output = new byte[count];
-            if (count != 0)
+            int numBytesWritten = 0;
+
+            if (input.Length != 0)
             {
-                int numBytesWritten = Transform(input, inputOffset, count, output, 0);
-                Debug.Assert(numBytesWritten == count);  // Our implementation of Transform() guarantees this. See comment above.
+                numBytesWritten = Transform(input, output);
+                Debug.Assert(numBytesWritten == input.Length);  // Our implementation of Transform() guarantees this. See comment above.
             }
 
             Reset();
-            return output;
+            return numBytesWritten;
         }
 
         private void Reset()

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -94,7 +94,8 @@ namespace Internal.Cryptography
 
             // Decrypt the data, then strip the padding to get the final decrypted data. Note that even if the cipherText length is 0, we must
             // invoke TransformFinal() so that the cipher object knows to reset for the next cipher operation.
-            byte[] decryptedBytes = BasicSymmetricCipher.TransformFinal(ciphertext, 0, ciphertext.Length);
+            int decryptWritten = BasicSymmetricCipher.TransformFinal(ciphertext.AsSpan(0, ciphertext.Length), ciphertext);
+            byte[] decryptedBytes = ciphertext.AsSpan(0, decryptWritten).ToArray();
             byte[] outputData;
             if (ciphertext.Length > 0)
             {

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -42,7 +42,7 @@ namespace Internal.Cryptography
                 // If we have data saved from a previous call, decrypt that into the output first
                 if (_heldoverCipher != null)
                 {
-                    int depadDecryptLength = BasicSymmetricCipher.Transform(_heldoverCipher, 0, _heldoverCipher.Length, outputBuffer, outputOffset);
+                    int depadDecryptLength = BasicSymmetricCipher.Transform(_heldoverCipher, outputBuffer.AsSpan(outputOffset));
                     outputOffset += depadDecryptLength;
                     decryptedBytes += depadDecryptLength;
                 }
@@ -61,7 +61,7 @@ namespace Internal.Cryptography
 
             if (inputCount > 0)
             {
-                decryptedBytes += BasicSymmetricCipher.Transform(inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset);
+                decryptedBytes += BasicSymmetricCipher.Transform(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
             }
 
             return decryptedBytes;

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -130,7 +130,7 @@ namespace Internal.Cryptography
                     try
                     {
                         written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), rented);
-                        return rented.AsSpan().Slice(0, written).ToArray();
+                        return rented.AsSpan(0, written).ToArray();
                     }
                     finally
                     {

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -109,7 +109,7 @@ namespace Internal.Cryptography
 
             if (decryptedBytes.Length > 0)
             {
-                unpaddedLength = DepadBlock(decryptedBytes);
+                unpaddedLength = GetPaddingLength(decryptedBytes);
                 decryptedBytes.Slice(0, unpaddedLength).CopyTo(outputBuffer);
                 CryptographicOperations.ZeroMemory(decryptedBytes);
             }
@@ -193,12 +193,11 @@ namespace Internal.Cryptography
         }
 
         /// <summary>
-        ///     Remove the padding from the last blocks being decrypted
+        ///     Gets the length of the padding applied to the block, and validates
+        ///     the padding, if possible.
         /// </summary>
-        private int DepadBlock(ReadOnlySpan<byte> block)
+        private int GetPaddingLength(ReadOnlySpan<byte> block)
         {
-            Debug.Assert(0 <= block.Length);
-
             int padBytes = 0;
 
             // See PadBlock for a description of the padding modes.

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -82,20 +82,20 @@ namespace Internal.Cryptography
 
             if (_heldoverCipher == null)
             {
-#if NET5_0
-                ciphertext = GC.AllocateUninitializedArray<byte>(inputBuffer.Length);
-#else
+#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP3_0
                 ciphertext = new byte[inputBuffer.Length];
+#else
+                ciphertext = GC.AllocateUninitializedArray<byte>(inputBuffer.Length);
 #endif
                 inputCiphertext = inputBuffer;
             }
             else
             {
                 Span<byte> continuedCiphertext;
-#if NET5_0
-                continuedCiphertext = GC.AllocateUninitializedArray<byte>(_heldoverCipher.Length + inputBuffer.Length);
-#else
+#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP3_0
                 continuedCiphertext = new byte[_heldoverCipher.Length + inputBuffer.Length];
+#else
+                continuedCiphertext = GC.AllocateUninitializedArray<byte>(_heldoverCipher.Length + inputBuffer.Length);
 #endif
                 _heldoverCipher.AsSpan().CopyTo(continuedCiphertext);
                 inputBuffer.CopyTo(continuedCiphertext.Slice(_heldoverCipher.Length));
@@ -148,10 +148,10 @@ namespace Internal.Cryptography
             }
             else
             {
-#if NET5_0
-                byte[] buffer = GC.AllocateUninitializedArray<byte>(inputCount);
-#else
+#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP3_0
                 byte[] buffer = new byte[inputCount];
+#else
+                byte[] buffer = GC.AllocateUninitializedArray<byte>(inputCount);
 #endif
                 int written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), buffer);
                 Debug.Assert(written == buffer.Length);

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoDecryptor.cs
@@ -103,7 +103,7 @@ namespace Internal.Cryptography
             // Decrypt the data, then strip the padding to get the final decrypted data. Note that even if the cipherText length is 0, we must
             // invoke TransformFinal() so that the cipher object knows to reset for the next cipher operation.
             int decryptWritten = BasicSymmetricCipher.TransformFinal(inputCiphertext, ciphertext);
-            ReadOnlySpan<byte> decryptedBytes = ciphertext.Slice(0, decryptWritten);
+            Span<byte> decryptedBytes = ciphertext.Slice(0, decryptWritten);
 
             int unpaddedLength = 0;
 
@@ -111,6 +111,7 @@ namespace Internal.Cryptography
             {
                 unpaddedLength = DepadBlock(decryptedBytes);
                 decryptedBytes.Slice(0, unpaddedLength).CopyTo(outputBuffer);
+                CryptographicOperations.ZeroMemory(decryptedBytes);
             }
 
             Reset();

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -30,6 +30,10 @@ namespace Internal.Cryptography
 
         protected override int UncheckedTransformFinalBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer)
         {
+            // The only caller of this method is the array-allocating overload, outputBuffer is
+            // always new memory, not a user-provided buffer.
+            Debug.Assert(!inputBuffer.Overlaps(outputBuffer));
+
             int padWritten = PadBlock(inputBuffer, outputBuffer);
             int transformWritten = BasicSymmetricCipher.TransformFinal(outputBuffer.Slice(0, padWritten), outputBuffer);
 

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -25,7 +25,7 @@ namespace Internal.Cryptography
 
         protected sealed override int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
         {
-            return BasicSymmetricCipher.Transform(inputBuffer, inputOffset, inputCount, outputBuffer, outputOffset);
+            return BasicSymmetricCipher.Transform(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
         }
 
         protected sealed override unsafe byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -42,7 +42,12 @@ namespace Internal.Cryptography
 
         protected override byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
-            byte[] buffer = GC.AllocateUninitializedArray<byte>(GetCiphertextLength(inputCount));
+            byte[] buffer;
+#if NET5_0
+            buffer = GC.AllocateUninitializedArray<byte>(GetCiphertextLength(inputCount));
+#else
+            buffer = new byte[GetCiphertextLength(inputCount)];
+#endif
             int written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), buffer);
             Debug.Assert(written == buffer.Length);
             return buffer;

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -36,7 +36,9 @@ namespace Internal.Cryptography
             try
             {
                 padWritten = PadBlock(inputBuffer.AsSpan(inputOffset, inputCount), padBuffer);
-                return BasicSymmetricCipher.TransformFinal(padBuffer, 0, padWritten);
+                int transformWritten = BasicSymmetricCipher.TransformFinal(padBuffer.AsSpan(0, padWritten), padBuffer);
+                Debug.Assert(padWritten == transformWritten);
+                return padBuffer.AsSpan(0, transformWritten).ToArray();
             }
             finally
             {

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -23,12 +23,12 @@ namespace Internal.Cryptography
         {
         }
 
-        protected sealed override int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        protected override int UncheckedTransformBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer)
         {
-            return BasicSymmetricCipher.Transform(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
+            return BasicSymmetricCipher.Transform(inputBuffer, outputBuffer);
         }
 
-        protected sealed override unsafe byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        protected override unsafe byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
             // Rent a buffer with enough space to hold at most a hold block of padding if the input is
             // is the block size.

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -73,7 +73,7 @@ namespace Internal.Cryptography
             }
         }
 
-        internal int PadBlock(ReadOnlySpan<byte> block, Span<byte> destination)
+        private int PadBlock(ReadOnlySpan<byte> block, Span<byte> destination)
         {
             int count = block.Length;
             int paddingRemainder = count % InputBlockSize;

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoEncryptor.cs
@@ -43,10 +43,10 @@ namespace Internal.Cryptography
         protected override byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
             byte[] buffer;
-#if NET5_0
-            buffer = GC.AllocateUninitializedArray<byte>(GetCiphertextLength(inputCount));
-#else
+#if NETSTANDARD || NETFRAMEWORK || NETCOREAPP3_0
             buffer = new byte[GetCiphertextLength(inputCount)];
+#else
+            buffer = GC.AllocateUninitializedArray<byte>(GetCiphertextLength(inputCount));
 #endif
             int written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), buffer);
             Debug.Assert(written == buffer.Length);

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
@@ -114,8 +114,27 @@ namespace Internal.Cryptography
             return UncheckedTransformBlock(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
         }
 
-        protected abstract byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount);
+        protected unsafe byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            byte[] rented = CryptoPool.Rent(inputCount + OutputBlockSize);
+            int written = 0;
+
+            fixed (byte* pRented = rented)
+            {
+                try
+                {
+                    written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), rented);
+                    return rented.AsSpan().Slice(0, written).ToArray();
+                }
+                finally
+                {
+                    CryptoPool.Return(rented, clearSize: written);
+                }
+            }
+        }
+
         protected abstract int UncheckedTransformBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer);
+        protected abstract int UncheckedTransformFinalBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer);
 
         protected PaddingMode PaddingMode { get; private set; }
         protected BasicSymmetricCipher BasicSymmetricCipher { get; private set; }

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
@@ -109,8 +109,13 @@ namespace Internal.Cryptography
             }
         }
 
-        protected abstract int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset);
+        protected int UncheckedTransformBlock(byte[] inputBuffer, int inputOffset, int inputCount, byte[] outputBuffer, int outputOffset)
+        {
+            return UncheckedTransformBlock(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
+        }
+
         protected abstract byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount);
+        protected abstract int UncheckedTransformBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer);
 
         protected PaddingMode PaddingMode { get; private set; }
         protected BasicSymmetricCipher BasicSymmetricCipher { get; private set; }

--- a/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/UniversalCryptoTransform.cs
@@ -114,26 +114,11 @@ namespace Internal.Cryptography
             return UncheckedTransformBlock(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset));
         }
 
-        protected unsafe byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
-        {
-            byte[] rented = CryptoPool.Rent(inputCount + OutputBlockSize);
-            int written = 0;
-
-            fixed (byte* pRented = rented)
-            {
-                try
-                {
-                    written = UncheckedTransformFinalBlock(inputBuffer.AsSpan(inputOffset, inputCount), rented);
-                    return rented.AsSpan().Slice(0, written).ToArray();
-                }
-                finally
-                {
-                    CryptoPool.Return(rented, clearSize: written);
-                }
-            }
-        }
-
         protected abstract int UncheckedTransformBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer);
+
+        // For final block, encryption and decryption can give better context for the returning byte size, so we
+        // don't provide an implementation here.
+        protected abstract byte[] UncheckedTransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount);
         protected abstract int UncheckedTransformFinalBlock(ReadOnlySpan<byte> inputBuffer, Span<byte> outputBuffer);
 
         protected PaddingMode PaddingMode { get; private set; }

--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptEncryptDecrypt.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptEncryptDecrypt.cs
@@ -14,57 +14,43 @@ internal static partial class Interop
     internal static partial class BCrypt
     {
         // Note: input and output are allowed to be the same buffer. BCryptEncrypt will correctly do the encryption in place according to CNG documentation.
-        internal static int BCryptEncrypt(SafeKeyHandle hKey, byte[] input, int inputOffset, int inputCount, byte[]? iv, byte[] output, int outputOffset, int outputCount)
+        internal static int BCryptEncrypt(SafeKeyHandle hKey, ReadOnlySpan<byte> input, byte[]? iv, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(inputCount >= 0);
-            Debug.Assert(inputCount <= input.Length - inputOffset);
-            Debug.Assert(output != null);
-            Debug.Assert(outputOffset >= 0);
-            Debug.Assert(outputCount >= 0);
-            Debug.Assert(outputCount <= output.Length - outputOffset);
-
             unsafe
             {
                 fixed (byte* pbInput = input)
+                fixed (byte* pbOutput = output)
                 {
-                    fixed (byte* pbOutput = output)
+                    int cbResult;
+                    NTSTATUS ntStatus = BCryptEncrypt(hKey, pbInput, input.Length, IntPtr.Zero, iv, iv == null ? 0 : iv.Length, pbOutput, output.Length, out cbResult, 0);
+
+                    if (ntStatus != NTSTATUS.STATUS_SUCCESS)
                     {
-                        int cbResult;
-                        NTSTATUS ntStatus = BCryptEncrypt(hKey, pbInput + inputOffset, inputCount, IntPtr.Zero, iv, iv == null ? 0 : iv.Length, pbOutput + outputOffset, outputCount, out cbResult, 0);
-                        if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                            throw CreateCryptographicException(ntStatus);
-                        return cbResult;
+                        throw CreateCryptographicException(ntStatus);
                     }
+
+                    return cbResult;
                 }
             }
         }
 
         // Note: input and output are allowed to be the same buffer. BCryptDecrypt will correctly do the decryption in place according to CNG documentation.
-        internal static int BCryptDecrypt(SafeKeyHandle hKey, byte[] input, int inputOffset, int inputCount, byte[]? iv, byte[] output, int outputOffset, int outputCount)
+        internal static int BCryptDecrypt(SafeKeyHandle hKey, ReadOnlySpan<byte> input, byte[]? iv, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(inputCount >= 0);
-            Debug.Assert(inputCount <= input.Length - inputOffset);
-            Debug.Assert(output != null);
-            Debug.Assert(outputOffset >= 0);
-            Debug.Assert(outputCount >= 0);
-            Debug.Assert(outputCount <= output.Length - outputOffset);
-
             unsafe
             {
                 fixed (byte* pbInput = input)
+                fixed (byte* pbOutput = output)
                 {
-                    fixed (byte* pbOutput = output)
+                    int cbResult;
+                    NTSTATUS ntStatus = BCryptDecrypt(hKey, pbInput, input.Length, IntPtr.Zero, iv, iv == null ? 0 : iv.Length, pbOutput, output.Length, out cbResult, 0);
+
+                    if (ntStatus != NTSTATUS.STATUS_SUCCESS)
                     {
-                        int cbResult;
-                        NTSTATUS ntStatus = BCryptDecrypt(hKey, pbInput + inputOffset, inputCount, IntPtr.Zero, iv, iv == null ? 0 : iv.Length, pbOutput + outputOffset, outputCount, out cbResult, 0);
-                        if (ntStatus != NTSTATUS.STATUS_SUCCESS)
-                            throw CreateCryptographicException(ntStatus);
-                        return cbResult;
+                        throw CreateCryptographicException(ntStatus);
                     }
+
+                    return cbResult;
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
@@ -64,12 +64,11 @@ namespace Internal.Cryptography
                 return 0;
             }
 
-            Span<byte> outputBuffer = new byte[input.Length];
-            int outputBytes = CipherUpdate(input, outputBuffer);
+            int outputBytes = CipherUpdate(input, output);
             int ret;
             int errorCode;
 
-            fixed (byte* outputStart = outputBuffer)
+            fixed (byte* outputStart = output)
             {
                 byte* outputCurrent = outputStart + outputBytes;
                 int bytesWritten;
@@ -77,7 +76,7 @@ namespace Internal.Cryptography
                 ret = Interop.AppleCrypto.CryptorFinal(
                     _cryptor,
                     outputCurrent,
-                    outputBuffer.Length - outputBytes,
+                    output.Length - outputBytes,
                     out bytesWritten,
                     out errorCode);
 
@@ -86,12 +85,6 @@ namespace Internal.Cryptography
 
             ProcessInteropError(ret, errorCode);
 
-            if (outputBytes == 0)
-            {
-                return 0;
-            }
-
-            outputBuffer.Slice(0, outputBytes).CopyTo(output);
             return outputBytes;
         }
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
@@ -39,46 +39,37 @@ namespace Internal.Cryptography
             base.Dispose(disposing);
         }
 
-        public override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        public override int Transform(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null, "Expected valid input, got null");
-            Debug.Assert(inputOffset >= 0, $"Expected non-negative inputOffset, got {inputOffset}");
-            Debug.Assert(count > 0, $"Expected positive count, got {count}");
-            Debug.Assert((count % BlockSizeInBytes) == 0, $"Expected count aligned to block size {BlockSizeInBytes}, got {count}");
-            Debug.Assert(input.Length - inputOffset >= count, $"Expected valid input length/offset/count triplet, got {input.Length}/{inputOffset}/{count}");
-            Debug.Assert(output != null, "Expected valid output, got null");
-            Debug.Assert(outputOffset >= 0, $"Expected non-negative outputOffset, got {outputOffset}");
-            Debug.Assert(output.Length - outputOffset >= count, $"Expected valid output length/offset/count triplet, got {output.Length}/{outputOffset}/{count}");
+            Debug.Assert(input.Length > 0);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
-            return CipherUpdate(input, inputOffset, count, output, outputOffset);
+            return CipherUpdate(input, output);
         }
 
-        public override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        public override int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null, "Expected valid input, got null");
-            Debug.Assert(inputOffset >= 0, $"Expected non-negative inputOffset, got {inputOffset}");
-            Debug.Assert(count >= 0, $"Expected non-negative count, got {count}");
-            Debug.Assert((count % BlockSizeInBytes) == 0, $"Expected count aligned to block size {BlockSizeInBytes}, got {count}");
-            Debug.Assert(input.Length - inputOffset >= count, $"Expected valid input length/offset/count triplet, got {input.Length}/{inputOffset}/{count}");
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length <= output.Length);
 
-            byte[] output = ProcessFinalBlock(input, inputOffset, count);
+            int written = ProcessFinalBlock(input, output);
             Reset();
-            return output;
+            return written;
         }
 
-        private unsafe byte[] ProcessFinalBlock(byte[] input, int inputOffset, int count)
+        private unsafe int ProcessFinalBlock(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            if (count == 0)
+            if (input.Length == 0)
             {
-                return Array.Empty<byte>();
+                return 0;
             }
 
-            byte[] output = new byte[count];
-            int outputBytes = CipherUpdate(input, inputOffset, count, output, 0);
+            Span<byte> outputBuffer = new byte[input.Length];
+            int outputBytes = CipherUpdate(input, outputBuffer);
             int ret;
             int errorCode;
 
-            fixed (byte* outputStart = &output[0])
+            fixed (byte* outputStart = outputBuffer)
             {
                 byte* outputCurrent = outputStart + outputBytes;
                 int bytesWritten;
@@ -86,7 +77,7 @@ namespace Internal.Cryptography
                 ret = Interop.AppleCrypto.CryptorFinal(
                     _cryptor,
                     outputCurrent,
-                    output.Length - outputBytes,
+                    outputBuffer.Length - outputBytes,
                     out bytesWritten,
                     out errorCode);
 
@@ -95,44 +86,35 @@ namespace Internal.Cryptography
 
             ProcessInteropError(ret, errorCode);
 
-            if (outputBytes == output.Length)
-            {
-                return output;
-            }
-
             if (outputBytes == 0)
             {
-                return Array.Empty<byte>();
+                return 0;
             }
 
-            byte[] userData = new byte[outputBytes];
-            Buffer.BlockCopy(output, 0, userData, 0, outputBytes);
-            return userData;
+            outputBuffer.Slice(0, outputBytes).CopyTo(output);
+            return outputBytes;
         }
 
-        private unsafe int CipherUpdate(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        private unsafe int CipherUpdate(ReadOnlySpan<byte> input, Span<byte> output)
         {
             int ret;
             int ccStatus;
             int bytesWritten;
 
-            if (count == 0)
+            if (input.Length == 0)
             {
                 return 0;
             }
 
-            fixed (byte* inputStart = input)
-            fixed (byte* outputStart = output)
+            fixed (byte* pInput = input)
+            fixed (byte* pOutput = output)
             {
-                byte* inputCurrent = inputStart + inputOffset;
-                byte* outputCurrent = outputStart + outputOffset;
-
                 ret = Interop.AppleCrypto.CryptorUpdate(
                     _cryptor,
-                    inputCurrent,
-                    count,
-                    outputCurrent,
-                    output.Length - outputOffset,
+                    pInput,
+                    input.Length,
+                    pOutput,
+                    output.Length,
                     out bytesWritten,
                     out ccStatus);
             }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AppleCCCryptor.cs
@@ -68,6 +68,8 @@ namespace Internal.Cryptography
             int ret;
             int errorCode;
 
+            Debug.Assert(output.Length > 0);
+
             fixed (byte* outputStart = output)
             {
                 byte* outputCurrent = outputStart + outputBytes;

--- a/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Internal/Cryptography/BasicSymmetricCipherNCrypt.cs
@@ -38,28 +38,20 @@ namespace Internal.Cryptography
             Reset();
         }
 
-        public sealed override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        public sealed override int Transform(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(count > 0);
-            Debug.Assert((count % BlockSizeInBytes) == 0);
-            Debug.Assert(input.Length - inputOffset >= count);
-            Debug.Assert(output != null);
-            Debug.Assert(outputOffset >= 0);
-            Debug.Assert(output.Length - outputOffset >= count);
+            Debug.Assert(input.Length > 0);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
             int numBytesWritten;
             ErrorCode errorCode;
             using (SafeNCryptKeyHandle keyHandle = _cngKey!.Handle)
             {
-                var inputSpan = new ReadOnlySpan<byte>(input, inputOffset, count);
-                var outputSpan = new Span<byte>(output, outputOffset, count);
                 unsafe
                 {
                     errorCode = _encrypting ?
-                        Interop.NCrypt.NCryptEncrypt(keyHandle, inputSpan, inputSpan.Length, null, outputSpan, outputSpan.Length, out numBytesWritten, AsymmetricPaddingMode.None) :
-                        Interop.NCrypt.NCryptDecrypt(keyHandle, inputSpan, inputSpan.Length, null, outputSpan, outputSpan.Length, out numBytesWritten, AsymmetricPaddingMode.None);
+                        Interop.NCrypt.NCryptEncrypt(keyHandle, input, input.Length, null, output, output.Length, out numBytesWritten, AsymmetricPaddingMode.None) :
+                        Interop.NCrypt.NCryptDecrypt(keyHandle, input, input.Length, null, output, output.Length, out numBytesWritten, AsymmetricPaddingMode.None);
                 }
             }
             if (errorCode != ErrorCode.ERROR_SUCCESS)
@@ -67,7 +59,7 @@ namespace Internal.Cryptography
                 throw errorCode.ToCryptographicException();
             }
 
-            if (numBytesWritten != count)
+            if (numBytesWritten != input.Length)
             {
                 // CNG gives us no way to tell NCryptDecrypt() that we're decrypting the final block, nor is it performing any padding/depadding for us.
                 // So there's no excuse for a provider to hold back output for "future calls." Though this isn't technically our problem to detect, we might as well
@@ -78,23 +70,20 @@ namespace Internal.Cryptography
             return numBytesWritten;
         }
 
-        public sealed override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        public sealed override int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(count >= 0);
-            Debug.Assert((count % BlockSizeInBytes) == 0);
-            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
-            byte[] output = new byte[count];
-            if (count != 0)
+            int numBytesWritten = 0;
+
+            if (input.Length != 0)
             {
-                int numBytesWritten = Transform(input, inputOffset, count, output, 0);
-                Debug.Assert(numBytesWritten == count);  // Our implementation of Transform() guarantees this. See comment above.
+                numBytesWritten = Transform(input, output);
+                Debug.Assert(numBytesWritten == input.Length);  // Our implementation of Transform() guarantees this. See comment above.
             }
 
             Reset();
-            return output;
+            return numBytesWritten;
         }
 
         protected sealed override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -267,4 +267,7 @@
   <data name="Cryptography_InvalidECCharacteristic2Curve" xml:space="preserve">
     <value>The specified Characteristic2 curve parameters are not valid. Polynomial, A, B, G.X, G.Y, and Order are required. A, B, G.X, G.Y must be the same length, and the same length as Q.X, Q.Y and D if those are specified. Seed, Cofactor and Hash are optional. Other parameters are not allowed.</value>
   </data>
+  <data name="Argument_DestinationTooShort" xml:space="preserve">
+    <value>Destination is too short.</value>
+  </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Csp/src/Internal/Cryptography/BasicSymmetricCipherCsp.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/Internal/Cryptography/BasicSymmetricCipherCsp.cs
@@ -61,56 +61,47 @@ namespace Internal.Cryptography
             base.Dispose(disposing);
         }
 
-        public override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        public override int Transform(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            return Transform(input, inputOffset, count, output, outputOffset, false);
+            return Transform(input, output, false);
         }
 
-        public override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        public override int TransformFinal(ReadOnlySpan<byte> input, Span<byte> output)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(count >= 0);
-            Debug.Assert((count % BlockSizeInBytes) == 0);
-            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
-            byte[] output = new byte[count];
-            if (count != 0)
+            int numBytesWritten = 0;
+
+            if (input.Length != 0)
             {
-                int numBytesWritten = Transform(input, inputOffset, count, output, 0, true);
-                Debug.Assert(numBytesWritten == count);  // Our implementation of Transform() guarantees this.
+                numBytesWritten = Transform(input, output, true);
+                Debug.Assert(numBytesWritten == input.Length);  // Our implementation of Transform() guarantees this.
             }
 
             Reset();
 
-            return output;
+            return numBytesWritten;
         }
 
         private void Reset()
         {
             // Ensure we've called CryptEncrypt with the final=true flag so the handle is reset property
-            EncryptData(_hKey, Array.Empty<byte>(), 0, 0, Array.Empty<byte>(), 0, 0, true);
+            EncryptData(_hKey, default, default, true);
         }
 
-        private int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset, bool isFinal)
+        private int Transform(ReadOnlySpan<byte> input, Span<byte> output, bool isFinal)
         {
-            Debug.Assert(input != null);
-            Debug.Assert(inputOffset >= 0);
-            Debug.Assert(count > 0);
-            Debug.Assert((count % BlockSizeInBytes) == 0);
-            Debug.Assert(input.Length - inputOffset >= count);
-            Debug.Assert(output != null);
-            Debug.Assert(outputOffset >= 0);
-            Debug.Assert(output.Length - outputOffset >= count);
+            Debug.Assert(input.Length > 0);
+            Debug.Assert((input.Length % BlockSizeInBytes) == 0);
 
             int numBytesWritten;
             if (_encrypting)
             {
-                numBytesWritten = EncryptData(_hKey, input, inputOffset, count, output, outputOffset, output.Length - outputOffset, isFinal);
+                numBytesWritten = EncryptData(_hKey, input, output, isFinal);
             }
             else
             {
-                numBytesWritten = DecryptData(_hKey, input, inputOffset, count, output, outputOffset, output.Length - outputOffset);
+                numBytesWritten = DecryptData(_hKey, input, output);
             }
 
             return numBytesWritten;

--- a/src/libraries/System.Security.Cryptography.Csp/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Csp/src/Resources/Strings.resx
@@ -1,16 +1,16 @@
 ﻿<root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -25,36 +25,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -217,5 +217,8 @@
   </data>
   <data name="Cryptography_PlatformNotSupported_Browser" xml:space="preserve">
     <value>System.Security.Cryptography is not supported on Browser.</value>
+  </data>
+  <data name="Argument_DestinationTooShort" xml:space="preserve">
+    <value>Destination is too short.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -29,6 +29,8 @@
              Link="Internal\Cryptography\Helpers.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\KeySizeHelpers.cs"
              Link="Common\System\Security\Cryptography\KeySizeHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Security\Cryptography\CryptoPool.cs"
+             Link="Common\System\Security\Cryptography\CryptoPool.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Security\Cryptography\CapiHelper.Unix.cs" />

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -819,13 +819,13 @@ namespace Internal.NativeCrypto
             Debug.Assert(encryptedData != null, "Encrypted Data is null");
             Debug.Assert(encryptedDataLength >= 0, "Encrypted data length is less than 0");
 
-            byte[] dataTobeDecrypted = new byte[encryptedDataLength];
-            Buffer.BlockCopy(encryptedData, 0, dataTobeDecrypted, 0, encryptedDataLength);
-            Array.Reverse(dataTobeDecrypted);
+            byte[] dataToBeDecrypted = new byte[encryptedDataLength];
+            Buffer.BlockCopy(encryptedData, 0, dataToBeDecrypted, 0, encryptedDataLength);
+            Array.Reverse(dataToBeDecrypted);
 
             int dwFlags = fOAEP ? (int)Interop.Advapi32.CryptDecryptFlags.CRYPT_OAEP : 0;
             int decryptedDataLength = encryptedDataLength;
-            if (!Interop.Advapi32.CryptDecrypt(safeKeyHandle, SafeHashHandle.InvalidHandle, true, dwFlags, dataTobeDecrypted, ref decryptedDataLength))
+            if (!Interop.Advapi32.CryptDecrypt(safeKeyHandle, SafeHashHandle.InvalidHandle, true, dwFlags, dataToBeDecrypted, ref decryptedDataLength))
             {
                 int ErrCode = GetErrorCode();
                 // If we're using OAEP mode and we received an NTE_BAD_FLAGS error, then OAEP is not supported on
@@ -853,7 +853,7 @@ namespace Internal.NativeCrypto
 
 
             decryptedData = new byte[decryptedDataLength];
-            Buffer.BlockCopy(dataTobeDecrypted, 0, decryptedData, 0, decryptedDataLength);
+            Buffer.BlockCopy(dataToBeDecrypted, 0, decryptedData, 0, decryptedDataLength);
             return;
         }
 
@@ -952,18 +952,18 @@ namespace Internal.NativeCrypto
             VerifyValidHandle(hKey);
             Debug.Assert((input.Length % 8) == 0);
 
-            byte[] dataTobeDecrypted = new byte[input.Length];
-            input.CopyTo(dataTobeDecrypted);
+            byte[] dataToBeDecrypted = new byte[input.Length];
+            input.CopyTo(dataToBeDecrypted);
 
             int decryptedDataLength = input.Length;
 
             // Always call decryption with false (not final); deal with padding manually
-            if (!Interop.Advapi32.CryptDecrypt(hKey, SafeHashHandle.InvalidHandle, false, 0, dataTobeDecrypted, ref decryptedDataLength))
+            if (!Interop.Advapi32.CryptDecrypt(hKey, SafeHashHandle.InvalidHandle, false, 0, dataToBeDecrypted, ref decryptedDataLength))
             {
                 throw GetErrorCode().ToCryptographicException();
             }
 
-            dataTobeDecrypted.AsSpan(0, decryptedDataLength).CopyTo(output);
+            dataToBeDecrypted.AsSpan(0, decryptedDataLength).CopyTo(output);
             return decryptedDataLength;
         }
 

--- a/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.Windows.cs
@@ -935,7 +935,7 @@ namespace Internal.NativeCrypto
                 throw GetErrorCode().ToCryptographicException();
             }
 
-            // If isFinal, padding was added so ignore it by using outputCount as size
+            // If isFinal, padding was added so ignore it by using original input length as size
             int outputCount = isFinal ? input.Length : encryptedDataLength;
             Debug.Assert(encryptedDataLength == cbEncryptedData);
             Debug.Assert(outputCount <= output.Length);


### PR DESCRIPTION
This changes the underlying `UniversalCryptoTransform`, derived types, and symmetric cryptographic primitives to operate on span.

This gains some performance benefits already, either by avoiding temporary arrays (removing and adding padding) and using `CryptoPool` where possible.

~This also would pave the way for `{ReadOnly}Span<byte>` to `ICryptoTransform` and the built-in primitives, provided that a sensible default behavior is possible with DIM.~

These changes are also motivated by #2406, which will operate on span.

<details>
<summary>Performance Numbers</summary>
<pre>
|                      Method |        Job |   Toolchain | DataSize |  Mode |            Mean |         Error |        StdDev |          Median | Ratio | RatioSD |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|---------------------------- |----------- |------------ |--------- |------ |----------------:|--------------:|--------------:|----------------:|------:|--------:|---------:|---------:|---------:|----------:|
|      Encrypt_TransformBlock | Job-QQUEGF | crypto-span |  1048576 | PKCS7 | 1,026,981.62 ns |  9,912.516 ns |  8,787.188 ns | 1,029,210.30 ns |  1.00 |    0.01 |        - |        - |        - |       1 B |
|      Encrypt_TransformBlock | Job-PLPBZT |      master |  1048576 | PKCS7 | 1,024,755.20 ns |  3,505.305 ns |  3,278.864 ns | 1,024,598.03 ns |  1.00 |    0.00 |        - |        - |        - |       1 B |
|                             |            |             |          |       |                 |               |               |                 |       |         |          |          |          |           |
|      Decrypt_TransformBlock | Job-QQUEGF | crypto-span |  1048576 | PKCS7 |   135,297.81 ns |    453.515 ns |    424.218 ns |   135,393.02 ns |  0.98 |    0.01 |        - |        - |        - |         - |
|      Decrypt_TransformBlock | Job-PLPBZT |      master |  1048576 | PKCS7 |   138,163.82 ns |    687.527 ns |    609.475 ns |   138,280.70 ns |  1.00 |    0.00 |        - |        - |        - |         - |
|                             |            |             |          |       |                 |               |               |                 |       |         |          |          |          |           |
| Encrypt_TransformFinalBlock | Job-QQUEGF | crypto-span |  1048576 | PKCS7 | 1,225,488.74 ns | 11,252.529 ns |  9,975.074 ns | 1,226,682.06 ns |  0.80 |    0.01 | 195.3125 | 195.3125 | 195.3125 | 1048668 B |
| Encrypt_TransformFinalBlock | Job-PLPBZT |      master |  1048576 | PKCS7 | 1,531,450.18 ns | 12,607.728 ns | 10,528.024 ns | 1,534,052.30 ns |  1.00 |    0.00 | 250.0000 | 250.0000 | 250.0000 | 2097299 B |
|                             |            |             |          |       |                 |               |               |                 |       |         |          |          |          |           |
| Decrypt_TransformFinalBlock | Job-QQUEGF | crypto-span |  1048576 | PKCS7 |   806,700.19 ns | 11,034.824 ns | 10,321.981 ns |   808,663.70 ns |  0.73 |    0.03 | 397.4609 | 397.4609 | 397.4609 | 3145944 B |
| Decrypt_TransformFinalBlock | Job-PLPBZT |      master |  1048576 | PKCS7 | 1,111,906.51 ns | 21,502.634 ns | 27,193.948 ns | 1,121,153.26 ns |  1.00 |    0.00 | 269.5313 | 269.5313 | 269.5313 | 3145905 B |

</pre>
</details>