### PR TITLE
enable GS Cookie on OSX

### DIFF
--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -484,13 +484,6 @@ void InitGSCookie()
     }
     CONTRACTL_END;
 
-#if defined(TARGET_OSX) && defined(CORECLR_EMBEDDED)
-    // OSX does not like the way we change section protection when running in a superhost bundle
-    // disabling this for now
-    // https://github.com/dotnet/runtime/issues/38184
-    return;
-#endif
-
     volatile GSCookie * pGSCookiePtr = GetProcessGSCookiePtr();
 
 #ifdef TARGET_UNIX

--- a/src/coreclr/src/vm/vars.hpp
+++ b/src/coreclr/src/vm/vars.hpp
@@ -694,7 +694,7 @@ typedef DPTR(GSCookie) PTR_GSCookie;
 #define READONLY_ATTR
 #else
 #ifdef __APPLE__
-#define READONLY_ATTR_ARGS section("__TEXT,__const")
+#define READONLY_ATTR_ARGS section("__DATA,__const")
 #else
 #define READONLY_ATTR_ARGS section(".rodata")
 #endif


### PR DESCRIPTION
Use '#define READONLY_ATTR_ARGS section("**__DATA**,__const")'  for the s_gsCookie

which puts it in read only data segment. 
It used to be readonly TEXT segment and that was causing issues when container is the singlefile host executable.

Fixes:https://github.com/dotnet/runtime/issues/38184