### PR TITLE
AdvSimd support for System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -79,7 +79,7 @@ namespace System.Text.Unicode
             long tempUtf8CodeUnitCountAdjustment = 0;
             int tempScalarCountAdjustment = 0;
 
-            if (AdvSimd.Arm64.IsSupported || Sse2.IsSupported)
+            if ((AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian) || Sse2.IsSupported)
             {
                 if (inputLength >= Vector128<ushort>.Count)
                 {
@@ -87,11 +87,6 @@ namespace System.Text.Unicode
                     Vector128<ushort> vectorA800 = Vector128.Create((ushort)0xA800);
                     Vector128<short> vector8800 = Vector128.Create(unchecked((short)0x8800));
                     Vector128<ushort> vectorZero = Vector128<ushort>.Zero;
-
-
-                    Vector128<byte> initialMask = Vector128.Create((ushort)0x1001).AsByte();
-                    Vector128<byte> mostSignficantBitMask = Vector128.Create((byte)0x80).AsByte();
-
                     do
                     {
                         Vector128<ushort> utf16Data;
@@ -103,18 +98,19 @@ namespace System.Text.Unicode
                         {
                             utf16Data = Sse2.LoadVector128((ushort*)pInputBuffer); // unaligned
                         }
-                        uint mask;
 
                         Vector128<ushort> charIsNonAscii;
 
-                        // Sets the 0x0080 bit of each element in 'charIsNonAscii' if the corresponding
-                        // input was 0x0080 <= [value]. (i.e., [value] is non-ASCII.)
                         if (AdvSimd.Arm64.IsSupported)
                         {
+                            // Sets the 0x0080 bit of each element in 'charIsNonAscii' if the corresponding
+                            // input was 0x0080 <= [value]. (i.e., [value] is non-ASCII.)
                             charIsNonAscii = AdvSimd.Min(utf16Data, vector0080);
                         }
                         else if (Sse41.IsSupported)
                         {
+                            // Sets the 0x0080 bit of each element in 'charIsNonAscii' if the corresponding
+                            // input was 0x0080 <= [value]. (i.e., [value] is non-ASCII.)
                             charIsNonAscii = Sse41.Min(utf16Data, vector0080);
                         }
                         else
@@ -131,7 +127,7 @@ namespace System.Text.Unicode
                         uint debugMask;
                         if (AdvSimd.Arm64.IsSupported)
                         {
-                            debugMask = (uint)Arm64MoveMask(charIsNonAscii.AsByte(), initialMask, mostSignficantBitMask);
+                            debugMask = GetNonAsciiBytes(charIsNonAscii.AsByte());
                         }
                         else
                         {
@@ -144,17 +140,18 @@ namespace System.Text.Unicode
                         // input was 0x0800 <= [value]. This also handles the missing range a few lines above.
 
                         Vector128<ushort> charIsThreeByteUtf8Encoded;
+                        uint mask;
+
                         if (AdvSimd.IsSupported)
                         {
                             charIsThreeByteUtf8Encoded = AdvSimd.Subtract(vectorZero, AdvSimd.ShiftRightLogical(utf16Data, 11));
-                            mask = (uint)Arm64MoveMask(AdvSimd.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte(), initialMask, mostSignficantBitMask);
+                            mask = GetNonAsciiBytes(AdvSimd.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte());
                         }
                         else
                         {
                             charIsThreeByteUtf8Encoded = Sse2.Subtract(vectorZero, Sse2.ShiftRightLogical(utf16Data, 11));
                             mask = (uint)Sse2.MoveMask(Sse2.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte());
                         }
-
 
                         // Each even bit of mask will be 1 only if the char was >= 0x0080,
                         // and each odd bit of mask will be 1 only if the char was >= 0x0800.
@@ -188,7 +185,7 @@ namespace System.Text.Unicode
                         if (AdvSimd.Arm64.IsSupported)
                         {
                             utf16Data = AdvSimd.Add(utf16Data, vectorA800);
-                            mask = (uint)Arm64MoveMask(AdvSimd.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte(), initialMask, mostSignficantBitMask);
+                            mask = GetNonAsciiBytes(AdvSimd.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte());
                         }
                         else
                         {
@@ -222,7 +219,7 @@ namespace System.Text.Unicode
                             uint mask2;
                             if (AdvSimd.Arm64.IsSupported)
                             {
-                                mask2 = (uint)Arm64MoveMask(AdvSimd.ShiftRightLogical(utf16Data, 3).AsByte(), initialMask, mostSignficantBitMask);
+                                mask2 = GetNonAsciiBytes(AdvSimd.ShiftRightLogical(utf16Data, 3).AsByte());
                             }
                             else
                             {
@@ -483,15 +480,26 @@ namespace System.Text.Unicode
             return pInputBuffer;
         }
 
+        private static readonly Vector128<byte> s_mostSignficantBitMask = Vector128.Create((byte)0x80);
+        private static readonly Vector128<byte> s_bitMask128 = BitConverter.IsLittleEndian ?
+                                                Vector128.Create(0x80402010_08040201).AsByte() :
+                                                Vector128.Create(0x01020408_10204080).AsByte();
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong Arm64MoveMask(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
+        private static uint GetNonAsciiBytes(Vector128<byte> value)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
+            // extractedBits[i] = (value[i] & 0x80) == 0x80 & (1 << i);
+            Vector128<byte> mostSignficantBitMask = s_mostSignficantBitMask;
             Vector128<byte> mostSignificantBitIsSet = AdvSimd.CompareEqual(AdvSimd.And(value, mostSignficantBitMask), mostSignficantBitMask);
-            Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, initialMask);
+            Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, s_bitMask128);
+
+            // self-pairwise add until all flags have moved to the first two bytes of the vector
             extractedBits = AdvSimd.Arm64.AddPairwise(extractedBits, extractedBits);
-            return extractedBits.AsUInt64().ToScalar();
+            extractedBits = AdvSimd.Arm64.AddPairwise(extractedBits, extractedBits);
+            extractedBits = AdvSimd.Arm64.AddPairwise(extractedBits, extractedBits);
+            return extractedBits.AsUInt16().ToScalar();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -130,7 +130,7 @@ namespace System.Text.Unicode
                         uint debugMask;
                         if (AdvSimd.Arm64.IsSupported)
                         {
-                            debugMask = Arm64MoveMask(charIsNonAscii.AsByte(), initialMask, mostSignficantBitMask);
+                            debugMask = (uint)Arm64MoveMask(charIsNonAscii.AsByte(), initialMask, mostSignficantBitMask);
                         }
                         else
                         {
@@ -146,7 +146,7 @@ namespace System.Text.Unicode
                         if (AdvSimd.IsSupported)
                         {
                             charIsThreeByteUtf8Encoded = AdvSimd.Subtract(vectorZero, AdvSimd.ShiftRightLogical(utf16Data, 11));
-                            mask = Arm64MoveMask(AdvSimd.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte(), initialMask, mostSignficantBitMask);
+                            mask = (uint)Arm64MoveMask(AdvSimd.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte(), initialMask, mostSignficantBitMask);
                         }
                         else
                         {
@@ -187,7 +187,7 @@ namespace System.Text.Unicode
                         if (AdvSimd.Arm64.IsSupported)
                         {
                             utf16Data = AdvSimd.Add(utf16Data, vectorA800);
-                            mask = Arm64MoveMask(AdvSimd.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte(), initialMask, mostSignficantBitMask);
+                            mask = (uint)Arm64MoveMask(AdvSimd.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte(), initialMask, mostSignficantBitMask);
                         }
                         else
                         {
@@ -221,7 +221,7 @@ namespace System.Text.Unicode
                             uint mask2;
                             if (AdvSimd.Arm64.IsSupported)
                             {
-                                mask2 = Arm64MoveMask(AdvSimd.ShiftRightLogical(utf16Data, 3).AsByte(), initialMask, mostSignficantBitMask);
+                                mask2 = (uint)Arm64MoveMask(AdvSimd.ShiftRightLogical(utf16Data, 3).AsByte(), initialMask, mostSignficantBitMask);
                             }
                             else
                             {
@@ -483,14 +483,14 @@ namespace System.Text.Unicode
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint Arm64MoveMask(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
+        private static ulong Arm64MoveMask(Vector128<byte> value, Vector128<byte> initialMask, Vector128<byte> mostSignficantBitMask)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
             Vector128<byte> mostSignificantBitIsSet = AdvSimd.CompareEqual(AdvSimd.And(value, mostSignficantBitMask), mostSignficantBitMask);
             Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, initialMask);
             extractedBits = AdvSimd.Arm64.AddPairwise(extractedBits, extractedBits);
-            return extractedBits.AsUInt16().ToScalar();
+            return extractedBits.AsUInt64().ToScalar();
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -143,9 +143,9 @@ namespace System.Text.Unicode
                         // input was 0x0800 <= [value]. This also handles the missing range a few lines above.
 
                         Vector128<ushort> charIsThreeByteUtf8Encoded;
-                        if (AdvSimd.Arm64.IsSupported)
+                        if (AdvSimd.IsSupported)
                         {
-                            charIsThreeByteUtf8Encoded = AdvSimd.Arm64.Subtract(vectorZero.AsDouble(), AdvSimd.ShiftRightLogical(utf16Data, 11).AsDouble()).AsUInt16();
+                            charIsThreeByteUtf8Encoded = AdvSimd.Subtract(vectorZero, AdvSimd.ShiftRightLogical(utf16Data, 11));
                             mask = Arm64MoveMask(AdvSimd.Or(charIsNonAscii, charIsThreeByteUtf8Encoded).AsByte(), initialMask, mostSignficantBitMask);
                         }
                         else
@@ -187,7 +187,7 @@ namespace System.Text.Unicode
                         if (AdvSimd.Arm64.IsSupported)
                         {
                             utf16Data = AdvSimd.Add(utf16Data, vectorA800);
-                            mask = Arm64MoveMask(AdvSimd.Arm64.CompareLessThan(utf16Data.AsDouble(), vector8800.AsDouble()).AsByte(), initialMask, mostSignficantBitMask);
+                            mask = Arm64MoveMask(AdvSimd.CompareLessThan(utf16Data.AsInt16(), vector8800).AsByte(), initialMask, mostSignficantBitMask);
                         }
                         else
                         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -480,7 +480,6 @@ namespace System.Text.Unicode
             return pInputBuffer;
         }
 
-        private static readonly Vector128<byte> s_mostSignficantBitMask = Vector128.Create((byte)0x80);
         private static readonly Vector128<byte> s_bitMask128 = BitConverter.IsLittleEndian ?
                                                 Vector128.Create(0x80402010_08040201).AsByte() :
                                                 Vector128.Create(0x01020408_10204080).AsByte();
@@ -491,8 +490,7 @@ namespace System.Text.Unicode
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
             // extractedBits[i] = (value[i] & 0x80) == 0x80 & (1 << i);
-            Vector128<byte> mostSignficantBitMask = s_mostSignficantBitMask;
-            Vector128<byte> mostSignificantBitIsSet = AdvSimd.CompareEqual(AdvSimd.And(value, mostSignficantBitMask), mostSignficantBitMask);
+            Vector128<byte> mostSignificantBitIsSet = AdvSimd.ShiftRightArithmetic(value.AsSByte(), 7).AsByte();
             Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, s_bitMask128);
 
             // self-pairwise add until all flags have moved to the first two bytes of the vector

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -489,7 +489,6 @@ namespace System.Text.Unicode
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 
-            // extractedBits[i] = (value[i] & 0x80) == 0x80 & (1 << i);
             Vector128<byte> mostSignificantBitIsSet = AdvSimd.ShiftRightArithmetic(value.AsSByte(), 7).AsByte();
             Vector128<byte> extractedBits = AdvSimd.And(mostSignificantBitIsSet, s_bitMask128);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -90,7 +90,8 @@ namespace System.Text.Unicode
 
 
                     Vector128<byte> initialMask = Vector128.Create((ushort)0x1001).AsByte();
-                    Vector128<byte> mostSignficantBitMask = Vector128.Create((byte)0x80);
+                    Vector128<byte> mostSignficantBitMask = Vector128.Create((byte)0x80).AsByte();
+
                     do
                     {
                         Vector128<ushort> utf16Data;

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -16,11 +16,14 @@ namespace System.Runtime.Intrinsics
 
     internal static class Vector128
     {
+        public static Vector128<long> Create(long value) => throw new PlatformNotSupportedException();
         public static Vector128<short> Create(short value) => throw new PlatformNotSupportedException();
+        public static Vector128<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
         public static Vector128<ushort> Create(ushort value) => throw new PlatformNotSupportedException();
         public static Vector128<ulong> CreateScalarUnsafe(ulong value) => throw new PlatformNotSupportedException();
         public static Vector128<byte> AsByte<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<short> AsInt16<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
+        public static Vector128<sbyte> AsSByte<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<ushort> AsUInt16<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<uint> AsUInt32<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<ulong> AsUInt64<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();


### PR DESCRIPTION
Contributes to #35035

Adds AdvSimd support for
`System.Text.Unicode.Utf16Utility.GetPointerToFirstInvalidChar()`
inside the file
`runtime\src\libraries\System.Private.CoreLib\src\System\Text\Unicode\Utf16Utility.Validation.cs`

I've been having difficulties testing this in my ARM device so I want to analyze the CI results.
I manually executed an additional "Libraries Test Run" pipeline to ensure arm64 is run in all platforms.