### PR TITLE
Use mono_runtime_delegate_invoke in EventPipeInternal::CreateProvider.

### DIFF
--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -172,6 +172,43 @@ mono_eventpipe_fini (void)
 	ep_rt_mono_initialized = FALSE;
 }
 
+static
+void
+delegate_callback_func (
+	const uint8_t *source_id,
+	unsigned long is_enabled,
+	uint8_t level,
+	uint64_t match_any_keywords,
+	uint64_t match_all_keywords,
+	EventFilterDescriptor *filter_data,
+	void *callback_context)
+{
+
+	/*internal unsafe delegate void EtwEnableCallback(
+		in Guid sourceId,
+		int isEnabled,
+		byte level,
+		long matchAnyKeywords,
+		long matchAllKeywords,
+		EVENT_FILTER_DESCRIPTOR* filterData,
+		void* callbackContext);*/
+
+	MonoObject *delegate_object = (MonoObject *)callback_context;
+	if (delegate_object) {
+		void *params [7];
+		params [0] = (void *)source_id;
+		params [1] = (void *)&is_enabled;
+		params [2] = (void *)&level;
+		params [3] = (void *)&match_any_keywords;
+		params [4] = (void *)&match_all_keywords;
+		params [5] = (void *)filter_data;
+		params [6] = NULL;
+
+		ERROR_DECL (error);
+		mono_runtime_delegate_invoke_checked (delegate_object, params, error);
+	}
+}
+
 gconstpointer
 ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider (
 	MonoStringHandle provider_name,
@@ -179,26 +216,19 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_CreateProvider (
 	MonoError *error)
 {
 	EventPipeProvider *provider = NULL;
-	gpointer delegate_func = NULL;
+	MonoObject *delegate_object = NULL;
 
 	if (MONO_HANDLE_IS_NULL (provider_name)) {
 		mono_error_set_argument_null (error, "providerName", "");
 		return NULL;
 	}
 
-#ifndef HOST_WASM
-	if (!MONO_HANDLE_IS_NULL (callback_func)) {
-		delegate_func = mono_delegate_to_ftnptr_impl (callback_func, error);
-		if (!is_ok (error) || !delegate_func) {
-			mono_error_set_argument_null (error, "callback_func", "");
-			return NULL;
-		}
-	}
-#endif
+	if (!MONO_HANDLE_IS_NULL (callback_func))
+		delegate_object = MONO_HANDLE_RAW (MONO_HANDLE_CAST (MonoObject, callback_func));
 
 	char *provider_name_utf8 = mono_string_handle_to_utf8 (provider_name, error);
 	if (is_ok (error) && provider_name_utf8) {
-		provider = ep_create_provider (provider_name_utf8, (EventPipeCallback)delegate_func, NULL);
+		provider = ep_create_provider (provider_name_utf8, delegate_callback_func, delegate_object);
 	}
 
 	g_free (provider_name_utf8);


### PR DESCRIPTION
Due to issues on some platforms related to mono_delegate_to_ftnptr_impl, switch to use mono_runtime_delegate_invoke without need for delegate wrapper generation currently not supported on all platforms.