### PR TITLE
Return true for PlatformDection.IsMonoInterpreter on WASM

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20316.1</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20316.1</MicrosoftDotNetGenAPIVersion>
     <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20316.1</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20316.1</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20353.2</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20316.1</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20316.1</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20325.16</MicrosoftDotNetRemoteExecutorVersion>

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -22,7 +22,6 @@ namespace System
         public static bool IsNetCore => Environment.Version.Major >= 5 || RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
         public static bool IsMonoInterpreter => GetIsRunningOnMonoInterpreter();
-        public static bool IsNotMonoInterpreter => !IsMonoInterpreter;
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsiOS => RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS"));
@@ -30,6 +29,7 @@ namespace System
         public static bool IsIllumos => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ILLUMOS"));
         public static bool IsSolaris => RuntimeInformation.IsOSPlatform(OSPlatform.Create("SOLARIS"));
         public static bool IsBrowser => RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+        public static bool IsNotBrowser => !IsBrowser;
 
         public static bool IsArmProcess => RuntimeInformation.ProcessArchitecture == Architecture.Arm;
         public static bool IsNotArmProcess => !IsArmProcess;
@@ -286,6 +286,10 @@ namespace System
 
         private static bool GetIsRunningOnMonoInterpreter()
         {
+            // Browser is always using interpreter right now
+            if (IsBrowser)
+                return true;
+
             // This is a temporary solution because mono does not support interpreter detection
             // within the runtime.
             var val = Environment.GetEnvironmentVariable("MONO_ENV_OPTIONS");

--- a/src/libraries/System.Drawing.Common/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Drawing.Common/tests/AssemblyInfo.cs
@@ -5,4 +5,4 @@
 using System;
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35917", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoInterpreter))]
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35917", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]

--- a/src/libraries/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
+++ b/src/libraries/System.Net.ServicePoint/tests/ServicePointManagerTest.cs
@@ -284,7 +284,7 @@ namespace System.Net.Tests
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36217", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36217", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         public static void FindServicePoint_Collectible()
         {
             RemoteExecutor.Invoke(() =>

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterTests.cs
@@ -24,7 +24,7 @@ namespace System.Runtime.Serialization.Formatters.Tests
         // On 32-bit we can't test these high inputs as they cause OutOfMemoryExceptions.
         [ConditionalTheory(typeof(Environment), nameof(Environment.Is64BitProcess))]
         [SkipOnCoreClr("Long running tests: https://github.com/dotnet/runtime/issues/11191", RuntimeConfiguration.Checked)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/35915", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/35915", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         [InlineData(2 * 6_584_983 - 2)] // previous limit
         [InlineData(2 * 7_199_369 - 2)] // last pre-computed prime number
         public void SerializeHugeObjectGraphs(int limit)

--- a/src/libraries/System.Text.Json/tests/Serialization/Stream.Collections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Stream.Collections.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Tests
     public static partial class StreamTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/35927", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
         public static async Task HandleCollectionsAsync()
         {
             await RunTest<string>();

--- a/src/libraries/System.Threading.Tasks/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Threading.Tasks/tests/AssemblyInfo.cs
@@ -5,4 +5,4 @@
 using System;
 using Xunit;
 
-[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35916", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoInterpreter))]
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/35916", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter), nameof(PlatformDetection.IsNotBrowser))]


### PR DESCRIPTION
The property only checked for the `MONO_ENV_OPTIONS=--interpreter` env var which isn't set on WebAssembly.

This needed an arcade fix to correct an inverted condition in the ActiveIssue discoverer: https://github.com/dotnet/arcade/pull/5744