### PR TITLE
Remove static variable holding unboxing stubs

### DIFF
--- a/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/src/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1010,7 +1010,14 @@ namespace Internal.JitInterface
                 else
                 {
                     var methodContext = (MethodDesc)typeOrMethodContext;
-                    Debug.Assert((!methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
+                    // Allow cases where the method's do not have instantiations themselves, if
+                    // 1. The method defining the context is generic, but the target method is not
+                    // 2. Both methods are not generic
+                    // 3. The methods are the same generic
+                    // AND
+                    // The methods are on the same type
+                    Debug.Assert((methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
+                        (!methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
                         methodContext.GetTypicalMethodDefinition() == owningMethod.GetTypicalMethodDefinition() ||
                         (owningMethod.Name == "CreateDefaultInstance" && methodContext.Name == "CreateInstance"));
                     Debug.Assert(methodContext.OwningType.HasSameTypeDefinition(owningMethod.OwningType));

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadMethodImport.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelayLoadMethodImport.cs
@@ -21,7 +21,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
             MethodWithGCInfo localMethod,
-            bool isUnboxingStub,
             bool isInstantiatingStub)
             : base(
                   factory,
@@ -30,7 +29,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                   factory.MethodSignature(
                       fixupKind,
                       method,
-                      isUnboxingStub,
                       isInstantiatingStub))
         {
             _localMethod = localMethod;

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DelegateCtorSignature.cs
@@ -44,11 +44,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 SignatureContext innerContext = builder.EmitFixup(factory, ReadyToRunFixupKind.DelegateCtor, _methodToken.Module, factory.SignatureContext);
 
                 builder.EmitMethodSignature(
-                    new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null),
+                    new MethodWithToken(_targetMethod.Method, _methodToken, constrainedType: null, unboxing: false),
                     enforceDefEncoding: false,
                     enforceOwningType: false,
                     innerContext,
-                    isUnboxingStub: false,
                     isInstantiatingStub: _targetMethod.Method.HasInstantiation);
 
                 builder.EmitTypeSignature(_delegateType, innerContext);

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GenericLookupSignature.cs
@@ -106,12 +106,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             dataBuilder.EmitByte((byte)_fixupKind);
             if (_methodArgument != null)
             {
+                Debug.Assert(_methodArgument.Unboxing == false);
+
                 dataBuilder.EmitMethodSignature(
                     _methodArgument,
                     enforceDefEncoding: false,
                     enforceOwningType: false,
                     context: innerContext,
-                    isUnboxingStub: false,
                     isInstantiatingStub: true);
             }
             else if (_typeArgument != null)

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/InstanceEntryPointTableNode.cs
@@ -62,11 +62,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
                 ArraySignatureBuilder signatureBuilder = new ArraySignatureBuilder();
                 signatureBuilder.EmitMethodSignature(
-                    new MethodWithToken(method.Method, moduleToken, constrainedType: null),
+                    new MethodWithToken(method.Method, moduleToken, constrainedType: null, unboxing: false),
                     enforceDefEncoding: true,
                     enforceOwningType: _factory.CompilationModuleGroup.EnforceOwningType(moduleToken.Module),
                     factory.SignatureContext,
-                    isUnboxingStub: false,
                     isInstantiatingStub: false);
                 byte[] signature = signatureBuilder.ToArray();
                 BlobVertex signatureBlob;

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -19,19 +19,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly MethodWithToken _method;
 
-        private readonly bool _isUnboxingStub;
-
         private readonly bool _isInstantiatingStub;
 
         public MethodFixupSignature(
             ReadyToRunFixupKind fixupKind, 
-            MethodWithToken method, 
-            bool isUnboxingStub,
+            MethodWithToken method,
             bool isInstantiatingStub)
         {
             _fixupKind = fixupKind;
             _method = method;
-            _isUnboxingStub = isUnboxingStub;
             _isInstantiatingStub = isInstantiatingStub;
 
             // Ensure types in signature are loadable and resolvable, otherwise we'll fail later while emitting the signature
@@ -45,7 +41,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public override int ClassCode => 150063499;
 
-        public bool IsUnboxingStub => _isUnboxingStub;
+        public bool IsUnboxingStub => _method.Unboxing;
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
         {
@@ -61,7 +57,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Optimize some of the fixups into a more compact form
             ReadyToRunFixupKind fixupKind = _fixupKind;
             bool optimized = false;
-            if (!_isUnboxingStub && !_isInstantiatingStub && _method.ConstrainedType == null &&
+            if (!_method.Unboxing && !_isInstantiatingStub && _method.ConstrainedType == null &&
                 fixupKind == ReadyToRunFixupKind.MethodEntry)
             {
                 if (!_method.Method.OwningType.HasInstantiation && !_method.Method.OwningType.IsArray)
@@ -85,13 +81,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 if (method.Token.TokenType == CorTokenType.mdtMethodSpec)
                 {
-                    method = new MethodWithToken(method.Method, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType);
+                    method = new MethodWithToken(method.Method, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType, unboxing: _method.Unboxing);
                 }
                 else if (!optimized && (method.Token.TokenType == CorTokenType.mdtMemberRef))
                 {
                     if (method.Method.OwningType.GetTypeDefinition() is EcmaType)
                     {
-                        method = new MethodWithToken(method.Method, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType);
+                        method = new MethodWithToken(method.Method, factory.SignatureContext.GetModuleTokenForMethod(method.Method, throwIfNotFound: false), method.ConstrainedType, unboxing: _method.Unboxing);
                     }
                 }
             }
@@ -108,7 +104,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
             else
             {
-                dataBuilder.EmitMethodSignature(method, enforceDefEncoding: false, enforceOwningType: false, innerContext, _isUnboxingStub, _isInstantiatingStub);
+                dataBuilder.EmitMethodSignature(method, enforceDefEncoding: false, enforceOwningType: false, innerContext, _isInstantiatingStub);
             }
 
             return dataBuilder.ToObjectData();
@@ -119,10 +115,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             sb.Append(nameMangler.CompilationUnitPrefix);
             sb.Append($@"MethodFixupSignature(");
             sb.Append(_fixupKind.ToString());
-            if (_isUnboxingStub)
-            {
-                sb.Append(" [UNBOX]");
-            }
             if (_isInstantiatingStub)
             {
                 sb.Append(" [INST]");
@@ -135,10 +127,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             MethodFixupSignature otherNode = (MethodFixupSignature)other;
             int result = ((int)_fixupKind).CompareTo((int)otherNode._fixupKind);
-            if (result != 0)
-                return result;
-
-            result = _isUnboxingStub.CompareTo(otherNode._isUnboxingStub);
             if (result != 0)
                 return result;
 

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeMethodImport.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/PrecodeMethodImport.cs
@@ -22,14 +22,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
             MethodWithGCInfo localMethod,
-            bool isUnboxingStub,
             bool isInstantiatingStub) :
             base (
                 factory,
                 factory.MethodSignature(
                       fixupKind,
                       method,
-                      isUnboxingStub,
                       isInstantiatingStub)
             )
         {

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/SignatureBuilder.cs
@@ -396,11 +396,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             bool enforceDefEncoding,
             bool enforceOwningType,
             SignatureContext context,
-            bool isUnboxingStub,
             bool isInstantiatingStub)
         {
             uint flags = 0;
-            if (isUnboxingStub)
+            if (method.Unboxing)
             {
                 flags |= (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub;
             }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -224,7 +224,6 @@ namespace ILCompiler.DependencyAnalysis
                 return new MethodFixupSignature(
                     key.FixupKind,
                     key.TypeAndMethod.Method,
-                    key.TypeAndMethod.IsUnboxingStub,
                     key.TypeAndMethod.IsInstantiatingStub
                 );
             });
@@ -246,7 +245,6 @@ namespace ILCompiler.DependencyAnalysis
                     MethodSignature(
                         ReadyToRunFixupKind.VirtualEntry,
                         key.Method,
-                        isUnboxingStub: key.IsUnboxingStub,
                         isInstantiatingStub: key.IsInstantiatingStub));
             });
 
@@ -347,7 +345,6 @@ namespace ILCompiler.DependencyAnalysis
         private IMethodNode CreateMethodEntrypoint(TypeAndMethod key)
         {
             MethodWithToken method = key.Method;
-            bool isUnboxingStub = key.IsUnboxingStub;
             bool isInstantiatingStub = key.IsInstantiatingStub;
             bool isPrecodeImportRequired = key.IsPrecodeImportRequired;
             MethodDesc compilableMethod = method.Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
@@ -365,7 +362,6 @@ namespace ILCompiler.DependencyAnalysis
                     ReadyToRunFixupKind.MethodEntry,
                     method,
                     methodWithGCInfo,
-                    isUnboxingStub,
                     isInstantiatingStub);
             }
             else
@@ -375,14 +371,13 @@ namespace ILCompiler.DependencyAnalysis
                     ReadyToRunFixupKind.MethodEntry,
                     method,
                     methodWithGCInfo,
-                    isUnboxingStub,
                     isInstantiatingStub);
             }
         }
 
-        public IMethodNode MethodEntrypoint(MethodWithToken method, bool isUnboxingStub, bool isInstantiatingStub, bool isPrecodeImportRequired)
+        public IMethodNode MethodEntrypoint(MethodWithToken method, bool isInstantiatingStub, bool isPrecodeImportRequired)
         {
-            TypeAndMethod key = new TypeAndMethod(method.ConstrainedType, method, isUnboxingStub, isInstantiatingStub, isPrecodeImportRequired);
+            TypeAndMethod key = new TypeAndMethod(method.ConstrainedType, method, isInstantiatingStub, isPrecodeImportRequired);
             return _importMethods.GetOrAdd(key);
         }
 
@@ -401,7 +396,7 @@ namespace ILCompiler.DependencyAnalysis
                 EcmaModule module = ((EcmaMethod)method.GetTypicalMethodDefinition()).Module;
                 ModuleToken moduleToken = Resolver.GetModuleTokenForMethod(method, throwIfNotFound: true);
 
-                IMethodNode methodNodeDebug = MethodEntrypoint(new MethodWithToken(method, moduleToken, constrainedType: null), false, false, false);
+                IMethodNode methodNodeDebug = MethodEntrypoint(new MethodWithToken(method, moduleToken, constrainedType: null, unboxing: false), false, false);
                 MethodWithGCInfo methodCodeNodeDebug = methodNodeDebug as MethodWithGCInfo;
                 if (methodCodeNodeDebug == null && methodNodeDebug is DelayLoadMethodImport DelayLoadMethodImport)
                 {
@@ -453,10 +448,9 @@ namespace ILCompiler.DependencyAnalysis
         public MethodFixupSignature MethodSignature(
             ReadyToRunFixupKind fixupKind,
             MethodWithToken method,
-            bool isUnboxingStub,
             bool isInstantiatingStub)
         {
-            TypeAndMethod key = new TypeAndMethod(method.ConstrainedType, method, isUnboxingStub, isInstantiatingStub, false);
+            TypeAndMethod key = new TypeAndMethod(method.ConstrainedType, method, isInstantiatingStub, false);
             return _methodSignatures.GetOrAdd(new MethodFixupKey(fixupKind, key));
         }
 

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/TypeAndMethod.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/TypeAndMethod.cs
@@ -15,15 +15,13 @@ namespace ILCompiler.DependencyAnalysis
     {
         public readonly TypeDesc Type;
         public readonly MethodWithToken Method;
-        public readonly bool IsUnboxingStub;
         public readonly bool IsInstantiatingStub;
         public readonly bool IsPrecodeImportRequired;
 
-        public TypeAndMethod(TypeDesc type, MethodWithToken method, bool isUnboxingStub, bool isInstantiatingStub, bool isPrecodeImportRequired)
+        public TypeAndMethod(TypeDesc type, MethodWithToken method, bool isInstantiatingStub, bool isPrecodeImportRequired)
         {
             Type = type;
             Method = method;
-            IsUnboxingStub = isUnboxingStub;
             IsInstantiatingStub = isInstantiatingStub;
             IsPrecodeImportRequired = isPrecodeImportRequired;
         }
@@ -32,7 +30,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             return Type == other.Type &&
                    Method.Equals(other.Method) &&
-                   IsUnboxingStub == other.IsUnboxingStub &&
                    IsInstantiatingStub == other.IsInstantiatingStub &&
                    IsPrecodeImportRequired == other.IsPrecodeImportRequired;
         }
@@ -46,7 +43,6 @@ namespace ILCompiler.DependencyAnalysis
         {
             return (Type?.GetHashCode() ?? 0) ^
                 unchecked(Method.GetHashCode() * 31) ^
-                (IsUnboxingStub ? -0x80000000 : 0) ^
                 (IsInstantiatingStub ? 0x40000000 : 0) ^
                 (IsPrecodeImportRequired ? 0x20000000 : 0);
         }

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -30,12 +30,15 @@ namespace Internal.JitInterface
         public readonly MethodDesc Method;
         public readonly ModuleToken Token;
         public readonly TypeDesc ConstrainedType;
+        public readonly bool Unboxing;
 
-        public MethodWithToken(MethodDesc method, ModuleToken token, TypeDesc constrainedType)
+        public MethodWithToken(MethodDesc method, ModuleToken token, TypeDesc constrainedType, bool unboxing)
         {
+            Debug.Assert(!method.IsUnboxingThunk());
             Method = method;
             Token = token;
             ConstrainedType = constrainedType;
+            Unboxing = unboxing;
         }
 
         public override bool Equals(object obj)
@@ -51,7 +54,7 @@ namespace Internal.JitInterface
 
         public bool Equals(MethodWithToken methodWithToken)
         {
-            return Method == methodWithToken.Method && Token.Equals(methodWithToken.Token) && ConstrainedType == methodWithToken.ConstrainedType;
+            return Method == methodWithToken.Method && Token.Equals(methodWithToken.Token) && ConstrainedType == methodWithToken.ConstrainedType && Unboxing == methodWithToken.Unboxing;
         }
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
@@ -64,6 +67,8 @@ namespace Internal.JitInterface
             }
             sb.Append("; ");
             sb.Append(Token.ToString());
+            if (Unboxing)
+                sb.Append("; UNBOXING");
         }
 
         public int CompareTo(MethodWithToken other, TypeSystemComparer comparer)
@@ -85,7 +90,11 @@ namespace Internal.JitInterface
             if (result != 0)
                 return result;
 
-            return Token.CompareTo(other.Token);
+            result = Token.CompareTo(other.Token);
+            if (result != 0)
+                return result;
+
+            return Unboxing.CompareTo(other.Unboxing);
         }
     }
 
@@ -140,8 +149,7 @@ namespace Internal.JitInterface
         private OffsetMapping[] _debugLocInfos;
         private NativeVarInfo[] _debugVarInfos;
         private ArrayBuilder<MethodDesc> _inlinedMethods;
-
-        private static readonly UnboxingMethodDescFactory s_unboxingThunkFactory = new UnboxingMethodDescFactory();
+        private UnboxingMethodDescFactory _unboxingThunkFactory = new UnboxingMethodDescFactory();
 
         public CorInfoImpl(ReadyToRunCodegenCompilation compilation)
             : this()
@@ -305,7 +313,7 @@ namespace Internal.JitInterface
                         object helperArg = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
                         if (helperArg is MethodDesc methodDesc)
                         {
-                            helperArg = new MethodWithToken(methodDesc, HandleToModuleToken(ref pResolvedToken), constrainedType);
+                            helperArg = new MethodWithToken(methodDesc, HandleToModuleToken(ref pResolvedToken), constrainedType, unboxing: false);
                         }
 
                         GenericContext methodContext = new GenericContext(entityFromContext(pResolvedToken.tokenContext));
@@ -333,7 +341,9 @@ namespace Internal.JitInterface
 #endif
 
             TypeDesc delegateTypeDesc = HandleToObject(delegateType);
-            MethodWithToken targetMethod = new MethodWithToken(HandleToObject(pTargetMethod.hMethod), HandleToModuleToken(ref pTargetMethod), constrainedType: null);
+            MethodDesc targetMethodDesc = HandleToObject(pTargetMethod.hMethod);
+            Debug.Assert(!targetMethodDesc.IsUnboxingThunk());
+            MethodWithToken targetMethod = new MethodWithToken(targetMethodDesc, HandleToModuleToken(ref pTargetMethod), constrainedType: null, unboxing: false);
 
             pLookup.lookupKind.needsRuntimeLookup = false;
             pLookup.constLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.DelegateCtor(delegateTypeDesc, targetMethod));
@@ -1554,8 +1564,7 @@ namespace Internal.JitInterface
 
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
                             _compilation.SymbolNodeFactory.InterfaceDispatchCell(
-                                new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType: null),
-                                isUnboxingStub: false,
+                                new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType: null, unboxing: false),
                                 MethodBeingCompiled));
                         }
                     break;
@@ -1589,8 +1598,7 @@ namespace Internal.JitInterface
                         // READYTORUN: FUTURE: Direct calls if possible
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
                             _compilation.NodeFactory.MethodEntrypoint(
-                                new MethodWithToken(nonUnboxingMethod, HandleToModuleToken(ref pResolvedToken, nonUnboxingMethod), constrainedType),
-                                isUnboxingStub,
+                                new MethodWithToken(nonUnboxingMethod, HandleToModuleToken(ref pResolvedToken, nonUnboxingMethod), constrainedType, unboxing: isUnboxingStub),
                                 isInstantiatingStub: useInstantiatingStub,
                                 isPrecodeImportRequired: (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_LDFTN) != 0));
                     }
@@ -1607,7 +1615,7 @@ namespace Internal.JitInterface
                         bool atypicalCallsite = (flags & CORINFO_CALLINFO_FLAGS.CORINFO_CALLINFO_ATYPICAL_CALLSITE) != 0;
                         pResult->codePointerOrStubLookup.constLookup = CreateConstLookupToSymbol(
                             _compilation.NodeFactory.DynamicHelperCell(
-                                new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType: null),
+                                new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType: null, unboxing: false),
                                 useInstantiatingStub));
 
                         Debug.Assert(!pResult->sig.hasTypeArg());
@@ -1634,7 +1642,7 @@ namespace Internal.JitInterface
                     {
                         pResult->instParamLookup = CreateConstLookupToSymbol(_compilation.SymbolNodeFactory.CreateReadyToRunHelper(
                             ReadyToRunHelperId.MethodDictionary,
-                            new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType)));
+                            new MethodWithToken(targetMethod, HandleToModuleToken(ref pResolvedToken, targetMethod), constrainedType, unboxing: false)));
                     }
                     else
                     {
@@ -1865,14 +1873,15 @@ namespace Internal.JitInterface
                             MethodDesc md = HandleToObject(pResolvedToken.hMethod);
                             TypeDesc td = HandleToObject(pResolvedToken.hClass);
 
+                            bool unboxingStub = false;
                             if ((td.IsValueType) && !md.Signature.IsStatic)
                             {
-                                md = getUnboxingThunk(md);
+                                unboxingStub = true;
                             }
 
                             symbolNode = _compilation.SymbolNodeFactory.CreateReadyToRunHelper(
                                 ReadyToRunHelperId.MethodHandle,
-                                new MethodWithToken(md, HandleToModuleToken(ref pResolvedToken), constrainedType: null));
+                                new MethodWithToken(md, HandleToModuleToken(ref pResolvedToken), constrainedType: null, unboxing: unboxingStub));
                         }
                         break;
 
@@ -1892,7 +1901,7 @@ namespace Internal.JitInterface
 
         private MethodDesc getUnboxingThunk(MethodDesc method)
         {
-            return s_unboxingThunkFactory.GetUnboxingMethod(method);
+            return _unboxingThunkFactory.GetUnboxingMethod(method);
         }
 
         private CORINFO_METHOD_STRUCT_* embedMethodHandle(CORINFO_METHOD_STRUCT_* handle, ref void* ppIndirection)
@@ -2100,7 +2109,7 @@ namespace Internal.JitInterface
                 methodDesc = rawPInvoke.Target;
             EcmaMethod ecmaMethod = (EcmaMethod)methodDesc;
             ModuleToken moduleToken = new ModuleToken(ecmaMethod.Module, ecmaMethod.Handle);
-            MethodWithToken methodWithToken = new MethodWithToken(ecmaMethod, moduleToken, constrainedType: null);
+            MethodWithToken methodWithToken = new MethodWithToken(ecmaMethod, moduleToken, constrainedType: null, unboxing: false);
 
             if (ecmaMethod.IsSuppressGCTransition())
             {

--- a/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/CommandLineOptions.cs
@@ -47,7 +47,7 @@ namespace ILCompiler
 
         public string SingleMethodTypeName { get; set; }
         public string SingleMethodName { get; set; }
-        public string[] SingleMethodGenericArgs { get; set; }
+        public string[] SingleMethodGenericArg { get; set; }
 
         public string[] CodegenOptions { get; set; }
 

--- a/src/coreclr/src/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/src/tools/aot/crossgen2/Program.cs
@@ -574,7 +574,7 @@ namespace ILCompiler
 
         private MethodDesc CheckAndParseSingleMethodModeArguments(CompilerTypeSystemContext context)
         {
-            if (_commandLineOptions.SingleMethodName == null && _commandLineOptions.SingleMethodTypeName == null && _commandLineOptions.SingleMethodGenericArgs == null)
+            if (_commandLineOptions.SingleMethodName == null && _commandLineOptions.SingleMethodTypeName == null && _commandLineOptions.SingleMethodGenericArg == null)
                 return null;
 
             if (_commandLineOptions.SingleMethodName == null || _commandLineOptions.SingleMethodTypeName == null)
@@ -587,8 +587,8 @@ namespace ILCompiler
             if (method == null)
                 throw new CommandLineException(string.Format(SR.MethodNotFoundOnType, _commandLineOptions.SingleMethodName, _commandLineOptions.SingleMethodTypeName));
 
-            if (method.HasInstantiation != (_commandLineOptions.SingleMethodGenericArgs != null) ||
-                (method.HasInstantiation && (method.Instantiation.Length != _commandLineOptions.SingleMethodGenericArgs.Length)))
+            if (method.HasInstantiation != (_commandLineOptions.SingleMethodGenericArg != null) ||
+                (method.HasInstantiation && (method.Instantiation.Length != _commandLineOptions.SingleMethodGenericArg.Length)))
             {
                 throw new CommandLineException(
                     string.Format(SR.GenericArgCountMismatch, method.Instantiation.Length, _commandLineOptions.SingleMethodName, _commandLineOptions.SingleMethodTypeName));
@@ -597,7 +597,7 @@ namespace ILCompiler
             if (method.HasInstantiation)
             {
                 List<TypeDesc> genericArguments = new List<TypeDesc>();
-                foreach (var argString in _commandLineOptions.SingleMethodGenericArgs)
+                foreach (var argString in _commandLineOptions.SingleMethodGenericArg)
                     genericArguments.Add(FindType(context, argString));
                 method = method.MakeInstantiatedMethod(genericArguments.ToArray());
             }

--- a/src/coreclr/tests/src/readytorun/crossgen2/helperdll.cs
+++ b/src/coreclr/tests/src/readytorun/crossgen2/helperdll.cs
@@ -44,3 +44,29 @@ public interface IGenericWithSealedDefaultMethodAcrossModule<T>
     }
 
 }
+
+public struct GenericStructForLdtoken<T>
+{
+    T _value;
+    int _intVal;
+
+    public int NonGenericFunction(T genericValue, int inputIntValue)
+    {
+        if (!((object)genericValue).Equals(_value))
+            return 0;
+        if (inputIntValue != _intVal)
+            return 0;
+        return inputIntValue;
+    }
+
+    public int GenericFunction<V>(T genericValue, V genericMethodValue, string toStringResult, int inputIntValue)
+    {
+        if (!((object)genericValue).Equals(_value))
+            return 0;
+        if (genericMethodValue.ToString() != toStringResult)
+            return 0;
+        if (inputIntValue != _intVal)
+            return 0;
+        return inputIntValue;
+    }
+}

--- a/src/coreclr/tests/src/readytorun/crossgen2/helperildll.il
+++ b/src/coreclr/tests/src/readytorun/crossgen2/helperildll.il
@@ -22,4 +22,49 @@
      calli void()
      ret
   }
+
+  .method public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle GetNonGenericFunctionMethodHandle() cil managed noinlining
+  {
+     ldtoken method instance int32 valuetype [helperdll]GenericStructForLdtoken`1<string>::NonGenericFunction(!0, int32)
+     ret
+  }
+
+  .method  public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle GetGenericFunctionMethodHandle() cil managed noinlining
+  {
+     ldtoken method instance int32 valuetype [helperdll]GenericStructForLdtoken`1<string>::GenericFunction<valuetype [helperdll]GenericStructForLdtoken`1<object>>(!0, !!0, string, int32)
+     ret
+  }
+
+  .method  public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle GetGenericFunctionMethodHandle<V>() cil managed noinlining
+  {
+     ldtoken method instance int32 valuetype [helperdll]GenericStructForLdtoken`1<string>::GenericFunction<!!0>(!0, !!0, string, int32)
+     ret
+  }
+
+  .method public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle ForceStuffToBeCompiled() cil managed noinlining
+  {
+     call valuetype[mscorlib]System.RuntimeMethodHandle class HelperGenericILCode`1<object>::GetGenericFunctionMethodHandle<valuetype [helperdll]GenericStructForLdtoken`1<string>>()
+     ret
+  }
+  .method public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle ForceStuffToBeCompiled2() cil managed noinlining
+  {
+     call valuetype[mscorlib]System.RuntimeMethodHandle HelperILCode::GetGenericFunctionMethodHandle<string>()
+     ret
+  }
+}
+
+.class auto ansi public beforefieldinit HelperGenericILCode`1<T>
+       extends [mscorlib]System.Object
+{
+  .method  public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle GetNonGenericFunctionMethodHandle() cil managed noinlining
+  {
+     ldtoken method instance int32 valuetype [helperdll]GenericStructForLdtoken`1<!0>::NonGenericFunction(!0, int32)
+     ret
+  }
+
+  .method  public hidebysig static valuetype[mscorlib]System.RuntimeMethodHandle GetGenericFunctionMethodHandle<V>() cil managed noinlining
+  {
+     ldtoken method instance int32 valuetype [helperdll]GenericStructForLdtoken`1<!0>::GenericFunction<!!0>(!0, !!0, string, int32)
+     ret
+  }
 }


### PR DESCRIPTION
- UnboxingMethodDesc is a type that is not intended to escape JIT
interface
- This fix is a combination of 2 changes.
  - First, a change for creation of ldtoken to a generic valuetype method
  - Second, moving a bool to indicate whether or not a method is an
  unboxing stub into the MethodWithToken data structure instead of
  passing it as a side parameter everywhere
- Also, a test case for various generic ldtoken cases is added to
crossgen2smoke
- And, minor fix to make single method compilation of a generic method
function correctly. (There was a typo)

Fix issue #35531 