### PR TITLE
Fix: FileStream.Dispose silently fails on Dispose when disk has run out of space

### DIFF
--- a/src/libraries/System.IO.FileSystem/System.IO.FileSystem.sln
+++ b/src/libraries/System.IO.FileSystem/System.IO.FileSystem.sln
@@ -22,6 +22,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{2E666815-2ED
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestUtilities", "..\Common\tests\TestUtilities\TestUtilities.csproj", "{66810085-C596-4ED4-ACEE-C939CBD55C4E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.IO.FileSystem.ManualTests", "tests\ManualTests\System.IO.FileSystem.Manual.Tests.csproj", "{70FA2031-8D6E-4127-901E-2B0D90420E08}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{66810085-C596-4ED4-ACEE-C939CBD55C4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66810085-C596-4ED4-ACEE-C939CBD55C4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66810085-C596-4ED4-ACEE-C939CBD55C4E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70FA2031-8D6E-4127-901E-2B0D90420E08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
@@ -23,8 +23,6 @@ namespace System.IO.ManualTests
             In remote machine:
                 - Install openssh-server.
                 - Create an ext4 partition of 1 MB size.
-                - Fill the new drive with files until almost full, leave a couple of bytes free.
-                - Make sure to also include a small file that is larger than the available free space left and name it "copyme.txt".
                 
             In local machine:
                 - Install sshfs and openssh-client.

--- a/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using Microsoft.DotNet.XUnitExtensions;
+using Xunit;
+
+namespace System.IO.ManualTests
+{
+    public class FileSystemManualTests
+    {
+        public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
+        
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public static void Throw_FileStreamDispose_WhenRemoteMountRunsOutOfSpace()
+        {
+            /*
+            Pre-requisites to run this test:
+
+            - The remote machine has a folder ~/share, where a small 1MB drive is mounted.
+            - The remote drive is almost full.
+            - The remote drive has one file, called "copyme.txt", large enough that if we attempt to programatically copy it into
+              the same folder, the action should fail because the file is slightly larger than the available free space in the disk.
+            - The local machine has a folder named "mountedremote" located in the local user's home folder.
+            - The remote folder is mounted into "mountedremote".too
+
+
+            Example of mounting a remote folder using sshfs and two Linux machines:
+
+            In remote machine:
+                - Install openssh-server.
+                - Create a partition of 1 MB. You can use gparted and a spare USB drive. The filesystem does not seem to matter, but the bug could be repro'd with ext4.
+                - Mount the drive in the 
+                - Fill the new drive with files until almost full, leave a couple of bytes free.
+                - Make sure to also include a small file that is larger than the available free space left and name it "copyme.txt".
+                
+            In local machine:
+                - Install sshfs and openssh-client
+                - Create a local folder inside the current user's home, named "mountedremote":
+                    $ mkdir ~/mountedremote
+                - Mount the remote folder into "mountedremote":
+                    $ sudo sshfs -o allow_other,default_permissions remoteuser@xxx.xxx.xxx.xxx:/home/remoteuser/share /home/localuser/mountedremote
+                - Set the environment variable MANUAL_TESTS=1
+                - Run this manual test.
+                - Expect the exception.
+                - Unmount the folder:
+                    $ fusermount -u ~/mountedremote
+            */
+            
+            string mountedPath = $"{Environment.GetEnvironmentVariable("HOME")}/mountedremote";
+            string origin      = $"{mountedPath}/copyme.txt";
+            string destination = $"{mountedPath}/destination.txt";
+
+            Assert.True(File.Exists(origin));
+
+            if (File.Exists(destination))
+            {
+                File.Delete(destination);
+            }
+
+            Assert.Throws<IOException>(() =>
+            {
+                using (FileStream originStream = new FileStream(origin, FileMode.Open, FileAccess.Read))
+                {
+                    using (Stream destinationStream = new FileStream(destination, FileMode.Create, FileAccess.Write))
+                    {
+                        originStream.CopyTo(destinationStream, 1);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/ManualTests/ManualTests.cs
@@ -12,20 +12,11 @@ namespace System.IO.ManualTests
     {
         public static bool ManualTestsEnabled => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MANUAL_TESTS"));
 
-        [Fact]//[ConditionalFact(nameof(ManualTestsEnabled))]
+        [ConditionalFact(nameof(ManualTestsEnabled))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public static void Throw_FileStreamDispose_WhenRemoteMountRunsOutOfSpace()
         {
             /*
-            Pre-requisites to run this test:
-
-            - The remote machine has a folder ~/share, where a small ext4 1MB drive is mounted.
-            - The remote drive is almost full.
-            - The remote drive has one file, called "copyme.txt", large enough that if we attempt to programatically copy it into
-              the same folder, the action should fail because the file is slightly larger than the available free space in the disk.
-            - The local machine has a folder named "mountedremote" located in the local user's home folder.
-            - The remote folder is mounted into "mountedremote".too
-
 
             Example of mounting a remote folder using sshfs and two Linux machines:
 
@@ -68,7 +59,7 @@ namespace System.IO.ManualTests
                 File.WriteAllBytes(largefile, new byte[925696]);
             }
 
-            // Craete original file if not exists
+            // Create original file if not exists
             if (!File.Exists(origin))
             {
                 File.WriteAllBytes(origin, new byte[8192]);

--- a/src/libraries/System.IO.FileSystem/tests/ManualTests/System.IO.FileSystem.Manual.Tests.csproj
+++ b/src/libraries/System.IO.FileSystem/tests/ManualTests/System.IO.FileSystem.Manual.Tests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ManualTests.cs" />
+  </ItemGroup>
+</Project>

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -92,8 +92,9 @@ namespace Microsoft.Win32.SafeHandles
             return ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
         }
 
+        // Each thread will have its own copy. This locks the file and avoids race conditions if the handle had the last error.
         [ThreadStatic]
-        internal Interop.ErrorInfo? t_lastCloseErrorInfo;
+        internal static Interop.ErrorInfo? t_lastCloseErrorInfo;
 
         protected override bool ReleaseHandle()
         {
@@ -112,7 +113,6 @@ namespace Microsoft.Win32.SafeHandles
             if (result != 0)
             {
                 t_lastCloseErrorInfo = Interop.Sys.GetLastErrorInfo();
-                Debug.Fail($"Close failed with result {result} and error {t_lastCloseErrorInfo}");
             }
             return result == 0;
         }

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -92,19 +92,8 @@ namespace Microsoft.Win32.SafeHandles
             return ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
         }
 
-        /// <summary>Opens a SafeFileHandle for a file descriptor created by a provided delegate.</summary>
-        /// <param name="fdFunc">
-        /// The function that creates the file descriptor. Returns the file descriptor on success, or an invalid
-        /// file descriptor on error with Marshal.GetLastWin32Error() set to the error code.
-        /// </param>
-        /// <returns>The created SafeFileHandle.</returns>
-        internal static SafeFileHandle Open(Func<SafeFileHandle> fdFunc)
-        {
-            SafeFileHandle handle = Interop.CheckIo(fdFunc());
-
-            Debug.Assert(!handle.IsInvalid, "File descriptor is invalid");
-            return handle;
-        }
+        [ThreadStatic]
+        internal Interop.ErrorInfo? t_lastCloseErrorInfo;
 
         protected override bool ReleaseHandle()
         {
@@ -120,7 +109,11 @@ namespace Microsoft.Win32.SafeHandles
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
             int result = Interop.Sys.Close(handle);
-            Debug.Assert(result == 0, $"Close failed with result {result} and error {Interop.Sys.GetLastErrorInfo()}");
+            if (result != 0)
+            {
+                t_lastCloseErrorInfo = Interop.Sys.GetLastErrorInfo();
+                Debug.Fail($"Close failed with result {result} and error {t_lastCloseErrorInfo}");
+            }
             return result == 0;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Win32.SafeHandles
             return ((fileinfo.Mode & Interop.Sys.FileTypes.S_IFMT) == Interop.Sys.FileTypes.S_IFDIR);
         }
 
-        // Each thread will have its own copy. This locks the file and avoids race conditions if the handle had the last error.
+        // Each thread will have its own copy. This prevents race conditions if the handle had the last error.
         [ThreadStatic]
         internal static Interop.ErrorInfo? t_lastCloseErrorInfo;
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
@@ -267,6 +267,20 @@ namespace System.IO
                         // name will be removed immediately.
                         Interop.Sys.Unlink(_path); // ignore errors; it's valid that the path may no longer exist
                     }
+
+                    // Closing the file handle can fail, e.g. due to out of disk space
+                    // Throw these errors as exceptions when disposing
+                    if (_fileHandle != null && !_fileHandle.IsClosed && disposing)
+                    {
+                        _fileHandle.t_lastCloseErrorInfo = null;
+
+                        _fileHandle.Dispose();
+
+                        if (_fileHandle.t_lastCloseErrorInfo != null)
+                        {
+                            throw Interop.GetExceptionForIoErrno(_fileHandle.t_lastCloseErrorInfo.GetValueOrDefault(), _path, isDirectory: false);
+                        }
+                    }
                 }
             }
             finally

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs
@@ -272,13 +272,13 @@ namespace System.IO
                     // Throw these errors as exceptions when disposing
                     if (_fileHandle != null && !_fileHandle.IsClosed && disposing)
                     {
-                        _fileHandle.t_lastCloseErrorInfo = null;
+                        SafeFileHandle.t_lastCloseErrorInfo = null;
 
                         _fileHandle.Dispose();
 
-                        if (_fileHandle.t_lastCloseErrorInfo != null)
+                        if (SafeFileHandle.t_lastCloseErrorInfo != null)
                         {
-                            throw Interop.GetExceptionForIoErrno(_fileHandle.t_lastCloseErrorInfo.GetValueOrDefault(), _path, isDirectory: false);
+                            throw Interop.GetExceptionForIoErrno(SafeFileHandle.t_lastCloseErrorInfo.GetValueOrDefault(), _path, isDirectory: false);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1816

On Unix, when the disk runs out of space before a `FileStream` is disposed and the buffer is flushed to disk, `Dispose` silently succeeds, causing files to be corrupted and preventing the user from taking corrective action.

On Windows we throw at the expected moment, allowing the user to react appropriately.

The suggested fix is to save any error thrown when the `SafeFileHandle.ReleaseHandle` method is called when the handle is disposed, then check that saved error in `FileStream.Dispose`, and throw an exception if there was an error.

The original issue was reported for a case where a file was being copied and pasted within the same drive which was mounted from the network.

I performed two tests with which I was able to reproduce the issue identically:

- One with a Linux partition from a remote machine mounted locally using sshfs.
- Another one with a NTFS partition created in my local hard drive in my Windows machine, which I accessed via WSL.

On both cases I followed the same steps:

- I filled the partitions almost completely with a bunch of large files, and only left 1 MB of disk space.
- I tried to copy one of those files into another file within the same drive, which would not fit in the remaining space.
- I used code like this, and I only varied the origin and destination files depending on the test case:
```cs
     try
     {
         using (Stream source = new FileStream(fileOrigin, FileMode.Open, FileAccess.Read))
         {
             using (Stream dest = new FileStream(fileDestination, FileMode.Create, FileAccess.Write))
             {
                 source.CopyTo(dest, bufferSize);
             }
         }
     }
     catch (Exception ex)
     {
         // Reaching here means the fix worked
        throw ex;
     }
      // Reaching here would be a bug because Dispose unexpectedly failed silently
     Debugger.Break();
```

Due to the nature of this issue, I am not sure how to write a unit test to verify this behavior. As far as I know, we do not have a mechanism to simulate network partitions of limited size.

### Original investigation result

I found that the native `write` method does not consider it an error when the number of bytes written is smaller than the number of bytes requested to write, even if, as the documentation says, it _could_ mean there's not enough disk space (ENOSPC error).

But the documentation also states there's no guarantee that the data will be successfully committed to disk when `write` finishes successfully. Only until the user calls `fsync` will the user know if the data can be committed or not.

In our code, `fsync` is wrapped by `FlushOSBuffer`, which throws on failure, which is what I used. Adding this call fixes the bug in Linux to throw like we do [on Windows](https://github.com/dotnet/runtime/blob/110282c71b3f7e1f91ea339953f4a0eba362a62c/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Windows.cs#L712-L730) (the bug does does not repro on Windows).

Unfortunately, making this additional flush call would be very expensive if added in the proposed location, so Jan suggested the alternative approach of saving a last error info if there's an error when attempting to release the `SafeFileHandle`, and then read it in `FileStream.Dispose`.
