### PR TITLE
[mono] Re-enable IsByRef_Get_ReturnsExpected test

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
@@ -195,7 +195,6 @@ namespace System.Tests.Types
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31713", TestRuntimes.Mono)]
         public void IsByRef_Get_ReturnsExpected()
         {
             Type t = CreateType();


### PR DESCRIPTION
Not sure when this was fixed, but a standalone repro appears to work now.

Fixes https://github.com/dotnet/runtime/issues/31713