### PR TITLE
Build refs only for applicable BuildTFMs

### DIFF
--- a/eng/referenceAssemblies.props
+++ b/eng/referenceAssemblies.props
@@ -1,7 +1,12 @@
 <Project>
-  <PropertyGroup>
-    <AdditionalBuildTargetFrameworks Condition="'$(BuildAllProjects)' == 'true'">$(AdditionalBuildTargetFrameworks);netstandard2.0;netstandard2.1</AdditionalBuildTargetFrameworks>    
+  <PropertyGroup Condition="'$(BuildAllProjects)' == 'true' and
+                            !$(BuildTargetFramework.StartsWith('netstandard'))">
+    <AdditionalBuildTargetFrameworks Condition="!$(BuildTargetFramework.StartsWith('net45'))'">$(AdditionalBuildTargetFrameworks);netstandard2.0</AdditionalBuildTargetFrameworks>
+    <AdditionalBuildTargetFrameworks Condition="!$(BuildTargetFramework.StartsWith('netcoreapp2.0')) and
+                                                !$(BuildTargetFramework.StartsWith('net4'))">$(AdditionalBuildTargetFrameworks);netstandard2.1</AdditionalBuildTargetFrameworks>
+  </PropertyGroup>
 
+  <PropertyGroup>
     <!-- disable warnings about unused fields -->
     <NoWarn>$(NoWarn);CS0169;CS0649;CS8618</NoWarn>
 

--- a/eng/referenceAssemblies.props
+++ b/eng/referenceAssemblies.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup Condition="'$(BuildAllProjects)' == 'true' and
                             !$(BuildTargetFramework.StartsWith('netstandard'))">
-    <AdditionalBuildTargetFrameworks Condition="!$(BuildTargetFramework.StartsWith('net45'))'">$(AdditionalBuildTargetFrameworks);netstandard2.0</AdditionalBuildTargetFrameworks>
+    <AdditionalBuildTargetFrameworks Condition="!$(BuildTargetFramework.StartsWith('net45'))">$(AdditionalBuildTargetFrameworks);netstandard2.0</AdditionalBuildTargetFrameworks>
     <AdditionalBuildTargetFrameworks Condition="!$(BuildTargetFramework.StartsWith('netcoreapp2.0')) and
                                                 !$(BuildTargetFramework.StartsWith('net4'))">$(AdditionalBuildTargetFrameworks);netstandard2.1</AdditionalBuildTargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
In response to

> the build fails with following build error (it still builds 2.0 configuration)

from https://github.com/dotnet/runtime/issues/1919

cc @marek-safar 