### PR TITLE
Implementation of CSE for GT_CNS_INT benefits ARM64

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6360,6 +6360,7 @@ protected:
 
         ValueNum defConservNormVN; // if all def occurrences share the same conservative normal value
                                    // number, this will reflect it; otherwise, NoVN.
+                                   // not used for shared const CSE's
     };
 
     static const size_t s_optCSEhashSize;

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6328,7 +6328,7 @@ protected:
     {
         CSEdsc* csdNextInBucket; // used by the hash table
 
-        unsigned csdHashKey; // the orginal hashkey
+        size_t   csdHashKey;       // the orginal hashkey
 
         unsigned csdIndex; // 1..optCSECandidateCount
         bool     csdLiveAcrossCall;

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6326,14 +6326,12 @@ protected:
 
     struct CSEdsc
     {
-        CSEdsc* csdNextInBucket; // used by the hash table
-
+        CSEdsc*  csdNextInBucket;  // used by the hash table
         size_t   csdHashKey;       // the orginal hashkey
-        ssize_t  csdConstDefValue; // When we CSE similar constants this is the value that we use as the def
-        ValueNum csdConstDefVN;    // When we CSE similar constants this is the ValueNumber that we use for the LclVar
+        ssize_t  csdConstDefValue; // When we CSE similar constants, this is the value that we use as the def
+        ValueNum csdConstDefVN;    // When we CSE similar constants, this is the ValueNumber that we use for the LclVar
                                    // assignment
-
-        unsigned csdIndex; // 1..optCSECandidateCount
+        unsigned csdIndex;         // 1..optCSECandidateCount
         bool     csdLiveAcrossCall;
 
         unsigned short csdDefCount; // definition   count
@@ -6408,6 +6406,16 @@ protected:
 #ifdef DEBUG
     void optEnsureClearCSEInfo();
 #endif // DEBUG
+
+    static bool Is_Shared_Const_CSE(size_t key)
+    {
+        return ((key & TARGET_SIGN_BIT) != 0);
+    }
+
+    static size_t Decode_Shared_Const_CSE_Value(size_t key)
+    {
+        return (key & ~TARGET_SIGN_BIT) << CSE_CONST_SHARED_LOW_BITS;
+    }
 
 #endif // FEATURE_ANYCSE
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6329,6 +6329,9 @@ protected:
         CSEdsc* csdNextInBucket; // used by the hash table
 
         size_t   csdHashKey;       // the orginal hashkey
+        ssize_t  csdConstDefValue; // When we CSE similar constants this is the value that we use as the def
+        ValueNum csdConstDefVN;    // When we CSE similar constants this is the ValueNumber that we use for the LclVar
+                                   // assignment
 
         unsigned csdIndex; // 1..optCSECandidateCount
         bool     csdLiveAcrossCall;

--- a/src/coreclr/src/jit/gentree.cpp
+++ b/src/coreclr/src/jit/gentree.cpp
@@ -3250,16 +3250,50 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
         switch (oper)
         {
 #ifdef TARGET_ARM
-            case GT_CNS_LNG:
-                costSz = 9;
-                costEx = 4;
-                goto COMMON_CNS;
-
             case GT_CNS_STR:
                 // Uses movw/movt
-                costSz = 7;
-                costEx = 3;
+                costSz = 8;
+                costEx = 2;
                 goto COMMON_CNS;
+
+            case GT_CNS_LNG:
+            {
+                GenTreeIntConCommon* con = tree->AsIntConCommon();
+
+                INT64 lngVal = con->LngValue();
+                INT32 loVal  = (INT32)(lngVal & 0xffffffff);
+                INT32 hiVal  = (INT32)(lngVal >> 32);
+
+                if (lngVal == 0)
+                {
+                    costSz = 1;
+                    costEx = 1;
+                }
+                else
+                {
+                    // Minimum of one instruction to setup hiVal,
+                    // and one instruction to setup loVal
+                    costSz = 4 + 4;
+                    costEx = 1 + 1;
+
+                    if (!codeGen->validImmForInstr(INS_mov, (target_ssize_t)hiVal) &&
+                        !codeGen->validImmForInstr(INS_mvn, (target_ssize_t)hiVal))
+                    {
+                        // Needs extra instruction: movw/movt
+                        costSz += 4;
+                        costEx += 1;
+                    }
+
+                    if (!codeGen->validImmForInstr(INS_mov, (target_ssize_t)loVal) &&
+                        !codeGen->validImmForInstr(INS_mvn, (target_ssize_t)loVal))
+                    {
+                        // Needs extra instruction: movw/movt
+                        costSz += 4;
+                        costEx += 1;
+                    }
+                }
+                goto COMMON_CNS;
+            }
 
             case GT_CNS_INT:
             {
@@ -3267,61 +3301,87 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                 //  applied to it.
                 // Any constant that requires a reloc must use the movw/movt sequence
                 //
-                GenTreeIntConCommon* con = tree->AsIntConCommon();
+                GenTreeIntConCommon* con    = tree->AsIntConCommon();
+                INT32                conVal = con->IconValue();
 
-                if (con->ImmedValNeedsReloc(this) ||
-                    !codeGen->validImmForInstr(INS_mov, (target_ssize_t)tree->AsIntCon()->gtIconVal))
+                if (con->ImmedValNeedsReloc(this))
                 {
-                    // Uses movw/movt
-                    costSz = 7;
-                    costEx = 3;
+                    // Requires movw/movt
+                    costSz = 8;
+                    costEx = 2;
                 }
-                else if (((unsigned)tree->AsIntCon()->gtIconVal) <= 0x00ff)
+                else if (codeGen->validImmForInstr(INS_add, (target_ssize_t)conVal))
                 {
-                    // mov  Rd, <const8>
-                    costSz = 1;
+                    // Typically included with parent oper
+                    costSz = 2;
+                    costEx = 1;
+                }
+                else if (codeGen->validImmForInstr(INS_mov, (target_ssize_t)conVal) &&
+                         codeGen->validImmForInstr(INS_mvn, (target_ssize_t)conVal))
+                {
+                    // Uses mov or mvn
+                    costSz = 4;
                     costEx = 1;
                 }
                 else
                 {
-                    // Uses movw/mvn
-                    costSz = 3;
-                    costEx = 1;
+                    // Needs movw/movt
+                    costSz = 8;
+                    costEx = 2;
                 }
                 goto COMMON_CNS;
             }
 
 #elif defined TARGET_XARCH
 
-            case GT_CNS_LNG:
-                costSz = 10;
-                costEx = 3;
-                goto COMMON_CNS;
-
             case GT_CNS_STR:
+#ifdef TARGET_AMD64
+                costSz = 10;
+                costEx = 2;
+#else // TARGET_X86
                 costSz = 4;
                 costEx = 1;
+#endif
                 goto COMMON_CNS;
 
+            case GT_CNS_LNG:
             case GT_CNS_INT:
             {
+                GenTreeIntConCommon* con       = tree->AsIntConCommon();
+                ssize_t              conVal    = (oper == GT_CNS_LNG) ? (ssize_t)con->LngValue() : con->IconValue();
+                bool                 fitsInVal = true;
+
+#ifdef TARGET_X86
+                if (oper == GT_CNS_LNG)
+                {
+                    INT64 lngVal = con->LngValue();
+
+                    conVal = (ssize_t)lngVal; // truncate to 32-bits
+
+                    fitsInVal = ((INT64)conVal == lngVal);
+                }
+#endif // TARGET_X86
+
                 // If the constant is a handle then it will need to have a relocation
                 //  applied to it.
                 //
-                GenTreeIntConCommon* con = tree->AsIntConCommon();
-
                 bool iconNeedsReloc = con->ImmedValNeedsReloc(this);
 
-                if (!iconNeedsReloc && con->FitsInI8())
+                if (iconNeedsReloc)
+                {
+                    costSz = 4;
+                    costEx = 1;
+                }
+                else if (fitsInVal && GenTreeIntConCommon::FitsInI8(conVal))
                 {
                     costSz = 1;
                     costEx = 1;
                 }
-#if defined(TARGET_AMD64)
-                else if (iconNeedsReloc || !con->FitsInI32())
+#ifdef TARGET_AMD64
+                else if (!GenTreeIntConCommon::FitsInI32(conVal))
                 {
                     costSz = 10;
-                    costEx = 3;
+                    costEx = 2;
                 }
 #endif // TARGET_AMD64
                 else
@@ -3329,21 +3389,83 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                     costSz = 4;
                     costEx = 1;
                 }
+#ifdef TARGET_X86
+                if (oper == GT_CNS_LNG)
+                {
+                    costSz += fitsInVal ? 1 : 4;
+                    costEx += 1;
+                }
+#endif // TARGET_X86
+
                 goto COMMON_CNS;
             }
 
 #elif defined(TARGET_ARM64)
-            case GT_CNS_LNG:
+
             case GT_CNS_STR:
+            case GT_CNS_LNG:
             case GT_CNS_INT:
-                // TODO-ARM64-NYI: Need cost estimates.
-                costSz = 1;
-                costEx = 1;
+            {
+                GenTreeIntConCommon* con            = tree->AsIntConCommon();
+                bool                 iconNeedsReloc = con->ImmedValNeedsReloc(this);
+                INT64                imm            = con->LngValue();
+                emitAttr             size           = EA_SIZE(emitActualTypeSize(tree));
+
+                if (iconNeedsReloc)
+                {
+                    costSz = 8;
+                    costEx = 2;
+                }
+                else if (emitter::emitIns_valid_imm_for_add(imm, size))
+                {
+                    costSz = 2;
+                    costEx = 1;
+                }
+                else if (emitter::emitIns_valid_imm_for_mov(imm, size))
+                {
+                    costSz = 4;
+                    costEx = 1;
+                }
+                else
+                {
+                    // Arm64 allows any arbitrary 16-bit constant to be loaded into a register halfword
+                    // There are three forms
+                    //    movk which loads into any halfword preserving the remaining halfwords
+                    //    movz which loads into any halfword zeroing the remaining halfwords
+                    //    movn which loads into any halfword zeroing the remaining halfwords then bitwise inverting
+                    //    the register
+                    // In some cases it is preferable to use movn, because it has the side effect of filling the
+                    // other halfwords
+                    // with ones
+
+                    // Determine whether movn or movz will require the fewest instructions to populate the immediate
+                    bool preferMovz       = false;
+                    bool preferMovn       = false;
+                    int  instructionCount = 4;
+
+                    for (int i = (size == EA_8BYTE) ? 48 : 16; i >= 0; i -= 16)
+                    {
+                        if (!preferMovn && (uint16_t(imm >> i) == 0x0000))
+                        {
+                            preferMovz = true; // by using a movk to start we can save one instruction
+                            instructionCount--;
+                        }
+                        else if (!preferMovz && (uint16_t(imm >> i) == 0xffff))
+                        {
+                            preferMovn = true; // by using a movn to start we can save one instruction
+                            instructionCount--;
+                        }
+                    }
+
+                    costEx = instructionCount;
+                    costSz = 4 * instructionCount;
+                }
+            }
                 goto COMMON_CNS;
 
 #else
-            case GT_CNS_LNG:
             case GT_CNS_STR:
+            case GT_CNS_LNG:
             case GT_CNS_INT:
 #error "Unknown TARGET"
 #endif

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -285,6 +285,14 @@ CONFIG_INTEGER(JitDisableSimdVN, W("JitDisableSimdVN"), 0) // Default 0, ValueNu
                                                            // If 3, disable both SIMD and HW Intrinsic nodes
 #endif                                                     // FEATURE_SIMD
 
+// Default 0, enable the CSE of Constants, including nearby offsets. (only for ARM64)
+// If 1, disable all the CSE of Constants
+// If 2, enable the CSE of Constants but don't combine with nearby offsets. (only for ARM64)
+// If 3, enable the CSE of Constants including nearby offsets. (all platforms)
+// If 4, enable the CSE of Constants but don't combine with nearby offsets. (all platforms)
+//
+CONFIG_INTEGER(JitDisableConstCSE, W("JitDisableConstCSE"), 0)
+
 ///
 /// JIT
 ///

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -291,7 +291,7 @@ CONFIG_INTEGER(JitDisableSimdVN, W("JitDisableSimdVN"), 0) // Default 0, ValueNu
 // If 3, enable the CSE of Constants including nearby offsets. (all platforms)
 // If 4, enable the CSE of Constants but don't combine with nearby offsets. (all platforms)
 //
-CONFIG_INTEGER(JitDisableConstCSE, W("JitDisableConstCSE"), 0)
+CONFIG_INTEGER(JitConstCSE, W("JitConstCSE"), 0)
 
 ///
 /// JIT

--- a/src/coreclr/src/jit/jitconfigvalues.h
+++ b/src/coreclr/src/jit/jitconfigvalues.h
@@ -293,6 +293,12 @@ CONFIG_INTEGER(JitDisableSimdVN, W("JitDisableSimdVN"), 0) // Default 0, ValueNu
 //
 CONFIG_INTEGER(JitConstCSE, W("JitConstCSE"), 0)
 
+#define CONST_CSE_ENABLE_ARM64 0
+#define CONST_CSE_DISABLE_ALL 1
+#define CONST_CSE_ENABLE_ARM64_NO_SHARING 2
+#define CONST_CSE_ENABLE_ALL 3
+#define CONST_CSE_ENABLE_ALL_NO_SHARING 4
+
 ///
 /// JIT
 ///

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -2708,8 +2708,10 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
 #endif
         indirectCellAddress->SetRegNum(REG_R2R_INDIRECT_PARAM);
 #ifdef TARGET_ARM
-        // Don't attempt to CSE this constant
-        // This hits an assert: Assertion failed 'candidates != candidateBit' in lsra.cpp Line: 3723
+        // Issue #xxxx : Don't attempt to CSE this constant on ARM32
+        //
+        // This constant has specific register requirements, and LSRA doesn't currently correctly
+        // handle them when the value is in a CSE'd local.
         indirectCellAddress->SetDoNotCSE();
 #endif // TARGET_ARM
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -2707,6 +2707,11 @@ void Compiler::fgInitArgInfo(GenTreeCall* call)
         indirectCellAddress->AsIntCon()->gtTargetHandle = (size_t)call->gtCallMethHnd;
 #endif
         indirectCellAddress->SetRegNum(REG_R2R_INDIRECT_PARAM);
+#ifdef TARGET_ARM
+        // Don't attempt to CSE this constant
+        // This hits an assert: Assertion failed 'candidates != candidateBit' in lsra.cpp Line: 3723
+        indirectCellAddress->SetDoNotCSE();
+#endif // TARGET_ARM
 
         // Push the stub address onto the list of arguments.
         call->gtCallArgs = gtPrependNewCallArg(indirectCellAddress, call->gtCallArgs);

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -407,7 +407,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
     CSEdsc*  hashDsc;
     bool     isIntConstHash       = false;
     bool     enableSharedConstCSE = false;
-    int      configValue          = JitConfig.JitDisableConstCSE();
+    int      configValue          = JitConfig.JitConstCSE();
 
 #if defined(TARGET_ARM64)
     // ARM64 - allow to combine with nearby offsets, when config is not 2 or 4
@@ -724,7 +724,7 @@ unsigned Compiler::optValnumCSE_Locate()
 
     bool disableConstCSE = false;
 
-    int configValue = JitConfig.JitDisableConstCSE();
+    int configValue = JitConfig.JitConstCSE();
 
     // all platforms - disable CSE of constant values when config is 1
     if (configValue == 1)

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -401,7 +401,7 @@ void Compiler::optValnumCSE_Init()
 //
 unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
 {
-    unsigned key;
+    size_t   key;
     unsigned hash;
     unsigned hval;
     CSEdsc*  hashDsc;
@@ -446,11 +446,11 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         //
         if (vnOp2Lib != vnLib)
         {
-            key = (unsigned)vnLib; // include the exc set in the hash key
+            key = vnLib; // include the exc set in the hash key
         }
         else
         {
-            key = (unsigned)vnLibNorm;
+            key = vnLibNorm;
         }
 
         // If we didn't do the above we would have op1 as the CSE def
@@ -461,12 +461,15 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
     }
     else // Not a GT_COMMA
     {
-        key = (unsigned)vnLibNorm;
+        key = vnLibNorm;
     }
 
     // Compute the hash value for the expression
 
-    hash = key;
+    hash = (unsigned)key;
+#ifdef TARGET_64BIT
+    hash ^= (unsigned)(key >> 32);
+#endif
     hash *= (unsigned)(s_optCSEhashSize + 1);
     hash >>= 7;
 
@@ -645,8 +648,8 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
 #ifdef DEBUG
         if (verbose)
         {
-            printf("\nCSE candidate #%02u, vn=", CSEindex);
-            vnPrint(key, 0);
+            printf("\nCSE candidate #%02u, key=", CSEindex);
+            vnPrint((ValueNum)key, 0);
             printf(" in " FMT_BB ", [cost=%2u, size=%2u]: \n", compCurBB->bbNum, tree->GetCostEx(), tree->GetCostSz());
             gtDispTree(tree);
         }

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -410,8 +410,8 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
     int      configValue          = JitConfig.JitDisableConstCSE();
 
 #if defined(TARGET_ARM64)
-    // ARM64 - allow to combine with nearby offsets, when config is not 2
-    if (configValue != 2)
+    // ARM64 - allow to combine with nearby offsets, when config is not 2 or 4
+    if ((configValue != 2) && (configValue != 4))
     {
         enableSharedConstCSE = true;
     }

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -2002,7 +2002,7 @@ typedef unsigned __int64 target_size_t;
 typedef __int64          target_ssize_t;
 #define TARGET_SIGN_BIT (1ULL << 63)
 
-#else  // !TARGET_64BIT
+#else // !TARGET_64BIT
 typedef unsigned int target_size_t;
 typedef int          target_ssize_t;
 #define TARGET_SIGN_BIT (1ULL << 31)

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -31,12 +31,15 @@
 // with static const members of Target
 #if defined(TARGET_XARCH)
 #define REGMASK_BITS 32
+#define CSE_CONST_SHARED_LOW_BITS 16
 
 #elif defined(TARGET_ARM)
 #define REGMASK_BITS 64
+#define CSE_CONST_SHARED_LOW_BITS 12
 
 #elif defined(TARGET_ARM64)
 #define REGMASK_BITS 64
+#define CSE_CONST_SHARED_LOW_BITS 12
 
 #else
 #error Unsupported or unset target architecture
@@ -1997,9 +2000,13 @@ C_ASSERT((RBM_INT_CALLEE_SAVED & RBM_FPBASE) == RBM_NONE);
 #ifdef TARGET_64BIT
 typedef unsigned __int64 target_size_t;
 typedef __int64          target_ssize_t;
+#define TARGET_SIGN_BIT (1ULL << 63)
+
 #else  // !TARGET_64BIT
 typedef unsigned int target_size_t;
 typedef int          target_ssize_t;
+#define TARGET_SIGN_BIT (1ULL << 31)
+
 #endif // !TARGET_64BIT
 
 C_ASSERT(sizeof(target_size_t) == TARGET_POINTER_SIZE);

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r4.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/beq_r8.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r4.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_r8.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r4.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bge_un_r8.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r4.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r4.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r8.ilproj
+++ b/src/tests/JIT/IL_Conformance/Old/Conformance_Base/bne_un_r8.ilproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RestorePackages>true</RestorePackages>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>

--- a/src/tests/JIT/Methodical/NaN/arithm64_cs_d.csproj
+++ b/src/tests/JIT/Methodical/NaN/arithm64_cs_d.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/NaN/arithm64_cs_do.csproj
+++ b/src/tests/JIT/Methodical/NaN/arithm64_cs_do.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/JIT/Methodical/NaN/arithm64_cs_r.csproj
+++ b/src/tests/JIT/Methodical/NaN/arithm64_cs_r.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/Methodical/NaN/arithm64_cs_ro.csproj
+++ b/src/tests/JIT/Methodical/NaN/arithm64_cs_ro.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>


### PR DESCRIPTION
    Implementation of code size optimization, CSE of constant values for ARM64
    We will share a single CSE for constants that differ only in their low 12 bits on ARM64

    Number of shared constant low bits set in target.h  CSE_CONST_SHARED_LOW_BITS
    we use 12 bits on Arm platforms and 16 bits on XArch platforms

    Disable the CSE of the REG_R2R_INDIRECT_PARAM on Arm32
    as it hits  Assertion failed 'candidates != candidateBit' in lsra.cpp Line: 3723

    Config variable: COMPlus_JitConstCSE
    // Default 0, enable the CSE of Constants, including nearby offsets. (only for ARM64)
    // If 1, disable all the CSE of Constants
    // If 2, enable the CSE of Constants but don't combine with nearby offsets. (only for ARM64)
    // If 3, enable the CSE of Constants including nearby offsets. (all platforms)
    // If 4, enable the CSE of Constants but don't combine with nearby offsets. (all platforms)

    Don't auto retry when using the AltJit as that results in two copies of every method in the output file
    Added additional Priority 0 test coverage for Floating Point optimizations