### PR TITLE
x86 P/Invokes marked with UnmanagedCallersOnly require marshalling

### DIFF
--- a/src/coreclr/src/vm/comdelegate.cpp
+++ b/src/coreclr/src/vm/comdelegate.cpp
@@ -2031,8 +2031,9 @@ void COMDelegate::ThrowIfInvalidUnmanagedCallersOnlyUsage(MethodDesc* pMD)
     if (pMD->HasClassOrMethodInstantiation())
         EX_THROW(EEResourceException, (kInvalidProgramException, W("InvalidProgram_GenericMethod")));
 
-    // Arguments
-    if (NDirect::MarshalingRequired(pMD, pMD->GetSig(), pMD->GetModule()))
+    // Arguments - Scenarios involving UnmanagedCallersOnly are handled during the jit.
+    bool unmanagedCallersOnlyRequiresMarshalling = false;
+    if (NDirect::MarshalingRequired(pMD, NULL, NULL, unmanagedCallersOnlyRequiresMarshalling))
         EX_THROW(EEResourceException, (kInvalidProgramException, W("InvalidProgram_NonBlittableTypes")));
 }
 

--- a/src/coreclr/src/vm/dllimport.cpp
+++ b/src/coreclr/src/vm/dllimport.cpp
@@ -3019,7 +3019,11 @@ HRESULT NDirect::HasNAT_LAttribute(IMDInternalImport *pInternalImport, mdToken t
 
 // Either MD or signature & module must be given.
 /*static*/
-BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*/, Module *pModule /*= NULL*/)
+BOOL NDirect::MarshalingRequired(
+    _In_opt_ MethodDesc* pMD,
+    _In_opt_ PCCOR_SIGNATURE pSig,
+    _In_opt_ Module* pModule,
+    _In_ bool unmanagedCallersOnlyRequiresMarshalling)
 {
     CONTRACTL
     {
@@ -3060,7 +3064,9 @@ BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*
             // don't support a DllImport with this attribute and we
             // error out during IL Stub generation so we indicate that
             // when checking if an IL Stub is needed.
-            if (pMD->HasUnmanagedCallersOnlyAttribute())
+            //
+            // Callers can indicate the check doesn't need to be performed.
+            if (unmanagedCallersOnlyRequiresMarshalling && pMD->HasUnmanagedCallersOnlyAttribute())
                 return TRUE;
 
             NDirectMethodDesc* pNMD = (NDirectMethodDesc*)pMD;

--- a/src/coreclr/src/vm/dllimport.h
+++ b/src/coreclr/src/vm/dllimport.h
@@ -83,7 +83,11 @@ public:
     static VOID NDirectLink(NDirectMethodDesc *pMD);
 
     // Either MD or signature & module must be given.
-    static BOOL MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig = NULL, Module *pModule = NULL);
+    static BOOL MarshalingRequired(
+        _In_opt_ MethodDesc* pMD,
+        _In_opt_ PCCOR_SIGNATURE pSig = NULL,
+        _In_opt_ Module* pModule = NULL,
+        _In_ bool unmanagedCallersOnlyRequiresMarshalling = true);
     static void PopulateNDirectMethodDesc(NDirectMethodDesc* pNMD, PInvokeStaticSigInfo* pSigInfo, BOOL throwOnError = TRUE);
 
     static MethodDesc* CreateCLRToNativeILStub(

--- a/src/coreclr/src/vm/jitinterface.cpp
+++ b/src/coreclr/src/vm/jitinterface.cpp
@@ -9824,7 +9824,15 @@ BOOL CEEInfo::pInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method, CORINFO_SI
 
     JIT_TO_EE_TRANSITION();
 
-    if (method != 0)
+    if (method == NULL)
+    {
+        // check the call site signature
+        result = NDirect::MarshalingRequired(
+                    NULL,
+                    callSiteSig->pSig,
+                    GetModule(callSiteSig->scope));
+    }
+    else
     {
         MethodDesc* ftn = GetMethod(method);
         _ASSERTE(ftn->IsNDirect());
@@ -9853,14 +9861,6 @@ BOOL CEEInfo::pInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method, CORINFO_SI
         // without NDirectImportPrecode.
         result = TRUE;
 #endif
-    }
-    else
-    {
-        // check the call site signature
-        result = NDirect::MarshalingRequired(
-                    GetMethod(method),
-                    callSiteSig->pSig,
-                    GetModule(callSiteSig->scope));
     }
 
     EE_TO_JIT_TRANSITION();

--- a/src/coreclr/tests/src/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
+++ b/src/coreclr/tests/src/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
@@ -354,15 +354,16 @@ public class Program
            void TestUnmanagedCallersOnlyNonStatic()
            {
                 .locals init ([0] native int ptr)
-                IL_0000:  nop
-                IL_0001:  ldftn      int CallbackNonStatic(int)
-                IL_0007:  stloc.0
+                nop
+                ldftn      int CallbackNonStatic(int)
+                stloc.0
 
-                IL_0008:  ldloc.0
-                IL_0009:  ldc.i4     <n> local
-                IL_000e:  call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                ldloc.0
+                ldc.i4     <n> local
+                call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                pop
 
-                IL_0013:  ret
+                ret
              }
         */
         DynamicMethod testUnmanagedCallersOnly = new DynamicMethod("TestUnmanagedCallersOnlyNonStatic", null, null, typeof(Program).Module);
@@ -378,6 +379,7 @@ public class Program
         int n = 12345;
         il.Emit(OpCodes.Ldc_I4, n);
         il.Emit(OpCodes.Call, typeof(UnmanagedCallersOnlyDll).GetMethod("CallManagedProc"));
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
         var testNativeMethod = (NativeMethodInvoker)testUnmanagedCallersOnly.CreateDelegate(typeof(NativeMethodInvoker));
@@ -401,15 +403,16 @@ public class Program
            void TestUnmanagedCallersOnlyNonBlittable()
            {
                 .locals init ([0] native int ptr)
-                IL_0000:  nop
-                IL_0001:  ldftn      int CallbackMethodNonBlittable(bool)
-                IL_0007:  stloc.0
+                nop
+                ldftn      int CallbackMethodNonBlittable(bool)
+                stloc.0
 
-                IL_0008:  ldloc.0
-                IL_0009:  ldc.i4     <n> local
-                IL_000e:  call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                ldloc.0
+                ldc.i4     <n> local
+                call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                pop
 
-                IL_0013:  ret
+                ret
              }
         */
         DynamicMethod testUnmanagedCallersOnly = new DynamicMethod("TestUnmanagedCallersOnlyNonBlittable", null, null, typeof(Program).Module);
@@ -425,6 +428,7 @@ public class Program
         int n = 12345;
         il.Emit(OpCodes.Ldc_I4, n);
         il.Emit(OpCodes.Call, typeof(UnmanagedCallersOnlyDll).GetMethod("CallManagedProc"));
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
         var testNativeMethod = (NativeMethodInvoker)testUnmanagedCallersOnly.CreateDelegate(typeof(NativeMethodInvoker));
@@ -478,15 +482,16 @@ public class Program
            void TestUnmanagedCallersOnlyInstGenericArguments()
            {
                 .locals init ([0] native int ptr)
-                IL_0000:  nop
-                IL_0001:  ldftn      void CallbackMethodGeneric(int)
-                IL_0007:  stloc.0
+                nop
+                ldftn      void CallbackMethodGeneric(int)
+                stloc.0
 
-                IL_0008:  ldloc.0
-                IL_0009:  ldc.i4     <n> local
-                IL_000e:  call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                ldloc.0
+                ldc.i4     <n> local
+                call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                pop
 
-                IL_0013:  ret
+                ret
              }
         */
         DynamicMethod testUnmanagedCallersOnly = new DynamicMethod("TestUnmanagedCallersOnlyInstGenericArguments", null, null, typeof(Program).Module);
@@ -502,6 +507,7 @@ public class Program
         int n = 12345;
         il.Emit(OpCodes.Ldc_I4, n);
         il.Emit(OpCodes.Call, typeof(UnmanagedCallersOnlyDll).GetMethod("CallManagedProc"));
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
         var testNativeMethod = (NativeMethodInvoker)testUnmanagedCallersOnly.CreateDelegate(typeof(NativeMethodInvoker));
@@ -527,15 +533,16 @@ public class Program
            void TestUnmanagedCallersOnlyInstGenericType()
            {
                 .locals init ([0] native int ptr)
-                IL_0000:  nop
-                IL_0001:  ldftn      int GenericClass<int>::CallbackMethod(int)
-                IL_0007:  stloc.0
+                nop
+                ldftn      int GenericClass<int>::CallbackMethod(int)
+                stloc.0
 
-                IL_0008:  ldloc.0
-                IL_0009:  ldc.i4     <n> local
-                IL_000e:  call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                ldloc.0
+                ldc.i4     <n> local
+                call       bool UnmanagedCallersOnlyDll::CallManagedProc(native int, int)
+                pop
 
-                IL_0013:  ret
+                ret
              }
         */
         DynamicMethod testUnmanagedCallersOnly = new DynamicMethod("TestUnmanagedCallersOnlyInstGenericClass", null, null, typeof(Program).Module);
@@ -551,6 +558,7 @@ public class Program
         int n = 12345;
         il.Emit(OpCodes.Ldc_I4, n);
         il.Emit(OpCodes.Call, typeof(UnmanagedCallersOnlyDll).GetMethod("CallManagedProc"));
+        il.Emit(OpCodes.Pop);
         il.Emit(OpCodes.Ret);
 
         var testNativeMethod = (NativeMethodInvoker)testUnmanagedCallersOnly.CreateDelegate(typeof(NativeMethodInvoker));
@@ -759,6 +767,15 @@ public class Program
 
         IntNativeMethodInvoker testNativeMethod = (IntNativeMethodInvoker)testUnmanagedCallersOnly.CreateDelegate(typeof(IntNativeMethodInvoker));
 
-        Assert.Throws<NotSupportedException>(() => testNativeMethod());
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
+        {
+            // This is due to a semantic change in NDirect::MarshalingRequired().
+            // See https://github.com/dotnet/runtime/issues/38697#issuecomment-653310319.
+            Assert.Throws<InvalidProgramException>(() => testNativeMethod());
+        }
+        else
+        {
+            Assert.Throws<NotSupportedException>(() => testNativeMethod());
+        }
     }
 }

--- a/src/coreclr/tests/src/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
+++ b/src/coreclr/tests/src/Interop/UnmanagedCallersOnly/UnmanagedCallersOnlyTest.cs
@@ -767,15 +767,6 @@ public class Program
 
         IntNativeMethodInvoker testNativeMethod = (IntNativeMethodInvoker)testUnmanagedCallersOnly.CreateDelegate(typeof(IntNativeMethodInvoker));
 
-        if (RuntimeInformation.ProcessArchitecture == Architecture.X86)
-        {
-            // This is due to a semantic change in NDirect::MarshalingRequired().
-            // See https://github.com/dotnet/runtime/issues/38697#issuecomment-653310319.
-            Assert.Throws<InvalidProgramException>(() => testNativeMethod());
-        }
-        else
-        {
-            Assert.Throws<NotSupportedException>(() => testNativeMethod());
-        }
+        Assert.Throws<NotSupportedException>(() => testNativeMethod());
     }
 }


### PR DESCRIPTION
On x86 the `InvalidProgramException` is thrown since all P/Invokes marked
  with `UnmanagedCallersOnly` now require marshalling. The test is expecting
  a different exception. For now the test will be updated to accept
  `InvalidProgramException` on x86.
Fix generated IL for test.

Fixes #38697 
Fixes #38737 

/cc @elinor-fung @jkoritzinsky 