### PR TITLE
Prevent shutdown being blocked by finalization

### DIFF
--- a/src/coreclr/src/vm/finalizerthread.cpp
+++ b/src/coreclr/src/vm/finalizerthread.cpp
@@ -125,7 +125,7 @@ void FinalizerThread::FinalizeAllObjects(int bitToCheck)
     Thread *pThread = GetThread();
 
     // Finalize everyone
-    while (fobj)
+    while (fobj && !fQuitFinalizer)
     {
         if (fobj->GetHeader()->GetBits() & bitToCheck)
         {

--- a/src/libraries/System.Runtime/tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System/GCTests.cs
@@ -114,6 +114,26 @@ namespace System.Tests
             }
         }
 
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public static void ExpensiveFinalizerDoesNotBlockShutdown()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                for (int i = 0; i < 100000; i++)
+                    GC.KeepAlive(new ObjectWithExpensiveFinalizer());
+                GC.Collect();
+                Thread.Sleep(100); // Give the finalizer thread a chance to start running
+            }).Dispose();
+        }
+
+        private class ObjectWithExpensiveFinalizer
+        {
+            ~ObjectWithExpensiveFinalizer()
+            {
+                Thread.Sleep(100);
+            }
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
         public static void KeepAlive()
         {


### PR DESCRIPTION
The finalization queue can be long or constantly growing when the finalization thread is not able to
keep up with finalizable object allocation rate. This can lead to shutdown being blocked for a long
time or indefinitely.

The fix is stop the finalization loop once we enter shutdown instead of trying to empty the finalization
queue.

Fixes #314