### PR TITLE
Fix fd leak in Diagnostics Server and add better error handling

### DIFF
--- a/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -188,7 +188,7 @@ IpcStream *IpcStream::DiagnosticsIpc::Connect(ErrorCallback callback)
         if (callback != nullptr)
             callback(strerror(errno), errno);
 
-        const bool fCloseSuccess = ::close(clientSocket) != 0;
+        const bool fCloseSuccess = ::close(clientSocket) == 0;
         if (!fCloseSuccess && callback != nullptr)
             callback(strerror(errno), errno);
         return nullptr;

--- a/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/unix/diagnosticsipc.cpp
@@ -187,6 +187,10 @@ IpcStream *IpcStream::DiagnosticsIpc::Connect(ErrorCallback callback)
     {
         if (callback != nullptr)
             callback(strerror(errno), errno);
+
+        const bool fCloseSuccess = ::close(clientSocket) != 0;
+        if (!fCloseSuccess && callback != nullptr)
+            callback(strerror(errno), errno);
         return nullptr;
     }
 
@@ -223,12 +227,11 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
     // Check results
     if (retval < 0)
     {
-        for (uint32_t i = 0; i < nHandles; i++)
-        {
-            if ((pollfds[i].revents & POLLERR) && callback != nullptr)
-                callback(strerror(errno), errno);
-            rgIpcPollHandles[i].revents = (uint8_t)PollEvents::ERR;
-        }
+        //     If poll() returns with an error, including one due to an interrupted call, the fds
+        //  array will be unmodified and the global variable errno will be set to indicate the error.
+        // - POLL(2)
+        if (callback != nullptr)
+            callback(strerror(errno), errno);
         delete[] pollfds;
         return -1;
     }
@@ -261,7 +264,7 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
                 delete[] pollfds;
                 return -1;
             }
-            else if (pollfds[i].revents & POLLIN)
+            else if (pollfds[i].revents & (POLLIN|POLLPRI))
             {
                 rgIpcPollHandles[i].revents = (uint8_t)PollEvents::SIGNALED;
                 break;

--- a/src/coreclr/src/debug/inc/diagnosticsipc.h
+++ b/src/coreclr/src/debug/inc/diagnosticsipc.h
@@ -35,7 +35,7 @@ public:
 
         enum class PollEvents : uint8_t
         {
-            TIMEOUT  = 0x00, // implies timeout
+            NONE     = 0x00, // no events
             SIGNALED = 0x01, // ready for use
             HANGUP   = 0x02, // connection remotely closed
             ERR      = 0x04  // other error

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -677,6 +677,17 @@ void EEStartupHelper()
         PAL_SetShutdownCallback(EESocketCleanupHelper);
 #endif // TARGET_UNIX
 
+#ifdef STRESS_LOG
+        if (REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_StressLog, g_pConfig->StressLog ()) != 0) {
+            unsigned facilities = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::INTERNAL_LogFacility, LF_ALL);
+            unsigned level = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::EXTERNAL_LogLevel, LL_INFO1000);
+            unsigned bytesPerThread = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_StressLogSize, STRESSLOG_CHUNK_SIZE * 4);
+            unsigned totalBytes = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_TotalStressLogSize, STRESSLOG_CHUNK_SIZE * 1024);
+            StressLog::Initialize(facilities, level, bytesPerThread, totalBytes, GetModuleInst());
+            g_pStressLog = &StressLog::theLog;
+        }
+#endif
+
 #ifdef FEATURE_PERFTRACING
         DiagnosticServer::Initialize();
         DiagnosticServer::PauseForDiagnosticsMonitor();
@@ -702,16 +713,6 @@ void EEStartupHelper()
 #endif // CROSSGEN_COMPILE
 
 
-#ifdef STRESS_LOG
-        if (REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_StressLog, g_pConfig->StressLog ()) != 0) {
-            unsigned facilities = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::INTERNAL_LogFacility, LF_ALL);
-            unsigned level = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::EXTERNAL_LogLevel, LL_INFO1000);
-            unsigned bytesPerThread = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_StressLogSize, STRESSLOG_CHUNK_SIZE * 4);
-            unsigned totalBytes = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_TotalStressLogSize, STRESSLOG_CHUNK_SIZE * 1024);
-            StressLog::Initialize(facilities, level, bytesPerThread, totalBytes, GetModuleInst());
-            g_pStressLog = &StressLog::theLog;
-        }
-#endif
 
 #ifdef LOGGING
         InitializeLogging();

--- a/src/coreclr/src/vm/ipcstreamfactory.cpp
+++ b/src/coreclr/src/vm/ipcstreamfactory.cpp
@@ -166,9 +166,10 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
             s_pollTimeoutInfinite :
             GetNextTimeout(pollTimeoutMs);
 
-        int32_t retval = IpcStream::DiagnosticsIpc::Poll(rgIpcPollHandles.Ptr(), (uint32_t)rgIpcPollHandles.Size(), pollTimeoutMs, callback);
         nPollAttempts++;
         STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - Poll attempt: %d, timeout: %dms.\n", nPollAttempts, pollTimeoutMs);
+        int32_t retval = IpcStream::DiagnosticsIpc::Poll(rgIpcPollHandles.Ptr(), (uint32_t)rgIpcPollHandles.Size(), pollTimeoutMs, callback);
+        bool fSawError = false;
 
         if (retval != 0)
         {
@@ -178,21 +179,32 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
                 {
                     case IpcStream::DiagnosticsIpc::PollEvents::HANGUP:
                         ((ConnectionState*)(rgIpcPollHandles[i].pUserData))->Reset(callback);
-                        STRESS_LOG1(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - Poll attempt: %d, connection hung up.\n", nPollAttempts);
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - HUP :: Poll attempt: %d, connection %d hung up.\n", nPollAttempts, i);
                         pollTimeoutMs = s_pollTimeoutMinMs;
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::SIGNALED:
                         if (pStream == nullptr) // only use first signaled stream; will get others on subsequent calls
                             pStream = ((ConnectionState*)(rgIpcPollHandles[i].pUserData))->GetConnectedStream(callback);
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - SIG :: Poll attempt: %d, connection %d signalled.\n", nPollAttempts, i);
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::ERR:
-                        return nullptr;
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - ERR :: Poll attempt: %d, connection %d errored.\n", nPollAttempts, i);
+                        fSawError = true;
+                        break;
+                    case IpcStream::DiagnosticsIpc::PollEvents::NONE:
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - NON :: Poll attempt: %d, connection %d had no events.\n", nPollAttempts, i);
+                        fSawError = true;
+                        break;
                     default:
-                        // TODO: Error handling
+                        STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - UNK :: Poll attempt: %d, connection %d had invalid PollEvent.\n", nPollAttempts, i);
                         break;
                 }
             }
         }
+
+
+        if (pStream == nullptr && fSawError)
+            return nullptr;
 
         // clear the view
         while (rgIpcPollHandles.Size() > 0)

--- a/src/coreclr/src/vm/ipcstreamfactory.cpp
+++ b/src/coreclr/src/vm/ipcstreamfactory.cpp
@@ -193,10 +193,10 @@ IpcStream *IpcStreamFactory::GetNextAvailableStream(ErrorCallback callback)
                         break;
                     case IpcStream::DiagnosticsIpc::PollEvents::NONE:
                         STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - NON :: Poll attempt: %d, connection %d had no events.\n", nPollAttempts, i);
-                        fSawError = true;
                         break;
                     default:
                         STRESS_LOG2(LF_DIAGNOSTICS_PORT, LL_INFO10, "IpcStreamFactory::GetNextAvailableStream - UNK :: Poll attempt: %d, connection %d had invalid PollEvent.\n", nPollAttempts, i);
+                        fSawError = true;
                         break;
                 }
             }

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -24,9 +24,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/Vector3Interop_ro/*">
             <Issue>https://github.com/dotnet/runtime/issues/35798</Issue>
         </ExcludeList>
-        <ExcludeList Include = "$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/pauseonstart/**">
-            <Issue>https://github.com/dotnet/runtime/issues/38847</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- All OS/Arch CoreCLR excludes -->

--- a/src/tests/tracing/eventpipe/reverse/reverse.csproj
+++ b/src/tests/tracing/eventpipe/reverse/reverse.csproj
@@ -4,7 +4,7 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
     <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->

--- a/src/tests/tracing/eventpipe/reverseouter/reverseouter.csproj
+++ b/src/tests/tracing/eventpipe/reverseouter/reverseouter.csproj
@@ -4,7 +4,7 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>


### PR DESCRIPTION
The Diagnostics Server would call `socket` every time it attempted to connect to a reverse connection, but wouldn't call `close` on that fd if the subsequent `connect` failed.  I believe this is what was causing test failures in CI (#38156).  ~I have temporarily turned on these tests and moved them all back to Pri0 to test while this is in draft mode.~

Turns reverse server testing back on.

I also increased the error handling for `GetNextAvailableStream`.

fixes #38156

CC @tommcdon @lateralusX @janvorli @BruceForstall @jashook @noahfalk @sywhang 