### PR TITLE
increase BufferPtrSendOperation  test coverage

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/LoggingTest.cs
@@ -57,7 +57,7 @@ namespace System.Net.Sockets.Tests
                         new SendReceiveApm(null).SendRecv_Stream_TCP(IPAddress.Loopback, false).GetAwaiter();
                         new SendReceiveApm(null).SendRecv_Stream_TCP(IPAddress.Loopback, true).GetAwaiter();
 
-                        new NetworkStreamTest().CopyToAsync_AllDataCopied(4096).GetAwaiter().GetResult();
+                        new NetworkStreamTest().CopyToAsync_AllDataCopied(4096, true).GetAwaiter().GetResult();
                         new NetworkStreamTest().Timeout_ValidData_Roundtrips().GetAwaiter().GetResult();
                     });
                     Assert.DoesNotContain(events, ev => ev.EventId == 0); // errors from the EventSource itself

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/NetworkStreamTest.cs
@@ -634,14 +634,14 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        public static IEnumerable<object[]> CopyToAsync_AllDataCopied_MemberData() =>
+            from asyncWrite in new bool[] { true, false }
+            from byteCount in new int[] { 0, 1, 1024, 4096, 4095, 1024 * 1024 }
+            select new object[] { byteCount, asyncWrite };
+
         [Theory]
-        [InlineData(0)]
-        [InlineData(1)]
-        [InlineData(1024)]
-        [InlineData(4096)]
-        [InlineData(4095)]
-        [InlineData(1024*1024)]
-        public async Task CopyToAsync_AllDataCopied(int byteCount)
+        [MemberData(nameof(CopyToAsync_AllDataCopied_MemberData))]
+        public async Task CopyToAsync_AllDataCopied(int byteCount, bool asyncWrite)
         {
             await RunWithConnectedNetworkStreamsAsync(async (server, client) =>
             {
@@ -650,7 +650,16 @@ namespace System.Net.Sockets.Tests
                 new Random().NextBytes(dataToCopy);
 
                 Task copyTask = client.CopyToAsync(results);
-                await server.WriteAsync(dataToCopy, 0, dataToCopy.Length);
+
+                if (asyncWrite)
+                {
+                    await server.WriteAsync(dataToCopy, 0, dataToCopy.Length);
+                }
+                else
+                {
+                    server.Write(new ReadOnlySpan<byte>(dataToCopy, 0, dataToCopy.Length));
+                }
+
                 server.Dispose();
                 await copyTask;
 


### PR DESCRIPTION
@stephentoub wrote in https://github.com/dotnet/runtime/pull/38762#issuecomment-653668960

> What distresses me is that the tests passed with this PR. If anything, the thing to fix here is ensuring we have tests in place to cover this case. This type will be used when performing synchronous sends on a socket that previously had asynchronous operations performed on it, and a mistake in the arguments here would manifest as a bug if the send didn't complete in one call due to the kernel buffer being full, so it's certainly harder to test, but not impossible.

recently I've spent some time debugging `CopyToAsync_AllDataCopied` (#38747) and I think that it's a good candidate for extending to test the sync path as well