### PR TITLE
Move printf in PauseOnStart

### DIFF
--- a/src/coreclr/src/vm/diagnosticserver.cpp
+++ b/src/coreclr/src/vm/diagnosticserver.cpp
@@ -276,7 +276,7 @@ void DiagnosticServer::PauseForDiagnosticsMonitor()
             {
                 wprintf(W("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a server at '%s'.\n"), (LPWSTR)pDotnetDiagnosticsMonitorAddress);
                 fflush(stdout);
-                STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_ALWAYS, "The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command and has waitied 5 seconds.");
+                STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_ALWAYS, "The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command and has waited 5 seconds.");
                 const DWORD dwWait = s_ResumeRuntimeStartupEvent->Wait(INFINITE, false);
             }
         }

--- a/src/coreclr/src/vm/diagnosticserver.cpp
+++ b/src/coreclr/src/vm/diagnosticserver.cpp
@@ -270,12 +270,12 @@ void DiagnosticServer::PauseForDiagnosticsMonitor()
         if (dwDotnetDiagnosticsMonitorPauseOnStart != 0)
         {
             _ASSERTE(s_ResumeRuntimeStartupEvent != nullptr && s_ResumeRuntimeStartupEvent->IsValid());
-            wprintf(W("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a server at '%s'.\n"), (LPWSTR)pDotnetDiagnosticsMonitorAddress);
-            fflush(stdout);
             STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_ALWAYS, "The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command.");
             const DWORD dwFiveSecondWait = s_ResumeRuntimeStartupEvent->Wait(5000, false);
             if (dwFiveSecondWait == WAIT_TIMEOUT)
             {
+                wprintf(W("The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command from a server at '%s'.\n"), (LPWSTR)pDotnetDiagnosticsMonitorAddress);
+                fflush(stdout);
                 STRESS_LOG0(LF_DIAGNOSTICS_PORT, LL_ALWAYS, "The runtime has been configured to pause during startup and is awaiting a Diagnostics IPC ResumeStartup command and has waitied 5 seconds.");
                 const DWORD dwWait = s_ResumeRuntimeStartupEvent->Wait(INFINITE, false);
             }


### PR DESCRIPTION
Only print to the console from the runtime when PauseOnStart has waited long enough.