### PR TITLE
Mmap R2R images at and non-page-boundary

### DIFF
--- a/src/coreclr/src/inc/pedecoder.h
+++ b/src/coreclr/src/inc/pedecoder.h
@@ -131,6 +131,7 @@ class PEDecoder
     PEDecoder();
     PEDecoder(void *flatBase, COUNT_T size);              // flatBase is the raw disk layout data (using MapViewOfFile)
     PEDecoder(PTR_VOID mappedBase, bool relocated = FALSE);  // mappedBase is the mapped/expanded file (using LoadLibrary)
+    virtual ~PEDecoder();
 
     void Init(void *flatBase, COUNT_T size);
     HRESULT Init(void *mappedBase, bool relocated = FALSE);
@@ -138,6 +139,7 @@ class PEDecoder
 
     PTR_VOID GetBase() const;            // Currently loaded base, as opposed to GetPreferredBase()
     BOOL IsMapped() const;
+    virtual BOOL IsInBundle() const;
     BOOL IsRelocated() const;
     BOOL IsFlat() const;
     BOOL HasContents() const;

--- a/src/coreclr/src/inc/pedecoder.inl
+++ b/src/coreclr/src/inc/pedecoder.inl
@@ -56,6 +56,14 @@ inline BOOL PEDecoder::IsMapped() const
     return (m_flags & FLAG_MAPPED) != 0;
 }
 
+inline BOOL PEDecoder::IsInBundle() const
+{
+    LIMITED_METHOD_CONTRACT;
+    SUPPORTS_DAC;
+
+    return false;
+}
+
 inline BOOL PEDecoder::IsRelocated() const
 {
     LIMITED_METHOD_CONTRACT;
@@ -1411,6 +1419,16 @@ inline READYTORUN_HEADER * PEDecoder::GetReadyToRunHeader() const
         RETURN m_pReadyToRunHeader;
 
     RETURN FindReadyToRunHeader();
+}
+
+inline PEDecoder::~PEDecoder()
+{
+    CONTRACTL
+    {
+        DESTRUCTOR_CHECK;
+        NOTHROW;
+    }
+    CONTRACTL_END;
 }
 
 #endif // _PEDECODER_INL_

--- a/src/coreclr/src/pal/src/map/map.cpp
+++ b/src/coreclr/src/pal/src/map/map.cpp
@@ -2138,6 +2138,18 @@ MAPRecordMapping(
     return palError;
 }
 
+static size_t OffsetWithinPage(off_t offset)
+{
+    return offset & (GetVirtualPageSize() - 1);
+}
+
+static size_t RoundToPage(size_t size, off_t offset)
+{
+    size_t result = size + OffsetWithinPage(offset);
+    _ASSERTE(result >= size);
+    return result;
+}
+
 // Do the actual mmap() call, and record the mapping in the MappedViewList list.
 // This call assumes the mapping_critsec has already been taken.
 static PAL_ERROR
@@ -2156,9 +2168,13 @@ MAPmmapAndRecord(
     _ASSERTE(pPEBaseAddress != NULL);
 
     PAL_ERROR palError = NO_ERROR;
-    off_t adjust = offset & (GetVirtualPageSize() - 1);
+    off_t adjust = OffsetWithinPage(offset);
     LPVOID pvBaseAddress = static_cast<char *>(addr) - adjust;
 
+    // Ensure address and offset arguments mmap() are page-aligned.
+    _ASSERTE(OffsetWithinPage(offset - adjust) == 0);
+    _ASSERTE(OffsetWithinPage((off_t)pvBaseAddress) == 0);
+    
 #ifdef __APPLE__
     if ((prot & PROT_EXEC) != 0 && IsRunningOnMojaveHardenedRuntime())
     {
@@ -2177,7 +2193,7 @@ MAPmmapAndRecord(
     else
 #endif
     {
-        pvBaseAddress = mmap(static_cast<char *>(addr) - adjust, len + adjust, prot, flags, fd, offset - adjust);
+        pvBaseAddress = mmap(pvBaseAddress, len + adjust, prot, flags, fd, offset - adjust);
         if (MAP_FAILED == pvBaseAddress)
         {
             ERROR_(LOADER)( "mmap failed with code %d: %s.\n", errno, strerror( errno ) );
@@ -2361,7 +2377,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     // We're going to start adding mappings to the mapping list, so take the critical section
     InternalEnterCriticalSection(pThread, &mapping_critsec);
 
-    reserveSize = virtualSize;
+    reserveSize = RoundToPage(virtualSize, offset);
     if ((ntHeader.OptionalHeader.SectionAlignment) > GetVirtualPageSize())
     {
         reserveSize += ntHeader.OptionalHeader.SectionAlignment;
@@ -2426,6 +2442,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
 
     size_t headerSize;
     headerSize = GetVirtualPageSize(); // if there are lots of sections, this could be wrong
+    headerSize = RoundToPage(headerSize, offset);
 
     if (forceOveralign)
     {
@@ -2442,11 +2459,14 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     //we have now reserved memory (potentially we got rebased).  Walk the PE sections and map each part
     //separately.
 
-
     //first, map the PE header to the first page in the image.  Get pointers to the section headers
+    loadedHeader = (IMAGE_DOS_HEADER*)(static_cast<char*>(loadedBase) + OffsetWithinPage(offset));
+
+    LPVOID loadedHeaderBase;
+    loadedHeaderBase = NULL;
     palError = MAPmmapAndRecord(pFileObject, loadedBase,
-                    loadedBase, headerSize, PROT_READ, readOnlyFlags, fd, offset,
-                    (void**)&loadedHeader);
+                    (LPVOID)loadedHeader, headerSize, PROT_READ, readOnlyFlags, fd, offset,
+                    &loadedHeaderBase);
     if (NO_ERROR != palError)
     {
         ERROR_(LOADER)( "mmap of PE header failed\n" );
@@ -2454,7 +2474,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     }
 
     TRACE_(LOADER)("PE header loaded @ %p\n", loadedHeader);
-    _ASSERTE(loadedHeader == loadedBase); // we already preallocated the space, and we used MAP_FIXED, so we should have gotten this address
+    _ASSERTE(loadedHeaderBase == loadedBase); // we already preallocated the space, and we used MAP_FIXED, so we should have gotten this address
     IMAGE_SECTION_HEADER * firstSection;
     firstSection = (IMAGE_SECTION_HEADER*)(((char *)loadedHeader)
                                            + loadedHeader->e_lfanew
@@ -2466,9 +2486,9 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     // Validation
     char* sectionHeaderEnd;
     sectionHeaderEnd = (char*)firstSection + numSections * sizeof(IMAGE_SECTION_HEADER);
-    if (   ((void*)firstSection < loadedBase)
+    if (   ((void*)firstSection < loadedHeader)
         || ((char*)firstSection > sectionHeaderEnd)
-        || (sectionHeaderEnd > (char*)loadedBase + virtualSize)
+        || (sectionHeaderEnd > (char*)loadedHeader + virtualSize)
         )
     {
         ERROR_(LOADER)( "image is corrupt\n" );
@@ -2477,7 +2497,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     }
 
     void* prevSectionEnd;
-    prevSectionEnd = (char*)loadedBase + headerSize; // the first "section" for our purposes is the header
+    prevSectionEnd = (char*)loadedHeader + headerSize; // the first "section" for our purposes is the header
     for (unsigned i = 0; i < numSections; ++i)
     {
         //for each section, map the section of the file to the correct virtual offset.  Gather the
@@ -2486,13 +2506,13 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
         int prot = 0;
         IMAGE_SECTION_HEADER &currentHeader = firstSection[i];
 
-        void* sectionBase = (char*)loadedBase + currentHeader.VirtualAddress;
+        void* sectionBase = (char*)loadedHeader + currentHeader.VirtualAddress;
         void* sectionBaseAligned = ALIGN_DOWN(sectionBase, GetVirtualPageSize());
 
         // Validate the section header
-        if (   (sectionBase < loadedBase)                                                           // Did computing the section base overflow?
+        if (   (sectionBase < loadedHeader)                                                           // Did computing the section base overflow?
             || ((char*)sectionBase + currentHeader.SizeOfRawData < (char*)sectionBase)              // Does the section overflow?
-            || ((char*)sectionBase + currentHeader.SizeOfRawData > (char*)loadedBase + virtualSize) // Does the section extend past the end of the image as the header stated?
+            || ((char*)sectionBase + currentHeader.SizeOfRawData > (char*)loadedHeader + virtualSize) // Does the section extend past the end of the image as the header stated?
             || (prevSectionEnd > sectionBase)                                                       // Does this section overlap the previous one?
             )
         {
@@ -2601,7 +2621,7 @@ done:
 
     if (palError == ERROR_SUCCESS)
     {
-        retval = loadedBase;
+        retval = loadedHeader;
         LOGEXIT("MAPMapPEFile returns %p\n", retval);
     }
     else

--- a/src/coreclr/src/utilcode/pedecoder.cpp
+++ b/src/coreclr/src/utilcode/pedecoder.cpp
@@ -291,7 +291,11 @@ CHECK PEDecoder::CheckNTHeaders() const
         // Ideally we would require the layout address to honor the section alignment constraints.
         // However, we do have 8K aligned IL only images which we load on 32 bit platforms. In this
         // case, we can only guarantee OS page alignment (which after all, is good enough.)
-        CHECK(CheckAligned(m_base, GetOsPageSize()));
+
+        // In the case of files embedded within a single-file app, the default alignment for assemblies is 16 bytes.
+        UINT alignment = IsInBundle() ? 16 : GetOsPageSize();
+
+        CHECK(CheckAligned(m_base, alignment));
     }
 
     // @todo: check NumberOfSections for overflow of SizeOfHeaders

--- a/src/coreclr/src/vm/peimagelayout.h
+++ b/src/coreclr/src/vm/peimagelayout.h
@@ -70,6 +70,7 @@ public:
     const SString& GetPath();
 
     void ApplyBaseRelocations();
+    virtual BOOL IsInBundle() const;
 
 public:
 #ifdef DACCESS_COMPILE

--- a/src/coreclr/src/vm/peimagelayout.inl
+++ b/src/coreclr/src/vm/peimagelayout.inl
@@ -117,4 +117,9 @@ inline BOOL PEImageLayout::CompareBase(UPTR base, UPTR mapping)
 
 }
 
+inline BOOL PEImageLayout::IsInBundle() const
+{
+    return m_pOwner->IsInBundle();
+}
+
 #endif //PEIMAGEVIEW_INL_


### PR DESCRIPTION
Assemblies embedded within a single-file are aligned at 16 byte boundaries.

However, currently MappedImageLayout assumes that assemblies are mapped at 4K offsets.
This results in map failure and subsequent failure to load the image in a mapped layout.
Subsequently, the image was loaded as IL as a fallback.

The change fixes this problem by:

mmap() pages containing sections/headers using appropriate ROUND_DOWN and ROUND_UP operations
Load sections at unaligned offsets in MAPMapPEFile.

Fixes: #38061