### PR TITLE
fix failing revocation & ssl tests

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -860,7 +860,7 @@ SingleResponse ::= SEQUENCE {
             bool registerAuthorities = true,
             bool pkiOptionsInSubject = false,
             string subjectName = null,
-            int KeySize = DefaultKeySize)
+            int keySize = DefaultKeySize)
         {
             bool rootDistributionViaHttp = !pkiOptions.HasFlag(PkiOptions.NoRootCertDistributionUri);
             bool issuerRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.IssuerRevocationViaCrl);
@@ -875,9 +875,9 @@ SingleResponse ::= SEQUENCE {
                     endEntityRevocationViaCrl || endEntityRevocationViaOcsp,
                 "At least one revocation mode is enabled");
 
-            using (RSA rootKey = RSA.Create(KeySize))
-            using (RSA intermedKey = RSA.Create(KeySize))
-            using (RSA eeKey = RSA.Create(KeySize))
+            using (RSA rootKey = RSA.Create(keySize))
+            using (RSA intermedKey = RSA.Create(keySize))
+            using (RSA eeKey = RSA.Create(keySize))
             {
                 var rootReq = new CertificateRequest(
                     BuildSubject("A Revocation Test Root", testName, pkiOptions, pkiOptionsInSubject),

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -25,7 +25,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests.Common
         IssuerRevocationViaOcsp = 1 << 1,
         EndEntityRevocationViaCrl = 1 << 2,
         EndEntityRevocationViaOcsp = 1 << 3,
-        EndEntityIsServer = 1 << 4,
 
         CrlEverywhere = IssuerRevocationViaCrl | EndEntityRevocationViaCrl,
         OcspEverywhere = IssuerRevocationViaOcsp | EndEntityRevocationViaOcsp,
@@ -833,7 +832,6 @@ SingleResponse ::= SEQUENCE {
             bool issuerDistributionViaHttp = !pkiOptions.HasFlag(PkiOptions.NoIssuerCertDistributionUri);
             bool endEntityRevocationViaCrl = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaCrl);
             bool endEntityRevocationViaOcsp = pkiOptions.HasFlag(PkiOptions.EndEntityRevocationViaOcsp);
-            bool endEntityIsServer = pkiOptions.HasFlag(PkiOptions.EndEntityIsServer);
 
             Assert.True(
                 issuerRevocationViaCrl || issuerRevocationViaOcsp ||

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/CertificateAuthority.cs
@@ -908,7 +908,8 @@ SingleResponse ::= SEQUENCE {
 
                 endEntityCert = intermediateAuthority.CreateEndEntity(
                         BuildSubject(subjectName ?? "A Revocation Test Cert", testName, pkiOptions, pkiOptionsInSubject),
-                        eeKey, extensions);
+                        eeKey,
+                        extensions);
 
                 endEntityCert = endEntityCert.CopyWithPrivateKey(eeKey);
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -55,13 +55,14 @@ namespace System.Net.Security.Tests
             X509Certificate2Collection chain = new X509Certificate2Collection();
 
             CertificateAuthority.BuildPrivatePki(
-                PkiOptions.IssuerRevocationViaCrl,
+                PkiOptions.IssuerRevocationViaCrl | PkiOptions.EndEntityIsServer,
                 out RevocationResponder responder,
                 out CertificateAuthority root,
                 out CertificateAuthority intermediate,
                 out X509Certificate2 endEntity,
                 subjectName: name,
-                testName: testName);
+                testName: testName,
+                KeySize: 2048);
 
             chain.Add(intermediate.CloneIssuerCert());
             chain.Add(root.CloneIssuerCert());

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -62,7 +62,7 @@ namespace System.Net.Security.Tests
                 out X509Certificate2 endEntity,
                 subjectName: name,
                 testName: testName,
-                KeySize: 2048);
+                keySize: 2048);
 
             chain.Add(intermediate.CloneIssuerCert());
             chain.Add(root.CloneIssuerCert());

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -14,6 +14,22 @@ namespace System.Net.Security.Tests
 {
     public static class TestHelper
     {
+        private static readonly X509KeyUsageExtension s_eeKeyUsage =
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment | X509KeyUsageFlags.DataEncipherment,
+                critical: false);
+
+        private static readonly X509EnhancedKeyUsageExtension s_tlsServerEku =
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection
+                {
+                    new Oid("1.3.6.1.5.5.7.3.1", null)
+                },
+                false);
+
+        private static readonly X509BasicConstraintsExtension s_eeConstraints =
+            new X509BasicConstraintsExtension(false, false, 0, false);
+
         public static (Stream ClientStream, Stream ServerStream) GetConnectedStreams()
         {
             if (Capability.SecurityForceSocketStreams())
@@ -54,6 +70,15 @@ namespace System.Net.Security.Tests
         {
             X509Certificate2Collection chain = new X509Certificate2Collection();
 
+            X509ExtensionCollection extensions = new X509ExtensionCollection();
+
+            SubjectAlternativeNameBuilder builder = new SubjectAlternativeNameBuilder();
+            builder.AddDnsName(name);
+            extensions.Add(builder.Build());
+            extensions.Add(s_eeConstraints);
+            extensions.Add(s_eeKeyUsage);
+            extensions.Add(s_tlsServerEku);
+
             CertificateAuthority.BuildPrivatePki(
                 PkiOptions.IssuerRevocationViaCrl | PkiOptions.EndEntityIsServer,
                 out RevocationResponder responder,
@@ -62,7 +87,8 @@ namespace System.Net.Security.Tests
                 out X509Certificate2 endEntity,
                 subjectName: name,
                 testName: testName,
-                keySize: 2048);
+                keySize: 2048,
+                extensions: extensions);
 
             chain.Add(intermediate.CloneIssuerCert());
             chain.Add(root.CloneIssuerCert());

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/TestHelper.cs
@@ -80,7 +80,7 @@ namespace System.Net.Security.Tests
             extensions.Add(s_tlsServerEku);
 
             CertificateAuthority.BuildPrivatePki(
-                PkiOptions.IssuerRevocationViaCrl | PkiOptions.EndEntityIsServer,
+                PkiOptions.IssuerRevocationViaCrl,
                 out RevocationResponder responder,
                 out CertificateAuthority root,
                 out CertificateAuthority intermediate,


### PR DESCRIPTION
fix tests broken by #38182. 
This adds fork for Ssl server leaving revocation tests as before.
It adds keySize parameter to avoid failures on Debian 10 (requiring stronger crypto)

fixes  #38805
fixes #38744 