### PR TITLE
Include member name when constructing ValidationResult in CompareAttribute

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/CompareAttribute.cs
@@ -46,7 +46,10 @@ namespace System.ComponentModel.DataAnnotations
                     OtherPropertyDisplayName = GetDisplayNameForProperty(otherPropertyInfo);
                 }
 
-                return new ValidationResult(FormatErrorMessage(validationContext.DisplayName));
+                string[] memberNames = validationContext.MemberName != null
+                   ? new[] { validationContext.MemberName }
+                   : null;
+                return new ValidationResult(FormatErrorMessage(validationContext.DisplayName), memberNames);
             }
 
             return null;

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/CompareAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/CompareAttributeTests.cs
@@ -75,6 +75,34 @@ namespace System.ComponentModel.DataAnnotations.Tests
         }
 
         [Fact]
+        [SkipOnTargetFramework(~TargetFrameworkMonikers.NetFramework)]
+        public static void Validate_IncludesMemberName_NetFx()
+        {
+            ValidationContext validationContext = new ValidationContext(new CompareObject("a"));
+            validationContext.MemberName = nameof(CompareObject.CompareProperty);
+            CompareAttribute attribute = new CompareAttribute(nameof(CompareObject.ComparePropertyCased));
+
+            ValidationResult validationResult = attribute.GetValidationResult("b", validationContext);
+
+            Assert.NotNull(validationResult.ErrorMessage);
+            Assert.Empty(validationResult.MemberNames);
+        }
+
+        [Fact]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
+        public static void Validate_IncludesMemberName_Netcoreapp()
+        {
+            ValidationContext validationContext = new ValidationContext(new CompareObject("a"));
+            validationContext.MemberName = nameof(CompareObject.CompareProperty);
+            CompareAttribute attribute = new CompareAttribute(nameof(CompareObject.ComparePropertyCased));
+
+            ValidationResult validationResult = attribute.GetValidationResult("b", validationContext);
+
+            Assert.NotNull(validationResult.ErrorMessage);
+            Assert.Equal(new[] { nameof(CompareObject.CompareProperty) }, validationResult.MemberNames);
+        }
+
+        [Fact]
         public static void Validate_PrivateProperty_ThrowsArgumentException()
         {
             CompareAttribute attribute = new CompareAttribute("PrivateProperty");


### PR DESCRIPTION

Fixes https://github.com/dotnet/runtime/issues/29214