### PR TITLE
Remove illegal `delete` of `Instr` objects

### DIFF
--- a/src/coreclr/src/ilasm/assembler.cpp
+++ b/src/coreclr/src/ilasm/assembler.cpp
@@ -2021,7 +2021,6 @@ void Assembler::EmitInstrStringLiteral(Instr* instr, BinStr* literal, BOOL Conve
             }
             if(sz)  report->error("Failed to convert string '%s' to Unicode: %s\n",(char*)pb,sz);
             else    report->error("Failed to convert string '%s' to Unicode: error 0x%08X\n",(char*)pb,dw);
-            delete instr;
             goto OuttaHere;
         }
         L--;
@@ -2052,7 +2051,6 @@ void Assembler::EmitInstrStringLiteral(Instr* instr, BinStr* literal, BOOL Conve
     {
         report->error("Failed to add user string using DefineUserString, hr=0x%08x, data: '%S'\n",
                hr, UnicodeString);
-        delete instr;
     }
     else
     {
@@ -2077,7 +2075,6 @@ void Assembler::EmitInstrSig(Instr* instr, BinStr* sig)
     if (FAILED(m_pEmitter->GetTokenFromSig(mySig, cSig, &MetadataToken)))
     {
         report->error("Unable to convert signature to metadata token.\n");
-        delete instr;
     }
     else
     {


### PR DESCRIPTION
`Instr` objects come from a static pool and should not be deleted
with `delete`. Instead, they are marked no longer used by setting
their `opcode` field to -1.

Fixes #12433