### PR TITLE
WASM: Enable System.Threading.Tasks.Dataflow tests

### DIFF
--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/AssemblyInfo.cs
@@ -1,8 +1,0 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-// See the LICENSE file in the project root for more information.
-
-using System;
-using Xunit;
-
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/38283", TestPlatforms.Browser)]

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/ActionBlockTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/ActionBlockTests.cs
@@ -197,7 +197,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestInputCount()
         {
             foreach (bool sync in DataflowTestHelpers.BooleanValues)
@@ -254,7 +254,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestNonGreedy()
         {
             foreach (bool sync in DataflowTestHelpers.BooleanValues)
@@ -417,7 +417,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 actual: sumOfOdds);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestParallelExecution()
         {
             int dop = 2;
@@ -437,7 +437,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestReleasingOfPostponedMessages()
         {
             foreach (bool sync in DataflowTestHelpers.BooleanValues)

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockExtensionTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockExtensionTests.cs
@@ -454,7 +454,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Throws<ArgumentNullException>(() => source.LinkTo(target, null, i => true));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void TestLinkTo_TwoPhaseCommit()
         {
             var source1 = new BufferBlock<int>();
@@ -478,7 +478,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Equal(expected: 43, actual: tuple.Item2);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestLinkTo_DoubleLinking()
         {
             foreach (bool greedy in DataflowTestHelpers.BooleanValues)
@@ -971,7 +971,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Equal(expected: 0, actual: buffer.Count);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestReceive_NotYetAvailable()
         {
             var buffer = new BufferBlock<int>();
@@ -1028,7 +1028,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         }
 
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestReceive_Cancellation()
         {
             var bb = new BufferBlock<int>();
@@ -1066,7 +1066,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestReceive_CanceledSource()
         {
             foreach (bool beforeReceive in DataflowTestHelpers.BooleanValues)
@@ -1121,6 +1121,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // uses a lot of stack
         public async Task TestReceiveAsync_LongChain()
         {
             const int Length = 10000;
@@ -1706,7 +1707,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 () => DataflowBlock.Encapsulate<int, int>(new BufferBlock<int>(), new BufferBlock<int>()).Fault(null));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void TestEncapsulate_LinkingAndUnlinking()
         {
             var buffer = new BufferBlock<int>();
@@ -1921,6 +1922,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // uses a lot of stack
         public async Task TestOutputAvailableAsync_LongSequence()
         {
             const int iterations = 10000; // enough to stack overflow if there's a problem

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/DebugAttributeTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/DebugAttributeTests.cs
@@ -9,7 +9,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 {
     public class DebugAttributeTests
     {
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void TestDebuggerDisplaysAndTypeProxies()
         {
             // Test both canceled and non-canceled

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/JoinBlockTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/JoinBlockTests.cs
@@ -72,7 +72,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             DataflowTestHelpers.TestArgumentsExceptions<Tuple<int, int, int>>(new JoinBlock<int, int, int>());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task TestPostThenReceive()
         {
             const int Iters = 3;

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/SimpleNetworkTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/SimpleNetworkTests.cs
@@ -169,7 +169,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Equal(expected: Iterations / b.BatchSize, actual: completedCount);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task BroadcastToActions()
         {
             var b = new BroadcastBlock<int>(i => i);

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformBlockTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformBlockTests.cs
@@ -283,7 +283,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Equal(expected: 0, actual: tb.OutputCount);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void TestInputCount()
         {
             foreach (bool sync in DataflowTestHelpers.BooleanValues)
@@ -635,7 +635,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             await tb.Completion;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestOrdering_Sync_OrderedDisabled()
         {
             // If ordering were enabled, this test would hang.

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
@@ -311,7 +311,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             Assert.Equal(expected: 0, actual: tb.OutputCount);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void TestInputCount()
         {
             foreach (bool sync in DataflowTestHelpers.BooleanValues)
@@ -748,7 +748,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             await tb.Completion;
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(true)]
         [InlineData(false)]
         public async Task TestOrdering_Sync_OrderedDisabled(bool trustedEnumeration)
@@ -776,7 +776,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             await tb.Completion;
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public async Task TestOrdering_Sync_BlockingEnumeration_NoDeadlock(bool ensureOrdered)

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/WriteOnceBlockTests.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/Dataflow/WriteOnceBlockTests.cs
@@ -174,7 +174,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             await wob.Completion;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task TestReceiveThenPost()
         {
             var wob = new WriteOnceBlock<int>(null);
@@ -207,7 +207,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
             await wob.Completion;
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task TestBroadcasting()
         {
             var wob = new WriteOnceBlock<int>(i => i + 1);

--- a/src/libraries/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/libraries/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Dataflow\ActionBlockTests.cs" />
     <Compile Include="Dataflow\BatchBlockTests.cs" />
     <Compile Include="Dataflow\BatchedJoinBlockTests.cs" />

--- a/src/mono/wasm/Makefile
+++ b/src/mono/wasm/Makefile
@@ -122,11 +122,11 @@ app-builder:
 	$(DOTNET) build $(TOP)/tools-local/tasks/mobile.tasks/WasmAppBuilder
 
 run-tests-v8-%:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) /p:JSEngine=V8
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) /p:JSEngine=V8 $(MSBUILD_ARGS)
 run-tests-sm-%:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) /p:JSEngine=SpiderMonkey
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) /p:JSEngine=SpiderMonkey $(MSBUILD_ARGS)
 run-tests-jsc-%:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) /p:JSEngine=JavaScriptCore
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) /p:JSEngine=JavaScriptCore $(MSBUILD_ARGS)
 
 run-tests-%:
-	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG)
+	PATH="$(JSVU):$(PATH)" $(DOTNET) build $(TOP)/src/libraries/$*/tests/ /t:Test /p:TargetOS=Browser /p:TargetArchitecture=wasm /p:Configuration=$(CONFIG) $(MSBUILD_ARGS)


### PR DESCRIPTION
With the recent async Tasks fix we can now skip just a handful of tests to get the testsuite to passing: `Tests run: 317, Errors: 0, Failures: 0, Skipped: 18. Time: 18.780363s`