### PR TITLE
Throw with ParamName=value instead of Encoding

### DIFF
--- a/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -144,7 +144,7 @@ namespace System.Net
             get { return _encoding; }
             set
             {
-                ThrowIfNull(value, nameof(Encoding));
+                ThrowIfNull(value, nameof(value));
                 _encoding = value;
             }
         }

--- a/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
+++ b/src/libraries/System.Net.WebClient/tests/WebClientTest.cs
@@ -43,7 +43,7 @@ namespace System.Net.Tests
             var wc = new WebClient();
 
             AssertExtensions.Throws<ArgumentException>("value", () => { wc.BaseAddress = "http::/invalid url"; });
-            AssertExtensions.Throws<ArgumentNullException>("Encoding", () => { wc.Encoding = null; });
+            AssertExtensions.Throws<ArgumentNullException>("value", () => { wc.Encoding = null; });
         }
 
         [Fact]


### PR DESCRIPTION
Contributes to #36517 (I'm keeping it as "contributes" instead of "fixes" in case you plan to make this consistent through the whole repo)