### PR TITLE
Check loh_compacted_p of the right heap

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -24126,17 +24126,24 @@ void gc_heap::relocate_address (uint8_t** pold_address THREAD_NUMBER_DCL)
     }
 
 #ifdef FEATURE_LOH_COMPACTION
-    if (loh_compacted_p)
+    if (settings.loh_compaction)
     {
         heap_segment* pSegment = seg_mapping_table_segment_of ((uint8_t*)old_address);
-        size_t flags = pSegment->flags;
-        if ((flags & heap_segment_flags_loh)
-#ifdef FEATURE_BASICFREEZE
-            && !(flags & heap_segment_flags_readonly)
+#ifdef MULTIPLE_HEAPS
+        if (heap_segment_heap (pSegment)->loh_compacted_p)
+#else
+        if (loh_compacted_p)
 #endif
-            )
         {
-            *pold_address = old_address + loh_node_relocation_distance (old_address);
+            size_t flags = pSegment->flags;
+            if ((flags & heap_segment_flags_loh)
+#ifdef FEATURE_BASICFREEZE
+                && !(flags & heap_segment_flags_readonly)
+#endif
+                )
+            {
+                *pold_address = old_address + loh_node_relocation_distance (old_address);
+            }
         }
     }
 #endif //FEATURE_LOH_COMPACTION


### PR DESCRIPTION
This change is intended to fix a heap corruption caused by a missing relocation.

There are two necessary conditions for LOH compaction to occur:

- `settings.loh_compaction = TRUE`, and when that happens
- for each heap, `plan_loh` is called and if it also returned `TRUE`, then the LOH compaction of that heap will be performed.

Before LOH compaction, any pointers pointing into the LOH must be moved. This is performed by the `relocate_address` function. To determine whether a pointer needs to be moved, the code checked against a boolean flag `loh_compacted_p`. I believe the intent of this check is to avoid the cost of computing where the pointer should go. After all, if the LOH is not compacted, then there is no need to move the pointers.

However, the check was wrong. The check was checking against the heap that is current garbage collected, not the heap that the pointer points to. If heap X contains a pointer to the LOH of heap Y, heap X is not doing LOH compaction, but heap Y is, then we would miss the relocation.

The fix addresses this problem by making sure we check the `loh_compacted_p` for the right heap. Determining which heap the pointer is pointing to is taking time, and this is going to be work that needs to be performed per pointer, therefore optimization is added to check again `settings.loh_compaction`. If `settings.loh_compaction` is false, then there is no way we can have LOH compaction and therefore we can skip the work entirely.