### PR TITLE
WASM Re-enable Threading.Channels serialization tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -42,6 +42,8 @@ namespace System
         public static bool IsNotWindows => !IsWindows;
 
         public static bool IsThreadingSupported => !IsBrowser;
+        public static bool IsBinaryFormatterSupported => !IsBrowser;
+
         // Please make sure that you have the libgdiplus dependency installed.
         // For details, see https://docs.microsoft.com/dotnet/core/install/dependencies?pivots=os-macos&tabs=netcore31#libgdiplus
         public static bool IsDrawingSupported

--- a/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
@@ -9,8 +9,7 @@ namespace System.Threading.Channels.Tests
 {
     public partial class ChannelClosedExceptionTests
     {
-        [Fact]
-        [PlatformSpecific(~TestPlatforms.Browser)] // BinaryFormatter not supported in wasm
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public void Serialization_Roundtrip()
         {
             var s = new MemoryStream();

--- a/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
@@ -10,6 +10,7 @@ namespace System.Threading.Channels.Tests
     public partial class ChannelClosedExceptionTests
     {
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // BinaryFormatter not supported in wasm
         public void Serialization_Roundtrip()
         {
             var s = new MemoryStream();

--- a/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelClosedExceptionTests.netcoreapp.cs
@@ -10,7 +10,6 @@ namespace System.Threading.Channels.Tests
     public partial class ChannelClosedExceptionTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37648", TestPlatforms.Browser)]
         public void Serialization_Roundtrip()
         {
             var s = new MemoryStream();


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/37648

This test was fixed by: https://github.com/dotnet/runtime/pull/38948

