### PR TITLE
Ignore 0-byte responses from AIA fetch

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/RevocationResponder.cs
@@ -29,6 +29,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
         public string UriPrefix { get; }
 
+        public bool RespondEmpty { get; set; }
+
         private RevocationResponder(HttpListener listener, string uriPrefix)
         {
             _listener = listener;
@@ -133,7 +135,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                 catch (Exception)
                 {
                 }
-                
+
                 return;
             }
 
@@ -159,7 +161,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
             if (_aiaPaths.TryGetValue(url, out authority))
             {
-                byte[] certData = authority.GetCertData();
+                byte[] certData = RespondEmpty ? Array.Empty<byte>() : authority.GetCertData();
 
                 responded = true;
                 context.Response.StatusCode = 200;
@@ -171,7 +173,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
 
             if (_crlPaths.TryGetValue(url, out authority))
             {
-                byte[] crl = authority.GetCrl();
+                byte[] crl = RespondEmpty ? Array.Empty<byte>() : authority.GetCrl();
 
                 responded = true;
                 context.Response.StatusCode = 200;
@@ -208,7 +210,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
                             return;
                         }
 
-                        byte[] ocspResponse = authority.BuildOcspResponse(certId, nonce);
+                        byte[] ocspResponse = RespondEmpty ? Array.Empty<byte>() : authority.BuildOcspResponse(certId, nonce);
 
                         responded = true;
                         context.Response.StatusCode = 200;
@@ -234,7 +236,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
         internal static RevocationResponder CreateAndListen()
         {
             HttpListener listener = OpenListener(out string uriPrefix);
-            
+
             RevocationResponder responder = new RevocationResponder(listener, uriPrefix);
             responder.HandleRequests();
             return responder;

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/CertificateAssetDownloader.cs
@@ -23,14 +23,16 @@ namespace Internal.Cryptography.Pal
         {
             byte[]? data = DownloadAsset(uri, ref remainingDownloadTime);
 
-            if (data == null)
+            if (data == null || data.Length == 0)
             {
                 return null;
             }
 
             try
             {
-                return new X509Certificate2(data);
+                X509Certificate2 certificate = new X509Certificate2(data);
+                certificate.ThrowIfInvalid();
+                return certificate;
             }
             catch (CryptographicException)
             {


### PR DESCRIPTION
When fetching a certificate with AIA, we should ignore responses that
are zero bytes in length. A zero-length byte array  passed to X509Certificate2
will create a default certificate with a null PAL. This was being
passed in to the OpenSSL chain builder, and would pass in a null handle
for the certificate.

Fixes #38704 