### PR TITLE
Support resolve reference for typeof(object) on deserialize

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.cs
@@ -318,7 +318,7 @@ namespace System.Text.Json
                 Debug.Assert(status == OperationStatus.Done);
                 Debug.Assert(consumed == utf16Text.Length);
 
-                result = TextEquals(index, otherUtf8Text.Slice(0, written), isPropertyName);
+                result = TextEquals(index, otherUtf8Text.Slice(0, written), isPropertyName, shouldUnescape: true);
             }
 
             if (otherUtf8TextArray != null)
@@ -330,7 +330,7 @@ namespace System.Text.Json
             return result;
         }
 
-        internal bool TextEquals(int index, ReadOnlySpan<byte> otherUtf8Text, bool isPropertyName)
+        internal bool TextEquals(int index, ReadOnlySpan<byte> otherUtf8Text, bool isPropertyName, bool shouldUnescape)
         {
             CheckNotDisposed();
 
@@ -345,12 +345,12 @@ namespace System.Text.Json
             ReadOnlySpan<byte> data = _utf8Json.Span;
             ReadOnlySpan<byte> segment = data.Slice(row.Location, row.SizeOrLength);
 
-            if (otherUtf8Text.Length > segment.Length)
+            if (otherUtf8Text.Length > segment.Length || (!shouldUnescape && otherUtf8Text.Length != segment.Length))
             {
                 return false;
             }
 
-            if (row.HasComplexChildren)
+            if (row.HasComplexChildren && shouldUnescape)
             {
                 if (otherUtf8Text.Length < segment.Length / JsonConstants.MaxExpansionFactorWhileEscaping)
                 {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonElement.cs
@@ -1230,7 +1230,7 @@ namespace System.Text.Json
                 return utf8Text == default;
             }
 
-            return TextEqualsHelper(utf8Text, isPropertyName: false);
+            return TextEqualsHelper(utf8Text, isPropertyName: false, shouldUnescape: true);
         }
 
         /// <summary>
@@ -1261,11 +1261,11 @@ namespace System.Text.Json
             return TextEqualsHelper(text, isPropertyName: false);
         }
 
-        internal bool TextEqualsHelper(ReadOnlySpan<byte> utf8Text, bool isPropertyName)
+        internal bool TextEqualsHelper(ReadOnlySpan<byte> utf8Text, bool isPropertyName, bool shouldUnescape)
         {
             CheckValidInstance();
 
-            return _parent.TextEquals(_idx, utf8Text, isPropertyName);
+            return _parent.TextEquals(_idx, utf8Text, isPropertyName, shouldUnescape);
         }
 
         internal bool TextEqualsHelper(ReadOnlySpan<char> text, bool isPropertyName)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonProperty.cs
@@ -67,7 +67,7 @@ namespace System.Text.Json
         /// </remarks>
         public bool NameEquals(ReadOnlySpan<byte> utf8Text)
         {
-            return Value.TextEqualsHelper(utf8Text, isPropertyName: true);
+            return Value.TextEqualsHelper(utf8Text, isPropertyName: true, shouldUnescape: true);
         }
 
         /// <summary>
@@ -88,6 +88,11 @@ namespace System.Text.Json
         public bool NameEquals(ReadOnlySpan<char> text)
         {
             return Value.TextEqualsHelper(text, isPropertyName: true);
+        }
+
+        internal bool EscapedNameEquals(ReadOnlySpan<byte> utf8Text)
+        {
+            return Value.TextEqualsHelper(utf8Text, isPropertyName: true, shouldUnescape: false);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -150,6 +150,19 @@ namespace System.Text.Json.Serialization
                         ref reader);
                 }
 
+                if (CanBePolymorphic && options.ReferenceHandler != null)
+                {
+                    // Edge case where we want to lookup for a reference when parsing into typeof(object)
+                    // instead of return `value` as a JsonElement.
+                    Debug.Assert(TypeToConvert == typeof(object));
+                    Debug.Assert(value is JsonElement);
+
+                    if (JsonSerializer.TryGetReferenceFromJsonElement(ref state, (JsonElement)(object)value, out object? referenceValue))
+                    {
+                        value = (T)referenceValue;
+                    }
+                }
+
                 return true;
             }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -13,6 +13,9 @@ namespace System.Text.Json
         internal static readonly byte[] s_idPropertyName
             = new byte[] { (byte)'$', (byte)'i', (byte)'d' };
 
+        internal static ReadOnlySpan<byte> s_refPropertyName
+            => new byte[] { (byte)'$', (byte)'r', (byte)'e', (byte)'f' };
+
         /// <summary>
         /// Returns true if successful, false is the reader ran out of buffer.
         /// Sets state.Current.ReturnValue to the $ref target for MetadataRefProperty cases.
@@ -270,6 +273,47 @@ namespace System.Text.Json
             }
 
             return MetadataPropertyName.NoMetadata;
+        }
+
+        internal static bool TryGetReferenceFromJsonElement(
+            ref ReadStack state,
+            JsonElement element,
+            out object? referenceValue)
+        {
+            bool refMetadataFound = false;
+            referenceValue = default;
+
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                int propertyCount = 0;
+                foreach (JsonProperty property in element.EnumerateObject())
+                {
+                    propertyCount++;
+                    if (refMetadataFound)
+                    {
+                        // There are more properties in an object with $ref.
+                        ThrowHelper.ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties();
+                    }
+                    else if (property.EscapedNameEquals(s_refPropertyName))
+                    {
+                        if (propertyCount > 1)
+                        {
+                            // $ref was found but there were other properties before.
+                            ThrowHelper.ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties();
+                        }
+
+                        if (property.Value.ValueKind != JsonValueKind.String)
+                        {
+                            ThrowHelper.ThrowJsonException_MetadataValueWasNotString(property.Value.ValueKind);
+                        }
+
+                        referenceValue = state.ReferenceResolver.ResolveReference(property.Value.GetString()!);
+                        refMetadataFound = true;
+                    }
+                }
+            }
+
+            return refMetadataFound;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -469,9 +469,23 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowJsonException_MetadataValueWasNotString(JsonValueKind valueKind)
+        {
+            ThrowJsonException(SR.Format(SR.MetadataValueWasNotString, valueKind));
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties(ReadOnlySpan<byte> propertyName, ref ReadStack state)
         {
             state.Current.JsonPropertyName = propertyName.ToArray();
+            ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties();
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties()
+        {
             ThrowJsonException(SR.MetadataReferenceCannotContainOtherProperties);
         }
 

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.cs
@@ -4,8 +4,10 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Text.Encodings.Web;
 using System.Text.Json.Tests;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -13,7 +15,6 @@ namespace System.Text.Json.Serialization.Tests
 {
     public static partial class ReferenceHandlerTests
     {
-
         [Fact]
         public static void ThrowByDefaultOnLoop()
         {
@@ -698,5 +699,98 @@ namespace System.Text.Json.Serialization.Tests
             }
         }
         #endregion
+
+        [Fact]
+        public static void PreserveReferenceOfTypeObject()
+        {
+            var root = new ClassWithObjectProperty();
+            root.Child = new ClassWithObjectProperty();
+            root.Sibling = root.Child;
+
+            Assert.Same(root.Child, root.Sibling);
+
+            string json = JsonSerializer.Serialize(root, s_serializerOptionsPreserve);
+
+            ClassWithObjectProperty rootCopy = JsonSerializer.Deserialize<ClassWithObjectProperty>(json, s_serializerOptionsPreserve);
+            Assert.Same(rootCopy.Child, rootCopy.Sibling);
+        }
+
+        [Fact]
+        public static async Task PreserveReferenceOfTypeObjectAsync()
+        {
+            var root = new ClassWithObjectProperty();
+            root.Child = new ClassWithObjectProperty();
+            root.Sibling = root.Child;
+
+            Assert.Same(root.Child, root.Sibling);
+
+            var stream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(stream, root, s_serializerOptionsPreserve);
+            stream.Position = 0;
+
+            ClassWithObjectProperty rootCopy = await JsonSerializer.DeserializeAsync<ClassWithObjectProperty>(stream, s_serializerOptionsPreserve);
+            Assert.Same(rootCopy.Child, rootCopy.Sibling);
+        }
+
+        [Fact]
+        public static void PreserveReferenceOfTypeOfObjectOnCollection()
+        {
+            var root = new ClassWithListOfObjectProperty();
+            root.Child = new ClassWithListOfObjectProperty();
+
+            root.ListOfObjects = new List<object>();
+            root.ListOfObjects.Add(root.Child);
+
+            Assert.Same(root.Child, root.ListOfObjects[0]);
+
+            string json = JsonSerializer.Serialize(root, s_serializerOptionsPreserve);
+            ClassWithListOfObjectProperty rootCopy = JsonSerializer.Deserialize<ClassWithListOfObjectProperty>(json, s_serializerOptionsPreserve);
+            Assert.Same(rootCopy.Child, rootCopy.ListOfObjects[0]);
+        }
+
+        [Fact]
+        public static void DoNotPreserveReferenceWhenRefPropertyIsAbsent()
+        {
+            string json = @"{""Child"":{""$id"":""1""},""Sibling"":{""foo"":""1""}}";
+            ClassWithObjectProperty root = JsonSerializer.Deserialize<ClassWithObjectProperty>(json);
+            Assert.IsType<JsonElement>(root.Sibling);
+
+            // $ref with any escaped character shall not be treated as metadata, hence Sibling must be JsonElement.
+            json = @"{""Child"":{""$id"":""1""},""Sibling"":{""\\u0024ref"":""1""}}";
+            root = JsonSerializer.Deserialize<ClassWithObjectProperty>(json);
+            Assert.IsType<JsonElement>(root.Sibling);
+        }
+
+        [Fact]
+        public static void VerifyValidationsOnPreservedReferenceOfTypeObject()
+        {
+            const string baseJson = @"{""Child"":{""$id"":""1""},""Sibling"":";
+
+            // A JSON object that contains a '$ref' metadata property must not contain any other properties.
+            string testJson = baseJson + @"{""foo"":""value"",""$ref"":""1""}}";
+            JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithObjectProperty>(testJson, s_serializerOptionsPreserve));
+            Assert.Equal("$.Sibling", ex.Path);
+
+            testJson = baseJson + @"{""$ref"":""1"",""bar"":""value""}}";
+            ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithObjectProperty>(testJson, s_serializerOptionsPreserve));
+            Assert.Equal("$.Sibling", ex.Path);
+
+            // The '$id' and '$ref' metadata properties must be JSON strings.
+            testJson = baseJson + @"{""$ref"":1}}";
+            ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithObjectProperty>(testJson, s_serializerOptionsPreserve));
+            Assert.Equal("$.Sibling", ex.Path);
+        }
+
+        private class ClassWithObjectProperty
+        {
+            public ClassWithObjectProperty Child { get; set; }
+            public object Sibling { get; set; }
+        }
+
+        private class ClassWithListOfObjectProperty
+        {
+            public ClassWithListOfObjectProperty Child { get; set; }
+            public List<object> ListOfObjects { get; set; }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/Stream.Collections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Stream.Collections.cs
@@ -60,21 +60,21 @@ namespace System.Text.Json.Serialization.Tests
         {
             string expectedjson = JsonSerializer.Serialize(obj, options);
 
-            using (var memoryStream = new MemoryStream())
-            {
-                await JsonSerializer.SerializeAsync(memoryStream, obj, options);
-                string serialized = Encoding.UTF8.GetString(memoryStream.ToArray());
-                JsonTestHelper.AssertJsonEqual(expectedjson, serialized);
+            using var memoryStream = new MemoryStream();
+            await JsonSerializer.SerializeAsync(memoryStream, obj, options);
+            string serialized = Encoding.UTF8.GetString(memoryStream.ToArray());
+            JsonTestHelper.AssertJsonEqual(expectedjson, serialized);
 
-                memoryStream.Position = 0;
-                await TestDeserialization<TElement>(memoryStream, expectedjson, type, options);
-            }
+            memoryStream.Position = 0;
 
-            // Deserialize with extra whitespace
-            string jsonWithWhiteSpace = GetPayloadWithWhiteSpace(expectedjson);
-            using (var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(jsonWithWhiteSpace)))
+            if (options.ReferenceHandler == null || !GetTypesNonRoundtrippableWithReferenceHandler().Contains(type))
             {
                 await TestDeserialization<TElement>(memoryStream, expectedjson, type, options);
+
+                // Deserialize with extra whitespace
+                string jsonWithWhiteSpace = GetPayloadWithWhiteSpace(expectedjson);
+                using var memoryStreamWithWhiteSpace = new MemoryStream(Encoding.UTF8.GetBytes(jsonWithWhiteSpace));
+                await TestDeserialization<TElement>(memoryStreamWithWhiteSpace, expectedjson, type, options);
             }
         }
 
@@ -351,6 +351,16 @@ namespace System.Text.Json.Serialization.Tests
             typeof(WrapperForIEnumerable),
             typeof(WrapperForIReadOnlyCollectionOfT<TElement>),
             typeof(GenericIReadOnlyDictionaryWrapper<string, TElement>)
+        };
+
+        // Non-generic types cannot roundtrip when they contain a $ref written on serialization and they are the root type.
+        private static HashSet<Type> GetTypesNonRoundtrippableWithReferenceHandler() => new HashSet<Type>
+        {
+            typeof(Hashtable),
+            typeof(Queue),
+            typeof(Stack),
+            typeof(WrapperForIList),
+            typeof(WrapperForIEnumerable)
         };
 
         private class ClassWithKVP


### PR DESCRIPTION
Fixes #1776

Analyze the `JsonElement` to be returned, determines if it can be interpreted as a reference (`{"$ref":"1"}`), lookup for the reference and returns it instead.

This is performed to enable round-tripping on scenarios where a property that is `typeof(object)` is a reference to an instance of another type e.g:
```cs
private class Node
{
    public Node Child { get; set; }
    public object Sibling { get; set; }
}
```

This change also grants parity with Json.NET in said scenario.