### PR TITLE
Validate baseline files in ApiCompat for unused diffs

### DIFF
--- a/src/libraries/shims/ApiCompat.proj
+++ b/src/libraries/shims/ApiCompat.proj
@@ -37,7 +37,7 @@
     <PropertyGroup>
       <ApiCompatImplementationDirs>$(BuildTargetFrameworkRefPath.TrimEnd('\/'))</ApiCompatImplementationDirs>
       <ApiCompatArgs Condition="'$(ApiCompatExcludeAttributeList)' != ''">$(ApiCompatArgs) --exclude-attributes "$(ApiCompatExcludeAttributeList)"</ApiCompatArgs>
-      <ApiCompatArgs>$(ApiCompatArgs) --impl-dirs "$(ApiCompatImplementationDirs)"</ApiCompatArgs>
+      <ApiCompatArgs>$(ApiCompatArgs) --impl-dirs "$(ApiCompatImplementationDirs)" --validate-baseline</ApiCompatArgs>
       <BaselineApiCompatArgs Condition="Exists($(ApiCompatBaselineIgnoreFile))">--baseline "$(ApiCompatBaselineIgnoreFile)"</BaselineApiCompatArgs>
       <ApiCompatExitCode>0</ApiCompatExitCode>
     </PropertyGroup>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/28571

https://github.com/dotnet/arcade/commit/f107638b378faff179c42c22b5e0715f9f7eb8d4 added the ability to validate baseline files against unused diffs. Enabled this in dotnet/runtime.