### PR TITLE
Fix STOREIND optimization.

### DIFF
--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6530,6 +6530,8 @@ void Lowering::LowerBlockStoreCommon(GenTreeBlk* blkNode)
 bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
 {
     assert(blkNode->OperIs(GT_STORE_BLK, GT_STORE_DYN_BLK, GT_STORE_OBJ));
+    return false;
+#if 0 // the optimization is temporary disabled due to https://github.com/dotnet/wpf/issues/3226 issue.
     if (blkNode->OperIs(GT_STORE_DYN_BLK))
     {
         return false;
@@ -6597,4 +6599,5 @@ bool Lowering::TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode)
     }
     LowerStoreIndirCommon(blkNode);
     return true;
+#endif
 }

--- a/src/tests/JIT/Regression/JitBlue/WPF_3226/CSharpRepro/WPF_3226.cs
+++ b/src/tests/JIT/Regression/JitBlue/WPF_3226/CSharpRepro/WPF_3226.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[StructLayout(LayoutKind.Sequential)]
+class POINT 
+{
+    public int x;
+    public int y;
+    public override string ToString() => $"{{{x}, {y}}}";
+}
+
+[StructLayout(LayoutKind.Sequential)]
+class MINMAXINFO 
+{
+    public POINT ptMinTrackSize = new POINT();
+    public POINT ptMaxTrackSize = new POINT();
+}
+
+class Test
+{
+    static void WmGetMinMaxInfo(IntPtr lParam)
+    {
+        MINMAXINFO mmi = new MINMAXINFO();
+
+        mmi.ptMinTrackSize.x = 100101;
+        mmi.ptMinTrackSize.y = 102103;
+        mmi.ptMaxTrackSize.x = 200201;
+        mmi.ptMaxTrackSize.y = 202203;
+
+        Marshal.StructureToPtr(mmi, lParam, true);
+    }
+
+    public unsafe static int Main()
+    {
+        MINMAXINFO mmi = new MINMAXINFO();
+        IntPtr pmmi = Marshal.AllocHGlobal(Marshal.SizeOf(mmi));
+        WmGetMinMaxInfo(pmmi);
+        mmi = (MINMAXINFO) Marshal.PtrToStructure(pmmi, typeof(MINMAXINFO));
+        bool valid =  mmi.ptMinTrackSize.x == 100101 &&  mmi.ptMinTrackSize.y == 102103 &&  mmi.ptMaxTrackSize.x == 200201 && mmi.ptMaxTrackSize.y == 202203;
+        if (!valid)
+        {
+            Console.WriteLine($"Got {mmi.ptMinTrackSize}, expected {{100101, 102103}}");
+            Console.WriteLine($"Got {mmi.ptMaxTrackSize}, expected {{200201, 202203}}");
+        }
+        return valid ? 100 : -1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/WPF_3226/CSharpRepro/WPF_3226.csproj
+++ b/src/tests/JIT/Regression/JitBlue/WPF_3226/CSharpRepro/WPF_3226.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
https://github.com/dotnet/wpf/issues/3226 exposed a scenario when optimization from https://github.com/dotnet/runtime/pull/38316 did not work correctly.

That PR adds a repro case for that behavior (the scenario requires very specific conditions to expose the problem) and a fix.

In short we need to get a tree like:
```
               [000008] -A-XG-------              *  ASG       struct (copy)
               [000007] -------N----              +--*  BLK       struct<8>
                                                                     \--* smth
               [000004] ---XG--N----              \--*  FIELD     byte   a
```
where `FIELD byte` survives `lclMorph` and `globalMorph`, in order to do that the dest struct has to be non-promotable (in my repro >4 fields) and `FIELD` has to be in the form of
```
               [000004] ---XG--N----              \--*  FIELD     byte   a
               [000003] *--XG-------                 \--*  IND       long
               [000002] ------------                    \--*  LCL_VAR   long   V00 arg0
```
(otherwise, lclMorph optimizes it to a `LCL_FLD byte` and then `fgMorphBlockOperand` creates a correct `IND struct(ADDR(LCL_FLD byte))` on top of it.

if these conditions were met we could have had an IR like (after global morph):
```
               [000008] -A-XG+------              *  ASG       struct (copy)
               [000000] D----+-N----              +--*  LCL_VAR   struct<B, 8> V02 loc1
               [000004] ---XG+-N----              \--*  IND       byte
               [000003] *--XG+------                 \--*  IND       long   Zero Fseq[a]
               [000002] -----+------                    \--*  LCL_VAR   long   V00 arg0
```
that was transformed into:
```
N003 (  7,  5) [000004] ---XG--N----         t4 = *  IND       byte   <l:$283, c:$282>
                                                  /--*  t4     byte
N005 ( 11,  8) [000008] DA-XG-------              *  STORE_LCL_VAR struct<B, 8> V02 loc1         d:2
```
and then the added optimization was transforming it into:
```
N003 (  7,  5) [000004] ---XG--N----         t4 = *  IND       byte   <l:$283, c:$282>
               [000013] D------N----        t13 =    LCL_VAR_ADDR byref  V02 loc1
                                                  /--*  t13    byref
                                                  +--*  t4     byte
N005 ( 11,  8) [000008] -A----------              *  STOREIND  long
```

without the added optimization we also ended with a wrong `IND byte`, but we always mark `STORE_OBJ` src as contained, so we did not put it in a register and `STORE_OBJ` was reading the number of bytes written in `DST`, not in `SRC`.


Note: I did not have a chance to shrink the repro and fix names etc, will do tomorrow.