### PR TITLE
Fix precondition on OSX 10.15 mutable store tests

### DIFF
--- a/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/tests/X509StoreMutableTests.OSX.cs
@@ -22,17 +22,25 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             {
                 const int errSecWrPerm = -61;
                 const int errSecInteractionNotAllowed = -25308;
+                const int kPOSIXErrorBase = 100000;
 
-                if (e.HResult == errSecInteractionNotAllowed)
+                switch (e.HResult)
                 {
-                    Console.WriteLine("Run 'security unlock-keychain' to make tests runable.");
-                    return false;
+                    case errSecInteractionNotAllowed:
+                        Console.WriteLine("Run 'security unlock-keychain' to make tests runable.");
+                        return false;
+                    case kPOSIXErrorBase:
+                        // kPOSIXErrorBase is returned for "unknown error from a subsystem",
+                        // which seems to happen on writes from SSH sessions even if the keychain
+                        // was unlocked.
+                        Console.WriteLine("Writing precondition failed with kPOSIXErrorBase, skipping tests.");
+                        return false;
+                    case errSecWrPerm:
+                        Console.WriteLine("Writing precondition failed with permission denied, skipping tests.");
+                        return false;
                 }
 
-                if (e.HResult == errSecWrPerm)
-                {
-                    return false;
-                }
+                Console.WriteLine($"Precondition test failed with unknown code {e.HResult}, running anyways.");
             }
             catch
             {


### PR DESCRIPTION
While these tests pass on an interactive session, they're still getting deep-down errors over SSH on 10.15 after running `security unlock-keychain`.

So when the wonderful "unknown error" appears in the pretest, just skip the mutable tests.

Fixes #30394.