### PR TITLE
[wasm] Enable System.Threading.Channels.Tests

### DIFF
--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Threading.Tasks;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Threading.Channels.Tests
@@ -288,7 +289,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(10000)]
@@ -314,7 +315,7 @@ namespace System.Threading.Channels.Tests
                 }));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(10000)]
@@ -389,7 +390,7 @@ namespace System.Threading.Channels.Tests
             Assert.True(await write2);
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [MemberData(nameof(ThreeBools))]
         public void AllowSynchronousContinuations_Reading_ContinuationsInvokedAccordingToSetting(bool allowSynchronousContinuations, bool cancelable, bool waitToReadAsync)
         {
@@ -409,11 +410,16 @@ namespace System.Threading.Channels.Tests
             r.GetAwaiter().GetResult();
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(false)]
         [InlineData(true)]
         public void AllowSynchronousContinuations_CompletionTask_ContinuationsInvokedAccordingToSetting(bool allowSynchronousContinuations)
         {
+            if (!allowSynchronousContinuations && !PlatformDetection.IsThreadingSupported)
+            {
+                throw new SkipTestException(nameof(PlatformDetection.IsThreadingSupported));
+            }
+
             var c = Channel.CreateBounded<int>(new BoundedChannelOptions(1) { AllowSynchronousContinuations = allowSynchronousContinuations });
 
             int expectedId = Environment.CurrentManagedThreadId;

--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -177,7 +177,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(0, result);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task TryWrite_DropNewest_WrappedAroundInternalQueue()
         {
             var c = Channel.CreateBounded<int>(new BoundedChannelOptions(3) { FullMode = BoundedChannelFullMode.DropNewest });
@@ -249,7 +249,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(0, result);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task CancelPendingWrite_Reading_DataTransferredFromCorrectWriter()
         {
             var c = Channel.CreateBounded<int>(1);
@@ -288,7 +288,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(10000)]
@@ -314,7 +314,7 @@ namespace System.Threading.Channels.Tests
                 }));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(10000)]
@@ -371,7 +371,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal((NumItems * (NumItems + 1L)) / 2, readTotal);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WaitToWriteAsync_AfterFullThenRead_ReturnsTrue()
         {
             var c = Channel.CreateBounded<int>(1);
@@ -389,7 +389,7 @@ namespace System.Threading.Channels.Tests
             Assert.True(await write2);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [MemberData(nameof(ThreeBools))]
         public void AllowSynchronousContinuations_Reading_ContinuationsInvokedAccordingToSetting(bool allowSynchronousContinuations, bool cancelable, bool waitToReadAsync)
         {
@@ -409,7 +409,7 @@ namespace System.Threading.Channels.Tests
             r.GetAwaiter().GetResult();
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public void AllowSynchronousContinuations_CompletionTask_ContinuationsInvokedAccordingToSetting(bool allowSynchronousContinuations)
@@ -427,7 +427,7 @@ namespace System.Threading.Channels.Tests
             r.GetAwaiter().GetResult();
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task TryWrite_NoBlockedReaders_WaitingReader_WaiterNotified()
         {
             Channel<int> c = CreateChannel();

--- a/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
@@ -145,7 +145,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void SingleProducerConsumer_ConcurrentReadWrite_Success()
         {
             Channel<int> c = CreateChannel();
@@ -168,7 +168,7 @@ namespace System.Threading.Channels.Tests
                 }));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void SingleProducerConsumer_PingPong_Success()
         {
             Channel<int> c1 = CreateChannel();
@@ -194,7 +194,7 @@ namespace System.Threading.Channels.Tests
                 }));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         [InlineData(1, 1)]
         [InlineData(1, 10)]
         [InlineData(10, 1)]

--- a/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
@@ -67,7 +67,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(TaskStatus.RanToCompletion, completion.Status);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_AfterEmpty_NoWaiters_TriggersCompletion()
         {
             Channel<int> c = CreateChannel();
@@ -75,7 +75,7 @@ namespace System.Threading.Channels.Tests
             await c.Reader.Completion;
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_AfterEmpty_WaitingReader_TriggersCompletion()
         {
             Channel<int> c = CreateChannel();
@@ -85,7 +85,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAnyAsync<InvalidOperationException>(() => r);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_BeforeEmpty_WaitingReaders_TriggersCompletion()
         {
             Channel<int> c = CreateChannel();
@@ -112,7 +112,7 @@ namespace System.Threading.Channels.Tests
             Assert.False(c.Writer.TryComplete());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task TryComplete_ErrorsPropage()
         {
             Channel<int> c;
@@ -145,7 +145,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public void SingleProducerConsumer_ConcurrentReadWrite_Success()
         {
             Channel<int> c = CreateChannel();
@@ -168,7 +168,7 @@ namespace System.Threading.Channels.Tests
                 }));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public void SingleProducerConsumer_PingPong_Success()
         {
             Channel<int> c1 = CreateChannel();
@@ -194,7 +194,7 @@ namespace System.Threading.Channels.Tests
                 }));
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(1, 1)]
         [InlineData(1, 10)]
         [InlineData(10, 1)]
@@ -326,7 +326,7 @@ namespace System.Threading.Channels.Tests
             Assert.True(write.Result);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WaitToWriteAsync_ManyConcurrent_SatisifedByReaders()
         {
             if (RequiresSingleReader || RequiresSingleWriter)
@@ -375,7 +375,7 @@ namespace System.Threading.Channels.Tests
             Assert.False(c.Writer.TryWrite(42));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WriteAsync_AfterComplete_ThrowsException()
         {
             Channel<int> c = CreateChannel();
@@ -383,7 +383,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAnyAsync<InvalidOperationException>(async () => await c.Writer.WriteAsync(42));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithException_PropagatesToCompletion()
         {
             Channel<int> c = CreateChannel();
@@ -392,7 +392,7 @@ namespace System.Threading.Channels.Tests
             Assert.Same(exc, await Assert.ThrowsAsync<FormatException>(() => c.Reader.Completion));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithCancellationException_PropagatesToCompletion()
         {
             Channel<int> c = CreateChannel();
@@ -407,7 +407,7 @@ namespace System.Threading.Channels.Tests
             await AssertCanceled(c.Reader.Completion, cts.Token);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithException_PropagatesToExistingWriter()
         {
             Channel<int> c = CreateFullChannel();
@@ -420,7 +420,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithException_PropagatesToNewWriter()
         {
             Channel<int> c = CreateChannel();
@@ -430,7 +430,7 @@ namespace System.Threading.Channels.Tests
             Assert.Same(exc, (await Assert.ThrowsAsync<ChannelClosedException>(async () => await write)).InnerException);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithException_PropagatesToExistingWaitingReader()
         {
             Channel<int> c = CreateChannel();
@@ -440,7 +440,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<FormatException>(async () => await read);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithException_PropagatesToNewWaitingReader()
         {
             Channel<int> c = CreateChannel();
@@ -450,7 +450,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<FormatException>(async () => await read);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task Complete_WithException_PropagatesToNewWaitingWriter()
         {
             Channel<int> c = CreateChannel();
@@ -524,7 +524,7 @@ namespace System.Threading.Channels.Tests
             Assert.True(waitTask.IsCanceled);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task WaitToReadAsync_DataWritten_CompletesSuccessfully(bool cancelable)
@@ -540,7 +540,7 @@ namespace System.Threading.Channels.Tests
             Assert.True(await read);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WaitToReadAsync_NoDataWritten_Canceled_CompletesAsCanceled()
         {
             Channel<int> c = CreateChannel();
@@ -552,7 +552,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await read);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_ThenWriteAsync_Succeeds()
         {
             Channel<int> c = CreateChannel();
@@ -566,7 +566,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(42, await r);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WriteAsync_ReadAsync_Succeeds()
         {
             Channel<int> c = CreateChannel();
@@ -594,7 +594,7 @@ namespace System.Threading.Channels.Tests
             Assert.True(readTask.IsCanceled);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_Canceled_CanceledAsynchronously()
         {
             Channel<int> c = CreateChannel();
@@ -613,7 +613,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_WriteAsync_ManyConcurrentReaders_SerializedWriters_Success()
         {
             if (RequiresSingleReader)
@@ -633,7 +633,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal((Items * (Items - 1)) / 2, Enumerable.Sum(await Task.WhenAll(readers.Select(r => r.AsTask()))));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_TryWrite_ManyConcurrentReaders_SerializedWriters_Success()
         {
             if (RequiresSingleReader)
@@ -658,7 +658,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal((Items * (Items - 1)) / 2, Enumerable.Sum(await Task.WhenAll(readers)));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_AlreadyCompleted_Throws()
         {
             Channel<int> c = CreateChannel();
@@ -666,7 +666,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<ChannelClosedException>(() => c.Reader.ReadAsync().AsTask());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_SubsequentlyCompleted_Throws()
         {
             Channel<int> c = CreateChannel();
@@ -676,7 +676,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<ChannelClosedException>(() => r);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_AfterFaultedChannel_Throws()
         {
             Channel<int> c = CreateChannel();
@@ -689,7 +689,7 @@ namespace System.Threading.Channels.Tests
             Assert.Same(e, cce.InnerException);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_AfterCanceledChannel_Throws()
         {
             Channel<int> c = CreateChannel();
@@ -701,7 +701,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() => c.Reader.ReadAsync().AsTask());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_Canceled_WriteAsyncCompletesNextReader()
         {
             Channel<int> c = CreateChannel();
@@ -722,7 +722,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_ConsecutiveReadsSucceed()
         {
             Channel<int> c = CreateChannel();
@@ -734,7 +734,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WaitToReadAsync_ConsecutiveReadsSucceed()
         {
             Channel<int> c = CreateChannel();
@@ -832,7 +832,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WaitToReadAsync_AwaitThenGetResult_Throws()
         {
             Channel<int> c = CreateChannel();
@@ -845,7 +845,7 @@ namespace System.Threading.Channels.Tests
             Assert.Throws<InvalidOperationException>(() => read.GetAwaiter().GetResult());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAsync_AwaitThenGetResult_Throws()
         {
             Channel<int> c = CreateChannel();
@@ -858,7 +858,7 @@ namespace System.Threading.Channels.Tests
             Assert.Throws<InvalidOperationException>(() => read.GetAwaiter().GetResult());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WaitToWriteAsync_AwaitThenGetResult_Throws()
         {
             Channel<int> c = CreateFullChannel();
@@ -875,7 +875,7 @@ namespace System.Threading.Channels.Tests
             Assert.Throws<InvalidOperationException>(() => write.GetAwaiter().GetResult());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task WriteAsync_AwaitThenGetResult_Throws()
         {
             Channel<int> c = CreateFullChannel();
@@ -992,7 +992,7 @@ namespace System.Threading.Channels.Tests
             from setNonDefaultTaskScheduler in new[] { true, false }
             select new object[] { readOrWait, completeBeforeOnCompleted, flowExecutionContext, continueOnCapturedContext, setNonDefaultTaskScheduler };
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [MemberData(nameof(Reader_ContinuesOnCurrentContextIfDesired_MemberData))]
         public async Task Reader_ContinuesOnCurrentSynchronizationContextIfDesired(
             bool readOrWait, bool completeBeforeOnCompleted, bool flowExecutionContext, bool? continueOnCapturedContext, bool setNonDefaultTaskScheduler)
@@ -1088,7 +1088,7 @@ namespace System.Threading.Channels.Tests
             from setDefaultSyncContext in new[] { true, false }
             select new object[] { readOrWait, completeBeforeOnCompleted, flowExecutionContext, continueOnCapturedContext, setDefaultSyncContext };
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [MemberData(nameof(Reader_ContinuesOnCurrentSchedulerIfDesired_MemberData))]
         public async Task Reader_ContinuesOnCurrentTaskSchedulerIfDesired(
             bool readOrWait, bool completeBeforeOnCompleted, bool flowExecutionContext, bool? continueOnCapturedContext, bool setDefaultSyncContext)

--- a/src/libraries/System.Threading.Channels/tests/ChannelTestBase.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTestBase.netcoreapp.cs
@@ -22,7 +22,7 @@ namespace System.Threading.Channels.Tests
             Assert.NotSame(e, c.Reader.ReadAllAsync());
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ReadAllAsync_UseMoveNextAsyncAfterCompleted_ReturnsFalse(bool completeWhilePending)
@@ -76,7 +76,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAllAsync_UnavailableDataCompletesAsynchronously()
         {
             Channel<int> c = CreateChannel();
@@ -102,7 +102,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(128)]
@@ -140,7 +140,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(producedTotal, consumedTotal);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAllAsync_MultipleEnumerationsToEnd()
         {
             Channel<int> c = CreateChannel();
@@ -193,7 +193,7 @@ namespace System.Threading.Channels.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ReadAllAsync_DualConcurrentEnumeration_AllItemsEnumerated(bool sameEnumerable)
@@ -238,7 +238,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(producerTotal, consumerTotal);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Theory]
         [InlineData(false)]
         [InlineData(true)]
         public async Task ReadAllAsync_CanceledBeforeMoveNextAsync_Throws(bool dataAvailable)
@@ -260,7 +260,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(cts.Token, oce.CancellationToken);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task ReadAllAsync_CanceledAfterMoveNextAsync_Throws()
         {
             Channel<int> c = CreateChannel();

--- a/src/libraries/System.Threading.Channels/tests/ChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTests.cs
@@ -113,7 +113,7 @@ namespace System.Threading.Channels.Tests
             Assert.False(t.IsCompleted);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task DefaultWriteAsync_CatchesTryWriteExceptions()
         {
             var w = new TryWriteThrowingWriter<int>();
@@ -122,7 +122,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<FormatException>(async () => await t);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task DefaultReadAsync_CatchesTryWriteExceptions()
         {
             var r = new TryReadThrowingReader<int>();
@@ -131,7 +131,7 @@ namespace System.Threading.Channels.Tests
             await Assert.ThrowsAsync<FieldAccessException>(() => t);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public async Task TestBaseClassReadAsync()
         {
             WrapperChannel<int> channel = new WrapperChannel<int>(10);

--- a/src/libraries/System.Threading.Channels/tests/UnboundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/UnboundedChannelTests.cs
@@ -137,7 +137,7 @@ namespace System.Threading.Channels.Tests
             await c.Reader.Completion;
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void AllowSynchronousContinuations_WaitToReadAsync_ContinuationsInvokedAccordingToSetting()
         {
             Channel<int> c = CreateChannel();
@@ -153,7 +153,7 @@ namespace System.Threading.Channels.Tests
             r.GetAwaiter().GetResult();
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void AllowSynchronousContinuations_CompletionTask_ContinuationsInvokedAccordingToSetting()
         {
             Channel<int> c = CreateChannel();
@@ -208,7 +208,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(42, await t2);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public void Stress_TryWrite_TryRead()
         {
             const int NumItems = 3000000;

--- a/src/libraries/System.Threading.Channels/tests/UnboundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/UnboundedChannelTests.cs
@@ -137,7 +137,7 @@ namespace System.Threading.Channels.Tests
             await c.Reader.Completion;
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public void AllowSynchronousContinuations_WaitToReadAsync_ContinuationsInvokedAccordingToSetting()
         {
             Channel<int> c = CreateChannel();
@@ -153,7 +153,7 @@ namespace System.Threading.Channels.Tests
             r.GetAwaiter().GetResult();
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public void AllowSynchronousContinuations_CompletionTask_ContinuationsInvokedAccordingToSetting()
         {
             Channel<int> c = CreateChannel();
@@ -208,7 +208,7 @@ namespace System.Threading.Channels.Tests
             Assert.Equal(42, await t2);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [Fact]
         public void Stress_TryWrite_TryRead()
         {
             const int NumItems = 3000000;


### PR DESCRIPTION
Contributes to #38422  
```Tests run: 1096, Errors: 0, Failures: 0, Skipped: 32. Time: 3.3619789s```

The tests failing that are now skipped by the second commit were either `Cannot wait on events on this runtime.` or `Cannot wait on monitors on this runtime.`