### PR TITLE
Fix handling of native runtime components for Crossgen2 package

### DIFF
--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -57,14 +57,11 @@
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)jitinterface$(LibraryFileExtension)" />
       <Crossgen2File Include="$(CoreCLRCrossgen2Dir)$(LibraryFilePrefix)clrjit-$(TargetSpec)$(LibraryFileExtension)" />
       <!-- Include the native and managed files from the Microsoft.NETCore.App shared framework -->
-      <Crossgen2File Include="@(RuntimeFile)" Condition="'%(RuntimeFile.TargetPath)' == 'runtimes/$(PackageRID)/native'" />
+      <Crossgen2File Include="@(RuntimeFile)" Condition="'%(RuntimeFile.TargetPath)' == 'runtimes/$(PackageRID)/native' and '%(RuntimeFile.Extension)' != '$(StaticLibraryFileExtension)'" />
       <Crossgen2File Include="@(RuntimeFile)" Condition="'%(RuntimeFile.TargetPath)' == 'runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)'" />
       <!-- Include the native hosting layer -->
       <Crossgen2File Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostfxr$(LibraryFileExtension)" />
       <Crossgen2File Include="$(DotNetHostBinDir)/$(LibraryFilePrefix)hostpolicy$(LibraryFileExtension)" />
-      <!-- Include native runtime components -->
-      <Crossgen2File Include="$(LibrariesNativeArtifactsPath)$(LibraryFilePrefix)*$(LibraryFileExtension)"
-        Exclude="$(LibrariesNativeArtifactsPath)$(LibraryFilePrefix)System.IO.Ports.Native$(LibraryFileExtension)" />
     </ItemGroup>
 
     <MSBuild Projects="$(CoreClrProjectRoot)src/tools/aot/crossgen2/crossgen2.csproj"

--- a/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
+++ b/src/installer/pkg/projects/netcoreapp/src/netcoreapp.depproj
@@ -100,7 +100,7 @@
 
     <ItemGroup Condition="'$(PackageRID)' != ''">
       <LibrariesRuntimeFiles Condition="'%(IsNative)' != 'true'" TargetPath="runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)" />
-      <LibrariesRuntimeFiles Condition="'%(IsNative)' == 'true'" TargetPath="runtimes/$(PackageRID)/native/%(LibrariesRuntimeFiles.NativeSubDirectory)%(RecursiveDir)" />
+      <LibrariesRuntimeFiles Condition="'%(IsNative)' == 'true'" TargetPath="$([System.String]::new('runtimes/$(PackageRID)/native/%(LibrariesRuntimeFiles.NativeSubDirectory)%(RecursiveDir)').TrimEnd('/'))" />
       <ReferenceCopyLocalPaths Include="@(LibrariesRuntimeFiles)" />
     </ItemGroup>
 


### PR DESCRIPTION
Amendment to #38600.  I figured out that the issue was caused by appending a trailing slash to TargetPath in netcoreapp.depproj file in #36781: https://github.com/dotnet/runtime/pull/36781/files#diff-9fac0b3c275ca346bd7e392f9ae3807cL108-R108, which made the native libraries to be omitted by the following line in Microsoft.NETCore.App.Crossgen2.pkgproj:
```xml
<Crossgen2File Include="@(RuntimeFile)" Condition="'%(RuntimeFile.TargetPath)' == 'runtimes/$(PackageRID)/native'" />
```
The changes in this PR remove the trailing slash and exclude static `.a` libraries, which are not used by Crossgen2. @dotnet/crossgen-contrib