### PR TITLE
Preserve AsyncValueTaskMethodBuilder.ObjectIdForDebugger

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.Shared.xml
@@ -42,6 +42,12 @@
       <property name="ObjectIdForDebugger" />
       <method name="SetNotificationForWaitCompletion" />
     </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder">
+      <property name="ObjectIdForDebugger" />
+    </type>
+    <type fullname="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1">
+      <property name="ObjectIdForDebugger" />
+    </type>
     <type fullname="System.Threading.Tasks.Task">
       <!-- Methods is used by VS Tasks Window. -->
       <method name="GetActiveTaskFromId" />


### PR DESCRIPTION
These internal properties are used by the debugger, so they should be preserved when debugging is supported.