### PR TITLE
PAL: Update CreateThread

### DIFF
--- a/src/coreclr/src/pal/src/thread/thread.cpp
+++ b/src/coreclr/src/pal/src/thread/thread.cpp
@@ -758,7 +758,7 @@ CorUnix::InternalCreateThread(
         }
 
         st = pthread_attr_setaffinity_np(&pthreadAttr, sizeof(cpu_set_t), &cpuSet);
-        if (st != 0)
+        if (st != 0 && st != EPERM)
         {
             if (st == ENOMEM)
             {


### PR DESCRIPTION
I _think_ this fixes #1634, though without a simple test-case I'm not certain.

I tried to write a pal test but could not figure-out how to mock the `phtread_attr_setaffinity_np` call to always return `EPERM` during the test. I _have_ run the pre-existing pal tests against the modified code, however, and they show the threading functions working as they are expected to, so at least I don't think I've broken it ;-) I'm not very proficient with C and C++, so please treat this change with extreme prejudice, especially as this is in the CoreCLR and would affect a LOT of people if I've screwed it up!

* Silently continue if `pthread_attr_setaffinity_np` returns `EPERM` in `CreateThread`.
  Fixes #1634.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>