### PR TITLE
[browser][wasm][tests] Deactivate Map tests due to CI failures

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -12,6 +12,6 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\DataViewTests.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\TypedArrayTests.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\ArrayTests.cs" />
-    <Compile Include="System\Runtime\InteropServices\JavaScript\MapTests.cs" />
+    <!-- <Compile Include="System\Runtime\InteropServices\JavaScript\MapTests.cs" /> -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Having the Map tests active are causing intermittent failures.

Remove the Map tests for now until the cause is identified.