### PR TITLE
[Wasm] Enable System.IO.Compression.ZipFile tests

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Create.cs
@@ -282,19 +282,23 @@ namespace System.IO.Compression.Tests
                 Assert.Equal(new DateTime(1980, 1, 1, 0, 0, 0), archive.Entries[0].LastWriteTime.DateTime);
             }
 
-            FileInfo fileWithBadDate = new FileInfo(GetTestFilePath());
-            fileWithBadDate.Create().Dispose();
-            fileWithBadDate.LastWriteTimeUtc = new DateTime(1970, 1, 1, 1, 1, 1);
+            // Browser VFS does not support saving file attributes, so skip
+            if (!PlatformDetection.IsBrowser)
+            {
+                FileInfo fileWithBadDate = new FileInfo(GetTestFilePath());
+                fileWithBadDate.Create().Dispose();
+                fileWithBadDate.LastWriteTimeUtc = new DateTime(1970, 1, 1, 1, 1, 1);
 
-            string archivePath = GetTestFilePath();
-            using (FileStream output = File.Open(archivePath, FileMode.Create))
-            using (ZipArchive archive = new ZipArchive(output, ZipArchiveMode.Create))
-            {
-                archive.CreateEntryFromFile(fileWithBadDate.FullName, "SomeEntryName");
-            }
-            using (ZipArchive archive = ZipFile.OpenRead(archivePath))
-            {
-                Assert.Equal(new DateTime(1980, 1, 1, 0, 0, 0), archive.Entries[0].LastWriteTime.DateTime);
+                string archivePath = GetTestFilePath();
+                using (FileStream output = File.Open(archivePath, FileMode.Create))
+                using (ZipArchive archive = new ZipArchive(output, ZipArchiveMode.Create))
+                {
+                    archive.CreateEntryFromFile(fileWithBadDate.FullName, "SomeEntryName");
+                }
+                using (ZipArchive archive = ZipFile.OpenRead(archivePath))
+                {
+                    Assert.Equal(new DateTime(1980, 1, 1, 0, 0, 0), archive.Entries[0].LastWriteTime.DateTime);
+                }
             }
         }
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -46,7 +46,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\System.Globalization.Calendars.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Extensions\tests\System.Globalization.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression.ZipFile\tests\System.IO.Compression.ZipFile.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem.DriveInfo\tests\System.IO.FileSystem.DriveInfo.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />


### PR DESCRIPTION
Found that the emscripten VFS may not write user specified file attributes (at least initially), so skip the part of ZipFile_Create.InvalidDates that expects this to be supported.