### PR TITLE
AdvSimd support for System.Text.Unicode.Utf8Utility.TranscodeToUtf8

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -960,8 +960,8 @@ namespace System.Text.Unicode
                                 }
 
                                 Vector64<sbyte> lower = AdvSimd.ExtractNarrowingSaturateLower(utf16Data);
-                                Vector128<sbyte> source = AdvSimd.ExtractNarrowingSaturateUpper(lower, AdvSimd.LoadVector128((short*)pInputBuffer));
-                                AdvSimd.Store((ulong*)pOutputBuffer, source.AsUInt64());
+                                Vector128<sbyte> result = AdvSimd.ExtractNarrowingSaturateUpper(lower, utf16Data);
+                                AdvSimd.Store((ulong*)pOutputBuffer, result.AsUInt64());
                             }
                             else
                             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -941,7 +941,7 @@ namespace System.Text.Unicode
                     uint inputCharsRemaining = (uint)(pFinalPosWhereCanReadDWordFromInputBuffer - pInputBuffer) + 2;
                     uint minElementsRemaining = (uint)Math.Min(inputCharsRemaining, outputBytesRemaining);
 
-                    if ((AdvSimd.IsSupported || Sse41.X64.IsSupported) && BitConverter.IsLittleEndian)
+                    if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian))
                     {
                         // Try reading and writing 8 elements per iteration.
                         uint maxIters = minElementsRemaining / 8;
@@ -995,8 +995,7 @@ namespace System.Text.Unicode
                             if (AdvSimd.IsSupported)
                             {
                                 Vector64<byte> lower = AdvSimd.ExtractNarrowingSaturateUnsignedLower(utf16Data);
-                                Vector128<byte> source = AdvSimd.ExtractNarrowingSaturateUnsignedUpper(lower, AdvSimd.LoadVector128((short*)pInputBuffer + Vector128<short>.Count));
-                                AdvSimd.StoreSelectedScalar((uint*)pOutputBuffer, source.AsUInt32(), 0);
+                                AdvSimd.StoreSelectedScalar((uint*)pOutputBuffer, lower.AsUInt32(), 0);
                             }
                             else
                             {
@@ -1026,8 +1025,7 @@ namespace System.Text.Unicode
                             if (AdvSimd.IsSupported)
                             {
                                 Vector64<byte> lower = AdvSimd.ExtractNarrowingSaturateUnsignedLower(utf16Data);
-                                Vector128<byte> source = AdvSimd.ExtractNarrowingSaturateUnsignedUpper(lower, AdvSimd.LoadVector128((short*)pOutputBuffer + Vector128<short>.Count));
-                                Unsafe.WriteUnaligned<uint>(pOutputBuffer, source.AsUInt32().ToScalar());
+                                AdvSimd.StoreSelectedScalar((uint*)pOutputBuffer, lower.AsUInt32(), 0);
                             }
                             else
                             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -954,7 +954,7 @@ namespace System.Text.Unicode
 
                             if (AdvSimd.IsSupported)
                             {
-                                if (AdvSimd.CompareTest(utf16Data, nonAsciiUtf16DataMask).ToScalar() == 0)
+                                if (AdvSimd.CompareTest(utf16Data, nonAsciiUtf16DataMask).ToScalar() != 0)
                                 {
                                     goto LoopTerminatedDueToNonAsciiDataInVectorLocal;
                                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -955,15 +955,15 @@ namespace System.Text.Unicode
                             if (AdvSimd.IsSupported)
                             {
                                 Vector128<short> isUtf16DataNonAscii = AdvSimd.CompareTest(utf16Data, nonAsciiUtf16DataMask);
-                                bool hasNonAsciiDataInVector = AdvSimd.Arm64.MinAcross(isUtf16DataNonAscii).ToScalar() != 0;
+                                bool hasNonAsciiDataInVector = AdvSimd.Arm64.MaxPairwise(isUtf16DataNonAscii, isUtf16DataNonAscii).AsUInt64().ToScalar() != 0;
+
                                 if (hasNonAsciiDataInVector)
                                 {
                                     goto LoopTerminatedDueToNonAsciiDataInVectorLocal;
                                 }
 
-                                Vector64<sbyte> lower = AdvSimd.ExtractNarrowingSaturateLower(utf16Data);
-                                Vector128<sbyte> result = AdvSimd.ExtractNarrowingSaturateUpper(lower, utf16Data);
-                                AdvSimd.Store((ulong*)pOutputBuffer, result.AsUInt64());
+                                Vector64<byte> lower = AdvSimd.ExtractNarrowingSaturateUnsignedLower(utf16Data);
+                                AdvSimd.Store(pOutputBuffer, lower);
                             }
                             else
                             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -955,7 +955,7 @@ namespace System.Text.Unicode
                             if (AdvSimd.IsSupported)
                             {
                                 Vector128<short> isUtf16DataNonAscii = AdvSimd.CompareTest(utf16Data, nonAsciiUtf16DataMask);
-                                bool hasNonAsciiDataInVector = AdvSimd.Arm64.MaxPairwise(isUtf16DataNonAscii, isUtf16DataNonAscii).AsUInt64().ToScalar() != 0;
+                                bool hasNonAsciiDataInVector = AdvSimd.Arm64.MinPairwise(isUtf16DataNonAscii, isUtf16DataNonAscii).AsUInt64().ToScalar() != 0;
 
                                 if (hasNonAsciiDataInVector)
                                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -954,7 +954,9 @@ namespace System.Text.Unicode
 
                             if (AdvSimd.IsSupported)
                             {
-                                if (AdvSimd.CompareTest(utf16Data, nonAsciiUtf16DataMask).ToScalar() != 0)
+                                Vector128<short> isUtf16DataNonAscii = AdvSimd.CompareTest(utf16Data, nonAsciiUtf16DataMask);
+                                bool hasNonAsciiDataInVector = AdvSimd.Arm64.MinAcross(isUtf16DataNonAscii).ToScalar() != 0;
+                                if (hasNonAsciiDataInVector)
                                 {
                                     goto LoopTerminatedDueToNonAsciiDataInVectorLocal;
                                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -883,7 +883,7 @@ namespace System.Text.Unicode
             // is not enabled.
 
             Unsafe.SkipInit(out Vector128<short> nonAsciiUtf16DataMask);
-            if (Sse41.X64.IsSupported)
+            if (Sse41.X64.IsSupported || (AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian))
             {
                 nonAsciiUtf16DataMask = Vector128.Create(unchecked((short)0xFF80)); // mask of non-ASCII bits in a UTF-16 char
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -1014,7 +1014,15 @@ namespace System.Text.Unicode
                     LoopTerminatedDueToNonAsciiDataInVectorLocal:
 
                         outputBytesRemaining -= 8 * i;
-                        possibleNonAsciiQWord = Sse2.X64.ConvertToUInt64(utf16Data.AsUInt64());
+
+                        if (Sse2.X64.IsSupported)
+                        {
+                            possibleNonAsciiQWord = Sse2.X64.ConvertToUInt64(utf16Data.AsUInt64());
+                        }
+                        else
+                        {
+                            possibleNonAsciiQWord = utf16Data.AsUInt64().ToScalar();
+                        }
 
                         // Temporarily set 'possibleNonAsciiQWord' to be the low 64 bits of the vector,
                         // then check whether it's all-ASCII. If so, narrow and write to the destination

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -8,6 +8,7 @@ namespace System.Runtime.Intrinsics
         public static Vector64<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
         public static Vector64<uint> CreateScalar(uint value) => throw new PlatformNotSupportedException();
         public static Vector64<byte> AsByte<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
+        public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector64<T>
         where T : struct


### PR DESCRIPTION
Contributes to #35035

Adds AdvSimd support for
`System.Text.Unicode.Utf8Utility.TranscodeToUtf8()`
inside the file
`runtime\src\libraries\System.Private.CoreLib\src\System\Text\Unicode\Utf8Utility.Transcoding.cs`

I've been having difficulties testing this in my ARM device so I want to analyze the CI results.
I manually executed an additional "Libraries Test Run" pipeline to ensure arm64 is run in all platforms.