### PR TITLE
[wasm] Skip System.Net.WebClient test suite

### DIFF
--- a/src/libraries/System.Net.WebClient/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebClient/src/Resources/Strings.resx
@@ -75,4 +75,7 @@
   <data name="net_webstatus_MessageLengthLimitExceeded" xml:space="preserve">
     <value>The message length limit was exceeded</value>
   </data>
+  <data name="net_webclient_PlatformNotSupported" xml:space="preserve">
+    <value>System.Net.WebClient is not supported on this platform. Use System.Net.Http.HttpClient instead.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.net_webclient_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Net\WebClient.cs" />
     <Compile Include="$(CommonPath)System\IO\DelegatingStream.cs"

--- a/src/libraries/System.Net.WebClient/tests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.WebClient/tests/AssemblyInfo.cs
@@ -5,3 +5,4 @@
 using Xunit;
 
 [assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
+[assembly: SkipOnMono("System.Net.WebClient is not recommended for new development and not supported on wasm", TestPlatforms.Browser)] 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -24,7 +24,6 @@
     <!-- Builds and runs but fails hard enough to not produce any output XML -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http.Json\tests\FunctionalTests\System.Net.Http.Json.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NetworkInformation\tests\FunctionalTests\System.Net.NetworkInformation.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebClient\tests\System.Net.WebClient.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests.csproj" />
     <!-- Builds currently do not pass -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Configuration.FileExtensions\tests\Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj" />


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

Actually System.Net.WebClient test suite crashes with the error described in https://github.com/dotnet/runtime/issues/38807. But since WebClient class is not recommended for new development, I just skipped the respective tests on WASM. 
Besides that, I updated System.Net.WebClient with throwing PNSE on wasm.


