### PR TITLE
Fix Log Formatter mutating its arguments.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/LogValuesFormatter.cs
@@ -115,15 +115,18 @@ namespace Microsoft.Extensions.Logging
 
         public string Format(object[] values)
         {
+            object[] formattedValues = null;
+
             if (values != null)
             {
+                formattedValues = new object[values.Length];
                 for (int i = 0; i < values.Length; i++)
                 {
-                    values[i] = FormatArgument(values[i]);
+                    formattedValues[i] = FormatArgument(values[i]);
                 }
             }
 
-            return string.Format(CultureInfo.InvariantCulture, _format, values ?? Array.Empty<object>());
+            return string.Format(CultureInfo.InvariantCulture, _format, formattedValues ?? Array.Empty<object>());
         }
 
         internal string Format()

--- a/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging/tests/Common/LoggerTest.cs
@@ -109,6 +109,25 @@ namespace Microsoft.Extensions.Logging.Test
         }
 
         [Fact]
+        public void LoggerFormatterDoesNotMutatesParams()
+        {
+            var store = new List<string>();
+            var loggerFactory = new LoggerFactory();
+            var logger = loggerFactory.CreateLogger("Test");
+
+            loggerFactory.AddProvider(new CustomLoggerProvider("provider1", ThrowExceptionAt.None, store));
+
+            var values = new object[] { null, 5, 4.4, "Test", new object[] { }  };
+            logger.LogInformation("These are the values", values);
+
+            Assert.IsNotType<string>(values[0]);
+            Assert.IsType<int>(values[1]);
+            Assert.IsType<double>(values[2]);
+            Assert.IsType<string>(values[3]);
+            Assert.IsType<object[]>(values[4]);
+        }
+
+        [Fact]
         public void LoggerCanGetProviderAfterItIsCreated()
         {
             // Arrange


### PR DESCRIPTION
Log Formatter now creates a new object array and inserts the formatted
parameters there instead of the original array.
Also added a test to verify if the types of the original objects remain
unchanged.

Fix #36165