### PR TITLE
Fix standalone GC on ARM32

### DIFF
--- a/src/coreclr/src/gc/env/gcenv.object.h
+++ b/src/coreclr/src/gc/env/gcenv.object.h
@@ -4,6 +4,13 @@
 #ifndef __GCENV_OBJECT_H__
 #define __GCENV_OBJECT_H__
 
+// ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
+// Additionally the platform ABI requires these types and composite type containing them to be similarly
+// aligned when passed as arguments.
+#ifdef TARGET_ARM
+#define FEATURE_64BIT_ALIGNMENT
+#endif
+
 //-------------------------------------------------------------------------------------------------
 //
 // Low-level types describing GC object layouts.

--- a/src/coreclr/src/gc/env/gcenv.object.h
+++ b/src/coreclr/src/gc/env/gcenv.object.h
@@ -42,13 +42,15 @@ public:
 
 static_assert(sizeof(ObjHeader) == sizeof(uintptr_t), "this assumption is made by the VM!");
 
-#define MTFlag_RequireAlign8        0x00001000
-#define MTFlag_ContainsPointers     0x01000000
-#define MTFlag_HasCriticalFinalizer 0x08000000
-#define MTFlag_HasFinalizer         0x00100000
-#define MTFlag_IsArray              0x00080000
-#define MTFlag_Collectible          0x10000000
-#define MTFlag_HasComponentSize     0x80000000
+#define MTFlag_RequireAlign8            0x00001000
+#define MTFlag_Category_ValueType       0x00040000
+#define MTFlag_Category_ValueType_Mask  0x000C0000
+#define MTFlag_ContainsPointers         0x01000000
+#define MTFlag_HasCriticalFinalizer     0x08000000
+#define MTFlag_HasFinalizer             0x00100000
+#define MTFlag_IsArray                  0x00080000
+#define MTFlag_Collectible              0x10000000
+#define MTFlag_HasComponentSize         0x80000000
 
 class MethodTable
 {
@@ -99,6 +101,11 @@ public:
     bool RequiresAlign8()
     {
         return (m_flags & MTFlag_RequireAlign8) != 0;
+    }
+
+    bool IsValueType()
+    {
+        return (m_flags & MTFlag_Category_ValueType_Mask) == MTFlag_Category_ValueType;
     }
 
     bool HasComponentSize()

--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -55,6 +55,13 @@ inline void FATAL_GC_ERROR()
 // turned on.
 #define FEATURE_LOH_COMPACTION
 
+// ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
+// Additionally the platform ABI requires these types and composite type containing them to be similarly
+// aligned when passed as arguments.
+#ifdef TARGET_ARM
+#define FEATURE_64BIT_ALIGNMENT
+#endif
+
 #ifdef FEATURE_64BIT_ALIGNMENT
 // We need the following feature as part of keeping 64-bit types aligned in the GC heap.
 #define RESPECT_LARGE_ALIGNMENT //Preserve double alignment of objects during relocation

--- a/src/coreclr/src/gc/gcpriv.h
+++ b/src/coreclr/src/gc/gcpriv.h
@@ -55,13 +55,6 @@ inline void FATAL_GC_ERROR()
 // turned on.
 #define FEATURE_LOH_COMPACTION
 
-// ARM requires that 64-bit primitive types are aligned at 64-bit boundaries for interlocked-like operations.
-// Additionally the platform ABI requires these types and composite type containing them to be similarly
-// aligned when passed as arguments.
-#ifdef TARGET_ARM
-#define FEATURE_64BIT_ALIGNMENT
-#endif
-
 #ifdef FEATURE_64BIT_ALIGNMENT
 // We need the following feature as part of keeping 64-bit types aligned in the GC heap.
 #define RESPECT_LARGE_ALIGNMENT //Preserve double alignment of objects during relocation


### PR DESCRIPTION
The standalone build of GC on ARM32 was missing the FEATURE_64BIT_ALIGNMENT,
which caused aligment failures at runtime for objects that require align
on 8 byte boundary and were not getting it.

This change fixes that. I had to modify the copy of MethodTable that the
standalone GC uses so that the RequireAlign8 flag can be checked.