### PR TITLE
Throw when reference cannot be assigned to converter.TypeToConvert

### DIFF
--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -545,4 +545,7 @@
   <data name="ConverterCanConvertNullableRedundant" xml:space="preserve">
     <value>The converter '{0}' handles type '{1}' but is being asked to convert type '{2}'. Either create a separate converter for type '{2}' or change the converter's 'CanConvert' method to only return 'true' for a single type.</value>
   </data>
+  <data name="MetadataReferenceOfTypeCannotBeAssignedToType" xml:space="preserve">
+    <value>The object with reference id '{0}' of type '{1}' cannot be assigned to the type '{2}'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -141,12 +141,11 @@ namespace System.Text.Json.Serialization.Converters
                 bool preserveReferences = options.ReferenceHandler != null;
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options, out string? referenceId))
+                    if (JsonSerializer.ResolveMetadataForJsonObject<TCollection>(ref reader, ref state, options))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
-                            value = JsonSerializer.TryCastPreservedValue<TCollection>(
-                                state.Current.ReturnValue!, referenceId!);
+                            value = (TCollection)state.Current.ReturnValue!;
                             return true;
                         }
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -145,6 +145,7 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
+                            // This will never throw since it was previously validated in ResolveMetadataForJsonObject.
                             value = (TCollection)state.Current.ReturnValue!;
                             return true;
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -141,11 +141,12 @@ namespace System.Text.Json.Serialization.Converters
                 bool preserveReferences = options.ReferenceHandler != null;
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options))
+                    if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options, out string? referenceId))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
-                            value = (TCollection)state.Current.ReturnValue!;
+                            value = JsonSerializer.TryCastPreservedValue<TCollection>(
+                                state.Current.ReturnValue!, referenceId!);
                             return true;
                         }
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -115,11 +115,12 @@ namespace System.Text.Json.Serialization.Converters
                 // Handle the metadata properties.
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadataForJsonArray(ref reader, ref state, options))
+                    if (JsonSerializer.ResolveMetadataForJsonArray(ref reader, ref state, options, out string? referenceId))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
-                            value = (TCollection)state.Current.ReturnValue!;
+                            value = JsonSerializer.TryCastPreservedValue<TCollection>(
+                                state.Current.ReturnValue!, referenceId!);
                             return true;
                         }
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -115,12 +115,11 @@ namespace System.Text.Json.Serialization.Converters
                 // Handle the metadata properties.
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadataForJsonArray(ref reader, ref state, options, out string? referenceId))
+                    if (JsonSerializer.ResolveMetadataForJsonArray<TCollection>(ref reader, ref state, options))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
-                            value = JsonSerializer.TryCastPreservedValue<TCollection>(
-                                state.Current.ReturnValue!, referenceId!);
+                            value = (TCollection)state.Current.ReturnValue!;
                             return true;
                         }
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -119,6 +119,7 @@ namespace System.Text.Json.Serialization.Converters
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
+                            // This will never throw since it was previously validated in ResolveMetadataForJsonArray.
                             value = (TCollection)state.Current.ReturnValue!;
                             return true;
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -81,6 +81,7 @@ namespace System.Text.Json.Serialization.Converters
                         {
                             if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                             {
+                                // This will never throw since it was previously validated in ResolveMetadataForJsonObject.
                                 value = (T)state.Current.ReturnValue!;
                                 return true;
                             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -77,12 +77,11 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     if (options.ReferenceHandler != null)
                     {
-                        if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options, out string? referenceId))
+                        if (JsonSerializer.ResolveMetadataForJsonObject<T>(ref reader, ref state, options))
                         {
                             if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                             {
-                                value = JsonSerializer.TryCastPreservedValue<T>(
-                                    state.Current.ReturnValue!, referenceId!);
+                                value = (T)state.Current.ReturnValue!;
                                 return true;
                             }
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -77,11 +77,12 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     if (options.ReferenceHandler != null)
                     {
-                        if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options))
+                        if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options, out string? referenceId))
                         {
                             if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                             {
-                                value = (T)state.Current.ReturnValue!;
+                                value = JsonSerializer.TryCastPreservedValue<T>(
+                                    state.Current.ReturnValue!, referenceId!);
                                 return true;
                             }
                         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -251,10 +251,16 @@ namespace System.Text.Json
                     ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
                 }
 
-                string key = reader.GetString()!;
+                string referenceId = reader.GetString()!;
+                object value = state.ReferenceResolver.ResolveReference(referenceId);
+                Type typeOfValue = value.GetType();
 
-                // todo: https://github.com/dotnet/runtime/issues/32354
-                state.Current.ReturnValue = state.ReferenceResolver.ResolveReference(key);
+                if (!converter.TypeToConvert.IsAssignableFrom(value.GetType()))
+                {
+                    ThrowHelper.ThrowJsonException_MetadataReferenceOfTypeCannotBeAssignedToType(referenceId, typeOfValue, converter.TypeToConvert);
+                }
+
+                state.Current.ReturnValue = value;
                 state.Current.ObjectState = StackFrameObjectState.ReadAheadRefEndObject;
             }
             else if (state.Current.ObjectState == StackFrameObjectState.ReadIdValue)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -257,7 +257,7 @@ namespace System.Text.Json
 
                 if (!converter.TypeToConvert.IsAssignableFrom(value.GetType()))
                 {
-                    ThrowHelper.ThrowJsonException_MetadataReferenceOfTypeCannotBeAssignedToType(referenceId, typeOfValue, converter.TypeToConvert);
+                    ThrowHelper.ThrowInvalidOperationException_MetadataReferenceOfTypeCannotBeAssignedToType(referenceId, typeOfValue, converter.TypeToConvert);
                 }
 
                 state.Current.ReturnValue = value;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -606,9 +606,9 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_MetadataReferenceOfTypeCannotBeAssignedToType(string referenceId, Type currentType, Type typeToConvert)
+        public static void ThrowInvalidOperationException_MetadataReferenceOfTypeCannotBeAssignedToType(string referenceId, Type currentType, Type typeToConvert)
         {
-            ThrowJsonException(SR.Format(SR.MetadataReferenceOfTypeCannotBeAssignedToType, referenceId, currentType, typeToConvert));
+            throw new InvalidOperationException(SR.Format(SR.MetadataReferenceOfTypeCannotBeAssignedToType, referenceId, currentType, typeToConvert));
         }
 
         [DoesNotReturn]

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -605,6 +605,13 @@ namespace System.Text.Json
         }
 
         [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowJsonException_MetadataReferenceOfTypeCannotBeAssignedToType(string referenceId, Type currentType, Type typeToConvert)
+        {
+            ThrowJsonException(SR.Format(SR.MetadataReferenceOfTypeCannotBeAssignedToType, referenceId, currentType, typeToConvert));
+        }
+
+        [DoesNotReturn]
         internal static void ThrowUnexpectedMetadataException(
             ReadOnlySpan<byte> propertyName,
             ref Utf8JsonReader reader,

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.Deserialize.cs
@@ -1543,5 +1543,34 @@ namespace System.Text.Json.Serialization.Tests
         }
         #endregion
         #endregion
+
+        [Fact]
+        public static void ReferenceIsAssignableFrom()
+        {
+            const string json = @"{""Derived"":{""$id"":""my_id_1""},""Base"":{""$ref"":""my_id_1""}}";
+            BaseAndDerivedWrapper root = JsonSerializer.Deserialize<BaseAndDerivedWrapper>(json, s_serializerOptionsPreserve);
+
+            Assert.Same(root.Base, root.Derived);
+        }
+
+        [Fact]
+        public static void ReferenceIsNotAssignableFrom()
+        {
+            const string json = @"{""Base"":{""$id"":""my_id_1""},""Derived"":{""$ref"":""my_id_1""}}";
+            JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<BaseAndDerivedWrapper>(json, s_serializerOptionsPreserve));
+
+            Assert.Contains("my_id_1", ex.Message);
+            Assert.Contains(typeof(Derived).ToString(), ex.Message);
+            Assert.Contains(typeof(Base).ToString(), ex.Message);
+        }
+
+        private class BaseAndDerivedWrapper
+        {
+            public Base Base { get; set; }
+            public Derived Derived { get; set; }
+        }
+
+        private class Derived : Base { }
+        private class Base { }
     }
 }

--- a/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.Deserialize.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/ReferenceHandlerTests.Deserialize.cs
@@ -1557,7 +1557,7 @@ namespace System.Text.Json.Serialization.Tests
         public static void ReferenceIsNotAssignableFrom()
         {
             const string json = @"{""Base"":{""$id"":""my_id_1""},""Derived"":{""$ref"":""my_id_1""}}";
-            JsonException ex = Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<BaseAndDerivedWrapper>(json, s_serializerOptionsPreserve));
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<BaseAndDerivedWrapper>(json, s_serializerOptionsPreserve));
 
             Assert.Contains("my_id_1", ex.Message);
             Assert.Contains(typeof(Derived).ToString(), ex.Message);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/32354

Instead of letting the code throw an `InvalidCastException`, we check ahead if the object found in the bag of references can be cast to `JsonConverter<T>.TypeToConvert`. If it can't be assigned we throw a `JsonException` similar to:
```
The object with reference id '1' of type 'Foo' cannot be assigned to the type 'Bar'.
```