### PR TITLE
Allow XmlSerializer.Generator to run on Core > 2.x

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/pkg/build/dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/pkg/build/dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json
@@ -4,6 +4,7 @@
     "framework": {
       "name": "Microsoft.NETCore.App",
       "version": "2.0.0"
-    }
+    },
+    "rollForward": "Major"
   }
 }

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -45,6 +45,7 @@
     <Message Text="Running Serialization Tool" Importance="normal" />
     <Exec Command="$(GeneratorCommand) $(OutputPath)dotnet-Microsoft.XmlSerializer.Generator.dll $(OutputPath)Microsoft.XmlSerializer.Generator.Tests.dll --force --quiet" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).cs') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).cs" />
+    <Copy SourceFiles="$(OutputPath)$(SerializerName).cs" DestinationFiles="$(OutputPath)LKG.$(SerializerName).cs" />
     <Csc Condition="Exists('$(OutputPath)$(SerializerName).cs') == 'true'" OutputAssembly="$(OutputPath)$(SerializerName).dll" References="@(ReferencePath);@(IntermediateAssembly)" EmitDebugInformation="$(DebugSymbols)" DebugType="$(DebugType)" Sources="$(OutputPath)$(SerializerName).cs" TargetType="Library" ToolExe="$(CscToolExe)" ToolPath="$(CscToolPath)" DisabledWarnings="$(NoWarn), 219" UseSharedCompilation="true" />
     <Warning Condition="Exists('$(OutputPath)$(SerializerName).dll') != 'true'" Text="Fail to generate $(OutputPath)$(SerializerName).dll" />
     <ItemGroup>

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/Microsoft.XmlSerializer.Generator.Tests.csproj
@@ -4,27 +4,30 @@
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <SkipTestsOnPlatform Condition="'$(TargetsMobile)' == 'true' or '$(TargetOS)' == 'FreeBSD' or '$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'armel' or '$(TargetArchitecture)' == 'wasm'">true</SkipTestsOnPlatform>
   </PropertyGroup>
+
   <PropertyGroup>
-    <!-- Reuse the same runtimeconfig used by MSBuild. -->
-    <GeneratorRuntimeConfig>$(MSBuildToolsPath)\MSBuild.runtimeconfig.json</GeneratorRuntimeConfig>
-    <GeneratorCommand>"$(TestHostRootPath)$([System.IO.Path]::GetFileName('$(DotNetTool)'))" --fx-version $(ProductVersion)</GeneratorCommand>
+    <GeneratorRuntimeConfig>$(MSBuildThisFileDirectory)..\pkg\build\dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</GeneratorRuntimeConfig>
+    <GeneratorCommand>"$(DotNetTool)"</GeneratorCommand>
     <GeneratorCommand Condition="'$(TargetOS)' == 'Windows_NT'">set DOTNET_MULTILEVEL_LOOKUP=0 &amp; $(GeneratorCommand)</GeneratorCommand>
     <GeneratorCommand Condition="'$(TargetOS)' != 'Windows_NT'">export DOTNET_MULTILEVEL_LOOKUP=0 &amp;&amp; $(GeneratorCommand)</GeneratorCommand>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true' ">
-    <Compile Include=".\SGenTests.cs" />
+
+  <ItemGroup Condition=" '$(SkipTestsOnPlatform)' != 'true'">
+    <Compile Include="SGenTests.cs" />
     <Compile Include="$(CommonTestPath)System\Runtime\Serialization\Utils.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
     <Compile Include="$(TestSourceFolder)..\..\System.Private.Xml\tests\XmlSerializer\XmlSerializerTests.cs" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include=".\AlwaysPassTest.cs" />
+    <Compile Include="AlwaysPassTest.cs" />
     <Content Include="$(GeneratorRuntimeConfig)">
       <!-- Rename it to match the Generator application name -->
       <Link>dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
   <ItemGroup>
     <ReferenceFromRuntime Include="dotnet-Microsoft.XmlSerializer.Generator">
       <!-- Copy this to our test output directory and run from there.
@@ -32,6 +35,7 @@
       <Private>true</Private>
     </ReferenceFromRuntime>
   </ItemGroup>
+
   <!-- This target runs before binplacing as it needs to provide a test assembly to binplace, and depends on CopyFilesToOutputDirectory
        so that the Generator app dll and runtimeconfig will be copied to the OutputPath -->
   <Target Name="GenerateSerializationAssembly" DependsOnTargets="CopyFilesToOutputDirectory" AfterTargets="PrepareForRun" Condition=" '$(SkipTestsOnPlatform)' != 'true' ">

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.XmlSerializer.Generator.Tests
         public static void SgenCommandTest()
         {
             const string CodeFile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
-            long lkgSize = new System.IO.FileInfo(CodeFile).Length;
+            const string LKGCodeFile = "LKG." + CodeFile;
 
             var type = Type.GetType("Microsoft.XmlSerializer.Generator.Sgen, dotnet-Microsoft.XmlSerializer.Generator");
             MethodInfo md = type.GetMethod("Main", BindingFlags.Static | BindingFlags.Public);
@@ -27,7 +27,7 @@ namespace Microsoft.XmlSerializer.Generator.Tests
             Assert.True(File.Exists(CodeFile), string.Format("Fail to generate {0}.", CodeFile));
             // Compare the generated CodeFiles from the LKG with the live built shared framework one.
             // Not comparing byte per byte as the generated output isn't deterministic.
-            Assert.Equal(lkgSize, new System.IO.FileInfo(CodeFile).Length);
+            Assert.Equal(new System.IO.FileInfo(LKGCodeFile).Length, new System.IO.FileInfo(CodeFile).Length);
         }
     }
 }

--- a/src/libraries/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/tests/SGenTests.cs
@@ -15,13 +15,19 @@ namespace Microsoft.XmlSerializer.Generator.Tests
         [Fact]
         public static void SgenCommandTest()
         {
-            string codefile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
+            const string CodeFile = "Microsoft.XmlSerializer.Generator.Tests.XmlSerializers.cs";
+            long lkgSize = new System.IO.FileInfo(CodeFile).Length;
+
             var type = Type.GetType("Microsoft.XmlSerializer.Generator.Sgen, dotnet-Microsoft.XmlSerializer.Generator");
             MethodInfo md = type.GetMethod("Main", BindingFlags.Static | BindingFlags.Public);
             string[] args = new string[] { "Microsoft.XmlSerializer.Generator.Tests.dll", "--force", "--quiet" };
             int n = (int)md.Invoke(null, new object[] { args });
+
             Assert.Equal(0, n);
-            Assert.True(File.Exists(codefile), string.Format("Fail to generate {0}.", codefile));
+            Assert.True(File.Exists(CodeFile), string.Format("Fail to generate {0}.", CodeFile));
+            // Compare the generated CodeFiles from the LKG with the live built shared framework one.
+            // Not comparing byte per byte as the generated output isn't deterministic.
+            Assert.Equal(lkgSize, new System.IO.FileInfo(CodeFile).Length);
         }
     }
 }


### PR DESCRIPTION
Allow XmlSerializer.Generator to run on Core > 2.x by adding a rollforward policy.

Use the repo local dotnet toolchain to generate the sgen output.
Adding a test to verify that the repo local and the live built outputs
are identical by size.

cc @HongGit