### PR TITLE
[mono] Add support for UnmanagedCallersOnlyAttribute

### DIFF
--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -1516,6 +1516,9 @@ mono_method_is_constructor (MonoMethod *method);
 gboolean
 mono_class_has_default_constructor (MonoClass *klass, gboolean public_only);
 
+gboolean
+mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method);
+
 // There are many ways to do on-demand initialization.
 //   Some allow multiple concurrent initializations. Some do not.
 //   Some allow multiple concurrent writes to the global. Some do not.

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -308,6 +308,7 @@ MONO_JIT_ICALL (mono_threads_state_poll) \
 MONO_JIT_ICALL (mono_throw_exception) \
 MONO_JIT_ICALL (mono_throw_method_access) \
 MONO_JIT_ICALL (mono_throw_bad_image) \
+MONO_JIT_ICALL (mono_throw_not_supported) \
 MONO_JIT_ICALL (mono_throw_invalid_program) \
 MONO_JIT_ICALL (mono_trace_enter_method) \
 MONO_JIT_ICALL (mono_trace_leave_method) \

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -308,6 +308,7 @@ MONO_JIT_ICALL (mono_threads_state_poll) \
 MONO_JIT_ICALL (mono_throw_exception) \
 MONO_JIT_ICALL (mono_throw_method_access) \
 MONO_JIT_ICALL (mono_throw_bad_image) \
+MONO_JIT_ICALL (mono_throw_invalid_program) \
 MONO_JIT_ICALL (mono_trace_enter_method) \
 MONO_JIT_ICALL (mono_trace_leave_method) \
 MONO_JIT_ICALL (mono_trace_tail_method) \

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6784,7 +6784,7 @@ mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method)
 	ERROR_DECL (attr_error);
 	MonoClass *attr_klass = NULL;
 #ifdef ENABLE_NETCORE
-	attr_klass = = mono_class_try_get_unmanaged_callers_only_attribute_class ();
+	attr_klass = mono_class_try_get_unmanaged_callers_only_attribute_class ();
 #endif
 	if (!attr_klass)
 		return FALSE;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3664,7 +3664,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 
 	gboolean unmanaged_callers_only = FALSE;
 
-	if (G_UNLIKELY (pinvoke && (mono_method_has_unmanaged_callers_only_attribute (method)))) {
+	if (G_UNLIKELY (pinvoke && mono_method_has_unmanaged_callers_only_attribute (method))) {
 		/* emit a wrapper that throws a NotSupportedException */
 		get_marshal_cb ()->mb_emit_exception (mb, "System", "NotSupportedException", "Method canot be marked with both  DllImportAttribute and UnmanagedCallersOnlyAttribute");
 

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3662,8 +3662,6 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 
 	mb->method->save_lmf = 1;
 
-	gboolean unmanaged_callers_only = FALSE;
-
 	if (G_UNLIKELY (pinvoke && mono_method_has_unmanaged_callers_only_attribute (method))) {
 		/* emit a wrapper that throws a NotSupportedException */
 		get_marshal_cb ()->mb_emit_exception (mb, "System", "NotSupportedException", "Method canot be marked with both  DllImportAttribute and UnmanagedCallersOnlyAttribute");

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3987,6 +3987,14 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 		}
 		invoke = NULL;
 		invoke_sig = mono_method_signature_internal (method);
+		if (invoke_sig->hasthis) {
+			mono_error_set_invalid_program (error, "method %s with UnamanagedCallersOnlyAttribute is an instance method", mono_method_full_name (method, TRUE));
+			return NULL;
+		}
+		if (method->is_generic || method->is_inflated || mono_class_is_ginst (method->klass)) {
+			mono_error_set_invalid_program (error, "method %s with UnamangedCallersOnlyAttribute is generic", mono_method_full_name (method, TRUE));
+			return NULL;
+		}
 		mspecs = g_new0 (MonoMarshalSpec*, invoke_sig->param_count + 1);
 	} else {
 		invoke = mono_get_delegate_invoke_internal (delegate_klass);

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3979,7 +3979,6 @@ type_is_blittable (MonoType *type)
 	case MONO_TYPE_R8:
 	case MONO_TYPE_I:
 	case MONO_TYPE_U:
-	case MONO_TYPE_CHAR:
 	case MONO_TYPE_PTR:
 	case MONO_TYPE_FNPTR:
 		return TRUE;

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -4111,7 +4111,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	}
 	mono_mb_free (mb);
 
-	for (i = mono_method_signature_internal (invoke)->param_count; i >= 0; i--)
+	for (i = invoke_sig->param_count; i >= 0; i--)
 		if (mspecs [i])
 			mono_metadata_free_marshal_spec (mspecs [i]);
 	g_free (mspecs);

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -113,7 +113,7 @@ static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_function_pointer_attribute, 
 
 #ifdef ENABLE_NETCORE
 static GENERATE_TRY_GET_CLASS_WITH_CACHE (suppress_gc_transition_attribute, "System.Runtime.InteropServices", "SuppressGCTransitionAttribute")
-static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_callers_only_attribute, "System.Runtime.InteropServicea", "UnmanagedCallersOnlyAttribute")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE (unmanaged_callers_only_attribute, "System.Runtime.InteropServices", "UnmanagedCallersOnlyAttribute")
 #endif
 
 static MonoImage*

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -4056,7 +4056,7 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 			return NULL;
 		}
 		if (!method_signature_is_blittable (invoke_sig)) {
-			mono_error_set_invalid_program (error, "method %s with UnmanagedCallersOnlyAttribute has non-blittable parameters", mono_method_full_name (method, TRUE));
+			mono_error_set_invalid_program (error, "method %s with UnmanagedCallersOnlyAttribute has non-blittable parameters or return type", mono_method_full_name (method, TRUE));
 			return NULL;
 		}
 		mspecs = g_new0 (MonoMarshalSpec*, invoke_sig->param_count + 1);

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6851,11 +6851,12 @@ get_marshal_cb (void)
 gboolean
 mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method)
 {
+#ifndef ENABLE_NETCORE
+	return FALSE;
+#else
 	ERROR_DECL (attr_error);
 	MonoClass *attr_klass = NULL;
-#ifdef ENABLE_NETCORE
 	attr_klass = mono_class_try_get_unmanaged_callers_only_attribute_class ();
-#endif
 	if (!attr_klass)
 		return FALSE;
 	MonoCustomAttrInfo *cinfo;
@@ -6869,4 +6870,5 @@ mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method)
 	if (!cinfo->cached)
 		mono_custom_attrs_free (cinfo);
 	return result;
+#endif
 }

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -4019,7 +4019,8 @@ mono_marshal_get_managed_wrapper (MonoMethod *method, MonoClass *delegate_klass,
 	m.csig = csig;
 	m.image = get_method_image (method);
 
-	mono_marshal_set_callconv_from_modopt (invoke, csig, TRUE);
+	if (invoke)
+		mono_marshal_set_callconv_from_modopt (invoke, csig, TRUE);
 
 	/* The attribute is only available in Net 2.0 */
 	if (delegate_klass && mono_class_try_get_unmanaged_function_pointer_attribute_class ()) {

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6779,9 +6779,6 @@ get_marshal_cb (void)
 gboolean
 mono_method_has_unmanaged_callers_only_attribute (MonoMethod *method)
 {
-	/* TODO: if this is slow and called repeatedly for the same method, add a bit to MonoMethod that is true if the
-	 * method doesn't have the UnmanagedCallersOnlyAttribute, and false if we haven't checked yet, or if the
-	 * attribute is present. */
 	ERROR_DECL (attr_error);
 	MonoClass *attr_klass = NULL;
 #ifdef ENABLE_NETCORE

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -3761,7 +3761,13 @@ encode_method_ref (MonoAotCompile *acfg, MonoMethod *method, guint8 *buf, guint8
 		case MONO_WRAPPER_NATIVE_TO_MANAGED: {
 			g_assert (info);
 			encode_method_ref (acfg, info->d.native_to_managed.method, p, &p);
-			encode_klass_ref (acfg, info->d.native_to_managed.klass, p, &p);
+			MonoClass *klass = info->d.native_to_managed.klass;
+			if (!klass) {
+				encode_value (0, p, &p);
+			} else {
+				encode_value (1, p, &p);
+				encode_klass_ref (acfg, klass, p, &p);
+			}
 			break;
 		}
 		default:

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -1313,8 +1313,10 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 			if (!m)
 				return FALSE;
 			klass = decode_klass_ref (module, p, &p, error);
+#if 0
 			if (!klass)
 				return FALSE;
+#endif
 			ref->method = mono_marshal_get_managed_wrapper (m, klass, 0, error);
 			if (!is_ok (error))
 				return FALSE;

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -1312,11 +1312,13 @@ decode_method_ref_with_target (MonoAotModule *module, MethodRef *ref, MonoMethod
 			m = decode_resolve_method_ref (module, p, &p, error);
 			if (!m)
 				return FALSE;
-			klass = decode_klass_ref (module, p, &p, error);
-#if 0
-			if (!klass)
-				return FALSE;
-#endif
+			gboolean has_class = decode_value (p, &p);
+			if (has_class) {
+				klass = decode_klass_ref (module, p, &p, error);
+				if (!klass)
+					return FALSE;
+			} else
+				klass = NULL;
 			ref->method = mono_marshal_get_managed_wrapper (m, klass, 0, error);
 			if (!is_ok (error))
 				return FALSE;

--- a/src/mono/mono/mini/aot-runtime.h
+++ b/src/mono/mono/mini/aot-runtime.h
@@ -11,7 +11,7 @@
 #include "mini.h"
 
 /* Version number of the AOT file format */
-#define MONO_AOT_FILE_VERSION 178
+#define MONO_AOT_FILE_VERSION 179
 
 #define MONO_AOT_TRAMP_PAGE_SIZE 16384
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -846,8 +846,7 @@ interp_generate_ipe_throw_with_msg (TransformData *td, MonoError *error_msg)
 {
 	MonoJitICallInfo *info = &mono_get_jit_icall_info ()->mono_throw_invalid_program;
 
-	/* FIXME: is this the right mempool? */
-	char *msg = mono_mempool_strdup (m_class_get_image (td->method->klass)->mempool, mono_error_get_message (error_msg));
+	char *msg = mono_mempool_strdup (td->rtm->domain->mp, mono_error_get_message (error_msg));
 
 	interp_add_ins (td, MINT_MONO_LDPTR);
 	td->last_ins->data [0] = get_data_item_index (td, msg);

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -39,6 +39,18 @@ mono_ldftn (MonoMethod *method)
 	gpointer addr;
 	ERROR_DECL (error);
 
+	if (G_UNLIKELY ((method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 &&
+			method->wrapper_type == MONO_WRAPPER_NONE &&
+			mono_method_has_unmanaged_callers_only_attribute (method))) {
+		MonoClass *delegate_klass = NULL;
+		MonoGCHandle target_handle = 0;
+		method = mono_marshal_get_managed_wrapper (method, delegate_klass, target_handle, error);
+		if (!is_ok (error)) {
+			mono_error_set_pending_exception (error);
+			return NULL;
+		}
+	}
+
 	if (mono_llvm_only) {
 		// FIXME: No error handling
 

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -54,7 +54,12 @@ mono_ldftn (MonoMethod *method)
 		return addr;
 	}
 
-	addr = mono_create_jump_trampoline (mono_domain_get (), method, FALSE, error);
+	/* if we're need the address of a native-to-managed wrapper, just compile it now, trampoline needs thread local
+	 * variables that won't be there if we run on a thread that's not attached yet. */
+	if (method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED)
+		addr = mono_compile_method_checked (method, error);
+	else
+		addr = mono_create_jump_trampoline (mono_domain_get (), method, FALSE, error);
 	if (!is_ok (error)) {
 		mono_error_set_pending_exception (error);
 		return NULL;

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -54,7 +54,7 @@ mono_ldftn (MonoMethod *method)
 		return addr;
 	}
 
-	/* if we're need the address of a native-to-managed wrapper, just compile it now, trampoline needs thread local
+	/* if we need the address of a native-to-managed wrapper, just compile it now, trampoline needs thread local
 	 * variables that won't be there if we run on a thread that's not attached yet. */
 	if (method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED)
 		addr = mono_compile_method_checked (method, error);

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1596,6 +1596,14 @@ mono_throw_bad_image ()
 }
 
 void
+mono_throw_not_supported ()
+{
+	ERROR_DECL (error);
+	mono_error_set_generic_error (error, "System", "NotSupportedException", "");
+	mono_error_set_pending_exception (error);
+}
+
+void
 mono_throw_invalid_program (const char *msg)
 {
 	ERROR_DECL (error);

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -39,18 +39,6 @@ mono_ldftn (MonoMethod *method)
 	gpointer addr;
 	ERROR_DECL (error);
 
-	if (G_UNLIKELY ((method->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 &&
-			method->wrapper_type == MONO_WRAPPER_NONE &&
-			mono_method_has_unmanaged_callers_only_attribute (method))) {
-		MonoClass *delegate_klass = NULL;
-		MonoGCHandle target_handle = 0;
-		method = mono_marshal_get_managed_wrapper (method, delegate_klass, target_handle, error);
-		if (!is_ok (error)) {
-			mono_error_set_pending_exception (error);
-			return NULL;
-		}
-	}
-
 	if (mono_llvm_only) {
 		// FIXME: No error handling
 

--- a/src/mono/mono/mini/jit-icalls.c
+++ b/src/mono/mono/mini/jit-icalls.c
@@ -1596,6 +1596,14 @@ mono_throw_bad_image ()
 }
 
 void
+mono_throw_invalid_program (const char *msg)
+{
+	ERROR_DECL (error);
+	mono_error_set_invalid_program (error, "Invalid IL due to: %s", msg);
+	mono_error_set_pending_exception (error);
+}
+
+void
 mono_dummy_jit_icall (void)
 {
 }

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -223,6 +223,8 @@ ICALL_EXTERN_C void mono_throw_method_access (MonoMethod *caller, MonoMethod *ca
 
 ICALL_EXTERN_C void mono_throw_bad_image (void);
 
+ICALL_EXTERN_C void mono_throw_not_supported (void);
+
 ICALL_EXTERN_C void mono_throw_invalid_program (const char *msg);
 
 ICALL_EXTERN_C void mono_dummy_jit_icall (void);

--- a/src/mono/mono/mini/jit-icalls.h
+++ b/src/mono/mono/mini/jit-icalls.h
@@ -223,6 +223,8 @@ ICALL_EXTERN_C void mono_throw_method_access (MonoMethod *caller, MonoMethod *ca
 
 ICALL_EXTERN_C void mono_throw_bad_image (void);
 
+ICALL_EXTERN_C void mono_throw_invalid_program (const char *msg);
+
 ICALL_EXTERN_C void mono_dummy_jit_icall (void);
 
 #endif /* __MONO_JIT_ICALLS_H__ */

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -2311,8 +2311,7 @@ static void
 emit_invalid_program_with_msg (MonoCompile *cfg, MonoError *error_msg, MonoMethod *caller, MonoMethod *callee)
 {
 	g_assert (!is_ok (error_msg));
-	/* FIXME: is this the right mempool? */
-	char *str = mono_mempool_strdup (m_class_get_image (cfg->method->klass)->mempool, mono_error_get_message (error_msg));
+	char *str = mono_mempool_strdup (cfg->domain->mp, mono_error_get_message (error_msg));
 	MonoInst *iargs[1];
 	if (cfg->compile_aot)
 		EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -11106,6 +11106,17 @@ mono_ldptr:
 				}
 			}
 
+			/* UnmanagedCallersOnlyAttribute means ldftn should return a method callable from native */
+			if (G_UNLIKELY ((cmethod->flags & METHOD_ATTRIBUTE_PINVOKE_IMPL) == 0 &&
+					cmethod->wrapper_type == MONO_WRAPPER_NONE &&
+					mono_method_has_unmanaged_callers_only_attribute (cmethod))) {
+				MonoClass *delegate_klass = NULL;
+				MonoGCHandle target_handle = 0;
+				cmethod = mono_marshal_get_managed_wrapper (cmethod, delegate_klass, target_handle, cfg->error);
+				CHECK_CFG_ERROR;
+			}
+
+
 			argconst = emit_get_rgctx_method (cfg, context_used, cmethod, MONO_RGCTX_INFO_METHOD);
 			ins = mono_emit_jit_icall (cfg, mono_ldftn, &argconst);
 			*sp++ = ins;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4887,6 +4887,7 @@ register_icalls (void)
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_throw_method_access, mono_icall_sig_void_ptr_ptr, FALSE);
 	register_icall (mono_throw_bad_image, mono_icall_sig_void, FALSE);
+	register_icall (mono_throw_not_supported, mono_icall_sig_void, FALSE);
 	register_icall (mono_throw_invalid_program, mono_icall_sig_void_ptr, FALSE);
 	register_icall_no_wrapper (mono_dummy_jit_icall, mono_icall_sig_void);
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4887,6 +4887,7 @@ register_icalls (void)
 	register_icall (mono_get_method_object, mono_icall_sig_object_ptr, TRUE);
 	register_icall (mono_throw_method_access, mono_icall_sig_void_ptr_ptr, FALSE);
 	register_icall (mono_throw_bad_image, mono_icall_sig_void, FALSE);
+	register_icall (mono_throw_invalid_program, mono_icall_sig_void_ptr, FALSE);
 	register_icall_no_wrapper (mono_dummy_jit_icall, mono_icall_sig_void);
 
 	register_icall_with_wrapper (mono_monitor_enter_internal, mono_icall_sig_int32_obj);

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnmanagedCallersOnlyTest.cs" />

--- a/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
+++ b/src/tests/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnmanagedCallersOnlyTest.cs" />


### PR DESCRIPTION
When we see a method tagged with `UnmanagedCallersOnlyAttribute` in an `ldtn` instruction, load a pointer to a native-to-managed wrapper instead of a pointer to the managed method.

See https://github.com/dotnet/csharplang/blob/master/proposals/functionpointers.md#systemruntimeinteropservicesunmanagedcallersonlyattribute

TODO:
- [x] Throw exceptions for all the unsupported scenarios:
   - Attempting to call by creating a delegate
   - Invoking via reflection
   - Using unsupported argument or return types
- [x] ~Figure out why the CoreCLR tests are either not running or somehow passing.~
   ~The tests are in https://github.com/dotnet/runtime/tree/master/src/coreclr/tests/src/Interop/UnmanagedCallersOnly which doesn't seem to be in https://github.com/dotnet/runtime/blob/master/src/coreclr/tests/issues.targets but in that case Mono should be failing a number of the tests in there on CI.~
   It's because we only run P0 tests on CI for Mono.  I temporarily set it to P0 for this PR just to watch the tests fail.
- [x] Revert tests back to P1