### PR TITLE
[wasm][debugger] DebugDirectoryEntryType = Reproducible means that has debug information

### DIFF
--- a/src/mono/mono/metadata/debug-internals.h
+++ b/src/mono/mono/metadata/debug-internals.h
@@ -53,6 +53,7 @@ typedef struct
 
 typedef enum {
 	DEBUG_DIR_ENTRY_CODEVIEW = 2,
+	DEBUG_DIR_REPRODUCIBLE = 16,
 	DEBUG_DIR_ENTRY_PPDB = 17,
 	DEBUG_DIR_PDB_CHECKSUM = 19
 } DebugDirectoryEntryType;

--- a/src/mono/mono/metadata/image.c
+++ b/src/mono/mono/metadata/image.c
@@ -1038,8 +1038,7 @@ mono_has_pdb_checksum (char *raw_data, uint32_t raw_data_len)
 				debug_dir.major_version   = read16(data + 8);
 				debug_dir.minor_version   = read16(data + 10);
 				debug_dir.type            = read32(data + 12);
-				printf("debug_dir.type - %d\n", debug_dir.type);
-				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM)
+				if (debug_dir.type == DEBUG_DIR_PDB_CHECKSUM || debug_dir.type == DEBUG_DIR_REPRODUCIBLE)
 					return TRUE;
 			}
 		}


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20083,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Considering DebugDirectoryEntryType = Reproducible as an assembly that has debug information.

Fixes mono/mono#20075


