### PR TITLE
Add a repro test for `IsCompatibleType(cseLclVarTyp, expTyp)`

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_35144/Runtime_35144.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_35144/Runtime_35144.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType />

--- a/src/tests/JIT/Regression/JitBlue/Runtime_35724/Runtime_35724.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_35724/Runtime_35724.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+// SIMD8 could be retyped as a long in the past and if that long value was CSE-ed together with original SIMD8
+// values we could hit an assert `IsCompatibleType(cseLclVarTyp, expTyp)`.
+
+class Runtime_35724
+{
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	static Vector2 Test()
+    {
+        Vector2 a = new Vector2(1);
+        Vector2 b = new Vector2(2);
+        Vector2 c = a / b;
+        Vector2 d = a / b;
+        Console.WriteLine(c.X + d.Y);
+        return a / b;
+    }
+	
+    public static int Main()
+    {
+        Test();
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_35724/Runtime_35724.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_35724/Runtime_35724.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Closes #35724.

The issue was fixed by #38484 (we don't longer try to CSE `IND SIMD8` there), that PR adds a repro test that does not require crossgen2. 
