### PR TITLE
WASM Enable System.Collections tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -160,9 +160,27 @@ namespace System
             }
         }
 
-        private static Lazy<Version> m_icuVersion = new Lazy<Version>(GetICUVersion);
+        private static readonly Lazy<bool> m_isInvariant = new Lazy<bool>(GetIsInvariantGlobalization);
+
+        private static bool GetIsInvariantGlobalization()
+        {
+            Type globalizationMode = Type.GetType("System.Globalization.GlobalizationMode");
+            if (globalizationMode != null)
+            {
+                MethodInfo methodInfo = globalizationMode.GetProperty("Invariant", BindingFlags.NonPublic | BindingFlags.Static)?.GetMethod;
+                if (methodInfo != null)
+                {
+                    return (bool)methodInfo.Invoke(null, null);
+                }
+            }
+
+            return false;
+        }
+
+        private static readonly Lazy<Version> m_icuVersion = new Lazy<Version>(GetICUVersion);
         public static Version ICUVersion => m_icuVersion.Value;
 
+        public static bool IsInvariantGlobalization => m_isInvariant.Value;
         public static bool IsIcuGlobalization => ICUVersion > new Version(0,0,0,0);
         public static bool IsNlsGlobalization => !IsIcuGlobalization;
 

--- a/src/libraries/System.Collections/tests/StructuralComparisonsTests.cs
+++ b/src/libraries/System.Collections/tests/StructuralComparisonsTests.cs
@@ -20,8 +20,9 @@ namespace System.Collections.Tests
             yield return new object[] { null, "abc", -1 };
             yield return new object[] { "abc", null, 1 };
             yield return new object[] { "abc", "abc", 0 };
-            yield return new object[] { "abc", "def", -1 };
-            yield return new object[] { "def", "abc", 1 };
+            // Invariant mode comparison of strings, ends up returning firstChar - secondChar when different, i.e 'd' - 'a'
+            yield return new object[] { "abc", "def", PlatformDetection.IsInvariantGlobalization ? -3 : -1 };
+            yield return new object[] { "def", "abc", PlatformDetection.IsInvariantGlobalization ? 3 : 1 };
             yield return new object[] { new StructuralObject(), "abc", 5 };
             yield return new object[] { new StructuralObject(), 123, -5 };
         }

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -29,7 +29,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.CodeDom\tests\System.CodeDom.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.NonGeneric\tests\System.Collections.NonGeneric.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Specialized\tests\System.Collections.Specialized.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections\tests\System.Collections.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Annotations\tests\System.ComponentModel.Annotations.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Primitives\tests\System.ComponentModel.Primitives.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter\tests\System.ComponentModel.TypeConverter.Tests.csproj" />


### PR DESCRIPTION
Fix failing tests in System.Collections on WASM because currently WASM is running on invariant mode.

This depends on: https://github.com/dotnet/runtime/pull/38948 to be green.

Contributes towards: https://github.com/dotnet/runtime/issues/38422

cc: @tarekgh @akoeplinger @steveisok 