### PR TITLE
Add logic for non-generic Stack/Queue to share add-method delegates

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -21,6 +21,9 @@ namespace System.Text.Json
 
         public object? CreateObjectWithArgs { get; set; }
 
+        // Add method delegate for non-generic Stack and Queue; and types that derive from them.
+        public object? AddMethodDelegate { get; set; }
+
         public ClassType ClassType { get; private set; }
 
         public JsonPropertyInfo? DataExtensionProperty { get; private set; }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -39,9 +39,6 @@ namespace System.Text.Json
         public int PropertyIndex;
         public List<PropertyRef>? PropertyRefCache;
 
-        // Add method delegate for Non-generic Stack and Queue; and types that derive from them.
-        public object? AddMethodDelegate;
-
         // Holds relevant state when deserializing objects with parameterized constructors.
         public int CtorArgumentStateIndex;
         public ArgumentState? CtorArgumentState;
@@ -89,7 +86,6 @@ namespace System.Text.Json
 
         public void Reset()
         {
-            AddMethodDelegate = null;
             CtorArgumentStateIndex = 0;
             CtorArgumentState = null;
             JsonClassInfo = null!;


### PR DESCRIPTION
...rather than have each converter instance create one.

This is a follow up to https://github.com/dotnet/runtime/pull/35080#issuecomment-618799920.

Also, the delegate no longer lives on ReadStackFrame, so we save on an extra assignment on every `Reset()`.