### PR TITLE
[wasm] Mark System.Net.WebSockets.Tests.WebSocketProtocolCreateTests class with an active issue

### DIFF
--- a/src/libraries/System.Net.WebSockets.WebSocketProtocol/tests/WebSocketProtocolTests.cs
+++ b/src/libraries/System.Net.WebSockets.WebSocketProtocol/tests/WebSocketProtocolTests.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using Xunit;
 
 namespace System.Net.WebSockets.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/38807", TestPlatforms.Browser)]
     public sealed class WebSocketProtocolCreateTests : WebSocketCreateTest
     {
         protected override WebSocket CreateFromStream(Stream stream, bool isServer, string subProtocol, TimeSpan keepAliveInterval) =>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -25,7 +25,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http.Json\tests\FunctionalTests\System.Net.Http.Json.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.WebSocketProtocol\tests\System.Net.WebSockets.WebSocketProtocol.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
     <!-- Builds currently do not pass -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.FileExtensions\tests\Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj" />


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

This test class crashes with the same issue as mentioned in https://github.com/dotnet/runtime/pull/38808