### PR TITLE
Trim NetEventSource when EventSource.IsSupported is false

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.Ssl.cs
@@ -399,7 +399,7 @@ internal static partial class Interop
                 case 1:
                     return true;
                 default:
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Error(null, $"AppleCryptoNative_SslIsHostnameMatch returned '{result}' for '{hostName}'");
                     Debug.Fail($"AppleCryptoNative_SslIsHostnameMatch returned {result}");
                     throw new SslException();

--- a/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
+++ b/src/libraries/Common/src/Interop/Windows/HttpApi/Interop.HttpApi.cs
@@ -663,13 +663,13 @@ internal static partial class Interop
 
         private static unsafe string GetKnownHeader(HTTP_REQUEST* request, long fixup, int headerIndex)
         {
-            if (NetEventSource.IsEnabled) { NetEventSource.Enter(null); }
+            if (NetEventSource.Log.IsEnabled()) { NetEventSource.Enter(null); }
 
             string header = null;
 
             HTTP_KNOWN_HEADER* pKnownHeader = (&request->Headers.KnownHeaders) + headerIndex;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(null, $"HttpApi::GetKnownHeader() pKnownHeader:0x{(IntPtr)pKnownHeader}");
                 NetEventSource.Info(null, $"HttpApi::GetKnownHeader() pRawValue:0x{(IntPtr)pKnownHeader->pRawValue} RawValueLength:{pKnownHeader->RawValueLength}");
@@ -682,7 +682,7 @@ internal static partial class Interop
                 header = new string(pKnownHeader->pRawValue + fixup, 0, pKnownHeader->RawValueLength);
             }
 
-            if (NetEventSource.IsEnabled) { NetEventSource.Exit(null, $"HttpApi::GetKnownHeader() return:{header}"); }
+            if (NetEventSource.Log.IsEnabled()) { NetEventSource.Exit(null, $"HttpApi::GetKnownHeader() return:{header}"); }
             return header;
         }
 
@@ -776,7 +776,7 @@ internal static partial class Interop
 
         internal static unsafe uint GetChunks(IntPtr memoryBlob, IntPtr originalAddress, ref int dataChunkIndex, ref uint dataChunkOffset, byte[] buffer, int offset, int size)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(null, $"HttpApi::GetChunks() memoryBlob:{memoryBlob}");
             }
@@ -828,7 +828,7 @@ internal static partial class Interop
                 dataChunkIndex = -1;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(null);
             }
@@ -854,7 +854,7 @@ internal static partial class Interop
 
         internal static unsafe IPEndPoint GetRemoteEndPoint(IntPtr memoryBlob, IntPtr originalAddress)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
 
             SocketAddress v4address = new SocketAddress(AddressFamily.InterNetwork, IPv4AddressSize);
             SocketAddress v6address = new SocketAddress(AddressFamily.InterNetworkV6, IPv6AddressSize);
@@ -874,13 +874,13 @@ internal static partial class Interop
                 endpoint = new IPEndPoint(IPAddress.IPv6Any, IPEndPoint.MinPort).Create(v6address) as IPEndPoint;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null);
             return endpoint;
         }
 
         internal static unsafe IPEndPoint GetLocalEndPoint(IntPtr memoryBlob, IntPtr originalAddress)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
 
             SocketAddress v4address = new SocketAddress(AddressFamily.InterNetwork, IPv4AddressSize);
             SocketAddress v6address = new SocketAddress(AddressFamily.InterNetworkV6, IPv6AddressSize);
@@ -900,7 +900,7 @@ internal static partial class Interop
                 endpoint = s_ipv6Any.Create(v6address) as IPEndPoint;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null);
             return endpoint;
         }
 

--- a/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.IntPtr.cs
@@ -40,7 +40,7 @@ namespace System.Net
                     }
 
                     var cert = new X509Certificate2(new IntPtr(next));
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(certContext, $"Adding remote certificate:{cert}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(certContext, $"Adding remote certificate:{cert}");
 
                     result.Add(cert);
                     last = next;

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/NegotiationInfoClass.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/NegotiationInfoClass.cs
@@ -14,7 +14,7 @@ namespace System.Net
         {
             if (safeHandle.IsInvalid)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Invalid handle:{safeHandle}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Invalid handle:{safeHandle}");
                 return null;
             }
 
@@ -23,7 +23,7 @@ namespace System.Net
             {
                 safeHandle.DangerousAddRef(ref gotRef);
                 IntPtr packageInfo = safeHandle.DangerousGetHandle();
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"packageInfo:{packageInfo} negotiationState:{negotiationState:x}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"packageInfo:{packageInfo} negotiationState:{negotiationState:x}");
 
                 if (negotiationState == Interop.SspiCli.SECPKG_NEGOTIATION_COMPLETE ||
                     negotiationState == Interop.SspiCli.SECPKG_NEGOTIATION_OPTIMISTIC)
@@ -34,7 +34,7 @@ namespace System.Net
                         name = Marshal.PtrToStringUni(((SecurityPackageInfo*)packageInfo)->Name);
                     }
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"packageInfo:{packageInfo} negotiationState:{negotiationState:x} name:{name}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"packageInfo:{packageInfo} negotiationState:{negotiationState:x} name:{name}");
 
                     // An optimization for future string comparisons.
                     return

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIAuthType.cs
@@ -26,7 +26,7 @@ namespace System.Net
 
         public int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             return SafeFreeContextBuffer.EnumeratePackages(out pkgnum, out pkgArray);
         }
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPISecureChannelType.cs
@@ -26,7 +26,7 @@ namespace System.Net
 
         public int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             return SafeFreeContextBuffer.EnumeratePackages(out pkgnum, out pkgArray);
         }
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SSPIWrapper.cs
@@ -14,7 +14,7 @@ namespace System.Net
     {
         internal static SecurityPackageInfoClass[] EnumerateSecurityPackages(ISSPIInterface secModule)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
 
             if (secModule.SecurityPackages == null)
             {
@@ -27,7 +27,7 @@ namespace System.Net
                         try
                         {
                             int errorCode = secModule.EnumerateSecurityPackages(out moduleCount, out arrayBaseHandle);
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"arrayBase: {arrayBaseHandle}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"arrayBase: {arrayBaseHandle}");
                             if (errorCode != 0)
                             {
                                 throw new Win32Exception(errorCode);
@@ -39,7 +39,7 @@ namespace System.Net
                             for (i = 0; i < moduleCount; i++)
                             {
                                 securityPackages[i] = new SecurityPackageInfoClass(arrayBaseHandle, i);
-                                if (NetEventSource.IsEnabled) NetEventSource.Log.EnumerateSecurityPackages(securityPackages[i].Name);
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.EnumerateSecurityPackages(securityPackages[i].Name);
                             }
 
                             secModule.SecurityPackages = securityPackages;
@@ -52,7 +52,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null);
             return secModule.SecurityPackages;
         }
 
@@ -70,7 +70,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.SspiPackageNotFound(packageName);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.SspiPackageNotFound(packageName);
 
             if (throwIfMissing)
             {
@@ -82,7 +82,7 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireDefaultCredential(ISSPIInterface secModule, string package, Interop.SspiCli.CredentialUse intent)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(null, package);
                 NetEventSource.Log.AcquireDefaultCredential(package, intent);
@@ -93,7 +93,7 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(AcquireDefaultCredential), $"0x{errorCode:X}"));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(AcquireDefaultCredential), $"0x{errorCode:X}"));
                 throw new Win32Exception(errorCode);
             }
             return outCredential;
@@ -101,14 +101,14 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireCredentialsHandle(ISSPIInterface secModule, string package, Interop.SspiCli.CredentialUse intent, ref SafeSspiAuthDataHandle authdata)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Log.AcquireCredentialsHandle(package, intent, authdata);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.AcquireCredentialsHandle(package, intent, authdata);
 
             SafeFreeCredentials? credentialsHandle = null;
             int errorCode = secModule.AcquireCredentialsHandle(package, intent, ref authdata, out credentialsHandle);
 
             if (errorCode != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(AcquireCredentialsHandle), $"0x{errorCode:X}"));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(AcquireCredentialsHandle), $"0x{errorCode:X}"));
                 throw new Win32Exception(errorCode);
             }
 
@@ -117,7 +117,7 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireCredentialsHandle(ISSPIInterface secModule, string package, Interop.SspiCli.CredentialUse intent, Interop.SspiCli.SCHANNEL_CRED scc)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(null, package);
                 NetEventSource.Log.AcquireCredentialsHandle(package, intent, scc);
@@ -132,32 +132,32 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(AcquireCredentialsHandle), $"0x{errorCode:X}"));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(AcquireCredentialsHandle), $"0x{errorCode:X}"));
                 throw new Win32Exception(errorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, outCredential);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, outCredential);
             return outCredential;
         }
 
         internal static int InitializeSecurityContext(ISSPIInterface secModule, ref SafeFreeCredentials? credential, ref SafeDeleteSslContext? context, string? targetName, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness datarep, InputSecurityBuffers inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Log.InitializeSecurityContext(credential, context, targetName, inFlags);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.InitializeSecurityContext(credential, context, targetName, inFlags);
 
             int errorCode = secModule.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, datarep, inputBuffers, ref outputBuffer, ref outFlags);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.SecurityContextInputBuffers(nameof(InitializeSecurityContext), inputBuffers.Count, outputBuffer.size, (Interop.SECURITY_STATUS)errorCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.SecurityContextInputBuffers(nameof(InitializeSecurityContext), inputBuffers.Count, outputBuffer.size, (Interop.SECURITY_STATUS)errorCode);
 
             return errorCode;
         }
 
         internal static int AcceptSecurityContext(ISSPIInterface secModule, SafeFreeCredentials? credential, ref SafeDeleteSslContext? context, Interop.SspiCli.ContextFlags inFlags, Interop.SspiCli.Endianness datarep, InputSecurityBuffers inputBuffers, ref SecurityBuffer outputBuffer, ref Interop.SspiCli.ContextFlags outFlags)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Log.AcceptSecurityContext(credential, context, inFlags);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.AcceptSecurityContext(credential, context, inFlags);
 
             int errorCode = secModule.AcceptSecurityContext(credential, ref context, inputBuffers, inFlags, datarep, ref outputBuffer, ref outFlags);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.SecurityContextInputBuffers(nameof(AcceptSecurityContext), inputBuffers.Count, outputBuffer.size, (Interop.SECURITY_STATUS)errorCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.SecurityContextInputBuffers(nameof(AcceptSecurityContext), inputBuffers.Count, outputBuffer.size, (Interop.SECURITY_STATUS)errorCode);
 
             return errorCode;
         }
@@ -166,7 +166,7 @@ namespace System.Net
         {
             int errorCode = secModule.CompleteAuthToken(ref context, in inputBuffer);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.OperationReturnedSomething(nameof(CompleteAuthToken), (Interop.SECURITY_STATUS)errorCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.OperationReturnedSomething(nameof(CompleteAuthToken), (Interop.SECURITY_STATUS)errorCode);
 
             return errorCode;
         }
@@ -175,7 +175,7 @@ namespace System.Net
         {
             int errorCode = secModule.ApplyControlToken(ref context, in inputBuffer);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.OperationReturnedSomething(nameof(ApplyControlToken), (Interop.SECURITY_STATUS)errorCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.OperationReturnedSomething(nameof(ApplyControlToken), (Interop.SECURITY_STATUS)errorCode);
 
             return errorCode;
         }
@@ -337,7 +337,7 @@ namespace System.Net
                     }
                 }
 
-                if (NetEventSource.IsEnabled && errorCode != 0)
+                if (NetEventSource.Log.IsEnabled() && errorCode != 0)
                 {
                     if (errorCode == Interop.SspiCli.SEC_I_RENEGOTIATE)
                     {
@@ -355,23 +355,23 @@ namespace System.Net
 
         public static SafeFreeContextBufferChannelBinding? QueryContextChannelBinding(ISSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, contextAttribute);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, contextAttribute);
 
             SafeFreeContextBufferChannelBinding result;
             int errorCode = secModule.QueryContextChannelBinding(securityContext, contextAttribute, out result);
             if (errorCode != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
                 return null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, result);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, result);
             return result;
         }
 
         public static bool QueryBlittableContextAttributes<T>(ISSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute, ref T attribute) where T : unmanaged
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, contextAttribute);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, contextAttribute);
 
             Span<T> span =
 #if NETSTANDARD2_0
@@ -392,18 +392,18 @@ namespace System.Net
             {
                 if (errorCode != 0)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
                     return false;
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, attribute);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, attribute);
                 return true;
             }
         }
 
         public static bool QueryBlittableContextAttributes<T>(ISSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute, Type safeHandleType, out SafeHandle? sspiHandle, ref T attribute) where T : unmanaged
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, contextAttribute);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, contextAttribute);
 
             Span<T> span =
 #if NETSTANDARD2_0
@@ -422,11 +422,11 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
                 return false;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, attribute);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, attribute);
             return true;
         }
 
@@ -436,7 +436,7 @@ namespace System.Net
                 contextAttribute == Interop.SspiCli.ContextAttribute.SECPKG_ATTR_NAMES ||
                 contextAttribute == Interop.SspiCli.ContextAttribute.SECPKG_ATTR_CLIENT_SPECIFIED_TARGET);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, contextAttribute);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, contextAttribute);
 
             Span<IntPtr> buffer = stackalloc IntPtr[1];
             int errorCode = secModule.QueryContextAttributes(
@@ -452,19 +452,19 @@ namespace System.Net
             {
                 if (errorCode != 0)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
                     return null;
                 }
 
                 string? result = Marshal.PtrToStringUni(sspiHandle.DangerousGetHandle());
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, result);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, result);
                 return result;
             }
         }
 
         public static SafeFreeCertContext? QueryContextAttributes_SECPKG_ATTR_REMOTE_CERT_CONTEXT(ISSPIInterface secModule, SafeDeleteContext securityContext)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
 
             Span<IntPtr> buffer = stackalloc IntPtr[1];
             int errorCode = secModule.QueryContextAttributes(
@@ -477,18 +477,18 @@ namespace System.Net
             if (errorCode != 0)
             {
                 sspiHandle?.Dispose();
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
                 return null;
             }
 
             var result = (SafeFreeCertContext)sspiHandle!;
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, result);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, result);
             return result;
         }
 
         public static bool QueryContextAttributes_SECPKG_ATTR_ISSUER_LIST_EX(ISSPIInterface secModule, SafeDeleteContext securityContext, ref Interop.SspiCli.SecPkgContext_IssuerListInfoEx ctx, out SafeHandle? sspiHandle)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
 
             Span<Interop.SspiCli.SecPkgContext_IssuerListInfoEx> buffer =
 #if NETSTANDARD2_0
@@ -508,11 +508,11 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"ERROR = {ErrorDescription(errorCode)}");
                 return false;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ctx);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, ctx);
             return true;
         }
 

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecurityPackageInfoClass.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecurityPackageInfoClass.cs
@@ -27,12 +27,12 @@ namespace System.Net
         {
             if (safeHandle.IsInvalid)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Invalid handle: {safeHandle}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Invalid handle: {safeHandle}");
                 return;
             }
 
             IntPtr unmanagedAddress = safeHandle.DangerousGetHandle() + (sizeof(SecurityPackageInfo) * index);
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"unmanagedAddress: {unmanagedAddress}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"unmanagedAddress: {unmanagedAddress}");
 
             SecurityPackageInfo* pSecurityPackageInfo = (SecurityPackageInfo*)unmanagedAddress;
 
@@ -47,17 +47,17 @@ namespace System.Net
             if (unmanagedString != IntPtr.Zero)
             {
                 Name = Marshal.PtrToStringUni(unmanagedString);
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Name: {Name}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Name: {Name}");
             }
 
             unmanagedString = pSecurityPackageInfo->Comment;
             if (unmanagedString != IntPtr.Zero)
             {
                 Comment = Marshal.PtrToStringUni(unmanagedString);
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Comment: {Comment}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Comment: {Comment}");
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, this.ToString());
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, this.ToString());
         }
 
         public override string ToString()

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -199,7 +199,7 @@ namespace System.Net.Security
             Interop.SspiCli.CredentialUse intent,
             out SafeFreeCredentials outCredential)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, package, intent);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, package, intent);
 
             int errorCode = -1;
             long timeStamp;
@@ -217,7 +217,7 @@ namespace System.Net.Security
                             ref outCredential._handle,
                             out timeStamp);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
 
             if (errorCode != 0)
             {
@@ -262,7 +262,7 @@ namespace System.Net.Security
             ref Interop.SspiCli.SCHANNEL_CRED authdata,
             out SafeFreeCredentials outCredential)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, package, intent, authdata);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, package, intent, authdata);
 
             int errorCode = -1;
             long timeStamp;
@@ -297,7 +297,7 @@ namespace System.Net.Security
                 authdata.paCred = copiedPtr;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Verbose(null, $"{nameof(Interop.SspiCli.AcquireCredentialsHandleW)} returns 0x{errorCode:x}, handle = {outCredential}");
 
             if (errorCode != 0)
             {
@@ -389,7 +389,7 @@ namespace System.Net.Security
             ref SecurityBuffer outSecBuffer,
             ref Interop.SspiCli.ContextFlags outFlags)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, $"credential:{inCredentials}, crefContext:{refContext}, targetName:{targetName}, inFlags:{inFlags}, endianness:{endianness}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, $"credential:{inCredentials}, crefContext:{refContext}, targetName:{targetName}, inFlags:{inFlags}, endianness:{endianness}");
 
             if (inCredentials == null)
             {
@@ -498,7 +498,7 @@ namespace System.Net.Security
                                             outFreeContextBuffer);
                         }
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Marshalling OUT buffer");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Marshalling OUT buffer");
 
                         // Get unmanaged buffer with index 0 as the only one passed into PInvoke.
                         outSecBuffer.size = outUnmanagedBuffer.cbBuffer;
@@ -514,7 +514,7 @@ namespace System.Net.Security
                 outFreeContextBuffer?.Dispose();
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"errorCode:0x{errorCode:x8}, refContext:{refContext}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"errorCode:0x{errorCode:x8}, refContext:{refContext}");
             return errorCode;
         }
 
@@ -621,7 +621,7 @@ namespace System.Net.Security
             ref SecurityBuffer outSecBuffer,
             ref Interop.SspiCli.ContextFlags outFlags)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, $"credential={inCredentials}, refContext={refContext}, inFlags={inFlags}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, $"credential={inCredentials}, refContext={refContext}, inFlags={inFlags}");
 
             if (inCredentials == null)
             {
@@ -727,7 +727,7 @@ namespace System.Net.Security
                                         ref outFlags,
                                         outFreeContextBuffer);
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Marshaling OUT buffer");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Marshaling OUT buffer");
 
                         // No data written out but there is Alert
                         if (outUnmanagedBuffer[0].cbBuffer == 0 && outUnmanagedBuffer[1].cbBuffer > 0)
@@ -756,7 +756,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"errorCode:0x{errorCode:x8}, refContext:{refContext}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"errorCode:0x{errorCode:x8}, refContext:{refContext}");
             return errorCode;
         }
 
@@ -854,7 +854,7 @@ namespace System.Net.Security
             ref SafeDeleteSslContext? refContext,
             in SecurityBuffer inSecBuffer)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(null, "SafeDeleteContext::CompleteAuthToken");
                 NetEventSource.Info(null, $"    refContext       = {refContext}");
@@ -906,7 +906,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"unmanaged CompleteAuthToken() errorCode:0x{errorCode:x8} refContext:{refContext}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"unmanaged CompleteAuthToken() errorCode:0x{errorCode:x8} refContext:{refContext}");
             return errorCode;
         }
 
@@ -914,7 +914,7 @@ namespace System.Net.Security
             ref SafeDeleteContext? refContext,
             in SecurityBuffer inSecBuffer)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(null);
                 NetEventSource.Info(null, $"    refContext       = {refContext}");
@@ -968,7 +968,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, $"unmanaged ApplyControlToken() errorCode:0x{errorCode:x8} refContext: {refContext}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, $"unmanaged ApplyControlToken() errorCode:0x{errorCode:x8} refContext: {refContext}");
             return errorCode;
         }
     }

--- a/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
+++ b/src/libraries/Common/src/Interop/Windows/WinSock/SafeNativeOverlapped.cs
@@ -17,7 +17,7 @@ namespace System.Net.Sockets
         private SafeNativeOverlapped()
             : this(IntPtr.Zero)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
         }
 
         private SafeNativeOverlapped(IntPtr handle)
@@ -31,7 +31,7 @@ namespace System.Net.Sockets
         {
             _socketHandle = socketHandle;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"socketHandle:{socketHandle}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"socketHandle:{socketHandle}");
         }
 
         public override bool IsInvalid
@@ -41,7 +41,7 @@ namespace System.Net.Sockets
 
         protected override bool ReleaseHandle()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             FreeNativeOverlapped();
 

--- a/src/libraries/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/libraries/Common/src/System/Net/ContextAwareResult.cs
@@ -274,7 +274,7 @@ namespace System.Net
         protected override void Cleanup()
         {
             base.Cleanup();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             CleanupInternal();
         }
 
@@ -298,7 +298,7 @@ namespace System.Net
             // capturing the context won't be sufficient.
             if ((_flags & StateFlags.CaptureIdentity) != 0 && !InternalPeekCompleted && (!capturingContext))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "starting identity capture");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "starting identity capture");
                 SafeCaptureIdentity();
             }
 
@@ -306,7 +306,7 @@ namespace System.Net
             // Note that Capture() can return null, for example if SuppressFlow() is in effect.
             if (capturingContext && !InternalPeekCompleted)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "starting capture");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "starting capture");
 
                 if (cachedContext == null)
                 {
@@ -326,12 +326,12 @@ namespace System.Net
                     }
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_context:{_context}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_context:{_context}");
             }
             else
             {
                 // Otherwise we have to have completed synchronously, or not needed the context.
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Skipping capture");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Skipping capture");
 
                 cachedContext = null;
                 if (AsyncCallback != null && !CompletedSynchronously)
@@ -347,7 +347,7 @@ namespace System.Net
             DebugProtectState(false);
             if (CompletedSynchronously)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Completing synchronously");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Completing synchronously");
                 base.Complete(IntPtr.Zero);
                 return true;
             }
@@ -358,7 +358,7 @@ namespace System.Net
         // This method is guaranteed to be called only once.  If called with a non-zero userToken, the context is not flowed.
         protected override void Complete(IntPtr userToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_context(set):{_context != null} userToken:{userToken}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_context(set):{_context != null} userToken:{userToken}");
 
             // If no flowing, just complete regularly.
             if ((_flags & StateFlags.PostBlockStarted) == 0)
@@ -390,7 +390,7 @@ namespace System.Net
 
         private void CompleteCallback()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Context set, calling callback.");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Context set, calling callback.");
             base.Complete(IntPtr.Zero);
         }
 

--- a/src/libraries/Common/src/System/Net/DebugCriticalHandleMinusOneIsInvalid.cs
+++ b/src/libraries/Common/src/System/Net/DebugCriticalHandleMinusOneIsInvalid.cs
@@ -18,12 +18,12 @@ namespace System.Net
         protected DebugCriticalHandleMinusOneIsInvalid() : base()
         {
             _trace = "WARNING! GC-ed  >>" + this.GetType().FullName + "<< (should be explicitly closed) \r\n";
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Creating SafeHandle");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Creating SafeHandle");
         }
 
         ~DebugCriticalHandleMinusOneIsInvalid()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, _trace);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, _trace);
         }
     }
 #endif // DEBUG

--- a/src/libraries/Common/src/System/Net/DebugCriticalHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/libraries/Common/src/System/Net/DebugCriticalHandleZeroOrMinusOneIsInvalid.cs
@@ -18,12 +18,12 @@ namespace System.Net
         protected DebugCriticalHandleZeroOrMinusOneIsInvalid() : base()
         {
             _trace = "WARNING! GC-ed  >>" + this.GetType().FullName + "<< (should be explicitly closed) \r\n";
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Creating SafeHandle");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Creating SafeHandle");
         }
 
         ~DebugCriticalHandleZeroOrMinusOneIsInvalid()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, _trace);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, _trace);
         }
     }
 #endif // DEBUG

--- a/src/libraries/Common/src/System/Net/DebugSafeHandle.cs
+++ b/src/libraries/Common/src/System/Net/DebugSafeHandle.cs
@@ -33,7 +33,7 @@ namespace System.Net
 
         ~DebugSafeHandle()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, _trace);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, _trace);
         }
     }
 #endif // DEBUG

--- a/src/libraries/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
+++ b/src/libraries/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
@@ -18,12 +18,12 @@ namespace System.Net
         protected DebugSafeHandleMinusOneIsInvalid(bool ownsHandle) : base(ownsHandle)
         {
             _trace = "WARNING! GC-ed  >>" + this.GetType().FullName + "<< (should be explicitly closed) \r\n";
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Creating SafeHandle");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Creating SafeHandle");
         }
 
         ~DebugSafeHandleMinusOneIsInvalid()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, _trace);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, _trace);
         }
     }
 #endif // DEBUG

--- a/src/libraries/Common/src/System/Net/Http/WinInetProxyHelper.cs
+++ b/src/libraries/Common/src/System/Net/Http/WinInetProxyHelper.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
                     _proxy = Marshal.PtrToStringUni(proxyConfig.Proxy)!;
                     _proxyBypass = Marshal.PtrToStringUni(proxyConfig.ProxyBypass)!;
 
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(this, $"AutoConfigUrl={AutoConfigUrl}, AutoDetect={AutoDetect}, Proxy={Proxy}, ProxyBypass={ProxyBypass}");
                     }
@@ -44,10 +44,10 @@ namespace System.Net.Http
                 {
                     // We match behavior of WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY and ignore errors.
                     int lastError = Marshal.GetLastWin32Error();
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"error={lastError}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"error={lastError}");
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_useProxy={_useProxy}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_useProxy={_useProxy}");
             }
 
             finally
@@ -128,7 +128,7 @@ namespace System.Net.Http
                     ref autoProxyOptions,
                     out proxyInfo))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Using autoconfig proxy settings");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Using autoconfig proxy settings");
                     useProxy = true;
 
                     break;
@@ -136,7 +136,7 @@ namespace System.Net.Http
                 else
                 {
                     var lastError = Marshal.GetLastWin32Error();
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"error={lastError}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"error={lastError}");
 
                     if (lastError == Interop.WinHttp.ERROR_WINHTTP_LOGIN_FAILURE)
                     {
@@ -172,11 +172,11 @@ namespace System.Net.Http
                 proxyInfo.ProxyBypass = string.IsNullOrEmpty(ProxyBypass) ?
                     IntPtr.Zero : Marshal.StringToHGlobalUni(ProxyBypass);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Fallback to Proxy={Proxy}, ProxyBypass={ProxyBypass}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Fallback to Proxy={Proxy}, ProxyBypass={ProxyBypass}");
                 useProxy = true;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"useProxy={useProxy}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"useProxy={useProxy}");
 
             return useProxy;
         }

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/NetEventSource.Common.cs
@@ -29,8 +29,8 @@ namespace System.Net
     // Usage:
     // - Operations that may allocate (e.g. boxing a value type, using string interpolation, etc.) or that may have computations
     //   at call sites should guard access like:
-    //       if (NetEventSource.IsEnabled) NetEventSource.Enter(this, refArg1, valueTypeArg2); // entering an instance method with a value type arg
-    //       if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Found certificate: {cert}"); // info logging with a formattable string
+    //       if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, refArg1, valueTypeArg2); // entering an instance method with a value type arg
+    //       if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Found certificate: {cert}"); // info logging with a formattable string
     // - Operations that have zero allocations / measurable computations at call sites can use a simpler pattern, calling methods like:
     //       NetEventSource.Enter(this);                   // entering an instance method
     //       NetEventSource.Info(this, "literal string");  // arbitrary message with a literal string
@@ -103,7 +103,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs entrance to a method.</summary>
@@ -115,7 +115,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)})");
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)})");
         }
 
         /// <summary>Logs entrance to a method.</summary>
@@ -129,7 +129,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
             DebugValidateArg(arg1);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)})");
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)})");
         }
 
         /// <summary>Logs entrance to a method.</summary>
@@ -145,7 +145,7 @@ namespace System.Net
             DebugValidateArg(arg0);
             DebugValidateArg(arg1);
             DebugValidateArg(arg2);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
         }
 
         [Event(EnterEventId, Level = EventLevel.Informational, Keywords = Keywords.EnterExit)]
@@ -163,7 +163,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Exit(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Exit(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs exit from a method.</summary>
@@ -175,7 +175,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
-            if (IsEnabled) Log.Exit(IdOf(thisOrContextObject), memberName, Format(arg0).ToString());
+            if (Log.IsEnabled()) Log.Exit(IdOf(thisOrContextObject), memberName, Format(arg0).ToString());
         }
 
         /// <summary>Logs exit from a method.</summary>
@@ -189,7 +189,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
             DebugValidateArg(arg1);
-            if (IsEnabled) Log.Exit(IdOf(thisOrContextObject), memberName, $"{Format(arg0)}, {Format(arg1)}");
+            if (Log.IsEnabled()) Log.Exit(IdOf(thisOrContextObject), memberName, $"{Format(arg0)}, {Format(arg1)}");
         }
 
         [Event(ExitEventId, Level = EventLevel.Informational, Keywords = Keywords.EnterExit)]
@@ -207,7 +207,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs an information message.</summary>
@@ -219,7 +219,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(InfoEventId, Level = EventLevel.Informational, Keywords = Keywords.Default)]
@@ -237,7 +237,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
         }
 
         /// <summary>Logs an error message.</summary>
@@ -249,7 +249,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(ErrorEventId, Level = EventLevel.Error, Keywords = Keywords.Default)]
@@ -268,7 +268,7 @@ namespace System.Net
             // Don't call DebugValidateArg on args, as we expect Fail to be used in assert/failure situations
             // that should never happen in production, and thus we don't care about extra costs.
 
-            if (IsEnabled) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(formattableString));
             Debug.Fail(Format(formattableString), $"{IdOf(thisOrContextObject)}.{memberName}");
         }
 
@@ -282,7 +282,7 @@ namespace System.Net
             // Don't call DebugValidateArg on args, as we expect Fail to be used in assert/failure situations
             // that should never happen in production, and thus we don't care about extra costs.
 
-            if (IsEnabled) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(message).ToString());
             Debug.Fail(Format(message).ToString(), $"{IdOf(thisOrContextObject)}.{memberName}");
         }
 
@@ -311,7 +311,7 @@ namespace System.Net
         [NonEvent]
         public static void DumpBuffer(object? thisOrContextObject, byte[] buffer, int offset, int count, [CallerMemberName] string? memberName = null)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 if (offset < 0 || offset > buffer.Length - count)
                 {
@@ -343,7 +343,7 @@ namespace System.Net
             Debug.Assert(bufferPtr != IntPtr.Zero);
             Debug.Assert(count >= 0);
 
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 var buffer = new byte[Math.Min(count, MaxDumpSize)];
                 fixed (byte* targetPtr = buffer)
@@ -369,7 +369,7 @@ namespace System.Net
         {
             DebugValidateArg(first);
             DebugValidateArg(second);
-            if (IsEnabled) Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
+            if (Log.IsEnabled()) Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
         }
 
         /// <summary>Logs a relationship between two objects.</summary>
@@ -383,7 +383,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(first);
             DebugValidateArg(second);
-            if (IsEnabled) Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
+            if (Log.IsEnabled()) Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
         }
 
         [Event(AssociateEventId, Level = EventLevel.Informational, Keywords = Keywords.Default, Message = "[{2}]<-->[{3}]")]
@@ -396,7 +396,7 @@ namespace System.Net
         [Conditional("DEBUG_NETEVENTSOURCE_MISUSE")]
         private static void DebugValidateArg(object? arg)
         {
-            if (!IsEnabled)
+            if (!Log.IsEnabled())
             {
                 Debug.Assert(!(arg is ValueType), $"Should not be passing value type {arg?.GetType()} to logging without IsEnabled check");
                 Debug.Assert(!(arg is FormattableString), $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
@@ -406,11 +406,8 @@ namespace System.Net
         [Conditional("DEBUG_NETEVENTSOURCE_MISUSE")]
         private static void DebugValidateArg(FormattableString? arg)
         {
-            Debug.Assert(IsEnabled || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
+            Debug.Assert(Log.IsEnabled() || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
         }
-
-        public static new bool IsEnabled =>
-            Log.IsEnabled();
 
         [NonEvent]
         public static string IdOf(object? value) => value != null ? value.GetType().Name + "#" + GetHashCode(value) : NullInstance;

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicConnection.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicConnection.cs
@@ -51,20 +51,20 @@ namespace System.Net.Quic.Implementations.MsQuic
         // constructor for inbound connections
         public MsQuicConnection(IPEndPoint localEndPoint, IPEndPoint remoteEndPoint, IntPtr nativeObjPtr)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             _localEndPoint = localEndPoint;
             _remoteEndPoint = remoteEndPoint;
             _ptr = nativeObjPtr;
 
             SetCallbackHandler();
             SetIdleTimeout(TimeSpan.FromSeconds(120));
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // constructor for outbound connections
         public MsQuicConnection(QuicClientConnectionOptions options)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // TODO need to figure out if/how we want to expose sessions
             // Creating a session per connection isn't ideal.
@@ -75,7 +75,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             SetCallbackHandler();
             SetIdleTimeout(options.IdleTimeout);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal override IPEndPoint LocalEndPoint
@@ -168,7 +168,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private uint HandleEventConnected(ConnectionEvent connectionEvent)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             SOCKADDR_INET inetAddress = MsQuicParameterHelpers.GetINetParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.CONNECTION, (uint)QUIC_PARAM_CONN.LOCAL_ADDRESS);
             _localEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(inetAddress);
@@ -179,13 +179,13 @@ namespace System.Net.Quic.Implementations.MsQuic
             // handle event shutdown initiated by transport
             _connectTcs.Complete(MsQuicStatusCodes.Success);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventShutdownInitiatedByTransport(ConnectionEvent connectionEvent)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (!_connected)
             {
@@ -194,7 +194,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             _acceptQueue.Writer.Complete();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
@@ -208,22 +208,22 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private uint HandleEventShutdownComplete(ConnectionEvent connectionEvent)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             _shutdownTcs.Complete(MsQuicStatusCodes.Success);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventNewStream(ConnectionEvent connectionEvent)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             MsQuicStream msQuicStream = new MsQuicStream(this, connectionEvent.StreamFlags, connectionEvent.Data.NewStream.Stream, inbound: true);
 
             _acceptQueue.Writer.TryWrite(msQuicStream);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
@@ -235,7 +235,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override async ValueTask<QuicStreamProvider> AcceptStreamAsync(CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -254,7 +254,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 };
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return stream;
         }
 
@@ -305,7 +305,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         private MsQuicStream StreamOpen(
             QUIC_STREAM_OPEN_FLAG flags)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             IntPtr streamPtr = IntPtr.Zero;
             QuicExceptionHelpers.ThrowIfFailed(
@@ -319,7 +319,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             MsQuicStream stream = new MsQuicStream(this, flags, streamPtr, inbound: false);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return stream;
         }
 
@@ -337,7 +337,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             QUIC_CONNECTION_SHUTDOWN_FLAG Flags,
             long ErrorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             uint status = MsQuicApi.Api.ConnectionShutdownDelegate(
                 _ptr,
@@ -345,7 +345,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 ErrorCode);
             QuicExceptionHelpers.ThrowIfFailed(status, "Failed to shutdown connection.");
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return _shutdownTcs.GetTypelessValueTask();
         }
 
@@ -377,7 +377,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 return;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (_ptr != IntPtr.Zero)
             {
@@ -395,7 +395,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             _disposed = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal override ValueTask CloseAsync(long errorCode, CancellationToken cancellationToken = default)

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -62,7 +62,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override async ValueTask<QuicConnectionProvider> AcceptConnectionAsync(CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -81,7 +81,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _options.CertificateFilePath,
                 _options.PrivateKeyFilePath).ConfigureAwait(false);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return connection;
         }
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -124,7 +124,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override async ValueTask WriteAsync(ReadOnlySequence<byte> buffers, bool endStream, CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -134,7 +134,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             HandleWriteCompletedState();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal override ValueTask WriteAsync(ReadOnlyMemory<ReadOnlyMemory<byte>> buffers, CancellationToken cancellationToken = default)
@@ -144,7 +144,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override async ValueTask WriteAsync(ReadOnlyMemory<ReadOnlyMemory<byte>> buffers, bool endStream, CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -154,12 +154,12 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             HandleWriteCompletedState();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, bool endStream, CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -169,7 +169,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             HandleWriteCompletedState();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private async ValueTask<CancellationTokenRegistration> HandleWriteStartState(CancellationToken cancellationToken)
@@ -228,7 +228,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -241,7 +241,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             {
                 if (_readState == ReadState.ReadsCompleted)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                     return 0;
                 }
                 else if (_readState == ReadState.Aborted)
@@ -310,7 +310,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return actual;
         }
@@ -319,7 +319,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         // If so, we need to complete the read here as well.
         internal override void AbortRead(long errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -330,12 +330,12 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             MsQuicApi.Api.StreamShutdownDelegate(_ptr, (uint)QUIC_STREAM_SHUTDOWN_FLAG.ABORT_RECV, errorCode);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal override void AbortWrite(long errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -357,12 +357,12 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             MsQuicApi.Api.StreamShutdownDelegate(_ptr, (uint)QUIC_STREAM_SHUTDOWN_FLAG.ABORT_SEND, errorCode);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal override ValueTask ShutdownWriteCompleted(CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -385,7 +385,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 }
             });
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return _shutdownWriteResettableCompletionSource.GetTypelessValueTask();
         }
@@ -434,7 +434,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 return default;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             CleanupSendState();
 
@@ -448,7 +448,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             _handle.Free();
 
             _disposed = true;
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return default;
         }
@@ -471,7 +471,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 return;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             CleanupSendState();
 
@@ -484,7 +484,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
             _handle.Free();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             _disposed = true;
         }
@@ -577,7 +577,7 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private unsafe uint HandleEventRecv(ref MsQuicNativeMethods.StreamEvent evt)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             StreamEventDataRecv receieveEvent = evt.Data.Recv;
             for (int i = 0; i < receieveEvent.BufferCount; i++)
@@ -600,14 +600,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _receiveResettableCompletionSource.Complete((uint)receieveEvent.TotalBufferLength);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Pending;
         }
 
         private uint HandleEventPeerRecvAborted(ref StreamEvent evt)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             bool shouldComplete = false;
             lock (_sync)
@@ -625,14 +625,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _sendResettableCompletionSource.CompleteException(new QuicStreamAbortedException(_sendErrorCode));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleStartComplete()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             bool shouldComplete = false;
             lock (_sync)
@@ -649,14 +649,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _sendResettableCompletionSource.Complete(MsQuicStatusCodes.Success);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventSendShutdownComplete(ref MsQuicNativeMethods.StreamEvent evt)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             bool shouldComplete = false;
             lock (_sync)
             {
@@ -672,14 +672,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _shutdownWriteResettableCompletionSource.Complete(MsQuicStatusCodes.Success);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventShutdownComplete()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             bool shouldReadComplete = false;
             bool shouldShutdownWriteComplete = false;
@@ -687,7 +687,7 @@ namespace System.Net.Quic.Implementations.MsQuic
             lock (_sync)
             {
                 // This event won't occur within the middle of a receive.
-                if (NetEventSource.IsEnabled) NetEventSource.Info("Completing resettable event source.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info("Completing resettable event source.");
 
                 if (_readState == ReadState.None)
                 {
@@ -713,14 +713,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _shutdownWriteResettableCompletionSource.Complete(MsQuicStatusCodes.Success);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventPeerSendAborted(ref StreamEvent evt)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             bool shouldComplete = false;
             lock (_sync)
@@ -738,21 +738,21 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _receiveResettableCompletionSource.CompleteException(new QuicStreamAbortedException(_readErrorCode));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventPeerSendShutdown()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             bool shouldComplete = false;
 
             lock (_sync)
             {
                 // This event won't occur within the middle of a receive.
-                if (NetEventSource.IsEnabled) NetEventSource.Info("Completing resettable event source.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info("Completing resettable event source.");
 
                 if (_readState == ReadState.None)
                 {
@@ -767,14 +767,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _receiveResettableCompletionSource.Complete(0);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }
 
         private uint HandleEventSendComplete(ref StreamEvent evt)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             CleanupSendState();
 
@@ -796,7 +796,7 @@ namespace System.Net.Quic.Implementations.MsQuic
                 _sendResettableCompletionSource.Complete(MsQuicStatusCodes.Success);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return MsQuicStatusCodes.Success;
         }

--- a/src/libraries/Common/src/System/Net/InternalException.cs
+++ b/src/libraries/Common/src/System/Net/InternalException.cs
@@ -16,7 +16,7 @@ namespace System.Net
         internal InternalException(object unexpectedValue)
         {
             _unexpectedValue = unexpectedValue;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Fail(this, $"InternalException thrown for unexpected value: {unexpectedValue}");
             }

--- a/src/libraries/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/libraries/Common/src/System/Net/LazyAsyncResult.cs
@@ -62,7 +62,7 @@ namespace System.Net
             _asyncState = myState;
             _asyncCallback = myCallBack;
             _result = DBNull.Value;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
         }
 
         // Interface method to return the original async object.
@@ -106,7 +106,7 @@ namespace System.Net
         {
             get
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
 #if DEBUG
                 // Can't be called when state is protected.
@@ -135,7 +135,7 @@ namespace System.Net
                     LazilyCreateEvent(out asyncEvent);
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncEvent);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncEvent);
                 return asyncEvent;
             }
         }
@@ -191,7 +191,7 @@ namespace System.Net
         {
             get
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
 #if DEBUG
                 // Can't be called when state is protected.
@@ -208,7 +208,7 @@ namespace System.Net
                     result = Interlocked.CompareExchange(ref _intCompleted, HighBit, 0);
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, result > 0);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, result > 0);
                 return result > 0;
             }
         }
@@ -218,7 +218,7 @@ namespace System.Net
         {
             get
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
 #if DEBUG
                 // Can't be called when state is protected.
@@ -309,7 +309,7 @@ namespace System.Net
         // the equivalent of InvokeCallback().
         protected void ProtectedInvokeCallback(object? result, IntPtr userToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, result, userToken);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, result, userToken);
 
             // Critical to disallow DBNull here - it could result in a stuck spinlock in WaitForCompletion.
             if (result == DBNull.Value)
@@ -374,11 +374,11 @@ namespace System.Net
                 ++threadContext._nestedIOCount;
                 if (_asyncCallback != null)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Invoking callback");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Invoking callback");
 
                     if (threadContext._nestedIOCount >= ForceAsyncCount)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "*** OFFLOADED the user callback ****");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "*** OFFLOADED the user callback ****");
 
                         Task.Factory.StartNew(
                             s => WorkerThreadComplete(s!),
@@ -396,7 +396,7 @@ namespace System.Net
                 }
                 else
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "No callback to invoke");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "No callback to invoke");
                 }
             }
             finally
@@ -459,7 +459,7 @@ namespace System.Net
             {
                 try
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Waiting for completion event {waitHandle}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Waiting for completion event {waitHandle}");
                     waitHandle.WaitOne(Timeout.Infinite);
                 }
                 catch (ObjectDisposedException)
@@ -494,7 +494,7 @@ namespace System.Net
                 sw.SpinOnce();
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, _result);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, _result);
             return _result;
         }
 

--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -30,8 +30,8 @@ namespace System.Net
     // Usage:
     // - Operations that may allocate (e.g. boxing a value type, using string interpolation, etc.) or that may have computations
     //   at call sites should guard access like:
-    //       if (NetEventSource.IsEnabled) NetEventSource.Enter(this, refArg1, valueTypeArg2); // entering an instance method with a value type arg
-    //       if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Found certificate: {cert}"); // info logging with a formattable string
+    //       if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, refArg1, valueTypeArg2); // entering an instance method with a value type arg
+    //       if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Found certificate: {cert}"); // info logging with a formattable string
     // - Operations that have zero allocations / measurable computations at call sites can use a simpler pattern, calling methods like:
     //       NetEventSource.Enter(this);                   // entering an instance method
     //       NetEventSource.Info(this, "literal string");  // arbitrary message with a literal string
@@ -104,7 +104,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs entrance to a method.</summary>
@@ -116,7 +116,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)})");
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)})");
         }
 
         /// <summary>Logs entrance to a method.</summary>
@@ -130,7 +130,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
             DebugValidateArg(arg1);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)})");
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)})");
         }
 
         /// <summary>Logs entrance to a method.</summary>
@@ -146,7 +146,7 @@ namespace System.Net
             DebugValidateArg(arg0);
             DebugValidateArg(arg1);
             DebugValidateArg(arg2);
-            if (IsEnabled) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
+            if (Log.IsEnabled()) Log.Enter(IdOf(thisOrContextObject), memberName, $"({Format(arg0)}, {Format(arg1)}, {Format(arg2)})");
         }
 
         [Event(EnterEventId, Level = EventLevel.Informational, Keywords = Keywords.EnterExit)]
@@ -164,7 +164,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Exit(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Exit(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs exit from a method.</summary>
@@ -176,7 +176,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
-            if (IsEnabled) Log.Exit(IdOf(thisOrContextObject), memberName, Format(arg0).ToString());
+            if (Log.IsEnabled()) Log.Exit(IdOf(thisOrContextObject), memberName, Format(arg0).ToString());
         }
 
         /// <summary>Logs exit from a method.</summary>
@@ -190,7 +190,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(arg0);
             DebugValidateArg(arg1);
-            if (IsEnabled) Log.Exit(IdOf(thisOrContextObject), memberName, $"{Format(arg0)}, {Format(arg1)}");
+            if (Log.IsEnabled()) Log.Exit(IdOf(thisOrContextObject), memberName, $"{Format(arg0)}, {Format(arg1)}");
         }
 
         [Event(ExitEventId, Level = EventLevel.Informational, Keywords = Keywords.EnterExit)]
@@ -208,7 +208,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
+            if (Log.IsEnabled()) Log.Info(IdOf(thisOrContextObject), memberName, formattableString != null ? Format(formattableString) : NoParameters);
         }
 
         /// <summary>Logs an information message.</summary>
@@ -220,7 +220,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.Info(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(InfoEventId, Level = EventLevel.Informational, Keywords = Keywords.Default)]
@@ -238,7 +238,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
         }
 
         /// <summary>Logs an error message.</summary>
@@ -250,7 +250,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(ErrorEventId, Level = EventLevel.Error, Keywords = Keywords.Default)]
@@ -272,7 +272,7 @@ namespace System.Net
             // Don't call DebugValidateArg on args, as we expect Fail to be used in assert/failure situations
             // that should never happen in production, and thus we don't care about extra costs.
 
-            if (IsEnabled) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(formattableString));
             Debug.Fail(Format(formattableString), $"{IdOf(thisOrContextObject)}.{memberName}");
         }
 
@@ -289,7 +289,7 @@ namespace System.Net
             // Don't call DebugValidateArg on args, as we expect Fail to be used in assert/failure situations
             // that should never happen in production, and thus we don't care about extra costs.
 
-            if (IsEnabled) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.CriticalFailure(IdOf(thisOrContextObject), memberName, Format(message).ToString());
             Debug.Fail(Format(message).ToString(), $"{IdOf(thisOrContextObject)}.{memberName}");
         }
 
@@ -308,7 +308,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(formattableString);
-            if (IsEnabled) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
+            if (Log.IsEnabled()) Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(formattableString));
         }
 
         /// <summary>Logs an info at verbose mode.</summary>
@@ -320,7 +320,7 @@ namespace System.Net
         {
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(message);
-            if (IsEnabled) Log.VerboseMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
+            if (Log.IsEnabled()) Log.VerboseMessage(IdOf(thisOrContextObject), memberName, Format(message).ToString());
         }
 
         [Event(ErrorEventId, Level = EventLevel.Verbose, Keywords = Keywords.Default)]
@@ -348,7 +348,7 @@ namespace System.Net
         [NonEvent]
         public static void DumpBuffer(object? thisOrContextObject, byte[] buffer, int offset, int count, [CallerMemberName] string? memberName = null)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 if (offset < 0 || offset > buffer.Length - count)
                 {
@@ -380,7 +380,7 @@ namespace System.Net
             Debug.Assert(bufferPtr != IntPtr.Zero);
             Debug.Assert(count >= 0);
 
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 var buffer = new byte[Math.Min(count, MaxDumpSize)];
                 fixed (byte* targetPtr = buffer)
@@ -406,7 +406,7 @@ namespace System.Net
         {
             DebugValidateArg(first);
             DebugValidateArg(second);
-            if (IsEnabled) Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
+            if (Log.IsEnabled()) Log.Associate(IdOf(first), memberName, IdOf(first), IdOf(second));
         }
 
         /// <summary>Logs a relationship between two objects.</summary>
@@ -420,7 +420,7 @@ namespace System.Net
             DebugValidateArg(thisOrContextObject);
             DebugValidateArg(first);
             DebugValidateArg(second);
-            if (IsEnabled) Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
+            if (Log.IsEnabled()) Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
         }
 
         [Event(AssociateEventId, Level = EventLevel.Informational, Keywords = Keywords.Default, Message = "[{2}]<-->[{3}]")]
@@ -433,7 +433,7 @@ namespace System.Net
         [Conditional("DEBUG_NETEVENTSOURCE_MISUSE")]
         private static void DebugValidateArg(object? arg)
         {
-            if (!IsEnabled)
+            if (!Log.IsEnabled())
             {
                 Debug.Assert(!(arg is ValueType), $"Should not be passing value type {arg?.GetType()} to logging without IsEnabled check");
                 Debug.Assert(!(arg is FormattableString), $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
@@ -443,11 +443,8 @@ namespace System.Net
         [Conditional("DEBUG_NETEVENTSOURCE_MISUSE")]
         private static void DebugValidateArg(FormattableString? arg)
         {
-            Debug.Assert(IsEnabled || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
+            Debug.Assert(Log.IsEnabled() || arg == null, $"Should not be formatting FormattableString \"{arg}\" if tracing isn't enabled");
         }
-
-        public static new bool IsEnabled =>
-            Log.IsEnabled();
 
         [NonEvent]
         public static string IdOf(object? value) => value != null ? value.GetType().Name + "#" + GetHashCode(value) : NullInstance;

--- a/src/libraries/Common/src/System/Net/NTAuthentication.Common.cs
+++ b/src/libraries/Common/src/System/Net/NTAuthentication.Common.cs
@@ -100,7 +100,7 @@ namespace System.Net
         [MemberNotNull(nameof(_package))]
         private void Initialize(bool isServer, string package, NetworkCredential credential, string? spn, ContextFlagsPal requestedContextFlags, ChannelBinding? channelBinding)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, package, spn, requestedContextFlags);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, package, spn, requestedContextFlags);
 
             _tokenSize = NegotiateStreamPal.QueryMaxTokenSize(package);
             _isServer = isServer;
@@ -110,7 +110,7 @@ namespace System.Net
             _package = package;
             _channelBinding = channelBinding;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Peer SPN-> '{_spn}'");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Peer SPN-> '{_spn}'");
 
             //
             // Check if we're using DefaultCredentials.
@@ -119,7 +119,7 @@ namespace System.Net
             Debug.Assert(CredentialCache.DefaultCredentials == CredentialCache.DefaultNetworkCredentials);
             if (credential == CredentialCache.DefaultCredentials)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "using DefaultCredentials");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "using DefaultCredentials");
                 _credentialsHandle = NegotiateStreamPal.AcquireDefaultCredential(package, _isServer);
             }
             else
@@ -212,7 +212,7 @@ namespace System.Net
         // Accepts an incoming binary security blob and returns an outgoing binary security blob.
         internal byte[]? GetOutgoingBlob(byte[]? incomingBlob, bool throwOnError, out SecurityStatusPal statusCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, incomingBlob);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, incomingBlob);
 
             byte[]? result = new byte[_tokenSize];
 
@@ -232,13 +232,13 @@ namespace System.Net
                         ref result,
                         ref _contextFlags);
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SSPIWrapper.InitializeSecurityContext() returns statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SSPIWrapper.InitializeSecurityContext() returns statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
 
                     if (statusCode.ErrorCode == SecurityStatusPalErrorCode.CompleteNeeded)
                     {
                         statusCode = NegotiateStreamPal.CompleteAuthToken(ref _securityContext, result);
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SSPIWrapper.CompleteAuthToken() returns statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SSPIWrapper.CompleteAuthToken() returns statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
 
                         result = null;
                     }
@@ -255,7 +255,7 @@ namespace System.Net
                         ref result,
                         ref _contextFlags);
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SSPIWrapper.AcceptSecurityContext() returns statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SSPIWrapper.AcceptSecurityContext() returns statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
                 }
             }
             finally
@@ -280,11 +280,11 @@ namespace System.Net
                 if (throwOnError)
                 {
                     Exception exception = NegotiateStreamPal.CreateExceptionFromError(statusCode);
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this, exception);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, exception);
                     throw exception;
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, $"null statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, $"null statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode})");
                 return null;
             }
             else if (firstTime && _credentialsHandle != null)
@@ -300,15 +300,15 @@ namespace System.Net
                 // Success.
                 _isCompleted = true;
             }
-            else if (NetEventSource.IsEnabled)
+            else if (NetEventSource.Log.IsEnabled())
             {
                 // We need to continue.
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"need continue statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode}) _securityContext:{_securityContext}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"need continue statusCode:0x{((int)statusCode.ErrorCode):x8} ({statusCode}) _securityContext:{_securityContext}");
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, $"IsCompleted: {IsCompleted}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, $"IsCompleted: {IsCompleted}");
             }
 
             return result;
@@ -323,7 +323,7 @@ namespace System.Net
 
             string? spn = NegotiateStreamPal.QueryContextClientSpecifiedSpn(_securityContext!);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"The client specified SPN is [{spn}]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"The client specified SPN is [{spn}]");
 
             return spn;
         }

--- a/src/libraries/Common/src/System/Net/Security/CertificateHelper.cs
+++ b/src/libraries/Common/src/System/Net/Security/CertificateHelper.cs
@@ -38,7 +38,7 @@ namespace System.Net.Security
             {
                 if (!cert.HasPrivateKey)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(candidateCerts, $"Skipping current X509Certificate2 {cert.GetHashCode()} since it doesn't have private key. Certificate Subject: {cert.Subject}, Thumbprint: {cert.Thumbprint}.");
                     }
@@ -47,7 +47,7 @@ namespace System.Net.Security
 
                 if (IsValidClientCertificate(cert))
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(candidateCerts, $"Choosing X509Certificate2 {cert.GetHashCode()} as the Client Certificate. Certificate Subject: {cert.Subject}, Thumbprint: {cert.Thumbprint}.");
                     }
@@ -55,7 +55,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(candidateCerts, "No eligible client certificate found.");
             }
@@ -68,7 +68,7 @@ namespace System.Net.Security
             {
                 if ((extension is X509EnhancedKeyUsageExtension eku) && !IsValidForClientAuthenticationEKU(eku))
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(cert, $"For Certificate {cert.GetHashCode()} - current X509EnhancedKeyUsageExtension {eku.GetHashCode()} is not valid for Client Authentication.");
                     }
@@ -76,7 +76,7 @@ namespace System.Net.Security
                 }
                 else if ((extension is X509KeyUsageExtension ku) && !IsValidForDigitalSignatureUsage(ku))
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(cert, $"For Certificate {cert.GetHashCode()} - current X509KeyUsageExtension {ku.GetHashCode()} is not valid for Digital Signature.");
                     }

--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Unix.cs
@@ -284,7 +284,7 @@ namespace System.Net.Security
 
             if (context == null)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     string protocol = isNtlmOnly ? "NTLM" : "SPNEGO";
                     NetEventSource.Info(context, $"requested protocol = {protocol}, target = {targetName}");
@@ -315,7 +315,7 @@ namespace System.Net.Security
 
                 if (done)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         string protocol = isNtlmOnly ? "NTLM" : isNtlmUsed ? "SPNEGO-NTLM" : "SPNEGO-Kerberos";
                         NetEventSource.Info(context, $"actual protocol = {protocol}");
@@ -344,7 +344,7 @@ namespace System.Net.Security
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
                 return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, ex);
             }
         }
@@ -431,7 +431,7 @@ namespace System.Net.Security
                 SecurityStatusPalErrorCode errorCode;
                 if (done)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         string protocol = isNtlmUsed ? "SPNEGO-NTLM" : "SPNEGO-Kerberos";
                         NetEventSource.Info(securityContext, $"AcceptSecurityContext: actual protocol = {protocol}");
@@ -449,12 +449,12 @@ namespace System.Net.Security
             }
             catch (Interop.NetSecurityNative.GssApiException gex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, gex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, gex);
                 return new SecurityStatusPal(GetErrorCode(gex), gex);
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
                 return new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, ex);
             }
         }
@@ -495,7 +495,7 @@ namespace System.Net.Security
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
                 throw;
             }
         }

--- a/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -43,7 +43,7 @@ namespace System.Net.Security
 
                 if (result != Interop.SECURITY_STATUS.OK)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(Interop.SspiCli.SspiEncodeStringsAsAuthIdentity), $"0x{(int)result:X}"));
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_log_operation_failed_with_error, nameof(Interop.SspiCli.SspiEncodeStringsAsAuthIdentity), $"0x{(int)result:X}"));
                     throw new Win32Exception((int)result);
                 }
 

--- a/src/libraries/Common/src/System/Net/Security/SSPIHandleCache.cs
+++ b/src/libraries/Common/src/System/Net/Security/SSPIHandleCache.cs
@@ -39,7 +39,7 @@ namespace System.Net.Security
             {
                 if (!ExceptionCheck.IsFatal(e))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Fail(null, $"Attempted to throw: {e}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Fail(null, $"Attempted to throw: {e}");
                 }
             }
         }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
 
             if (remoteCertificateStore.Count > 0)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     foreach (X509Certificate cert in remoteCertificateStore)
                     {
@@ -79,14 +79,14 @@ namespace System.Net.Http
                     {
                         if (status.dwError == Interop.Crypt32.CertChainPolicyErrors.CERT_E_CN_NO_MATCH)
                         {
-                            if (NetEventSource.IsEnabled) NetEventSource.Error(certificate, nameof(Interop.Crypt32.CertChainPolicyErrors.CERT_E_CN_NO_MATCH));
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(certificate, nameof(Interop.Crypt32.CertChainPolicyErrors.CERT_E_CN_NO_MATCH));
                             sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNameMismatch;
                         }
                     }
                     else
                     {
                         // Failure checking the policy. This is a rare error. We will assume the name check failed.
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(certificate, $"Failure calling {nameof(Interop.Crypt32.CertVerifyCertificateChainPolicy)}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(certificate, $"Failure calling {nameof(Interop.Crypt32.CertVerifyCertificateChainPolicy)}");
                         sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNameMismatch;
                     }
                 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
@@ -32,12 +32,12 @@ namespace System.Net.Http
                 try
                 {
                     cookieContainer.SetCookies(request.RequestUri, cookieHeader);
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(cookieContainer, $"Added cookie: {cookieHeader}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(cookieContainer, $"Added cookie: {cookieHeader}");
                 }
                 catch (CookieException)
                 {
                     // We ignore malformed cookies in the response.
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(cookieContainer, $"Ignoring invalid cookie: {cookieHeader}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(cookieContainer, $"Ignoring invalid cookie: {cookieHeader}");
                 }
             }
         }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -716,7 +716,7 @@ namespace System.Net.Http
                             accessType = Interop.WinHttp.WINHTTP_ACCESS_TYPE_AUTOMATIC_PROXY;
                         }
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Proxy accessType={accessType}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Proxy accessType={accessType}");
 
                         sessionHandle = Interop.WinHttp.WinHttpOpen(
                             IntPtr.Zero,
@@ -728,7 +728,7 @@ namespace System.Net.Http
                         if (sessionHandle.IsInvalid)
                         {
                             int lastError = Marshal.GetLastWin32Error();
-                            if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"error={lastError}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"error={lastError}");
                             if (lastError != Interop.WinHttp.ERROR_INVALID_PARAMETER)
                             {
                                 ThrowOnInvalidHandle(sessionHandle, nameof(Interop.WinHttp.WinHttpOpen));
@@ -897,7 +897,7 @@ namespace System.Net.Http
                 state.Tcs.TrySetResult(responseMessage);
 
                 // HttpStatusCode cast is needed for 308 Moved Permenantly, which we support but is not included in NetStandard status codes.
-                if (NetEventSource.IsEnabled &&
+                if (NetEventSource.Log.IsEnabled() &&
                     ((responseMessage.StatusCode >= HttpStatusCode.MultipleChoices && responseMessage.StatusCode <= HttpStatusCode.SeeOther) ||
                      (responseMessage.StatusCode >= HttpStatusCode.RedirectKeepVerb && responseMessage.StatusCode <= (HttpStatusCode)308)) &&
                     state.RequestMessage.RequestUri.Scheme == Uri.UriSchemeHttps && responseMessage.Headers.Location?.Scheme == Uri.UriSchemeHttp)
@@ -1200,11 +1200,11 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_OPTION_ENABLE_HTTP2_PLUS_CLIENT_CERT,
                 ref optionData))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "HTTP/2 with TLS client cert supported");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "HTTP/2 with TLS client cert supported");
             }
             else
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "HTTP/2 with TLS client cert not supported");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "HTTP/2 with TLS client cert not supported");
             }
         }
 
@@ -1250,11 +1250,11 @@ namespace System.Net.Http
                 Interop.WinHttp.WINHTTP_OPTION_ENABLE_HTTP_PROTOCOL,
                 ref optionData))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"HTTP/2 option supported, setting to {optionData}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"HTTP/2 option supported, setting to {optionData}");
             }
             else
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "HTTP/2 option not supported");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "HTTP/2 option not supported");
             }
         }
 
@@ -1363,7 +1363,7 @@ namespace System.Net.Http
             if (handle.IsInvalid)
             {
                 int lastError = Marshal.GetLastWin32Error();
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"error={lastError}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"error={lastError}");
                 throw WinHttpException.CreateExceptionUsingError(lastError, nameOfCalledFunction);
             }
         }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -27,11 +27,11 @@ namespace System.Net.Http
             IntPtr statusInformation,
             uint statusInformationLength)
         {
-            if (NetEventSource.IsEnabled) WinHttpTraceHelper.TraceCallbackStatus(null, handle, context, internetStatus);
+            if (NetEventSource.Log.IsEnabled()) WinHttpTraceHelper.TraceCallbackStatus(null, handle, context, internetStatus);
 
             if (Environment.HasShutdownStarted)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Environment.HasShutdownStarted returned True");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Environment.HasShutdownStarted returned True");
                 return;
             }
 
@@ -257,7 +257,7 @@ namespace System.Net.Http
                     ref certHandleSize))
                 {
                     int lastError = Marshal.GetLastWin32Error();
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(state, $"Error getting WINHTTP_OPTION_SERVER_CERT_CONTEXT, {lastError}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state, $"Error getting WINHTTP_OPTION_SERVER_CERT_CONTEXT, {lastError}");
 
                     if (lastError == Interop.WinHttp.ERROR_WINHTTP_INCORRECT_HANDLE_STATE)
                     {
@@ -327,7 +327,7 @@ namespace System.Net.Http
         {
             Debug.Assert(state != null, "OnRequestError: state is null");
 
-            if (NetEventSource.IsEnabled) WinHttpTraceHelper.TraceAsyncError(state, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) WinHttpTraceHelper.TraceAsyncError(state, asyncResult);
 
             Exception innerException = WinHttpException.CreateExceptionUsingError(unchecked((int)asyncResult.dwError), "WINHTTP_CALLBACK_STATUS_REQUEST_ERROR");
 
@@ -368,7 +368,7 @@ namespace System.Net.Http
                 case Interop.WinHttp.API_QUERY_DATA_AVAILABLE:
                     if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(state, "QUERY_DATA_AVAILABLE - ERROR_WINHTTP_OPERATION_CANCELLED");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state, "QUERY_DATA_AVAILABLE - ERROR_WINHTTP_OPERATION_CANCELLED");
                         state.LifecycleAwaitable.SetCanceled();
                     }
                     else
@@ -381,7 +381,7 @@ namespace System.Net.Http
                 case Interop.WinHttp.API_READ_DATA:
                     if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(state, "API_READ_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state, "API_READ_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
                         state.LifecycleAwaitable.SetCanceled();
                     }
                     else
@@ -393,7 +393,7 @@ namespace System.Net.Http
                 case Interop.WinHttp.API_WRITE_DATA:
                     if (asyncResult.dwError == Interop.WinHttp.ERROR_WINHTTP_OPERATION_CANCELLED)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(state, "API_WRITE_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(state, "API_WRITE_DATA - ERROR_WINHTTP_OPERATION_CANCELLED");
                         state.TcsInternalWriteDataToRequestStream.TrySetCanceled();
                     }
                     else

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -175,7 +175,7 @@ namespace System.Net.Http
 #if DEBUG
             Interlocked.Increment(ref s_dbg_callDispose);
 #endif
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GCHandle=0x{ToIntPtr().ToString("X")}, disposed={_disposed}, disposing={disposing}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GCHandle=0x{ToIntPtr().ToString("X")}, disposed={_disposed}, disposing={disposing}");
 
             // Since there is no finalizer and this class is sealed, the disposing parameter should be TRUE.
             Debug.Assert(disposing, "WinHttpRequestState.Dispose() should have disposing=TRUE");

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -344,7 +344,7 @@ namespace System.Net.Http
             {
                 if ((data & Interop.WinHttp.WINHTTP_PROTOCOL_FLAG_HTTP2) != 0)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(requestHandle, nameof(Interop.WinHttp.WINHTTP_PROTOCOL_FLAG_HTTP2));
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(requestHandle, nameof(Interop.WinHttp.WINHTTP_PROTOCOL_FLAG_HTTP2));
                     return true;
                 }
             }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -308,18 +308,18 @@ namespace System.Net.Http
         // a pending operation, it would cause random failures in the other threads when we expect a valid handle.
         private void CancelPendingResponseStreamReadOperation()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             lock (_state.Lock)
             {
                 if (_state.AsyncReadInProgress)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info("before dispose");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info("before dispose");
                     _requestHandle?.Dispose(); // null check necessary to handle race condition between stream disposal and cancellation
-                    if (NetEventSource.IsEnabled) NetEventSource.Info("after dispose");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info("after dispose");
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
     }
 }

--- a/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http
     {
         public static void TraceCallbackStatus(object thisOrContextObject, IntPtr handle, IntPtr context, uint status, [CallerMemberName] string memberName = null)
         {
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
 
             NetEventSource.Info(
                 thisOrContextObject,
@@ -21,7 +21,7 @@ namespace System.Net.Http
 
         public static void TraceAsyncError(object thisOrContextObject, Interop.WinHttp.WINHTTP_ASYNC_RESULT asyncResult, [CallerMemberName] string memberName = null)
         {
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
 
             uint apiIndex = (uint)asyncResult.dwResult.ToInt32();
             uint error = asyncResult.dwError;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs
@@ -31,7 +31,7 @@ namespace System.Net.Http
                 }
                 CheckDisposedOrStarted();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Associate(this, value);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, value);
                 _innerHandler = value;
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ByteArrayHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ByteArrayHeaderParser.cs
@@ -49,7 +49,7 @@ namespace System.Net.Http.Headers
             }
             catch (FormatException e)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_http_parser_invalid_base64_string, base64String, e.Message));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_http_parser_invalid_base64_string, base64String, e.Message));
             }
 
             return false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -142,7 +142,7 @@ namespace System.Net.Http.Headers
                     return qualityValue;
                 }
                 // If the stored value is an invalid quality value, just return null and log a warning.
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_invalid_quality, qualityParameter.Value));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_invalid_quality, qualityParameter.Value));
             }
             return null;
         }
@@ -381,7 +381,7 @@ namespace System.Net.Http.Headers
             }
             else
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_wrong_email_format, value));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_wrong_email_format, value));
                 return false;
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -800,7 +800,7 @@ namespace System.Net.Http.Headers
                 {
                     if (!TryParseAndAddRawHeaderValue(descriptor, info, rawValue, true))
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Log.HeadersInvalidValue(descriptor.Name, rawValue);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.HeadersInvalidValue(descriptor.Name, rawValue);
                     }
                 }
             }
@@ -822,7 +822,7 @@ namespace System.Net.Http.Headers
             {
                 if (!TryParseAndAddRawHeaderValue(descriptor, info, rawValue, true))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Log.HeadersInvalidValue(descriptor.Name, rawValue);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.HeadersInvalidValue(descriptor.Name, rawValue);
                 }
             }
         }
@@ -1148,7 +1148,7 @@ namespace System.Net.Http.Headers
         {
             if (HttpRuleParser.ContainsInvalidNewLine(value))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_no_newlines, name, value));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, SR.Format(SR.net_http_log_headers_no_newlines, name, value));
                 return true;
             }
             return false;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -65,7 +65,7 @@ namespace System.Net.Http
                 CheckBaseAddress(value, nameof(value));
                 CheckDisposedOrStarted();
 
-                if (NetEventSource.IsEnabled) NetEventSource.UriBaseAddress(this, value);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.UriBaseAddress(this, value);
 
                 _baseAddress = value;
             }
@@ -563,7 +563,7 @@ namespace System.Net.Http
                     }
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.ClientSendCompleted(this, response, request);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.ClientSendCompleted(this, response, request);
                 return response;
             }
             catch (Exception e)
@@ -595,20 +595,20 @@ namespace System.Net.Http
 
         private void HandleFinishSendAsyncError(Exception e, CancellationTokenSource cts)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Error(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
 
             // If the cancellation token was canceled, we consider the exception to be caused by the
             // cancellation (e.g. WebException when reading from canceled response stream).
             if (cts.IsCancellationRequested && e is HttpRequestException)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, "Canceled");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, "Canceled");
                 throw new OperationCanceledException(cts.Token);
             }
         }
 
         private void HandleSendTimeout(OperationCanceledException e)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Error(this, e);
                 NetEventSource.Error(this, "Canceled due to timeout");
@@ -645,7 +645,7 @@ namespace System.Net.Http
         public void CancelPendingRequests()
         {
             CheckDisposed();
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // With every request we link this cancellation token source.
             CancellationTokenSource currentCts = Interlocked.Exchange(ref _pendingRequestsCts,
@@ -654,7 +654,7 @@ namespace System.Net.Http
             currentCts.Cancel();
             currentCts.Dispose();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         #endregion Advanced Send Overloads

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -143,12 +143,12 @@ namespace System.Net.Http
         protected HttpContent()
         {
             // Log to get an ID for the current content. This ID is used when the content gets associated to a message.
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // We start with the assumption that we can calculate the content length.
             _canCalculateLength = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public Task<string> ReadAsStringAsync() =>
@@ -469,7 +469,7 @@ namespace System.Net.Http
             }
             catch (Exception e)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
 
                 if (CancellationHelper.ShouldWrapInOperationCanceledException(e, cancellationToken))
                 {
@@ -552,7 +552,7 @@ namespace System.Net.Http
             }
             catch (Exception e)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
                 throw;
             }
         }
@@ -709,7 +709,7 @@ namespace System.Net.Http
             if (task == null)
             {
                 var e = new InvalidOperationException(SR.net_http_content_no_task_returned);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
                 throw e;
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageHandler.cs
@@ -13,7 +13,7 @@ namespace System.Net.Http
     {
         protected HttpMessageHandler()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
         }
 
         // We cannot add abstract member to a public class in order to not to break already established contract of this class.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
@@ -21,19 +21,19 @@ namespace System.Net.Http
 
         public HttpMessageInvoker(HttpMessageHandler handler, bool disposeHandler)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, handler);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, handler);
 
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, handler);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, handler);
 
             _handler = handler;
             _disposeHandler = disposeHandler;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public virtual HttpResponseMessage Send(HttpRequestMessage request,
@@ -45,11 +45,11 @@ namespace System.Net.Http
             }
             CheckDisposed();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, request);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, request);
 
             HttpResponseMessage response = _handler.Send(request, cancellationToken);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, response);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, response);
 
             return response;
         }
@@ -63,11 +63,11 @@ namespace System.Net.Http
             }
             CheckDisposed();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, request);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, request);
 
             Task<HttpResponseMessage> task = _handler.SendAsync(request, cancellationToken);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, task);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, task);
 
             return task;
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -48,7 +48,7 @@ namespace System.Net.Http
             {
                 CheckDisposed();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     if (value == null)
                     {
@@ -130,14 +130,14 @@ namespace System.Net.Http
 
         public HttpRequestMessage(HttpMethod method, Uri? requestUri)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, method, requestUri);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, method, requestUri);
             InitializeValues(method, requestUri);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public HttpRequestMessage(HttpMethod method, string? requestUri)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, method, requestUri);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, method, requestUri);
 
             // It's OK to have a 'null' request Uri. If HttpClient is used, the 'BaseAddress' will be added.
             // If there is no 'BaseAddress', sending this request message will throw.
@@ -151,7 +151,7 @@ namespace System.Net.Http
                 InitializeValues(method, new Uri(requestUri, UriKind.RelativeOrAbsolute));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public override string ToString()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -48,7 +48,7 @@ namespace System.Net.Http
             {
                 CheckDisposed();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     if (value == null)
                     {
@@ -154,7 +154,7 @@ namespace System.Net.Http
 
         public HttpResponseMessage(HttpStatusCode statusCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, statusCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, statusCode);
 
             if (((int)statusCode < 0) || ((int)statusCode > 999))
             {
@@ -164,7 +164,7 @@ namespace System.Net.Http
             _statusCode = statusCode;
             _version = HttpUtilities.DefaultResponseVersion;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public HttpResponseMessage EnsureSuccessStatusCode()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpTelemetry.cs
@@ -23,8 +23,6 @@ namespace System.Net.Http
         private long _stoppedRequests;
         private long _abortedRequests;
 
-        public static new bool IsEnabled => Log.IsEnabled();
-
         // NOTE
         // - The 'Start' and 'Stop' suffixes on the following event names have special meaning in EventSource. They
         //   enable creating 'activities'.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -188,7 +188,7 @@ namespace System.Net.Http
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, ex);
                 throw;
             }
         }
@@ -233,7 +233,7 @@ namespace System.Net.Http
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, ex);
                 throw;
             }
         }
@@ -305,7 +305,7 @@ namespace System.Net.Http
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, ex);
                 throw;
             }
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -22,7 +22,7 @@ namespace System.Net
         [NonEvent]
         public static void UriBaseAddress(object obj, Uri? baseAddress)
         {
-            Debug.Assert(IsEnabled);
+            Debug.Assert(Log.IsEnabled());
             Log.UriBaseAddress(baseAddress?.ToString(), IdOf(obj), GetHashCode(obj));
         }
 
@@ -33,7 +33,7 @@ namespace System.Net
         [NonEvent]
         public static void ContentNull(object obj)
         {
-            Debug.Assert(IsEnabled);
+            Debug.Assert(Log.IsEnabled());
             Log.ContentNull(IdOf(obj), GetHashCode(obj));
         }
 
@@ -44,7 +44,7 @@ namespace System.Net
         [NonEvent]
         public static void ClientSendCompleted(HttpClient httpClient, HttpResponseMessage response, HttpRequestMessage request)
         {
-            Debug.Assert(IsEnabled);
+            Debug.Assert(Log.IsEnabled());
             Log.ClientSendCompleted(response?.ToString(), GetHashCode(request), GetHashCode(response), GetHashCode(httpClient));
         }
 
@@ -67,7 +67,7 @@ namespace System.Net
         [NonEvent]
         public static void AuthenticationInfo(Uri uri, string message)
         {
-            Debug.Assert(IsEnabled);
+            Debug.Assert(Log.IsEnabled());
             Log.AuthenticationInfo(uri?.ToString(), message);
         }
 
@@ -78,7 +78,7 @@ namespace System.Net
         [NonEvent]
         public static void AuthenticationError(Uri? uri, string message)
         {
-            Debug.Assert(IsEnabled);
+            Debug.Assert(Log.IsEnabled());
             Log.AuthenticationError(uri?.ToString(), message);
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.Digest.cs
@@ -54,7 +54,7 @@ namespace System.Net.Http
                     !algorithm.Equals(Sha256Sess, StringComparison.OrdinalIgnoreCase) &&
                     !algorithm.Equals(MD5Sess, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, $"Algorithm not supported: {algorithm}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(digestResponse, $"Algorithm not supported: {algorithm}");
                     return null;
                 }
             }
@@ -67,7 +67,7 @@ namespace System.Net.Http
             string? nonce;
             if (!digestResponse.Parameters.TryGetValue(Nonce, out nonce))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, "Nonce missing");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(digestResponse, "Nonce missing");
                 return null;
             }
 
@@ -78,7 +78,7 @@ namespace System.Net.Http
             string? realm;
             if (!digestResponse.Parameters.TryGetValue(Realm, out realm))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(digestResponse, "Realm missing");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(digestResponse, "Realm missing");
                 return null;
             }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http
             if (!isProxyAuth && connection.Kind == HttpConnectionKind.Proxy && !ProxySupportsConnectionAuth(response))
             {
                 // Proxy didn't indicate that it supports connection-based auth, so we can't proceed.
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(connection, $"Proxy doesn't support connection-based auth, uri={authUri}");
                 }
@@ -77,7 +77,7 @@ namespace System.Net.Http
                             needDrain = false;
                         }
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, Uri: {authUri.AbsoluteUri.ToString()}");
                         }
@@ -91,7 +91,7 @@ namespace System.Net.Http
                         {
                             // Use the host name without any normalization.
                             hostName = request.Headers.Host;
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                             {
                                 NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, Host: {hostName}");
                             }
@@ -115,7 +115,7 @@ namespace System.Net.Http
                         }
 
                         string spn = "HTTP/" + hostName;
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Info(connection, $"Authentication: {challenge.AuthenticationType}, SPN: {spn}");
                         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -92,7 +92,7 @@ namespace System.Net.Http
             {
                 // We have no credential for this auth type, so we can't respond to the challenge.
                 // We'll continue to look for a different auth type that we do have a credential for.
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.AuthenticationInfo(uri, $"Authentication scheme '{scheme}' supported by server, but not by client.");
                 }
@@ -100,7 +100,7 @@ namespace System.Net.Http
             }
 
             challenge = new AuthenticationChallenge(authenticationType, scheme, credential, challengeData);
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.AuthenticationInfo(uri, $"Authentication scheme '{scheme}' selected. Client username={challenge.Credential.UserName}");
             }
@@ -117,7 +117,7 @@ namespace System.Net.Http
 
             // Try to get a valid challenge for the schemes we support, in priority order.
             HttpHeaderValueCollection<AuthenticationHeaderValue> authenticationHeaderValues = GetResponseAuthenticationHeaderValues(response, isProxyAuth);
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.AuthenticationInfo(authUri, $"{(isProxyAuth ? "Proxy" : "Server")} authentication requested with WWW-Authenticate header value '{authenticationHeaderValues}'");
             }
@@ -191,7 +191,7 @@ namespace System.Net.Http
             // Any errors in obtaining parameter return false and we don't proceed with auth
             if (string.IsNullOrEmpty(parameter))
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.AuthenticationError(request.RequestUri, $"Unable to find 'Digest' authentication token when authenticating with {(isProxyAuth ? "proxy" : "server")}");
                 }
@@ -267,7 +267,7 @@ namespace System.Net.Http
                     case AuthenticationType.Basic:
                         if (performedBasicPreauth)
                         {
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                             {
                                 NetEventSource.AuthenticationError(authUri, $"Pre-authentication with {(isProxyAuth ? "proxy" : "server")} failed.");
                             }
@@ -284,7 +284,7 @@ namespace System.Net.Http
                             {
                                 case HttpStatusCode.ProxyAuthenticationRequired:
                                 case HttpStatusCode.Unauthorized:
-                                    if (NetEventSource.IsEnabled)
+                                    if (NetEventSource.Log.IsEnabled())
                                     {
                                         NetEventSource.AuthenticationError(authUri, $"Pre-authentication with {(isProxyAuth ? "proxy" : "server")} failed.");
                                     }
@@ -295,7 +295,7 @@ namespace System.Net.Http
                                     {
                                         try
                                         {
-                                            if (NetEventSource.IsEnabled)
+                                            if (NetEventSource.Log.IsEnabled())
                                             {
                                                 NetEventSource.Info(pool.PreAuthCredentials, $"Adding Basic credential to cache, uri={authUri}, username={challenge.Credential.UserName}");
                                             }
@@ -304,7 +304,7 @@ namespace System.Net.Http
                                         catch (ArgumentException)
                                         {
                                             // The credential already existed.
-                                            if (NetEventSource.IsEnabled)
+                                            if (NetEventSource.Log.IsEnabled())
                                             {
                                                 NetEventSource.Info(pool.PreAuthCredentials, $"Basic credential present in cache, uri={authUri}, username={challenge.Credential.UserName}");
                                             }
@@ -317,7 +317,7 @@ namespace System.Net.Http
                 }
             }
 
-            if (NetEventSource.IsEnabled && response.StatusCode == HttpStatusCode.Unauthorized)
+            if (NetEventSource.Log.IsEnabled() && response.StatusCode == HttpStatusCode.Unauthorized)
             {
                 NetEventSource.AuthenticationError(authUri, $"{(isProxyAuth ? "Proxy" : "Server")} authentication failed.");
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -56,7 +56,7 @@ namespace System.Net.Http
                     if (_connection == null)
                     {
                         // Fully consumed the response in ReadChunksFromConnectionBuffer.
-                        if (HttpTelemetry.IsEnabled) LogRequestStop();
+                        if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                         return 0;
                     }
 
@@ -362,7 +362,7 @@ namespace System.Net.Http
                                     cancellationRegistration.Dispose();
                                     CancellationHelper.ThrowIfCancellationRequested(cancellationRegistration.Token);
 
-                                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                                     _state = ParsingState.Done;
                                     _connection.CompleteResponse();
                                     _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -383,7 +383,7 @@ namespace System.Net.Http
                         default:
                         case ParsingState.Done: // shouldn't be called once we're done
                             Debug.Fail($"Unexpected state: {_state}");
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                             {
                                 NetEventSource.Error(this, $"Unexpected state: {_state}");
                             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -81,7 +81,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -143,7 +143,7 @@ namespace System.Net.Http
             private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
-                if (HttpTelemetry.IsEnabled) LogRequestStop();
+                if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                 _connection = null;
                 connection.Dispose();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -47,7 +47,7 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     // End of response body
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                     _connection.CompleteResponse();
                     _connection = null;
                 }
@@ -110,7 +110,7 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     // End of response body
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                     _connection.CompleteResponse();
                     _connection = null;
                 }
@@ -165,7 +165,7 @@ namespace System.Net.Http
 
             private void Finish()
             {
-                if (HttpTelemetry.IsEnabled) LogRequestStop();
+                if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                 _contentBytesRemaining = 0;
                 _connection!.CompleteResponse();
                 _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CookieHelper.cs
@@ -28,7 +28,7 @@ namespace System.Net.Http
                     catch (CookieException)
                     {
                         // Ignore invalid Set-Cookie header and continue processing.
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Error(response, $"Invalid Set-Cookie '{valuesArray[i]}' ignored.");
                         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/CreditManager.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http
             Debug.Assert(owner != null);
             Debug.Assert(!string.IsNullOrWhiteSpace(name));
 
-            if (NetEventSource.IsEnabled) owner.Trace($"{name}. {nameof(initialCredit)}={initialCredit}");
+            if (NetEventSource.Log.IsEnabled()) owner.Trace($"{name}. {nameof(initialCredit)}={initialCredit}");
             _owner = owner;
             _name = name;
             _current = initialCredit;
@@ -50,12 +50,12 @@ namespace System.Net.Http
                     Debug.Assert(_waitersTail is null, "Shouldn't have waiters when credit is available");
 
                     int granted = Math.Min(amount, _current);
-                    if (NetEventSource.IsEnabled) _owner.Trace($"{_name}. requested={amount}, current={_current}, granted={granted}");
+                    if (NetEventSource.Log.IsEnabled()) _owner.Trace($"{_name}. requested={amount}, current={_current}, granted={granted}");
                     _current -= granted;
                     return new ValueTask<int>(granted);
                 }
 
-                if (NetEventSource.IsEnabled) _owner.Trace($"{_name}. requested={amount}, no credit available.");
+                if (NetEventSource.Log.IsEnabled()) _owner.Trace($"{_name}. requested={amount}, no credit available.");
 
                 // Otherwise, create a new waiter.
                 CreditWaiter waiter = cancellationToken.CanBeCanceled ?
@@ -87,7 +87,7 @@ namespace System.Net.Http
 
             lock (SyncObject)
             {
-                if (NetEventSource.IsEnabled) _owner.Trace($"{_name}. {nameof(amount)}={amount}, current={_current}");
+                if (NetEventSource.Log.IsEnabled()) _owner.Trace($"{_name}. {nameof(amount)}={amount}, current={_current}");
 
                 if (_disposed)
                 {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -116,7 +116,7 @@ namespace System.Net.Http
             _maxConcurrentStreams = int.MaxValue;
             _pendingWindowUpdate = 0;
 
-            if (NetEventSource.IsEnabled) TraceConnection(stream);
+            if (NetEventSource.Log.IsEnabled()) TraceConnection(stream);
         }
 
         private object SyncObject => _httpStreams;
@@ -155,7 +155,7 @@ namespace System.Net.Http
 
         private async Task FlushOutgoingBytesAsync()
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(_outgoingBuffer.ActiveLength)}={_outgoingBuffer.ActiveLength}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(_outgoingBuffer.ActiveLength)}={_outgoingBuffer.ActiveLength}");
             Debug.Assert(_outgoingBuffer.ActiveLength > 0);
 
             try
@@ -176,7 +176,7 @@ namespace System.Net.Http
 
         private async ValueTask<FrameHeader> ReadFrameAsync(bool initialFrame = false)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(initialFrame)}={initialFrame}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(initialFrame)}={initialFrame}");
 
             // Ensure we've read enough data for the frame header.
             if (_incomingBuffer.ActiveLength < FrameHeader.Size)
@@ -195,7 +195,7 @@ namespace System.Net.Http
             FrameHeader frameHeader = FrameHeader.ReadFrom(_incomingBuffer.ActiveSpan);
             if (frameHeader.PayloadLength > FrameHeader.MaxPayloadLength)
             {
-                if (initialFrame && NetEventSource.IsEnabled)
+                if (initialFrame && NetEventSource.Log.IsEnabled())
                 {
                     string response = Encoding.ASCII.GetString(_incomingBuffer.ActiveSpan.Slice(0, Math.Min(20, _incomingBuffer.ActiveLength)));
                     Trace($"HTTP/2 handshake failed. Server returned {response}");
@@ -236,7 +236,7 @@ namespace System.Net.Http
                 {
                     ThrowProtocolError();
                 }
-                if (NetEventSource.IsEnabled) Trace($"Frame 0: {frameHeader}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Frame 0: {frameHeader}.");
 
                 // Process the initial SETTINGS frame. This will send an ACK.
                 ProcessSettingsFrame(frameHeader);
@@ -272,7 +272,7 @@ namespace System.Net.Http
 
                     // Read the frame.
                     frameHeader = await ReadFrameAsync().ConfigureAwait(false);
-                    if (NetEventSource.IsEnabled) Trace($"Frame {frameNum}: {frameHeader}.");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Frame {frameNum}: {frameHeader}.");
 
                     // Process the frame.
                     switch (frameHeader.Type)
@@ -323,7 +323,7 @@ namespace System.Net.Http
             }
             catch (Exception e)
             {
-                if (NetEventSource.IsEnabled) Trace($"{nameof(ProcessIncomingFramesAsync)}: {e.Message}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(ProcessIncomingFramesAsync)}: {e.Message}");
 
                 Abort(e);
             }
@@ -353,7 +353,7 @@ namespace System.Net.Http
 
         private async ValueTask ProcessHeadersFrame(FrameHeader frameHeader)
         {
-            if (NetEventSource.IsEnabled) Trace($"{frameHeader}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{frameHeader}");
             Debug.Assert(frameHeader.Type == FrameType.Headers);
 
             bool endStream = frameHeader.EndStreamFlag;
@@ -453,7 +453,7 @@ namespace System.Net.Http
         /// </remarks>
         private void ProcessAltSvcFrame(FrameHeader frameHeader)
         {
-            if (NetEventSource.IsEnabled) Trace($"{frameHeader}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{frameHeader}");
             Debug.Assert(frameHeader.Type == FrameType.AltSvc);
 
             ReadOnlySpan<byte> span = _incomingBuffer.ActiveSpan.Slice(0, frameHeader.PayloadLength);
@@ -590,7 +590,7 @@ namespace System.Net.Http
 
         private void ChangeMaxConcurrentStreams(uint newValue)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(newValue)}={newValue}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(newValue)}={newValue}");
 
             // The value is provided as a uint.
             // Limit this to int.MaxValue since the CreditManager implementation only supports singed values.
@@ -604,7 +604,7 @@ namespace System.Net.Http
 
         private void ChangeInitialWindowSize(int newSize)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(newSize)}={newSize}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(newSize)}={newSize}");
             Debug.Assert(newSize >= 0);
 
             lock (SyncObject)
@@ -676,7 +676,7 @@ namespace System.Net.Http
             }
 
             int amount = BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan) & 0x7FFFFFFF;
-            if (NetEventSource.IsEnabled) Trace($"{frameHeader}. {nameof(amount)}={amount}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{frameHeader}. {nameof(amount)}={amount}");
 
             Debug.Assert(amount >= 0);
             if (amount == 0)
@@ -726,7 +726,7 @@ namespace System.Net.Http
             }
 
             var protocolError = (Http2ProtocolErrorCode)BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan);
-            if (NetEventSource.IsEnabled) Trace(frameHeader.StreamId, $"{nameof(protocolError)}={protocolError}");
+            if (NetEventSource.Log.IsEnabled()) Trace(frameHeader.StreamId, $"{nameof(protocolError)}={protocolError}");
 
             _incomingBuffer.Discard(frameHeader.PayloadLength);
 
@@ -758,7 +758,7 @@ namespace System.Net.Http
 
             int lastValidStream = (int)(BinaryPrimitives.ReadUInt32BigEndian(_incomingBuffer.ActiveSpan) & 0x7FFFFFFF);
             var errorCode = (Http2ProtocolErrorCode)BinaryPrimitives.ReadInt32BigEndian(_incomingBuffer.ActiveSpan.Slice(sizeof(int)));
-            if (NetEventSource.IsEnabled) Trace(frameHeader.StreamId, $"{nameof(lastValidStream)}={lastValidStream}, {nameof(errorCode)}={errorCode}");
+            if (NetEventSource.Log.IsEnabled()) Trace(frameHeader.StreamId, $"{nameof(lastValidStream)}={lastValidStream}, {nameof(errorCode)}={errorCode}");
 
             StartTerminatingConnection(lastValidStream, new Http2ConnectionException(errorCode));
 
@@ -775,7 +775,7 @@ namespace System.Net.Http
         /// <param name="cancellationToken">The cancellation token to use while waiting.</param>
         private async Task PerformWriteAsync<T>(int writeBytes, T state, Func<T, Memory<byte>, FlushTiming> lockedAction, CancellationToken cancellationToken = default)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(writeBytes)}={writeBytes}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(writeBytes)}={writeBytes}");
 
             // Acquire the write lock
             ValueTask acquireLockTask = _writerLock.EnterAsync(cancellationToken);
@@ -876,7 +876,7 @@ namespace System.Net.Http
         private Task SendSettingsAckAsync() =>
             PerformWriteAsync(FrameHeader.Size, this, (thisRef, writeBuffer) =>
             {
-                if (NetEventSource.IsEnabled) thisRef.Trace("Started writing.");
+                if (NetEventSource.Log.IsEnabled()) thisRef.Trace("Started writing.");
 
                 FrameHeader.WriteTo(writeBuffer.Span, 0, FrameType.Settings, FrameFlags.Ack, streamId: 0);
 
@@ -887,7 +887,7 @@ namespace System.Net.Http
         private Task SendPingAckAsync(long pingContent) =>
             PerformWriteAsync(FrameHeader.Size + FrameHeader.PingLength, (thisRef: this, pingContent), (state, writeBuffer) =>
             {
-                if (NetEventSource.IsEnabled) state.thisRef.Trace("Started writing.");
+                if (NetEventSource.Log.IsEnabled()) state.thisRef.Trace("Started writing.");
 
                 Debug.Assert(sizeof(long) == FrameHeader.PingLength);
 
@@ -901,7 +901,7 @@ namespace System.Net.Http
         private Task SendRstStreamAsync(int streamId, Http2ProtocolErrorCode errorCode) =>
             PerformWriteAsync(FrameHeader.Size + FrameHeader.RstStreamLength, (thisRef: this, streamId, errorCode), (s, writeBuffer) =>
             {
-                if (NetEventSource.IsEnabled) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(s.errorCode)}={s.errorCode}");
+                if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(s.errorCode)}={s.errorCode}");
 
                 Span<byte> span = writeBuffer.Span;
                 FrameHeader.WriteTo(span, FrameHeader.RstStreamLength, FrameType.RstStream, FrameFlags.None, s.streamId);
@@ -917,7 +917,7 @@ namespace System.Net.Http
 
         private void WriteIndexedHeader(int index, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(index)}={index}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(index)}={index}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeIndexedHeaderField(index, headerBuffer.AvailableSpan, out bytesWritten))
@@ -930,7 +930,7 @@ namespace System.Net.Http
 
         private void WriteIndexedHeader(int index, string value, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(index)}={index}, {nameof(value)}={value}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(index)}={index}, {nameof(value)}={value}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexing(index, value, headerBuffer.AvailableSpan, out bytesWritten))
@@ -943,7 +943,7 @@ namespace System.Net.Http
 
         private void WriteLiteralHeader(string name, ReadOnlySpan<string> values, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(name)}={name}, {nameof(values)}={string.Join(", ", values.ToArray())}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(name)}={name}, {nameof(values)}={string.Join(", ", values.ToArray())}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeLiteralHeaderFieldWithoutIndexingNewName(name, values, HttpHeaderParser.DefaultSeparator, headerBuffer.AvailableSpan, out bytesWritten))
@@ -956,7 +956,7 @@ namespace System.Net.Http
 
         private void WriteLiteralHeaderValues(ReadOnlySpan<string> values, string? separator, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(values)}={string.Join(separator, values.ToArray())}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(values)}={string.Join(separator, values.ToArray())}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeStringLiterals(values, separator, headerBuffer.AvailableSpan, out bytesWritten))
@@ -969,7 +969,7 @@ namespace System.Net.Http
 
         private void WriteLiteralHeaderValue(string value, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(value)}={value}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(value)}={value}");
 
             int bytesWritten;
             while (!HPackEncoder.EncodeStringLiteral(value, headerBuffer.AvailableSpan, out bytesWritten))
@@ -982,7 +982,7 @@ namespace System.Net.Http
 
         private void WriteBytes(ReadOnlySpan<byte> bytes, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(bytes.Length)}={bytes.Length}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(bytes.Length)}={bytes.Length}");
 
             if (bytes.Length > headerBuffer.AvailableLength)
             {
@@ -995,7 +995,7 @@ namespace System.Net.Http
 
         private void WriteHeaderCollection(HttpHeaders headers, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace("");
+            if (NetEventSource.Log.IsEnabled()) Trace("");
 
             if (headers.HeaderStore is null)
             {
@@ -1061,7 +1061,7 @@ namespace System.Net.Http
 
         private void WriteHeaders(HttpRequestMessage request, ref ArrayBuffer headerBuffer)
         {
-            if (NetEventSource.IsEnabled) Trace("");
+            if (NetEventSource.Log.IsEnabled()) Trace("");
 
             // HTTP2 does not support Transfer-Encoding: chunked, so disable this on the request.
             if (request.HasHeaders && request.Headers.TransferEncodingChunked == true)
@@ -1232,7 +1232,7 @@ namespace System.Net.Http
                 {
                     try
                     {
-                        if (NetEventSource.IsEnabled) s.thisRef.Trace(s.http2Stream.StreamId, $"Started writing. {nameof(s.totalSize)}={s.totalSize}");
+                        if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Started writing. {nameof(s.totalSize)}={s.totalSize}");
 
                         // Allocate the next available stream ID. Note that if we fail before sending the headers,
                         // we'll just skip this stream ID, which is fine.
@@ -1268,7 +1268,7 @@ namespace System.Net.Http
                         span = span.Slice(FrameHeader.Size);
                         s.current.Span.CopyTo(span);
                         span = span.Slice(s.current.Length);
-                        if (NetEventSource.IsEnabled) s.thisRef.Trace(s.http2Stream.StreamId, $"Wrote HEADERS frame. Length={s.current.Length}, flags={s.flags}");
+                        if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Wrote HEADERS frame. Length={s.current.Length}, flags={s.flags}");
 
                         // Copy CONTINUATION frames, if any.
                         while (s.remaining.Length > 0)
@@ -1280,7 +1280,7 @@ namespace System.Net.Http
                             span = span.Slice(FrameHeader.Size);
                             s.current.Span.CopyTo(span);
                             span = span.Slice(s.current.Length);
-                            if (NetEventSource.IsEnabled) s.thisRef.Trace(s.http2Stream.StreamId, $"Wrote CONTINUATION frame. Length={s.current.Length}, flags={s.flags}");
+                            if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.http2Stream.StreamId, $"Wrote CONTINUATION frame. Length={s.current.Length}, flags={s.flags}");
                         }
 
                         Debug.Assert(span.Length == 0);
@@ -1323,7 +1323,7 @@ namespace System.Net.Http
                     await PerformWriteAsync(FrameHeader.Size + current.Length, (thisRef: this, streamId, current), (s, writeBuffer) =>
                     {
                         // Invoked while holding the lock:
-                        if (NetEventSource.IsEnabled) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(writeBuffer.Length)}={writeBuffer.Length}");
+                        if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(writeBuffer.Length)}={writeBuffer.Length}");
 
                         FrameHeader.WriteTo(writeBuffer.Span, s.current.Length, FrameType.Data, FrameFlags.None, s.streamId);
                         s.current.CopyTo(writeBuffer.Slice(FrameHeader.Size));
@@ -1343,7 +1343,7 @@ namespace System.Net.Http
         private Task SendEndStreamAsync(int streamId) =>
             PerformWriteAsync(FrameHeader.Size, (thisRef: this, streamId), (s, writeBuffer) =>
             {
-                if (NetEventSource.IsEnabled) s.thisRef.Trace(s.streamId, "Started writing.");
+                if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, "Started writing.");
 
                 FrameHeader.WriteTo(writeBuffer.Span, 0, FrameType.Data, FrameFlags.EndStream, s.streamId);
 
@@ -1356,7 +1356,7 @@ namespace System.Net.Http
             Debug.Assert(amount > 0);
             return PerformWriteAsync(FrameHeader.Size + FrameHeader.WindowUpdateLength, (thisRef: this, streamId, amount), (s, writeBuffer) =>
             {
-                if (NetEventSource.IsEnabled) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(s.amount)}={s.amount}");
+                if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(s.amount)}={s.amount}");
 
                 Span<byte> span = writeBuffer.Span;
                 FrameHeader.WriteTo(span, FrameHeader.WindowUpdateLength, FrameType.WindowUpdate, FrameFlags.None, s.streamId);
@@ -1368,7 +1368,7 @@ namespace System.Net.Http
 
         private void ExtendWindow(int amount)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(amount)}={amount}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(amount)}={amount}");
             Debug.Assert(amount > 0);
 
             int windowUpdateSize;
@@ -1379,7 +1379,7 @@ namespace System.Net.Http
                 _pendingWindowUpdate += amount;
                 if (_pendingWindowUpdate < ConnectionWindowThreshold)
                 {
-                    if (NetEventSource.IsEnabled) Trace($"{nameof(_pendingWindowUpdate)} {_pendingWindowUpdate} < {ConnectionWindowThreshold}.");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(_pendingWindowUpdate)} {_pendingWindowUpdate} < {ConnectionWindowThreshold}.");
                     return;
                 }
 
@@ -1396,7 +1396,7 @@ namespace System.Net.Http
         {
             // The connection has failed, e.g. failed IO or a connection-level frame error.
             if (Interlocked.CompareExchange(ref _abortException, abortException, null) != null &&
-                NetEventSource.IsEnabled &&
+                NetEventSource.Log.IsEnabled() &&
                 !ReferenceEquals(_abortException, abortException))
             {
                 // Lost the race to set the field to another exception, so just trace this one.
@@ -1431,7 +1431,7 @@ namespace System.Net.Http
                 (_httpStreams.Count == 0) &&
                 ((nowTicks - _idleSinceTickCount) > connectionIdleTimeout.TotalMilliseconds))
             {
-                if (NetEventSource.IsEnabled) Trace($"Connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Connection no longer usable. Idle {TimeSpan.FromMilliseconds(nowTicks - _idleSinceTickCount)} > {connectionIdleTimeout}.");
 
                 return true;
             }
@@ -1441,7 +1441,7 @@ namespace System.Net.Http
 
         private void AbortStreams(Exception abortException)
         {
-            if (NetEventSource.IsEnabled) Trace($"{nameof(abortException)}={abortException}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(abortException)}={abortException}");
 
             // Invalidate outside of lock to avoid race with HttpPool Dispose()
             // We should not try to grab pool lock while holding connection lock as on disposing pool,
@@ -1499,7 +1499,7 @@ namespace System.Net.Http
                     _lastStreamId = Math.Min(_lastStreamId, lastValidStream);
                 }
 
-                if (NetEventSource.IsEnabled) Trace($"{nameof(lastValidStream)}={lastValidStream}, {nameof(_lastStreamId)}={_lastStreamId}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(lastValidStream)}={lastValidStream}, {nameof(_lastStreamId)}={_lastStreamId}");
 
                 foreach (KeyValuePair<int, Http2Stream> kvp in _httpStreams)
                 {
@@ -1512,7 +1512,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        if (NetEventSource.IsEnabled) Trace($"Found {nameof(streamId)} {streamId} <= {_lastStreamId}.");
+                        if (NetEventSource.Log.IsEnabled()) Trace($"Found {nameof(streamId)} {streamId} <= {_lastStreamId}.");
                     }
                 }
 
@@ -1680,7 +1680,7 @@ namespace System.Net.Http
 
         public sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled) Trace($"{request}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{request}");
 
             try
             {
@@ -1723,7 +1723,7 @@ namespace System.Net.Http
                     }
                     catch (Exception e)
                     {
-                        if (NetEventSource.IsEnabled) Trace($"Sending request content failed: {e}");
+                        if (NetEventSource.Log.IsEnabled()) Trace($"Sending request content failed: {e}");
                         LogExceptions(responseHeadersTask); // Observe exception (if any) on responseHeadersTask.
                         throw;
                     }
@@ -1759,7 +1759,7 @@ namespace System.Net.Http
 
         private void RemoveStream(Http2Stream http2Stream)
         {
-            if (NetEventSource.IsEnabled) Trace(http2Stream.StreamId, "");
+            if (NetEventSource.Log.IsEnabled()) Trace(http2Stream.StreamId, "");
             Debug.Assert(http2Stream != null);
 
             lock (SyncObject)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -349,7 +349,7 @@ namespace System.Net.Http
                     _creditWaiter = null;
                 }
 
-                if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestStop();
             }
 
             private void Cancel()
@@ -385,7 +385,7 @@ namespace System.Net.Http
                     _waitSource.SetResult(true);
                 }
 
-                if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestAborted();
+                if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestAborted();
             }
 
             // Returns whether the waiter should be signalled or not.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -140,7 +140,7 @@ namespace System.Net.Http
             {
                 StreamId = streamId;
                 _availableCredit = initialWindowSize;
-                if (NetEventSource.IsEnabled) Trace($"{_request}, {nameof(initialWindowSize)}={initialWindowSize}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{_request}, {nameof(initialWindowSize)}={initialWindowSize}");
             }
 
             public int StreamId { get; private set; }
@@ -165,7 +165,7 @@ namespace System.Net.Http
                     return;
                 }
 
-                if (NetEventSource.IsEnabled) Trace($"{_request.Content}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{_request.Content}");
                 Debug.Assert(_requestBodyCancellationSource != null);
 
                 // Cancel the request body sending if cancellation is requested on the supplied cancellation token.
@@ -207,11 +207,11 @@ namespace System.Net.Http
                         }
                     }
 
-                    if (NetEventSource.IsEnabled) Trace($"Finished sending request body.");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Finished sending request body.");
                 }
                 catch (Exception e)
                 {
-                    if (NetEventSource.IsEnabled) Trace($"Failed to send request body: {e}");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Failed to send request body: {e}");
                     bool signalWaiter;
 
                     Debug.Assert(!Monitor.IsEntered(SyncObject));
@@ -289,7 +289,7 @@ namespace System.Net.Http
             public async ValueTask<bool> WaitFor100ContinueAsync(CancellationToken cancellationToken)
             {
                 Debug.Assert(_request?.Content != null);
-                if (NetEventSource.IsEnabled) Trace($"Waiting to send request body content for 100-Continue.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Waiting to send request body content for 100-Continue.");
 
                 // Use TCS created in constructor. It will complete when one of three things occurs:
                 // 1. we receive the relevant response from the server.
@@ -304,7 +304,7 @@ namespace System.Net.Http
                 await using (new Timer(s =>
                 {
                     var thisRef = (Http2Stream)s!;
-                    if (NetEventSource.IsEnabled) thisRef.Trace($"100-Continue timer expired.");
+                    if (NetEventSource.Log.IsEnabled()) thisRef.Trace($"100-Continue timer expired.");
                     thisRef._expect100ContinueWaiter?.TrySetResult(true);
                 }, this, _connection._pool.Settings._expect100ContinueTimeout, Timeout.InfiniteTimeSpan).ConfigureAwait(false))
                 {
@@ -323,7 +323,7 @@ namespace System.Net.Http
                 Debug.Assert(_requestCompletionState == StreamCompletionState.Failed || _responseCompletionState == StreamCompletionState.Failed,
                     "Reset called but neither request nor response is failed");
 
-                if (NetEventSource.IsEnabled) Trace($"Stream reset. Request={_requestCompletionState}, Response={_responseCompletionState}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Stream reset. Request={_requestCompletionState}, Response={_responseCompletionState}.");
 
                 // Don't send a RST_STREAM if we've already received one from the server.
                 if (_resetException == null)
@@ -338,7 +338,7 @@ namespace System.Net.Http
                 Debug.Assert(_requestCompletionState != StreamCompletionState.InProgress);
                 Debug.Assert(_responseCompletionState != StreamCompletionState.InProgress);
 
-                if (NetEventSource.IsEnabled) Trace($"Stream complete. Request={_requestCompletionState}, Response={_responseCompletionState}.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Stream complete. Request={_requestCompletionState}, Response={_responseCompletionState}.");
 
                 _connection.RemoveStream(this);
 
@@ -354,7 +354,7 @@ namespace System.Net.Http
 
             private void Cancel()
             {
-                if (NetEventSource.IsEnabled) Trace("");
+                if (NetEventSource.Log.IsEnabled()) Trace("");
 
                 CancellationTokenSource? requestBodyCancellationSource = null;
                 bool signalWaiter = false;
@@ -449,7 +449,7 @@ namespace System.Net.Http
 
             public void OnHeader(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
             {
-                if (NetEventSource.IsEnabled) Trace($"{Encoding.ASCII.GetString(name)}: {Encoding.ASCII.GetString(value)}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{Encoding.ASCII.GetString(name)}: {Encoding.ASCII.GetString(value)}");
                 Debug.Assert(name.Length > 0);
 
                 _headerBudgetRemaining -= name.Length + value.Length;
@@ -472,7 +472,7 @@ namespace System.Net.Http
                         if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingStatus)
                         {
                             // Pseudo-headers are allowed only in header block
-                            if (NetEventSource.IsEnabled) Trace($"Pseudo-header received in {_responseProtocolState} state.");
+                            if (NetEventSource.Log.IsEnabled()) Trace($"Pseudo-header received in {_responseProtocolState} state.");
                             throw new HttpRequestException(SR.net_http_invalid_response_pseudo_header_in_trailer);
                         }
 
@@ -480,7 +480,7 @@ namespace System.Net.Http
                         {
                             if (_responseProtocolState != ResponseProtocolState.ExpectingStatus)
                             {
-                                if (NetEventSource.IsEnabled) Trace("Received extra status header.");
+                                if (NetEventSource.Log.IsEnabled()) Trace("Received extra status header.");
                                 throw new HttpRequestException(SR.Format(SR.net_http_invalid_response_status_code, "duplicate status"));
                             }
 
@@ -495,7 +495,7 @@ namespace System.Net.Http
 
                                 if (_response.StatusCode == HttpStatusCode.Continue && _expect100ContinueWaiter != null)
                                 {
-                                    if (NetEventSource.IsEnabled) Trace("Received 100-Continue status.");
+                                    if (NetEventSource.Log.IsEnabled()) Trace("Received 100-Continue status.");
                                     _expect100ContinueWaiter.TrySetResult(true);
                                 }
                             }
@@ -509,14 +509,14 @@ namespace System.Net.Http
                                     // If the final status code is >= 300, skip sending the body.
                                     bool shouldSendBody = (statusValue < 300);
 
-                                    if (NetEventSource.IsEnabled) Trace($"Expecting 100 Continue but received final status {statusValue}.");
+                                    if (NetEventSource.Log.IsEnabled()) Trace($"Expecting 100 Continue but received final status {statusValue}.");
                                     _expect100ContinueWaiter.TrySetResult(shouldSendBody);
                                 }
                             }
                         }
                         else
                         {
-                            if (NetEventSource.IsEnabled) Trace($"Invalid response pseudo-header '{Encoding.ASCII.GetString(name)}'.");
+                            if (NetEventSource.Log.IsEnabled()) Trace($"Invalid response pseudo-header '{Encoding.ASCII.GetString(name)}'.");
                             throw new HttpRequestException(SR.net_http_invalid_response);
                         }
                     }
@@ -530,7 +530,7 @@ namespace System.Net.Http
 
                         if (_responseProtocolState != ResponseProtocolState.ExpectingHeaders && _responseProtocolState != ResponseProtocolState.ExpectingTrailingHeaders)
                         {
-                            if (NetEventSource.IsEnabled) Trace("Received header before status.");
+                            if (NetEventSource.Log.IsEnabled()) Trace("Received header before status.");
                             throw new HttpRequestException(SR.net_http_invalid_response);
                         }
 
@@ -605,7 +605,7 @@ namespace System.Net.Http
                         case ResponseProtocolState.ExpectingTrailingHeaders:
                             if (!endStream)
                             {
-                                if (NetEventSource.IsEnabled) Trace("Trailing headers received without endStream");
+                                if (NetEventSource.Log.IsEnabled()) Trace("Trailing headers received without endStream");
                                 ThrowProtocolError();
                             }
                             _responseProtocolState = ResponseProtocolState.Complete;
@@ -716,7 +716,7 @@ namespace System.Net.Http
             // (4) Receiving EOF from the server. If so, resetException will contain an exception like "expected 9 bytes of data", and canRetry will be false.
             public void OnReset(Exception resetException, Http2ProtocolErrorCode? resetStreamErrorCode = null, bool canRetry = false)
             {
-                if (NetEventSource.IsEnabled) Trace($"{nameof(resetException)}={resetException}, {nameof(resetStreamErrorCode)}={resetStreamErrorCode}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"{nameof(resetException)}={resetException}, {nameof(resetStreamErrorCode)}={resetStreamErrorCode}");
 
                 bool cancel = false;
                 CancellationTokenSource? requestBodyCancellationSource = null;
@@ -1258,14 +1258,14 @@ namespace System.Net.Http
 
                 ~Http2ReadStream()
                 {
-                    if (NetEventSource.IsEnabled) _http2Stream?.Trace("");
+                    if (NetEventSource.Log.IsEnabled()) _http2Stream?.Trace("");
                     try
                     {
                         Dispose(disposing: false);
                     }
                     catch (Exception e)
                     {
-                        if (NetEventSource.IsEnabled) _http2Stream?.Trace($"Error: {e}");
+                        if (NetEventSource.Log.IsEnabled()) _http2Stream?.Trace($"Error: {e}");
                     }
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -145,7 +145,7 @@ namespace System.Net.Http
 
                 _ = _connectionClosedTask.ContinueWith(closeTask =>
                 {
-                    if (closeTask.IsFaulted && NetEventSource.IsEnabled)
+                    if (closeTask.IsFaulted && NetEventSource.Log.IsEnabled())
                     {
                         Trace($"{nameof(QuicConnection)} failed to close: {closeTask.Exception!.InnerException}");
                     }
@@ -319,7 +319,7 @@ namespace System.Net.Http
 
             if (firstException != null)
             {
-                if (NetEventSource.IsEnabled && !ReferenceEquals(firstException, abortException))
+                if (NetEventSource.Log.IsEnabled() && !ReferenceEquals(firstException, abortException))
                 {
                     // Lost the race to set the field to another exception, so just trace this one.
                     Trace($"{nameof(abortException)}=={abortException}");
@@ -369,7 +369,7 @@ namespace System.Net.Http
                     // Server can send multiple GOAWAY frames.
                     // Spec says a server MUST NOT increase the stream ID in subsequent GOAWAYs,
                     // but doesn't specify what client should do if that is violated. Ignore for now.
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace("HTTP/3 server sent GOAWAY with increasing stream ID. Retried requests may have been double-processed by server.");
                     }
@@ -568,7 +568,7 @@ namespace System.Net.Http
                         default:
                             // Unknown stream type. Per spec, these must be ignored and aborted but not be considered a connection-level error.
 
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                             {
                                 // Read the rest of the integer, which might be more than 1 byte, so we can log it.
 
@@ -697,7 +697,7 @@ namespace System.Net.Http
             {
                 if (settingsPayloadLength > MaximumSettingsPayloadLength)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace($"Received SETTINGS frame with {settingsPayloadLength} byte payload exceeding the {MaximumSettingsPayloadLength} byte maximum.");
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -305,7 +305,7 @@ namespace System.Net.Http
 
                 if (frameType != Http3FrameType.Headers)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace($"Expected HEADERS as first response frame; recieved {frameType}.");
                     }
@@ -454,7 +454,7 @@ namespace System.Net.Http
                         // Per spec, 0-length payload is allowed.
                         if (payloadLength != 0)
                         {
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                             {
                                 Trace("Response content exceeded Content-Length.");
                             }
@@ -794,7 +794,7 @@ namespace System.Net.Http
                     }
                     else
                     {
-                        if (NetEventSource.IsEnabled) Trace($"Server closed response stream before entire header payload could be read. {headersLength:N0} bytes remaining.");
+                        if (NetEventSource.Log.IsEnabled()) Trace($"Server closed response stream before entire header payload could be read. {headersLength:N0} bytes remaining.");
                         throw new HttpRequestException(SR.net_http_invalid_response_premature_eof);
                     }
                 }
@@ -836,7 +836,7 @@ namespace System.Net.Http
         {
             if (!HeaderDescriptor.TryGetStaticQPackHeader(index, out descriptor, out knownValue))
             {
-                if (NetEventSource.IsEnabled) Trace($"Response contains invalid static header index '{index}'.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Response contains invalid static header index '{index}'.");
                 throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
             }
         }
@@ -852,13 +852,13 @@ namespace System.Net.Http
             {
                 if (descriptor.KnownHeader != KnownHeaders.PseudoStatus)
                 {
-                    if (NetEventSource.IsEnabled) Trace($"Received unknown pseudo-header '{descriptor.Name}'.");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Received unknown pseudo-header '{descriptor.Name}'.");
                     throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
                 }
 
                 if (_headerState != HeaderState.StatusHeader)
                 {
-                    if (NetEventSource.IsEnabled) Trace("Received extra status header.");
+                    if (NetEventSource.Log.IsEnabled()) Trace("Received extra status header.");
                     throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
                 }
 
@@ -907,7 +907,7 @@ namespace System.Net.Http
                         // If the final status code is >= 300, skip sending the body.
                         bool shouldSendBody = (statusCode < 300);
 
-                        if (NetEventSource.IsEnabled) Trace($"Expecting 100 Continue but received final status {statusCode}.");
+                        if (NetEventSource.Log.IsEnabled()) Trace($"Expecting 100 Continue but received final status {statusCode}.");
                         _expect100ContinueCompletionSource.TrySetResult(shouldSendBody);
                     }
                 }
@@ -924,7 +924,7 @@ namespace System.Net.Http
                 switch (_headerState)
                 {
                     case HeaderState.StatusHeader:
-                        if (NetEventSource.IsEnabled) Trace($"Received headers without :status.");
+                        if (NetEventSource.Log.IsEnabled()) Trace($"Received headers without :status.");
                         throw new Http3ConnectionException(Http3ErrorCode.ProtocolError);
                     case HeaderState.ResponseHeaders when descriptor.HeaderType.HasFlag(HttpHeaderType.Content):
                         _response!.Content!.Headers.TryAddWithoutValidation(descriptor, headerValue);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -85,7 +85,7 @@ namespace System.Net.Http
 
             _weakThisRef = new WeakReference<HttpConnection>(this);
 
-            if (NetEventSource.IsEnabled) TraceConnection(_stream);
+            if (NetEventSource.Log.IsEnabled()) TraceConnection(_stream);
         }
 
         public void Dispose() => Dispose(disposing: true);
@@ -96,7 +96,7 @@ namespace System.Net.Http
             // if the request and the response were running concurrently and both incurred an exception.
             if (Interlocked.Exchange(ref _disposed, 1) == 0)
             {
-                if (NetEventSource.IsEnabled) Trace("Connection closing.");
+                if (NetEventSource.Log.IsEnabled()) Trace("Connection closing.");
                 _pool.DecrementConnectionCount();
                 if (disposing)
                 {
@@ -156,7 +156,7 @@ namespace System.Net.Http
             catch (Exception error)
             {
                 // If reading throws, eat the error and don't pool the connection.
-                if (NetEventSource.IsEnabled) Trace($"Error performing read ahead: {error}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Error performing read ahead: {error}");
                 Dispose();
                 _readAheadTask = new ValueTask<int>(0);
             }
@@ -331,7 +331,7 @@ namespace System.Net.Http
             _canRetry = true;
 
             // Send the request.
-            if (NetEventSource.IsEnabled) Trace($"Sending request: {request}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Sending request: {request}");
             CancellationTokenRegistration cancellationRegistration = RegisterCancellation(cancellationToken);
             try
             {
@@ -436,7 +436,7 @@ namespace System.Net.Http
                 else
                 {
                     bool hasExpectContinueHeader = request.HasHeaders && request.Headers.ExpectContinue == true;
-                    if (NetEventSource.IsEnabled) Trace($"Request content is not null, start processing it. hasExpectContinueHeader = {hasExpectContinueHeader}");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Request content is not null, start processing it. hasExpectContinueHeader = {hasExpectContinueHeader}");
 
                     // Send the body if there is one.  We prefer to serialize the sending of the content before
                     // we try to receive any response, but if ExpectContinue has been set, we allow the sending
@@ -486,7 +486,7 @@ namespace System.Net.Http
                         vt.IsCompletedSuccessfully ? vt.Result :
                         async ? await vt.ConfigureAwait(false) :
                         vt.AsTask().GetAwaiter().GetResult();
-                    if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
 
                     if (bytesRead == 0)
                     {
@@ -532,7 +532,7 @@ namespace System.Net.Http
                     }
 
                     // In case read hangs which eventually leads to connection timeout.
-                    if (NetEventSource.IsEnabled) Trace($"Current {response.StatusCode} response is an interim response or not expected, need to read for a final response.");
+                    if (NetEventSource.Log.IsEnabled()) Trace($"Current {response.StatusCode} response is an interim response or not expected, need to read for a final response.");
 
                     // Discard headers that come with the interim 1xx responses.
                     // RFC7231: 1xx responses are terminated by the first empty line after the status-line.
@@ -608,7 +608,7 @@ namespace System.Net.Http
                 }
 
                 // Now we are sure that the request was fully sent.
-                if (NetEventSource.IsEnabled) Trace("Request is fully sent.");
+                if (NetEventSource.Log.IsEnabled()) Trace("Request is fully sent.");
 
                 // We're about to create the response stream, at which point responsibility for canceling
                 // the remainder of the response lies with the stream.  Thus we dispose of our registration
@@ -663,7 +663,7 @@ namespace System.Net.Http
                 }
                 ((HttpConnectionResponseContent)response.Content).SetStream(responseStream);
 
-                if (NetEventSource.IsEnabled) Trace($"Received response: {response}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Received response: {response}");
 
                 // Process Set-Cookie headers.
                 if (_pool.Settings._useCookies)
@@ -681,7 +681,7 @@ namespace System.Net.Http
                 // Make sure to complete the allowExpect100ToContinue task if it exists.
                 allowExpect100ToContinue?.TrySetResult(false);
 
-                if (NetEventSource.IsEnabled) Trace($"Error sending request: {error}");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Error sending request: {error}");
 
                 // In the rare case where Expect: 100-continue was used and then processing
                 // of the response headers encountered an error such that we weren't able to
@@ -760,7 +760,7 @@ namespace System.Net.Http
                 var weakThisRef = (WeakReference<HttpConnection>)s!;
                 if (weakThisRef.TryGetTarget(out HttpConnection? strongThisRef))
                 {
-                    if (NetEventSource.IsEnabled) strongThisRef.Trace("Cancellation requested. Disposing of the connection.");
+                    if (NetEventSource.Log.IsEnabled()) strongThisRef.Trace("Cancellation requested. Disposing of the connection.");
                     strongThisRef.Dispose();
                 }
             }, _weakThisRef);
@@ -789,7 +789,7 @@ namespace System.Net.Http
             // Flush any content that might still be buffered.
             await FlushAsync(async).ConfigureAwait(false);
 
-            if (NetEventSource.IsEnabled) Trace("Finished sending request content.");
+            if (NetEventSource.Log.IsEnabled()) Trace("Finished sending request content.");
         }
 
         private async Task SendRequestContentWithExpect100ContinueAsync(
@@ -805,12 +805,12 @@ namespace System.Net.Http
             // Send the content if we're supposed to.  Otherwise, we're done.
             if (sendRequestContent)
             {
-                if (NetEventSource.IsEnabled) Trace($"Sending request content for Expect: 100-continue.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Sending request content for Expect: 100-continue.");
                 await SendRequestContentAsync(request, stream, async, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                if (NetEventSource.IsEnabled) Trace($"Canceling request content for Expect: 100-continue.");
+                if (NetEventSource.Log.IsEnabled()) Trace($"Canceling request content for Expect: 100-continue.");
             }
         }
 
@@ -929,7 +929,7 @@ namespace System.Net.Http
             {
                 // Disallowed trailer fields.
                 // A recipient MUST ignore fields that are forbidden to be sent in a trailer.
-                if (NetEventSource.IsEnabled) connection.Trace($"Stripping forbidden {descriptor.Name} from trailer headers.");
+                if (NetEventSource.Log.IsEnabled()) connection.Trace($"Stripping forbidden {descriptor.Name} from trailer headers.");
                 return;
             }
 
@@ -1262,13 +1262,13 @@ namespace System.Net.Http
 
         private void WriteToStream(ReadOnlySpan<byte> source)
         {
-            if (NetEventSource.IsEnabled) Trace($"Writing {source.Length} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Writing {source.Length} bytes.");
             _stream.Write(source);
         }
 
         private ValueTask WriteToStreamAsync(ReadOnlyMemory<byte> source, bool async)
         {
-            if (NetEventSource.IsEnabled) Trace($"Writing {source.Length} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Writing {source.Length} bytes.");
 
             if (async)
             {
@@ -1451,7 +1451,7 @@ namespace System.Net.Http
                 await _stream.ReadAsync(new Memory<byte>(_readBuffer, _readLength, _readBuffer.Length - _readLength)).ConfigureAwait(false) :
                 _stream.Read(_readBuffer, _readLength, _readBuffer.Length - _readLength);
 
-            if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
             if (bytesRead == 0)
             {
                 throw new IOException(SR.net_http_invalid_response_premature_eof);
@@ -1492,7 +1492,7 @@ namespace System.Net.Http
             // Do an unbuffered read directly against the underlying stream.
             Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
             int count = _stream.Read(destination);
-            if (NetEventSource.IsEnabled) Trace($"Received {count} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Received {count} bytes.");
             return count;
         }
 
@@ -1520,7 +1520,7 @@ namespace System.Net.Http
             // Do an unbuffered read directly against the underlying stream.
             Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
             int count = await _stream.ReadAsync(destination).ConfigureAwait(false);
-            if (NetEventSource.IsEnabled) Trace($"Received {count} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Received {count} bytes.");
             return count;
         }
 
@@ -1551,7 +1551,7 @@ namespace System.Net.Http
             // Do a buffered read directly against the underlying stream.
             Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
             int bytesRead = _stream.Read(_readBuffer, 0, _readBuffer.Length);
-            if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
             _readLength = bytesRead;
 
             // Hand back as much data as we can fit.
@@ -1597,7 +1597,7 @@ namespace System.Net.Http
             // Do a buffered read directly against the underlying stream.
             Debug.Assert(_readAheadTask == null, "Read ahead task should have been consumed as part of the headers.");
             int bytesRead = await _stream.ReadAsync(_readBuffer.AsMemory()).ConfigureAwait(false);
-            if (NetEventSource.IsEnabled) Trace($"Received {bytesRead} bytes.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Received {bytesRead} bytes.");
             _readLength = bytesRead;
 
             // Hand back as much data as we can fit.
@@ -1611,7 +1611,7 @@ namespace System.Net.Http
         {
             Debug.Assert(count <= _readLength - _readOffset);
 
-            if (NetEventSource.IsEnabled) Trace($"Copying {count} bytes to stream.");
+            if (NetEventSource.Log.IsEnabled()) Trace($"Copying {count} bytes to stream.");
             if (async)
             {
                 await destination.WriteAsync(new ReadOnlyMemory<byte>(_readBuffer, _readOffset, count), cancellationToken).ConfigureAwait(false);
@@ -1784,7 +1784,7 @@ namespace System.Net.Http
             // may not even have it any more.
             if (_readLength != _readOffset)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     Trace("Unexpected data on connection after response read.");
                 }
@@ -1843,7 +1843,7 @@ namespace System.Net.Http
             // don't put the connection back in the pool.
             if (_connectionClose)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     Trace("Connection will not be reused.");
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -621,7 +621,7 @@ namespace System.Net.Http
                 Stream responseStream;
                 if (ReferenceEquals(normalizedMethod, HttpMethod.Head) || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
                 {
-                    if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestStop();
                     responseStream = EmptyReadStream.Instance;
                     CompleteResponse();
                 }
@@ -644,7 +644,7 @@ namespace System.Net.Http
                     long contentLength = response.Content.Headers.ContentLength.GetValueOrDefault();
                     if (contentLength <= 0)
                     {
-                        if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
+                        if (HttpTelemetry.Log.IsEnabled()) HttpTelemetry.Log.RequestStop();
                         responseStream = EmptyReadStream.Instance;
                         CompleteResponse();
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -68,7 +68,7 @@ namespace System.Net.Http
                 lifetime != Timeout.InfiniteTimeSpan &&
                 (lifetime == TimeSpan.Zero || (nowTicks - CreationTickCount) > lifetime.TotalMilliseconds);
 
-            if (expired && NetEventSource.IsEnabled) Trace($"Connection no longer usable. Alive {TimeSpan.FromMilliseconds((nowTicks - CreationTickCount))} > {lifetime}.");
+            if (expired && NetEventSource.Log.IsEnabled()) Trace($"Connection no longer usable. Alive {TimeSpan.FromMilliseconds((nowTicks - CreationTickCount))} > {lifetime}.");
             return expired;
         }
 
@@ -136,7 +136,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(task.IsFaulted);
                 Exception? e = task.Exception!.InnerException; // Access Exception even if not tracing, to avoid TaskScheduler.UnobservedTaskException firing
-                if (NetEventSource.IsEnabled) connection.Trace($"Exception from asynchronous processing: {e}");
+                if (NetEventSource.Log.IsEnabled()) connection.Trace($"Exception from asynchronous processing: {e}");
             }
         }
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -254,7 +254,7 @@ namespace System.Net.Http
                 PreAuthCredentials = new CredentialCache();
             }
 
-            if (NetEventSource.IsEnabled) Trace($"{this}");
+            if (NetEventSource.Log.IsEnabled()) Trace($"{this}");
         }
 
         private static readonly List<SslApplicationProtocol> s_http3ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http3 };
@@ -276,7 +276,7 @@ namespace System.Net.Http
             // pretends they're part of the default when running on Win7/2008R2.
             if (s_isWindows7Or2008R2 && sslOptions.EnabledSslProtocols == SslProtocols.None)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(poolManager, $"Win7OrWin2K8R2 platform, Changing default TLS protocols to {SecurityProtocol.DefaultSecurityProtocols}");
                 }
@@ -429,7 +429,7 @@ namespace System.Net.Http
                     if (validConnection)
                     {
                         // We found a valid connection.  Return it.
-                        if (NetEventSource.IsEnabled) conn.Trace("Found usable connection in pool.");
+                        if (NetEventSource.Log.IsEnabled()) conn.Trace("Found usable connection in pool.");
                         return new ValueTask<HttpConnection?>(conn);
                     }
                 }
@@ -437,12 +437,12 @@ namespace System.Net.Http
                 // We got a connection, but it was already closed by the server or the
                 // server sent unexpected data or the connection is too old.  In any case,
                 // we can't use the connection, so get rid of it and loop around to try again.
-                if (NetEventSource.IsEnabled) conn.Trace("Found invalid connection in pool.");
+                if (NetEventSource.Log.IsEnabled()) conn.Trace("Found invalid connection in pool.");
                 conn.Dispose();
             }
 
             // We are at the connection limit. Wait for an available connection or connection count (indicated by null).
-            if (NetEventSource.IsEnabled) Trace("Connection limit reached, waiting for available connection.");
+            if (NetEventSource.Log.IsEnabled()) Trace("Connection limit reached, waiting for available connection.");
             return async ?
                 waiter.WaitWithCancellationAsync(cancellationToken) :
                 new ValueTask<HttpConnection?>(waiter.Task.GetAwaiter().GetResult());
@@ -457,7 +457,7 @@ namespace System.Net.Http
                 return (connection, false, null);
             }
 
-            if (NetEventSource.IsEnabled) Trace("Creating new connection for pool.");
+            if (NetEventSource.Log.IsEnabled()) Trace("Creating new connection for pool.");
 
             try
             {
@@ -497,7 +497,7 @@ namespace System.Net.Http
                 else
                 {
                     // Connection exist and it is still good to use.
-                    if (NetEventSource.IsEnabled) Trace("Using existing HTTP2 connection.");
+                    if (NetEventSource.Log.IsEnabled()) Trace("Using existing HTTP2 connection.");
                     _usedSinceLastCleanup = true;
                     return (http2Connection, false, null);
                 }
@@ -528,7 +528,7 @@ namespace System.Net.Http
                 {
                     // Someone beat us to it
 
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace("Using existing HTTP2 connection.");
                     }
@@ -539,7 +539,7 @@ namespace System.Net.Http
                 // Recheck if HTTP2 has been disabled by a previous attempt.
                 if (_http2Enabled)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace("Attempting new HTTP2 connection.");
                     }
@@ -561,7 +561,7 @@ namespace System.Net.Http
                         Debug.Assert(_http2Connection == null);
                         _http2Connection = http2Connection;
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             Trace("New unencrypted HTTP2 connection established.");
                         }
@@ -585,7 +585,7 @@ namespace System.Net.Http
                         Debug.Assert(_http2Connection == null);
                         _http2Connection = http2Connection;
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             Trace("New HTTP2 connection established.");
                         }
@@ -603,7 +603,7 @@ namespace System.Net.Http
             {
                 // We established an SSL connection, but the server denied our request for HTTP2.
                 // Continue as an HTTP/1.1 connection.
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     Trace("Server does not support HTTP2; disabling HTTP2 use and proceeding with HTTP/1.1 connection");
                 }
@@ -635,7 +635,7 @@ namespace System.Net.Http
                 }
                 else
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace("Discarding downgraded HTTP/1.1 connection because connection limit is exceeded");
                     }
@@ -668,7 +668,7 @@ namespace System.Net.Http
                 else
                 {
                     // Connection exists and it is still good to use.
-                    if (NetEventSource.IsEnabled) Trace("Using existing HTTP3 connection.");
+                    if (NetEventSource.Log.IsEnabled()) Trace("Using existing HTTP3 connection.");
                     _usedSinceLastCleanup = true;
                     return (http3Connection, false, null);
                 }
@@ -693,7 +693,7 @@ namespace System.Net.Http
                 {
                     // Someone beat us to creating the connection.
 
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace("Using existing HTTP3 connection.");
                     }
@@ -701,7 +701,7 @@ namespace System.Net.Http
                     return (_http3Connection, false, null);
                 }
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     Trace("Attempting new HTTP3 connection.");
                 }
@@ -720,7 +720,7 @@ namespace System.Net.Http
                 http3Connection = new Http3Connection(this, _originAuthority, authority, quicConnection);
                 _http3Connection = http3Connection;
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     Trace("New HTTP3 connection established.");
                 }
@@ -773,7 +773,7 @@ namespace System.Net.Http
                 }
                 catch (HttpRequestException e) when (e.AllowRetry == RequestRetryType.RetryOnLowerHttpVersion)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace($"Retrying request after exception on existing connection: {e}");
                     }
@@ -786,7 +786,7 @@ namespace System.Net.Http
                 }
                 catch (HttpRequestException e) when (!isNewConnection && e.AllowRetry == RequestRetryType.RetryOnSameOrNextProxy)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace($"Retrying request after exception on existing connection: {e}");
                     }
@@ -1223,7 +1223,7 @@ namespace System.Net.Http
         {
             Debug.Assert(Monitor.IsEntered(SyncObj), $"Expected to be holding {nameof(SyncObj)}");
 
-            if (NetEventSource.IsEnabled) Trace(null);
+            if (NetEventSource.Log.IsEnabled()) Trace(null);
             _usedSinceLastCleanup = true;
 
             Debug.Assert(
@@ -1268,7 +1268,7 @@ namespace System.Net.Http
         /// </summary>
         public void DecrementConnectionCount()
         {
-            if (NetEventSource.IsEnabled) Trace(null);
+            if (NetEventSource.Log.IsEnabled()) Trace(null);
             lock (SyncObj)
             {
                 Debug.Assert(_associatedConnectionCount > 0 && _associatedConnectionCount <= _maxConnections,
@@ -1279,7 +1279,7 @@ namespace System.Net.Http
 
                 if (TransferConnection(null))
                 {
-                    if (NetEventSource.IsEnabled) Trace("Transferred connection count to waiter.");
+                    if (NetEventSource.Log.IsEnabled()) Trace("Transferred connection count to waiter.");
                     return;
                 }
 
@@ -1314,7 +1314,7 @@ namespace System.Net.Http
                         receivedUnexpectedData = connection.EnsureReadAheadAndPollRead();
                         if (!receivedUnexpectedData && TransferConnection(connection))
                         {
-                            if (NetEventSource.IsEnabled) connection.Trace("Transferred connection to waiter.");
+                            if (NetEventSource.Log.IsEnabled()) connection.Trace("Transferred connection to waiter.");
                             return;
                         }
                     }
@@ -1332,7 +1332,7 @@ namespace System.Net.Http
                     {
                         // Pool the connection by adding it to the list.
                         list.Add(new CachedConnection(connection));
-                        if (NetEventSource.IsEnabled) connection.Trace("Stored connection in pool.");
+                        if (NetEventSource.Log.IsEnabled()) connection.Trace("Stored connection in pool.");
                         return;
                     }
                 }
@@ -1340,7 +1340,7 @@ namespace System.Net.Http
 
             // The connection could be not be reused.  Dispose of it.
             // Disposing it will alert any waiters that a connection slot has become available.
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 connection.Trace(
                     lifetimeExpired ? "Disposing connection return to pool. Connection lifetime expired." :
@@ -1384,7 +1384,7 @@ namespace System.Net.Http
             {
                 if (!_disposed)
                 {
-                    if (NetEventSource.IsEnabled) Trace("Disposing pool.");
+                    if (NetEventSource.Log.IsEnabled()) Trace("Disposing pool.");
                     _disposed = true;
                     list.ForEach(c => c._connection.Dispose());
                     list.Clear();
@@ -1430,7 +1430,7 @@ namespace System.Net.Http
 
             try
             {
-                if (NetEventSource.IsEnabled) Trace("Cleaning pool.");
+                if (NetEventSource.Log.IsEnabled()) Trace("Cleaning pool.");
                 Monitor.Enter(SyncObj, ref tookLock);
 
                 // Get the current time.  This is compared against each connection's last returned
@@ -1592,7 +1592,7 @@ namespace System.Net.Http
                 if ((pooledConnectionIdleTimeout != Timeout.InfiniteTimeSpan) &&
                     ((nowTicks - _returnedTickCount) > pooledConnectionIdleTimeout.TotalMilliseconds))
                 {
-                    if (NetEventSource.IsEnabled) _connection.Trace($"Connection no longer usable. Idle {TimeSpan.FromMilliseconds((nowTicks - _returnedTickCount))} > {pooledConnectionIdleTimeout}.");
+                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Connection no longer usable. Idle {TimeSpan.FromMilliseconds((nowTicks - _returnedTickCount))} > {pooledConnectionIdleTimeout}.");
                     return false;
                 }
 
@@ -1605,7 +1605,7 @@ namespace System.Net.Http
                 // Validate that the connection hasn't received any stray data while in the pool.
                 if (poll && _connection.PollRead())
                 {
-                    if (NetEventSource.IsEnabled) _connection.Trace($"Connection no longer usable. Unexpected data received.");
+                    if (NetEventSource.Log.IsEnabled()) _connection.Trace($"Connection no longer usable. Unexpected data received.");
                     return false;
                 }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -339,7 +339,7 @@ namespace System.Net.Http
 
         public ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
-            return HttpTelemetry.IsEnabled && request.RequestUri != null ?
+            return HttpTelemetry.Log.IsEnabled() && request.RequestUri != null ?
                 SendAsyncWithLogging(request, async, doRequestAuth, cancellationToken) :
                 SendAsyncHelper(request, async, doRequestAuth, cancellationToken);
         }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -408,7 +408,7 @@ namespace System.Net.Http
             {
                 // Eat any exception from the IWebProxy and just treat it as no proxy.
                 // This matches the behavior of other handlers.
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Exception from {_proxy.GetType().Name}.GetProxy({request.RequestUri}): {ex}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Exception from {_proxy.GetType().Name}.GetProxy({request.RequestUri}): {ex}");
             }
 
             if (proxyUri != null && proxyUri.Scheme != UriScheme.Http)
@@ -482,7 +482,7 @@ namespace System.Net.Http
         /// <summary>Removes unusable connections from each pool, and removes stale pools entirely.</summary>
         private void RemoveStalePools()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             Debug.Assert(_cleaningTimer != null);
 
@@ -518,7 +518,7 @@ namespace System.Net.Http
             // future, there are a variety of possible ways to address it, such as allowing connections to
             // be returned to pools they weren't associated with.
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private static string GetIdentityIfDefaultCredentialsUsed(bool defaultCredentialsUsed)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentReadStream.cs
@@ -66,7 +66,7 @@ namespace System.Net.Http
                 {
                     bool drained = await DrainAsync(connection._pool.Settings._maxResponseDrainSize).ConfigureAwait(false);
 
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         connection.Trace(drained ?
                             "Connection drain succeeded" :
@@ -75,7 +75,7 @@ namespace System.Net.Http
                 }
                 catch (Exception e)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         connection.Trace($"Connection drain failed due to exception: {e}");
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpWindowsProxy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpWindowsProxy.cs
@@ -43,7 +43,7 @@ namespace System.Net.Http
 
             if (proxyHelper.AutoSettingsUsed)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(proxyHelper, $"AutoSettingsUsed, calling {nameof(Interop.WinHttp.WinHttpOpen)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(proxyHelper, $"AutoSettingsUsed, calling {nameof(Interop.WinHttp.WinHttpOpen)}");
                 sessionHandle = Interop.WinHttp.WinHttpOpen(
                     IntPtr.Zero,
                     Interop.WinHttp.WINHTTP_ACCESS_TYPE_NO_PROXY,
@@ -54,7 +54,7 @@ namespace System.Net.Http
                 if (sessionHandle.IsInvalid)
                 {
                     // Proxy failures are currently ignored by managed handler.
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(proxyHelper, $"{nameof(Interop.WinHttp.WinHttpOpen)} returned invalid handle");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(proxyHelper, $"{nameof(Interop.WinHttp.WinHttpOpen)} returned invalid handle");
                     return false;
                 }
             }
@@ -70,7 +70,7 @@ namespace System.Net.Http
 
             if (proxyHelper.ManualSettingsUsed)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(proxyHelper, $"ManualSettingsUsed, {proxyHelper.Proxy}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(proxyHelper, $"ManualSettingsUsed, {proxyHelper.Proxy}");
 
                 _secureProxy = MultiProxy.Parse(_failedProxies, proxyHelper.Proxy, true);
                 _insecureProxy = MultiProxy.Parse(_failedProxies, proxyHelper.Proxy, false);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -33,7 +33,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -81,7 +81,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -143,7 +143,7 @@ namespace System.Net.Http
             private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
-                if (HttpTelemetry.IsEnabled) LogRequestStop();
+                if (HttpTelemetry.Log.IsEnabled()) LogRequestStop();
                 connection.Dispose();
                 _connection = null;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -14,7 +14,7 @@ namespace System.Net.Http
         {
             public RawConnectionStream(HttpConnection connection) : base(connection)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             }
 
             public sealed override bool CanRead => true;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RedirectHandler.cs
@@ -27,7 +27,7 @@ namespace System.Net.Http
 
         internal override async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, request, cancellationToken);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, request, cancellationToken);
 
             HttpResponseMessage response = await _initialInnerHandler.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
 
@@ -42,7 +42,7 @@ namespace System.Net.Http
                 {
                     // If we exceed the maximum number of redirects
                     // then just return the 3xx response.
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         TraceError($"Exceeded max number of redirects. Redirect from {request.RequestUri} to {redirectUri} blocked.", request.GetHashCode());
                     }
@@ -55,7 +55,7 @@ namespace System.Net.Http
                 // Clear the authorization header.
                 request.Headers.Authorization = null;
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     Trace($"Redirecting from {request.RequestUri} to {redirectUri} in response to status code {(int)response.StatusCode} '{response.StatusCode}'.", request.GetHashCode());
                 }
@@ -64,7 +64,7 @@ namespace System.Net.Http
                 request.RequestUri = redirectUri;
                 if (RequestRequiresForceGet(response.StatusCode, request.Method))
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         Trace($"Modified request from {request.Method} to {HttpMethod.Get} in response to status code {(int)response.StatusCode} '{response.StatusCode}'.", request.GetHashCode());
                     }
@@ -81,7 +81,7 @@ namespace System.Net.Http
                 response = await _redirectInnerHandler.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return response;
         }
@@ -129,7 +129,7 @@ namespace System.Net.Http
             // Disallow automatic redirection from secure to non-secure schemes
             if (HttpUtilities.IsSupportedSecureScheme(requestUri.Scheme) && !HttpUtilities.IsSupportedSecureScheme(location.Scheme))
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     TraceError($"Insecure https to http redirect from '{requestUri}' to '{location}' blocked.", response.RequestMessage!.GetHashCode());
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http
             {
                 _start = content.Position;
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, content);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, content);
         }
 
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -102,7 +102,7 @@ namespace System.Net.Http
             catch (Exception e)
             {
                 // Dispose() should never throw, but since we're on an async codepath, make sure to catch the exception.
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, e);
             }
         }
     }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
@@ -29,7 +29,7 @@ namespace System.Net
 
         public HttpListener()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             _state = State.Stopped;
             _internalLock = new object();
@@ -42,7 +42,7 @@ namespace System.Net
             // config element
             _extendedProtectionPolicy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public AuthenticationSchemeSelector AuthenticationSchemeSelectorDelegate
@@ -105,16 +105,16 @@ namespace System.Net
         {
             get
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
                 CheckDisposed();
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
                 return _prefixes;
             }
         }
 
         internal void AddPrefix(string uriPrefix)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"uriPrefix:{uriPrefix}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"uriPrefix:{uriPrefix}");
             string registeredPrefix = null;
             try
             {
@@ -179,7 +179,7 @@ namespace System.Net
                     registeredPrefixBuilder[i] = (char)CaseInsensitiveAscii.AsciiToLower[(byte)registeredPrefixBuilder[i]];
                 }
                 registeredPrefix = registeredPrefixBuilder.ToString();
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"mapped uriPrefix: {uriPrefix} to registeredPrefix: {registeredPrefix}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"mapped uriPrefix: {uriPrefix} to registeredPrefix: {registeredPrefix}");
                 if (_state == State.Started)
                 {
                     AddPrefixCore(registeredPrefix);
@@ -189,12 +189,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, $"prefix: {registeredPrefix}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, $"prefix: {registeredPrefix}");
             }
         }
 
@@ -202,11 +202,11 @@ namespace System.Net
 
         internal bool RemovePrefix(string uriPrefix)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"uriPrefix: {uriPrefix}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"uriPrefix: {uriPrefix}");
             try
             {
                 CheckDisposed();
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"uriPrefix: {uriPrefix}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"uriPrefix: {uriPrefix}");
                 if (uriPrefix == null)
                 {
                     throw new ArgumentNullException(nameof(uriPrefix));
@@ -227,19 +227,19 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, $"uriPrefix: {uriPrefix}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, $"uriPrefix: {uriPrefix}");
             }
             return true;
         }
 
         internal void RemoveAll(bool clear)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 CheckDisposed();
@@ -263,7 +263,7 @@ namespace System.Net
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -299,20 +299,20 @@ namespace System.Net
 
         public void Close()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, nameof(Close));
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, nameof(Close));
             try
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info("HttpListenerRequest::Close()");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info("HttpListenerRequest::Close()");
                 ((IDisposable)this).Dispose();
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Close {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Close {exception}");
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerException.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerException.cs
@@ -13,23 +13,23 @@ namespace System.Net
     {
         public HttpListenerException() : base(Marshal.GetLastWin32Error())
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
         }
 
         public HttpListenerException(int errorCode) : base(errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
         }
 
         public HttpListenerException(int errorCode, string message) : base(errorCode, message)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
         }
 
         protected HttpListenerException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(serializationInfo, streamingContext)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, NativeErrorCode.ToString() + ":" + Message);
         }
 
         // the base class returns the HResult with this property

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -27,7 +27,7 @@ namespace System.Net
 
         private CookieCollection ParseCookies(Uri uri, string setCookieHeader)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "uri:" + uri + " setCookieHeader:" + setCookieHeader);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "uri:" + uri + " setCookieHeader:" + setCookieHeader);
             CookieCollection cookies = new CookieCollection();
             CookieParser parser = new CookieParser(setCookieHeader);
             while (true)
@@ -38,7 +38,7 @@ namespace System.Net
                     // EOF, done.
                     break;
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "CookieParser returned cookie: " + cookie.ToString());
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "CookieParser returned cookie: " + cookie.ToString());
                 if (cookie.Name.Length == 0)
                 {
                     continue;
@@ -185,7 +185,7 @@ namespace System.Net
                     }
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "_keepAlive=" + _keepAlive);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "_keepAlive=" + _keepAlive);
                 return _keepAlive.Value;
             }
         }
@@ -231,7 +231,7 @@ namespace System.Net
 
         public X509Certificate2 GetClientCertificate()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 if (ClientCertState == ListenerClientCertState.InProgress)
@@ -241,18 +241,18 @@ namespace System.Net
                 GetClientCertificateCore();
 
                 ClientCertState = ListenerClientCertState.Completed;
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_clientCertificate:{ClientCertificate}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_clientCertificate:{ClientCertificate}");
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
             return ClientCertificate;
         }
 
         public IAsyncResult BeginGetClientCertificate(AsyncCallback requestCallback, object state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             if (ClientCertState == ListenerClientCertState.InProgress)
                 throw new InvalidOperationException(SR.Format(SR.net_listener_callinprogress, $"{nameof(GetClientCertificate)}()/{nameof(BeginGetClientCertificate)}()"));
             ClientCertState = ListenerClientCertState.InProgress;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequestUriBuilder.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequestUriBuilder.cs
@@ -87,7 +87,7 @@ namespace System.Net
             // Creating a Uri from the cooked Uri should really always work: If not, we log at least.
             if (!isValid)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_create_uri, _cookedUriScheme, _cookedUriHost, _cookedUriPath, _cookedUriQuery));
             }
         }
@@ -112,7 +112,7 @@ namespace System.Net
             // Log that we weren't able to create a Uri from the raw string.
             if (!isValid)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_create_uri, _cookedUriScheme, _cookedUriHost, _rawPath, _cookedUriQuery));
             }
         }
@@ -161,7 +161,7 @@ namespace System.Net
 
             if (result != ParsingResult.Success)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_raw_path, _rawPath, encoding.EncodingName));
             }
 
@@ -242,7 +242,7 @@ namespace System.Net
             int codePointValue;
             if (!int.TryParse(codePoint, NumberStyles.HexNumber, null, out codePointValue))
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_percent_value, codePoint));
                 return false;
             }
@@ -257,13 +257,13 @@ namespace System.Net
             }
             catch (ArgumentOutOfRangeException)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_percent_value, codePoint));
             }
             catch (EncoderFallbackException e)
             {
                 // If utf8Encoding.GetBytes() fails
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_to_utf8, unicodeString, e.Message));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_to_utf8, unicodeString, e.Message));
             }
 
             return false;
@@ -274,7 +274,7 @@ namespace System.Net
             byte encodedValue;
             if (!byte.TryParse(escapedCharacter, NumberStyles.HexNumber, null, out encodedValue))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_percent_value, escapedCharacter));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_percent_value, escapedCharacter));
                 return false;
             }
 
@@ -312,12 +312,12 @@ namespace System.Net
             }
             catch (DecoderFallbackException e)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_bytes, GetOctetsAsString(_rawOctets), e.Message));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_bytes, GetOctetsAsString(_rawOctets), e.Message));
             }
             catch (EncoderFallbackException e)
             {
                 // If utf8Encoding.GetBytes() fails
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_to_utf8, decodedString, e.Message));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_cant_convert_to_utf8, decodedString, e.Message));
             }
 
             return false;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerResponse.cs
@@ -197,13 +197,13 @@ namespace System.Net
 
         public void AddHeader(string name, string value)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"name={name}, value={value}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"name={name}, value={value}");
             Headers.Set(name, value);
         }
 
         public void AppendHeader(string name, string value)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"name={name}, value={value}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"name={name}, value={value}");
             Headers.Add(name, value);
         }
 
@@ -213,13 +213,13 @@ namespace System.Net
             {
                 throw new ArgumentNullException(nameof(cookie));
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"cookie: {cookie}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"cookie: {cookie}");
             Cookies.Add(cookie);
         }
 
         private void ComputeCookies()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Entering Set-Cookie: {Headers[HttpResponseHeader.SetCookie]}, Set-Cookie2: {Headers[HttpKnownHeaderNames.SetCookie2]}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Entering Set-Cookie: {Headers[HttpResponseHeader.SetCookie]}, Set-Cookie2: {Headers[HttpKnownHeaderNames.SetCookie2]}");
 
             if (_cookies != null)
             {
@@ -233,7 +233,7 @@ namespace System.Net
                     {
                         continue;
                     }
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Now looking at index:{index} cookie: {cookie}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Now looking at index:{index} cookie: {cookie}");
                     if (cookie.IsRfc2965Variant())
                     {
                         setCookie2 = setCookie2 == null ? cookieString : setCookie2 + ", " + cookieString;
@@ -263,12 +263,12 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Exiting Set-Cookie: {Headers[HttpResponseHeader.SetCookie]} Set-Cookie2: {Headers[HttpKnownHeaderNames.SetCookie2]}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Exiting Set-Cookie: {Headers[HttpResponseHeader.SetCookie]} Set-Cookie2: {Headers[HttpKnownHeaderNames.SetCookie2]}");
         }
 
         public void Redirect(string url)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"url={url}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"url={url}");
             Headers[HttpResponseHeader.Location] = url;
             StatusCode = (int)HttpStatusCode.Redirect;
             StatusDescription = HttpStatusDescription.Get(StatusCode);
@@ -284,7 +284,7 @@ namespace System.Net
             Cookie newCookie = cookie.Clone();
             int added = Cookies.InternalAdd(newCookie, true);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"cookie: {cookie}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"cookie: {cookie}");
 
             if (added != 1)
             {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpRequestStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpRequestStream.cs
@@ -15,7 +15,7 @@ namespace System.Net
 
         public override int Read(byte[] buffer, int offset, int size)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
@@ -34,7 +34,7 @@ namespace System.Net
             }
             if (size == 0 || _closed)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Exit(this, "dataRead:0");
                 return 0;
             }
@@ -44,7 +44,7 @@ namespace System.Net
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
@@ -93,7 +93,7 @@ namespace System.Net
 
         protected override void Dispose(bool disposing)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, "_closed:" + _closed);
@@ -102,7 +102,7 @@ namespace System.Net
             _closed = true;
             base.Dispose(disposing);
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this);
         }
     }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpResponseStream.cs
@@ -42,7 +42,7 @@ namespace System.Net
 
         public override void Write(byte[] buffer, int offset, int size)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
@@ -61,7 +61,7 @@ namespace System.Net
             }
             if (_closed)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 return;
             }
 
@@ -70,7 +70,7 @@ namespace System.Net
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "buffer.Length:" + buffer?.Length + " size:" + size + " offset:" + offset);
             if (buffer == null)
             {
                 throw new ArgumentNullException(nameof(buffer));
@@ -89,7 +89,7 @@ namespace System.Net
 
         public override void EndWrite(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"asyncResult:{asyncResult}");
@@ -104,15 +104,15 @@ namespace System.Net
 
         protected override void Dispose(bool disposing)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 if (disposing)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "_closed:" + _closed);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "_closed:" + _closed);
                     if (_closed)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                         return;
                     }
                     _closed = true;
@@ -123,7 +123,7 @@ namespace System.Net
             {
                 base.Dispose(disposing);
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
     }
 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/HttpListener.Managed.cs
@@ -33,7 +33,7 @@ namespace System.Net
 
         public void Start()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             lock (_internalLock)
             {
                 try
@@ -49,12 +49,12 @@ namespace System.Net
                 catch (Exception exception)
                 {
                     _state = State.Closed;
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Start {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Start {exception}");
                     throw;
                 }
                 finally
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }
@@ -72,7 +72,7 @@ namespace System.Net
 
         public void Stop()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             lock (_internalLock)
             {
@@ -88,20 +88,20 @@ namespace System.Net
                 }
                 catch (Exception exception)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Stop {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Stop {exception}");
                     throw;
                 }
                 finally
                 {
                     _state = State.Stopped;
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }
 
         public void Abort()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             lock (_internalLock)
             {
@@ -120,20 +120,20 @@ namespace System.Net
                 }
                 catch (Exception exception)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Abort {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Abort {exception}");
                     throw;
                 }
                 finally
                 {
                     _state = State.Closed;
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }
 
         private void Dispose()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             lock (_internalLock)
             {
@@ -148,13 +148,13 @@ namespace System.Net
                 }
                 catch (Exception exception)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Dispose {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Dispose {exception}");
                     throw;
                 }
                 finally
                 {
                     _state = State.Closed;
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/ServiceNameStore.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/ServiceNameStore.cs
@@ -157,7 +157,7 @@ namespace System.Net
                 {
                     addedAny = true;
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, SR.Format(SR.net_log_listener_spn_add, spn, uriPrefix));
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.Format(SR.net_log_listener_spn_add, spn, uriPrefix));
                 }
             }
 
@@ -165,7 +165,7 @@ namespace System.Net
             {
                 _serviceNameCollection = null;
             }
-            else if (NetEventSource.IsEnabled)
+            else if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, SR.Format(SR.net_log_listener_spn_not_add, uriPrefix));
             }
@@ -187,7 +187,7 @@ namespace System.Net
                 _serviceNameCollection = null; //invalidate (readonly) ServiceNameCollection
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 if (needToRemove)
                 {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -110,7 +110,7 @@ namespace System.Net
             if (statusCode != Interop.HttpApi.ERROR_SUCCESS)
             {
                 HttpListenerException exception = new HttpListenerException((int)statusCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"HttpSetUrlGroupProperty:: Property: {property} {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"HttpSetUrlGroupProperty:: Property: {property} {exception}");
                 throw exception;
             }
         }
@@ -213,14 +213,14 @@ namespace System.Net
                 //
                 _serverSessionHandle?.Dispose();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"SetupV2Config {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"SetupV2Config {exception}");
                 throw;
             }
         }
 
         public void Start()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // Make sure there are no race conditions between Start/Stop/Abort/Close/Dispose and
             // calls to SetupV2Config: Start needs to setup all resources (esp. in V2 where besides
@@ -266,12 +266,12 @@ namespace System.Net
                     _state = State.Closed;
                     CloseRequestQueueHandle();
                     CleanupV2Config();
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Start {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Start {exception}");
                     throw;
                 }
                 finally
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }
@@ -300,7 +300,7 @@ namespace System.Net
 
             if (statusCode != Interop.HttpApi.ERROR_SUCCESS)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"CloseV2Config {SR.Format(SR.net_listener_close_urlgroup_error, statusCode)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"CloseV2Config {SR.Format(SR.net_listener_close_urlgroup_error, statusCode)}");
             }
             _urlGroupId = 0;
 
@@ -349,13 +349,13 @@ namespace System.Net
 
             if (statusCode != Interop.HttpApi.ERROR_SUCCESS)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"DetachRequestQueueFromUrlGroup {SR.Format(SR.net_listener_detach_error, statusCode)}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"DetachRequestQueueFromUrlGroup {SR.Format(SR.net_listener_detach_error, statusCode)}");
             }
         }
 
         public void Stop()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 lock (_internalLock)
@@ -380,12 +380,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Stop {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Stop {exception}");
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -407,7 +407,7 @@ namespace System.Net
 
         public void Abort()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             lock (_internalLock)
             {
@@ -429,20 +429,20 @@ namespace System.Net
                 }
                 catch (Exception exception)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Abort {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Abort {exception}");
                     throw;
                 }
                 finally
                 {
                     _state = State.Closed;
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }
 
         private void Dispose()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             lock (_internalLock)
             {
@@ -458,13 +458,13 @@ namespace System.Net
                 }
                 catch (Exception exception)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"Dispose {exception}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"Dispose {exception}");
                     throw;
                 }
                 finally
                 {
                     _state = State.Closed;
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 }
             }
         }
@@ -488,7 +488,7 @@ namespace System.Net
 
         private void AddPrefixCore(string registeredPrefix)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpAddUrl[ToUrlGroup]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpAddUrl[ToUrlGroup]");
 
             uint statusCode = Interop.HttpApi.HttpAddUrlToUrlGroup(
                                   _urlGroupId,
@@ -506,7 +506,7 @@ namespace System.Net
 
         public HttpListenerContext GetContext()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             SyncRequestContext memoryBlob = null;
             HttpListenerContext httpContext = null;
@@ -533,7 +533,7 @@ namespace System.Net
                 {
                     while (true)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Calling Interop.HttpApi.HttpReceiveHttpRequest RequestId: {requestId}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Calling Interop.HttpApi.HttpReceiveHttpRequest RequestId: {requestId}");
                         uint bytesTransferred = 0;
                         statusCode =
                             Interop.HttpApi.HttpReceiveHttpRequest(
@@ -545,7 +545,7 @@ namespace System.Net
                                 &bytesTransferred,
                                 null);
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveHttpRequest returned:" + statusCode);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveHttpRequest returned:" + statusCode);
 
                         if (statusCode == Interop.HttpApi.ERROR_INVALID_PARAMETER && requestId != 0)
                         {
@@ -584,7 +584,7 @@ namespace System.Net
                         memoryBlob = null;
                         stoleBlob = false;
                     }
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, ":HandleAuthentication() returned httpContext" + httpContext);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, ":HandleAuthentication() returned httpContext" + httpContext);
                     // if the request survived authentication, return it to the user
                     if (httpContext != null)
                     {
@@ -602,7 +602,7 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"{exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"{exception}");
                 throw;
             }
             finally
@@ -612,7 +612,7 @@ namespace System.Net
                     memoryBlob.ReleasePins();
                     memoryBlob.Close();
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "RequestTraceIdentifier: " + (httpContext != null ? httpContext.Request.RequestTraceIdentifier.ToString() : "<null>"));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, "RequestTraceIdentifier: " + (httpContext != null ? httpContext.Request.RequestTraceIdentifier.ToString() : "<null>"));
             }
         }
 
@@ -629,7 +629,7 @@ namespace System.Net
 
         public IAsyncResult BeginGetContext(AsyncCallback callback, object state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ListenerAsyncResult asyncResult = null;
             try
             {
@@ -653,12 +653,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"BeginGetContext {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"BeginGetContext {exception}");
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
 
             return asyncResult;
@@ -666,7 +666,7 @@ namespace System.Net
 
         public HttpListenerContext EndGetContext(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             HttpListenerContext httpContext = null;
             try
             {
@@ -675,7 +675,7 @@ namespace System.Net
                 {
                     throw new ArgumentNullException(nameof(asyncResult));
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"asyncResult: {asyncResult}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"asyncResult: {asyncResult}");
                 if (!(asyncResult is ListenerAsyncResult castedAsyncResult) || !(castedAsyncResult.AsyncObject is HttpListenerSession session) || session.Listener != this)
                 {
                     throw new ArgumentException(SR.net_io_invalidasyncresult, nameof(asyncResult));
@@ -694,19 +694,19 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"EndGetContext {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"EndGetContext {exception}");
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "EndGetContext " + httpContext == null ? "<no context>" : "HttpListenerContext" + httpContext.ToString() + " RequestTraceIdentifier#" + httpContext.Request.RequestTraceIdentifier);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, "EndGetContext " + httpContext == null ? "<no context>" : "HttpListenerContext" + httpContext.ToString() + " RequestTraceIdentifier#" + httpContext.Request.RequestTraceIdentifier);
             }
             return httpContext;
         }
 
         internal HttpListenerContext HandleAuthentication(HttpListenerSession session, RequestContextBase memoryBlob, out bool stoleBlob)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "HandleAuthentication() memoryBlob:0x" + ((IntPtr)memoryBlob.RequestBlob).ToString("x"));
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "HandleAuthentication() memoryBlob:0x" + ((IntPtr)memoryBlob.RequestBlob).ToString("x"));
 
             string challenge = null;
             stoleBlob = false;
@@ -718,7 +718,7 @@ namespace System.Net
             ulong requestId = memoryBlob.RequestBlob->RequestId;
             bool isSecureConnection = memoryBlob.RequestBlob->pSslInfo != null;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"HandleAuthentication() authorizationHeader: ({authorizationHeader})");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"HandleAuthentication() authorizationHeader: ({authorizationHeader})");
 
             // if the app has turned on AuthPersistence, an anonymous request might
             // be authenticated by virtue of it coming on a connection that was
@@ -734,7 +734,7 @@ namespace System.Net
                     WindowsPrincipal principal = disconnectResult?.AuthenticatedConnection;
                     if (principal != null)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Principal: {principal} principal.Identity.Name: {principal.Identity.Name} creating request");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Principal: {principal} principal.Identity.Name: {principal.Identity.Name} creating request");
                         stoleBlob = true;
                         HttpListenerContext ntlmContext = new HttpListenerContext(session, memoryBlob);
                         ntlmContext.SetIdentity(principal, null);
@@ -745,7 +745,7 @@ namespace System.Net
                 else
                 {
                     // They sent an authorization - destroy their previous credentials.
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Clearing principal cache");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Clearing principal cache");
                     if (disconnectResult != null)
                     {
                         disconnectResult.AuthenticatedConnection = null;
@@ -788,11 +788,11 @@ namespace System.Net
                         authenticationScheme = authenticationSelector(httpContext.Request);
                         // Cache the results of authenticationSelector (if any)
                         httpContext.AuthenticationSchemes = authenticationScheme;
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"AuthenticationScheme: {authenticationScheme}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"AuthenticationScheme: {authenticationScheme}");
                     }
                     catch (Exception exception) when (!ExceptionCheck.IsFatal(exception))
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Error(this, SR.Format(SR.net_log_listener_delegate_exception, exception));
                             NetEventSource.Info(this, $"authenticationScheme: {authenticationScheme}");
@@ -856,7 +856,7 @@ namespace System.Net
                         }
                         else
                         {
-                            if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_log_listener_unsupported_authentication_scheme, authorizationHeader, authenticationScheme));
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_unsupported_authentication_scheme, authorizationHeader, authenticationScheme));
                         }
                     }
                 }
@@ -868,7 +868,7 @@ namespace System.Net
                 // See if we found an acceptable auth header
                 if (headerScheme == AuthenticationSchemes.None)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, SR.Format(SR.net_log_listener_unmatched_authentication_scheme, authenticationScheme.ToString(), (authorizationHeader == null ? "<null>" : authorizationHeader)));
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, SR.Format(SR.net_log_listener_unmatched_authentication_scheme, authenticationScheme.ToString(), (authorizationHeader == null ? "<null>" : authorizationHeader)));
 
                     // If anonymous is allowed, just return the context.  Otherwise go for the 401.
                     if ((authenticationScheme & AuthenticationSchemes.Anonymous) != AuthenticationSchemes.None)
@@ -905,12 +905,12 @@ namespace System.Net
                     IPrincipal principal = null;
                     SecurityStatusPal statusCodeNew;
                     ChannelBinding binding;
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Performing Authentication headerScheme: {headerScheme}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Performing Authentication headerScheme: {headerScheme}");
                     switch (headerScheme)
                     {
                         case AuthenticationSchemes.Negotiate:
                         case AuthenticationSchemes.Ntlm:
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"context: {oldContext} for connectionId: {connectionId}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"context: {oldContext} for connectionId: {connectionId}");
 
                             string package = headerScheme == AuthenticationSchemes.Ntlm ? NegotiationInfoClass.NTLM : NegotiationInfoClass.Negotiate;
                             if (oldContext != null && oldContext.Package == package)
@@ -930,14 +930,14 @@ namespace System.Net
                             }
                             catch (FormatException)
                             {
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"FormatException from FormBase64String");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"FormatException from FormBase64String");
                                 httpError = HttpStatusCode.BadRequest;
                                 error = true;
                             }
                             if (!error)
                             {
                                 decodedOutgoingBlob = context.GetOutgoingBlob(bytes, false, out statusCodeNew);
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetOutgoingBlob returned IsCompleted: {context.IsCompleted} and statusCodeNew: {statusCodeNew}");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetOutgoingBlob returned IsCompleted: {context.IsCompleted} and statusCodeNew: {statusCodeNew}");
                                 error = !context.IsValidContext;
                                 if (error)
                                 {
@@ -979,7 +979,7 @@ namespace System.Net
                                             SafeDeleteContext securityContext = context.GetContext(out statusCodeNew);
                                             if (statusCodeNew.ErrorCode != SecurityStatusPalErrorCode.OK)
                                             {
-                                                if (NetEventSource.IsEnabled)
+                                                if (NetEventSource.Log.IsEnabled())
                                                 {
                                                     NetEventSource.Info(this,
                                                         $"HandleAuthentication GetContextToken failed with statusCodeNew: {statusCodeNew}");
@@ -991,7 +991,7 @@ namespace System.Net
                                             {
                                                 SSPIWrapper.QuerySecurityContextToken(GlobalSSPI.SSPIAuth, securityContext, out userContext);
 
-                                                if (NetEventSource.IsEnabled)
+                                                if (NetEventSource.Log.IsEnabled())
                                                 {
                                                     NetEventSource.Info(this,
                                                         $"HandleAuthentication creating new WindowsIdentity from user context: {userContext.DangerousGetHandle().ToString("x8")}");
@@ -1004,7 +1004,7 @@ namespace System.Net
                                                 // if appropriate, cache this credential on this connection
                                                 if (UnsafeConnectionNtlmAuthentication && context.ProtocolName == NegotiationInfoClass.NTLM)
                                                 {
-                                                    if (NetEventSource.IsEnabled)
+                                                    if (NetEventSource.Log.IsEnabled())
                                                     {
                                                         NetEventSource.Info(this,
                                                             $"HandleAuthentication inserting principal: {principal} for connectionId: {connectionId}");
@@ -1028,7 +1028,7 @@ namespace System.Net
                                                     else
                                                     {
                                                         // Registration failed - UnsafeConnectionNtlmAuthentication ignored.
-                                                        if (NetEventSource.IsEnabled)
+                                                        if (NetEventSource.Log.IsEnabled())
                                                         {
                                                             NetEventSource.Info(this, $"HandleAuthentication RegisterForDisconnectNotification failed.");
                                                         }
@@ -1068,7 +1068,7 @@ namespace System.Net
                                 {
                                     string userName = inBlob.Substring(0, index);
                                     string password = inBlob.Substring(index + 1);
-                                    if (NetEventSource.IsEnabled)
+                                    if (NetEventSource.Log.IsEnabled())
                                     {
                                         NetEventSource.Info(this, $"Basic Identity found, userName: {userName}");
                                     }
@@ -1082,7 +1082,7 @@ namespace System.Net
                             }
                             catch (FormatException)
                             {
-                                if (NetEventSource.IsEnabled)
+                                if (NetEventSource.Log.IsEnabled())
                                 {
                                     NetEventSource.Info(this, $"FromBase64String threw a FormatException.");
                                 }
@@ -1092,7 +1092,7 @@ namespace System.Net
 
                     if (principal != null)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Info(this, $"Got principal: {principal}, IdentityName: {principal.Identity.Name} for creating request.");
                         }
@@ -1101,7 +1101,7 @@ namespace System.Net
                     }
                     else
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Info(this, "Handshake has failed.");
                         }
@@ -1144,7 +1144,7 @@ namespace System.Net
                         // If we're sending something besides 401, do it here.
                         if (httpError != HttpStatusCode.Unauthorized)
                         {
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "ConnectionId:" + connectionId + " because of error:" + httpError.ToString());
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "ConnectionId:" + connectionId + " because of error:" + httpError.ToString());
                             SendError(session, requestId, httpError, null);
                             return null;
                         }
@@ -1181,7 +1181,7 @@ namespace System.Net
                             }
                         }
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "connectionId:" + connectionId + " because of failed HttpWaitForDisconnect");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "connectionId:" + connectionId + " because of failed HttpWaitForDisconnect");
                         SendError(session, requestId, HttpStatusCode.InternalServerError, null);
                         FreeContext(ref httpContext, memoryBlob);
                         return null;
@@ -1211,7 +1211,7 @@ namespace System.Net
                 if (httpContext == null)
                 {
                     SendError(session, requestId, challenges != null && challenges.Count > 0 ? HttpStatusCode.Unauthorized : HttpStatusCode.Forbidden, challenges);
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Scheme:" + authenticationScheme);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Scheme:" + authenticationScheme);
                     return null;
                 }
 
@@ -1321,27 +1321,27 @@ namespace System.Net
         {
             if (policy.PolicyEnforcement == PolicyEnforcement.Never)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, SR.net_log_listener_no_cbt_disabled);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.net_log_listener_no_cbt_disabled);
                 return null;
             }
 
             if (!isSecureConnection)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, SR.net_log_listener_no_cbt_http);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.net_log_listener_no_cbt_http);
                 return null;
             }
 
             if (policy.ProtectionScenario == ProtectionScenario.TrustedProxy)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, SR.net_log_listener_no_cbt_trustedproxy);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.net_log_listener_no_cbt_trustedproxy);
                 return null;
             }
 
             ChannelBinding result = GetChannelBindingFromTls(session, connectionId);
 
-            if (NetEventSource.IsEnabled && result != null)
+            if (NetEventSource.Log.IsEnabled() && result != null)
                 NetEventSource.Info(this, "GetChannelBindingFromTls returned null even though OS supposedly supports Extended Protection");
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, SR.net_log_listener_cbt);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, SR.net_log_listener_cbt);
             return result;
         }
 
@@ -1350,7 +1350,7 @@ namespace System.Net
             // Kerberos does SPN check already in ASC
             if (context.IsKerberos)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, SR.net_log_listener_no_spn_kerberos);
                 }
@@ -1360,7 +1360,7 @@ namespace System.Net
             // Don't check the SPN if Extended Protection is off or we already checked the CBT
             if (policy.PolicyEnforcement == PolicyEnforcement.Never)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, SR.net_log_listener_no_spn_disabled);
                 }
@@ -1369,7 +1369,7 @@ namespace System.Net
 
             if (ScenarioChecksChannelBinding(isSecureConnection, policy.ProtectionScenario))
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, SR.net_log_listener_no_spn_cbt);
                 }
@@ -1383,7 +1383,7 @@ namespace System.Net
             {
                 if (policy.PolicyEnforcement == PolicyEnforcement.WhenSupported)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(this,
                             SR.net_log_listener_no_spn_whensupported);
@@ -1392,7 +1392,7 @@ namespace System.Net
                 }
                 else
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                     {
                         NetEventSource.Info(this,
                             SR.net_log_listener_spn_failed_always);
@@ -1402,7 +1402,7 @@ namespace System.Net
             }
             else if (string.Equals(clientSpn, "http/localhost", StringComparison.OrdinalIgnoreCase))
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, SR.net_log_listener_no_spn_loopback);
                 }
@@ -1411,7 +1411,7 @@ namespace System.Net
             }
             else
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, SR.net_log_listener_spn, clientSpn);
                 }
@@ -1420,7 +1420,7 @@ namespace System.Net
 
                 bool found = serviceNames.Contains(clientSpn);
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     if (found)
                     {
@@ -1432,7 +1432,7 @@ namespace System.Net
 
                         if (serviceNames.Count == 0)
                         {
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                             {
                                 NetEventSource.Info(this, SR.net_log_listener_spn_failed_empty);
                             }
@@ -1550,7 +1550,7 @@ namespace System.Net
                 challenge = challenge.Trim();
                 if (challenge.Length > 0)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(null, "challenge:" + challenge);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "challenge:" + challenge);
                     if (challenges == null)
                     {
                         challenges = new ArrayList(4);
@@ -1563,7 +1563,7 @@ namespace System.Net
         private ArrayList BuildChallenge(AuthenticationSchemes authenticationScheme, ulong connectionId,
             out NTAuthentication newContext, ExtendedProtectionPolicy policy, bool isSecureConnection)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "AuthenticationScheme:" + authenticationScheme.ToString());
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "AuthenticationScheme:" + authenticationScheme.ToString());
             ArrayList challenges = null;
             newContext = null;
 
@@ -1591,7 +1591,7 @@ namespace System.Net
 
             try
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, "Calling Interop.HttpApi.HttpWaitForDisconnect");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, "Calling Interop.HttpApi.HttpWaitForDisconnect");
 
                 DisconnectAsyncResult result = new DisconnectAsyncResult(session, connectionId);
 
@@ -1600,7 +1600,7 @@ namespace System.Net
                     connectionId,
                     result.NativeOverlapped);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, "Call to Interop.HttpApi.HttpWaitForDisconnect returned:" + statusCode);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, "Call to Interop.HttpApi.HttpWaitForDisconnect returned:" + statusCode);
 
                 if (statusCode == Interop.HttpApi.ERROR_SUCCESS ||
                     statusCode == Interop.HttpApi.ERROR_IO_PENDING)
@@ -1620,13 +1620,13 @@ namespace System.Net
             catch (Win32Exception exception)
             {
                 uint statusCode = (uint)exception.NativeErrorCode;
-                if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, "Call to Interop.HttpApi.HttpWaitForDisconnect threw, statusCode:" + statusCode);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, "Call to Interop.HttpApi.HttpWaitForDisconnect threw, statusCode:" + statusCode);
             }
         }
 
         private static void SendError(HttpListenerSession session, ulong requestId, HttpStatusCode httpStatusCode, ArrayList challenges)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, $"RequestId: {requestId}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, $"RequestId: {requestId}");
             Interop.HttpApi.HTTP_RESPONSE httpResponse = default;
             httpResponse.Version = default;
             httpResponse.Version.MajorVersion = (ushort)1;
@@ -1678,7 +1678,7 @@ namespace System.Net
                             }
                         }
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, "Calling Interop.HttpApi.HttpSendHtthttpResponse");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, "Calling Interop.HttpApi.HttpSendHtthttpResponse");
                         statusCode =
                             Interop.HttpApi.HttpSendHttpResponse(
                                 session.RequestQueueHandle,
@@ -1715,11 +1715,11 @@ namespace System.Net
                     }
                 }
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, "Call to Interop.HttpApi.HttpSendHttpResponse returned:" + statusCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, "Call to Interop.HttpApi.HttpSendHttpResponse returned:" + statusCode);
             if (statusCode != Interop.HttpApi.ERROR_SUCCESS)
             {
                 // if we fail to send a 401 something's seriously wrong, abort the request
-                if (NetEventSource.IsEnabled) NetEventSource.Info(session.Listener, "SendUnauthorized returned:" + statusCode);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(session.Listener, "SendUnauthorized returned:" + statusCode);
                 HttpListenerContext.CancelRequest(session.RequestQueueHandle, requestId);
             }
         }
@@ -1741,7 +1741,7 @@ namespace System.Net
 
         internal static ChannelBinding GetChannelBindingFromTls(HttpListenerSession session, ulong connectionId)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(session.Listener, $"connectionId: {connectionId}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(session.Listener, $"connectionId: {connectionId}");
 
             // +128 since a CBT is usually <128 thus we need to call HRCC just once. If the CBT
             // is >128 we will get ERROR_MORE_DATA and call again
@@ -1793,7 +1793,7 @@ namespace System.Net
                     }
                     else if (statusCode == Interop.HttpApi.ERROR_INVALID_PARAMETER)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Error(session.Listener, SR.net_ssp_dont_support_cbt);
                         }
@@ -1861,14 +1861,14 @@ namespace System.Net
 
             internal unsafe DisconnectAsyncResult(HttpListenerSession session, ulong connectionId)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"HttpListener: {session.Listener}, ConnectionId: {connectionId}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"HttpListener: {session.Listener}, ConnectionId: {connectionId}");
                 _ownershipState = 1;
                 _listenerSession = session;
                 _connectionId = connectionId;
 
                 // we can call the Unsafe API here, we won't ever call user code
                 _nativeOverlapped = session.RequestQueueBoundHandle.AllocateNativeOverlapped(s_IOCallback, state: this, pinData: null);
-                if (NetEventSource.IsEnabled) NetEventSource.Info($"DisconnectAsyncResult: ThreadPoolBoundHandle.AllocateNativeOverlapped({session.RequestQueueBoundHandle}) -> {_nativeOverlapped->GetHashCode()}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"DisconnectAsyncResult: ThreadPoolBoundHandle.AllocateNativeOverlapped({session.RequestQueueBoundHandle}) -> {_nativeOverlapped->GetHashCode()}");
             }
 
             internal bool StartOwningDisconnectHandling()
@@ -1902,7 +1902,7 @@ namespace System.Net
 
             private static unsafe void IOCompleted(DisconnectAsyncResult asyncResult, uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, "_connectionId:" + asyncResult._connectionId);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "_connectionId:" + asyncResult._connectionId);
 
                 asyncResult._listenerSession.RequestQueueBoundHandle.FreeNativeOverlapped(nativeOverlapped);
                 if (Interlocked.Exchange(ref asyncResult._ownershipState, 2) == 0)
@@ -1913,7 +1913,7 @@ namespace System.Net
 
             private static unsafe void WaitCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"errorCode: {errorCode}, numBytes: {numBytes}, nativeOverlapped: {((IntPtr)nativeOverlapped).ToString("x")}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode: {errorCode}, numBytes: {numBytes}, nativeOverlapped: {((IntPtr)nativeOverlapped).ToString("x")}");
                 // take the DisconnectAsyncResult object from the state
                 DisconnectAsyncResult asyncResult = (DisconnectAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped);
                 IOCompleted(asyncResult, errorCode, numBytes, nativeOverlapped);
@@ -1923,7 +1923,7 @@ namespace System.Net
             {
                 HttpListener listener = _listenerSession.Listener;
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"DisconnectResults {listener.DisconnectResults} removing for _connectionId: {_connectionId}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"DisconnectResults {listener.DisconnectResults} removing for _connectionId: {_connectionId}");
                 listener.DisconnectResults.Remove(_connectionId);
                 if (_session != null)
                 {

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerContext.Windows.cs
@@ -18,13 +18,13 @@ namespace System.Net
 
         internal HttpListenerContext(HttpListenerSession session, RequestContextBase memoryBlob)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"httpListener {session.Listener} requestBlob={((IntPtr)memoryBlob.RequestBlob)}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"httpListener {session.Listener} requestBlob={((IntPtr)memoryBlob.RequestBlob)}");
             _listener = session.Listener;
             ListenerSession = session;
             Request = new HttpListenerRequest(this, memoryBlob);
             AuthenticationSchemes = _listener.AuthenticationSchemes;
             ExtendedProtectionPolicy = _listener.ExtendedProtectionPolicy;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"HttpListener: {_listener} HttpListenerRequest: {Request}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"HttpListener: {_listener} HttpListenerRequest: {Request}");
         }
 
         // Call this right after construction, and only once!  Not after it's been handed to a user.
@@ -32,7 +32,7 @@ namespace System.Net
         {
             _mutualAuthentication = mutualAuthentication;
             _user = principal;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"mutual: {(mutualAuthentication == null ? "<null>" : mutualAuthentication)}, Principal: {principal}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"mutual: {(mutualAuthentication == null ? "<null>" : mutualAuthentication)}, Principal: {principal}");
         }
 
         // This can be used to cache the results of HttpListener.ExtendedProtectionSelectorDelegate.
@@ -76,7 +76,7 @@ namespace System.Net
 
         internal void Close()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             try
             {
@@ -101,12 +101,12 @@ namespace System.Net
                     }
                 }
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal void Abort()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ForceCancelRequest(RequestQueueHandle, Request.RequestId);
             try
             {
@@ -116,12 +116,12 @@ namespace System.Net
             {
                 (_user?.Identity as IDisposable)?.Dispose();
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         internal Interop.HttpApi.HTTP_VERB GetKnownMethod()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Visited {nameof(GetKnownMethod)}()");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Visited {nameof(GetKnownMethod)}()");
             return Interop.HttpApi.GetKnownVerb(Request.RequestBuffer, Request.OriginalBlobAddress);
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerRequest.Windows.cs
@@ -47,7 +47,7 @@ namespace System.Net
 
         internal HttpListenerRequest(HttpListenerContext httpContext, RequestContextBase memoryBlob)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"httpContext:${httpContext} memoryBlob {((IntPtr)memoryBlob.RequestBlob)}");
                 NetEventSource.Associate(this, httpContext);
@@ -81,13 +81,13 @@ namespace System.Net
                 _cookedUrlQuery = Marshal.PtrToStringUni((IntPtr)cookedUrl.pQueryString, cookedUrl.QueryStringLength / 2);
             }
             _version = new Version(memoryBlob.RequestBlob->Version.MajorVersion, memoryBlob.RequestBlob->Version.MinorVersion);
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"RequestId:{RequestId} ConnectionId:{_connectionId} RawConnectionId:{memoryBlob.RequestBlob->RawConnectionId} UrlContext:{memoryBlob.RequestBlob->UrlContext} RawUrl:{_rawUrl} Version:{_version} Secure:{_sslStatus}");
                 NetEventSource.Info(this, $"httpContext:${httpContext} RequestUri:{RequestUri} Content-Length:{ContentLength64} HTTP Method:{HttpMethod}");
             }
             // Log headers
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 StringBuilder sb = new StringBuilder("HttpListenerRequest Headers:\n");
                 for (int i = 0; i < Headers.Count; i++)
@@ -181,7 +181,7 @@ namespace System.Net
                         }
                     }
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_contentLength:{_contentLength} _boundaryType:{_boundaryType}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_contentLength:{_contentLength} _boundaryType:{_boundaryType}");
                 return _contentLength;
             }
         }
@@ -194,7 +194,7 @@ namespace System.Net
                 {
                     _webHeaders = Interop.HttpApi.GetHeaders(RequestBuffer, OriginalBlobAddress);
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"webHeaders:{_webHeaders}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"webHeaders:{_webHeaders}");
                 return _webHeaders;
             }
         }
@@ -207,7 +207,7 @@ namespace System.Net
                 {
                     _httpMethod = Interop.HttpApi.GetVerb(RequestBuffer, OriginalBlobAddress);
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_httpMethod:{_httpMethod}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_httpMethod:{_httpMethod}");
                 return _httpMethod;
             }
         }
@@ -216,12 +216,12 @@ namespace System.Net
         {
             get
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
                 if (_requestStream == null)
                 {
                     _requestStream = HasEntityBody ? new HttpRequestStream(HttpListenerContext) : Stream.Null;
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 return _requestStream;
             }
         }
@@ -245,7 +245,7 @@ namespace System.Net
 
         private int GetClientCertificateErrorCore()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ClientCertificateError:{_clientCertificateError}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ClientCertificateError:{_clientCertificateError}");
             return _clientCertificateError;
         }
 
@@ -256,7 +256,7 @@ namespace System.Net
 
         public X509Certificate2 EndGetClientCertificate(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             X509Certificate2 clientCertificate = null;
             try
             {
@@ -275,11 +275,11 @@ namespace System.Net
                 }
                 clientCertAsyncResult.EndCalled = true;
                 clientCertificate = clientCertAsyncResult.InternalWaitForCompletion() as X509Certificate2;
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_clientCertificate:{ClientCertificate}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_clientCertificate:{ClientCertificate}");
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
             return clientCertificate;
         }
@@ -304,7 +304,7 @@ namespace System.Net
                 {
                     _remoteEndPoint = Interop.HttpApi.GetRemoteEndPoint(RequestBuffer, OriginalBlobAddress);
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "_remoteEndPoint" + _remoteEndPoint);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "_remoteEndPoint" + _remoteEndPoint);
                 return _remoteEndPoint;
             }
         }
@@ -317,7 +317,7 @@ namespace System.Net
                 {
                     _localEndPoint = Interop.HttpApi.GetLocalEndPoint(RequestBuffer, OriginalBlobAddress);
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_localEndPoint={_localEndPoint}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_localEndPoint={_localEndPoint}");
                 return _localEndPoint;
             }
         }
@@ -325,7 +325,7 @@ namespace System.Net
         //should only be called from httplistenercontext
         internal void Close()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             RequestContextBase memoryBlob = _memoryBlob;
             if (memoryBlob != null)
             {
@@ -333,7 +333,7 @@ namespace System.Net
                 _memoryBlob = null;
             }
             _isDisposed = true;
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private ListenerClientCertAsyncResult BeginGetClientCertificateCore(AsyncCallback requestCallback, object state)
@@ -380,7 +380,7 @@ namespace System.Net
                 {
                     while (true)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveClientCertificate size:" + size);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveClientCertificate size:" + size);
                         uint bytesReceived = 0;
 
                         uint statusCode =
@@ -393,7 +393,7 @@ namespace System.Net
                                 &bytesReceived,
                                 asyncResult.NativeOverlapped);
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveClientCertificate returned:" + statusCode + " bytesReceived:" + bytesReceived);
                         if (statusCode == Interop.HttpApi.ERROR_MORE_DATA)
                         {
@@ -435,7 +435,7 @@ namespace System.Net
 
         private void GetClientCertificateCore()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             //--------------------------------------------------------------------
             //When you configure the HTTP.SYS with a flag value 2
             //which means require client certificates, when the client makes the
@@ -479,7 +479,7 @@ namespace System.Net
                     {
                         Interop.HttpApi.HTTP_SSL_CLIENT_CERT_INFO* pClientCertInfo = (Interop.HttpApi.HTTP_SSL_CLIENT_CERT_INFO*)pClientCertInfoBlob;
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveClientCertificate size:" + size);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveClientCertificate size:" + size);
                         uint bytesReceived = 0;
 
                         uint statusCode =
@@ -492,7 +492,7 @@ namespace System.Net
                                 &bytesReceived,
                                 null);
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveClientCertificate returned:" + statusCode + " bytesReceived:" + bytesReceived);
                         if (statusCode == Interop.HttpApi.ERROR_MORE_DATA)
                         {
@@ -503,7 +503,7 @@ namespace System.Net
                         {
                             if (pClientCertInfo != null)
                             {
-                                if (NetEventSource.IsEnabled)
+                                if (NetEventSource.Log.IsEnabled())
                                     NetEventSource.Info(this, $"pClientCertInfo:{(IntPtr)pClientCertInfo} pClientCertInfo->CertFlags: {pClientCertInfo->CertFlags} pClientCertInfo->CertEncodedSize: {pClientCertInfo->CertEncodedSize} pClientCertInfo->pCertEncoded: {(IntPtr)pClientCertInfo->pCertEncoded} pClientCertInfo->Token: {(IntPtr)pClientCertInfo->Token} pClientCertInfo->CertDeniedByMapper: {pClientCertInfo->CertDeniedByMapper}");
 
                                 if (pClientCertInfo->pCertEncoded != null)
@@ -516,11 +516,11 @@ namespace System.Net
                                     }
                                     catch (CryptographicException exception)
                                     {
-                                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"CryptographicException={exception}");
+                                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"CryptographicException={exception}");
                                     }
                                     catch (SecurityException exception)
                                     {
-                                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SecurityException={exception}");
+                                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SecurityException={exception}");
                                     }
                                 }
                                 _clientCertificateError = (int)pClientCertInfo->CertFlags;
@@ -547,7 +547,7 @@ namespace System.Net
                         _rawUrl, RequestScheme, _cookedUrlHost, _cookedUrlPath, _cookedUrlQuery);
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_requestUri:{_requestUri}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_requestUri:{_requestUri}");
                 return _requestUri;
             }
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerResponse.Windows.cs
@@ -30,7 +30,7 @@ namespace System.Net
 
         internal HttpListenerResponse()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             _nativeResponse = default;
             _nativeResponse.StatusCode = (ushort)HttpStatusCode.OK;
             _nativeResponse.Version.MajorVersion = 1;
@@ -40,7 +40,7 @@ namespace System.Net
 
         internal HttpListenerResponse(HttpListenerContext httpContext) : this()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, httpContext);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, httpContext);
             _httpContext = httpContext;
         }
 
@@ -62,7 +62,7 @@ namespace System.Net
 
         public void CopyFrom(HttpListenerResponse templateResponse)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"templateResponse {templateResponse}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"templateResponse {templateResponse}");
             _nativeResponse = default;
             _responseState = ResponseState.Created;
             _webHeaders = templateResponse._webHeaders;
@@ -97,7 +97,7 @@ namespace System.Net
 
         public void Abort()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 if (Disposed)
@@ -110,27 +110,27 @@ namespace System.Net
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
         public void Close()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
                 ((IDisposable)this).Dispose();
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
         public void Close(byte[] responseEntity, bool willBlock)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"responseEntity={responseEntity},willBlock={willBlock}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"responseEntity={responseEntity},willBlock={willBlock}");
             try
             {
                 CheckDisposed();
@@ -138,7 +138,7 @@ namespace System.Net
                 {
                     throw new ArgumentNullException(nameof(responseEntity));
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ResponseState:{_responseState}, BoundaryType:{_boundaryType}, ContentLength:{_contentLength}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ResponseState:{_responseState}, BoundaryType:{_boundaryType}, ContentLength:{_contentLength}");
                 if (!SentHeaders && _boundaryType != BoundaryType.Chunked)
                 {
                     ContentLength64 = responseEntity.Length;
@@ -167,7 +167,7 @@ namespace System.Net
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -239,7 +239,7 @@ namespace System.Net
             Interop.HttpApi.HTTP_FLAGS flags,
             bool isWebSocketHandshake)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"pDataChunk: { ((IntPtr)pDataChunk)}, asyncResult: {asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"pDataChunk: { ((IntPtr)pDataChunk)}, asyncResult: {asyncResult}");
             Debug.Assert(!SentHeaders, "SentHeaders is true.");
 
             if (StatusCode == (int)HttpStatusCode.Unauthorized)
@@ -252,7 +252,7 @@ namespace System.Net
             }
 
             // Log headers
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 StringBuilder sb = new StringBuilder("HttpListenerResponse Headers:\n");
                 for (int i = 0; i < Headers.Count; i++)
@@ -263,7 +263,7 @@ namespace System.Net
                     sb.Append(Headers.Get(i));
                     sb.Append('\n');
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, sb.ToString());
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, sb.ToString());
             }
             _responseState = ResponseState.SentHeaders;
 
@@ -287,7 +287,7 @@ namespace System.Net
                     _nativeResponse.EntityChunkCount = 0;
                     _nativeResponse.pEntityChunks = null;
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendHttpResponse flags:" + flags);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendHttpResponse flags:" + flags);
                 if (StatusDescription.Length > 0)
                 {
                     byte[] statusDescriptionBytes = new byte[WebHeaderEncoding.GetByteCount(StatusDescription)];
@@ -347,7 +347,7 @@ namespace System.Net
                         }
                     }
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendHttpResponse returned:" + statusCode);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendHttpResponse returned:" + statusCode);
             }
             finally
             {
@@ -359,13 +359,13 @@ namespace System.Net
         internal Interop.HttpApi.HTTP_FLAGS ComputeHeaders()
         {
             Interop.HttpApi.HTTP_FLAGS flags = Interop.HttpApi.HTTP_FLAGS.NONE;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             Debug.Assert(!ComputedHeaders, "ComputedHeaders is true.");
             _responseState = ResponseState.ComputedHeaders;
 
             ComputeCoreHeaders();
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Info(this,
 $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength} _keepAlive: {_keepAlive}");
             if (_boundaryType == BoundaryType.None)
@@ -388,7 +388,7 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"flags:{flags} _BoundaryType:{_boundaryType} _contentLength:{_contentLength} _keepAlive: {_keepAlive}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"flags:{flags} _BoundaryType:{_boundaryType} _contentLength:{_contentLength} _keepAlive: {_keepAlive}");
             if (_boundaryType == BoundaryType.ContentLength)
             {
                 Headers[HttpResponseHeader.ContentLength] = _contentLength.ToString("D", NumberFormatInfo.InvariantInfo);
@@ -424,7 +424,7 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
                     Headers[HttpResponseHeader.KeepAlive] = "true";
                 }
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"flags:{flags} _BoundaryType:{_boundaryType} _contentLength:{_contentLength} _keepAlive: {_keepAlive}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"flags:{flags} _BoundaryType:{_boundaryType} _contentLength:{_contentLength} _keepAlive: {_keepAlive}");
             return flags;
         }
 
@@ -445,7 +445,7 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
             List<GCHandle> pinnedHeaders;
             GCHandle gcHandle;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "SerializeHeaders(HTTP_RESPONSE_HEADERS)");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "SerializeHeaders(HTTP_RESPONSE_HEADERS)");
             if (Headers.Count == 0)
             {
                 return null;
@@ -527,7 +527,7 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
                         {
                             lookup = -1;
                         }
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Info(this,
   $"index={index},headers.count={Headers.Count},headerName:{headerName},lookup:{lookup} headerValue:{headerValue}");
                         if (lookup == -1)
@@ -564,12 +564,12 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
                                 pinnedHeaders.Add(gcHandle);
                                 unknownHeaders[headers.UnknownHeaderCount].pRawValue = (sbyte*)gcHandle.AddrOfPinnedObject();
                                 headers.UnknownHeaderCount++;
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "UnknownHeaderCount:" + headers.UnknownHeaderCount);
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "UnknownHeaderCount:" + headers.UnknownHeaderCount);
                             }
                         }
                         else
                         {
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"HttpResponseHeader[{lookup}]:{((HttpResponseHeader)lookup)} headerValue:{headerValue}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"HttpResponseHeader[{lookup}]:{((HttpResponseHeader)lookup)} headerValue:{headerValue}");
                             if (headerValue != null)
                             {
                                 bytes = new byte[WebHeaderEncoding.GetByteCount(headerValue)];
@@ -578,7 +578,7 @@ $"flags: {flags} _boundaryType: {_boundaryType} _contentLength: {_contentLength}
                                 gcHandle = GCHandle.Alloc(bytes, GCHandleType.Pinned);
                                 pinnedHeaders.Add(gcHandle);
                                 pKnownHeaders[lookup].pRawValue = (sbyte*)gcHandle.AddrOfPinnedObject();
-                                if (NetEventSource.IsEnabled)
+                                if (NetEventSource.Log.IsEnabled())
                                 {
                                     NetEventSource.Info(this, $"pRawValue:{((IntPtr)(pKnownHeaders[lookup].pRawValue))} RawValueLength:{pKnownHeaders[lookup].RawValueLength} lookup: {lookup}");
                                 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerSession.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListenerSession.Windows.cs
@@ -23,7 +23,7 @@ namespace System.Net
                         if (_requestQueueBoundHandle == null)
                         {
                             _requestQueueBoundHandle = ThreadPoolBoundHandle.BindHandle(RequestQueueHandle);
-                            if (NetEventSource.IsEnabled) NetEventSource.Info($"ThreadPoolBoundHandle.BindHandle({RequestQueueHandle}) -> {_requestQueueBoundHandle}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"ThreadPoolBoundHandle.BindHandle({RequestQueueHandle}) -> {_requestQueueBoundHandle}");
                         }
                     }
                 }
@@ -64,7 +64,7 @@ namespace System.Net
             {
                 if (!RequestQueueHandle.IsInvalid)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info($"Dispose ThreadPoolBoundHandle: {_requestQueueBoundHandle}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"Dispose ThreadPoolBoundHandle: {_requestQueueBoundHandle}");
                     _requestQueueBoundHandle?.Dispose();
                     RequestQueueHandle.Dispose();
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpRequestStream.Windows.cs
@@ -19,7 +19,7 @@ namespace System.Net
 
         internal HttpRequestStream(HttpListenerContext httpContext)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"httpContextt:{httpContext}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"httpContextt:{httpContext}");
             _httpContext = httpContext;
         }
 
@@ -54,7 +54,7 @@ namespace System.Net
 
             if (_dataChunkIndex == -1 && dataRead < size)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "size:" + size + " offset:" + offset);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "size:" + size + " offset:" + offset);
                 uint statusCode = 0;
                 uint extraDataRead = 0;
                 offset += (int)dataRead;
@@ -69,7 +69,7 @@ namespace System.Net
                 fixed (byte* pBuffer = buffer)
                 {
                     // issue unmanaged blocking call
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveRequestEntityBody");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveRequestEntityBody");
 
                     uint flags = 0;
 
@@ -89,17 +89,17 @@ namespace System.Net
                             null);
 
                     dataRead += extraDataRead;
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveRequestEntityBody returned:" + statusCode + " dataRead:" + dataRead);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveRequestEntityBody returned:" + statusCode + " dataRead:" + dataRead);
                 }
                 if (statusCode != Interop.HttpApi.ERROR_SUCCESS && statusCode != Interop.HttpApi.ERROR_HANDLE_EOF)
                 {
                     Exception exception = new HttpListenerException((int)statusCode);
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception.ToString());
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception.ToString());
                     throw exception;
                 }
                 UpdateAfterRead(statusCode, dataRead);
             }
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.DumpBuffer(this, buffer, offset, (int)dataRead);
                 NetEventSource.Info(this, "returning dataRead:" + dataRead);
@@ -110,19 +110,19 @@ namespace System.Net
 
         private void UpdateAfterRead(uint statusCode, uint dataRead)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "statusCode:" + statusCode + " _closed:" + _closed);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "statusCode:" + statusCode + " _closed:" + _closed);
             if (statusCode == Interop.HttpApi.ERROR_HANDLE_EOF || dataRead == 0)
             {
                 Close();
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "statusCode:" + statusCode + " _closed:" + _closed);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "statusCode:" + statusCode + " _closed:" + _closed);
         }
 
         public IAsyncResult BeginReadCore(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
         {
             if (size == 0 || _closed)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 HttpRequestStreamAsyncResult result = new HttpRequestStreamAsyncResult(this, state, callback);
                 result.InvokeCallback((uint)0);
                 return result;
@@ -143,7 +143,7 @@ namespace System.Net
 
             if (_dataChunkIndex == -1 && dataRead < size)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "size:" + size + " offset:" + offset);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "size:" + size + " offset:" + offset);
                 uint statusCode = 0;
                 offset += (int)dataRead;
                 size -= (int)dataRead;
@@ -162,7 +162,7 @@ namespace System.Net
                     fixed (byte* pBuffer = buffer)
                     {
                         // issue unmanaged blocking call
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveRequestEntityBody");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpReceiveRequestEntityBody");
 
                         uint flags = 0;
 
@@ -181,12 +181,12 @@ namespace System.Net
                                 out bytesReturned,
                                 asyncResult._pOverlapped);
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveRequestEntityBody returned:" + statusCode + " dataRead:" + dataRead);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveRequestEntityBody returned:" + statusCode + " dataRead:" + dataRead);
                     }
                 }
                 catch (Exception e)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, e.ToString());
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e.ToString());
                     asyncResult.InternalCleanup();
                     throw;
                 }
@@ -202,7 +202,7 @@ namespace System.Net
                     else
                     {
                         Exception exception = new HttpListenerException((int)statusCode);
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception.ToString());
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception.ToString());
                         asyncResult.InternalCleanup();
                         throw exception;
                     }
@@ -214,13 +214,13 @@ namespace System.Net
                     asyncResult.IOCompleted(statusCode, bytesReturned);
                 }
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return asyncResult;
         }
 
         public override int EndRead(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"asyncResult: {asyncResult}");
@@ -244,7 +244,7 @@ namespace System.Net
             Exception exception = returnValue as Exception;
             if (exception != null)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, "Rethrowing exception:" + exception);
                     NetEventSource.Error(this, exception.ToString());
@@ -254,7 +254,7 @@ namespace System.Net
 
             uint dataRead = (uint)returnValue;
             UpdateAfterRead((uint)castedAsyncResult.ErrorCode, dataRead);
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"returnValue:{returnValue}");
                 NetEventSource.Exit(this);
@@ -265,7 +265,7 @@ namespace System.Net
 
         internal void SwitchToOpaqueMode()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             _inOpaqueMode = true;
         }
 
@@ -316,7 +316,7 @@ namespace System.Net
 
             private static void IOCompleted(HttpRequestStreamAsyncResult asyncResult, uint errorCode, uint numBytes)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"asyncResult: {asyncResult} errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"asyncResult: {asyncResult} errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes}");
                 object result = null;
                 try
                 {
@@ -328,9 +328,9 @@ namespace System.Net
                     else
                     {
                         result = numBytes;
-                        if (NetEventSource.IsEnabled) NetEventSource.DumpBuffer(asyncResult, (IntPtr)asyncResult._pPinnedBuffer, (int)numBytes);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.DumpBuffer(asyncResult, (IntPtr)asyncResult._pPinnedBuffer, (int)numBytes);
                     }
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"asyncResult: {asyncResult} calling Complete()");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"asyncResult: {asyncResult} calling Complete()");
                 }
                 catch (Exception e)
                 {
@@ -343,7 +343,7 @@ namespace System.Net
             {
                 HttpRequestStreamAsyncResult asyncResult = (HttpRequestStreamAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"asyncResult: {asyncResult} errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes} nativeOverlapped:0x {((IntPtr)nativeOverlapped).ToString("x8")}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"asyncResult: {asyncResult} errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes} nativeOverlapped:0x {((IntPtr)nativeOverlapped).ToString("x8")}");
 
                 IOCompleted(asyncResult, errorCode, numBytes);
             }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStream.Windows.cs
@@ -19,13 +19,13 @@ namespace System.Net
 
         internal HttpResponseStream(HttpListenerContext httpContext)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"httpContect: {httpContext}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"httpContect: {httpContext}");
             _httpContext = httpContext;
         }
 
         internal Interop.HttpApi.HTTP_FLAGS ComputeLeftToWrite()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "_LeftToWrite:" + _leftToWrite);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "_LeftToWrite:" + _leftToWrite);
             Interop.HttpApi.HTTP_FLAGS flags = Interop.HttpApi.HTTP_FLAGS.NONE;
             if (!_httpContext.Response.ComputedHeaders)
             {
@@ -35,7 +35,7 @@ namespace System.Net
             {
                 Interop.HttpApi.HTTP_VERB method = _httpContext.GetKnownMethod();
                 _leftToWrite = method != Interop.HttpApi.HTTP_VERB.HttpVerbHEAD ? _httpContext.Response.ContentLength64 : 0;
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "_LeftToWrite:" + _leftToWrite);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "_LeftToWrite:" + _leftToWrite);
             }
             return flags;
         }
@@ -52,7 +52,7 @@ namespace System.Net
             Interop.HttpApi.HTTP_FLAGS flags = ComputeLeftToWrite();
             if (size == 0 && _leftToWrite != 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 return;
             }
             if (_leftToWrite >= 0 && size > _leftToWrite)
@@ -104,7 +104,7 @@ namespace System.Net
                         }
                         else
                         {
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendResponseEntityBody");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendResponseEntityBody");
 
                             statusCode =
                                 Interop.HttpApi.HttpSendResponseEntityBody(
@@ -119,10 +119,10 @@ namespace System.Net
                                     null,
                                     null);
 
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendResponseEntityBody returned:" + statusCode);
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendResponseEntityBody returned:" + statusCode);
                             if (_httpContext.Listener.IgnoreWriteExceptions)
                             {
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Write() suppressing error");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Write() suppressing error");
                                 statusCode = Interop.HttpApi.ERROR_SUCCESS;
                             }
                         }
@@ -138,14 +138,14 @@ namespace System.Net
             if (statusCode != Interop.HttpApi.ERROR_SUCCESS && statusCode != Interop.HttpApi.ERROR_HANDLE_EOF)
             {
                 Exception exception = new HttpListenerException((int)statusCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception.ToString());
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception.ToString());
                 _closed = true;
                 _httpContext.Abort();
                 throw exception;
             }
             UpdateAfterWrite(dataToWrite);
-            if (NetEventSource.IsEnabled) NetEventSource.DumpBuffer(this, buffer, offset, (int)dataToWrite);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.DumpBuffer(this, buffer, offset, (int)dataToWrite);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private IAsyncResult BeginWriteCore(byte[] buffer, int offset, int size, AsyncCallback callback, object state)
@@ -153,7 +153,7 @@ namespace System.Net
             Interop.HttpApi.HTTP_FLAGS flags = ComputeLeftToWrite();
             if (_closed || (size == 0 && _leftToWrite != 0))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 HttpResponseStreamAsyncResult result = new HttpResponseStreamAsyncResult(this, state, callback);
                 result.InvokeCallback((uint)0);
                 return result;
@@ -180,7 +180,7 @@ namespace System.Net
                 }
                 else
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendResponseEntityBody");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendResponseEntityBody");
 
                     statusCode =
                         Interop.HttpApi.HttpSendResponseEntityBody(
@@ -195,12 +195,12 @@ namespace System.Net
                             asyncResult._pOverlapped,
                             null);
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendResponseEntityBody returned:" + statusCode);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendResponseEntityBody returned:" + statusCode);
                 }
             }
             catch (Exception e)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, e.ToString());
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e.ToString());
                 asyncResult.InternalCleanup();
                 _closed = true;
                 _httpContext.Abort();
@@ -212,12 +212,12 @@ namespace System.Net
                 asyncResult.InternalCleanup();
                 if (_httpContext.Listener.IgnoreWriteExceptions && sentHeaders)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "BeginWrite() Suppressing error");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "BeginWrite() Suppressing error");
                 }
                 else
                 {
                     Exception exception = new HttpListenerException((int)statusCode);
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception.ToString());
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception.ToString());
                     _closed = true;
                     _httpContext.Abort();
                     throw exception;
@@ -236,7 +236,7 @@ namespace System.Net
                 _lastWrite = asyncResult;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return asyncResult;
         }
 
@@ -258,18 +258,18 @@ namespace System.Net
             Exception exception = returnValue as Exception;
             if (exception != null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, "Rethrowing exception:" + exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, "Rethrowing exception:" + exception);
                 _closed = true;
                 _httpContext.Abort();
                 ExceptionDispatchInfo.Throw(exception);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private void UpdateAfterWrite(uint dataWritten)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "dataWritten:" + dataWritten + " _leftToWrite:" + _leftToWrite + " _closed:" + _closed);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "dataWritten:" + dataWritten + " _leftToWrite:" + _leftToWrite + " _closed:" + _closed);
             if (!_inOpaqueMode)
             {
                 if (_leftToWrite > 0)
@@ -283,7 +283,7 @@ namespace System.Net
                     _closed = true;
                 }
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "dataWritten:" + dataWritten + " _leftToWrite:" + _leftToWrite + " _closed:" + _closed);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "dataWritten:" + dataWritten + " _leftToWrite:" + _leftToWrite + " _closed:" + _closed);
         }
 
         private static readonly byte[] s_chunkTerminator = new byte[] { (byte)'0', (byte)'\r', (byte)'\n', (byte)'\r', (byte)'\n' };
@@ -298,7 +298,7 @@ namespace System.Net
             bool sentHeaders = _httpContext.Response.SentHeaders;
             if (sentHeaders && _leftToWrite == 0)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Exit(this);
                 return;
             }
@@ -327,7 +327,7 @@ namespace System.Net
                     }
                     else
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Info(this, "Calling Interop.HttpApi.HttpSendResponseEntityBody");
 
                         statusCode =
@@ -343,11 +343,11 @@ namespace System.Net
                                 null,
                                 null);
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Info(this, "Call to Interop.HttpApi.HttpSendResponseEntityBody returned:" + statusCode);
                         if (_httpContext.Listener.IgnoreWriteExceptions)
                         {
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                                 NetEventSource.Info(this, "Suppressing error");
                             statusCode = Interop.HttpApi.ERROR_SUCCESS;
                         }
@@ -364,7 +364,7 @@ namespace System.Net
             if (statusCode != Interop.HttpApi.ERROR_SUCCESS && statusCode != Interop.HttpApi.ERROR_HANDLE_EOF)
             {
                 Exception exception = new HttpListenerException((int)statusCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Error(this, exception.ToString());
                 _httpContext.Abort();
                 throw exception;
@@ -374,7 +374,7 @@ namespace System.Net
 
         internal void SwitchToOpaqueMode()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
             _inOpaqueMode = true;
             _leftToWrite = long.MaxValue;
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStreamAsyncResult.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpResponseStreamAsyncResult.cs
@@ -51,7 +51,7 @@ namespace System.Net
 
         private static byte[] GetChunkHeader(int size, out int offset)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, $"size:{size}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, $"size:{size}");
 
             uint Mask = 0xf0000000;
             byte[] Header = new byte[10];
@@ -106,7 +106,7 @@ namespace System.Net
             Header[8] = (byte)'\r';
             Header[9] = (byte)'\n';
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null);
             return Header;
         }
 
@@ -126,7 +126,7 @@ namespace System.Net
             {
                 _dataChunks = new Interop.HttpApi.HTTP_DATA_CHUNK[chunked ? 3 : 1];
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "m_pOverlapped:0x" + ((IntPtr)_pOverlapped).ToString("x8"));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "m_pOverlapped:0x" + ((IntPtr)_pOverlapped).ToString("x8"));
 
                 object[] objectsToPin = new object[1 + _dataChunks.Length];
                 objectsToPin[_dataChunks.Length] = _dataChunks;
@@ -188,7 +188,7 @@ namespace System.Net
 
         private static void IOCompleted(HttpResponseStreamAsyncResult asyncResult, uint errorCode, uint numBytes)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode:0x {errorCode.ToString("x8")} numBytes: {numBytes}");
             object result = null;
             try
             {
@@ -203,15 +203,15 @@ namespace System.Net
                     if (asyncResult._dataChunks == null)
                     {
                         result = (uint)0;
-                        if (NetEventSource.IsEnabled) { NetEventSource.DumpBuffer(null, IntPtr.Zero, 0); }
+                        if (NetEventSource.Log.IsEnabled()) { NetEventSource.DumpBuffer(null, IntPtr.Zero, 0); }
                     }
                     else
                     {
                         result = asyncResult._dataChunks.Length == 1 ? asyncResult._dataChunks[0].BufferLength : 0;
-                        if (NetEventSource.IsEnabled) { for (int i = 0; i < asyncResult._dataChunks.Length; i++) { NetEventSource.DumpBuffer(null, (IntPtr)asyncResult._dataChunks[0].pBuffer, (int)asyncResult._dataChunks[0].BufferLength); } }
+                        if (NetEventSource.Log.IsEnabled()) { for (int i = 0; i < asyncResult._dataChunks.Length; i++) { NetEventSource.DumpBuffer(null, (IntPtr)asyncResult._dataChunks[0].pBuffer, (int)asyncResult._dataChunks[0].BufferLength); } }
                     }
                 }
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Calling Complete()");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Calling Complete()");
             }
             catch (Exception e)
             {
@@ -224,7 +224,7 @@ namespace System.Net
         {
             object state = ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped);
             HttpResponseStreamAsyncResult asyncResult = state as HttpResponseStreamAsyncResult;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, "errorCode:0x" + errorCode.ToString("x8") + " numBytes:" + numBytes + " nativeOverlapped:0x" + ((IntPtr)nativeOverlapped).ToString("x8"));
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "errorCode:0x" + errorCode.ToString("x8") + " numBytes:" + numBytes + " nativeOverlapped:0x" + ((IntPtr)nativeOverlapped).ToString("x8"));
 
             IOCompleted(asyncResult, errorCode, numBytes);
         }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerAsyncResult.Windows.cs
@@ -23,7 +23,7 @@ namespace System.Net
             object result = null;
             try
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"errorCode:[{errorCode}] numBytes:[{numBytes}]");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode:[{errorCode}] numBytes:[{numBytes}]");
 
                 if (errorCode != Interop.HttpApi.ERROR_SUCCESS &&
                     errorCode != Interop.HttpApi.ERROR_MORE_DATA)
@@ -83,11 +83,11 @@ namespace System.Net
                 }
 
                 // complete the async IO and invoke the callback
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Calling Complete()");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Calling Complete()");
             }
             catch (Exception exception) when (!ExceptionCheck.IsFatal(exception))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Caught exception: {exception}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Caught exception: {exception}");
                 result = exception;
             }
             asyncResult.InvokeCallback(result);
@@ -104,7 +104,7 @@ namespace System.Net
             uint statusCode = Interop.HttpApi.ERROR_SUCCESS;
             while (true)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Calling Interop.HttpApi.HttpReceiveHttpRequest RequestId: {_requestContext.RequestBlob->RequestId}Buffer:0x {((IntPtr)_requestContext.RequestBlob).ToString("x")} Size: {_requestContext.Size}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Calling Interop.HttpApi.HttpReceiveHttpRequest RequestId: {_requestContext.RequestBlob->RequestId}Buffer:0x {((IntPtr)_requestContext.RequestBlob).ToString("x")} Size: {_requestContext.Size}");
                 uint bytesTransferred = 0;
                 HttpListenerSession listenerSession = (HttpListenerSession)AsyncObject;
                 statusCode = Interop.HttpApi.HttpReceiveHttpRequest(
@@ -116,7 +116,7 @@ namespace System.Net
                     &bytesTransferred,
                     _requestContext.NativeOverlapped);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveHttpRequest returned:" + statusCode);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Call to Interop.HttpApi.HttpReceiveHttpRequest returned:" + statusCode);
                 if (statusCode == Interop.HttpApi.ERROR_INVALID_PARAMETER && _requestContext.RequestBlob->RequestId != 0)
                 {
                     // we might get this if somebody stole our RequestId,

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/ListenerClientCertAsyncResult.Windows.cs
@@ -114,7 +114,7 @@ namespace System.Net
                     Interop.HttpApi.HTTP_SSL_CLIENT_CERT_INFO* pClientCertInfo = asyncResult._memoryBlob;
                     if (pClientCertInfo != null)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Info(null,
   $"pClientCertInfo:{(IntPtr)pClientCertInfo} pClientCertInfo->CertFlags: {pClientCertInfo->CertFlags} pClientCertInfo->CertEncodedSize: {pClientCertInfo->CertEncodedSize} pClientCertInfo->pCertEncoded: {(IntPtr)pClientCertInfo->pCertEncoded} pClientCertInfo->Token: {(IntPtr)pClientCertInfo->Token} pClientCertInfo->CertDeniedByMapper: {pClientCertInfo->CertDeniedByMapper}");
                         if (pClientCertInfo->pCertEncoded != null)
@@ -127,14 +127,14 @@ namespace System.Net
                             }
                             catch (CryptographicException exception)
                             {
-                                if (NetEventSource.IsEnabled)
+                                if (NetEventSource.Log.IsEnabled())
                                     NetEventSource.Info(null,
           $"HttpListenerRequest: {httpListenerRequest} caught CryptographicException: {exception}");
                                 result = exception;
                             }
                             catch (SecurityException exception)
                             {
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"HttpListenerRequest: {httpListenerRequest} caught SecurityException: {exception}");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"HttpListenerRequest: {httpListenerRequest} caught SecurityException: {exception}");
                                 result = exception;
                             }
                         }
@@ -143,7 +143,7 @@ namespace System.Net
                 }
 
                 // complete the async IO and invoke the callback
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Calling Complete()");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Calling Complete()");
             }
             catch (Exception exception) when (!ExceptionCheck.IsFatal(exception))
             {
@@ -163,7 +163,7 @@ namespace System.Net
         private static unsafe void WaitCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
             ListenerClientCertAsyncResult asyncResult = (ListenerClientCertAsyncResult)ThreadPoolBoundHandle.GetNativeOverlappedState(nativeOverlapped);
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"errorCode:[{errorCode}] numBytes:[{numBytes}] nativeOverlapped:[{((long)nativeOverlapped)}]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode:[{errorCode}] numBytes:[{numBytes}] nativeOverlapped:[{((long)nativeOverlapped)}]");
             IOCompleted(asyncResult, errorCode, numBytes);
         }
 

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/HttpWebSocket.Windows.cs
@@ -33,7 +33,7 @@ namespace System.Net.WebSockets
             ArraySegment<byte> internalBuffer)
         {
             HttpListenerWebSocketContext webSocketContext = null;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(null, context);
             }
@@ -84,7 +84,7 @@ namespace System.Net.WebSockets
                         hresult));
                 }
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(null, $"{HttpKnownHeaderNames.Origin} = {origin}");
                     NetEventSource.Info(null, $"{HttpKnownHeaderNames.SecWebSocketVersion} = {secWebSocketVersion}");
@@ -123,7 +123,7 @@ namespace System.Net.WebSockets
                                                                     secWebSocketKey,
                                                                     webSocket);
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Associate(context, webSocketContext);
                     NetEventSource.Associate(webSocketContext, webSocket);
@@ -131,7 +131,7 @@ namespace System.Net.WebSockets
             }
             catch (Exception ex)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(context, ex);
                 }
@@ -139,7 +139,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(context);
                 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketBase.cs
@@ -65,7 +65,7 @@ namespace System.Net.WebSockets
 
             string parameters = string.Empty;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 parameters = string.Format(CultureInfo.InvariantCulture,
                     "ReceiveBufferSize: {0}, SendBufferSize: {1},  Protocols: {2}, KeepAliveInterval: {3}, innerStream: {4}, internalBuffer: {5}",
@@ -85,7 +85,7 @@ namespace System.Net.WebSockets
             {
                 _innerStream = innerStream;
                 _internalBuffer = internalBuffer;
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Associate(this, _innerStream);
                     NetEventSource.Associate(this, _internalBuffer);
@@ -109,7 +109,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, parameters);
                 }
@@ -181,7 +181,7 @@ namespace System.Net.WebSockets
         private async Task<WebSocketReceiveResult> ReceiveAsyncCore(ArraySegment<byte> buffer,
             CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
             }
@@ -217,7 +217,7 @@ namespace System.Net.WebSockets
                     EnsureReceiveOperation();
                     receiveResult = await _receiveOperation.Process(buffer, linkedCancellationToken).SuppressContextFlow();
 
-                    if (NetEventSource.IsEnabled && receiveResult.Count > 0)
+                    if (NetEventSource.Log.IsEnabled() && receiveResult.Count > 0)
                     {
                         NetEventSource.DumpBuffer(this, buffer.Array, buffer.Offset, receiveResult.Count);
                     }
@@ -236,7 +236,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this);
                 }
@@ -278,7 +278,7 @@ namespace System.Net.WebSockets
             Debug.Assert(buffer.Array != null);
 
             string inputParameter = string.Empty;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 inputParameter = string.Format(CultureInfo.InvariantCulture,
                     "messageType: {0}, endOfMessage: {1}",
@@ -329,7 +329,7 @@ namespace System.Net.WebSockets
                         _sendOutstandingOperationHelper.CompleteOperation(ownsCancellationTokenSource);
                     }
 
-                    if (NetEventSource.IsEnabled && buffer.Count > 0)
+                    if (NetEventSource.Log.IsEnabled() && buffer.Count > 0)
                     {
                         NetEventSource.DumpBuffer(this, buffer.Array, buffer.Offset, buffer.Count);
                     }
@@ -352,7 +352,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, inputParameter);
                 }
@@ -405,7 +405,7 @@ namespace System.Net.WebSockets
         // MultiThreading: ThreadSafe; No-op if already in a terminal state
         public override void Abort()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
             }
@@ -446,7 +446,7 @@ namespace System.Net.WebSockets
             finally
             {
                 ReleaseLocks(ref thisLockTaken, ref sessionHandleLockTaken);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this);
                 }
@@ -468,7 +468,7 @@ namespace System.Net.WebSockets
             CancellationToken cancellationToken)
         {
             string inputParameter = string.Empty;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 inputParameter = string.Format(CultureInfo.InvariantCulture,
                     "closeStatus: {0}, statusDescription: {1}",
@@ -598,7 +598,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, inputParameter);
                 }
@@ -706,7 +706,7 @@ namespace System.Net.WebSockets
             CancellationToken cancellationToken)
         {
             string inputParameter = string.Empty;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 inputParameter = string.Format(CultureInfo.InvariantCulture,
                     "closeStatus: {0}, statusDescription: {1}",
@@ -857,7 +857,7 @@ namespace System.Net.WebSockets
                         // skip the statements in the if-block.
                         if (receiveResult != null)
                         {
-                            if (NetEventSource.IsEnabled && receiveResult.Count > 0)
+                            if (NetEventSource.Log.IsEnabled() && receiveResult.Count > 0)
                             {
                                 NetEventSource.DumpBuffer(this, closeMessageBuffer.Array, closeMessageBuffer.Offset, receiveResult.Count);
                             }
@@ -940,7 +940,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, inputParameter);
                 }
@@ -1199,7 +1199,7 @@ namespace System.Net.WebSockets
         {
             Debug.Assert(exception != null, "'exception' MUST NOT be NULL.");
 
-            if (NetEventSource.IsEnabled && !string.IsNullOrEmpty(methodName))
+            if (NetEventSource.Log.IsEnabled() && !string.IsNullOrEmpty(methodName))
             {
                 NetEventSource.Error(this, $"methodName: {methodName}, exception: {exception}");
             }
@@ -1337,7 +1337,7 @@ namespace System.Net.WebSockets
         {
             if (Interlocked.CompareExchange<Exception>(ref _pendingException, exception, null) == null)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, exception.ToString());
                 }
@@ -1405,7 +1405,7 @@ namespace System.Net.WebSockets
             _closeStatus = closeStatus;
             _closeStatusDescription = closeStatusDescription;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 string parameters = string.Format(CultureInfo.InvariantCulture,
                     "closeStatus: {0}, closeStatusDescription: {1}, _State: {2}",
@@ -1423,7 +1423,7 @@ namespace System.Net.WebSockets
             WebSocketBase thisPtr = sender as WebSocketBase;
             bool lockTaken = false;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(thisPtr);
             }
@@ -1486,7 +1486,7 @@ namespace System.Net.WebSockets
             {
                 ReleaseLock(thisPtr.SessionHandle, ref lockTaken);
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(thisPtr);
                 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketHttpListenerDuplexStream.cs
@@ -54,7 +54,7 @@ namespace System.Net.WebSockets
             _outputStream = outputStream;
             _context = context;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Associate(inputStream, this);
                 NetEventSource.Associate(outputStream, this);
@@ -127,7 +127,7 @@ namespace System.Net.WebSockets
 
         private async Task<int> ReadAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this, HttpWebSocket.GetTraceMsgForParameters(offset, count, cancellationToken));
             }
@@ -185,7 +185,7 @@ namespace System.Net.WebSockets
             {
                 cancellationTokenRegistration.Dispose();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, bytesRead);
                 }
@@ -199,7 +199,7 @@ namespace System.Net.WebSockets
         // true: async completion or error
         private unsafe bool ReadAsyncFast(HttpListenerAsyncEventArgs eventArgs)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
             }
@@ -299,7 +299,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, completedAsynchronouslyOrWithError);
                 }
@@ -356,7 +356,7 @@ namespace System.Net.WebSockets
             Debug.Assert(sendBuffers != null, "'sendBuffers' MUST NOT be NULL.");
             Debug.Assert(sendBuffers.Count == 2, "'sendBuffers.Count' MUST be '2' at this point.");
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
             }
@@ -397,7 +397,7 @@ namespace System.Net.WebSockets
             {
                 cancellationTokenRegistration.Dispose();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this);
                 }
@@ -418,7 +418,7 @@ namespace System.Net.WebSockets
 
         private async Task WriteAsyncCore(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this, HttpWebSocket.GetTraceMsgForParameters(offset, count, cancellationToken));
             }
@@ -467,7 +467,7 @@ namespace System.Net.WebSockets
             {
                 cancellationTokenRegistration.Dispose();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this);
                 }
@@ -479,7 +479,7 @@ namespace System.Net.WebSockets
         // true: async completion or with error
         private unsafe bool WriteAsyncFast(HttpListenerAsyncEventArgs eventArgs)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
             }
@@ -554,7 +554,7 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this, completedAsynchronouslyOrWithError);
                 }
@@ -607,7 +607,7 @@ namespace System.Net.WebSockets
             // need to yield here to make sure that we don't get any exception synchronously
             await Task.Yield();
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
             }
@@ -649,7 +649,7 @@ namespace System.Net.WebSockets
             {
                 cancellationTokenRegistration.Dispose();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Exit(this);
                 }
@@ -706,7 +706,7 @@ namespace System.Net.WebSockets
             WebSocketHttpListenerDuplexStream thisPtr = state as WebSocketHttpListenerDuplexStream;
             Debug.Assert(thisPtr != null, "'thisPtr' MUST NOT be NULL.");
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(state);
             }
@@ -721,7 +721,7 @@ namespace System.Net.WebSockets
             thisPtr._readTaskCompletionSource?.TrySetCanceled();
             thisPtr._writeTaskCompletionSource?.TrySetCanceled();
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(state);
             }
@@ -751,7 +751,7 @@ namespace System.Net.WebSockets
             _writeEventArgs = new HttpListenerAsyncEventArgs(webSocket, this);
             _writeEventArgs.Completed += s_OnWriteCompleted;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Associate(this, webSocket);
             }
@@ -767,7 +767,7 @@ namespace System.Net.WebSockets
                 "'thisPtr.m_OutstandingOperations.m_Writes' MUST NOT be negative.");
 #endif
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(thisPtr);
             }
@@ -781,7 +781,7 @@ namespace System.Net.WebSockets
                 thisPtr._writeTaskCompletionSource.TrySetResult();
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(thisPtr);
             }
@@ -797,7 +797,7 @@ namespace System.Net.WebSockets
                 "'thisPtr.m_OutstandingOperations.m_Reads' MUST NOT be negative.");
 #endif
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(thisPtr);
             }
@@ -811,7 +811,7 @@ namespace System.Net.WebSockets
                 thisPtr._readTaskCompletionSource.TrySetResult(eventArgs.BytesTransferred);
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(thisPtr);
             }
@@ -1168,7 +1168,7 @@ namespace System.Net.WebSockets
             {
                 SetResults(exception, 0);
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     string methodName = _completedOperation == HttpListenerAsyncOperation.Receive ? nameof(ReadAsyncFast) : nameof(WriteAsyncFast);
                     NetEventSource.Error(_currentStream, $"{methodName} {exception.ToString()}");
@@ -1182,9 +1182,9 @@ namespace System.Net.WebSockets
             {
                 SetResults(null, bytesTransferred);
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    if (_buffer != null && NetEventSource.IsEnabled)
+                    if (_buffer != null && NetEventSource.Log.IsEnabled())
                     {
                         string methodName = _completedOperation == HttpListenerAsyncOperation.Receive ? nameof(ReadAsyncFast) : nameof(WriteAsyncFast);
                         NetEventSource.DumpBuffer(_currentStream, _buffer, _offset, bytesTransferred, methodName);

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailMessage.cs
@@ -32,7 +32,7 @@ namespace System.Net.Mail
         public MailMessage()
         {
             _message = new Message();
-            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _message);
         }
 
         public MailMessage(string from, string to)
@@ -50,7 +50,7 @@ namespace System.Net.Mail
                 throw new ArgumentException(SR.Format(SR.net_emptystringcall, nameof(to)), nameof(to));
 
             _message = new Message(from, to);
-            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _message);
         }
 
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/MailPriority.cs
@@ -201,7 +201,7 @@ namespace System.Net.Mail
                 if (_headers == null)
                 {
                     _headers = new HeaderCollection();
-                    if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _headers);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _headers);
                 }
 
                 return _headers;
@@ -227,7 +227,7 @@ namespace System.Net.Mail
                 if (_envelopeHeaders == null)
                 {
                     _envelopeHeaders = new HeaderCollection();
-                    if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _envelopeHeaders);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _envelopeHeaders);
                 }
 
                 return _envelopeHeaders;

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -66,20 +66,20 @@ namespace System.Net.Mail
 
         public SmtpClient()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 Initialize();
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
         public SmtpClient(string? host)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, host);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, host);
             try
             {
                 _host = host;
@@ -87,13 +87,13 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
         public SmtpClient(string? host, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, host, port);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, host, port);
             try
             {
                 if (port < 0)
@@ -107,7 +107,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -117,7 +117,7 @@ namespace System.Net.Mail
         private void Initialize()
         {
             _transport = new SmtpTransport(this);
-            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _transport);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _transport);
             _onSendCompletedDelegate = new SendOrPostCallback(SendCompletedWaitCallback);
 
             if (_host != null && _host.Length != 0)
@@ -399,7 +399,7 @@ namespace System.Net.Mail
 
         internal MailWriter GetFileMailWriter(string? pickupDirectory)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"{nameof(pickupDirectory)}={pickupDirectory}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"{nameof(pickupDirectory)}={pickupDirectory}");
 
             if (!Path.IsPathRooted(pickupDirectory))
                 throw new SmtpException(SR.SmtpNeedAbsolutePickupDirectory);
@@ -440,7 +440,7 @@ namespace System.Net.Mail
 
         public void Send(MailMessage message)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, message);
 
             if (_disposed)
             {
@@ -448,7 +448,7 @@ namespace System.Net.Mail
             }
             try
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Info(this, $"DeliveryMethod={DeliveryMethod}");
                     NetEventSource.Associate(this, message);
@@ -552,7 +552,7 @@ namespace System.Net.Mail
                 }
                 catch (Exception e)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, e);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
 
                     if (e is SmtpFailedRecipientException && !((SmtpFailedRecipientException)e).fatal)
                     {
@@ -585,7 +585,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -605,7 +605,7 @@ namespace System.Net.Mail
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, message, userToken, _transport);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, message, userToken, _transport);
 
             try
             {
@@ -700,7 +700,7 @@ namespace System.Net.Mail
                             _operationCompletedResult = new ContextAwareResult(_transport.IdentityRequired, true, null, this, s_contextSafeCompleteCallback);
                             lock (_operationCompletedResult.StartPostingAsyncOp())
                             {
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Calling BeginConnect. Transport: {_transport}");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Calling BeginConnect. Transport: {_transport}");
                                 _transport.BeginGetConnection(_operationCompletedResult, ConnectCallback, _operationCompletedResult, Host!, Port);
                                 _operationCompletedResult.FinishPostingAsyncOp();
                             }
@@ -711,7 +711,7 @@ namespace System.Net.Mail
                 {
                     InCall = false;
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, e);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, e);
 
                     if (e is SmtpFailedRecipientException && !((SmtpFailedRecipientException)e).fatal)
                     {
@@ -732,7 +732,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -757,7 +757,7 @@ namespace System.Net.Mail
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             try
             {
@@ -771,7 +771,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -901,7 +901,7 @@ namespace System.Net.Mail
         private void Complete(Exception? exception, IAsyncResult result)
         {
             ContextAwareResult operationCompletedResult = (ContextAwareResult)result.AsyncState!;
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 if (_cancelled)
@@ -913,7 +913,7 @@ namespace System.Net.Mail
                 // An individual failed recipient exception is benign, only abort here if ALL the recipients failed.
                 else if (exception != null && (!(exception is SmtpFailedRecipientException) || ((SmtpFailedRecipientException)exception).fatal))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                     Abort();
 
                     if (!(exception is SmtpException))
@@ -942,7 +942,7 @@ namespace System.Net.Mail
                 operationCompletedResult.InvokeCallback(exception);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Complete");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Complete");
         }
 
         private static void ContextSafeCompleteCallback(IAsyncResult ar)
@@ -959,7 +959,7 @@ namespace System.Net.Mail
 
         private void SendMessageCallback(IAsyncResult result)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 _message!.EndSend(result);
@@ -972,14 +972,14 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
 
         private void SendMailCallback(IAsyncResult result)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 _writer = _transport.EndSendMail(result);
@@ -993,7 +993,7 @@ namespace System.Net.Mail
             catch (Exception e)
             {
                 Complete(e, result);
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 return;
             }
 
@@ -1015,13 +1015,13 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
         private void ConnectCallback(IAsyncResult result)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 _transport.EndGetConnection(result);
@@ -1045,7 +1045,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.cs
@@ -416,7 +416,7 @@ namespace System.Net.Mail
 
             internal void GetConnection()
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
                 if (_connection._isConnected)
                 {
                     throw new InvalidOperationException(SR.SmtpAlreadyConnected);
@@ -433,7 +433,7 @@ namespace System.Net.Mail
                     try
                     {
                         _connection.EndInitializeConnection(result);
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Connect returned");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Connect returned");
 
                         Handshake();
                     }
@@ -452,7 +452,7 @@ namespace System.Net.Mail
                     try
                     {
                         thisPtr._connection.EndInitializeConnection(result);
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Connect returned {thisPtr}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Connect returned {thisPtr}");
 
                         thisPtr.Handshake();
                     }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpLoginAuthenticationModule.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpLoginAuthenticationModule.cs
@@ -16,7 +16,7 @@ namespace System.Net.Mail
 
         public Authorization? Authenticate(string? challenge, NetworkCredential? credential, object sessionCookie, string? spn, ChannelBinding? channelBindingToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 lock (_sessions)
@@ -51,7 +51,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNegotiateAuthenticationModule.cs
@@ -17,7 +17,7 @@ namespace System.Net.Mail
 
         public Authorization? Authenticate(string? challenge, NetworkCredential? credential, object sessionCookie, string? spn, ChannelBinding? channelBindingToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, "Authenticate");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, "Authenticate");
             try
             {
                 lock (_sessions)
@@ -81,7 +81,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "Authenticate");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, "Authenticate");
             }
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpNtlmAuthenticationModule.cs
@@ -16,7 +16,7 @@ namespace System.Net.Mail
 
         public Authorization? Authenticate(string? challenge, NetworkCredential? credential, object sessionCookie, string? spn, ChannelBinding? channelBindingToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, "Authenticate");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, "Authenticate");
             try
             {
                 lock (_sessions)
@@ -55,7 +55,7 @@ namespace System.Net.Mail
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "Authenticate");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, "Authenticate");
             }
         }
 

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpTransport.cs
@@ -107,7 +107,7 @@ namespace System.Net.Mail
                     _shouldAbort = false;
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _connection);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _connection);
 
                 if (EnableSsl)
                 {
@@ -122,12 +122,12 @@ namespace System.Net.Mail
 
         internal IAsyncResult BeginGetConnection(ContextAwareResult outerResult, AsyncCallback? callback, object? state, string host, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             IAsyncResult? result = null;
             try
             {
                 _connection = new SmtpConnection(this, _client, _credentials, _authenticationModules);
-                if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _connection);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _connection);
                 if (EnableSsl)
                 {
                     _connection.EnableSsl = true;
@@ -141,7 +141,7 @@ namespace System.Net.Mail
                 throw new SmtpException(SR.MailHostNotFound, innerException);
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, "Sync completion");
                 NetEventSource.Exit(this);
@@ -151,14 +151,14 @@ namespace System.Net.Mail
 
         internal void EndGetConnection(IAsyncResult result)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 _connection!.EndGetConnection(result);
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -18,13 +18,13 @@ namespace System.Net
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             string name = NameResolutionPal.GetHostName();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, name);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, name);
             return name;
         }
 
         public static IPHostEntry GetHostEntry(IPAddress address)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(address, address);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (address is null)
@@ -34,19 +34,19 @@ namespace System.Net
 
             if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"Invalid address '{address}'");
                 throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(address)));
             }
 
             IPHostEntry ipHostEntry = GetHostEntryCore(address);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(address, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(address, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
             return ipHostEntry;
         }
 
         public static IPHostEntry GetHostEntry(string hostNameOrAddress)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostNameOrAddress is null)
@@ -60,7 +60,7 @@ namespace System.Net
             {
                 if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"Invalid address '{address}'");
                     throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(hostNameOrAddress)));
                 }
 
@@ -71,13 +71,13 @@ namespace System.Net
                 ipHostEntry = GetHostEntryCore(hostNameOrAddress);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostNameOrAddress, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(hostNameOrAddress, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
             return ipHostEntry;
         }
 
         public static Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
                 Task<IPHostEntry> t = GetHostEntryCoreAsync(hostNameOrAddress, justReturnParsedIp: false, throwOnIIPAny: true);
@@ -93,7 +93,7 @@ namespace System.Net
 
         public static Task<IPHostEntry> GetHostEntryAsync(IPAddress address)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(address, address);
 
             NameResolutionPal.EnsureSocketsAreInitialized();
 
@@ -104,50 +104,50 @@ namespace System.Net
 
             if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"Invalid address '{address}'");
                 throw new ArgumentException(SR.net_invalid_ip_addr, nameof(address));
             }
 
             return RunAsync(s => {
                     IPHostEntry ipHostEntry = GetHostEntryCore((IPAddress)s);
-                    if (NetEventSource.IsEnabled) NetEventSource.Exit((IPAddress)s, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit((IPAddress)s, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
                     return ipHostEntry;
                 }, address);
         }
 
         public static IAsyncResult BeginGetHostEntry(IPAddress address, AsyncCallback? requestCallback, object? stateObject)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(address, address);
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostEntryAsync(address), requestCallback, stateObject);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(address, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(address, asyncResult);
             return asyncResult;
         }
 
         public static IAsyncResult BeginGetHostEntry(string hostNameOrAddress, AsyncCallback? requestCallback, object? stateObject)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostEntryAsync(hostNameOrAddress), requestCallback, stateObject);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(asyncResult, asyncResult);
             return asyncResult;
         }
 
         public static IPHostEntry EndGetHostEntry(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(asyncResult, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(asyncResult, asyncResult);
 
             IPHostEntry ipHostEntry = TaskToApm.End<IPHostEntry>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries" );
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(asyncResult, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries" );
             return ipHostEntry;
         }
 
         public static IPAddress[] GetHostAddresses(string hostNameOrAddress)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostNameOrAddress is null)
@@ -161,7 +161,7 @@ namespace System.Net
             {
                 if (address.Equals(IPAddress.Any) || address.Equals(IPAddress.IPv6Any))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"Invalid address '{address}'");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"Invalid address '{address}'");
                     throw new ArgumentException(SR.Format(SR.net_invalid_ip_addr, nameof(hostNameOrAddress)));
                 }
 
@@ -172,7 +172,7 @@ namespace System.Net
                 addresses = GetHostAddressesCore(hostNameOrAddress);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostNameOrAddress, addresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(hostNameOrAddress, addresses);
             return addresses;
         }
 
@@ -181,21 +181,21 @@ namespace System.Net
 
         public static IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(hostNameOrAddress, hostNameOrAddress);
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostAddressesAsync(hostNameOrAddress), requestCallback, state);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostNameOrAddress, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(hostNameOrAddress, asyncResult);
             return asyncResult;
         }
 
         public static IPAddress[] EndGetHostAddresses(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(asyncResult, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(asyncResult, asyncResult);
 
             IPAddress[] addresses = TaskToApm.End<IPAddress[]>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, addresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(asyncResult, addresses);
             return addresses;
         }
 
@@ -220,29 +220,29 @@ namespace System.Net
         [Obsolete("BeginGetHostByName is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IAsyncResult BeginGetHostByName(string hostName, AsyncCallback? requestCallback, object? stateObject)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostName, hostName);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(hostName, hostName);
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: true, throwOnIIPAny: true), requestCallback, stateObject);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostName, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(hostName, asyncResult);
             return asyncResult;
         }
 
         [Obsolete("EndGetHostByName is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry EndGetHostByName(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(asyncResult, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(asyncResult, asyncResult);
 
             IPHostEntry ipHostEntry = TaskToApm.End<IPHostEntry>(asyncResult ?? throw new ArgumentNullException(nameof(asyncResult)));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(asyncResult, ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(asyncResult, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry GetHostByAddress(string address)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(address, address);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (address is null)
@@ -252,14 +252,14 @@ namespace System.Net
 
             IPHostEntry ipHostEntry = GetHostEntryCore(IPAddress.Parse(address));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(address, ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(address, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("GetHostByAddress is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry GetHostByAddress(IPAddress address)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(address, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(address, address);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (address is null)
@@ -269,14 +269,14 @@ namespace System.Net
 
             IPHostEntry ipHostEntry = GetHostEntryCore(address);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(address, ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(address, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("Resolve is obsoleted for this type, please use GetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry Resolve(string hostName)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(hostName, hostName);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(hostName, hostName);
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostName is null)
@@ -295,7 +295,7 @@ namespace System.Net
                 }
                 catch (SocketException ex)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, ex);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(hostName, ex);
                     ipHostEntry = CreateHostEntryForAddress(address);
                 }
             }
@@ -304,25 +304,25 @@ namespace System.Net
                 ipHostEntry = GetHostEntryCore(hostName);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(hostName, ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(hostName, ipHostEntry);
             return ipHostEntry;
         }
 
         [Obsolete("BeginResolve is obsoleted for this type, please use BeginGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IAsyncResult BeginResolve(string hostName, AsyncCallback? requestCallback, object? stateObject)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, hostName);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, hostName);
 
             IAsyncResult asyncResult = TaskToApm.Begin(GetHostEntryCoreAsync(hostName, justReturnParsedIp: false, throwOnIIPAny: false), requestCallback, stateObject);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, asyncResult);
             return asyncResult;
         }
 
         [Obsolete("EndResolve is obsoleted for this type, please use EndGetHostEntry instead. https://go.microsoft.com/fwlink/?linkid=14202")]
         public static IPHostEntry EndResolve(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, asyncResult);
             IPHostEntry ipHostEntry;
 
             try
@@ -341,11 +341,11 @@ namespace System.Net
                 if (address is null)
                     throw; // BeginResolve was called with a HostName, not an IPAddress
 
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
                 ipHostEntry = CreateHostEntryForAddress(address);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, ipHostEntry);
             return ipHostEntry;
         }
 
@@ -363,7 +363,7 @@ namespace System.Net
 
             if (errorCode != SocketError.Success)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"{hostName} DNS lookup failed with {errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(hostName, $"{hostName} DNS lookup failed with {errorCode}");
                 throw SocketExceptionFactory.CreateSocketException(errorCode, nativeErrorCode);
             }
 
@@ -396,7 +396,7 @@ namespace System.Net
             string? name = NameResolutionPal.TryGetNameInfo(address, out SocketError errorCode, out int nativeErrorCode);
             if (errorCode != SocketError.Success)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"{address} DNS lookup failed with {errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"{address} DNS lookup failed with {errorCode}");
                 throw SocketExceptionFactory.CreateSocketException(errorCode, nativeErrorCode);
             }
 
@@ -405,7 +405,7 @@ namespace System.Net
 
             if (errorCode != SocketError.Success)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(address, $"forward lookup for '{name}' failed with {errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(address, $"forward lookup for '{name}' failed with {errorCode}");
             }
 
             // One of three things happened:
@@ -444,7 +444,7 @@ namespace System.Net
             {
                 if (throwOnIIPAny && (ipAddress.Equals(IPAddress.Any) || ipAddress.Equals(IPAddress.IPv6Any)))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(hostName, $"Invalid address '{ipAddress}'");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(hostName, $"Invalid address '{ipAddress}'");
                     throw new ArgumentException(SR.net_invalid_ip_addr, nameof(hostName));
                 }
 

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -134,7 +134,7 @@ namespace System.Net
 
             if (result != SocketError.Success)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, $"GetHostName failed with {result}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, $"GetHostName failed with {result}");
                 throw new SocketException();
             }
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.Windows.cs
@@ -161,7 +161,7 @@ namespace System.Net.NetworkInformation
                     }
                     catch (NetworkInformationException nie)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(null, nie);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, nie);
                     }
                 }
 

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -71,7 +71,7 @@ namespace System.Net.NetworkInformation
             }
             catch (NetworkInformationException nie)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, nie);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, nie);
             }
 
             return false;

--- a/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -700,9 +700,9 @@ namespace System.Net
 
         internal CookieCollection CookieCutter(Uri uri, string? headerName, string setCookieHeader, bool isThrow)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"uri:{uri} headerName:{headerName} setCookieHeader:{setCookieHeader} isThrow:{isThrow}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"uri:{uri} headerName:{headerName} setCookieHeader:{setCookieHeader} isThrow:{isThrow}");
             }
 
             CookieCollection cookies = new CookieCollection();
@@ -729,7 +729,7 @@ namespace System.Net
                 do
                 {
                     Cookie? cookie = parser.Get();
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"CookieParser returned cookie:{cookie}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"CookieParser returned cookie:{cookie}");
 
                     if (cookie == null)
                     {

--- a/src/libraries/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -44,7 +44,7 @@ namespace System.Net
 
             var key = new CredentialKey(uriPrefix, authType);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Adding key:[{key}], cred:[{cred.Domain}],[{cred.UserName}]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Adding key:[{key}], cred:[{cred.Domain}],[{cred.UserName}]");
 
             if (_cache == null)
             {
@@ -89,7 +89,7 @@ namespace System.Net
 
             var key = new CredentialHostKey(host, port, authenticationType);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Adding key:[{key}], cred:[{credential.Domain}],[{credential.UserName}]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Adding key:[{key}], cred:[{credential.Domain}],[{credential.UserName}]");
 
             if (_cacheForHosts == null)
             {
@@ -110,7 +110,7 @@ namespace System.Net
 
             if (_cache == null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Short-circuiting because the dictionary is null.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Short-circuiting because the dictionary is null.");
                 return;
             }
 
@@ -118,7 +118,7 @@ namespace System.Net
 
             var key = new CredentialKey(uriPrefix, authType);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Removing key:[{key}]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Removing key:[{key}]");
 
             _cache.Remove(key);
         }
@@ -139,7 +139,7 @@ namespace System.Net
 
             if (_cacheForHosts == null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Short-circuiting because the dictionary is null.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Short-circuiting because the dictionary is null.");
                 return;
             }
 
@@ -147,7 +147,7 @@ namespace System.Net
 
             var key = new CredentialHostKey(host, port, authenticationType);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Removing key:[{key}]");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Removing key:[{key}]");
 
             _cacheForHosts.Remove(key);
         }
@@ -163,11 +163,11 @@ namespace System.Net
                 throw new ArgumentNullException(nameof(authType));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, uriPrefix, authType);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, uriPrefix, authType);
 
             if (_cache == null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "CredentialCache::GetCredential short-circuiting because the dictionary is null.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "CredentialCache::GetCredential short-circuiting because the dictionary is null.");
                 return null;
             }
 
@@ -194,7 +194,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Returning {(mostSpecificMatch == null ? "null" : "(" + mostSpecificMatch.UserName + ":" + mostSpecificMatch.Domain + ")")}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Returning {(mostSpecificMatch == null ? "null" : "(" + mostSpecificMatch.UserName + ":" + mostSpecificMatch.Domain + ")")}");
 
             return mostSpecificMatch;
         }
@@ -218,11 +218,11 @@ namespace System.Net
                 throw new ArgumentOutOfRangeException(nameof(port));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, host, port, authenticationType);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, host, port, authenticationType);
 
             if (_cacheForHosts == null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "CredentialCache::GetCredential short-circuiting because the dictionary is null.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "CredentialCache::GetCredential short-circuiting because the dictionary is null.");
                 return null;
             }
 
@@ -231,7 +231,7 @@ namespace System.Net
             NetworkCredential? match = null;
             _cacheForHosts.TryGetValue(key, out match);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Returning {((match == null) ? "null" : "(" + match.UserName + ":" + match.Domain + ")")}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Returning {((match == null) ? "null" : "(" + match.UserName + ":" + match.Domain + ")")}");
 
             return match;
         }
@@ -446,7 +446,7 @@ namespace System.Net
                 string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase) &&
                 Port == other.Port;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Equals({this},{other}) returns {equals}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Equals({this},{other}) returns {equals}");
 
             return equals;
         }
@@ -487,7 +487,7 @@ namespace System.Net
                 return false;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Match({UriPrefix} & {uri})");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Match({UriPrefix} & {uri})");
 
             return IsPrefix(uri, UriPrefix);
         }
@@ -538,7 +538,7 @@ namespace System.Net
                 string.Equals(AuthenticationType, other.AuthenticationType, StringComparison.OrdinalIgnoreCase) &&
                 UriPrefix.Equals(other.UriPrefix);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Equals({this},{other}) returns {equals}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Equals({this},{other}) returns {equals}");
 
             return equals;
         }

--- a/src/libraries/System.Net.Primitives/src/System/Net/SocketException.Unix.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/SocketException.Unix.cs
@@ -14,7 +14,7 @@ namespace System.Net.Sockets
 
         internal SocketException(SocketError errorCode, uint platformError) : base((int)platformError)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, errorCode, platformError);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, errorCode, platformError);
             _errorCode = errorCode;
         }
 

--- a/src/libraries/System.Net.Primitives/src/System/Net/SocketException.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/SocketException.cs
@@ -33,7 +33,7 @@ namespace System.Net.Sockets
         /// <summary>Creates a new instance of the <see cref='System.Net.Sockets.SocketException'/> class with the specified error code as SocketError.</summary>
         internal SocketException(SocketError socketError) : base(GetNativeErrorForSocketError(socketError))
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, socketError, Message);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, socketError, Message);
             _errorCode = socketError;
         }
 
@@ -44,7 +44,7 @@ namespace System.Net.Sockets
         protected SocketException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(serializationInfo, streamingContext)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"{NativeErrorCode}:{Message}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"{NativeErrorCode}:{Message}");
         }
 
         public override int ErrorCode => base.NativeErrorCode;

--- a/src/libraries/System.Net.Primitives/tests/PalTests/Fakes/NetEventSource.cs
+++ b/src/libraries/System.Net.Primitives/tests/PalTests/Fakes/NetEventSource.cs
@@ -1,13 +1,16 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Tracing;
+
 namespace System.Net
 {
-    public static class NetEventSource
+    public class NetEventSource : EventSource
     {
+        public static NetEventSource Log = new NetEventSource();
+
         public static void Enter(object thisOrContextObject, object arg1 = null, object arg2 = null, object arg3 = null) { }
         public static void Fail(object thisOrContextObject, object arg) { }
         public static void Info(object thisOrContextObject, object arg) { }
-        public static bool IsEnabled => false;
     }
 }

--- a/src/libraries/System.Net.Requests/src/System/Net/CommandStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/CommandStream.cs
@@ -44,7 +44,7 @@ namespace System.Net
 
         internal virtual void Abort(Exception e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "closing control Stream");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "closing control Stream");
 
             lock (this)
             {
@@ -72,7 +72,7 @@ namespace System.Net
 
         protected override void Dispose(bool disposing)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             InvokeRequestCallback(null);
 
@@ -205,7 +205,7 @@ namespace System.Net
                             if (index != -1)
                                 sendCommand = string.Concat(sendCommand.AsSpan(0, index), " ********");
                         }
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Sending command {sendCommand}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Sending command {sendCommand}");
                     }
 
                     try
@@ -658,7 +658,7 @@ namespace System.Net
             state.Resp.StatusDescription = responseString.Substring(0, completeLength);
             // Set the StatusDescription to the complete part of the response.  Note that the Buffer has already been taken care of above.
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Received response: {responseString.Substring(0, completeLength - 2)}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Received response: {responseString.Substring(0, completeLength - 2)}");
 
             if (_isAsync)
             {

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpControlStream.cs
@@ -222,7 +222,7 @@ namespace System.Net
         //    This function controls the setting up of a data socket/connection, and of saving off the server responses.
         protected override PipelineInstruction PipelineCallback(PipelineEntry? entry, ResponseDescription? response, bool timeout, ref Stream? stream)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Command:{entry?.Command} Description:{response?.StatusDescription}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Command:{entry?.Command} Description:{response?.StatusDescription}");
 
             // null response is not expected
             if (response == null)
@@ -453,7 +453,7 @@ namespace System.Net
             bool resetLoggedInState = false;
             FtpWebRequest request = (FtpWebRequest)req;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             _responseUri = request.RequestUri;
             ArrayList commandList = new ArrayList();
@@ -690,7 +690,7 @@ namespace System.Net
             {
                 IPEndPoint passiveEndPoint = _passiveEndPoint;
                 _passiveEndPoint = null;
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "starting Connect()");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "starting Connect()");
                 if (_isAsync)
                 {
                     _dataSocket!.BeginConnect(passiveEndPoint, s_connectCallbackDelegate, this);
@@ -704,7 +704,7 @@ namespace System.Net
             }
             else
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "starting Accept()");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "starting Accept()");
 
                 if (_isAsync)
                 {
@@ -1152,7 +1152,7 @@ namespace System.Net
 
         protected override bool CheckValid(ResponseDescription response, ref int validThrough, ref int completeLength)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"CheckValid({response.StatusBuffer})");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"CheckValid({response.StatusBuffer})");
 
             // If the response is less than 4 bytes long, it is too short to tell, so return true, valid so far.
             if (response.StatusBuffer.Length < 4)

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpDataStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpDataStream.cs
@@ -25,7 +25,7 @@ namespace System.Net
 
         internal FtpDataStream(NetworkStream networkStream, FtpWebRequest request, TriState writeOnly)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             _readable = true;
             _writeable = true;
@@ -59,7 +59,7 @@ namespace System.Net
         //TODO: Add this to FxCopBaseline.cs once https://github.com/dotnet/roslyn/issues/15728 is fixed
         void ICloseEx.CloseEx(CloseExState closeState)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"state = {closeState}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"state = {closeState}");
 
             lock (this)
             {

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpWebRequest.cs
@@ -490,7 +490,7 @@ namespace System.Net
 
         internal FtpWebRequest(Uri uri)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, uri);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, uri);
 
             if ((object)uri.Scheme != (object)Uri.UriSchemeFtp)
                 throw new ArgumentOutOfRangeException(nameof(uri));
@@ -527,10 +527,10 @@ namespace System.Net
         //
         public override WebResponse GetResponse()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Method: {_methodInfo.Method}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Method: {_methodInfo.Method}");
             }
 
             try
@@ -594,14 +594,14 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
 
                 // if _exception == null, we are about to throw an exception to the user
                 // and we haven't saved the exception, which also means we haven't dealt
                 // with it. So just release the connection and log this for investigation.
                 if (_exception == null)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                     SetException(exception);
                     FinishRequestStage(RequestStage.CheckForError);
                 }
@@ -609,7 +609,7 @@ namespace System.Net
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, _ftpWebResponse);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, _ftpWebResponse);
             }
             return _ftpWebResponse!;
         }
@@ -619,7 +619,7 @@ namespace System.Net
         /// </summary>
         public override IAsyncResult BeginGetResponse(AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"Method: {_methodInfo.Method}");
@@ -686,12 +686,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
 
             return asyncResult;
@@ -702,7 +702,7 @@ namespace System.Net
         /// </summary>
         public override WebResponse EndGetResponse(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             try
             {
                 // parameter validation
@@ -726,12 +726,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
 
             return _ftpWebResponse!;
@@ -742,7 +742,7 @@ namespace System.Net
         /// </summary>
         public override Stream GetRequestStream()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"Method: {_methodInfo.Method}");
@@ -787,12 +787,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
             return _stream;
         }
@@ -802,7 +802,7 @@ namespace System.Net
         /// </summary>
         public override IAsyncResult BeginGetRequestStream(AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"Method: {_methodInfo.Method}");
@@ -834,12 +834,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
 
             return asyncResult;
@@ -847,7 +847,7 @@ namespace System.Net
 
         public override Stream EndGetRequestStream(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             Stream? requestStream = null;
             try
             {
@@ -882,12 +882,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
             return requestStream;
         }
@@ -936,7 +936,7 @@ namespace System.Net
                         }
                     }
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Request being submitted");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Request being submitted");
 
                     connection.SetSocketTimeoutOption(RemainingTimeout);
 
@@ -1101,12 +1101,12 @@ namespace System.Net
         /// </summary>
         private void TimerCallback(TimerThread.Timer timer, int timeNoticed, object? context)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             FtpControlStream? connection = _connection;
             if (connection != null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "aborting connection");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "aborting connection");
                 connection.AbortConnect();
             }
         }
@@ -1145,7 +1145,7 @@ namespace System.Net
                 if (_connection != null)
                 {
                     _connection.CloseSocket();
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Releasing connection: {_connection}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Releasing connection: {_connection}");
                     _connection = null;
                 }
                 else
@@ -1161,7 +1161,7 @@ namespace System.Net
         /// </summary>
         private void SetException(Exception exception)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             if (exception is OutOfMemoryException)
             {
@@ -1220,7 +1220,7 @@ namespace System.Net
         //
         private void SyncRequestCallback(object? obj)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, obj);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, obj);
 
             RequestStage stageMode = RequestStage.CheckForError;
             try
@@ -1228,7 +1228,7 @@ namespace System.Net
                 bool completedRequest = obj == null;
                 Exception? exception = obj as Exception;
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"exp:{exception} completedRequest:{completedRequest}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"exp:{exception} completedRequest:{completedRequest}");
 
                 if (exception != null)
                 {
@@ -1261,7 +1261,7 @@ namespace System.Net
             finally
             {
                 FinishRequestStage(stageMode);
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 CheckError(); //will throw on error
             }
         }
@@ -1271,7 +1271,7 @@ namespace System.Net
         //
         private void AsyncRequestCallback(object? obj)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, obj);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, obj);
             RequestStage stageMode = RequestStage.CheckForError;
 
             try
@@ -1282,7 +1282,7 @@ namespace System.Net
 
                 bool completedRequest = (obj == null);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"stream:{stream} conn:{connection} exp:{exception} completedRequest:{completedRequest}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"stream:{stream} conn:{connection} exp:{exception} completedRequest:{completedRequest}");
                 while (true)
                 {
                     if (exception != null)
@@ -1308,12 +1308,12 @@ namespace System.Net
                         {
                             if (_aborted)
                             {
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Releasing connect:{connection}");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Releasing connect:{connection}");
                                 connection.CloseSocket();
                                 break;
                             }
                             _connection = connection;
-                            if (NetEventSource.IsEnabled) NetEventSource.Associate(this, _connection);
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Associate(this, _connection);
                         }
 
                         try
@@ -1373,7 +1373,7 @@ namespace System.Net
             finally
             {
                 FinishRequestStage(stageMode);
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -1391,7 +1391,7 @@ namespace System.Net
         //
         private RequestStage FinishRequestStage(RequestStage stage)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"state:{stage}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"state:{stage}");
 
             if (_exception != null)
                 stage = RequestStage.ReleaseConnection;
@@ -1455,7 +1455,7 @@ namespace System.Net
                     }
                     finally
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Releasing connection: {connection}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Releasing connection: {connection}");
                         connection.CloseSocket();
                         if (_async)
                             if (_requestCompleteAsyncResult != null)
@@ -1502,7 +1502,7 @@ namespace System.Net
             if (_aborted)
                 return;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             try
             {
@@ -1532,12 +1532,12 @@ namespace System.Net
             }
             catch (Exception exception)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, exception);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, exception);
                 throw;
             }
             finally
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             }
         }
 
@@ -1771,7 +1771,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Returns {_ftpWebResponse} with stream {_ftpWebResponse._responseStream}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Returns {_ftpWebResponse} with stream {_ftpWebResponse._responseStream}");
 
             return;
         }

--- a/src/libraries/System.Net.Requests/src/System/Net/FtpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FtpWebResponse.cs
@@ -23,7 +23,7 @@ namespace System.Net
 
         internal FtpWebResponse(Stream? responseStream, long contentLength, Uri responseUri, FtpStatusCode statusCode, string? statusLine, DateTime lastModified, string? bannerMessage, string? welcomeMessage, string? exitMessage)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, contentLength, statusLine);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, contentLength, statusLine);
 
             _responseStream = responseStream;
             if (responseStream == null && contentLength < 0)
@@ -81,9 +81,9 @@ namespace System.Net
         /// </summary>
         public override void Close()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             _responseStream?.Close();
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/TimerThread.cs
@@ -313,7 +313,7 @@ namespace System.Net
                 }
                 _timerState = TimerState.Ready;
                 _queueLock = queueLock;
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime}");
             }
 
             // A sentinel node - both the head and tail are one, which prevent the head and tail from ever having to be updated.
@@ -361,13 +361,13 @@ namespace System.Net
 
                             _timerState = TimerState.Cancelled;
 
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime} Cancel (success)");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime} Cancel (success)");
                             return true;
                         }
                     }
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime} Cancel (failure)");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime} Cancel (failure)");
                 return false;
             }
 
@@ -379,7 +379,7 @@ namespace System.Net
             {
                 if (_timerState == TimerState.Sentinel)
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "TimerQueue tried to Fire a Sentinel.");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "TimerQueue tried to Fire a Sentinel.");
                 }
 
                 if (_timerState != TimerState.Ready)
@@ -392,7 +392,7 @@ namespace System.Net
                 int nowMilliseconds = Environment.TickCount;
                 if (IsTickBetween(StartTime, Expiration, nowMilliseconds))
                 {
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime}::Fire() Not firing ({StartTime} <= {nowMilliseconds} < {Expiration})");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime}::Fire() Not firing ({StartTime} <= {nowMilliseconds} < {Expiration})");
                     return false;
                 }
 
@@ -401,7 +401,7 @@ namespace System.Net
                 {
                     if (_timerState == TimerState.Ready)
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime}::Fire() Firing ({StartTime} <= {nowMilliseconds} >= " + Expiration + ")");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"TimerThreadTimer#{StartTime}::Fire() Firing ({StartTime} <= {nowMilliseconds} >= " + Expiration + ")");
                         _timerState = TimerState.Fired;
 
                         // Remove it from the list.
@@ -429,7 +429,7 @@ namespace System.Net
                         if (ExceptionCheck.IsFatal(exception))
                             throw;
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"exception in callback: {exception}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"exception in callback: {exception}");
 
                         // This thread is not allowed to go into user code, so we should never get an exception here.
                         // So, in debug, throw it up, killing the AppDomain.  In release, we'll just ignore it.
@@ -483,7 +483,7 @@ namespace System.Net
         /// </summary>
         private static void ThreadProc()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
 
             // Set this thread as a background thread.  On AppDomain/Process shutdown, the thread will just be killed.
             Thread.CurrentThread.IsBackground = true;
@@ -556,19 +556,19 @@ namespace System.Net
                                     0) :
                                 ThreadIdleTimeoutMilliseconds;
 
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Waiting for {waitDuration}ms");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Waiting for {waitDuration}ms");
 
                             int waitResult = WaitHandle.WaitAny(s_threadEvents, waitDuration, false);
 
                             // 0 is s_ThreadShutdownEvent - die.
                             if (waitResult == 0)
                             {
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Awoke, cause: Shutdown");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Awoke, cause: Shutdown");
                                 running = false;
                                 break;
                             }
 
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Awoke, cause {(waitResult == WaitHandle.WaitTimeout ? "Timeout" : "Prod")}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Awoke, cause {(waitResult == WaitHandle.WaitTimeout ? "Timeout" : "Prod")}");
 
                             // If we timed out with nothing to do, shut down.
                             if (waitResult == WaitHandle.WaitTimeout && !haveNextTick)
@@ -594,7 +594,7 @@ namespace System.Net
                         if (ExceptionCheck.IsFatal(exception))
                             throw;
 
-                        if (NetEventSource.IsEnabled) NetEventSource.Error(null, exception);
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, exception);
 
                         // The only options are to continue processing and likely enter an error-loop,
                         // shut down timers for this AppDomain, or shut down the AppDomain.  Go with shutting
@@ -610,7 +610,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, "Stop");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, "Stop");
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Requests/src/System/Net/WebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/WebRequest.cs
@@ -66,7 +66,7 @@ namespace System.Net
         //     Newly created WebRequest.
         private static WebRequest Create(Uri requestUri, bool useUriBase)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, requestUri);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, requestUri);
 
             string LookupUri;
             WebRequestPrefixElement? Current = null;
@@ -125,12 +125,12 @@ namespace System.Net
             {
                 // We found a match, so just call the creator and return what it does.
                 WebRequest webRequest = Current!.Creator.Create(requestUri);
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(null, webRequest);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, webRequest);
                 return webRequest;
             }
 
             // Otherwise no match, throw an exception.
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null);
             throw new NotSupportedException(SR.net_unknown_prefix);
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.OSX.cs
@@ -38,7 +38,7 @@ namespace System.Net
                     {
                         errors |= SslPolicyErrors.RemoteCertificateNameMismatch;
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Error(sslContext, $"Cert name validation for '{hostName}' failed with status '{osStatus}'");
                     }
                 }
@@ -78,7 +78,7 @@ namespace System.Net
                 return null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(securityContext);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(securityContext);
 
             SafeSslHandle sslContext = ((SafeDeleteSslContext)securityContext).SslContext;
 
@@ -111,7 +111,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Log.RemoteCertificate(result);
                 NetEventSource.Exit(securityContext, result);

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -52,7 +52,7 @@ namespace System.Net
                 return null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(securityContext);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(securityContext);
 
             X509Certificate2? result = null;
             SafeFreeCertContext? remoteContext = null;
@@ -108,7 +108,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Log.RemoteCertificate(result);
                 NetEventSource.Exit(securityContext, result);

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -96,7 +96,7 @@ namespace System.Net
                 return null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(securityContext);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(securityContext);
 
             X509Certificate2? result = null;
             SafeFreeCertContext? remoteContext = null;
@@ -121,7 +121,7 @@ namespace System.Net
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Log.RemoteCertificate(result);
                 NetEventSource.Exit(null, result, securityContext);
@@ -157,7 +157,7 @@ namespace System.Net
                                 byte[] x = new Span<byte>((byte*)elements[i].pCertContext, checked((int)elements[i].cbSize)).ToArray();
                                 var x500DistinguishedName = new X500DistinguishedName(x);
                                 issuers[i] = x500DistinguishedName.Name;
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(securityContext, $"IssuerListEx[{issuers[i]}]");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(securityContext, $"IssuerListEx[{issuers[i]}]");
                             }
                         }
                     }
@@ -196,7 +196,7 @@ namespace System.Net
 
         private static unsafe uint Verify(SafeX509ChainHandle chainContext, ref Interop.Crypt32.CERT_CHAIN_POLICY_PARA cpp)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(chainContext, cpp.dwFlags);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(chainContext, cpp.dwFlags);
 
             Interop.Crypt32.CERT_CHAIN_POLICY_STATUS status = default;
             status.cbSize = (uint)sizeof(Interop.Crypt32.CERT_CHAIN_POLICY_STATUS);
@@ -208,7 +208,7 @@ namespace System.Net
                     ref cpp,
                     ref status);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(chainContext, $"CertVerifyCertificateChainPolicy returned: {errorCode}. Status: {status.dwError}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(chainContext, $"CertVerifyCertificateChainPolicy returned: {errorCode}. Status: {status.dwError}");
             return status.dwError;
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
@@ -47,7 +47,7 @@ namespace System.Net
                             // NOTE: that if this call fails we won't keep track and the next time we enter we will try to open the store again.
                             store = OpenStore(storeLocation);
 
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                                 NetEventSource.Info(null, $"storeLocation: {storeLocation} returned store {store}");
 
                             if (isMachineStore)
@@ -68,7 +68,7 @@ namespace System.Net
                                 return null;
                             }
 
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                                 NetEventSource.Error(null, SR.Format(SR.net_log_open_store_failed, storeLocation, exception));
 
                             throw;

--- a/src/libraries/System.Net.Security/src/System/Net/Logging/NetEventSource.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Logging/NetEventSource.cs
@@ -15,7 +15,7 @@ namespace System.Net
         [NonEvent]
         public static void DumpBuffer(object thisOrContextObject, ReadOnlyMemory<byte> buffer, [CallerMemberName] string? memberName = null)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 int count = Math.Min(buffer.Length, MaxDumpSize);
 

--- a/src/libraries/System.Net.Security/src/System/Net/NTAuthentication.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NTAuthentication.cs
@@ -20,7 +20,7 @@ namespace System.Net
                 }
 
                 string? name = NegotiateStreamPal.QueryContextAssociatedName(_securityContext!);
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"NTAuthentication: The context is associated with [{name}]");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"NTAuthentication: The context is associated with [{name}]");
                 return name;
             }
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStreamPal.Windows.cs
@@ -144,7 +144,7 @@ namespace System.Net.Security
             if (errorCode != 0)
             {
                 Exception e = new Win32Exception(errorCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, e);
                 throw e;
             }
 
@@ -223,7 +223,7 @@ namespace System.Net.Security
             if (errorCode != 0)
             {
                 Exception e = new Win32Exception(errorCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, e);
                 throw e;
             }
 
@@ -275,7 +275,7 @@ namespace System.Net.Security
             if (errorCode != 0)
             {
                 Exception e = new Win32Exception(errorCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, e);
                 throw new Win32Exception(errorCode);
             }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SecureChannel.cs
@@ -42,7 +42,7 @@ namespace System.Net.Security
 
         internal SecureChannel(SslAuthenticationOptions sslAuthenticationOptions, SslStream sslStream)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this, sslAuthenticationOptions.TargetHost, sslAuthenticationOptions.ClientCertificates);
                 NetEventSource.Log.SecureChannelCtor(this, sslStream, sslAuthenticationOptions.TargetHost!, sslAuthenticationOptions.ClientCertificates, sslAuthenticationOptions.EncryptionPolicy);
@@ -59,7 +59,7 @@ namespace System.Net.Security
             _refreshCredentialNeeded = true;
             _sslAuthenticationOptions = sslAuthenticationOptions;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this);
         }
 
@@ -98,7 +98,7 @@ namespace System.Net.Security
 
         internal ChannelBinding? GetChannelBinding(ChannelBindingKind kind)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this, kind);
 
             ChannelBinding? result = null;
@@ -107,7 +107,7 @@ namespace System.Net.Security
                 result = SslStreamPal.QueryContextChannelBinding(_securityContext, kind);
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this, result);
             return result;
         }
@@ -192,7 +192,7 @@ namespace System.Net.Security
                 return null;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Log.LocatingPrivateKey(certificate, instance);
 
             try
@@ -204,7 +204,7 @@ namespace System.Net.Security
                 {
                     if (certEx.HasPrivateKey)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.CertIsType2(instance);
 
                         return certEx;
@@ -227,7 +227,7 @@ namespace System.Net.Security
                     collectionEx = store.Certificates.Find(X509FindType.FindByThumbprint, certHash, false);
                     if (collectionEx.Count > 0 && collectionEx[0].HasPrivateKey)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.FoundCertInStore(isServer, instance);
                         return collectionEx[0];
                     }
@@ -239,7 +239,7 @@ namespace System.Net.Security
                     collectionEx = store.Certificates.Find(X509FindType.FindByThumbprint, certHash, false);
                     if (collectionEx.Count > 0 && collectionEx[0].HasPrivateKey)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.FoundCertInStore(!isServer, instance);
                         return collectionEx[0];
                     }
@@ -249,7 +249,7 @@ namespace System.Net.Security
             {
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Log.NotFoundCertInStore(instance);
             return null;
         }
@@ -331,7 +331,7 @@ namespace System.Net.Security
 
         private bool AcquireClientCredentials(ref byte[]? thumbPrint)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             // Acquire possible Client Certificate information and set it on the handle.
@@ -345,7 +345,7 @@ namespace System.Net.Security
             {
                 issuers = GetRequestCertificateAuthorities();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, "Calling CertificateSelectionCallback");
 
                 X509Certificate2? remoteCert = null;
@@ -372,21 +372,21 @@ namespace System.Net.Security
                     }
 
                     EnsureInitialized(ref filteredCerts).Add(clientCertificate);
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Log.CertificateFromDelegate(this);
                 }
                 else
                 {
                     if (_sslAuthenticationOptions.ClientCertificates == null || _sslAuthenticationOptions.ClientCertificates.Count == 0)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.NoDelegateNoClientCert(this);
 
                         sessionRestartAttempt = true;
                     }
                     else
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                             NetEventSource.Log.NoDelegateButClientCert(this);
                     }
                 }
@@ -402,7 +402,7 @@ namespace System.Net.Security
                     EnsureInitialized(ref filteredCerts).Add(clientCertificate);
                 }
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Log.AttemptingRestartUsingCert(clientCertificate, this);
             }
             else if (_sslAuthenticationOptions.ClientCertificates != null && _sslAuthenticationOptions.ClientCertificates.Count > 0)
@@ -412,7 +412,7 @@ namespace System.Net.Security
                 //
                 issuers = GetRequestCertificateAuthorities();
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     if (issuers == null || issuers.Length == 0)
                     {
@@ -442,7 +442,7 @@ namespace System.Net.Security
                                 continue;
                             }
 
-                            if (NetEventSource.IsEnabled)
+                            if (NetEventSource.Log.IsEnabled())
                                 NetEventSource.Info(this, $"Root cert: {certificateEx}");
 
                             chain = new X509Chain();
@@ -464,11 +464,11 @@ namespace System.Net.Security
                                     found = Array.IndexOf(issuers, issuer) != -1;
                                     if (found)
                                     {
-                                        if (NetEventSource.IsEnabled)
+                                        if (NetEventSource.Log.IsEnabled())
                                             NetEventSource.Info(this, $"Matched {issuer}");
                                         break;
                                     }
-                                    if (NetEventSource.IsEnabled)
+                                    if (NetEventSource.Log.IsEnabled())
                                         NetEventSource.Info(this, $"No match: {issuer}");
                                 }
                             }
@@ -498,7 +498,7 @@ namespace System.Net.Security
                         }
                     }
 
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Log.SelectedCert(_sslAuthenticationOptions.ClientCertificates[i], this);
 
                     EnsureInitialized(ref filteredCerts).Add(_sslAuthenticationOptions.ClientCertificates[i]);
@@ -510,7 +510,7 @@ namespace System.Net.Security
 
             clientCertificate = null;
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 if (filteredCerts != null && filteredCerts.Count != 0)
                 {
@@ -551,7 +551,7 @@ namespace System.Net.Security
                 NetEventSource.Fail(this, "'selectedCert' does not match 'clientCertificate'.");
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Info(this, $"Selected cert = {selectedCert}");
 
             try
@@ -571,7 +571,7 @@ namespace System.Net.Security
                     selectedCert != null &&
                     SslStreamPal.StartMutualAuthAsAnonymous)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Info(this, "Reset to anonymous session.");
 
                     // IIS does not renegotiate a restarted session if client cert is needed.
@@ -590,7 +590,7 @@ namespace System.Net.Security
 
                 if (cachedCredentialHandle != null)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Log.UsingCachedCredential(this);
 
                     _credentialsHandle = cachedCredentialHandle;
@@ -613,7 +613,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this, cachedCred, _credentialsHandle);
             return cachedCred;
         }
@@ -625,7 +625,7 @@ namespace System.Net.Security
         //
         private bool AcquireServerCredentials(ref byte[]? thumbPrint)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             X509Certificate? localCertificate = null;
@@ -641,12 +641,12 @@ namespace System.Net.Security
                 localCertificate = _sslAuthenticationOptions.ServerCertSelectionDelegate(_sslAuthenticationOptions.TargetHost);
                 if (localCertificate == null)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Error(this, $"ServerCertSelectionDelegate returned no certificaete for '{_sslAuthenticationOptions.TargetHost}'.");
                     throw new AuthenticationException(SR.net_ssl_io_no_server_cert);
                 }
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, "ServerCertSelectionDelegate selected Cert");
             }
             else if (_sslAuthenticationOptions.CertSelectionDelegate != null)
@@ -657,12 +657,12 @@ namespace System.Net.Security
                 localCertificate = _sslAuthenticationOptions.CertSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
                 if (localCertificate == null)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Error(this, $"CertSelectionDelegate returned no certificaete for '{_sslAuthenticationOptions.TargetHost}'.");
                     throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
                 }
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, "CertSelectionDelegate selected Cert");
             }
             else if (_sslAuthenticationOptions.CertificateContext != null)
@@ -676,7 +676,7 @@ namespace System.Net.Security
                 // Fail immediately if no certificate was given.
                 if (localCertificate == null)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Error(this, "Certiticate callback returned no certificaete.");
                     throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
                 }
@@ -716,7 +716,7 @@ namespace System.Net.Security
                 thumbPrint = guessedThumbPrint;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this, cachedCred, _credentialsHandle);
             return cachedCred;
         }
@@ -724,7 +724,7 @@ namespace System.Net.Security
         //
         internal ProtocolToken NextMessage(ReadOnlySpan<byte> incomingBuffer)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             byte[]? nextmsg = null;
@@ -732,7 +732,7 @@ namespace System.Net.Security
 
             if (!_sslAuthenticationOptions.IsServer && status.ErrorCode == SecurityStatusPalErrorCode.CredentialsNeeded)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, "NextMessage() returned SecurityStatusPal.CredentialsNeeded");
 
                 SetRefreshCredentialNeeded();
@@ -741,7 +741,7 @@ namespace System.Net.Security
 
             ProtocolToken token = new ProtocolToken(nextmsg, status);
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 if (token.Failed)
                 {
@@ -770,7 +770,7 @@ namespace System.Net.Security
         --*/
         private SecurityStatusPal GenerateToken(ReadOnlySpan<byte> inputBuffer, ref byte[]? output)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"_refreshCredentialNeeded = {_refreshCredentialNeeded}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"_refreshCredentialNeeded = {_refreshCredentialNeeded}");
 
             byte[]? result = Array.Empty<byte>();
             SecurityStatusPal status = default;
@@ -838,7 +838,7 @@ namespace System.Net.Security
             }
 
             output = result;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(this);
             }
@@ -855,7 +855,7 @@ namespace System.Net.Security
         --*/
         internal void ProcessHandshakeSuccess()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             if (_negotiatedApplicationProtocol == default)
@@ -883,7 +883,7 @@ namespace System.Net.Security
 
             SslStreamPal.QueryContextConnectionInfo(_securityContext!, out _connectionInfo);
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this);
         }
 
@@ -901,7 +901,7 @@ namespace System.Net.Security
         --*/
         internal SecurityStatusPal Encrypt(ReadOnlyMemory<byte> buffer, ref byte[] output, out int resultSize)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this, buffer, buffer.Length);
                 NetEventSource.DumpBuffer(this, buffer);
@@ -919,13 +919,13 @@ namespace System.Net.Security
 
             if (secStatus.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Exit(this, $"ERROR {secStatus}");
             }
             else
             {
                 output = writeBuffer;
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Exit(this, $"OK data size:{resultSize}");
             }
 
@@ -934,7 +934,7 @@ namespace System.Net.Security
 
         internal SecurityStatusPal Decrypt(byte[]? payload, ref int offset, ref int count)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this, payload, offset, count);
 
             if ((uint)offset > (uint)(payload == null ? 0 : payload.Length))
@@ -962,7 +962,7 @@ namespace System.Net.Security
         //This method validates a remote certificate.
         internal bool VerifyRemoteCertificate(RemoteCertValidationCallback? remoteCertValidationCallback, ref ProtocolToken? alertToken)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;
@@ -980,7 +980,7 @@ namespace System.Net.Security
 
                 if (remoteCertificateEx == null)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Exit(this, $"No remote certificate received. RemoteCertRequired: {RemoteCertRequired}");
                     sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
                 }
@@ -1023,10 +1023,10 @@ namespace System.Net.Security
                     }
                 }
 
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     LogCertificateValidation(remoteCertValidationCallback, sslPolicyErrors, success, chain!);
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Info(this, $"Cert validation, remote cert = {remoteCertificateEx}");
                 }
 
@@ -1063,7 +1063,7 @@ namespace System.Net.Security
                 remoteCertificateEx?.Dispose();
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this, success);
 
             return success;
@@ -1071,7 +1071,7 @@ namespace System.Net.Security
 
         public ProtocolToken? CreateFatalHandshakeAlertToken(SslPolicyErrors sslPolicyErrors, X509Chain chain)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             TlsAlertMessage alertMessage;
@@ -1090,7 +1090,7 @@ namespace System.Net.Security
                     break;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Info(this, $"alertMessage:{alertMessage}");
 
             SecurityStatusPal status;
@@ -1098,7 +1098,7 @@ namespace System.Net.Security
 
             if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, $"ApplyAlertToken() returned {status.ErrorCode}");
 
                 if (status.Exception != null)
@@ -1110,14 +1110,14 @@ namespace System.Net.Security
             }
 
             ProtocolToken token = GenerateAlertToken();
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this, token);
             return token;
         }
 
         public ProtocolToken? CreateShutdownToken()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Enter(this);
 
             SecurityStatusPal status;
@@ -1125,7 +1125,7 @@ namespace System.Net.Security
 
             if (status.ErrorCode != SecurityStatusPalErrorCode.OK)
             {
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(this, $"ApplyAlertToken() returned {status.ErrorCode}");
 
                 if (status.Exception != null)
@@ -1137,7 +1137,7 @@ namespace System.Net.Security
             }
 
             ProtocolToken token = GenerateAlertToken();
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
                 NetEventSource.Exit(this, token);
             return token;
         }
@@ -1205,7 +1205,7 @@ namespace System.Net.Security
 
         private void LogCertificateValidation(RemoteCertValidationCallback? remoteCertValidationCallback, SslPolicyErrors sslPolicyErrors, bool success, X509Chain chain)
         {
-            if (!NetEventSource.IsEnabled)
+            if (!NetEventSource.Log.IsEnabled())
                 return;
 
             if (sslPolicyErrors != SslPolicyErrors.None)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs
@@ -42,7 +42,7 @@ namespace System.Net.Security
             EncryptionPolicy = sslServerAuthenticationOptions.EncryptionPolicy;
             IsServer = true;
             RemoteCertRequired = sslServerAuthenticationOptions.ClientCertificateRequired;
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"Server RemoteCertRequired: {RemoteCertRequired}.");
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
@@ -117,7 +117,7 @@ namespace System.Net.Security
         {
             if (s_cachedCreds.Count == 0)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Not found, Current Cache Count = {s_cachedCreds.Count}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Not found, Current Cache Count = {s_cachedCreds.Count}");
                 return null;
             }
 
@@ -126,11 +126,11 @@ namespace System.Net.Security
             SafeCredentialReference? cached;
             if (!s_cachedCreds.TryGetValue(key, out cached) || cached.IsClosed || cached.Target.IsInvalid)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Not found or invalid, Current Cache Coun = {s_cachedCreds.Count}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Not found or invalid, Current Cache Coun = {s_cachedCreds.Count}");
                 return null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Found a cached Handle = {cached.Target}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Found a cached Handle = {cached.Target}");
 
             return cached.Target;
         }
@@ -149,7 +149,7 @@ namespace System.Net.Security
 
             if (creds!.IsInvalid)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Refused to cache an Invalid Handle {creds}, Current Cache Count = {s_cachedCreds.Count}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Refused to cache an Invalid Handle {creds}, Current Cache Count = {s_cachedCreds.Count}");
                 return;
             }
 
@@ -172,7 +172,7 @@ namespace System.Net.Security
                         }
 
                         s_cachedCreds[key] = cached;
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Caching New Handle = {creds}, Current Cache Count = {s_cachedCreds.Count}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Caching New Handle = {creds}, Current Cache Count = {s_cachedCreds.Count}");
 
                         //
                         // A simplest way of preventing infinite cache grows.
@@ -207,18 +207,18 @@ namespace System.Net.Security
                                     }
                                 }
                             }
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"Scavenged cache, New Cache Count = {s_cachedCreds.Count}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Scavenged cache, New Cache Count = {s_cachedCreds.Count}");
                         }
                     }
-                    else if (NetEventSource.IsEnabled)
+                    else if (NetEventSource.Log.IsEnabled())
                     {
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"CacheCredential() (locked retry) Found already cached Handle = {cached.Target}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"CacheCredential() (locked retry) Found already cached Handle = {cached.Target}");
                     }
                 }
             }
-            else if (NetEventSource.IsEnabled)
+            else if (NetEventSource.Log.IsEnabled())
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"CacheCredential() Ignoring incoming handle = {creds} since found already cached Handle = {cached.Target}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"CacheCredential() Ignoring incoming handle = {creds} since found already cached Handle = {cached.Target}");
             }
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -109,7 +109,7 @@ namespace System.Net.Security
 
             _innerStream = innerStream;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Log.SslStreamCtor(this, innerStream);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Log.SslStreamCtor(this, innerStream);
         }
 
         public SslApplicationProtocol NegotiatedApplicationProtocol

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -133,7 +133,7 @@ namespace System.Net.Security
                 flags = Interop.SspiCli.SCHANNEL_CRED.Flags.SCH_SEND_AUX_RECORD;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info($"flags=({flags}), ProtocolFlags=({protocolFlags}), EncryptionPolicy={policy}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info($"flags=({flags}), ProtocolFlags=({protocolFlags}), EncryptionPolicy={policy}");
             Interop.SspiCli.SCHANNEL_CRED secureCredential = CreateSecureCredential(
                 Interop.SspiCli.SCHANNEL_CRED.CurrentVersion,
                 certificate,
@@ -213,7 +213,7 @@ namespace System.Net.Security
 
                 if (errorCode != 0)
                 {
-                    if (NetEventSource.IsEnabled)
+                    if (NetEventSource.Log.IsEnabled())
                         NetEventSource.Info(securityContext, $"Encrypt ERROR {errorCode:X}");
                     resultSize = 0;
                     return SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Net.Sockets
             if (errorCode == SocketError.Success)
             {
                 _numBytes = numBytes;
-                if (NetEventSource.IsEnabled) LogBuffer(numBytes);
+                if (NetEventSource.Log.IsEnabled()) LogBuffer(numBytes);
 
                 // get the endpoint
                 remoteSocketAddress = IPEndPointExtensions.Serialize(_listenSocket._rightEndPoint!);
@@ -64,7 +64,7 @@ namespace System.Net.Sockets
                         errorCode = SocketPal.GetLastSocketError();
                     }
 
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"setsockopt handle:{handle}, AcceptSocket:{_acceptSocket}, returns:{errorCode}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"setsockopt handle:{handle}, AcceptSocket:{_acceptSocket}, returns:{errorCode}");
                 }
                 catch (ObjectDisposedException)
                 {
@@ -110,7 +110,7 @@ namespace System.Net.Sockets
             // This should only be called if tracing is enabled. However, there is the potential for a race
             // condition where tracing is disabled between a calling check and here, in which case the assert
             // may fire erroneously.
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
             Debug.Assert(_buffer != null);
 
             if (size > -1)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -19,7 +19,7 @@ namespace System.Net.Sockets
         public BaseOverlappedAsyncResult(Socket socket, object? asyncState, AsyncCallback? asyncCallback)
             : base(socket, asyncState, asyncCallback)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, socket);
         }
 
         protected void CompletionCallback(int numBytes, SocketError errorCode)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -22,7 +22,7 @@ namespace System.Net.Sockets
             : base(socket, asyncState, asyncCallback)
         {
             _cleanupCount = 1;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, socket);
         }
 
         // SetUnmanagedStructures
@@ -54,7 +54,7 @@ namespace System.Net.Sockets
                 _nativeOverlapped = new SafeNativeOverlapped(s.SafeHandle, overlapped);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"{boundHandle}::AllocateNativeOverlapped. return={_nativeOverlapped}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"{boundHandle}::AllocateNativeOverlapped. return={_nativeOverlapped}");
         }
 
         private static unsafe void CompletionPortCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
@@ -65,7 +65,7 @@ namespace System.Net.Sockets
             {
                 NetEventSource.Fail(null, $"asyncResult.IsCompleted: {asyncResult}");
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, $"errorCode:{errorCode} numBytes:{numBytes} nativeOverlapped:{(IntPtr)nativeOverlapped}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"errorCode:{errorCode} numBytes:{numBytes} nativeOverlapped:{(IntPtr)nativeOverlapped}");
 
             // Complete the IO and invoke the user's callback.
             SocketError socketError = (SocketError)errorCode;
@@ -196,7 +196,7 @@ namespace System.Net.Sockets
         protected virtual void ForceReleaseUnmanagedStructures()
         {
             // Free the unmanaged memory if allocated.
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             _nativeOverlapped!.Dispose();
             _nativeOverlapped = null;
             GC.SuppressFinalize(this);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
@@ -19,7 +19,7 @@ namespace System.Net
         [NonEvent]
         public static void Accepted(Socket socket, object? remoteEp, object? localEp)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 Log.Accepted(IdOf(remoteEp), IdOf(localEp), GetHashCode(socket));
             }
@@ -34,7 +34,7 @@ namespace System.Net
         [NonEvent]
         public static void Connected(Socket socket, object? localEp, object? remoteEp)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 Log.Connected(IdOf(localEp), IdOf(remoteEp), GetHashCode(socket));
             }
@@ -49,7 +49,7 @@ namespace System.Net
         [NonEvent]
         public static void ConnectedAsyncDns(Socket socket)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 Log.ConnectedAsyncDns(GetHashCode(socket));
             }
@@ -64,7 +64,7 @@ namespace System.Net
         [NonEvent]
         public static void NotLoggedFile(string filePath, Socket socket, SocketAsyncOperation completedOperation)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 Log.NotLoggedFile(filePath, GetHashCode(socket), completedOperation);
             }
@@ -95,7 +95,7 @@ namespace System.Net
         [NonEvent]
         public static void DumpBuffer(object thisOrContextObject, Memory<byte> buffer, int offset, int count, [CallerMemberName] string? memberName = null)
         {
-            if (IsEnabled)
+            if (Log.IsEnabled())
             {
                 if (offset < 0 || offset > buffer.Length - count)
                 {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -739,7 +739,7 @@ namespace System.Net.Sockets
         private int _currentWriteTimeout = -1;
         internal void SetSocketTimeoutOption(SocketShutdown mode, int timeout, bool silent)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, mode, timeout, silent);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, mode, timeout, silent);
 
             if (timeout < 0)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -98,7 +98,7 @@ namespace System.Net.Sockets
         // 3) failed.
         internal override object? PostCompletion(int numBytes)
         {
-            if (ErrorCode == 0 && NetEventSource.IsEnabled)
+            if (ErrorCode == 0 && NetEventSource.Log.IsEnabled())
             {
                 LogBuffer(numBytes);
             }
@@ -111,7 +111,7 @@ namespace System.Net.Sockets
             // This should only be called if tracing is enabled. However, there is the potential for a race
             // condition where tracing is disabled between a calling check and here, in which case the assert
             // may fire erroneously.
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
 
             if (size > -1)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
@@ -117,7 +117,7 @@ namespace System.Net.Sockets
         internal override object? PostCompletion(int numBytes)
         {
             InitIPPacketInformation();
-            if (ErrorCode == 0 && NetEventSource.IsEnabled)
+            if (ErrorCode == 0 && NetEventSource.Log.IsEnabled())
             {
                 LogBuffer(numBytes);
             }
@@ -130,7 +130,7 @@ namespace System.Net.Sockets
             // This should only be called if tracing is enabled. However, there is the potential for a race
             // condition where tracing is disabled between a calling check and here, in which case the assert
             // may fire erroneously.
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
 
             NetEventSource.DumpBuffer(this, _wsaBuffer->Pointer, Math.Min(_wsaBuffer->Length, size));
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
@@ -243,7 +243,7 @@ namespace System.Net.Sockets
             // EWOULDBLOCK, in which case we need to do some recovery.
             if (!abortive)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle} Following 'non-abortive' branch.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle} Following 'non-abortive' branch.");
 
                 // Close, and if its errno is other than EWOULDBLOCK, there's nothing more to do - we either succeeded or failed.
                 errorCode = CloseHandle(handle);
@@ -274,7 +274,7 @@ namespace System.Net.Sockets
 #if DEBUG
             _closeSocketLinger = SocketPal.GetSocketErrorForErrorCode(errorCode);
 #endif
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, setsockopt():{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, setsockopt():{errorCode}");
 
             switch (errorCode)
             {
@@ -309,7 +309,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, remappedError ?
                     $"handle:{handle}, close():ECONNRESET, but treating it as SUCCESS" :

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Windows.cs
@@ -44,7 +44,7 @@ namespace System.Net.Sockets
                 if (boundHandle == null)
                 {
                     // Bind the socket native _handle to the ThreadPool.
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "calling ThreadPool.BindHandle()");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "calling ThreadPool.BindHandle()");
 
                     try
                     {
@@ -129,14 +129,14 @@ namespace System.Net.Sockets
             // WSAEWOULDBLOCK, in which case we need to do some recovery.
             if (!abortive)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, Following 'blockable' branch");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, Following 'blockable' branch");
                 errorCode = Interop.Winsock.closesocket(handle);
 #if DEBUG
                 _closeSocketResult = errorCode;
 #endif
                 if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, closesocket()#1:{errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket()#1:{errorCode}");
 
                 // If it's not WSAEWOULDBLOCK, there's no more recourse - we either succeeded or failed.
                 if (errorCode != SocketError.WouldBlock)
@@ -153,7 +153,7 @@ namespace System.Net.Sockets
                     ref nonBlockCmd);
                 if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, ioctlsocket()#1:{errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, ioctlsocket()#1:{errorCode}");
 
                 // If that succeeded, try again.
                 if (errorCode == SocketError.Success)
@@ -163,7 +163,7 @@ namespace System.Net.Sockets
                     _closeSocketResult = errorCode;
 #endif
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, closesocket#2():{errorCode}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket#2():{errorCode}");
 
                     // If it's not WSAEWOULDBLOCK, there's no more recourse - we either succeeded or failed.
                     if (errorCode != SocketError.WouldBlock)
@@ -190,7 +190,7 @@ namespace System.Net.Sockets
             _closeSocketLinger = errorCode;
 #endif
             if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, setsockopt():{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, setsockopt():{errorCode}");
 
             if (errorCode != SocketError.Success && errorCode != SocketError.InvalidArgument && errorCode != SocketError.ProtocolOption)
             {
@@ -202,7 +202,7 @@ namespace System.Net.Sockets
 #if DEBUG
             _closeSocketResult = errorCode;
 #endif
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}, closesocket#3():{(errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode)}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}, closesocket#3():{(errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode)}");
 
             return errorCode;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.cs
@@ -72,7 +72,7 @@ namespace System.Net.Sockets
             _released = true;
             bool shouldClose = TryOwnClose();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"shouldClose={shouldClose}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"shouldClose={shouldClose}");
 
             // When shouldClose is true, the user called Dispose on the SafeHandle.
             // When it is false, the handle was closed from the Socket via CloseAsIs.
@@ -93,7 +93,7 @@ namespace System.Net.Sockets
 #endif
                 bool shouldClose = TryOwnClose();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"shouldClose={shouldClose}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"shouldClose={shouldClose}");
 
                 Dispose();
 
@@ -133,7 +133,7 @@ namespace System.Net.Sockets
             try
             {
 #endif
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{handle}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{handle}");
 
                 canceledOperations |= OnHandleClose();
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Windows.cs
@@ -19,7 +19,7 @@ namespace System.Net.Sockets
 
         public Socket(SocketInformation socketInformation)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             InitializeSockets();
 
@@ -80,7 +80,7 @@ namespace System.Net.Sockets
                 throw new SocketException((int)errorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private unsafe void LoadSocketTypeFromHandle(
@@ -111,7 +111,7 @@ namespace System.Net.Sockets
 
         public SocketInformation DuplicateAndClose(int targetProcessId)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, targetProcessId);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, targetProcessId);
 
             ThrowIfDisposed();
 
@@ -128,7 +128,7 @@ namespace System.Net.Sockets
 
             Close(timeout: -1);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return info;
         }
 
@@ -224,7 +224,7 @@ namespace System.Net.Sockets
                     return;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, address);
 
             var endPoint = new IPEndPoint(address, 0);
             DoBind(endPoint, IPEndPointExtensions.Serialize(endPoint));

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -84,7 +84,7 @@ namespace System.Net.Sockets
         // Initializes a new instance of the Sockets.Socket class.
         public Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, addressFamily);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, addressFamily);
 
             InitializeSockets();
 
@@ -103,7 +103,7 @@ namespace System.Net.Sockets
             _socketType = socketType;
             _protocolType = protocolType;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         /// <summary>Initializes a new instance of the <see cref="Socket"/> class for the specified socket handle.</summary>
@@ -293,7 +293,7 @@ namespace System.Net.Sockets
                 // This may throw ObjectDisposedException.
                 SocketError errorCode = SocketPal.GetAvailable(_handle, out argp);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetAvailable returns errorCode:{errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetAvailable returns errorCode:{errorCode}");
 
                 // Throw an appropriate SocketException if the native call fails.
                 if (errorCode != SocketError.Success)
@@ -421,7 +421,7 @@ namespace System.Net.Sockets
             {
                 ThrowIfDisposed();
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"value:{value} willBlock:{_willBlock} willBlockInternal:{_willBlockInternal}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"value:{value} willBlock:{_willBlock} willBlockInternal:{_willBlockInternal}");
 
                 bool current;
 
@@ -463,7 +463,7 @@ namespace System.Net.Sockets
         {
             get
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"_isConnected:{_isConnected}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"_isConnected:{_isConnected}");
 
                 if (_nonBlockingConnectInProgress && Poll(0, SelectMode.SelectWrite))
                 {
@@ -791,7 +791,7 @@ namespace System.Net.Sockets
         // Associates a socket with an end point.
         public void Bind(EndPoint localEP)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, localEP);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, localEP);
 
             ThrowIfDisposed();
 
@@ -801,12 +801,12 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException(nameof(localEP));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"localEP:{localEP}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"localEP:{localEP}");
 
             Internals.SocketAddress socketAddress = Serialize(ref localEP);
             DoBind(localEP, socketAddress);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         private void DoBind(EndPoint endPointSnapshot, Internals.SocketAddress socketAddress)
@@ -866,9 +866,9 @@ namespace System.Net.Sockets
 
             ValidateBlockingMode();
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"DST:{remoteEP}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"DST:{remoteEP}");
             }
 
             DnsEndPoint? dnsEP = remoteEP as DnsEndPoint;
@@ -900,7 +900,7 @@ namespace System.Net.Sockets
 
         public void Connect(IPAddress address, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, address);
 
             ThrowIfDisposed();
 
@@ -928,12 +928,12 @@ namespace System.Net.Sockets
 
             IPEndPoint remoteEP = new IPEndPoint(address, port);
             Connect(remoteEP);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public void Connect(string host, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, host);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, host);
 
             ThrowIfDisposed();
 
@@ -964,12 +964,12 @@ namespace System.Net.Sockets
                 Connect(addresses, port);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public void Connect(IPAddress[] addresses, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, addresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, addresses);
 
             ThrowIfDisposed();
 
@@ -1023,12 +1023,12 @@ namespace System.Net.Sockets
                 throw new ArgumentException(SR.net_invalidAddressList, nameof(addresses));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public void Close()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"timeout = {_closeTimeout}");
@@ -1036,12 +1036,12 @@ namespace System.Net.Sockets
 
             Dispose();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public void Close(int timeout)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, timeout);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, timeout);
             if (timeout < -1)
             {
                 throw new ArgumentOutOfRangeException(nameof(timeout));
@@ -1049,11 +1049,11 @@ namespace System.Net.Sockets
 
             _closeTimeout = timeout;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"timeout = {_closeTimeout}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"timeout = {_closeTimeout}");
 
             Dispose();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, timeout);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, timeout);
         }
 
         /// <summary>
@@ -1070,7 +1070,7 @@ namespace System.Net.Sockets
         /// <param name="backlog">The maximum length of the pending connections queue.</param>
         public void Listen(int backlog)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, backlog);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, backlog);
             ThrowIfDisposed();
 
             // This may throw ObjectDisposedException.
@@ -1082,13 +1082,13 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
             _isListening = true;
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Creates a new Sockets.Socket instance to handle an incoming connection.
         public Socket Accept()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // Validate input parameters.
 
@@ -1110,7 +1110,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint}");
 
             Internals.SocketAddress socketAddress =
                 _addressFamily == AddressFamily.InterNetwork || _addressFamily == AddressFamily.InterNetworkV6 ?
@@ -1136,7 +1136,7 @@ namespace System.Net.Sockets
             Debug.Assert(!acceptedSocketHandle.IsInvalid);
 
             Socket socket = CreateAcceptSocket(acceptedSocketHandle, _rightEndPoint.Create(socketAddress));
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Accepted(socket, socket.RemoteEndPoint!, socket.LocalEndPoint);
                 NetEventSource.Exit(this, socket);
@@ -1178,7 +1178,7 @@ namespace System.Net.Sockets
 
         public int Send(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             if (buffers == null)
@@ -1192,7 +1192,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint}");
 
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffers, socketFlags, out bytesTransferred);
@@ -1203,7 +1203,7 @@ namespace System.Net.Sockets
 
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, new SocketException((int)errorCode));
                     NetEventSource.Exit(this, 0);
@@ -1211,7 +1211,7 @@ namespace System.Net.Sockets
                 return 0;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -1229,7 +1229,7 @@ namespace System.Net.Sockets
 
         public int Send(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -1249,7 +1249,7 @@ namespace System.Net.Sockets
 
             errorCode = SocketError.Success;
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size}");
 
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
@@ -1261,7 +1261,7 @@ namespace System.Net.Sockets
 
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, new SocketException((int)errorCode));
                     NetEventSource.Exit(this, 0);
@@ -1269,7 +1269,7 @@ namespace System.Net.Sockets
                 return 0;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"Send returns:{bytesTransferred}");
                 NetEventSource.DumpBuffer(this, buffer, offset, bytesTransferred);
@@ -1291,7 +1291,7 @@ namespace System.Net.Sockets
 
         public int Send(ReadOnlySpan<byte> buffer, SocketFlags socketFlags, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
             ValidateBlockingMode();
 
@@ -1303,11 +1303,11 @@ namespace System.Net.Sockets
                 UpdateSendSocketErrorForDisposed(ref errorCode);
 
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, new SocketException((int)errorCode));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, new SocketException((int)errorCode));
                 bytesTransferred = 0;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -1318,7 +1318,7 @@ namespace System.Net.Sockets
 
         public void SendFile(string? fileName, byte[]? preBuffer, byte[]? postBuffer, TransmitFileOptions flags)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -1329,17 +1329,17 @@ namespace System.Net.Sockets
 
             ValidateBlockingMode();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"::SendFile() SRC:{LocalEndPoint} DST:{RemoteEndPoint} fileName:{fileName}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"::SendFile() SRC:{LocalEndPoint} DST:{RemoteEndPoint} fileName:{fileName}");
 
             SendFileInternal(fileName, preBuffer, postBuffer, flags);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Sends data to a specific end point, starting at the indicated location in the buffer.
         public int SendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -1362,7 +1362,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} size:{size} remoteEP:{remoteEP}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} size:{size} remoteEP:{remoteEP}");
 
             Internals.SocketAddress socketAddress = Serialize(ref remoteEP);
 
@@ -1383,7 +1383,7 @@ namespace System.Net.Sockets
                 _rightEndPoint = remoteEP;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.DumpBuffer(this, buffer, offset, size);
                 NetEventSource.Exit(this, bytesTransferred);
@@ -1437,7 +1437,7 @@ namespace System.Net.Sockets
 
         public int Receive(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -1455,7 +1455,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size}");
 
             int bytesTransferred;
             errorCode = SocketPal.Receive(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
@@ -1466,7 +1466,7 @@ namespace System.Net.Sockets
             {
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, new SocketException((int)errorCode));
                     NetEventSource.Exit(this, 0);
@@ -1474,7 +1474,7 @@ namespace System.Net.Sockets
                 return 0;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.DumpBuffer(this, buffer, offset, bytesTransferred);
                 NetEventSource.Exit(this, bytesTransferred);
@@ -1495,7 +1495,7 @@ namespace System.Net.Sockets
 
         public int Receive(Span<byte> buffer, SocketFlags socketFlags, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
             ValidateBlockingMode();
 
@@ -1507,11 +1507,11 @@ namespace System.Net.Sockets
             if (errorCode != SocketError.Success)
             {
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, new SocketException((int)errorCode));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, new SocketException((int)errorCode));
                 bytesTransferred = 0;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -1533,7 +1533,7 @@ namespace System.Net.Sockets
 
         public int Receive(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -1549,7 +1549,7 @@ namespace System.Net.Sockets
 
 
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint}");
 
             int bytesTransferred;
             errorCode = SocketPal.Receive(_handle, buffers, socketFlags, out bytesTransferred);
@@ -1559,7 +1559,7 @@ namespace System.Net.Sockets
             {
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, new SocketException((int)errorCode));
                     NetEventSource.Exit(this, 0);
@@ -1567,7 +1567,7 @@ namespace System.Net.Sockets
                 return 0;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
 
             return bytesTransferred;
         }
@@ -1576,7 +1576,7 @@ namespace System.Net.Sockets
         // the end point.
         public int ReceiveMessageFrom(byte[] buffer, int offset, int size, ref SocketFlags socketFlags, ref EndPoint remoteEP, out IPPacketInformation ipPacketInformation)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
             if (buffer == null)
             {
@@ -1645,7 +1645,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Error(this, errorCode);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, errorCode);
             return bytesTransferred;
         }
 
@@ -1653,7 +1653,7 @@ namespace System.Net.Sockets
         // the end point.
         public int ReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -1686,7 +1686,7 @@ namespace System.Net.Sockets
             SocketPal.CheckDualModeReceiveSupport(this);
 
             ValidateBlockingMode();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC{LocalEndPoint} size:{size} remoteEP:{remoteEP}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC{LocalEndPoint} size:{size} remoteEP:{remoteEP}");
 
             // We don't do a CAS demand here because the contents of remoteEP aren't used by
             // WSARecvFrom; all that matters is that we generate a unique-to-this-call SocketAddress
@@ -1706,7 +1706,7 @@ namespace System.Net.Sockets
             {
                 socketException = new SocketException((int)errorCode);
                 UpdateStatusAfterSocketError(socketException);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, socketException);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, socketException);
 
                 if (socketException.SocketErrorCode != SocketError.MessageSize)
                 {
@@ -1735,7 +1735,7 @@ namespace System.Net.Sockets
                 throw socketException;
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.DumpBuffer(this, buffer, offset, size);
                 NetEventSource.Exit(this, bytesTransferred);
@@ -1771,7 +1771,7 @@ namespace System.Net.Sockets
             // platforms, however.
             SocketError errorCode = SocketPal.WindowsIoctl(_handle, ioControlCode, optionInValue, optionOutValue, out realOptionLength);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"WindowsIoctl returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"WindowsIoctl returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1791,7 +1791,7 @@ namespace System.Net.Sockets
         public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
         {
             ThrowIfDisposed();
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue}");
 
             SetSocketOption(optionLevel, optionName, optionValue, false);
         }
@@ -1800,12 +1800,12 @@ namespace System.Net.Sockets
         {
             ThrowIfDisposed();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue}");
 
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.SetSockOpt(_handle, optionLevel, optionName, optionValue);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetSockOpt returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetSockOpt returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1831,7 +1831,7 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException(nameof(optionValue));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue}");
 
             if (optionLevel == SocketOptionLevel.Socket && optionName == SocketOptionName.Linger)
             {
@@ -1888,7 +1888,7 @@ namespace System.Net.Sockets
 
             SocketError errorCode = SocketPal.SetRawSockOpt(_handle, optionLevel, optionName, optionValue);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetSockOpt optionLevel:{optionLevel} optionName:{optionName} returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetSockOpt optionLevel:{optionLevel} optionName:{optionName} returns errorCode:{errorCode}");
 
             if (errorCode != SocketError.Success)
             {
@@ -1923,7 +1923,7 @@ namespace System.Net.Sockets
                 optionName,
                 out optionValue);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetSockOpt returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetSockOpt returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1948,7 +1948,7 @@ namespace System.Net.Sockets
                 optionValue!,
                 ref optionLength);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetSockOpt returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetSockOpt returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1972,7 +1972,7 @@ namespace System.Net.Sockets
                 optionValue,
                 ref realOptionLength);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetSockOpt returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetSockOpt returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2009,7 +2009,7 @@ namespace System.Net.Sockets
             int realOptionLength = optionValue.Length;
             SocketError errorCode = SocketPal.GetRawSockOpt(_handle, optionLevel, optionName, optionValue, ref realOptionLength);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetRawSockOpt optionLevel:{optionLevel} optionName:{optionName} returned errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetRawSockOpt optionLevel:{optionLevel} optionName:{optionName} returned errorCode:{errorCode}");
 
             if (errorCode != SocketError.Success)
             {
@@ -2047,7 +2047,7 @@ namespace System.Net.Sockets
 
             bool status;
             SocketError errorCode = SocketPal.Poll(_handle, microSeconds, mode, out status);
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Poll returns socketCount:{(int)errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Poll returns socketCount:{(int)errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2105,7 +2105,7 @@ namespace System.Net.Sockets
         public IAsyncResult BeginConnect(EndPoint remoteEP, AsyncCallback? callback, object? state)
         {
             // Validate input parameters.
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, remoteEP);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, remoteEP);
             ThrowIfDisposed();
 
             if (remoteEP == null)
@@ -2176,7 +2176,7 @@ namespace System.Net.Sockets
 
         public IAsyncResult BeginConnect(string host, int port, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, host);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, host);
             ThrowIfDisposed();
 
             if (host == null)
@@ -2206,7 +2206,7 @@ namespace System.Net.Sockets
             if (IPAddress.TryParse(host, out parsedAddress))
             {
                 IAsyncResult r = BeginConnect(parsedAddress, port, requestCallback, state);
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, r);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, r);
                 return r;
             }
 
@@ -2228,13 +2228,13 @@ namespace System.Net.Sockets
             // Done posting.
             result.FinishPostingAsyncOp(ref Caches.ConnectClosureCache);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, result);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, result);
             return result;
         }
 
         public IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, address);
             ThrowIfDisposed();
 
             if (address == null)
@@ -2259,13 +2259,13 @@ namespace System.Net.Sockets
             }
 
             IAsyncResult result = BeginConnect(new IPEndPoint(address, port), requestCallback, state);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, result);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, result);
             return result;
         }
 
         public IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, addresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, addresses);
             ThrowIfDisposed();
 
             if (addresses == null)
@@ -2310,13 +2310,13 @@ namespace System.Net.Sockets
             // Finished posting async op.  Possibly will call callback.
             result.FinishPostingAsyncOp(ref Caches.ConnectClosureCache);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, result);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, result);
             return result;
         }
 
         public IAsyncResult BeginDisconnect(bool reuseSocket, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Start context-flowing op.  No need to lock - we don't use the context till the callback.
@@ -2333,7 +2333,7 @@ namespace System.Net.Sockets
 
         private void DoBeginDisconnect(bool reuseSocket, DisconnectOverlappedAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             SocketError errorCode = SocketError.Success;
 
             errorCode = SocketPal.DisconnectAsync(this, _handle, reuseSocket, asyncResult);
@@ -2344,7 +2344,7 @@ namespace System.Net.Sockets
                 _remoteEndPoint = null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"UnsafeNclNativeMethods.OSSOCK.DisConnectEx returns:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"UnsafeNclNativeMethods.OSSOCK.DisConnectEx returns:{errorCode}");
 
             // If the call failed, update our status and throw
             if (!CheckErrorAndUpdateStatus(errorCode))
@@ -2352,12 +2352,12 @@ namespace System.Net.Sockets
                 throw new SocketException((int)errorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
         }
 
         public void Disconnect(bool reuseSocket)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             SocketError errorCode = SocketError.Success;
@@ -2365,7 +2365,7 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException (handle, and retrieving the delegate).
             errorCode = SocketPal.Disconnect(this, _handle, reuseSocket);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"UnsafeNclNativeMethods.OSSOCK.DisConnectEx returns:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"UnsafeNclNativeMethods.OSSOCK.DisConnectEx returns:{errorCode}");
 
             if (errorCode != SocketError.Success)
             {
@@ -2375,7 +2375,7 @@ namespace System.Net.Sockets
             SetToDisconnected();
             _remoteEndPoint = null;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Routine Description:
@@ -2392,7 +2392,7 @@ namespace System.Net.Sockets
         //    int - Return code from async Connect, 0 for success, SocketError.NotConnected otherwise
         public void EndConnect(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -2418,7 +2418,7 @@ namespace System.Net.Sockets
             castedAsyncResult.InternalWaitForCompletion();
             castedAsyncResult.EndCalled = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"asyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"asyncResult:{asyncResult}");
 
             Exception? ex = castedAsyncResult.Result as Exception;
             if (ex != null || (SocketError)castedAsyncResult.ErrorCode != SocketError.Success)
@@ -2433,11 +2433,11 @@ namespace System.Net.Sockets
                     ex = se;
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, ex);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, ex);
                 ExceptionDispatchInfo.Throw(ex);
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Connected(this, LocalEndPoint, RemoteEndPoint);
                 NetEventSource.Exit(this, "");
@@ -2446,7 +2446,7 @@ namespace System.Net.Sockets
 
         public void EndDisconnect(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
             ThrowIfDisposed();
 
             if (asyncResult == null)
@@ -2469,7 +2469,7 @@ namespace System.Net.Sockets
             castedAsyncResult.InternalWaitForCompletion();
             castedAsyncResult.EndCalled = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
             //
             // if the asynchronous native call failed asynchronously
@@ -2480,7 +2480,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketErrorAndThrowException((SocketError)castedAsyncResult.ErrorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Routine Description:
@@ -2513,7 +2513,7 @@ namespace System.Net.Sockets
 
         public IAsyncResult? BeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -2548,17 +2548,17 @@ namespace System.Net.Sockets
                 asyncResult.FinishPostingAsyncOp(ref Caches.SendClosureCache);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
         private SocketError DoBeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size} asyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} size:{size} asyncResult:{asyncResult}");
 
             SocketError errorCode = SocketPal.SendAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SendAsync returns:{errorCode} size:{size} AsyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SendAsync returns:{errorCode} size:{size} AsyncResult:{asyncResult}");
 
             // If the call failed, update our status
             if (!CheckErrorAndUpdateStatus(errorCode))
@@ -2582,7 +2582,7 @@ namespace System.Net.Sockets
 
         public IAsyncResult? BeginSend(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -2612,17 +2612,17 @@ namespace System.Net.Sockets
                 asyncResult = null;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
         private SocketError DoBeginSend(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} buffers:{buffers} asyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SRC:{LocalEndPoint} DST:{RemoteEndPoint} buffers:{buffers} asyncResult:{asyncResult}");
 
             SocketError errorCode = SocketPal.SendAsync(_handle, buffers, socketFlags, asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SendAsync returns:{errorCode} returning AsyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SendAsync returns:{errorCode} returning AsyncResult:{asyncResult}");
 
             // If the call failed, update our status
             if (!CheckErrorAndUpdateStatus(errorCode))
@@ -2658,7 +2658,7 @@ namespace System.Net.Sockets
 
         public int EndSend(IAsyncResult asyncResult, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -2680,7 +2680,7 @@ namespace System.Net.Sockets
             int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"bytesTransffered:{bytesTransferred}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"bytesTransffered:{bytesTransferred}");
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             errorCode = (SocketError)castedAsyncResult.ErrorCode;
@@ -2689,7 +2689,7 @@ namespace System.Net.Sockets
                 UpdateSendSocketErrorForDisposed(ref errorCode);
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, new SocketException((int)errorCode));
                     NetEventSource.Exit(this, 0);
@@ -2697,7 +2697,7 @@ namespace System.Net.Sockets
                 return 0;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -2708,7 +2708,7 @@ namespace System.Net.Sockets
 
         public IAsyncResult BeginSendFile(string? fileName, byte[]? preBuffer, byte[]? postBuffer, TransmitFileOptions flags, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -2717,17 +2717,17 @@ namespace System.Net.Sockets
                 throw new NotSupportedException(SR.net_notconnected);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"::DoBeginSendFile() SRC:{LocalEndPoint} DST:{RemoteEndPoint} fileName:{fileName}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"::DoBeginSendFile() SRC:{LocalEndPoint} DST:{RemoteEndPoint} fileName:{fileName}");
 
             IAsyncResult asyncResult = BeginSendFileInternal(fileName, preBuffer, postBuffer, flags, callback, state);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
         public void EndSendFile(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
 
             ThrowIfDisposed();
 
@@ -2738,7 +2738,7 @@ namespace System.Net.Sockets
 
             EndSendFileInternal(asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Routine Description:
@@ -2763,7 +2763,7 @@ namespace System.Net.Sockets
         //    IAsyncResult - Async result used to retrieve result
         public IAsyncResult BeginSendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -2796,13 +2796,13 @@ namespace System.Net.Sockets
             // Finish, possibly posting the callback.  The callback won't be posted before this point is reached.
             asyncResult.FinishPostingAsyncOp(ref Caches.SendClosureCache);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
         private void DoBeginSendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"size:{size}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"size:{size}");
 
             EndPoint? oldEndPoint = _rightEndPoint;
 
@@ -2818,7 +2818,7 @@ namespace System.Net.Sockets
 
                 errorCode = SocketPal.SendToAsync(_handle, buffer, offset, size, socketFlags, socketAddress, asyncResult);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SendToAsync returns:{errorCode} size:{size} returning AsyncResult:{asyncResult}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SendToAsync returns:{errorCode} size:{size} returning AsyncResult:{asyncResult}");
             }
             catch (ObjectDisposedException)
             {
@@ -2836,7 +2836,7 @@ namespace System.Net.Sockets
                 throw new SocketException((int)errorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"size:{size} returning AsyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"size:{size} returning AsyncResult:{asyncResult}");
         }
 
         // Routine Description:
@@ -2853,7 +2853,7 @@ namespace System.Net.Sockets
         //    int - Number of bytes transferred
         public int EndSendTo(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
 
             ThrowIfDisposed();
 
@@ -2876,7 +2876,7 @@ namespace System.Net.Sockets
             int bytesTransferred = castedAsyncResult.InternalWaitForCompletionInt32Result();
             castedAsyncResult.EndCalled = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"bytesTransferred:{bytesTransferred}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"bytesTransferred:{bytesTransferred}");
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             SocketError errorCode = (SocketError)castedAsyncResult.ErrorCode;
@@ -2886,7 +2886,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -2925,7 +2925,7 @@ namespace System.Net.Sockets
 
         public IAsyncResult? BeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -2961,20 +2961,20 @@ namespace System.Net.Sockets
                 asyncResult.FinishPostingAsyncOp(ref Caches.ReceiveClosureCache);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
         private SocketError DoBeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"size:{size}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"size:{size}");
 
 #if DEBUG
             IntPtr lastHandle = _handle.DangerousGetHandle();
 #endif
             SocketError errorCode = SocketPal.ReceiveAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ReceiveAsync returns:{errorCode} returning AsyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ReceiveAsync returns:{errorCode} returning AsyncResult:{asyncResult}");
 
             UpdateReceiveSocketErrorForDisposed(ref errorCode, bytesTransferred: 0);
             if (CheckErrorAndUpdateStatus(errorCode))
@@ -3002,7 +3002,7 @@ namespace System.Net.Sockets
 
         public IAsyncResult? BeginReceive(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, out SocketError errorCode, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -3035,7 +3035,7 @@ namespace System.Net.Sockets
                 asyncResult.FinishPostingAsyncOp(ref Caches.ReceiveClosureCache);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
@@ -3046,7 +3046,7 @@ namespace System.Net.Sockets
 #endif
             SocketError errorCode = SocketPal.ReceiveAsync(_handle, buffers, socketFlags, asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ReceiveAsync returns:{errorCode} returning AsyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ReceiveAsync returns:{errorCode} returning AsyncResult:{asyncResult}");
 
             UpdateReceiveSocketErrorForDisposed(ref errorCode, bytesTransferred: 0);
             if (!CheckErrorAndUpdateStatus(errorCode))
@@ -3096,7 +3096,7 @@ namespace System.Net.Sockets
 
         public int EndReceive(IAsyncResult asyncResult, out SocketError errorCode)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
 
             ThrowIfDisposed();
 
@@ -3127,20 +3127,20 @@ namespace System.Net.Sockets
             {
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                 {
                     NetEventSource.Error(this, new SocketException((int)errorCode));
                     NetEventSource.Exit(this, 0);
                 }
                 return 0;
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
         public IAsyncResult BeginReceiveMessageFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Enter(this);
                 NetEventSource.Info(this, $"size:{size}");
@@ -3216,7 +3216,7 @@ namespace System.Net.Sockets
                     }
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ReceiveMessageFromAsync returns:{errorCode} size:{size} returning AsyncResult:{asyncResult}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ReceiveMessageFromAsync returns:{errorCode} size:{size} returning AsyncResult:{asyncResult}");
             }
             catch (ObjectDisposedException)
             {
@@ -3248,7 +3248,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"size:{size} returning AsyncResult:{asyncResult}");
                 NetEventSource.Exit(this, asyncResult);
@@ -3258,7 +3258,7 @@ namespace System.Net.Sockets
 
         public int EndReceiveMessageFrom(IAsyncResult asyncResult, ref SocketFlags socketFlags, ref EndPoint endPoint, out IPPacketInformation ipPacketInformation)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
 
             ThrowIfDisposed();
             if (endPoint == null)
@@ -3303,7 +3303,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"bytesTransferred:{bytesTransferred}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"bytesTransferred:{bytesTransferred}");
 
             SocketError errorCode = (SocketError)castedAsyncResult.ErrorCode;
             UpdateReceiveSocketErrorForDisposed(ref errorCode, bytesTransferred);
@@ -3316,7 +3316,7 @@ namespace System.Net.Sockets
             socketFlags = castedAsyncResult.SocketFlags;
             ipPacketInformation = castedAsyncResult.IPPacketInformation;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -3346,7 +3346,7 @@ namespace System.Net.Sockets
         //    IAsyncResult - Async result used to retrieve result
         public IAsyncResult BeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -3404,7 +3404,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
@@ -3412,7 +3412,7 @@ namespace System.Net.Sockets
         {
             EndPoint? oldEndPoint = _rightEndPoint;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"size:{size}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"size:{size}");
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
@@ -3429,7 +3429,7 @@ namespace System.Net.Sockets
 
                 errorCode = SocketPal.ReceiveFromAsync(_handle, buffer, offset, size, socketFlags, socketAddress, asyncResult);
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ReceiveFromAsync returns:{errorCode} size:{size} returning AsyncResult:{asyncResult}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ReceiveFromAsync returns:{errorCode} size:{size} returning AsyncResult:{asyncResult}");
             }
             catch (ObjectDisposedException)
             {
@@ -3447,7 +3447,7 @@ namespace System.Net.Sockets
                 throw new SocketException((int)errorCode);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"size:{size} return AsyncResult:{asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"size:{size} return AsyncResult:{asyncResult}");
         }
 
         // Routine Description:
@@ -3465,7 +3465,7 @@ namespace System.Net.Sockets
         //    int - Number of bytes transferred
         public int EndReceiveFrom(IAsyncResult asyncResult, ref EndPoint endPoint)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
 
             ThrowIfDisposed();
 
@@ -3512,7 +3512,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"bytesTransferred:{bytesTransferred}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"bytesTransferred:{bytesTransferred}");
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             SocketError errorCode = (SocketError)castedAsyncResult.ErrorCode;
@@ -3521,7 +3521,7 @@ namespace System.Net.Sockets
             {
                 UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, bytesTransferred);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, bytesTransferred);
             return bytesTransferred;
         }
 
@@ -3550,7 +3550,7 @@ namespace System.Net.Sockets
                 return BeginAccept(0, callback, state);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             Debug.Assert(Disposed);
             ThrowObjectDisposedException();
@@ -3565,7 +3565,7 @@ namespace System.Net.Sockets
         // This is the truly async version that uses AcceptEx.
         public IAsyncResult BeginAccept(Socket? acceptSocket, int receiveSize, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -3584,7 +3584,7 @@ namespace System.Net.Sockets
             // Finish the flow capture, maybe complete here.
             asyncResult.FinishPostingAsyncOp(ref Caches.AcceptClosureCache);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, asyncResult);
             return asyncResult;
         }
 
@@ -3603,12 +3603,12 @@ namespace System.Net.Sockets
             SafeSocketHandle? acceptHandle;
             asyncResult.AcceptSocket = GetOrCreateAcceptSocket(acceptSocket, false, nameof(acceptSocket), out acceptHandle);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"AcceptSocket:{acceptSocket}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"AcceptSocket:{acceptSocket}");
 
             int socketAddressSize = GetAddressSize(_rightEndPoint);
             SocketError errorCode = SocketPal.AcceptAsync(this, _handle, acceptHandle, receiveSize, socketAddressSize, asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"AcceptAsync returns:{errorCode} {asyncResult}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"AcceptAsync returns:{errorCode} {asyncResult}");
 
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (!CheckErrorAndUpdateStatus(errorCode))
@@ -3652,7 +3652,7 @@ namespace System.Net.Sockets
 
         public Socket EndAccept(out byte[]? buffer, out int bytesTransferred, IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
             ThrowIfDisposed();
 
             // Validate input parameters.
@@ -3684,7 +3684,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketErrorAndThrowException(errorCode);
             }
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Accepted(socket, socket.RemoteEndPoint, socket.LocalEndPoint);
                 NetEventSource.Exit(this, socket);
@@ -3695,15 +3695,15 @@ namespace System.Net.Sockets
         // Disables sends and receives on a socket.
         public void Shutdown(SocketShutdown how)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, how);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, how);
             ThrowIfDisposed();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"how:{how}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"how:{how}");
 
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, how);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"Shutdown returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"Shutdown returns errorCode:{errorCode}");
 
             // Skip good cases: success, socket already closed.
             if (errorCode != SocketError.Success && errorCode != SocketError.NotSocket)
@@ -3713,13 +3713,13 @@ namespace System.Net.Sockets
 
             SetToDisconnected();
             InternalSetBlocking(_willBlockInternal);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         #region Async methods
         public bool AcceptAsync(SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -3760,7 +3760,7 @@ namespace System.Net.Sockets
             }
 
             bool pending = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
@@ -3769,7 +3769,7 @@ namespace System.Net.Sockets
 
         private bool ConnectAsync(SocketAsyncEventArgs e, bool userSocket)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
             bool pending;
 
             ThrowIfDisposed();
@@ -3802,7 +3802,7 @@ namespace System.Net.Sockets
 
             if (dnsEP != null)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.ConnectedAsyncDns(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.ConnectedAsyncDns(this);
 
                 ValidateForMultiConnect(isMultiEndpoint: true); // needs to come before CanTryAddressFamily call
 
@@ -3877,13 +3877,13 @@ namespace System.Net.Sockets
                 pending = (socketError == SocketError.IOPending);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
         public static bool ConnectAsync(SocketType socketType, ProtocolType protocolType, SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null);
             bool pending;
 
             if (e == null)
@@ -3938,7 +3938,7 @@ namespace System.Net.Sockets
                 pending = attemptSocket.ConnectAsync(e, userSocket: false);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, pending);
             return pending;
         }
 
@@ -3956,7 +3956,7 @@ namespace System.Net.Sockets
 
         public bool DisconnectAsync(SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // Throw if socket disposed
             ThrowIfDisposed();
@@ -3981,7 +3981,7 @@ namespace System.Net.Sockets
             }
 
             bool retval = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, retval);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, retval);
             return retval;
         }
 
@@ -3989,7 +3989,7 @@ namespace System.Net.Sockets
 
         private bool ReceiveAsync(SocketAsyncEventArgs e, CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -4013,13 +4013,13 @@ namespace System.Net.Sockets
             }
 
             bool pending = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
         public bool ReceiveFromAsync(SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -4063,13 +4063,13 @@ namespace System.Net.Sockets
             }
 
             bool pending = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
         public bool ReceiveMessageFromAsync(SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -4115,7 +4115,7 @@ namespace System.Net.Sockets
             }
 
             bool pending = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
@@ -4123,7 +4123,7 @@ namespace System.Net.Sockets
 
         private bool SendAsync(SocketAsyncEventArgs e, CancellationToken cancellationToken)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -4147,13 +4147,13 @@ namespace System.Net.Sockets
             }
 
             bool pending = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
         public bool SendPacketsAsync(SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -4185,13 +4185,13 @@ namespace System.Net.Sockets
             }
 
             bool pending = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, pending);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, pending);
             return pending;
         }
 
         public bool SendToAsync(SocketAsyncEventArgs e)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, e);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, e);
 
             ThrowIfDisposed();
 
@@ -4236,7 +4236,7 @@ namespace System.Net.Sockets
             }
 
             bool retval = (socketError == SocketError.IOPending);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, retval);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, retval);
             return retval;
         }
         #endregion
@@ -4330,7 +4330,7 @@ namespace System.Net.Sockets
 
         private void DoConnect(EndPoint endPointSnapshot, Internals.SocketAddress socketAddress)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, endPointSnapshot);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, endPointSnapshot);
 
             SocketError errorCode = SocketPal.Connect(_handle, socketAddress.Buffer, socketAddress.Size);
 
@@ -4341,7 +4341,7 @@ namespace System.Net.Sockets
                 // Update the internal state of this socket according to the error before throwing.
                 SocketException socketException = SocketExceptionFactory.CreateSocketException((int)errorCode, endPointSnapshot);
                 UpdateStatusAfterSocketError(socketException);
-                if (NetEventSource.IsEnabled) NetEventSource.Error(this, socketException);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, socketException);
                 throw socketException;
             }
 
@@ -4351,11 +4351,11 @@ namespace System.Net.Sockets
                 _rightEndPoint = endPointSnapshot;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"connection to:{endPointSnapshot}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"connection to:{endPointSnapshot}");
 
             // Update state and performance counters.
             SetToConnected();
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Connected(this, LocalEndPoint, RemoteEndPoint);
                 NetEventSource.Exit(this);
@@ -4364,7 +4364,7 @@ namespace System.Net.Sockets
 
         protected virtual void Dispose(bool disposing)
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 try
                 {
@@ -4377,7 +4377,7 @@ namespace System.Net.Sockets
             // Make sure we're the first call to Dispose
             if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 1)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 return;
             }
 
@@ -4398,7 +4398,7 @@ namespace System.Net.Sockets
                 if (timeout == 0 || !disposing)
                 {
                     // Abortive.
-                    if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling _handle.CloseAsIs()");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling _handle.CloseAsIs()");
                     _handle?.CloseAsIs(abortive: true);
                 }
                 else
@@ -4410,20 +4410,20 @@ namespace System.Net.Sockets
                     {
                         bool willBlock;
                         errorCode = SocketPal.SetBlocking(_handle, false, out willBlock);
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{_handle} ioctlsocket(FIONBIO):{errorCode}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{_handle} ioctlsocket(FIONBIO):{errorCode}");
                     }
 
                     if (timeout < 0)
                     {
                         // Close with existing user-specified linger option.
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Calling _handle.CloseAsIs()");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Calling _handle.CloseAsIs()");
                         _handle.CloseAsIs(abortive: false);
                     }
                     else
                     {
                         // Since our timeout is in ms and linger is in seconds, implement our own sortof linger here.
                         errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, SocketShutdown.Send);
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{_handle} shutdown():{errorCode}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{_handle} shutdown():{errorCode}");
 
                         // This should give us a timeout in milliseconds.
                         errorCode = SocketPal.SetSockOpt(
@@ -4431,7 +4431,7 @@ namespace System.Net.Sockets
                             SocketOptionLevel.Socket,
                             SocketOptionName.ReceiveTimeout,
                             timeout);
-                        if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{_handle} setsockopt():{errorCode}");
+                        if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{_handle} setsockopt():{errorCode}");
 
                         if (errorCode != SocketError.Success)
                         {
@@ -4441,7 +4441,7 @@ namespace System.Net.Sockets
                         {
                             int unused;
                             errorCode = SocketPal.Receive(_handle, Array.Empty<byte>(), 0, 0, SocketFlags.None, out unused);
-                            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{_handle} recv():{errorCode}");
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{_handle} recv():{errorCode}");
 
                             if (errorCode != (SocketError)0)
                             {
@@ -4453,7 +4453,7 @@ namespace System.Net.Sockets
                                 // We got a FIN or data.  Use ioctlsocket to find out which.
                                 int dataAvailable = 0;
                                 errorCode = SocketPal.GetAvailable(_handle, out dataAvailable);
-                                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"handle:{_handle} ioctlsocket(FIONREAD):{errorCode}");
+                                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"handle:{_handle} ioctlsocket(FIONREAD):{errorCode}");
 
                                 if (errorCode != SocketError.Success || dataAvailable != 0)
                                 {
@@ -4483,14 +4483,14 @@ namespace System.Net.Sockets
 
         public void Dispose()
         {
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"timeout = {_closeTimeout}");
                 NetEventSource.Enter(this);
             }
             Dispose(true);
             GC.SuppressFinalize(this);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         ~Socket()
@@ -4501,7 +4501,7 @@ namespace System.Net.Sockets
         // This version does not throw.
         internal void InternalShutdown(SocketShutdown how)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"how:{how}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"how:{how}");
 
             if (Disposed || _handle.IsInvalid)
             {
@@ -4548,18 +4548,18 @@ namespace System.Net.Sockets
 
         internal unsafe void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue, bool silent)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue} silent:{silent}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"optionLevel:{optionLevel} optionName:{optionName} optionValue:{optionValue} silent:{silent}");
 
             if (silent && (Disposed || _handle.IsInvalid))
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "skipping the call");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "skipping the call");
                 return;
             }
             SocketError errorCode = SocketError.Success;
             try
             {
                 errorCode = SocketPal.SetSockOpt(_handle, optionLevel, optionName, optionValue);
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetSockOpt returns errorCode:{errorCode}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetSockOpt returns errorCode:{errorCode}");
             }
             catch
             {
@@ -4593,7 +4593,7 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetMulticastOption(_handle, optionName, MR);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetMulticastOption returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetMulticastOption returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -4607,7 +4607,7 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetIPv6MulticastOption(_handle, optionName, MR);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetIPv6MulticastOption returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetIPv6MulticastOption returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -4620,7 +4620,7 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetLingerOption(_handle, lref);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetLingerOption returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetLingerOption returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -4634,7 +4634,7 @@ namespace System.Net.Sockets
             LingerOption? lingerOption;
             SocketError errorCode = SocketPal.GetLingerOption(_handle, out lingerOption);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetLingerOption returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetLingerOption returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -4650,7 +4650,7 @@ namespace System.Net.Sockets
             MulticastOption? multicastOption;
             SocketError errorCode = SocketPal.GetMulticastOption(_handle, optionName, out multicastOption);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetMulticastOption returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetMulticastOption returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -4667,7 +4667,7 @@ namespace System.Net.Sockets
             IPv6MulticastOption? multicastOption;
             SocketError errorCode = SocketPal.GetIPv6MulticastOption(_handle, optionName, out multicastOption);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"GetIPv6MulticastOption returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"GetIPv6MulticastOption returns errorCode:{errorCode}");
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -4682,11 +4682,11 @@ namespace System.Net.Sockets
         // error code, and will update internal state on success.
         private SocketError InternalSetBlocking(bool desired, out bool current)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, $"desired:{desired} willBlock:{_willBlock} willBlockInternal:{_willBlockInternal}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, $"desired:{desired} willBlock:{_willBlock} willBlockInternal:{_willBlockInternal}");
 
             if (Disposed)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this, "ObjectDisposed");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, "ObjectDisposed");
                 current = _willBlock;
                 return SocketError.Success;
             }
@@ -4703,7 +4703,7 @@ namespace System.Net.Sockets
                 errorCode = SocketError.NotSocket;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"SetBlocking returns errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"SetBlocking returns errorCode:{errorCode}");
 
             // We will update only internal state but only on successful win32 call
             // so if the native call fails, the state will remain the same.
@@ -4712,7 +4712,7 @@ namespace System.Net.Sockets
                 _willBlockInternal = willBlock;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"errorCode:{errorCode} willBlock:{_willBlock} willBlockInternal:{_willBlockInternal}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"errorCode:{errorCode} willBlock:{_willBlock} willBlockInternal:{_willBlockInternal}");
 
             current = _willBlockInternal;
             return errorCode;
@@ -4729,7 +4729,7 @@ namespace System.Net.Sockets
         // Since this is private, the unsafe mode is specified with a flag instead of an overload.
         private IAsyncResult BeginConnectEx(EndPoint remoteEP, bool flowContext, AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             EndPoint endPointSnapshot = remoteEP;
             Internals.SocketAddress socketAddress = Serialize(ref endPointSnapshot);
@@ -4763,7 +4763,7 @@ namespace System.Net.Sockets
                 throw;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"ConnectAsync returns:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"ConnectAsync returns:{errorCode}");
 
             if (errorCode == SocketError.Success)
             {
@@ -4784,7 +4784,7 @@ namespace System.Net.Sockets
             // This is a nop if the context isn't being flowed.
             asyncResult.FinishPostingAsyncOp(ref Caches.ConnectClosureCache);
 
-            if (NetEventSource.IsEnabled)
+            if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Info(this, $"{endPointSnapshot} returning AsyncResult:{asyncResult}");
                 NetEventSource.Exit(this, asyncResult);
@@ -5034,12 +5034,12 @@ namespace System.Net.Sockets
             // some point in time update the perf counter as well.
             _isConnected = true;
             _isDisconnected = false;
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, "now connected");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "now connected");
         }
 
         internal void SetToDisconnected()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (!_isConnected)
             {
@@ -5054,7 +5054,7 @@ namespace System.Net.Sockets
 
             if (!Disposed)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "!Disposed");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "!Disposed");
             }
         }
 
@@ -5063,7 +5063,7 @@ namespace System.Net.Sockets
             // Update the internal state of this socket according to the error before throwing.
             var socketException = new SocketException((int)error);
             UpdateStatusAfterSocketError(socketException);
-            if (NetEventSource.IsEnabled) NetEventSource.Error(this, socketException, memberName: callerName);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, socketException, memberName: callerName);
             throw socketException;
         }
 
@@ -5079,15 +5079,15 @@ namespace System.Net.Sockets
         {
             // If we already know the socket is disconnected
             // we don't need to do anything else.
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
-            if (NetEventSource.IsEnabled) NetEventSource.Error(this, $"errorCode:{errorCode}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(this, $"errorCode:{errorCode}");
 
             if (_isConnected && (_handle.IsInvalid || (errorCode != SocketError.WouldBlock &&
                     errorCode != SocketError.IOPending && errorCode != SocketError.NoBufferSpaceAvailable &&
                     errorCode != SocketError.TimedOut)))
             {
                 // The socket is no longer a valid socket.
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this, "Invalidating socket.");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, "Invalidating socket.");
                 SetToDisconnected();
             }
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -334,7 +334,7 @@ namespace System.Net.Sockets
             // This should only be called if tracing is enabled. However, there is the potential for a race
             // condition where tracing is disabled between a calling check and here, in which case the assert
             // may fire erroneously.
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
 
             if (_bufferList == null)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -64,7 +64,7 @@ namespace System.Net.Sockets
                 if (suppressFlow) ExecutionContext.RestoreFlow();
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(this, $"new PreAllocatedOverlapped {_preAllocatedOverlapped}");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this, $"new PreAllocatedOverlapped {_preAllocatedOverlapped}");
         }
 
         private void FreeInternals()
@@ -112,7 +112,7 @@ namespace System.Net.Sockets
                     try
                     {
                         bool canceled = Interop.Kernel32.CancelIoEx(handle, thisRef._pendingOverlappedForCancellation);
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             NetEventSource.Info(thisRef, canceled ?
                                 "Socket operation canceled." :
@@ -1039,7 +1039,7 @@ namespace System.Net.Sockets
             // This should only be called if tracing is enabled. However, there is the potential for a race
             // condition where tracing is disabled between a calling check and here, in which case the assert
             // may fire erroneously.
-            Debug.Assert(NetEventSource.IsEnabled);
+            Debug.Assert(NetEventSource.Log.IsEnabled());
 
             if (_bufferList != null)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -671,7 +671,7 @@ namespace System.Net.Sockets
         {
             SetResults(SocketError.Success, bytesTransferred, flags);
 
-            if (NetEventSource.IsEnabled && bytesTransferred > 0)
+            if (NetEventSource.Log.IsEnabled() && bytesTransferred > 0)
             {
                 LogBuffer(bytesTransferred);
             }
@@ -689,7 +689,7 @@ namespace System.Net.Sockets
                     {
                         _acceptSocket = _currentSocket.UpdateAcceptSocket(_acceptSocket!, _currentSocket._rightEndPoint!.Create(remoteSocketAddress));
 
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             try
                             {
@@ -710,7 +710,7 @@ namespace System.Net.Sockets
                     socketError = FinishOperationConnect();
                     if (socketError == SocketError.Success)
                     {
-                        if (NetEventSource.IsEnabled)
+                        if (NetEventSource.Log.IsEnabled())
                         {
                             try
                             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -94,7 +94,7 @@ namespace System.Net.Sockets
             }
 
             socket = new SafeSocketHandle(fd, ownsHandle: true);
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
 
             return errorCode;
         }
@@ -1027,7 +1027,7 @@ namespace System.Net.Sockets
             }
 
             socket = new SafeSocketHandle(acceptedFd, ownsHandle: true);
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
 
             return errorCode;
         }
@@ -2007,7 +2007,7 @@ namespace System.Net.Sockets
         {
             var res = new SafeSocketHandle(fileDescriptor, ownsHandle: true);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, res);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, res);
             return res;
         }
     }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -49,12 +49,12 @@ namespace System.Net.Sockets
             if (socket.IsInvalid)
             {
                 SocketError error = GetLastSocketError();
-                if (NetEventSource.IsEnabled) NetEventSource.Error(null, $"WSASocketW failed with error {error}");
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, $"WSASocketW failed with error {error}");
                 socket.Dispose();
                 return error;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
             return SocketError.Success;
         }
 
@@ -92,7 +92,7 @@ namespace System.Net.Sockets
                 if (socket.IsInvalid)
                 {
                     SocketError error = GetLastSocketError();
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(null, $"WSASocketW failed with error {error}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, $"WSASocketW failed with error {error}");
                     socket.Dispose();
                     return error;
                 }
@@ -102,13 +102,13 @@ namespace System.Net.Sockets
                     // Returning SocketError for consistency, since the call site can deal with conversion, and
                     // the most common SetHandleInformation error (AccessDenied) is included in SocketError anyways:
                     SocketError error = GetLastSocketError();
-                    if (NetEventSource.IsEnabled) NetEventSource.Error(null, $"SetHandleInformation failed with error {error}");
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, $"SetHandleInformation failed with error {error}");
                     socket.Dispose();
 
                     return error;
                 }
 
-                if (NetEventSource.IsEnabled) NetEventSource.Info(null, socket);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
 
                 Interop.Winsock.WSAPROTOCOL_INFOW* protocolInfo = (Interop.Winsock.WSAPROTOCOL_INFOW*)protocolInfoBytes;
                 addressFamily = protocolInfo->iAddressFamily;
@@ -181,7 +181,7 @@ namespace System.Net.Sockets
             IntPtr handle = Interop.Winsock.accept(listenSocket, socketAddress, ref socketAddressSize);
 
             socket = new SafeSocketHandle(handle, ownsHandle: true);
-            if (NetEventSource.IsEnabled) NetEventSource.Info(null, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, socket);
 
             return socket.IsInvalid ? GetLastSocketError() : SocketError.Success;
         }
@@ -986,7 +986,7 @@ namespace System.Net.Sockets
                                 IntPtr.Zero);
                     }
                 }
-                if (NetEventSource.IsEnabled)
+                if (NetEventSource.Log.IsEnabled())
                     NetEventSource.Info(null, $"Interop.Winsock.select returns socketCount:{socketCount}");
 
                 if ((SocketError)socketCount == SocketError.SocketError)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -30,7 +30,7 @@ namespace System.Net.Sockets
         // Initializes a new instance of the System.Net.Sockets.TcpClient class.
         public TcpClient(AddressFamily family)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, family);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, family);
 
             // Validate parameter
             if (family != AddressFamily.InterNetwork &&
@@ -43,13 +43,13 @@ namespace System.Net.Sockets
             _family = family;
             InitializeClientSocket();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Initializes a new instance of the System.Net.Sockets.TcpClient class with the specified end point.
         public TcpClient(IPEndPoint localEP)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, localEP);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, localEP);
 
             if (localEP == null)
             {
@@ -60,14 +60,14 @@ namespace System.Net.Sockets
             InitializeClientSocket();
             _clientSocket.Bind(localEP);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Initializes a new instance of the System.Net.Sockets.TcpClient class and connects to the specified port on
         // the specified host.
         public TcpClient(string hostname, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, hostname);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, hostname);
 
             if (hostname == null)
             {
@@ -88,18 +88,18 @@ namespace System.Net.Sockets
                 throw;
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Used by TcpListener.Accept().
         internal TcpClient(Socket acceptedSocket)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, acceptedSocket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, acceptedSocket);
 
             _clientSocket = acceptedSocket;
             _active = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Used by the class to indicate that a connection has been made.
@@ -139,7 +139,7 @@ namespace System.Net.Sockets
         // Connects the Client to the specified port on the specified host.
         public void Connect(string hostname, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, hostname);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, hostname);
 
             ThrowIfDisposed();
 
@@ -229,13 +229,13 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Connects the Client to the specified port on the specified host.
         public void Connect(IPAddress address, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, address);
 
             ThrowIfDisposed();
 
@@ -251,13 +251,13 @@ namespace System.Net.Sockets
             IPEndPoint remoteEP = new IPEndPoint(address, port);
             Connect(remoteEP);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Connect the Client to the specified end point.
         public void Connect(IPEndPoint remoteEP)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, remoteEP);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, remoteEP);
 
             ThrowIfDisposed();
 
@@ -270,47 +270,47 @@ namespace System.Net.Sockets
             _family = Client.AddressFamily;
             _active = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public void Connect(IPAddress[] ipAddresses, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, ipAddresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, ipAddresses);
 
             Client.Connect(ipAddresses, port);
             _family = Client.AddressFamily;
             _active = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public Task ConnectAsync(IPAddress address, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, address);
 
             Task result = CompleteConnectAsync(Client.ConnectAsync(address, port));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
         public Task ConnectAsync(string host, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, host);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, host);
 
             Task result = CompleteConnectAsync(Client.ConnectAsync(host, port));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
         public Task ConnectAsync(IPAddress[] addresses, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, addresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, addresses);
 
             Task result = CompleteConnectAsync(Client.ConnectAsync(addresses, port));
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
@@ -322,48 +322,48 @@ namespace System.Net.Sockets
 
         public IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, address);
 
             IAsyncResult result = Client.BeginConnect(address, port, requestCallback, state);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
         public IAsyncResult BeginConnect(string host, int port, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, (string)host);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, (string)host);
 
             IAsyncResult result = Client.BeginConnect(host, port, requestCallback, state);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
         public IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback? requestCallback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, addresses);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, addresses);
 
             IAsyncResult result = Client.BeginConnect(addresses, port, requestCallback, state);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
         public void EndConnect(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, asyncResult);
 
             _clientSocket.EndConnect(asyncResult);
             _active = true;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Returns the stream used to read and write data to the remote host.
         public NetworkStream GetStream()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             ThrowIfDisposed();
 
@@ -377,7 +377,7 @@ namespace System.Net.Sockets
                 _dataStream = new NetworkStream(Client, true);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, _dataStream);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, _dataStream);
             return _dataStream;
         }
 
@@ -386,7 +386,7 @@ namespace System.Net.Sockets
         // Disposes the Tcp connection.
         protected virtual void Dispose(bool disposing)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
             {
@@ -421,7 +421,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         public void Dispose() => Dispose(true);

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -19,21 +19,21 @@ namespace System.Net.Sockets
         // Initializes a new instance of the TcpListener class with the specified local end point.
         public TcpListener(IPEndPoint localEP)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, localEP);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, localEP);
             if (localEP == null)
             {
                 throw new ArgumentNullException(nameof(localEP));
             }
             _serverSocketEP = localEP;
             _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Initializes a new instance of the TcpListener class that listens to the specified IP address
         // and port.
         public TcpListener(IPAddress localaddr, int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this, localaddr);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this, localaddr);
             if (localaddr == null)
             {
                 throw new ArgumentNullException(nameof(localaddr));
@@ -45,7 +45,7 @@ namespace System.Net.Sockets
 
             _serverSocketEP = new IPEndPoint(localaddr, port);
             _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Initiailizes a new instance of the TcpListener class that listens on the specified port.
@@ -141,12 +141,12 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException(nameof(backlog));
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             // Already listening.
             if (_active)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
                 return;
             }
 
@@ -165,19 +165,19 @@ namespace System.Net.Sockets
             }
 
             _active = true;
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Closes the network connection.
         public void Stop()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             _serverSocket?.Dispose();
             _active = false;
             _serverSocket = null;
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
         }
 
         // Determine if there are pending connection requests.
@@ -194,7 +194,7 @@ namespace System.Net.Sockets
         // Accept the first pending connection
         public Socket AcceptSocket()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (!_active)
             {
@@ -203,13 +203,13 @@ namespace System.Net.Sockets
 
             Socket socket = _serverSocket!.Accept();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, socket);
             return socket;
         }
 
         public TcpClient AcceptTcpClient()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (!_active)
             {
@@ -219,13 +219,13 @@ namespace System.Net.Sockets
             Socket acceptedSocket = _serverSocket!.Accept();
             TcpClient returnValue = new TcpClient(acceptedSocket);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, returnValue);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, returnValue);
             return returnValue;
         }
 
         public IAsyncResult BeginAcceptSocket(AsyncCallback? callback, object? state)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (!_active)
             {
@@ -234,13 +234,13 @@ namespace System.Net.Sockets
 
             IAsyncResult result = _serverSocket!.BeginAccept(callback, state);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
             return result;
         }
 
         public Socket EndAcceptSocket(IAsyncResult asyncResult)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (asyncResult == null)
             {
@@ -257,7 +257,7 @@ namespace System.Net.Sockets
             // This will throw ObjectDisposedException if Stop() has been called.
             Socket socket = asyncSocket.EndAccept(asyncResult);
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this, socket);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this, socket);
             return socket;
         }
 
@@ -269,7 +269,7 @@ namespace System.Net.Sockets
 
         public Task<Socket> AcceptSocketAsync()
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(this);
 
             if (!_active)
             {
@@ -278,7 +278,7 @@ namespace System.Net.Sockets
 
             Task<Socket> result = _serverSocket!.AcceptAsync();
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(this);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(this);
 
             return result;
         }
@@ -295,7 +295,7 @@ namespace System.Net.Sockets
         // This creates a TcpListener that listens on both IPv4 and IPv6 on the given port.
         public static TcpListener Create(int port)
         {
-            if (NetEventSource.IsEnabled) NetEventSource.Enter(null, port);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(null, port);
 
             if (!TcpValidationHelpers.ValidatePortNumber(port))
             {
@@ -315,7 +315,7 @@ namespace System.Net.Sockets
                 listener = new TcpListener(IPAddress.Any, port);
             }
 
-            if (NetEventSource.IsEnabled) NetEventSource.Exit(null, port);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(null, port);
 
             return listener;
         }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -224,7 +224,7 @@ namespace System.Net.Sockets
         {
             if (disposing)
             {
-                if (NetEventSource.IsEnabled) NetEventSource.Info(this);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(this);
 
                 // The only resource we need to free is the network stream, since this
                 // is based on the client socket, closing the stream will cause us


### PR DESCRIPTION
Follow up to #38129. NetEventSource code was still left in even when EventSource.IsSupported is false, since all the usages of NetEventSource are keying off its own static property: NetEventSource.IsEnabled.

Remove NetEventSource.IsEnabled so the linker can trim NetEventSource code when EventSource.IsSupported is false.

cc @marek-safar 

This trims a little over 8 KB of IL in the CarChecker Blazor app, when EventSource.IsSupported is false.

| Build          | Size     |
|----------------|----------|
| master         | 3,719,168 bytes |
| proposed change   | 3,710,976 bytes |
