### PR TITLE
Allow ctor parameters to exactly match property name

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -35,14 +35,14 @@ namespace System.Text.Json
 
         // All of the serializable parameters on a POCO constructor keyed on parameter name.
         // Only paramaters which bind to properties are cached.
-        public volatile Dictionary<string, JsonParameterInfo>? ParameterCache;
+        public Dictionary<string, JsonParameterInfo>? ParameterCache;
 
         // All of the serializable properties on a POCO (except the optional extension property) keyed on property name.
-        public volatile Dictionary<string, JsonPropertyInfo>? PropertyCache;
+        public Dictionary<string, JsonPropertyInfo>? PropertyCache;
 
         // All of the serializable properties on a POCO including the optional extension property.
         // Used for performance during serialization instead of 'PropertyCache' above.
-        public volatile JsonPropertyInfo[]? PropertyCacheArray;
+        public JsonPropertyInfo[]? PropertyCacheArray;
 
         // Fast cache of constructor parameters by first JSON ordering; may not contain all parameters. Accessed before ParameterCache.
         // Use an array (instead of List<T>) for highest performance.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -283,10 +283,10 @@ namespace System.Text.Json
                 parameters.Length, Options.PropertyNameCaseInsensitive ? StringComparer.OrdinalIgnoreCase : null);
 
             // Cache the lookup from object property name to JsonPropertyInfo using a case-insensitive comparer.
-            // Case-insensitive is used to support both camel-cased parameter names and exact matches when C# record
-            // types or anonymous types are used.
-            // The property name key does not use [JsonPropertyName] or PropertyNamingPolicy since we are just binding the
-            // parameter name to the object property name and do not include the JSON version of the name here.
+            // Case-insensitive is used to support both camel-cased parameter names and exact matches when C#
+            // record types or anonymous types are used.
+            // The property name key does not use [JsonPropertyName] or PropertyNamingPolicy since we only bind
+            // the parameter name to the object property name and do not use the JSON version of the name here.
             var nameLookup = new Dictionary<string, ParameterLookupEntry>(PropertyCacheArray!.Length, StringComparer.OrdinalIgnoreCase);
             foreach (JsonPropertyInfo jsonProperty in PropertyCacheArray!)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -184,18 +184,18 @@ namespace System.Text.Json
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowInvalidOperationException_MultiplePropertiesBindToConstructorParameters(
             Type parentType,
-            ParameterInfo parameterInfo,
-            MemberInfo firstMatch,
-            MemberInfo secondMatch,
+            string parameterName,
+            string firstMatchName,
+            string secondMatchName,
             ConstructorInfo constructorInfo)
         {
             throw new InvalidOperationException(
                 SR.Format(
                     SR.MultipleMembersBindWithConstructorParameter,
-                    firstMatch.Name,
-                    secondMatch.Name,
+                    firstMatchName,
+                    secondMatchName,
                     parentType,
-                    parameterInfo.Name,
+                    parameterName,
                     constructorInfo));
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -31,7 +31,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Contains("Point_MultipleMembers_BindTo_OneConstructorParameter_Variant", exStr);
 
             ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => Serializer.DeserializeWrapper<Point_MultipleMembers_BindTo_OneConstructorParameter_Variant>("{}"));
+                () => Serializer.DeserializeWrapper<Url_BindTo_OneConstructorParameter>("{}"));
 
             exStr = ex.ToString();
             Assert.Contains("'URL'", exStr);
@@ -339,7 +339,9 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public async Task ExtensionPropertyRoundTripFails()
         {
-            JsonException e = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Parameterized_ClassWithExtensionProperty>(@"{""MyNestedClass"":{""UnknownProperty"":bad}}"));
+            JsonException e = await Assert.ThrowsAsync<JsonException>(() =>
+                Serializer.DeserializeWrapper<Parameterized_ClassWithExtensionProperty>(@"{""MyNestedClass"":{""UnknownProperty"":bad}}"));
+
             Assert.Equal("$.MyNestedClass.UnknownProperty", e.Path);
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -152,6 +152,31 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
         }
 
+        [Fact]
+        public void AnonymousObject_NamingPolicy()
+        {
+            const string Json = @"{""prop"":5}";
+
+            var obj = new { Prop = 5 };
+            Type objType = obj.GetType();
+
+            // 'Prop' property binds with a ctor arg called 'Prop'.
+
+            object newObj = JsonSerializer.Deserialize(Json, objType);
+            // Verify no match if no naming policy
+            Assert.Equal(0, objType.GetProperty("Prop").GetValue(newObj));
+
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            };
+
+            newObj = JsonSerializer.Deserialize(Json, objType, options);
+            // Verify match with naming policy
+            Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
+        }
+
+#if NETCOREAPP // These require the C# 9.0 "record" feature which is not available for all TFMs.
         private record MyRecord(int Prop);
 
         [Fact]
@@ -184,30 +209,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        public void AnonymousObject_NamingPolicy()
-        {
-            const string Json = @"{""prop"":5}";
-
-            var obj = new { Prop = 5 };
-            Type objType = obj.GetType();
-
-            // 'Prop' property binds with a ctor arg called 'Prop'.
-
-            object newObj = JsonSerializer.Deserialize(Json, objType);
-            // Verify no match if no naming policy
-            Assert.Equal(0, objType.GetProperty("Prop").GetValue(newObj));
-
-            var options = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-            };
-
-            newObj = JsonSerializer.Deserialize(Json, objType, options);
-            // Verify match with naming policy
-            Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
-        }
-
-        [Fact]
         public void Record_NamingPolicy()
         {
             const string Json = @"{""prop"":5}";
@@ -227,6 +228,7 @@ namespace System.Text.Json.Serialization.Tests
             obj = JsonSerializer.Deserialize<MyRecord>(Json, options);
             Assert.Equal(5, obj.Prop);
         }
+#endif
 
         [Fact]
         public async Task DeserializePathForObjectFails()

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -190,6 +190,18 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, obj.Prop);
         }
 
+        public record AgeRecord(int age)
+        {
+            public string Age { get; set; } = age.ToString();
+        }
+
+        [Fact]
+        public void RecordWithSamePropertyNameDifferentTypes()
+        {
+            AgeRecord obj = JsonSerializer.Deserialize<AgeRecord>(@"{""age"":1}");
+            Assert.Equal(1, obj.age);
+        }
+
         private record MyRecordWithUnboundCtorProperty(int IntProp1, int IntProp2)
         {
             public string StringProp { get; set; }
@@ -229,6 +241,24 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, obj.Prop);
         }
 #endif
+
+        [Fact]
+        public void PocoWithSamePropertyNameDifferentTypes()
+        {
+            AgePoco obj = JsonSerializer.Deserialize<AgePoco>(@"{""age"":1}");
+            Assert.Equal(1, obj.age);
+        }
+
+        private class AgePoco
+        {
+            public AgePoco(int age)
+            {
+                this.age = age;
+            }
+            public int age { get; set; }
+
+            public string Age { get; set; }
+        }
 
         [Fact]
         public async Task DeserializePathForObjectFails()

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -166,6 +166,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
         }
 
+        /* Enable when C# 9.0 'records' feature works in CI
         private record MyRecord(int Prop);
 
         [Fact]
@@ -178,6 +179,7 @@ namespace System.Text.Json.Serialization.Tests
             obj = JsonSerializer.Deserialize<MyRecord>(@"{""Prop"":5}");
             Assert.Equal(5, obj.Prop);
         }
+        */
 
         [Fact]
         public void AnonymousObject_NamingPolicy()
@@ -203,6 +205,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
         }
 
+        /* Enable when C# 9.0 'records' feature works in CI
         [Fact]
         public void Record_NamingPolicy()
         {
@@ -223,6 +226,7 @@ namespace System.Text.Json.Serialization.Tests
             obj = JsonSerializer.Deserialize<MyRecord>(Json, options);
             Assert.Equal(5, obj.Prop);
         }
+        */
 
         [Fact]
         public async Task DeserializePathForObjectFails()

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -10,48 +10,34 @@ namespace System.Text.Json.Serialization.Tests
     public abstract partial class ConstructorTests
     {
         [Fact]
-<<<<<<< HEAD
         public async Task MultipleProperties_Cannot_BindTo_TheSame_ConstructorParameter()
         {
             InvalidOperationException ex = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => Serializer.DeserializeWrapper<Point_MultipleMembers_BindTo_OneConstructorParameter>("{}"));
-=======
-        public void MultipleProperties_SameNameExceptCamelCase()
-        {
-            MultipleMembers_SameNameExceptCamelCasing obj =
-                Serializer.Deserialize<MultipleMembers_SameNameExceptCamelCasing>("{}");
-
-            obj = Serializer.Deserialize<MultipleMembers_SameNameExceptCamelCasing>(@"{""X"":1,""x"":2}");
-            Assert.Equal(1, obj.X);
-            Assert.Equal(2, obj.x);
-        }
-
-        [Fact]
-        public void MultipleProperties_Cannot_BindTo_TheSame_ConstructorParameter()
-        {
-            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(
-                () => Serializer.Deserialize<MultipleMembers_BindTo_OneConstructorParameter>("{}"));
->>>>>>> Allow ctor parameters to exactly match property name
 
             string exStr = ex.ToString();
-            Assert.Contains("'URL'", exStr);
-            Assert.Contains("'Url'", exStr);
-            Assert.Contains("(Int32)", exStr);
-            Assert.Contains("System.Text.Json.Serialization.Tests.MultipleMembers_BindTo_OneConstructorParameter", exStr);
+            Assert.Contains("'X'", exStr);
+            Assert.Contains("'x'", exStr);
+            Assert.Contains("(Int32, Int32)", exStr);
+            Assert.Contains("System.Text.Json.Serialization.Tests.Point_MultipleMembers_BindTo_OneConstructorParameter", exStr);
 
-<<<<<<< HEAD
+            ex = Assert.Throws<InvalidOperationException>(
+                () => Serializer.Deserialize<Point_MultipleMembers_BindTo_OneConstructorParameter_Variant>("{}"));
+
+            exStr = ex.ToString();
+            Assert.Contains("'X'", exStr);
+            Assert.Contains("'x'", exStr);
+            Assert.Contains("(Int32)", exStr);
+            Assert.Contains("Point_MultipleMembers_BindTo_OneConstructorParameter_Variant", exStr);
+
             ex = await Assert.ThrowsAsync<InvalidOperationException>(
                 () => Serializer.DeserializeWrapper<Point_MultipleMembers_BindTo_OneConstructorParameter_Variant>("{}"));
-=======
-            ex = Assert.Throws<InvalidOperationException>(
-                () => Serializer.Deserialize<MultipleMembers_BindTo_OneConstructorParameter>("{}"));
->>>>>>> Allow ctor parameters to exactly match property name
 
             exStr = ex.ToString();
             Assert.Contains("'URL'", exStr);
             Assert.Contains("'Url'", exStr);
             Assert.Contains("(Int32)", exStr);
-            Assert.Contains("System.Text.Json.Serialization.Tests.MultipleMembers_BindTo_OneConstructorParameter", exStr);
+            Assert.Contains("Url_BindTo_OneConstructorParameter", exStr);
         }
 
         [Fact]
@@ -166,7 +152,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
         }
 
-        /* Enable when C# 9.0 'records' feature works in CI
         private record MyRecord(int Prop);
 
         [Fact]
@@ -179,7 +164,24 @@ namespace System.Text.Json.Serialization.Tests
             obj = JsonSerializer.Deserialize<MyRecord>(@"{""Prop"":5}");
             Assert.Equal(5, obj.Prop);
         }
-        */
+
+        private record MyRecordWithUnboundCtorProperty(int IntProp1, int IntProp2)
+        {
+            public string StringProp { get; set; }
+        }
+
+        [Fact]
+        public void RecordWithAdditionalProperty()
+        {
+            MyRecordWithUnboundCtorProperty obj = JsonSerializer.Deserialize<MyRecordWithUnboundCtorProperty>(
+                @"{""IntProp1"":1,""IntProp2"":2,""StringProp"":""hello""}");
+
+            Assert.Equal(1, obj.IntProp1);
+            Assert.Equal(2, obj.IntProp2);
+
+            // StringProp is not bound to any constructor property.
+            Assert.Equal("hello", obj.StringProp);
+        }
 
         [Fact]
         public void AnonymousObject_NamingPolicy()
@@ -205,7 +207,6 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(5, objType.GetProperty("Prop").GetValue(newObj));
         }
 
-        /* Enable when C# 9.0 'records' feature works in CI
         [Fact]
         public void Record_NamingPolicy()
         {
@@ -226,7 +227,6 @@ namespace System.Text.Json.Serialization.Tests
             obj = JsonSerializer.Deserialize<MyRecord>(Json, options);
             Assert.Equal(5, obj.Prop);
         }
-        */
 
         [Fact]
         public async Task DeserializePathForObjectFails()
@@ -337,7 +337,6 @@ namespace System.Text.Json.Serialization.Tests
         }
 
         [Fact]
-        [ActiveIssue("JsonElement needs to support Path")]
         public async Task ExtensionPropertyRoundTripFails()
         {
             JsonException e = await Assert.ThrowsAsync<JsonException>(() => Serializer.DeserializeWrapper<Parameterized_ClassWithExtensionProperty>(@"{""MyNestedClass"":{""UnknownProperty"":bad}}"));

--- a/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -21,8 +21,8 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Contains("(Int32, Int32)", exStr);
             Assert.Contains("System.Text.Json.Serialization.Tests.Point_MultipleMembers_BindTo_OneConstructorParameter", exStr);
 
-            ex = Assert.Throws<InvalidOperationException>(
-                () => Serializer.Deserialize<Point_MultipleMembers_BindTo_OneConstructorParameter_Variant>("{}"));
+            ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => Serializer.DeserializeWrapper<Point_MultipleMembers_BindTo_OneConstructorParameter_Variant>("{}"));
 
             exStr = ex.ToString();
             Assert.Contains("'X'", exStr);

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
@@ -2060,13 +2060,26 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class Point_MultipleMembers_BindTo_OneConstructorParameter
+    public class MultipleMembers_SameNameExceptCamelCasing
     {
         public int X { get; }
 
         public int x { get; }
 
-        public Point_MultipleMembers_BindTo_OneConstructorParameter(int X, int x) { }
+        public MultipleMembers_SameNameExceptCamelCasing(int X, int x)
+        {
+            this.X = X;
+            this.x = x;
+        }
+    }
+
+    public class MultipleMembers_BindTo_OneConstructorParameter
+    {
+        public int URL { get; }
+
+        public int Url { get; }
+
+        public MultipleMembers_BindTo_OneConstructorParameter(int url) { }
     }
 
     public class Point_MultipleMembers_BindTo_OneConstructorParameter_Variant

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.Constructor.cs
@@ -2060,26 +2060,26 @@ namespace System.Text.Json.Serialization.Tests
         }
     }
 
-    public class MultipleMembers_SameNameExceptCamelCasing
+    public class Point_MultipleMembers_BindTo_OneConstructorParameter
     {
         public int X { get; }
 
         public int x { get; }
 
-        public MultipleMembers_SameNameExceptCamelCasing(int X, int x)
+        public Point_MultipleMembers_BindTo_OneConstructorParameter(int X, int x)
         {
             this.X = X;
             this.x = x;
         }
     }
 
-    public class MultipleMembers_BindTo_OneConstructorParameter
+    public class Url_BindTo_OneConstructorParameter
     {
         public int URL { get; }
 
         public int Url { get; }
 
-        public MultipleMembers_BindTo_OneConstructorParameter(int url) { }
+        public Url_BindTo_OneConstructorParameter(int url) { }
     }
 
     public class Point_MultipleMembers_BindTo_OneConstructorParameter_Variant

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- allow use of C# 9 'record' type -->
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -1,7 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- allow use of new C# 'record' type -->
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -1,9 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- allow use of C# 9 'record' type -->
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -2,8 +2,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- allow use of new C# 'record' type -->
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>


### PR DESCRIPTION
Supports the new C# "record" type as well as C# anonymous types.

Fixes https://github.com/dotnet/runtime/issues/38539
