### PR TITLE
Update DacHeapWalker to know about POH in SVR mode

### DIFF
--- a/src/coreclr/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/src/debug/daccess/dacdbiimpl.cpp
@@ -6380,7 +6380,8 @@ bool DacHeapWalker::GetSize(TADDR tMT, size_t &size)
 
         // The size is not guaranteed to be aligned, we have to
         // do that ourself.
-        if (mHeaps[mCurrHeap].Segments[mCurrSeg].Generation == 3)
+        if (mHeaps[mCurrHeap].Segments[mCurrSeg].Generation == 3
+            || mHeaps[mCurrHeap].Segments[mCurrSeg].Generation == 4)
             size = AlignLarge(size);
         else
             size = Align(size);


### PR DESCRIPTION
While testing #38146 I noticed that x86 was broken due to an incorrect alignment in the POH, and I never implemented the SVR mode for DacHeapWalker.