### PR TITLE
Add tizen-arm64 RIDs

### DIFF
--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -4606,6 +4606,18 @@
     "any",
     "base"
   ],
+  "tizen.4.0.0-arm64": [
+    "tizen.4.0.0-arm64",
+    "tizen.4.0.0",
+    "tizen-arm64",
+    "tizen",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "tizen.4.0.0-armel": [
     "tizen.4.0.0-armel",
     "tizen.4.0.0",
@@ -4635,6 +4647,20 @@
     "tizen.4.0.0",
     "tizen",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "tizen.5.0.0-arm64": [
+    "tizen.5.0.0-arm64",
+    "tizen.5.0.0",
+    "tizen.4.0.0-arm64",
+    "tizen.4.0.0",
+    "tizen-arm64",
+    "tizen",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -4673,6 +4699,22 @@
     "tizen.4.0.0",
     "tizen",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "tizen.5.5.0-arm64": [
+    "tizen.5.5.0-arm64",
+    "tizen.5.5.0",
+    "tizen.5.0.0-arm64",
+    "tizen.5.0.0",
+    "tizen.4.0.0-arm64",
+    "tizen.4.0.0",
+    "tizen-arm64",
+    "tizen",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
     "unix",
     "any",
     "base"
@@ -4723,14 +4765,17 @@
   "tizen.6.0.0-arm64": [
     "tizen.6.0.0-arm64",
     "tizen.6.0.0",
-    "tizen-arm64",
+    "tizen.5.5.0-arm64",
     "tizen.5.5.0",
+    "tizen.5.0.0-arm64",
+    "tizen.5.0.0",
+    "tizen.4.0.0-arm64",
+    "tizen.4.0.0",
+    "tizen-arm64",
     "tizen",
     "linux-arm64",
-    "tizen.5.0.0",
     "linux",
     "unix-arm64",
-    "tizen.4.0.0",
     "unix",
     "any",
     "base"

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.compatibility.json
@@ -4568,6 +4568,16 @@
     "any",
     "base"
   ],
+  "tizen-arm64": [
+    "tizen-arm64",
+    "tizen",
+    "linux-arm64",
+    "linux",
+    "unix-arm64",
+    "unix",
+    "any",
+    "base"
+  ],
   "tizen-armel": [
     "tizen-armel",
     "tizen",
@@ -4706,6 +4716,21 @@
     "tizen.4.0.0",
     "tizen",
     "linux",
+    "unix",
+    "any",
+    "base"
+  ],
+  "tizen.6.0.0-arm64": [
+    "tizen.6.0.0-arm64",
+    "tizen.6.0.0",
+    "tizen-arm64",
+    "tizen.5.5.0",
+    "tizen",
+    "linux-arm64",
+    "tizen.5.0.0",
+    "linux",
+    "unix-arm64",
+    "tizen.4.0.0",
     "unix",
     "any",
     "base"

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1975,6 +1975,12 @@
         "linux"
       ]
     },
+    "tizen-arm64": {
+      "#import": [
+        "tizen",
+        "linux-arm64"
+      ]
+    },
     "tizen-armel": {
       "#import": [
         "tizen",
@@ -2041,6 +2047,12 @@
     "tizen.6.0.0": {
       "#import": [
         "tizen.5.5.0"
+      ]
+    },
+    "tizen.6.0.0-arm64": {
+      "#import": [
+        "tizen.6.0.0",
+        "tizen-arm64"
       ]
     },
     "tizen.6.0.0-armel": {

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -1998,6 +1998,12 @@
         "tizen"
       ]
     },
+    "tizen.4.0.0-arm64": {
+      "#import": [
+        "tizen.4.0.0",
+        "tizen-arm64"
+      ]
+    },
     "tizen.4.0.0-armel": {
       "#import": [
         "tizen.4.0.0",
@@ -2015,6 +2021,12 @@
         "tizen.4.0.0"
       ]
     },
+    "tizen.5.0.0-arm64": {
+      "#import": [
+        "tizen.5.0.0",
+        "tizen.4.0.0-arm64"
+      ]
+    },
     "tizen.5.0.0-armel": {
       "#import": [
         "tizen.5.0.0",
@@ -2030,6 +2042,12 @@
     "tizen.5.5.0": {
       "#import": [
         "tizen.5.0.0"
+      ]
+    },
+    "tizen.5.5.0-arm64": {
+      "#import": [
+        "tizen.5.5.0",
+        "tizen.5.0.0-arm64"
       ]
     },
     "tizen.5.5.0-armel": {
@@ -2052,7 +2070,7 @@
     "tizen.6.0.0-arm64": {
       "#import": [
         "tizen.6.0.0",
-        "tizen-arm64"
+        "tizen.5.5.0-arm64"
       ]
     },
     "tizen.6.0.0-armel": {

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -192,6 +192,11 @@
       <Architectures>x86;armel</Architectures>
       <Versions>4.0.0;5.0.0;5.5.0;6.0.0</Versions>
     </RuntimeGroup>
+    <RuntimeGroup Include="tizen">
+      <Parent>linux</Parent>
+      <Architectures>arm64</Architectures>
+      <Versions>6.0.0</Versions>
+    </RuntimeGroup>
 
     <RuntimeGroup Include="tvos">
       <Parent>unix</Parent>

--- a/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
+++ b/src/libraries/pkg/Microsoft.NETCore.Platforms/runtimeGroups.props
@@ -189,13 +189,8 @@
 
     <RuntimeGroup Include="tizen">
       <Parent>linux</Parent>
-      <Architectures>x86;armel</Architectures>
+      <Architectures>x86;armel;arm64</Architectures>
       <Versions>4.0.0;5.0.0;5.5.0;6.0.0</Versions>
-    </RuntimeGroup>
-    <RuntimeGroup Include="tizen">
-      <Parent>linux</Parent>
-      <Architectures>arm64</Architectures>
-      <Versions>6.0.0</Versions>
     </RuntimeGroup>
 
     <RuntimeGroup Include="tvos">


### PR DESCRIPTION
Since tizen 6.0.0, arm64 will be supported.
