### PR TITLE
Make DependencyInjection more linker trimmable

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection/Microsoft.Extensions.DependencyInjection.sln
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/Microsoft.Extensions.DependencyInjection.sln
@@ -13,9 +13,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.Depend
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DependencyInjection", "src\Microsoft.Extensions.DependencyInjection.csproj", "{0BD0C911-A456-40DA-B5B7-D51887777BF9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DependencyInjection.Tests", "tests\Microsoft.Extensions.DependencyInjection.Tests.csproj", "{85D59394-C2FA-42D0-B04A-B1F8E244E619}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DependencyInjection.Tests", "tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj", "{85D59394-C2FA-42D0-B04A-B1F8E244E619}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{62FF9AD2-6603-4F9C-AB56-FCACEE3B6723}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{62FF9AD2-6603-4F9C-AB56-FCACEE3B6723}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests", "tests\DI.External.Tests\Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj", "{01D2CC74-63FC-4091-B278-8BD264C325E3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{62FF9AD2-6603-4F9C-AB56-FCACEE3B6723}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{62FF9AD2-6603-4F9C-AB56-FCACEE3B6723}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{62FF9AD2-6603-4F9C-AB56-FCACEE3B6723}.Release|Any CPU.Build.0 = Release|Any CPU
+		{01D2CC74-63FC-4091-B278-8BD264C325E3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{01D2CC74-63FC-4091-B278-8BD264C325E3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{01D2CC74-63FC-4091-B278-8BD264C325E3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{01D2CC74-63FC-4091-B278-8BD264C325E3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -48,6 +54,7 @@ Global
 		{0BD0C911-A456-40DA-B5B7-D51887777BF9} = {BF719C68-E106-47F7-AD0D-F996739BA266}
 		{85D59394-C2FA-42D0-B04A-B1F8E244E619} = {615C17D7-1F66-4409-A982-73C31C517388}
 		{62FF9AD2-6603-4F9C-AB56-FCACEE3B6723} = {615C17D7-1F66-4409-A982-73C31C517388}
+		{01D2CC74-63FC-4091-B278-8BD264C325E3} = {615C17D7-1F66-4409-A982-73C31C517388}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {91C254CC-F9EE-4916-8A19-F816C708AE3C}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/DependencyInjectionEventSource.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics.Tracing;
 using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -82,22 +81,27 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         [NonEvent]
-        public void ExpressionTreeGenerated(Type serviceType, Expression expression)
-        {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
-            {
-                var visitor = new NodeCountingVisitor();
-                visitor.Visit(expression);
-                ExpressionTreeGenerated(serviceType.ToString(), visitor.NodeCount);
-            }
-        }
-
-        [NonEvent]
         public void DynamicMethodBuilt(Type serviceType, int methodSize)
         {
             if (IsEnabled(EventLevel.Verbose, EventKeywords.All))
             {
                 DynamicMethodBuilt(serviceType.ToString(), methodSize);
+            }
+        }
+    }
+
+    internal static class DependencyInjectionEventSourceExtensions
+    {
+        // This is an extension method because this assembly is trimmed at a "type granular" level in Blazor,
+        // and the whole DependencyInjectionEventSource type can't be trimmed. So extracting this to a separate
+        // type allows for the System.Linq.Expressions usage to be trimmed by the ILLinker.
+        public static void ExpressionTreeGenerated(this DependencyInjectionEventSource source, Type serviceType, Expression expression)
+        {
+            if (source.IsEnabled(EventLevel.Verbose, EventKeywords.All))
+            {
+                var visitor = new NodeCountingVisitor();
+                visitor.Visit(expression);
+                source.ExpressionTreeGenerated(serviceType.ToString(), visitor.NodeCount);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceCollectionContainerBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceCollectionContainerBuilderExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Extensions.DependencyInjection
             IServiceProviderEngine engine;
 
 #if !NETCOREAPP
-            engine = new DynamicServiceProviderEngine(serviceDescriptors);
+            engine = new DynamicServiceProviderEngine(services);
 #else
             if (RuntimeFeature.IsDynamicCodeCompiled)
             {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceCollectionContainerBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceCollectionContainerBuilderExtensions.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -57,7 +59,23 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(options));
             }
 
-            return new ServiceProvider(services, options);
+            IServiceProviderEngine engine;
+
+#if !NETCOREAPP
+            engine = new DynamicServiceProviderEngine(serviceDescriptors);
+#else
+            if (RuntimeFeature.IsDynamicCodeCompiled)
+            {
+                engine = new DynamicServiceProviderEngine(services);
+            }
+            else
+            {
+                // Don't try to compile Expressions/IL if they are going to get interpreted
+                engine = new RuntimeServiceProviderEngine(services);
+            }
+#endif
+
+            return new ServiceProvider(services, engine, options);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CompiledServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CompiledServiceProviderEngine.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public ExpressionResolverBuilder ResolverBuilder { get; }
 #endif
 
-        public CompiledServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public CompiledServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors)
+            : base(serviceDescriptors)
         {
 #if IL_EMIT
             ResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/DynamicServiceProviderEngine.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class DynamicServiceProviderEngine : CompiledServiceProviderEngine
     {
-        public DynamicServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public DynamicServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors)
+            : base(serviceDescriptors)
         {
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/Expressions/ExpressionsServiceProviderEngine.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal class ExpressionsServiceProviderEngine : ServiceProviderEngine
     {
         private readonly ExpressionResolverBuilder _expressionResolverBuilder;
-        public ExpressionsServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public ExpressionsServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors) : base(serviceDescriptors)
         {
             _expressionResolverBuilder = new ExpressionResolverBuilder(RuntimeResolver, this, Root);
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ILEmit/ILEmitServiceProviderEngine.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal class ILEmitServiceProviderEngine : ServiceProviderEngine
     {
         private readonly ILEmitResolverBuilder _expressionResolverBuilder;
-        public ILEmitServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public ILEmitServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors) : base(serviceDescriptors)
         {
             _expressionResolverBuilder = new ILEmitResolverBuilder(RuntimeResolver, this, Root);
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/IServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/IServiceProviderEngine.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
     internal interface IServiceProviderEngine : IServiceProvider, IDisposable, IAsyncDisposable
     {
         IServiceScope RootScope { get; }
+        void InitializeCallback(IServiceProviderEngineCallback callback);
         void ValidateService(ServiceDescriptor descriptor);
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/RuntimeServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/RuntimeServiceProviderEngine.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal class RuntimeServiceProviderEngine : ServiceProviderEngine
     {
-        public RuntimeServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback) : base(serviceDescriptors, callback)
+        public RuntimeServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors) : base(serviceDescriptors)
         {
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngine.cs
@@ -11,16 +11,15 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
 {
     internal abstract class ServiceProviderEngine : IServiceProviderEngine, IServiceScopeFactory
     {
-        private readonly IServiceProviderEngineCallback _callback;
+        private IServiceProviderEngineCallback _callback;
 
         private readonly Func<Type, Func<ServiceProviderEngineScope, object>> _createServiceAccessor;
 
         private bool _disposed;
 
-        protected ServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngineCallback callback)
+        protected ServiceProviderEngine(IEnumerable<ServiceDescriptor> serviceDescriptors)
         {
             _createServiceAccessor = CreateServiceAccessor;
-            _callback = callback;
             Root = new ServiceProviderEngineScope(this);
             RuntimeResolver = new CallSiteRuntimeResolver();
             CallSiteFactory = new CallSiteFactory(serviceDescriptors);
@@ -38,6 +37,11 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
         public ServiceProviderEngineScope Root { get; }
 
         public IServiceScope RootScope => Root;
+
+        void IServiceProviderEngine.InitializeCallback(IServiceProviderEngineCallback callback)
+        {
+            _callback = callback;
+        }
 
         public void ValidateService(ServiceDescriptor descriptor)
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
@@ -19,48 +18,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private readonly CallSiteValidator _callSiteValidator;
 
-        internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, ServiceProviderOptions options)
+        internal ServiceProvider(IEnumerable<ServiceDescriptor> serviceDescriptors, IServiceProviderEngine engine, ServiceProviderOptions options)
         {
-            IServiceProviderEngineCallback callback = null;
+            _engine = engine;
+
             if (options.ValidateScopes)
             {
-                callback = this;
+                _engine.InitializeCallback(this);
                 _callSiteValidator = new CallSiteValidator();
-            }
-
-            switch (options.Mode)
-            {
-                case ServiceProviderMode.Default:
-#if !NETCOREAPP
-                    _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback);
-#else
-                    if (RuntimeFeature.IsSupported("IsDynamicCodeCompiled"))
-                    {
-                        _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback);
-                    }
-                    else
-                    {
-                        // Don't try to compile Expressions/IL if they are going to get interpreted
-                        _engine = new RuntimeServiceProviderEngine(serviceDescriptors, callback);
-                    }
-#endif
-                    break;
-                case ServiceProviderMode.Dynamic:
-                    _engine = new DynamicServiceProviderEngine(serviceDescriptors, callback);
-                    break;
-                case ServiceProviderMode.Runtime:
-                    _engine = new RuntimeServiceProviderEngine(serviceDescriptors, callback);
-                    break;
-#if IL_EMIT
-                case ServiceProviderMode.ILEmit:
-                    _engine = new ILEmitServiceProviderEngine(serviceDescriptors, callback);
-                    break;
-#endif
-                case ServiceProviderMode.Expressions:
-                    _engine = new ExpressionsServiceProviderEngine(serviceDescriptors, callback);
-                    break;
-                default:
-                    throw new NotSupportedException(nameof(options.Mode));
             }
 
             if (options.ValidateOnBuild)

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProviderOptions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProviderOptions.cs
@@ -24,7 +24,5 @@ namespace Microsoft.Extensions.DependencyInjection
         /// NOTE: this check doesn't verify open generics services.
         /// </summary>
         public bool ValidateOnBuild { get; set; }
-
-        internal ServiceProviderMode Mode { get; set; } = ServiceProviderMode.Default;
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/CallSiteTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
         public void BuiltExpressionWillReturnResolvedServiceWhenAppropriate(
             ServiceDescriptor[] descriptors, Type serviceType, Func<object, object, bool> compare)
         {
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
 
             var callSite = provider.CallSiteFactory.GetCallSite(serviceType, new CallSiteChain());
             var collectionCallSite = provider.CallSiteFactory.GetCallSite(typeof(IEnumerable<>).MakeGenericType(serviceType), new CallSiteChain());
@@ -111,7 +111,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddScoped<ServiceB>();
             descriptors.AddScoped<ServiceC>();
 
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
             var callSite = provider.CallSiteFactory.GetCallSite(typeof(ServiceC), new CallSiteChain());
             var compiledCallSite = CompileCallSite(callSite, provider);
 
@@ -133,7 +133,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.Add(ServiceDescriptor.Describe(typeof(ServiceC), typeof(DisposableServiceC), lifetime));
 
             var disposables = new List<object>();
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
             provider.Root._captureDisposableCallback = obj =>
             {
                 disposables.Add(obj);
@@ -159,7 +159,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
                 typeof(ServiceC), p => new DisposableServiceC(p.GetService<ServiceB>()), lifetime));
 
             var disposables = new List<object>();
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
             provider.Root._captureDisposableCallback = obj =>
             {
                 disposables.Add(obj);
@@ -188,7 +188,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddTransient<ServiceC>();
 
             var disposables = new List<object>();
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
             provider.Root._captureDisposableCallback = obj =>
             {
                 disposables.Add(obj);
@@ -213,7 +213,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.Add(ServiceDescriptor.Describe(typeof(ServiceD), typeof(ServiceD), lifetime));
 
             var disposables = new List<object>();
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
             provider.Root._captureDisposableCallback = obj =>
             {
                 disposables.Add(obj);
@@ -234,7 +234,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddTransient<ClassWithThrowingCtor>();
             descriptors.AddTransient<IFakeService, FakeService>();
 
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
 
             var callSite1 = provider.CallSiteFactory.GetCallSite(typeof(ClassWithThrowingEmptyCtor), new CallSiteChain());
             var compiledCallSite1 = CompileCallSite(callSite1, provider);
@@ -257,7 +257,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             descriptors.AddTransient<ServiceD>();
             descriptors.AddTransient<ServiceE>();
 
-            var provider = new DynamicServiceProviderEngine(descriptors, null);
+            var provider = new DynamicServiceProviderEngine(descriptors);
 
             var callSite1 = provider.CallSiteFactory.GetCallSite(typeof(ServiceE), new CallSiteChain());
             var compileCallSite = CompileCallSite(callSite1, provider);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/DependencyInjectionEventSourceTests.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.DependencyInjection.Specification.Fakes;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     [CollectionDefinition(nameof(EventSourceTests), DisableParallelization = true)]
     public class EventSourceTests : ICollectionFixture<EventSourceTests>
@@ -181,7 +181,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddTransient<IFakeService, FakeService>();
 
-            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Expressions });
+            var serviceProvider = serviceCollection.BuildServiceProvider(ServiceProviderMode.Expressions);
 
             serviceProvider.GetService<IFakeService>();
 
@@ -200,7 +200,7 @@ namespace Microsoft.Extensions.DependencyInjection
             var serviceCollection = new ServiceCollection();
             serviceCollection.AddTransient<IFakeService, FakeService>();
 
-            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.ILEmit });
+            var serviceProvider = serviceCollection.BuildServiceProvider(ServiceProviderMode.ILEmit);
 
             serviceProvider.GetService<IFakeService>();
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionContainerBuilderTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionContainerBuilderTestExtensions.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection.ServiceLookup;
 
 namespace Microsoft.Extensions.DependencyInjection.Tests
@@ -12,12 +11,13 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     {
         public static ServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderMode mode)
         {
+            if (mode == ServiceProviderMode.Default)
+            {
+                return services.BuildServiceProvider();
+            }
+
             IServiceProviderEngine engine = mode switch
             {
-                ServiceProviderMode.Default =>
-                    RuntimeFeature.IsDynamicCodeCompiled ?
-                        (IServiceProviderEngine)new DynamicServiceProviderEngine(services) :
-                        new RuntimeServiceProviderEngine(services),
                 ServiceProviderMode.Dynamic => new DynamicServiceProviderEngine(services),
                 ServiceProviderMode.Runtime => new RuntimeServiceProviderEngine(services),
                 ServiceProviderMode.Expressions => new ExpressionsServiceProviderEngine(services),

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionContainerBuilderTestExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceCollectionContainerBuilderTestExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.DependencyInjection.ServiceLookup;
+
+namespace Microsoft.Extensions.DependencyInjection.Tests
+{
+    internal static class ServiceCollectionContainerBuilderTestExtensions
+    {
+        public static ServiceProvider BuildServiceProvider(this IServiceCollection services, ServiceProviderMode mode)
+        {
+            IServiceProviderEngine engine = mode switch
+            {
+                ServiceProviderMode.Default =>
+                    RuntimeFeature.IsDynamicCodeCompiled ?
+                        (IServiceProviderEngine)new DynamicServiceProviderEngine(services) :
+                        new RuntimeServiceProviderEngine(services),
+                ServiceProviderMode.Dynamic => new DynamicServiceProviderEngine(services),
+                ServiceProviderMode.Runtime => new RuntimeServiceProviderEngine(services),
+                ServiceProviderMode.Expressions => new ExpressionsServiceProviderEngine(services),
+                ServiceProviderMode.ILEmit => new ILEmitServiceProviderEngine(services),
+                _ => throw new NotSupportedException()
+            };
+
+            return new ServiceProvider(services, engine, ServiceProviderOptions.Default);
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderCompilationTest.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderCompilationTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
             var stackSize = 256 * 1024;
             var serviceCollection = new ServiceCollection();
             CompilationTestDataProvider.Register(serviceCollection);
-            var serviceProvider = serviceCollection.BuildServiceProvider(new ServiceProviderOptions { Mode = mode });
+            var serviceProvider = serviceCollection.BuildServiceProvider(mode);
 
             // Act + Assert
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderDefaultContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderDefaultContainerTests.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     public class ServiceProviderDefaultContainerTests : ServiceProviderContainerTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
-            collection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Default });
+            collection.BuildServiceProvider(ServiceProviderMode.Default);
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderExpressionsContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderExpressionsContainerTests.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     public class ServiceProviderExpressionsContainerTests : ServiceProviderContainerTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
-            collection.BuildServiceProvider(new ServiceProviderOptions { Mode = ServiceProviderMode.Expressions });
+            collection.BuildServiceProvider(ServiceProviderMode.Expressions);
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderILEmitContainerTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderILEmitContainerTests.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Extensions.DependencyInjection.Tests
     public class ServiceProviderILEmitContainerTests : ServiceProviderContainerTests
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection collection) =>
-            collection.BuildServiceProvider(new ServiceProviderOptions() { Mode = ServiceProviderMode.ILEmit});
+            collection.BuildServiceProvider(ServiceProviderMode.ILEmit);
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderMode.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/DI.Tests/ServiceProviderMode.cs
@@ -1,8 +1,8 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace Microsoft.Extensions.DependencyInjection
+namespace Microsoft.Extensions.DependencyInjection.Tests
 {
     internal enum ServiceProviderMode
     {


### PR DESCRIPTION
Allow the unused ServiceProviderEngine strategy types to be trimmed by the ILLinker by removing the `ServiceProviderMode` enum and only have the "default" behavior in the product. The `ServiceProviderMode` enum is only used for testing, so move it to the tests.

Fix #38678

This allows for System.Linq.Expressions to be completely removed in a default Blazor application. It also removes one of two usages of System.Reflection.Emit (the other being #38693).

With this change, the IL size of a Blazor WASM default template application:

| Build          | Size     |
|----------------|----------|
| master         | 3,366,912 bytes |
| PR             | 3,039,232 bytes |