### PR TITLE
Unignore some Makefiles in src/mono

### DIFF
--- a/src/mono/netcore/.gitignore
+++ b/src/mono/netcore/.gitignore
@@ -13,3 +13,4 @@ packs/
 /obj
 .configured
 /config.make
+!Makefile

--- a/src/mono/wasm/.gitignore
+++ b/src/mono/wasm/.gitignore
@@ -1,1 +1,2 @@
 /emsdk_env.sh
+!Makefile


### PR DESCRIPTION
The global .gitignore ignores `Makefile` since it's typically just a build artifact of CMake/automake.
However we have a few real Makefiles in src/mono that were excluded by this, resulting in VSCode's search not looking in them.