### PR TITLE
Bump version for Microsoft.DotNet.XunitExtensions again

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -56,7 +56,7 @@
     <MicrosoftDotNetCodeAnalysisVersion>5.0.0-beta.20330.3</MicrosoftDotNetCodeAnalysisVersion>
     <MicrosoftDotNetGenAPIVersion>5.0.0-beta.20330.3</MicrosoftDotNetGenAPIVersion>
     <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20330.3</MicrosoftDotNetGenFacadesVersion>
-    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20330.3</MicrosoftDotNetXUnitExtensionsVersion>
+    <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20353.2</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20330.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
     <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20330.3</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20330.3</MicrosoftDotNetRemoteExecutorVersion>


### PR DESCRIPTION
The recent darc update from https://github.com/dotnet/runtime/commit/9dc660148121c128dc960bf090b83fe67af3bc6f removed my https://github.com/dotnet/runtime/commit/4aea0a14f930eff557bb6e4f30b99be8a583d475 which is necessary to correctly detect WASM/Browser as using the Mono interpreter.