### PR TITLE
[wasm] Enable System.Net.WebSockets tests; mark System.Net.WebSocketsTests.WebSocketTests with an active issue

### DIFF
--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Net.WebSockets.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/38807", TestPlatforms.Browser)]
     public sealed class WebSocketTests : WebSocketCreateTest
     {
         protected override WebSocket CreateFromStream(Stream stream, bool isServer, string subProtocol, TimeSpan keepAliveInterval) =>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -25,7 +25,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http.Json\tests\FunctionalTests\System.Net.Http.Json.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets\tests\System.Net.WebSockets.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\tests\System.Net.WebSockets.WebSocketProtocol.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
     <!-- Builds currently do not pass -->


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

- WebSocketReceiveResultTests and WebSocketExceptionTests from that suite pass.
- WebSocketTests class still crashes due to an emscripten issue (https://github.com/dotnet/runtime/issues/38807).

The result of the local run: `Tests run: 136, Errors: 0, Failures: 0, Skipped: 0.`