### PR TITLE
Add 2 new pipelines of jitstress just for armarch

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -126,7 +126,7 @@ jobs:
       # gc reliability may take up to 2 hours to shutdown. Some scenarios have very long iteration times.
       - name: timeoutPerTestInMinutes
         value: 240
-    - ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitelthookenabled' ) }}:
+    - ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstress-isas-x86', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitstress2-jitstressregs-armarch', 'jitelthookenabled' ) }}:
       - name: timeoutPerTestCollectionInMinutes
         value: 120
       - name: timeoutPerTestInMinutes
@@ -169,7 +169,7 @@ jobs:
       timeoutInMinutes: 270
     ${{ if in(parameters.testGroup, 'gc-longrunning', 'gc-simulator') }}:
       timeoutInMinutes: 480
-    ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'gcstress0x3-gcstress0xc', 'ilasm') }}:
+    ${{ if in(parameters.testGroup, 'jitstress', 'jitstress-isas-arm', 'jitstressregs-x86', 'jitstressregs', 'jitstress2-jitstressregs', 'jitstress2-jitstressregs-armarch', 'gcstress0x3-gcstress0xc', 'ilasm') }}:
       timeoutInMinutes: 390
     ${{ if in(parameters.testGroup, 'jitstress-isas-x86', 'gcstress-extra', 'r2r-extra', 'clrinterpreter') }}:
       timeoutInMinutes: 510
@@ -390,6 +390,16 @@ jobs:
           - jitstress2_jitstressregs0x10
           - jitstress2_jitstressregs0x80
           - jitstress2_jitstressregs0x1000
+        ${{ if in(parameters.testGroup, 'jitstress2-jitstressregs-armarch') }}:
+          scenarios:
+          - jitstress2_jitstressregs1
+          - jitstress2_jitstressregs2
+          - jitstress2_jitstressregs3
+          - jitstress2_jitstressregs4
+          - jitstress2_jitstressregs8
+          - jitstress2_jitstressregs0x10
+          - jitstress2_jitstressregs0x80
+          - jitstress2_jitstressregs0x1000          
         ${{ if in(parameters.testGroup, 'gcstress0x3-gcstress0xc') }}:
           scenarios:
           - gcstress0x3

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs-armarch.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs-armarch.yml
@@ -1,0 +1,59 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 17 * * 6,0"
+  displayName: Sat and Sun at 9:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+#
+# Checkout repository
+#
+- template: /eng/pipelines/common/checkout-job.yml
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Windows_NT_arm
+    - Windows_NT_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: jitstress2-jitstressregs-armarch
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: checked
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    buildConfig: checked
+    platforms:
+    # Linux tests are built on the OSX machines.
+    - OSX_x64
+    - Linux_arm
+    - Linux_arm64
+    - Windows_NT_arm
+    - Windows_NT_arm64
+    helixQueueGroup: ci
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      testGroup: jitstress2-jitstressregs-armarch
+      liveLibrariesBuildConfig: Release

--- a/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs-armarch.yml
+++ b/eng/pipelines/coreclr/libraries-jitstress2-jitstressregs-armarch.yml
@@ -1,0 +1,65 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 9 * * 6"
+  displayName: Sat at 1:00 AM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+#
+# Checkout repository
+#
+- template: /eng/pipelines/common/checkout-job.yml
+
+#
+# Build CoreCLR checked and libraries Release
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Windows_NT_arm64
+
+#
+# Libraries Test Build - Release innerloop. All libraries are built on x64 and reused on all platforms.
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/build-test-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_x64
+    - Windows_NT_x64
+    jobParameters:
+      liveRuntimeBuildConfig: checked
+      testScope: innerloop
+
+#
+# Libraries Test Run using Release libraries, Checked CoreCLR, and stress modes
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/libraries/run-test-job.yml
+    buildConfig: Release
+    platforms:
+    - Linux_arm
+    - Linux_arm64
+    - Windows_NT_arm64
+    helixQueueGroup: libraries
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    jobParameters:
+      # Default timeout is 150 minutes (2.5 hours), which is not enough for stress.
+      timeoutInMinutes: 300
+      testScope: innerloop
+      liveRuntimeBuildConfig: checked
+      dependsOnTestBuildConfiguration: Release
+      dependsOnTestArchitecture: x64
+      coreclrTestGroup: jitstress2-jitstressregs-armarch

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -144,3 +144,13 @@ jobs:
               - jitstress2_jitstressregs0x10
               - jitstress2_jitstressregs0x80
               - jitstress2_jitstressregs0x1000
+            ${{ if in(parameters.coreclrTestGroup, 'jitstress2-jitstressregs-armarch') }}:
+              scenarios:
+              - jitstress2_jitstressregs1
+              - jitstress2_jitstressregs2
+              - jitstress2_jitstressregs3
+              - jitstress2_jitstressregs4
+              - jitstress2_jitstressregs8
+              - jitstress2_jitstressregs0x10
+              - jitstress2_jitstressregs0x80
+              - jitstress2_jitstressregs0x1000


### PR DESCRIPTION
With more and more work happening on ARM platforms, cloned the existing `jitstress2-jitstressregs` pipeline into `jitstress2-jitstressregs-armarch` to just run for ARM/ARM64 architecture so we don't waste x86 and x64 resources.