### PR TITLE
Preserve DebuggerTypeProxyAttribute classes

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -19,6 +19,17 @@
     </ItemGroup>
   </Target>
 
+  <!-- This will need to change to AfterTargets=PrepareForILLink when we get a new SDK -->
+  <Target Name="EnsureAllAssembliesAreLinked"
+          AfterTargets="_SetILLinkDefaults"> 
+    <ItemGroup>
+      <!-- This will need to change to ManagedAssemblyToLink and TrimMode=link when we get a new SDK -->
+      <_ManagedAssembliesToLink>
+        <action>link</action>
+      </_ManagedAssembliesToLink>
+    </ItemGroup>
+  </Target>
+
   <Target Name="PublishTrimmed" DependsOnTargets="RestoreProject;UpdateRuntimePack;Publish" />
 
 </Project>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebuggerTypeProxyAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/DebuggerTypeProxyAttribute.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.Diagnostics
 {
     [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true)]
@@ -8,7 +10,8 @@ namespace System.Diagnostics
     {
         private Type? _target;
 
-        public DebuggerTypeProxyAttribute(Type type)
+        public DebuggerTypeProxyAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
         {
             if (type == null)
             {
@@ -18,11 +21,15 @@ namespace System.Diagnostics
             ProxyTypeName = type.AssemblyQualifiedName!;
         }
 
-        public DebuggerTypeProxyAttribute(string typeName)
+        public DebuggerTypeProxyAttribute(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] string typeName)
         {
             ProxyTypeName = typeName;
         }
 
+        // The Proxy is only invoked by the debugger, so it needs to have its
+        // members preserved
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
         public string ProxyTypeName { get; }
 
         public Type? Target

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5715,8 +5715,9 @@ namespace System.Diagnostics
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple=true)]
     public sealed partial class DebuggerTypeProxyAttribute : System.Attribute
     {
-        public DebuggerTypeProxyAttribute(string typeName) { }
-        public DebuggerTypeProxyAttribute(System.Type type) { }
+        public DebuggerTypeProxyAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] string typeName) { }
+        public DebuggerTypeProxyAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] System.Type type) { }
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]
         public string ProxyTypeName { get { throw null; } }
         public System.Type? Target { get { throw null; } set { } }
         public string? TargetTypeName { get { throw null; } set { } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -5717,7 +5717,7 @@ namespace System.Diagnostics
     {
         public DebuggerTypeProxyAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] string typeName) { }
         public DebuggerTypeProxyAttribute([System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)] System.Type type) { }
-        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicEvents)]
+        [System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.All)]
         public string ProxyTypeName { get { throw null; } }
         public System.Type? Target { get { throw null; } set { } }
         public string? TargetTypeName { get { throw null; } set { } }

--- a/src/libraries/System.Runtime/tests/TrimmingTests/DebuggerTypeProxyAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/DebuggerTypeProxyAttributeTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Diagnostics;
+
+/// <summary>
+/// Tests that types used by DebuggerTypeProxyAttribute are not trimmed out
+/// when Debugger.IsSupported is true (the default).
+/// </summary>
+class Program
+{
+    static int Main(string[] args)
+    {
+        MyClass myClass = new MyClass() { Name = "trimmed" };
+
+        Type[] allTypes = typeof(MyClass).Assembly.GetTypes();
+        for (int i = 0; i < allTypes.Length; i++)
+        {
+            if (allTypes[i].Name.Contains("DebuggerProxy"))
+            {
+                Type proxyType = allTypes[i];
+                if (proxyType.GetProperties().Length == 1 &&
+                    proxyType.GetConstructors().Length == 1)
+                {
+                    return 100;
+                }
+            }
+        }
+
+        // didn't find the proxy type, or it wasn't preserved correctly
+        return -1;
+    }
+
+    [DebuggerTypeProxy(typeof(DebuggerProxy))]
+    public class MyClass
+    {
+        public string Name { get; set; }
+
+        private class DebuggerProxy
+        {
+            private MyClass _instance;
+
+            public DebuggerProxy(MyClass instance)
+            {
+                _instance = instance;
+            }
+
+            public string DebuggerName => _instance.Name;
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/TrimmingTests/DefaultValueAttributeCtorTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/DefaultValueAttributeCtorTest.cs
@@ -10,6 +10,10 @@ class Program
 {
     static int Main(string[] args)
     {
+        // workaround TypeConverterAttribute not being annotated correctly
+        // https://github.com/dotnet/runtime/issues/39125
+        var _ = new MyStringConverter();
+
         TypeDescriptor.AddAttributes(typeof(string), new TypeConverterAttribute(typeof(MyStringConverter)));
 
         var attribute = new DefaultValueAttribute(typeof(string), "Hello, world!");

--- a/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/System.Runtime.TrimmingTests.proj
@@ -6,6 +6,8 @@
     <TestConsoleAppSourceFiles Include="AppDomainGetThreadWindowsPrincipalTest.cs">
       <SkipOnTestRuntimes>osx-x64;linux-x64</SkipOnTestRuntimes>
     </TestConsoleAppSourceFiles>
+    <TestConsoleAppSourceFiles Include="DebuggerTypeProxyAttributeTests.cs" />
+    <TestConsoleAppSourceFiles Include="DefaultValueAttributeCtorTest.cs" />
     <TestConsoleAppSourceFiles Include="GenericArraySortHelperTest.cs" />
     <TestConsoleAppSourceFiles Include="StackFrameHelperTest.cs">
       <!-- There is a bug with the linker where it is corrupting the pdbs while trimming


### PR DESCRIPTION
Also, ensure the test app assembly is linked, and not copied during trimming tests, which was a bug in our test infrastructure.

Fix #37307

Note that this will actually make apps larger now that we are preserving the `DebuggerTypeProxyAttribute` classes by default.

Once https://github.com/dotnet/runtime/pull/39000 is merged, we can add the `DebuggerTypeProxyAttribute` (and other debugging related attributes) to be removed when the feature switch `System.Diagnostics.Debugger.IsSupported` is `false`.

cc @stephentoub @MichalStrehovsky @vitek-karas 