### PR TITLE
Disable HandlerInvokedForSigQuit test on macOS

### DIFF
--- a/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
+++ b/src/libraries/System.Console/tests/CancelKeyPress.Unix.cs
@@ -24,6 +24,7 @@ public partial class CancelKeyPressTests
         HandlerInvokedForSignal(SIGINT);
     }
 
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/38998", TestPlatforms.OSX)]
     [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
     [SkipOnMono("Mono doesn't call CancelKeyPress for SIGQUIT.")]
     public void HandlerInvokedForSigQuit()


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/38998