### PR TITLE
Remove type pattern from descriptor

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -33,7 +33,7 @@
       <property name="ObjectIdForDebugger" />
       <method name="SetNotificationForWaitCompletion" />
     </type>
-    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder&lt;TResult&gt;">
+    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1">
       <property name="ObjectIdForDebugger" />
       <method name="SetNotificationForWaitCompletion" />
     </type>

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -29,7 +29,11 @@
     <type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder">
       <property name="ObjectIdForDebugger" />
     </type>
-    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder*">
+    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder">
+      <property name="ObjectIdForDebugger" />
+      <method name="SetNotificationForWaitCompletion" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder&lt;TResult&gt;">
       <property name="ObjectIdForDebugger" />
       <method name="SetNotificationForWaitCompletion" />
     </type>


### PR DESCRIPTION
The type pattern used here will not only match `System.Runtime.CompilerServices.AsyncTaskMethodBuilder` and `System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>` but also all its nested types, which causes the linker to emit the following warnings:

```
resource System.Private.CoreLib.xml in System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e : error IL2009: Could not find method 'SetNotificationForWaitCompletion' in type 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.DebugFinalizableAsyncStateMachineBox<TStateMachine>' specified in resource System.Private.CoreLib.xml ...
resource System.Private.CoreLib.xml in System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e : error IL2009: Could not find method 'SetNotificationForWaitCompletion' in type 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.AsyncStateMachineBox<TStateMachine>' specified in resource System.Private.CoreLib.xml ...
resource System.Private.CoreLib.xml in System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e : error IL2017: Could not find property 'ObjectIdForDebugger' in type 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder<TResult>.AsyncStateMachineBox<TStateMachine>' specified in resource System.Private.CoreLib.xml ...
```

This will stop the linker from emiting such warnings.


