### PR TITLE
Fix TestOnStartWithArgsThenStop and make service tests more reliable

### DIFF
--- a/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/src/System/ServiceProcess/ServiceBase.cs
@@ -305,6 +305,8 @@ namespace System.ServiceProcess
         /// <devdoc>
         ///    <para>Disposes of the resources (other than memory ) used by
         ///       the <see cref='System.ServiceProcess.ServiceBase'/>.</para>
+        ///    This is called from <see cref="Run(ServiceBase[])"/> when all
+        ///    services in the process have entered the SERVICE_STOPPED state.
         /// </devdoc>
         protected override void Dispose(bool disposing)
         {

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/Program.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/Program.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+
 namespace System.ServiceProcess.Tests
 {
     public class Program
     {
         static int Main(string[] args)
         {
+            Thread.CurrentThread.Name = "Test Service";
             if (args.Length == 1 || args.Length == 2)
             {
                 TestService testService;

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -116,6 +116,10 @@ namespace System.ServiceProcess.Tests
             }
         }
 
+        /// <summary>
+        /// This is called from <see cref="ServiceBase.Run(ServiceBase[])"/> when all services in the process
+        /// have entered the SERVICE_STOPPED state. It disposes the named pipe stream.
+        /// </summary>
         protected override void Dispose(bool disposing)
         {
             if (!_disposed)

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -9,6 +9,11 @@ namespace System.ServiceProcess.Tests
 {
     public class TestService : ServiceBase
     {
+        // To view tracing, use DbgView from systinternals.com;
+        // run it elevated, check "Capture>Global Win32" and "Capture>Win32",
+        // and filter to just messages beginning with "##"
+        internal const bool DebugTracing = false;
+
         private bool _disposed;
         private Task _waitClientConnect;
         private NamedPipeServerStream _serverStream;
@@ -16,6 +21,7 @@ namespace System.ServiceProcess.Tests
 
         public TestService(string serviceName, Exception throwException = null)
         {
+            DebugTrace("TestService " + ServiceName + ": Ctor");
             this.ServiceName = serviceName;
 
             // Enable all the events
@@ -27,10 +33,11 @@ namespace System.ServiceProcess.Tests
             this.CanHandleSessionChangeEvent = false;
             this.CanHandlePowerEvent = false;
             this._exception = throwException;
-
             this._serverStream = new NamedPipeServerStream(serviceName);
             _waitClientConnect = this._serverStream.WaitForConnectionAsync();
-            _waitClientConnect.ContinueWith((t) => WriteStreamAsync(PipeMessageByteCode.Connected));
+            _waitClientConnect = _waitClientConnect.ContinueWith(_ => DebugTrace("TestService " + ServiceName + ": Connected"));
+            _waitClientConnect.ContinueWith(t => WriteStreamAsync(PipeMessageByteCode.Connected));
+            DebugTrace("TestService " + ServiceName + ": Ctor completed");
         }
 
         protected override void OnContinue()
@@ -72,6 +79,7 @@ namespace System.ServiceProcess.Tests
 
         protected override void OnStart(string[] args)
         {
+            DebugTrace("TestService " + ServiceName + ": OnStart");
             base.OnStart(args);
             if (_exception != null)
             {
@@ -89,31 +97,27 @@ namespace System.ServiceProcess.Tests
 
         protected override void OnStop()
         {
+            DebugTrace("TestService " + ServiceName + ": OnStop");
             base.OnStop();
             WriteStreamAsync(PipeMessageByteCode.Stop).Wait();
         }
 
         public async Task WriteStreamAsync(PipeMessageByteCode code, int command = 0)
         {
-            if (_waitClientConnect.IsCompleted)
+            DebugTrace("TestService " + ServiceName + ": WriteStreamAsync writing " + code.ToString());
+
+            const int WriteTimeout = 60000;
+            var toWrite = (code == PipeMessageByteCode.OnCustomCommand) ? new byte[] { (byte)command } : new byte[] { (byte)code };
+
+            // Wait for the client connection before writing to the pipe.
+            // Exception: if it's a Stop message, it may be because the test has completed and we're cleaning up the test service so there's no client at all.
+            // Tests that verify "Stop" itself should ensure the client connection has completed before calling stop, by waiting on some other message from the pipe first.
+            if (code != PipeMessageByteCode.Stop)
             {
-                Task writeCompleted;
-                const int WriteTimeout = 60000;
-                if (code == PipeMessageByteCode.OnCustomCommand)
-                {
-                    writeCompleted = _serverStream.WriteAsync(new byte[] { (byte)command }, 0, 1);
-                }
-                else
-                {
-                    writeCompleted = _serverStream.WriteAsync(new byte[] { (byte)code }, 0, 1);
-                }
-                await writeCompleted.TimeoutAfter(WriteTimeout).ConfigureAwait(false);
+                await _waitClientConnect;
             }
-            else
-            {
-                // We get here if the service is getting torn down before a client ever connected.
-                // some tests do this.
-            }
+            await _serverStream.WriteAsync(toWrite, 0, 1).TimeoutAfter(WriteTimeout).ConfigureAwait(false);
+            DebugTrace("TestService " + ServiceName + ": WriteStreamAsync completed");
         }
 
         /// <summary>
@@ -124,9 +128,20 @@ namespace System.ServiceProcess.Tests
         {
             if (!_disposed)
             {
+                DebugTrace("TestService " + ServiceName + ": Disposing");
                 _serverStream.Dispose();
                 _disposed = true;
                 base.Dispose();
+            }
+        }
+
+        internal static void DebugTrace(string message)
+        {
+            if (DebugTracing)
+            {
+#pragma warning disable CS0162 // unreachable code
+                Debug.WriteLine("## " + message);
+#pragma warning restore
             }
         }
     }

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestService.cs
@@ -9,7 +9,7 @@ namespace System.ServiceProcess.Tests
 {
     public class TestService : ServiceBase
     {
-        // To view tracing, use DbgView from systinternals.com;
+        // To view tracing, use DbgView from sysinternals.com;
         // run it elevated, check "Capture>Global Win32" and "Capture>Win32",
         // and filter to just messages beginning with "##"
         internal const bool DebugTracing = false;

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.TestService/TestServiceInstaller.cs
@@ -102,6 +102,7 @@ namespace System.ServiceProcess.Tests
                     {
                         if (svc.Status != ServiceControllerStatus.Running)
                         {
+                            TestService.DebugTrace("TestServiceInstaller: instructing ServiceController to Start service " + ServiceName);
                             svc.Start();
                             if (!ServiceName.StartsWith("PropagateExceptionFromOnStart"))
                                 svc.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromSeconds(120));
@@ -124,7 +125,6 @@ namespace System.ServiceProcess.Tests
                 // Meantime we still want this service to get deleted, so we'll go ahead and call
                 // DeleteService, which will schedule it to get deleted on reboot.
                 // We won't catch the exception: we do want the test to fail.
-
                 DeleteService();
 
                 ServiceName = null;
@@ -141,6 +141,7 @@ namespace System.ServiceProcess.Tests
                 {
                     try
                     {
+                        TestService.DebugTrace("TestServiceInstaller: instructing ServiceController to Stop service " + ServiceName);
                         svc.Stop();
                     }
                     catch (InvalidOperationException)
@@ -172,6 +173,7 @@ namespace System.ServiceProcess.Tests
                     if (serviceHandle.IsInvalid)
                         throw new Win32Exception($"Could not find service '{ServiceName}'");
 
+                    TestService.DebugTrace("TestServiceInstaller: instructing ServiceController to Delete service " + ServiceName);
                     if (!Interop.Advapi32.DeleteService(serviceHandle))
                     {
                         throw new Win32Exception($"Could not delete service '{ServiceName}'");

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -10,6 +10,11 @@ namespace System.ServiceProcess.Tests
 {
     internal sealed class TestServiceProvider
     {
+        // To view tracing, use DbgView from systinternals.com;
+        // run it elevated, check "Capture>Global Win32" and "Capture>Win32",
+        // and filter to just messages beginning with "##"
+        internal const bool DebugTracing = false;
+
         private const int readTimeout = 60000;
 
         private static readonly Lazy<bool> s_runningWithElevatedPrivileges = new Lazy<bool>(
@@ -28,6 +33,7 @@ namespace System.ServiceProcess.Tests
             {
                 if (_client == null)
                 {
+                    DebugTrace("TestServiceProvider: Creating client stream");
                     _client = new NamedPipeClientStream(".", TestServiceName, PipeDirection.In);
                 }
                 return _client;
@@ -36,10 +42,12 @@ namespace System.ServiceProcess.Tests
             {
                 if (value == null)
                 {
+                    DebugTrace("TestServiceProvider: Disposing client stream");
                     _client.Dispose();
                     _client = null;
                 }
             }
+
         }
 
         public readonly string TestServiceAssembly = typeof(TestService).Assembly.Location;
@@ -125,6 +133,7 @@ namespace System.ServiceProcess.Tests
             {
                 if (_client != null)
                 {
+                    DebugTrace("TestServiceProvider: Disposing client stream in Dispose()");
                     _client.Dispose();
                     _client = null;
                 }
@@ -141,6 +150,16 @@ namespace System.ServiceProcess.Tests
                 {
                     _dependentServices.DeleteTestServices();
                 }
+            }
+        }
+
+        internal static void DebugTrace(string message)
+        {
+            if (DebugTracing)
+            {
+#pragma warning disable CS0162 // unreachable code
+                Debug.WriteLine("## " + message);
+#pragma warning restore
             }
         }
     }

--- a/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
+++ b/src/libraries/System.ServiceProcess.ServiceController/tests/TestServiceProvider.cs
@@ -10,7 +10,7 @@ namespace System.ServiceProcess.Tests
 {
     internal sealed class TestServiceProvider
     {
-        // To view tracing, use DbgView from systinternals.com;
+        // To view tracing, use DbgView from sysinternals.com;
         // run it elevated, check "Capture>Global Win32" and "Capture>Win32",
         // and filter to just messages beginning with "##"
         internal const bool DebugTracing = false;


### PR DESCRIPTION
Fixes #38945

There were two bugs
1. Test service does not mutually synchronize connect and start messages, but one of the test expects them to be ordered. This is the cause of the failure. I experimented with making the start message write a continuation of the connect message write, but this problem only occurs for these two messages. All other messages can be handled sequentially, because the test can wait on the matching SCM status. The simplest approach is simply to recognize these messages are unordered and allow either ordering in the test.

2. Test service did not wait for the client to connect before writing to the pipe. This was because when test services are being torn down, the test service installer will issue the Stop command to the service via the SCM, which will cause the test service to write a stop message to the pipe, which no longer has a client planning to connect to it, so in a previous change we stopped waiting on the connection, introducing flakiness. Fix: wait on the client connection, unless the message is a stop message. (Tests that may wait on a stop message all wait on some previous message before it, so the test service will always have a pipe when it writes to such tests.)

Using a debugger to figure out what is happening is painful because of the various threads and processes. Tracing is far more convenient and useful. I added a bunch of tracing to the test code. With luck this is the last timing problem in these tests, but we've had a series of such problems so I've left the tracing in for next time, disabled by default.

Also added a comment about Dispose, which was confusing.
