### PR TITLE
Remove additional testhost binplacing

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -100,12 +100,6 @@
       <NativePath>$(MicrosoftNetCoreAppRuntimePackNativeDir)</NativePath>
       <RuntimePath>$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)</RuntimePath>
     </BinPlaceTargetFrameworks>
-    <!-- Corresponding libMono and system.native libraries are added to testhost shared framework -->
-    <BinPlaceTargetFrameworks Include="$(NetCoreAppCurrent)-$(TargetOS)"
-                              Condition="'$(BinPlaceTestSharedFramework)' == 'true'">
-      <NativePath>$(NETCoreAppTestSharedFrameworkPath)</NativePath>
-      <ItemName>TestHostBinPlaceItem</ItemName>
-    </BinPlaceTargetFrameworks>
 
     <!-- binplace targeting packs which may be different from Build TargetFramework -->
     <BinPlaceTargetFrameworks Include="netstandard2.0">

--- a/src/libraries/Native/native-binplace.proj
+++ b/src/libraries/Native/native-binplace.proj
@@ -26,11 +26,6 @@
       <BinPlaceItem Condition="'$(TargetOS)' == 'Browser'" Include="$(NativeBinDir)dotnet.wasm" />
       <FileWrites Include="@(BinPlaceItem)" />
     </ItemGroup>
-
-    <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono' and '$(TargetsMobile)' != 'true'">
-      <TestHostBinPlaceItem Include="@(BinPlaceItem)" />
-      <FileWrites Include="@(TestHostBinPlaceItem)" />
-    </ItemGroup>
   </Target>
 
   <Target Name="Build" DependsOnTargets="BinPlace" />

--- a/src/libraries/restore/runtime/runtime.depproj
+++ b/src/libraries/restore/runtime/runtime.depproj
@@ -70,9 +70,6 @@
         <DestinationSubDirectory>include/%(RecursiveDir)</DestinationSubDirectory>
       </BinPlaceItem>
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetsMobile)' != 'true'">
-      <TestHostBinPlaceItem Include="@(RuntimeFiles)" />
-    </ItemGroup>
   </Target>
 
   <Target Name="OverrideRuntimeCoreCLR"


### PR DESCRIPTION
The additional testhost binplacing is dead code as the native assets
are already binplaced by default into the testhost.

@akoeplinger verifying my assumption on CI :) 