### PR TITLE
Create copies of mutable properties on X509Certificate2

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -323,7 +323,7 @@ namespace Internal.Cryptography.Pal
             get
             {
                 EnsureCertData();
-                return _certData.RawData;
+                return _certData.RawData.CloneByteArray();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/AppleCertificatePal.cs
@@ -186,10 +186,23 @@ namespace Internal.Cryptography.Pal
             }
         }
 
+        public string Issuer
+        {
+            get
+            {
+                EnsureCertData();
+                return _certData.IssuerName;
+            }
+        }
 
-        public string Issuer => IssuerName.Name;
-
-        public string Subject => SubjectName.Name;
+        public string Subject
+        {
+            get
+            {
+                EnsureCertData();
+                return _certData.SubjectName;
+            }
+        }
 
         public string LegacyIssuer => IssuerName.Decode(X500DistinguishedNameFlags.None);
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificateData.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.OSX/CertificateData.cs
@@ -50,6 +50,8 @@ namespace Internal.Cryptography.Pal
         internal X500DistinguishedName Issuer;
         internal X500DistinguishedName Subject;
         internal List<X509Extension> Extensions;
+        internal string IssuerName;
+        internal string SubjectName;
 
         internal int Version => certificate.TbsCertificate.Version;
 
@@ -82,6 +84,8 @@ namespace Internal.Cryptography.Pal
             certificate.TbsCertificate.ValidateVersion();
             Issuer = new X500DistinguishedName(certificate.TbsCertificate.Issuer.ToArray());
             Subject = new X500DistinguishedName(certificate.TbsCertificate.Subject.ToArray());
+            IssuerName = Issuer.Name;
+            SubjectName = Subject.Name;
 
             AsnWriter writer = new AsnWriter(AsnEncodingRules.DER);
             certificate.TbsCertificate.SubjectPublicKeyInfo.Encode(writer);

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -24,6 +24,8 @@ namespace Internal.Cryptography.Pal
         private SafeEvpPKeyHandle? _privateKey;
         private X500DistinguishedName? _subjectName;
         private X500DistinguishedName? _issuerName;
+        private string? _subject;
+        private string? _issuer;
 
         public static ICertificatePal FromHandle(IntPtr handle)
         {
@@ -259,9 +261,37 @@ namespace Internal.Cryptography.Pal
             get { return _cert; }
         }
 
-        public string Issuer => IssuerName.Name;
+        public string Issuer
+        {
+            get
+            {
+                if (_issuer == null)
+                {
+                    // IssuerName is mutable to callers in X509Certificate. We want to be
+                    // able to get the issuer even if IssuerName has been mutated, so we
+                    // don't use it here.
+                    _issuer = Interop.Crypto.LoadX500Name(Interop.Crypto.X509GetIssuerName(_cert)).Name;
+                }
 
-        public string Subject => SubjectName.Name;
+                return _issuer;
+            }
+        }
+
+        public string Subject
+        {
+            get
+            {
+                if (_subject == null)
+                {
+                    // SubjectName is mutable to callers in X509Certificate. We want to be
+                    // able to get the subject even if SubjectName has been mutated, so we
+                    // don't use it here.
+                    _subject = Interop.Crypto.LoadX500Name(Interop.Crypto.X509GetSubjectName(_cert)).Name;
+                }
+
+                return _subject;
+            }
+        }
 
         public string LegacyIssuer => IssuerName.Decode(X500DistinguishedNameFlags.None);
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -275,7 +275,7 @@ namespace System.Security.Cryptography.X509Certificates
                 X500DistinguishedName? issuerName = _lazyIssuerName;
                 if (issuerName == null)
                     issuerName = _lazyIssuerName = Pal.IssuerName;
-                return new X500DistinguishedName(issuerName);
+                return issuerName;
             }
         }
 
@@ -356,7 +356,7 @@ namespace System.Security.Cryptography.X509Certificates
                 X500DistinguishedName? subjectName = _lazySubjectName;
                 if (subjectName == null)
                     subjectName = _lazySubjectName = Pal.SubjectName;
-                return new X500DistinguishedName(subjectName);
+                return subjectName;
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -275,7 +275,7 @@ namespace System.Security.Cryptography.X509Certificates
                 X500DistinguishedName? issuerName = _lazyIssuerName;
                 if (issuerName == null)
                     issuerName = _lazyIssuerName = Pal.IssuerName;
-                return issuerName;
+                return new X500DistinguishedName(issuerName);
             }
         }
 
@@ -356,7 +356,7 @@ namespace System.Security.Cryptography.X509Certificates
                 X500DistinguishedName? subjectName = _lazySubjectName;
                 if (subjectName == null)
                     subjectName = _lazySubjectName = Pal.SubjectName;
-                return subjectName;
+                return new X500DistinguishedName(subjectName);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -445,6 +445,30 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Fact]
+        public static void CopyResult_IssuerName()
+        {
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                X500DistinguishedName first = cert.IssuerName;
+                X500DistinguishedName second = cert.IssuerName;
+                Assert.NotSame(first, second);
+                Assert.NotSame(first.RawData, second.RawData);
+            }
+        }
+
+        [Fact]
+        public static void CopyResult_SubjectName()
+        {
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                X500DistinguishedName first = cert.SubjectName;
+                X500DistinguishedName second = cert.SubjectName;
+                Assert.NotSame(first, second);
+                Assert.NotSame(first.RawData, second.RawData);
+            }
+        }
+
         public static IEnumerable<object[]> StorageFlags => CollectionImportTests.StorageFlags;
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -446,26 +446,24 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        public static void CopyResult_IssuerName()
+        public static void MutateDistinguishedName_IssuerName_DoesNotImpactIssuer()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
             {
-                X500DistinguishedName first = cert.IssuerName;
-                X500DistinguishedName second = cert.IssuerName;
-                Assert.NotSame(first, second);
-                Assert.NotSame(first.RawData, second.RawData);
+                byte[] issuerBytes = cert.IssuerName.RawData;
+                Array.Clear(issuerBytes, 0, issuerBytes.Length);
+                Assert.Equal("CN=Microsoft Code Signing PCA, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", cert.Issuer);
             }
         }
 
         [Fact]
-        public static void CopyResult_SubjectName()
+        public static void MutateDistinguishedName_SubjectName_DoesNotImpactSubject()
         {
             using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
             {
-                X500DistinguishedName first = cert.SubjectName;
-                X500DistinguishedName second = cert.SubjectName;
-                Assert.NotSame(first, second);
-                Assert.NotSame(first.RawData, second.RawData);
+                byte[] subjectBytes = cert.SubjectName.RawData;
+                Array.Clear(subjectBytes, 0, subjectBytes.Length);
+                Assert.Equal("CN=Microsoft Corporation, OU=MOPR, O=Microsoft Corporation, L=Redmond, S=Washington, C=US", cert.Subject);
             }
         }
 

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -434,6 +434,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [Fact]
+        public static void CopyResult_RawData()
+        {
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                byte[] first = cert.RawData;
+                byte[] second = cert.RawData;
+                Assert.NotSame(first, second);
+            }
+        }
+
         public static IEnumerable<object[]> StorageFlags => CollectionImportTests.StorageFlags;
     }
 }

--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
@@ -9,6 +9,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ExportTests
     {
         [Fact]
+        public static void ExportAsCert_CreatesCopy()
+        {
+            using (X509Certificate2 cert = new X509Certificate2(TestData.MsCertificate))
+            {
+                byte[] first = cert.Export(X509ContentType.Cert);
+                byte[] second = cert.Export(X509ContentType.Cert);
+                Assert.NotSame(first, second);
+            }
+        }
+
+        [Fact]
         public static void ExportAsCert()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))


### PR DESCRIPTION
`Export(X509ContentType.Cert)` on macOS was returning the byte array from a field in the PAL, which allowed callers to mutate the underlying certificate.

`IssuerName` and `SubjectName` return mutable data on `RawData`, so the `get` there returns a copy.

Fixes #38864.