### PR TITLE
Allow building libs tests for all configurations

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,7 +17,6 @@
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Blob storage container that has the "Latest" channel to publish to. -->
     <ContainerName>dotnet</ContainerName>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -17,6 +17,7 @@
     <!-- Opt-in/out repo features -->
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
     <UsingToolIbcOptimization>true</UsingToolIbcOptimization>
+    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>false</UsingToolXliff>
     <!-- Blob storage container that has the "Latest" channel to publish to. -->
     <ContainerName>dotnet</ContainerName>

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -94,21 +94,6 @@ jobs:
       buildArgs: -subset mono+libs /p:RuntimeFlavor=Mono
 
 #
-# Build Mono + Libraries. This excercises the code path where we build libraries tests
-# for all configurations.
-#
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    buildConfig: debug
-    platforms:
-    - Linux_x64
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: Mono_LibrariesTests_AllConfigurations
-      buildArgs: -subset mono+libs+libs.tests -allconfigurations
-
-#
 # SourceBuild Build
 #
 - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -102,7 +102,7 @@ jobs:
     jobTemplate: /eng/pipelines/common/global-build-job.yml
     buildConfig: debug
     platforms:
-    - Windows_NT_x64
+    - Linux_x64
     jobParameters:
       testGroup: innerloop
       nameSuffix: Mono_LibrariesTests_AllConfigurations

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -94,6 +94,21 @@ jobs:
       buildArgs: -subset mono+libs /p:RuntimeFlavor=Mono
 
 #
+# Build Mono + Libraries. This excercises the code path where we build libraries tests
+# for all configurations.
+#
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    buildConfig: debug
+    platforms:
+    - Windows_NT_x64
+    jobParameters:
+      testGroup: innerloop
+      nameSuffix: Mono_LibrariesTests_AllConfigurations
+      buildArgs: -subset mono+libs+libs.tests -allconfigurations
+
+#
 # SourceBuild Build
 #
 - template: /eng/pipelines/common/platform-matrix.yml

--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -43,6 +43,7 @@ jobs:
         # rename this variable, due to collision with build-native.proj
         - _runtimeOSArg: ''
         - _finalFrameworkArg: ''
+        - _testModeArg: ''
         - _buildScript: $(_buildScriptFileName)$(scriptExt)
         - _testScopeArg: ''
         - _extraHelixArguments: ''
@@ -73,7 +74,8 @@ jobs:
 
         - ${{ if eq(parameters.framework, 'allConfigurations') }}:
           - _finalFrameworkArg: -allConfigurations
-          - _extraHelixArguments: /p:BuildAllConfigurations=true
+          - _testModeArg: /p:TestAssemblies=false /p:TestPackages=true
+          - _extraHelixArguments: /p:TestPackages=true
 
         - ${{ if eq(parameters.isOfficialAllConfigurations, true) }}:
           - librariesBuildArtifactName: 'libraries_bin_official_allconfigurations'
@@ -106,7 +108,7 @@ jobs:
         - ${{ if ne(parameters.osGroup, 'Windows_NT') }}:
           - _buildScript: ./$(_buildScriptFileName)$(scriptExt)
 
-        - _buildArguments: $(_runtimeConfigurationArg) -configuration ${{ parameters.buildConfig }} -ci -arch ${{ parameters.archType }} $(_finalFrameworkArg) $(_testScopeArg) $(_runtimeOSArg) $(_msbuildCommonParameters) $(_runtimeArtifactsPathArg) $(_crossBuildPropertyArg)
+        - _buildArguments: $(_runtimeConfigurationArg) -configuration ${{ parameters.buildConfig }} -ci -arch ${{ parameters.archType }} $(_finalFrameworkArg) $(_testModeArg) $(_testScopeArg) $(_runtimeOSArg) $(_msbuildCommonParameters) $(_runtimeArtifactsPathArg) $(_crossBuildPropertyArg)
         - ${{ parameters.variables }}
 
         # we need to override this value to support build-coreclr-and-libraries-job.yml

--- a/src/libraries/pkg/test/test.msbuild
+++ b/src/libraries/pkg/test/test.msbuild
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Restore;Test">
   <ItemGroup>
-    <TestPackageOverride Condition="'$(TestPackageOverride)' != ''" Include="$(TestPackageOverride)" />
+    <PackagesToTest Condition="'$(PackagesToTest)' != ''" Include="$(PackagesToTest)" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -11,8 +11,8 @@
 
   <Target Name="GetProjects">
     <ItemGroup>
-      <Project Condition="'@(TestPackageOverride)' == ''" Include="$(PackageTestProjectsDir)\**\*.csproj" />
-      <Project Condition="'@(TestPackageOverride)' != ''" Include="$(PackageTestProjectsDir)\%(TestPackageOverride.Identity)\**\*.csproj" />
+      <Project Condition="'@(PackagesToTest)' == ''" Include="$(PackageTestProjectsDir)\**\*.csproj" />
+      <Project Condition="'@(PackagesToTest)' != ''" Include="$(PackageTestProjectsDir)\%(PackagesToTest.Identity)\**\*.csproj" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/pkg/test/test.msbuild
+++ b/src/libraries/pkg/test/test.msbuild
@@ -1,6 +1,6 @@
 <Project DefaultTargets="Restore;Test">
   <ItemGroup>
-    <TestPackages Condition="'$(TestPackages)' != ''" Include="$(TestPackages)" />
+    <TestPackageOverride Condition="'$(TestPackageOverride)' != ''" Include="$(TestPackageOverride)" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -11,8 +11,8 @@
 
   <Target Name="GetProjects">
     <ItemGroup>
-      <Project Condition="'@(TestPackages)' == ''" Include="$(PackageTestProjectsDir)\**\*.csproj" />
-      <Project Condition="'@(TestPackages)' != ''" Include="$(PackageTestProjectsDir)\%(TestPackages.Identity)\**\*.csproj" />
+      <Project Condition="'@(TestPackageOverride)' == ''" Include="$(PackageTestProjectsDir)\**\*.csproj" />
+      <Project Condition="'@(TestPackageOverride)' != ''" Include="$(PackageTestProjectsDir)\%(TestPackageOverride.Identity)\**\*.csproj" />
     </ItemGroup>
   </Target>
 

--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -2,13 +2,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestPackages Condition="'$(TestPackages)' != ''" Include="$(TestPackages)" />
+    <TestPackageOverride Condition="'$(TestPackageOverride)' != ''" Include="$(TestPackageOverride)" />
     <!-- transport package not expected to be closure complete  -->
     <ExcludePackages Include="Microsoft.Extensions.Internal.Transport" />
     <ExcludePackages Include="$(ExcludePackages)" />
 
-    <PackageReports Condition="'@(TestPackages)' == ''" Include="$(PackageReportDir)*.json" Exclude="@(ExcludePackages->'$(PackageReportDir)%(Identity).json')"/>
-    <PackageReports Condition="'@(TestPackages)' != ''" Include="@(TestPackages->'$(PackageReportDir)%(Identity).json')" />
+    <PackageReports Condition="'@(TestPackageOverride)' == ''" Include="$(PackageReportDir)*.json" Exclude="@(ExcludePackages->'$(PackageReportDir)%(Identity).json')"/>
+    <PackageReports Condition="'@(TestPackageOverride)' != ''" Include="@(TestPackageOverride->'$(PackageReportDir)%(Identity).json')" />
 
     <!-- support override via commandline -->
     <RuntimesToInclude Condition="'$(RuntimesToInclude)' != ''" Include="$(RuntimesToInclude)" />
@@ -183,7 +183,7 @@
       <TestRestoreCommand>$(TestRestoreCommand) /p:LocalPackagesPath=$(PackageOutputPath)</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /nr:false</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /warnaserror</TestRestoreCommand>
-      <TestRestoreCommand  Condition="'$(TestPackages)' != ''">$(TestRestoreCommand) /p:TestPackages=$(TestPackages)</TestRestoreCommand>
+      <TestRestoreCommand  Condition="'$(TestPackageOverride)' != ''">$(TestRestoreCommand) /p:TestPackageOverride=$(TestPackageOverride)</TestRestoreCommand>
     </PropertyGroup>
 
     <Message Importance="High" Text="*** Restoring ***" />
@@ -200,7 +200,7 @@
       <TestBuildCommand>$(TestBuildCommand) /t:Test</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /nr:false</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /warnaserror</TestBuildCommand>
-      <TestBuildCommand  Condition="'$(TestPackages)' != ''">$(TestBuildCommand) /p:TestPackages=$(TestPackages)</TestBuildCommand>
+      <TestBuildCommand  Condition="'$(TestPackageOverride)' != ''">$(TestBuildCommand) /p:TestPackageOverride=$(TestPackageOverride)</TestBuildCommand>
     </PropertyGroup>
 
     <Message Importance="High" Text="*** Testing *** %(SupportedPackage.Identity)" />

--- a/src/libraries/pkg/test/testPackages.proj
+++ b/src/libraries/pkg/test/testPackages.proj
@@ -2,13 +2,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
 
   <ItemGroup>
-    <TestPackageOverride Condition="'$(TestPackageOverride)' != ''" Include="$(TestPackageOverride)" />
+    <PackagesToTest Condition="'$(PackagesToTest)' != ''" Include="$(PackagesToTest)" />
     <!-- transport package not expected to be closure complete  -->
     <ExcludePackages Include="Microsoft.Extensions.Internal.Transport" />
     <ExcludePackages Include="$(ExcludePackages)" />
 
-    <PackageReports Condition="'@(TestPackageOverride)' == ''" Include="$(PackageReportDir)*.json" Exclude="@(ExcludePackages->'$(PackageReportDir)%(Identity).json')"/>
-    <PackageReports Condition="'@(TestPackageOverride)' != ''" Include="@(TestPackageOverride->'$(PackageReportDir)%(Identity).json')" />
+    <PackageReports Condition="'@(PackagesToTest)' == ''" Include="$(PackageReportDir)*.json" Exclude="@(ExcludePackages->'$(PackageReportDir)%(Identity).json')"/>
+    <PackageReports Condition="'@(PackagesToTest)' != ''" Include="@(PackagesToTest->'$(PackageReportDir)%(Identity).json')" />
 
     <!-- support override via commandline -->
     <RuntimesToInclude Condition="'$(RuntimesToInclude)' != ''" Include="$(RuntimesToInclude)" />
@@ -183,7 +183,7 @@
       <TestRestoreCommand>$(TestRestoreCommand) /p:LocalPackagesPath=$(PackageOutputPath)</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /nr:false</TestRestoreCommand>
       <TestRestoreCommand>$(TestRestoreCommand) /warnaserror</TestRestoreCommand>
-      <TestRestoreCommand  Condition="'$(TestPackageOverride)' != ''">$(TestRestoreCommand) /p:TestPackageOverride=$(TestPackageOverride)</TestRestoreCommand>
+      <TestRestoreCommand  Condition="'$(PackagesToTest)' != ''">$(TestRestoreCommand) /p:PackagesToTest=$(PackagesToTest)</TestRestoreCommand>
     </PropertyGroup>
 
     <Message Importance="High" Text="*** Restoring ***" />
@@ -200,7 +200,7 @@
       <TestBuildCommand>$(TestBuildCommand) /t:Test</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /nr:false</TestBuildCommand>
       <TestBuildCommand>$(TestBuildCommand) /warnaserror</TestBuildCommand>
-      <TestBuildCommand  Condition="'$(TestPackageOverride)' != ''">$(TestBuildCommand) /p:TestPackageOverride=$(TestPackageOverride)</TestBuildCommand>
+      <TestBuildCommand  Condition="'$(PackagesToTest)' != ''">$(TestBuildCommand) /p:PackagesToTest=$(PackagesToTest)</TestBuildCommand>
     </PropertyGroup>
 
     <Message Importance="High" Text="*** Testing *** %(SupportedPackage.Identity)" />

--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -80,8 +80,8 @@
     <TargetsWindows Condition="'$(TargetOS)' == 'Windows_NT'">true</TargetsWindows>
 
     <!-- The Helix correlation payload file -->
-    <TestArchiveRuntimeFile Condition="'$(BuildAllConfigurations)' != 'true'">$(TestArchiveRuntimeRoot)test-runtime-$(BuildSettings).zip</TestArchiveRuntimeFile>
-    <TestArchiveRuntimeFile Condition="'$(BuildAllConfigurations)' == 'true'">$(TestArchiveRuntimeRoot)packages-testPayload-$(Configuration).zip</TestArchiveRuntimeFile>
+    <TestArchiveRuntimeFile Condition="'$(TestPackages)' != 'true'">$(TestArchiveRuntimeRoot)test-runtime-$(BuildSettings).zip</TestArchiveRuntimeFile>
+    <TestArchiveRuntimeFile Condition="'$(TestPackages)' == 'true'">$(TestArchiveRuntimeRoot)packages-testPayload-$(Configuration).zip</TestArchiveRuntimeFile>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -144,7 +144,7 @@
   <Target Name="CompressRuntimeDirectory"
           Inputs="@(_RuntimeInputs);@(TestArchiveRuntimeDependency)"
           Outputs="$(TestArchiveRuntimeFile)"
-          Condition="'$(BuildAllConfigurations)' != 'true' and '$(TargetsMobile)' != 'true'">
+          Condition="'$(TestPackages)' != 'true' and '$(TargetsMobile)' != 'true'">
 
     <!-- Compress the test files, testhost, and per-scenario scripts into a single ZIP file for sending to the Helix machines. -->
 

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -23,7 +23,7 @@
 
     <!-- We need to enable xunit reporter so that it parses test results
          Package testing doesn't run on xunit. -->
-    <EnableXunitReporter Condition="'$(BuildAllConfigurations)' != 'true'">true</EnableXunitReporter>
+    <EnableXunitReporter Condition="'$(TestPackages)' != 'true'">true</EnableXunitReporter>
 
     <!-- The Helix runtime payload and the tests to run -->
     <!-- TestArchiveRuntimeFile will be passed as a property by the calling project -->
@@ -45,7 +45,7 @@
     <FailOnTestFailure Condition="'$(WaitForWorkItemCompletion)' != ''">$(WaitForWorkItemCompletion)</FailOnTestFailure>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(BuildAllConfigurations)' == 'true'">
+  <PropertyGroup Condition="'$(TestPackages)' == 'true'">
     <!-- Use Helix feature to include dotnet CLI for every workitem and add it to the path -->
     <IncludeDotNetCli>true</IncludeDotNetCli>
     <DotNetCliPackageType>sdk</DotNetCliPackageType>
@@ -59,20 +59,20 @@
     <!-- For PRs we want HelixType to be the same for all frameworks except package testing-->
     <TestScope Condition="'$(TestScope)' == ''">innerloop</TestScope>
     <HelixType>test/functional/cli/$(TestScope)/</HelixType>
-    <HelixType Condition="'$(BuildAllConfigurations)' == 'true'">test/functional/packaging/</HelixType>
+    <HelixType Condition="'$(TestPackages)' == 'true'">test/functional/packaging/</HelixType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetOS)' == 'Browser'">
     <IncludeXHarnessCli>true</IncludeXHarnessCli>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(HelixCommand)' == '' and '$(BuildAllConfigurations)' == 'true'">
+  <ItemGroup Condition="'$(HelixCommand)' == '' and '$(TestPackages)' == 'true'">
     <HelixPreCommand Include="set DOTNET_CLI_TELEMETRY_OPTOUT=1" />
     <HelixPreCommand Include="set DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1" />
     <HelixPreCommand Include="set DOTNET_MULTILEVEL_LOOKUP=0" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(HelixCommand)' == '' and '$(BuildAllConfigurations)' == 'true'">
+  <PropertyGroup Condition="'$(HelixCommand)' == '' and '$(TestPackages)' == 'true'">
     <HelixCommand>dotnet msbuild %HELIX_CORRELATION_PAYLOAD%\test.msbuild</HelixCommand>
     <HelixCommand>$(HelixCommand) /warnaserror</HelixCommand>
     <HelixCommand>$(HelixCommand) /p:PackageTestProjectsDir=%HELIX_WORKITEM_PAYLOAD%</HelixCommand>
@@ -172,7 +172,7 @@
   </Target>
 
   <Target Name="PrintBuildTargetFramework">
-    <Message Condition="'$(BuildAllConfigurations)' != 'true'" Importance="High" Text="Build TargetFramework: $(BuildTargetFramework)" />
-    <Message Condition="'$(BuildAllConfigurations)' == 'true'" Importance="High" Text="Doing Package Testing" />
+    <Message Condition="'$(TestPackages)' != 'true'" Importance="High" Text="Build TargetFramework: $(BuildTargetFramework)" />
+    <Message Condition="'$(TestPackages)' == 'true'" Importance="High" Text="Doing Package Testing" />
   </Target>
 </Project>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -8,8 +8,8 @@
     <CoverageReportInputPath>$(ArtifactsBinDir)\*.Tests\**\coverage.opencover.xml</CoverageReportInputPath>
     <CoverageReportDir>$(ArtifactsDir)coverage</CoverageReportDir>
     <EnableCoverageSupport>true</EnableCoverageSupport>
-
     <TestAssemblies Condition="'$(TestAssemblies)' == ''">true</TestAssemblies>
+    <TestPackages Condition="'$(TestPackages)' == ''">false</TestPackages>
     <TestTrimming Condition="'$(TestTrimming)' == ''">false</TestTrimming>
   </PropertyGroup>
   
@@ -98,23 +98,21 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ValueTuple\tests\System.ValueTuple.Tests.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TestAssemblies)' == 'true'">
-    <!-- We currently only test with C# projects. -->
+  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\tests\**\*.Tests.csproj"
                       Exclude="@(ProjectExclusions)"
-                      Condition="'$(BuildAllConfigurations)' != 'true'" />
+                      Condition="'$(TestAssemblies)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)pkg\test\testPackages.proj"
-                      Condition="'$(BuildAllConfigurations)' == 'true'" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TestTrimming)' == 'true'">
+                      Condition="'$(TestPackages)' == 'true'" />
     <ProjectReference Include="$(MSBuildThisFileDirectory)*\tests\**\*.TrimmingTests.proj"
-                      Exclude="@(ProjectExclusions)" />
+                      Exclude="@(ProjectExclusions)"
+                      Condition="'$(TestTrimming)' == 'true'" />
   </ItemGroup>
 
   <Target Name="GenerateMergedCoverageReport"
-          Condition="'$(Coverage)' == 'true'"
           AfterTargets="Test"
-          DependsOnTargets="GenerateCoverageReport" />
+          DependsOnTargets="GenerateCoverageReport"
+          Condition="'$(TestAssemblies)' == 'true' and
+                     '$(Coverage)' == 'true'" />
 
 </Project>


### PR DESCRIPTION
Building libraries tests and passing in the -allconfigurations switch
results in the libraries packages being built and tested. Conditioning
the packages build/test on the /p:TestPackages switch.