### PR TITLE
Inlined GC Polls for call to methods with SuppressGCTransitionAttribute

### DIFF
--- a/src/coreclr/src/jit/block.h
+++ b/src/coreclr/src/jit/block.h
@@ -446,6 +446,7 @@ struct BasicBlock : private LIR::Range
 #define BBF_DOMINATED_BY_EXCEPTIONAL_ENTRY 0x800000000 // Block is dominated by exceptional entry.
 #define BBF_BACKWARD_JUMP_TARGET          0x1000000000 // Block is a target of a backward jump
 #define BBF_PATCHPOINT                    0x2000000000 // Block is a patchpoint
+#define BBF_HAS_SUPPRESSGC_CALL           0x4000000000 // BB contains a call to a method with SuppressGCTransitionAttribute
 
 // clang-format on
 

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -4842,6 +4842,9 @@ void Compiler::compCompile(void** methodCodePtr, ULONG* methodCodeSize, JitFlags
     compQuirkForPPPflag = compQuirkForPPP();
 #endif
 
+    // Insert GC Polls
+    DoPhase(this, PHASE_INSERT_GC_POLLS, &Compiler::fgInsertGCPolls);
+
     // Determine start of cold region if we are hot/cold splitting
     //
     DoPhase(this, PHASE_DETERMINE_FIRST_COLD_BLOCK, &Compiler::fgDetermineFirstColdBlock);

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4982,10 +4982,11 @@ public:
     void fgInitBlockVarSets();
 
     // true if we've gone through and created GC Poll calls.
-    bool fgGCPollsCreated;
-    void fgMarkGCPollBlocks();
-    void fgCreateGCPolls();
-    bool fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement* stmt = nullptr);
+    bool        fgGCPollsCreated;
+    void        fgMarkGCPollBlocks();
+    void        fgCreateGCPolls();
+    PhaseStatus fgInsertGCPolls();
+    BasicBlock* fgCreateGCPoll(GCPollType pollType, BasicBlock* block);
 
     // Requires that "block" is a block that returns from
     // a finally.  Returns the number of successors (jump targets of
@@ -6509,6 +6510,7 @@ public:
 #define OMF_HAS_GUARDEDDEVIRT 0x00000080    // Method contains guarded devirtualization candidate
 #define OMF_HAS_EXPRUNTIMELOOKUP 0x00000100 // Method contains a runtime lookup to an expandable dictionary.
 #define OMF_HAS_PATCHPOINT 0x00000200       // Method contains patchpoints
+#define OMF_NEEDS_GCPOLLS 0x00000400        // Method needs GC polls
 
     bool doesMethodHaveFatPointer()
     {

--- a/src/coreclr/src/jit/compphases.h
+++ b/src/coreclr/src/jit/compphases.h
@@ -87,6 +87,7 @@ CompPhaseNameMacro(PHASE_ASSERTION_PROP_MAIN,    "Assertion prop",              
 #endif
 CompPhaseNameMacro(PHASE_OPT_UPDATE_FLOW_GRAPH,  "Update flow graph opt pass",     "UPD-FG-O", false, -1, false)
 CompPhaseNameMacro(PHASE_COMPUTE_EDGE_WEIGHTS2,  "Compute edge weights (2, false)",       "EDG-WGT2", false, -1, false)
+CompPhaseNameMacro(PHASE_INSERT_GC_POLLS,        "Insert GC Polls",                "GC-POLLS", false, -1, true)
 CompPhaseNameMacro(PHASE_DETERMINE_FIRST_COLD_BLOCK, "Determine first cold block", "COLD-BLK", false, -1, true)
 CompPhaseNameMacro(PHASE_RATIONALIZE,            "Rationalize IR",                 "RAT",      false, -1, false)
 CompPhaseNameMacro(PHASE_SIMPLE_LOWERING,        "Do 'simple' lowering",           "SMP-LWR",  false, -1, false)

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -3557,10 +3557,177 @@ void Compiler::fgInitBlockVarSets()
     fgBBVarSetsInited = true;
 }
 
+//------------------------------------------------------------------------------
+// fgInsertGCPolls : Insert GC polls for basic blocks containing calls to methods
+//                   with SuppressGCTransitionAttribute.
+//
+// Notes:
+//    When not optimizing, the method relies on BBF_HAS_SUPPRESSGC_CALL flag to
+//    find the basic blocks that require GC polls; when optimizing the tree nodes
+//    are scanned to find calls to methods with SuppressGCTransitionAttribute.
+//
+// Returns:
+//    PhaseStatus indicating what, if anything, was changed.
+//
+
+PhaseStatus Compiler::fgInsertGCPolls()
+{
+    PhaseStatus result = PhaseStatus::MODIFIED_NOTHING;
+
+    if ((optMethodFlags & OMF_NEEDS_GCPOLLS) == 0)
+    {
+        return result;
+    }
+
+    bool createdPollBlocks = false;
+
+#ifdef DEBUG
+    if (verbose)
+    {
+        printf("*************** In fgInsertGCPolls() for %s\n", info.compFullName);
+        fgDispBasicBlocks(false);
+        printf("\n");
+    }
+#endif // DEBUG
+
+    BasicBlock* block;
+
+    // Walk through the blocks and hunt for a block that has needs a GC Poll
+    for (block = fgFirstBB; block; block = block->bbNext)
+    {
+        bool blockNeedsGCPoll = false;
+        if (opts.OptimizationDisabled())
+        {
+            if ((block->bbFlags & BBF_HAS_SUPPRESSGC_CALL) != 0)
+            {
+                blockNeedsGCPoll = true;
+            }
+        }
+        else
+        {
+            // When optimizations are enabled, we can't rely on BBF_HAS_SUPPRESSGC_CALL flag:
+            // the call could've been moved, e.g., hoisted from a loop, CSE'd, etc.
+            for (Statement* stmt = block->FirstNonPhiDef(); !blockNeedsGCPoll && (stmt != nullptr);
+                 stmt            = stmt->GetNextStmt())
+            {
+                if ((stmt->GetRootNode()->gtFlags & GTF_CALL) != 0)
+                {
+                    for (GenTree* tree = stmt->GetTreeList(); !blockNeedsGCPoll && (tree != nullptr);
+                         tree          = tree->gtNext)
+                    {
+                        if (tree->OperGet() == GT_CALL)
+                        {
+                            GenTreeCall* call = tree->AsCall();
+                            if (call->IsUnmanaged() && call->IsSuppressGCTransition())
+                            {
+                                blockNeedsGCPoll = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (!blockNeedsGCPoll)
+        {
+            continue;
+        }
+
+        result = PhaseStatus::MODIFIED_EVERYTHING;
+
+        // This block needs a GC poll. We either just insert a callout or we split the block and inline part of
+        // the test.
+
+        // If we're doing GCPOLL_CALL, just insert a GT_CALL node before the last node in the block.
+        CLANG_FORMAT_COMMENT_ANCHOR;
+
+#ifdef DEBUG
+        switch (block->bbJumpKind)
+        {
+            case BBJ_RETURN:
+            case BBJ_ALWAYS:
+            case BBJ_COND:
+            case BBJ_SWITCH:
+            case BBJ_NONE:
+            case BBJ_THROW:
+                break;
+            default:
+                assert(!"Unexpected block kind");
+        }
+#endif // DEBUG
+
+        GCPollType pollType = GCPOLL_INLINE;
+
+        // We'd like to inset an inline poll. Below is the list of places where we
+        // can't or don't want to emit an inline poll. Check all of those. If after all of that we still
+        // have INLINE, then emit an inline check.
+
+        if (opts.OptimizationDisabled())
+        {
+#ifdef DEBUG
+            if (verbose)
+            {
+                printf("Selecting CALL poll in block " FMT_BB " because of debug/minopts\n", block->bbNum);
+            }
+#endif // DEBUG
+
+            // Don't split blocks and create inlined polls unless we're optimizing.
+            pollType = GCPOLL_CALL;
+        }
+        else if (genReturnBB == block)
+        {
+#ifdef DEBUG
+            if (verbose)
+            {
+                printf("Selecting CALL poll in block " FMT_BB " because it is the single return block\n", block->bbNum);
+            }
+#endif // DEBUG
+
+            // we don't want to split the single return block
+            pollType = GCPOLL_CALL;
+        }
+        else if (BBJ_SWITCH == block->bbJumpKind)
+        {
+#ifdef DEBUG
+            if (verbose)
+            {
+                printf("Selecting CALL poll in block " FMT_BB " because it is a SWITCH block\n", block->bbNum);
+            }
+#endif // DEBUG
+
+            // We don't want to deal with all the outgoing edges of a switch block.
+            pollType = GCPOLL_CALL;
+        }
+
+        BasicBlock* curBasicBlock = fgCreateGCPoll(pollType, block);
+        createdPollBlocks |= (block != curBasicBlock);
+        block = curBasicBlock;
+    }
+
+    // If we split a block to create a GC Poll, then rerun fgReorderBlocks to push the rarely run blocks out
+    // past the epilog.  We should never split blocks unless we're optimizing.
+    if (createdPollBlocks)
+    {
+        noway_assert(opts.OptimizationEnabled());
+        fgReorderBlocks();
+        fgUpdateChangedFlowGraph();
+    }
+#ifdef DEBUG
+    if (verbose)
+    {
+        printf("*************** After fgInsertGCPolls()\n");
+        fgDispBasicBlocks(true);
+    }
+#endif // DEBUG
+
+    return result;
+}
+
 /*****************************************************************************
  *
  *  The following does the final pass on BBF_NEEDS_GCPOLL and then actually creates the GC Polls.
  */
+
 void Compiler::fgCreateGCPolls()
 {
     if (GCPOLL_NONE == opts.compGCPollType)
@@ -3832,7 +3999,8 @@ void Compiler::fgCreateGCPolls()
 
         // TODO-Cleanup: potentially don't split if we're in an EH region.
 
-        createdPollBlocks |= fgCreateGCPoll(pollType, block);
+        BasicBlock* curBasicBlock = fgCreateGCPoll(pollType, block);
+        createdPollBlocks |= (block != curBasicBlock);
     }
 
     // If we split a block to create a GC Poll, then rerun fgReorderBlocks to push the rarely run blocks out
@@ -3852,13 +4020,18 @@ void Compiler::fgCreateGCPolls()
 #endif // DEBUG
 }
 
-/*****************************************************************************
- *
- *  Actually create a GCPoll in the given block. Returns true if it created
- *  a basic block.
- */
+//------------------------------------------------------------------------------
+// fgCreateGCPoll : Insert a GC poll of the specified type for the given basic block.
+//
+// Arguments:
+//    pollType  - The type of GC poll to insert
+//    block     - Basic block to insert the poll for
+//
+// Return Value:
+//    If new basic blocks are inserted, the last inserted block; otherwise, the input block.
+//
 
-bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement* stmt)
+BasicBlock* Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block)
 {
     bool createdPollBlocks;
 
@@ -3873,51 +4046,26 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
         pollType = GCPOLL_CALL;
     }
 
-#ifdef DEBUG
-    // If a statment was supplied it should be contained in the block.
-    if (stmt != nullptr)
-    {
-        bool containsStmt = false;
-        for (Statement* stmtMaybe : block->Statements())
-        {
-            containsStmt = (stmtMaybe == stmt);
-            if (containsStmt)
-            {
-                break;
-            }
-        }
-
-        assert(containsStmt);
-    }
-#endif
     // Create the GC_CALL node
     GenTree* call = gtNewHelperCallNode(CORINFO_HELP_POLL_GC, TYP_VOID);
     call          = fgMorphCall(call->AsCall());
     gtSetEvalOrder(call);
 
+    BasicBlock* bottom = nullptr;
+
     if (pollType == GCPOLL_CALL)
     {
         createdPollBlocks = false;
 
-        if (stmt != nullptr)
-        {
-            // The GC_POLL should be inserted relative to the supplied statement. The safer
-            // location for the insertion is prior to the current statement since the supplied
-            // statement could be a GT_JTRUE (see fgNewStmtNearEnd() for more details).
-            Statement* newStmt = gtNewStmt(call);
-
-            // Set the GC_POLL statement to have the same IL offset at the subsequent one.
-            newStmt->SetILOffsetX(stmt->GetILOffsetX());
-            fgInsertStmtBefore(block, stmt, newStmt);
-        }
-        else if (block->bbJumpKind == BBJ_ALWAYS)
+        Statement* newStmt = nullptr;
+        if (block->bbJumpKind == BBJ_ALWAYS)
         {
             // for BBJ_ALWAYS I don't need to insert it before the condition.  Just append it.
-            fgNewStmtAtEnd(block, call);
+            newStmt = fgNewStmtAtEnd(block, call);
         }
         else
         {
-            Statement* newStmt = fgNewStmtNearEnd(block, call);
+            newStmt = fgNewStmtNearEnd(block, call);
             // For DDB156656, we need to associate the GC Poll with the IL offset (and therefore sequence
             // point) of the tree before which we inserted the poll.  One example of when this is a
             // problem:
@@ -3943,6 +4091,12 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
                 // Is it possible for gtNextStmt to be NULL?
                 newStmt->SetILOffsetX(nextStmt->GetILOffsetX());
             }
+        }
+
+        if (fgStmtListThreaded)
+        {
+            gtSetStmtInfo(newStmt);
+            fgSetStmtSeq(newStmt);
         }
 
         block->bbFlags |= BBF_GC_SAFE_POINT;
@@ -3974,8 +4128,8 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
             lpIndexFallThrough = topFallThrough->bbNatLoopNum;
         }
 
-        BasicBlock*   poll        = fgNewBBafter(BBJ_NONE, top, true);
-        BasicBlock*   bottom      = fgNewBBafter(top->bbJumpKind, poll, true);
+        BasicBlock* poll          = fgNewBBafter(BBJ_NONE, top, true);
+        bottom                    = fgNewBBafter(top->bbJumpKind, poll, true);
         BBjumpKinds   oldJumpKind = top->bbJumpKind;
         unsigned char lpIndex     = top->bbNatLoopNum;
 
@@ -4010,12 +4164,16 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
         }
 
         // Add the GC_CALL node to Poll.
-        fgNewStmtAtEnd(poll, call);
-
-        // Remove the last statement from Top and add it to Bottom.
-        if (oldJumpKind != BBJ_ALWAYS)
+        Statement* pollStmt = fgNewStmtAtEnd(poll, call);
+        if (fgStmtListThreaded)
         {
-            // if I'm always jumping to the target, then this is not a condition that needs moving.
+            gtSetStmtInfo(pollStmt);
+            fgSetStmtSeq(pollStmt);
+        }
+
+        // Remove the last statement from Top and add it to Bottom if necessary.
+        if ((oldJumpKind == BBJ_COND) || (oldJumpKind == BBJ_RETURN) || (oldJumpKind == BBJ_THROW))
+        {
             Statement* stmt = top->firstStmt();
             while (stmt->GetNextStmt() != nullptr)
             {
@@ -4063,7 +4221,12 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
         trapRelop->gtFlags |= GTF_RELOP_JMP_USED | GTF_DONT_CSE;
         GenTree* trapCheck = gtNewOperNode(GT_JTRUE, TYP_VOID, trapRelop);
         gtSetEvalOrder(trapCheck);
-        fgNewStmtAtEnd(top, trapCheck);
+        Statement* trapCheckStmt = fgNewStmtAtEnd(top, trapCheck);
+        if (fgStmtListThreaded)
+        {
+            gtSetStmtInfo(trapCheckStmt);
+            fgSetStmtSeq(trapCheckStmt);
+        }
 
 #ifdef DEBUG
         if (verbose)
@@ -4087,10 +4250,10 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
         switch (oldJumpKind)
         {
             case BBJ_NONE:
-                // nothing to update. This can happen when inserting a GC Poll
-                // when suppressing a GC transition during an unmanaged call.
+                fgReplacePred(bottom->bbNext, top, bottom);
                 break;
             case BBJ_RETURN:
+            case BBJ_THROW:
                 // no successors
                 break;
             case BBJ_COND:
@@ -4136,7 +4299,7 @@ bool Compiler::fgCreateGCPoll(GCPollType pollType, BasicBlock* block, Statement*
 #endif // DEBUG
     }
 
-    return createdPollBlocks;
+    return createdPollBlocks ? bottom : block;
 }
 
 /*****************************************************************************
@@ -21223,7 +21386,8 @@ void Compiler::fgDebugCheckBBlist(bool checkBBNum /* = false */, bool checkBBRef
             assert(block->lastNode()->gtNext == nullptr &&
                    (block->lastNode()->gtOper == GT_SWITCH || block->lastNode()->gtOper == GT_SWITCH_TABLE));
         }
-        else if (!(block->bbJumpKind == BBJ_ALWAYS || block->bbJumpKind == BBJ_RETURN))
+        else if (!(block->bbJumpKind == BBJ_ALWAYS || block->bbJumpKind == BBJ_RETURN ||
+                   block->bbJumpKind == BBJ_NONE || block->bbJumpKind == BBJ_THROW))
         {
             // this block cannot have a poll
             assert(!(block->bbFlags & BBF_NEEDS_GCPOLL));

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -7536,8 +7536,9 @@ GenTree* Compiler::fgMorphPotentialTailCall(GenTreeCall* call)
         // fgSetBlockOrder() is going to mark the method as fully interruptible
         // if the block containing this tail call is reachable without executing
         // any call.
+        BasicBlock* curBlock = compCurBB;
         if (canFastTailCall || (fgFirstBB->bbFlags & BBF_GC_SAFE_POINT) || (compCurBB->bbFlags & BBF_GC_SAFE_POINT) ||
-            (fgCreateGCPoll(GCPOLL_INLINE, compCurBB) == compCurBB))
+            (fgCreateGCPoll(GCPOLL_INLINE, compCurBB) == curBlock))
         {
             // We didn't insert a poll block, so we need to morph the call now
             // (Normally it will get morphed when we get to the split poll block)

--- a/src/coreclr/src/jit/optimizer.cpp
+++ b/src/coreclr/src/jit/optimizer.cpp
@@ -9249,7 +9249,7 @@ void Compiler::optRemoveRedundantZeroInits()
             Statement* next = stmt->GetNextStmt();
             for (GenTree* tree = stmt->GetTreeList(); tree != nullptr; tree = tree->gtNext)
             {
-                if (((tree->gtFlags & GTF_CALL) != 0) && (!tree->IsCall() || !tree->AsCall()->IsSuppressGCTransition()))
+                if (((tree->gtFlags & GTF_CALL) != 0))
                 {
                     hasGCSafePoint = true;
                 }


### PR DESCRIPTION
* Emit inlined GC Polls for methods with SuppressGCTransitionAttribute
  when possible and when optimizing.

* Emit only one GC poll per basic block.

* Move insertion of GC polls to a new phase `fgInsertGCPolls` that runs after
  most optimizations so that we don't insert unnecessary GC polls.

* I plan to delete `fgCreateGCPolls` phase that was previously used to insert
  GC polls for platforms that don't support hijacking in a subsequent PR.
  We currently don't support such platforms.

* Fix `fgCreateGCPoll` to be able to insert inlined GC polls for `BBJ_NONE` and
`BBJ_THROW` basic blocks.