### PR TITLE
[metadata] Move rarely used bits out of MonoMethod and give 1 bit back to MonoMethod:slot

### DIFF
--- a/src/mono/mono/metadata/class-init.c
+++ b/src/mono/mono/metadata/class-init.c
@@ -3394,7 +3394,8 @@ mono_class_setup_methods (MonoClass *klass)
 			if (methods [i]->flags & METHOD_ATTRIBUTE_VIRTUAL)
 			{
 				if (method_is_reabstracted (methods[i]->flags)) {
-					methods [i]->is_reabstracted = 1;
+					if (!methods [i]->is_inflated)
+						mono_method_set_is_reabstracted (methods [i]);
 					continue;
 				}
 				methods [i]->slot = slot++;

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -76,7 +76,7 @@ struct _MonoMethod {
 	unsigned int verification_success:1; /* whether this method has been verified successfully.*/
 	unsigned int is_reabstracted:1; /* whenever this is a reabstraction of another interface */
 	unsigned int is_covariant_override_impl:1; /* whether this is an override with a signature different from its declared method */
-	signed int slot : 15;
+	signed int slot : 16;
 
 	/*
 	 * If is_generic is TRUE, the generic_container is stored in image->property_hash, 

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -53,6 +53,7 @@ typedef enum {
 } MonoRemotingTarget;
 
 #define MONO_METHOD_PROP_GENERIC_CONTAINER 0
+#define MONO_METHOD_PROP_VERIFICATION_SUCCESS 1
 
 struct _MonoMethod {
 	guint16 flags;  /* method flags */
@@ -73,7 +74,6 @@ struct _MonoMethod {
 	unsigned int is_generic:1; /* whenever this is a generic method definition */
 	unsigned int is_inflated:1; /* whether we're a MonoMethodInflated */
 	unsigned int skip_visibility:1; /* whenever to skip JIT visibility checks */
-	unsigned int verification_success:1; /* whether this method has been verified successfully.*/
 	unsigned int is_reabstracted:1; /* whenever this is a reabstraction of another interface */
 	unsigned int is_covariant_override_impl:1; /* whether this is an override with a signature different from its declared method */
 	signed int slot : 16;
@@ -886,6 +886,12 @@ mono_generic_class_get_context (MonoGenericClass *gclass);
 
 void
 mono_method_set_generic_container (MonoMethod *method, MonoGenericContainer* container);
+
+void
+mono_method_set_verification_success (MonoMethod *method);
+
+gboolean
+mono_method_get_verification_success (MonoMethod *method);
 
 MonoMethod*
 mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context, MonoError *error);

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -54,6 +54,15 @@ typedef enum {
 
 #define MONO_METHOD_PROP_GENERIC_CONTAINER 0
 #define MONO_METHOD_PROP_VERIFICATION_SUCCESS 1
+#define MONO_METHOD_PROP_INFREQUENT_BITS 2
+
+/* Infrequently accessed bits of method definitions stored in the image properties.
+ * The method must not be inflated.
+ */
+typedef struct _MonoMethodDefInfrequentBits {
+	unsigned int is_reabstracted:1;  /* whenever this is a reabstraction of another interface */
+	unsigned int is_covariant_override_impl:1; /* whether this is an override with a signature different from its declared method */
+} MonoMethodDefInfrequentBits;
 
 struct _MonoMethod {
 	guint16 flags;  /* method flags */
@@ -74,8 +83,6 @@ struct _MonoMethod {
 	unsigned int is_generic:1; /* whenever this is a generic method definition */
 	unsigned int is_inflated:1; /* whether we're a MonoMethodInflated */
 	unsigned int skip_visibility:1; /* whenever to skip JIT visibility checks */
-	unsigned int is_reabstracted:1; /* whenever this is a reabstraction of another interface */
-	unsigned int is_covariant_override_impl:1; /* whether this is an override with a signature different from its declared method */
 	signed int slot : 16;
 
 	/*
@@ -892,6 +899,24 @@ mono_method_set_verification_success (MonoMethod *method);
 
 gboolean
 mono_method_get_verification_success (MonoMethod *method);
+
+const MonoMethodDefInfrequentBits *
+mono_method_lookup_infrequent_bits (MonoMethod *methoddef);
+
+MonoMethodDefInfrequentBits *
+mono_method_get_infrequent_bits (MonoMethod *methoddef);
+
+gboolean
+mono_method_get_is_reabstracted (MonoMethod *method);
+
+void
+mono_method_set_is_reabstracted (MonoMethod *methoddef);
+
+gboolean
+mono_method_get_is_covariant_override_impl (MonoMethod *method);
+
+void
+mono_method_set_is_covariant_override_impl (MonoMethod *methoddef);
 
 MonoMethod*
 mono_class_inflate_generic_method_full_checked (MonoMethod *method, MonoClass *klass_hint, MonoGenericContext *context, MonoError *error);

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -88,6 +88,7 @@ struct _MonoMethod {
 	unsigned int is_generic:1; /* whenever this is a generic method definition */
 	unsigned int is_inflated:1; /* whether we're a MonoMethodInflated */
 	unsigned int skip_visibility:1; /* whenever to skip JIT visibility checks */
+	unsigned int _unused : 2 /* unused */
 	signed int slot : 16;
 
 	/*

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -88,7 +88,7 @@ struct _MonoMethod {
 	unsigned int is_generic:1; /* whenever this is a generic method definition */
 	unsigned int is_inflated:1; /* whether we're a MonoMethodInflated */
 	unsigned int skip_visibility:1; /* whenever to skip JIT visibility checks */
-	unsigned int _unused : 2 /* unused */
+	unsigned int _unused : 2; /* unused */
 	signed int slot : 16;
 
 	/*

--- a/src/mono/mono/metadata/class-internals.h
+++ b/src/mono/mono/metadata/class-internals.h
@@ -53,11 +53,16 @@ typedef enum {
 } MonoRemotingTarget;
 
 #define MONO_METHOD_PROP_GENERIC_CONTAINER 0
+/* verification success bit, protected by the image lock */
 #define MONO_METHOD_PROP_VERIFICATION_SUCCESS 1
+/* infrequent vtable layout bits protected by the loader lock */
 #define MONO_METHOD_PROP_INFREQUENT_BITS 2
 
 /* Infrequently accessed bits of method definitions stored in the image properties.
  * The method must not be inflated.
+ *
+ * LOCKING: Reading the bits acquires the image lock.  Writing the bits assumes
+ * the loader lock is held.
  */
 typedef struct _MonoMethodDefInfrequentBits {
 	unsigned int is_reabstracted:1;  /* whenever this is a reabstraction of another interface */

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1379,6 +1379,41 @@ mono_method_set_generic_container (MonoMethod *method, MonoGenericContainer* con
 	mono_image_property_insert (mono_method_get_image (method), method, MONO_METHOD_PROP_GENERIC_CONTAINER, container);
 }
 
+/**
+ * mono_method_set_verification_success:
+ *
+ * Sets a bit indicating that the method has been verified.
+ *
+ * LOCKING: acquires the image lock.
+ */
+void
+mono_method_set_verification_success (MonoMethod *method)
+{
+	g_assert (!method->is_inflated);
+
+	mono_image_property_insert (mono_method_get_image (method), method, MONO_METHOD_PROP_VERIFICATION_SUCCESS, GUINT_TO_POINTER(1));
+}
+
+/**
+ * mono_method_get_verification_sucess:
+ *
+ * Returns \c TRUE if the method has been verified successfully.
+ *
+ * LOCKING: acquires the image lock.
+ */
+gboolean
+mono_method_get_verification_success (MonoMethod *method)
+{
+	if (method->is_inflated)
+		method = ((MonoMethodInflated *)method)->declaring;
+
+	gpointer value = mono_image_property_lookup (mono_method_get_image (method), method, MONO_METHOD_PROP_VERIFICATION_SUCCESS);
+
+	if (!value)
+		return FALSE;
+	return TRUE;
+}
+
 /** 
  * mono_class_find_enum_basetype:
  * \param class The enum class

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1416,7 +1416,8 @@ mono_method_get_verification_success (MonoMethod *method)
  * mono_method_lookup_infrequent_bits:
  *
  * Looks for existing \c MonoMethodDefInfrequentBits struct associated with
- * this method definition.
+ * this method definition.  Unlike \c mono_method_get_infrequent bits, this
+ * does not allocate a new struct if one doesn't exist.
  *
  * LOCKING: Acquires the image lock
  */
@@ -1433,6 +1434,9 @@ mono_method_lookup_infrequent_bits (MonoMethod *method)
  *
  * Looks for an existing, or allocates a new \c MonoMethodDefInfrequentBits struct for this method definition.
  * Method must not be inflated.
+ *
+ * Unlike \c mono_method_lookup_infrequent_bits, this will allocate a new
+ * struct if the method didn't have one.
  *
  * LOCKING: Acquires the image lock
  */

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1409,9 +1409,7 @@ mono_method_get_verification_success (MonoMethod *method)
 
 	gpointer value = mono_image_property_lookup (mono_method_get_image (method), method, MONO_METHOD_PROP_VERIFICATION_SUCCESS);
 
-	if (!value)
-		return FALSE;
-	return TRUE;
+	return value != NULL;
 }
 
 /**

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -1414,6 +1414,96 @@ mono_method_get_verification_success (MonoMethod *method)
 	return TRUE;
 }
 
+/**
+ * mono_method_lookup_infrequent_bits:
+ *
+ * Looks for existing \c MonoMethodDefInfrequentBits struct associated with
+ * this method definition.
+ *
+ * LOCKING: Acquires the image lock
+ */
+const MonoMethodDefInfrequentBits*
+mono_method_lookup_infrequent_bits (MonoMethod *method)
+{
+	g_assert (!method->is_inflated);
+
+	return (const MonoMethodDefInfrequentBits*)mono_image_property_lookup (mono_method_get_image (method), method, MONO_METHOD_PROP_INFREQUENT_BITS);
+}
+
+/**
+ * mono_method_get_infrequent_bits:
+ *
+ * Looks for an existing, or allocates a new \c MonoMethodDefInfrequentBits struct for this method definition.
+ * Method must not be inflated.
+ *
+ * LOCKING: Acquires the image lock
+ */
+MonoMethodDefInfrequentBits *
+mono_method_get_infrequent_bits (MonoMethod *method)
+{
+	g_assert (!method->is_inflated);
+	MonoImage *image = mono_method_get_image (method);
+	MonoMethodDefInfrequentBits *infrequent_bits = NULL;
+	mono_image_lock (image);
+	infrequent_bits = (MonoMethodDefInfrequentBits *)mono_image_property_lookup (image, method, MONO_METHOD_PROP_INFREQUENT_BITS);
+	if (!infrequent_bits) {
+		infrequent_bits = (MonoMethodDefInfrequentBits *)mono_image_alloc0 (image, sizeof (MonoMethodDefInfrequentBits));
+		mono_image_property_insert (image, method, MONO_METHOD_PROP_INFREQUENT_BITS, infrequent_bits);
+	}
+	mono_image_unlock (image);
+	return infrequent_bits;
+}
+
+gboolean
+mono_method_get_is_reabstracted (MonoMethod *method)
+{
+	if (method->is_inflated)
+		method = ((MonoMethodInflated*)method)->declaring;
+	const MonoMethodDefInfrequentBits *infrequent_bits = mono_method_lookup_infrequent_bits (method);
+	return infrequent_bits != NULL && infrequent_bits->is_reabstracted;
+}
+
+gboolean
+mono_method_get_is_covariant_override_impl (MonoMethod *method)
+{
+	if (method->is_inflated)
+		method = ((MonoMethodInflated*)method)->declaring;
+	const MonoMethodDefInfrequentBits *infrequent_bits = mono_method_lookup_infrequent_bits (method);
+	return infrequent_bits != NULL && infrequent_bits->is_covariant_override_impl;
+}
+
+/**
+ * mono_method_set_is_reabstracted:
+ *
+ * Sets the \c MonoMethodDefInfrequentBits:is_reabstracted bit for this method
+ * definition.  The bit means that the method is a default interface method
+ * that used to have a default implementation in an ancestor interface, but is
+ * now abstract once again.
+ *
+ * LOCKING: Assumes the loader lock is held
+ */
+void
+mono_method_set_is_reabstracted (MonoMethod *method)
+{
+	mono_method_get_infrequent_bits (method)->is_reabstracted = 1;
+}
+
+/**
+ * mono_method_set_is_covariant_override_impl:
+ *
+ * Sets the \c MonoMethodDefInfrequentBits:is_covariant_override_impl bit for
+ * this method definition.  The bit means that the method is an override with a
+ * signature that is not equal to the signature of the method that it is
+ * overriding.
+ *
+ * LOCKING: Assumes the loader lock is held
+ */
+void
+mono_method_set_is_covariant_override_impl (MonoMethod *method)
+{
+	mono_method_get_infrequent_bits (method)->is_covariant_override_impl = 1;
+}
+
 /** 
  * mono_class_find_enum_basetype:
  * \param class The enum class

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -2034,7 +2034,7 @@ mono_method_get_header_internal (MonoMethod *method, MonoError *error)
 	// FIXME: for internal callers maybe it makes sense to do this check at the call site, not
 	// here?
 	if (mono_method_has_no_body (method)) {
-		if (method->is_reabstracted == 1)
+		if (mono_method_get_is_reabstracted (method))
 			mono_error_set_generic_error (error, "System", "EntryPointNotFoundException", "%s", method->name);
 		else
 			mono_error_set_bad_image (error, img, "Method has no body");

--- a/src/mono/mono/mini/mini.c
+++ b/src/mono/mono/mini/mini.c
@@ -968,7 +968,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 	GSList *tmp, *res;
 	gboolean is_fulltrust;
 
-	if (method->verification_success)
+	if (mono_method_get_verification_success (method))
 		return FALSE;
 
 	if (!mono_verifier_is_enabled_for_method (method))
@@ -1018,7 +1018,7 @@ mini_method_verify (MonoCompile *cfg, MonoMethod *method, gboolean fail_compile)
 		}
 		mono_free_verify_list (res);
 	}
-	method->verification_success = 1;
+	mono_method_set_verification_success (method);
 	return FALSE;
 }
 


### PR DESCRIPTION
The `MonoMethod:slot` width was accidentally changed in https://github.com/dotnet/runtime/commit/8465be73eb40a9c409dc8974b9d6b235a1b5158f

To compensate, we move 3 bits out to image properties
   * `verification_success` - rarely used nowadays, protected by the image lock (like all image properties)
   * `is_reabstracted`, `is_covariant_override_impl` - infrequently used features of newer C# language features (default interface methods and covariant returns).  Setting these assumes the loader lock is held.