### PR TITLE
WASM: don't compile brotli sources into System.IO.Compression.Native

### DIFF
--- a/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
@@ -15,7 +15,7 @@ set(NATIVECOMPRESSION_SOURCES
     ../../AnyOS/zlib/pal_zlib.c
 )
 
-if (!CLR_CMAKE_TARGET_BROWSER)
+if (NOT CLR_CMAKE_TARGET_BROWSER)
     add_definitions(-DBROTLI_SHARED_COMPILATION)
 
     #Include Brotli include files

--- a/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.IO.Compression.Native/CMakeLists.txt
@@ -15,38 +15,40 @@ set(NATIVECOMPRESSION_SOURCES
     ../../AnyOS/zlib/pal_zlib.c
 )
 
-add_definitions(-DBROTLI_SHARED_COMPILATION)
+if (!CLR_CMAKE_TARGET_BROWSER)
+    add_definitions(-DBROTLI_SHARED_COMPILATION)
 
-#Include Brotli include files
-include_directories("../../AnyOS/brotli/include")
+    #Include Brotli include files
+    include_directories("../../AnyOS/brotli/include")
 
-set (NATIVECOMPRESSION_SOURCES
-    ${NATIVECOMPRESSION_SOURCES}
-    ../../AnyOS/brotli/common/dictionary.c
-    ../../AnyOS/brotli/common/transform.c
-    ../../AnyOS/brotli/dec/bit_reader.c
-    ../../AnyOS/brotli/dec/decode.c
-    ../../AnyOS/brotli/dec/huffman.c
-    ../../AnyOS/brotli/dec/state.c
-    ../../AnyOS/brotli/enc/backward_references.c
-    ../../AnyOS/brotli/enc/backward_references_hq.c
-    ../../AnyOS/brotli/enc/bit_cost.c
-    ../../AnyOS/brotli/enc/block_splitter.c
-    ../../AnyOS/brotli/enc/brotli_bit_stream.c
-    ../../AnyOS/brotli/enc/cluster.c
-    ../../AnyOS/brotli/enc/compress_fragment.c
-    ../../AnyOS/brotli/enc/compress_fragment_two_pass.c
-    ../../AnyOS/brotli/enc/dictionary_hash.c
-    ../../AnyOS/brotli/enc/encode.c
-    ../../AnyOS/brotli/enc/encoder_dict.c
-    ../../AnyOS/brotli/enc/entropy_encode.c
-    ../../AnyOS/brotli/enc/histogram.c
-    ../../AnyOS/brotli/enc/literal_cost.c
-    ../../AnyOS/brotli/enc/memory.c
-    ../../AnyOS/brotli/enc/metablock.c
-    ../../AnyOS/brotli/enc/static_dict.c
-    ../../AnyOS/brotli/enc/utf8_util.c
-)
+    set (NATIVECOMPRESSION_SOURCES
+        ${NATIVECOMPRESSION_SOURCES}
+        ../../AnyOS/brotli/common/dictionary.c
+        ../../AnyOS/brotli/common/transform.c
+        ../../AnyOS/brotli/dec/bit_reader.c
+        ../../AnyOS/brotli/dec/decode.c
+        ../../AnyOS/brotli/dec/huffman.c
+        ../../AnyOS/brotli/dec/state.c
+        ../../AnyOS/brotli/enc/backward_references.c
+        ../../AnyOS/brotli/enc/backward_references_hq.c
+        ../../AnyOS/brotli/enc/bit_cost.c
+        ../../AnyOS/brotli/enc/block_splitter.c
+        ../../AnyOS/brotli/enc/brotli_bit_stream.c
+        ../../AnyOS/brotli/enc/cluster.c
+        ../../AnyOS/brotli/enc/compress_fragment.c
+        ../../AnyOS/brotli/enc/compress_fragment_two_pass.c
+        ../../AnyOS/brotli/enc/dictionary_hash.c
+        ../../AnyOS/brotli/enc/encode.c
+        ../../AnyOS/brotli/enc/encoder_dict.c
+        ../../AnyOS/brotli/enc/entropy_encode.c
+        ../../AnyOS/brotli/enc/histogram.c
+        ../../AnyOS/brotli/enc/literal_cost.c
+        ../../AnyOS/brotli/enc/memory.c
+        ../../AnyOS/brotli/enc/metablock.c
+        ../../AnyOS/brotli/enc/static_dict.c
+        ../../AnyOS/brotli/enc/utf8_util.c
+    )
+endif()
 
 if (GEN_SHARED_LIB)
     add_library(System.IO.Compression.Native


### PR DESCRIPTION
Brotli isn't supported so we don't need it.