### PR TITLE
Fix g_TrapReturningThreads to be accessed as 32-bit in asm and JIT code on arm64

### DIFF
--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -3835,13 +3835,13 @@ GenTree* Lowering::CreateReturnTrapSeq()
     GenTree* testTree;
     if (addrOfCaptureThreadGlobal != nullptr)
     {
-        testTree = Ind(AddrGen(addrOfCaptureThreadGlobal));
+        testTree = AddrGen(addrOfCaptureThreadGlobal);
     }
     else
     {
-        testTree = Ind(Ind(AddrGen(pAddrOfCaptureThreadGlobal)));
+        testTree = Ind(AddrGen(pAddrOfCaptureThreadGlobal));
     }
-    return comp->gtNewOperNode(GT_RETURNTRAP, TYP_INT, testTree);
+    return comp->gtNewOperNode(GT_RETURNTRAP, TYP_INT, Ind(testTree, TYP_INT));
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -176,9 +176,9 @@ private:
     GenTree* AddrGen(ssize_t addr);
     GenTree* AddrGen(void* addr);
 
-    GenTree* Ind(GenTree* tree)
+    GenTree* Ind(GenTree* tree, var_types type = TYP_I_IMPL)
     {
-        return comp->gtNewOperNode(GT_IND, TYP_I_IMPL, tree);
+        return comp->gtNewOperNode(GT_IND, type, tree);
     }
 
     GenTree* PhysReg(regNumber reg, var_types type = TYP_I_IMPL)

--- a/src/coreclr/src/vm/arm64/PInvokeStubs.asm
+++ b/src/coreclr/src/vm/arm64/PInvokeStubs.asm
@@ -179,8 +179,8 @@ __PInvokeStubWorkerName SETS "$FuncPrefix":CC:"StubWorker"
 
             ;; Check return trap
             ldr     x9, =g_TrapReturningThreads
-            ldr     x9, [x9]
-            cbnz    x9, RarePath
+            ldr     w9, [x9]
+            cbnz    w9, RarePath
 
             ;; pThread->m_pFrame = pFrame->m_Next
             ldr     x9, [x0, #Frame__m_Next]

--- a/src/coreclr/src/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/src/vm/arm64/asmhelpers.asm
@@ -45,7 +45,6 @@
     IMPORT  g_lowest_address
     IMPORT  g_highest_address
     IMPORT  g_card_table
-    IMPORT  g_TrapReturningThreads
     IMPORT  g_dispatch_cache_chain_success_counter
 #ifdef WRITE_BARRIER_CHECK
     SETALIAS g_GCShadow, ?g_GCShadow@@3PEAEEA

--- a/src/coreclr/src/vm/arm64/pinvokestubs.S
+++ b/src/coreclr/src/vm/arm64/pinvokestubs.S
@@ -157,8 +157,8 @@ LOCAL_LABEL(\__PInvokeStubFuncName\()_0):
 
         // Check return trap
         PREPARE_EXTERNAL_VAR g_TrapReturningThreads, x9
-        ldr     x9, [x9]
-        cbnz    x9, LOCAL_LABEL(RarePath)
+        ldr     w9, [x9]
+        cbnz    w9, LOCAL_LABEL(RarePath)
 
         // pThread->m_pFrame = pFrame->m_Next
         ldr     x9, [x0, #Frame__m_Next]


### PR DESCRIPTION
Fixes #39054