### PR TITLE
Ensure Http Telemetry correctness

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs
@@ -57,7 +57,7 @@ namespace System.Net.Http
                     if (_connection == null)
                     {
                         // Fully consumed the response in ReadChunksFromConnectionBuffer.
-                        if (HttpTelemetry.IsEnabled) LogRequestStop();
+                        LogRequestStop();
                         return 0;
                     }
 
@@ -363,7 +363,7 @@ namespace System.Net.Http
                                     cancellationRegistration.Dispose();
                                     CancellationHelper.ThrowIfCancellationRequested(cancellationRegistration.Token);
 
-                                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                                    LogRequestStop();
                                     _state = ParsingState.Done;
                                     _connection.CompleteResponse();
                                     _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionCloseReadStream.cs
@@ -29,7 +29,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -82,7 +82,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -144,7 +144,7 @@ namespace System.Net.Http
             private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
-                if (HttpTelemetry.IsEnabled) LogRequestStop();
+                LogRequestStop();
                 _connection = null;
                 connection.Dispose();
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthReadStream.cs
@@ -48,7 +48,7 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     // End of response body
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    LogRequestStop();
                     _connection.CompleteResponse();
                     _connection = null;
                 }
@@ -111,7 +111,7 @@ namespace System.Net.Http
                 if (_contentBytesRemaining == 0)
                 {
                     // End of response body
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    LogRequestStop();
                     _connection.CompleteResponse();
                     _connection = null;
                 }
@@ -166,7 +166,7 @@ namespace System.Net.Http
 
             private void Finish()
             {
-                if (HttpTelemetry.IsEnabled) LogRequestStop();
+                LogRequestStop();
                 _contentBytesRemaining = 0;
                 _connection!.CompleteResponse();
                 _connection = null;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -350,7 +350,7 @@ namespace System.Net.Http
                     _creditWaiter = null;
                 }
 
-                if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
+                _request.OnStopped();
             }
 
             private void Cancel()
@@ -386,7 +386,7 @@ namespace System.Net.Http
                     _waitSource.SetResult(true);
                 }
 
-                if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestAborted();
+                _request.OnAborted();
             }
 
             // Returns whether the waiter should be signalled or not.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -49,7 +49,7 @@ namespace System.Net.Http
         private readonly TransportContext? _transportContext;
         private readonly WeakReference<HttpConnection> _weakThisRef;
 
-        private HttpRequestMessage? _currentRequest;
+        internal HttpRequestMessage? _currentRequest;
         private readonly byte[] _writeBuffer;
         private int _writeOffset;
         private int _allowedReadLineBytes;
@@ -622,7 +622,7 @@ namespace System.Net.Http
                 Stream responseStream;
                 if (ReferenceEquals(normalizedMethod, HttpMethod.Head) || response.StatusCode == HttpStatusCode.NoContent || response.StatusCode == HttpStatusCode.NotModified)
                 {
-                    if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
+                    _currentRequest.OnStopped();
                     responseStream = EmptyReadStream.Instance;
                     CompleteResponse();
                 }
@@ -645,7 +645,7 @@ namespace System.Net.Http
                     long contentLength = response.Content.Headers.ContentLength.GetValueOrDefault();
                     if (contentLength <= 0)
                     {
-                        if (HttpTelemetry.IsEnabled) HttpTelemetry.Log.RequestStop();
+                        _currentRequest.OnStopped();
                         responseStream = EmptyReadStream.Instance;
                         CompleteResponse();
                     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -355,20 +355,22 @@ namespace System.Net.Http
                 request.RequestUri.PathAndQuery,
                 request.Version.Major,
                 request.Version.Minor);
+
+            request.MarkAsTrackedByTelemetry();
+
             try
             {
                 return await SendAsyncHelper(request, async, doRequestAuth, cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (LogException(e))
+            catch when (LogException(request))
             {
                 // This code should never run.
                 throw;
             }
 
-            static bool LogException(Exception e)
+            static bool LogException(HttpRequestMessage request)
             {
-                HttpTelemetry.Log.RequestAborted();
-                HttpTelemetry.Log.RequestStop();
+                request.OnAborted();
 
                 // Returning false means the catch handler isn't run.
                 // So the exception isn't considered to be caught so it will now propagate up the stack.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpContentStream.cs
@@ -2,16 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
-
 namespace System.Net.Http
 {
     internal abstract class HttpContentStream : HttpBaseStream
     {
         protected HttpConnection? _connection;
-
-        // Makes sure we don't call HttpTelemetry events more than once.
-        private int _requestStopCalled; // 0==no, 1==yes
 
         public HttpContentStream(HttpConnection connection)
         {
@@ -48,10 +43,7 @@ namespace System.Net.Http
 
         protected void LogRequestStop()
         {
-            if (Interlocked.Exchange(ref _requestStopCalled, 1) == 0)
-            {
-                HttpTelemetry.Log.RequestStop();
-            }
+            _connection?._currentRequest?.OnStopped();
         }
 
         private HttpConnection ThrowObjectDisposedException() => throw new ObjectDisposedException(GetType().Name);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/RawConnectionStream.cs
@@ -34,7 +34,7 @@ namespace System.Net.Http
                 if (bytesRead == 0)
                 {
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -82,7 +82,7 @@ namespace System.Net.Http
                     CancellationHelper.ThrowIfCancellationRequested(cancellationToken);
 
                     // We cannot reuse this connection, so close it.
-                    if (HttpTelemetry.IsEnabled) LogRequestStop();
+                    LogRequestStop();
                     _connection = null;
                     connection.Dispose();
                 }
@@ -144,7 +144,7 @@ namespace System.Net.Http
             private void Finish(HttpConnection connection)
             {
                 // We cannot reuse this connection, so close it.
-                if (HttpTelemetry.IsEnabled) LogRequestStop();
+                LogRequestStop();
                 connection.Dispose();
                 _connection = null;
             }

--- a/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/Fakes/HttpTelemetry.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    internal class HttpTelemetry
+    {
+        public static HttpTelemetry Log => new HttpTelemetry();
+
+        public void RequestStop() { }
+
+        public void RequestAborted() { }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -242,6 +242,7 @@
              Link="ProductionCode\System\Net\Http\HttpHandlerDefaults.cs" />
     <Compile Include="DigestAuthenticationTests.cs" />
     <Compile Include="Fakes\HttpClientHandler.cs" />
+    <Compile Include="Fakes\HttpTelemetry.cs" />
     <Compile Include="Fakes\MacProxy.cs" Condition=" ('$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true') and '$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
     <Compile Include="Headers\AltSvcHeaderParserTest.cs" />
     <Compile Include="Headers\AuthenticationHeaderValueTest.cs" />


### PR DESCRIPTION
The Http Telemetry implementation from #37619 has a few problems:
1) Checking `Telemetry.IsEnabled` on start and stop opens up a race condition where any request that is in-flight when EventSource is enabled will log a `Stop` event without a corresponding `Start`. This leads to the `Current requests` counter always under-reporting the number of requests by an offset, even going into negative numbers. This is almost impossible **not** to hit unless Telemetry is started before any request is made, effectively making the `dotnet-counters` tool unusable for this Telemetry.
2) The `Stop` event is not guaranteed to run every time (for example if the response stream isn't read till the end). This shows up as a perpetually increasing `Current requests` counter.

This PR solves these issues by:
1) Keeping the telemetry state on the `HttpRequestMessage` object. This way we only call `Stop` if we called `Start`.
2) Using a finalizer object on HttpRequestMessage to ensure `Stop` is called. A different object is used for the finalizer as `HttpRequestMessage` is not sealed and we can't suppress the finalizer as aggressively.

Allocation impact:
- `HttpContentStream`'s object size is reduced by one `int` field
- `HttpRequestMessage`'s object size is increased by one reference field
- An extra object allocation (empty object - only a finalizer) per `HttpRequestMessage` when Telemetry is enabled

Extra:
When looking at events in PerfView, I see that many (let's say half) of `RequestStop` events don't have `DURATION_MSEC` info, while `NameResolution.ResolutionStop` events from #38409 always do. Can this indicate that HTTP activity events couldn't be correlated (I can provide the events capture if needed)?

Contributes to #37428