### PR TITLE
[wasm] Skip System.Configuration.ConfigurationManager test suite

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+[assembly: SkipOnMono("System.Configuration.ConfigurationManager is not supported on WASM", TestPlatforms.Browser)]

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System.Configuration.ConfigurationManager.Tests.csproj
@@ -23,6 +23,7 @@
              Link="Source\UrlPath.cs" />
     <Compile Include="..\src\System\Configuration\ValidatorUtils.cs"
              Link="Source\ValidatorUtils.cs" />
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Mono\CallbackValidatorTest.cs" />
     <Compile Include="Mono\CommaDelimitedStringCollectionConverterTest.cs" />
     <Compile Include="Mono\CommaDelimitedStringCollectionTest.cs" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -22,7 +22,6 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">
     <!-- Builds and runs but fails hard enough to not produce any output XML -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Configuration.ConfigurationManager\tests\System.Configuration.ConfigurationManager.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http.Json\tests\FunctionalTests\System.Net.Http.Json.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Mail\tests\Functional\System.Net.Mail.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

<s>I marked some test classes/methods in System.Configuration.ConfigurationManager test suite as not running on Browser.
Some of them are time consuming, a couple of them just fail.
Someone could take a look to decide whether they make sense on Wasm and if it's worth fixing/enabling them. 
Most of the disabled tests contain an invocations of `ConfigurationManager.OpenExeConfiguration`.


The intermediate results of the local run:   
<s>`Tests run: 510, Errors: 0, Failures: 0, Skipped: 1.`</s>
`Tests run: 536, Errors: 0, Failures: 0, Skipped: 1`</s>

Since `System.Configuration.ConfigurationManager` is a legacy netstandard library, delivered as independent nuget package, it makes sense to skip the whole test suite.