### PR TITLE
Fix IndexOutOfRangeException in CallSite.MoveRule.

### DIFF
--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -266,11 +266,16 @@ namespace System.Runtime.CompilerServices
             if (i > 1)
             {
                 T[] rules = Rules!;
-                T rule = rules[i];
+                // Synchronization of AddRule is omitted for performance. Concurrent invocations of AddRule
+                // may cause Rules to revert back to an older (smaller) version, making i out of bounds.
+                if (i < rules.Length)
+                {
+                    T rule = rules[i];
 
-                rules[i] = rules[i - 1];
-                rules[i - 1] = rules[i - 2];
-                rules[i - 2] = rule;
+                    rules[i] = rules[i - 1];
+                    rules[i - 1] = rules[i - 2];
+                    rules[i - 2] = rule;
+                }
             }
         }
 


### PR DESCRIPTION
Fix #36983

Please feel free to reject this PR if you plan to fix this issue in a different way or plan to add a concurrency test. (I failed to add a test because this fix is extremely hard to test using the public API surface...) Thank you in advance for the review!

Review perspectives:

- This fix does not hide any fundamental problems in the code. (No synchronization is the design choice.)
- The comments are correct.