### PR TITLE
Remove commented libraries windows helix queues

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -90,7 +90,6 @@ jobs:
       # netcoreapp
       - ${{ if notIn(parameters.jobParameters.framework, 'allConfigurations', 'net472') }}:
         - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-
           - Windows.81.Amd64.Open
           - Windows.10.Amd64.ServerRS5.Open
           - Windows.10.Amd64.Server19H1.Open

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -90,16 +90,13 @@ jobs:
       # netcoreapp
       - ${{ if notIn(parameters.jobParameters.framework, 'allConfigurations', 'net472') }}:
         - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
-          # Bring back once: https://github.com/dotnet/runtime/issues/35689 is fixed
-          # - Windows.7.Amd64.Open
+
           - Windows.81.Amd64.Open
           - Windows.10.Amd64.ServerRS5.Open
           - Windows.10.Amd64.Server19H1.Open
           - ${{ if ne(parameters.jobParameters.runtimeFlavor, 'mono') }}:
             - (Windows.Nano.1809.Amd64.Open)windows.10.amd64.serverrs5.open@mcr.microsoft.com/dotnet-buildtools/prereqs:nanoserver-1809-helix-amd64-08e8e40-20200107182504
         - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
-          # Bring back once: https://github.com/dotnet/runtime/issues/35689 is fixed
-          # - Windows.7.Amd64.Open
           - Windows.81.Amd64.Open
           - Windows.10.Amd64.Server19H1.ES.Open
           - ${{ if ne(parameters.jobParameters.runtimeFlavor, 'mono') }}:
@@ -119,8 +116,6 @@ jobs:
       - ${{ if notIn(parameters.jobParameters.framework, 'allConfigurations', 'net472') }}:
         - ${{ if eq(parameters.jobParameters.isFullMatrix, true) }}:
           - Windows.7.Amd64.Open
-          # Bring back once: https://github.com/dotnet/runtime/issues/35689 is fixed
-          # - Windows.81.Amd64.Open
           - Windows.10.Amd64.ServerRS5.Open
           - Windows.10.Amd64.Server19H1.Open
         - ${{ if eq(parameters.jobParameters.isFullMatrix, false) }}:
@@ -128,8 +123,6 @@ jobs:
             - Windows.10.Amd64.Server19H1.ES.Open
           - ${{ if eq(parameters.jobParameters.buildConfig, 'Debug') }}:
             - Windows.7.Amd64.Open
-            # Bring back once: https://github.com/dotnet/runtime/issues/35689 is fixed
-            # - Windows.81.Amd64.Open
             - Windows.10.Amd64.Server19H1.Open
 
       # NET472


### PR DESCRIPTION
We're already testing for Windows7 and Windows8.1 on both PRs and CI with a balanced approach so we can remove these commented entries.

Fixes: https://github.com/dotnet/runtime/issues/35689