### PR TITLE
Fix mark overflow processing

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -19802,10 +19802,10 @@ void gc_heap::process_mark_overflow_internal (int condemned_gen_number,
             int align_const = get_alignment_constant (i < uoh_start_generation);
 
             PREFIX_ASSUME(seg != NULL);
-            uint8_t*  o = max (heap_segment_mem (seg), min_add);
 
             while (seg)
             {
+                uint8_t*  o = max (heap_segment_mem (seg), min_add);
                 uint8_t*  end = heap_segment_allocated (seg);
 
                 while ((o < end) && (o <= max_add))


### PR DESCRIPTION
A relatively recent refactoring PR #1688 has regressed GC processing of mark overflow.
If GC heap segments in the segment linked list are not ordered in an ascending
order by their addresses, the mark overflow processing misses segments on
lower addresses if they follow segments on higher addresses.
This leads to some objects that are alive to not to be reported and freed.

This change fixes the problem by making sure the segment order doesn't matter.