### PR TITLE
Fix creating OperatingSystem with PlatformID.Other

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -19,7 +19,7 @@ namespace System
 
         internal OperatingSystem(PlatformID platform, Version version, string? servicePack)
         {
-            if (platform < PlatformID.Win32S || platform > PlatformID.MacOSX)
+            if (platform < PlatformID.Win32S || platform > PlatformID.Other)
             {
                 throw new ArgumentOutOfRangeException(nameof(platform), platform, SR.Format(SR.Arg_EnumIllegalVal, platform));
             }
@@ -65,6 +65,7 @@ namespace System
                         case PlatformID.Unix: os = "Unix "; break;
                         case PlatformID.Xbox: os = "Xbox "; break;
                         case PlatformID.MacOSX: os = "Mac OS X "; break;
+                        case PlatformID.Other: os = "Other"; break;
                         default:
                             Debug.Fail($"Unknown platform {_platform}");
                             os = "<unknown> "; break;

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -127,9 +127,8 @@ namespace System.Tests
         public void OSVersion_MatchesPlatform()
         {
             PlatformID id = Environment.OSVersion.Platform;
-            Assert.Equal(
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? PlatformID.Win32NT : PlatformID.Unix,
-                id);
+            PlatformID expected = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? PlatformID.Win32NT : RuntimeInformation.IsOSPlatform(OSPlatform.Browser) ? PlatformID.Other : PlatformID.Unix;
+            Assert.Equal(expected, id);
         }
 
         [Fact]
@@ -142,12 +141,14 @@ namespace System.Tests
             Assert.True(version.Major > 0);
 
             Assert.Contains(version.ToString(2), versionString);
-            Assert.Contains(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Windows" : "Unix", versionString);
+
+            string expectedOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Windows" : RuntimeInformation.IsOSPlatform(OSPlatform.Browser) ? "Other" : "Unix";
+            Assert.Contains(expectedOS, versionString);
         }
 
         // On non-OSX Unix, we must parse the version from uname -r
         [Theory]
-        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.OSX)]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.OSX & ~TestPlatforms.Browser)]
         [InlineData("2.6.19-1.2895.fc6", 2, 6, 19, 1)]
         [InlineData("xxx1yyy2zzz3aaa4bbb", 1, 2, 3, 4)]
         [InlineData("2147483647.2147483647.2147483647.2147483647", int.MaxValue, int.MaxValue, int.MaxValue, int.MaxValue)]

--- a/src/libraries/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/OperatingSystemTests.cs
@@ -8,6 +8,7 @@ namespace System.Tests
     public static class OperatingSystemTests
     {
         [Theory]
+        [InlineData(PlatformID.Other, "1.0.0.0")]
         [InlineData(PlatformID.MacOSX, "1.2")]
         [InlineData(PlatformID.Unix, "1.2.3")]
         [InlineData(PlatformID.Win32NT, "1.2.3.4")]


### PR DESCRIPTION
Creating an OperatingSystem with PlatformID.Other would result in an exception about an unexpected enum value.
https://github.com/dotnet/runtime/pull/38790 was missing some tests that verified this behavior.

