### PR TITLE
Avoid unnecessary CultureInfo.CurrentCulture accesses in Enum

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -1032,67 +1032,67 @@ namespace System
 
         bool IConvertible.ToBoolean(IFormatProvider? provider)
         {
-            return Convert.ToBoolean(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToBoolean(GetValue(), null);
         }
 
         char IConvertible.ToChar(IFormatProvider? provider)
         {
-            return Convert.ToChar(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToChar(GetValue(), null);
         }
 
         sbyte IConvertible.ToSByte(IFormatProvider? provider)
         {
-            return Convert.ToSByte(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToSByte(GetValue(), null);
         }
 
         byte IConvertible.ToByte(IFormatProvider? provider)
         {
-            return Convert.ToByte(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToByte(GetValue(), null);
         }
 
         short IConvertible.ToInt16(IFormatProvider? provider)
         {
-            return Convert.ToInt16(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToInt16(GetValue(), null);
         }
 
         ushort IConvertible.ToUInt16(IFormatProvider? provider)
         {
-            return Convert.ToUInt16(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToUInt16(GetValue(), null);
         }
 
         int IConvertible.ToInt32(IFormatProvider? provider)
         {
-            return Convert.ToInt32(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToInt32(GetValue(), null);
         }
 
         uint IConvertible.ToUInt32(IFormatProvider? provider)
         {
-            return Convert.ToUInt32(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToUInt32(GetValue(), null);
         }
 
         long IConvertible.ToInt64(IFormatProvider? provider)
         {
-            return Convert.ToInt64(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToInt64(GetValue(), null);
         }
 
         ulong IConvertible.ToUInt64(IFormatProvider? provider)
         {
-            return Convert.ToUInt64(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToUInt64(GetValue(), null);
         }
 
         float IConvertible.ToSingle(IFormatProvider? provider)
         {
-            return Convert.ToSingle(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToSingle(GetValue(), null);
         }
 
         double IConvertible.ToDouble(IFormatProvider? provider)
         {
-            return Convert.ToDouble(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToDouble(GetValue(), null);
         }
 
         decimal IConvertible.ToDecimal(IFormatProvider? provider)
         {
-            return Convert.ToDecimal(GetValue(), CultureInfo.CurrentCulture);
+            return Convert.ToDecimal(GetValue(), null);
         }
 
         DateTime IConvertible.ToDateTime(IFormatProvider? provider)

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -1032,67 +1032,67 @@ namespace System
 
         bool IConvertible.ToBoolean(IFormatProvider? provider)
         {
-            return Convert.ToBoolean(GetValue(), null);
+            return Convert.ToBoolean(GetValue());
         }
 
         char IConvertible.ToChar(IFormatProvider? provider)
         {
-            return Convert.ToChar(GetValue(), null);
+            return Convert.ToChar(GetValue());
         }
 
         sbyte IConvertible.ToSByte(IFormatProvider? provider)
         {
-            return Convert.ToSByte(GetValue(), null);
+            return Convert.ToSByte(GetValue());
         }
 
         byte IConvertible.ToByte(IFormatProvider? provider)
         {
-            return Convert.ToByte(GetValue(), null);
+            return Convert.ToByte(GetValue());
         }
 
         short IConvertible.ToInt16(IFormatProvider? provider)
         {
-            return Convert.ToInt16(GetValue(), null);
+            return Convert.ToInt16(GetValue());
         }
 
         ushort IConvertible.ToUInt16(IFormatProvider? provider)
         {
-            return Convert.ToUInt16(GetValue(), null);
+            return Convert.ToUInt16(GetValue());
         }
 
         int IConvertible.ToInt32(IFormatProvider? provider)
         {
-            return Convert.ToInt32(GetValue(), null);
+            return Convert.ToInt32(GetValue());
         }
 
         uint IConvertible.ToUInt32(IFormatProvider? provider)
         {
-            return Convert.ToUInt32(GetValue(), null);
+            return Convert.ToUInt32(GetValue());
         }
 
         long IConvertible.ToInt64(IFormatProvider? provider)
         {
-            return Convert.ToInt64(GetValue(), null);
+            return Convert.ToInt64(GetValue());
         }
 
         ulong IConvertible.ToUInt64(IFormatProvider? provider)
         {
-            return Convert.ToUInt64(GetValue(), null);
+            return Convert.ToUInt64(GetValue());
         }
 
         float IConvertible.ToSingle(IFormatProvider? provider)
         {
-            return Convert.ToSingle(GetValue(), null);
+            return Convert.ToSingle(GetValue());
         }
 
         double IConvertible.ToDouble(IFormatProvider? provider)
         {
-            return Convert.ToDouble(GetValue(), null);
+            return Convert.ToDouble(GetValue());
         }
 
         decimal IConvertible.ToDecimal(IFormatProvider? provider)
         {
-            return Convert.ToDecimal(GetValue(), null);
+            return Convert.ToDecimal(GetValue());
         }
 
         DateTime IConvertible.ToDateTime(IFormatProvider? provider)


### PR DESCRIPTION
Enum can only be backed by primitive numerical types, and using the IConvertible interface implementations to convert to numerical types won't pay any attention to culture, so just as there's no need to pass through the supplied provider, there's no need to access CultureInfo.CurrentCulture.

(As suggested by @GrabYourPitchforks at https://github.com/dotnet/runtime/issues/38779#issuecomment-653720130.)

```C#
[Benchmark]
public int ToInt() => Convert.ToInt32(DayOfWeek.Tuesday);
```

| Method |           Toolchain |     Mean |    Error |   StdDev | Ratio | Allocated |
|------- |-------------------- |---------:|---------:|---------:|------:|----------:|
|  ToInt | \master\corerun.exe | 20.82 ns | 0.108 ns | 0.101 ns |  1.00 |      48 B |
|  ToInt |     \pr\corerun.exe | 16.55 ns | 0.247 ns | 0.231 ns |  0.79 |      48 B |