### PR TITLE
[wasm] Addressing System.Runtime.InteropServices.RuntimeInformation.Tests failures

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -32,6 +32,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
                     Assert.Equal(IntPtr.Size == 4 ? Architecture.Arm : Architecture.Arm64, processArch);
                     break;
 
+                case Architecture.Wasm:
+                    Assert.Equal(Architecture.Wasm, processArch);
+                    break;
+
                 default:
                     Assert.False(true, "Unexpected Architecture.");
                     break;

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/DescriptionNameTests.cs
@@ -12,6 +12,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class DescriptionNameTests
     {
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // throws PNSE when binariesLocation is not an empty string.
         public void DumpRuntimeInformationToConsole()
         {
             // Not really a test, but useful to dump a variety of information to the test log to help

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/RuntimeIdentifierTests.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
     public class RuntimeIdentifierTests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39074", TestPlatforms.Browser)]
         public void VerifyOSRid()
         {
             Assert.NotNull(RuntimeInformation.RuntimeIdentifier);

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -79,7 +79,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.Reader\tests\System.Resources.Reader.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.ResourceManager\tests\System.Resources.ResourceManager.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Extensions\tests\System.Runtime.Extensions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices.RuntimeInformation\tests\System.Runtime.InteropServices.RuntimeInformation.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\System.Runtime.InteropServices.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\DefaultContext\System.Runtime.Loader.DefaultContext.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Loader\tests\System.Runtime.Loader.Tests.csproj" />


### PR DESCRIPTION
Contributes to #38422
This PR looks to address test failures in `System.Runtime.InteropServices.RuntimeInformation` when running on Browser wasm.
`Tests run: 7, Errors: 0, Failures: 0, Skipped: 3. Time: 0.048805s`
`RuntimeInformation.RuntimeIdentifier` currently returns `unknown` on Browser, and it is typically set by the hosting app.
`typeof(object).Assembly.Location` currently returns `""` on Browser, also probably set by the hosting app.