### PR TITLE
WASM: Add PlatformNotSupportedException for System.Net.Ping

### DIFF
--- a/src/libraries/System.Net.Ping/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Ping/src/Resources/Strings.resx
@@ -87,4 +87,7 @@
   <data name="net_ping_not_supported_uwp" xml:space="preserve">
     <value>Ping functionality is not currently supported in UWP.</value>
   </data>
+  <data name="Ping_PlatformNotSupported" xml:space="preserve">
+    <value>System.Net.Ping is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
@@ -5,7 +5,10 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <ItemGroup>
+  <PropertyGroup>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Ping_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
     <Compile Include="System\Net\NetworkInformation\IPStatus.cs" />
     <Compile Include="System\Net\NetworkInformation\NetEventSource.Ping.cs" />
     <Compile Include="System\Net\NetworkInformation\Ping.cs" />
@@ -13,31 +16,25 @@
     <Compile Include="System\Net\NetworkInformation\PingException.cs" />
     <Compile Include="System\Net\NetworkInformation\PingOptions.cs" />
     <Compile Include="System\Net\NetworkInformation\PingReply.cs" />
-  </ItemGroup>
-  <!-- System.Net Common -->
-  <ItemGroup>
+    <!-- System.Net Common -->
     <Compile Include="$(CommonPath)System\Net\ByteOrder.cs"
              Link="Common\System\Net\ByteOrder.cs" />
     <Compile Include="$(CommonPath)System\Net\IPAddressParserStatics.cs"
              Link="Common\System\Net\IPAddressParserStatics.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketAddress.cs"
              Link="Common\System\Net\SocketAddress.cs" />
-  </ItemGroup>
-  <!-- Logging -->
-  <ItemGroup>
+    <!-- Logging -->
     <Compile Include="$(CommonPath)System\Net\Logging\NetEventSource.Common.cs"
              Link="Common\System\Net\Logging\NetEventSource.Common.cs" />
     <Compile Include="$(CommonPath)System\Net\InternalException.cs"
              Link="Common\System\Net\InternalException.cs" />
-  </ItemGroup>
-  <!-- System.Net.Internals -->
-  <ItemGroup>
+    <!-- System.Net.Internals -->
     <Compile Include="$(CommonPath)System\Net\Internals\IPAddressExtensions.cs"
              Link="Common\System\Net\Internals\IPAddressExtensions.cs" />
     <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs"
              Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true' ">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Net\NetworkInformation\IcmpV4MessageConstants.cs" />
     <Compile Include="System\Net\NetworkInformation\IcmpV6MessageConstants.cs" />
     <Compile Include="System\Net\NetworkInformation\Ping.Unix.cs" />
@@ -66,8 +63,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <Compile Include="System\Net\NetworkInformation\Ping.Windows.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
     <!-- System.Net Common -->
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Windows.cs"
              Link="Common\System\Net\SocketAddressPal.Windows.cs" />
@@ -107,7 +102,7 @@
     <Reference Include="System.Threading" />
     <Reference Include="System.Threading.ThreadPool" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Reference Include="System.Diagnostics.Process" />
     <Reference Include="System.IO.FileSystem" />
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+[assembly: SkipOnMono("System.Net.Ping is not supported on Browser", TestPlatforms.Browser)]

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/System.Net.Ping.Functional.Tests.csproj
@@ -3,9 +3,11 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
+    <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
   </PropertyGroup>
   <!-- Test APIs introduced after 1.0 -->
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="PingTest.cs" />
     <Compile Include="LoggingTest.cs" />
     <Compile Include="PingExceptionTest.cs" />


### PR DESCRIPTION
The library isn't supported on WebAssembly.