### PR TITLE
Fix EventActivityIdControl test on MonoVM.

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -1664,9 +1664,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/Regressions/coreclr/22021/consumer/**">
             <Issue>needs triage</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventactivityidcontrol/eventactivityidcontrol/**">
-            <Issue>needs triage</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/tracing/tracevalidation/jittingstarted/JittingStarted/**">
             <Issue>needs triage</Issue>
         </ExcludeList>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -75,7 +75,7 @@ namespace System.Diagnostics.Tracing
         // Get or set the per-thread activity ID.
         int IEventProvider.EventActivityIdControl(Interop.Advapi32.ActivityControl ControlCode, ref Guid ActivityId)
         {
-            return EventPipeInternal.EventActivityIdControl((uint)ControlCode, ref ActivityId);
+            return EventActivityIdControl(ControlCode, ref ActivityId);
         }
 
         // Define an EventPipeEvent handle.
@@ -84,6 +84,12 @@ namespace System.Diagnostics.Tracing
         {
             IntPtr eventHandlePtr = EventPipeInternal.DefineEvent(m_provHandle, eventID, keywords, eventVersion, level, pMetadata, metadataLength);
             return eventHandlePtr;
+        }
+
+        // Get or set the per-thread activity ID.
+        internal static int EventActivityIdControl(Interop.Advapi32.ActivityControl ControlCode, ref Guid ActivityId)
+        {
+            return EventPipeInternal.EventActivityIdControl((uint)ControlCode, ref ActivityId);
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -546,8 +546,8 @@ namespace System.Diagnostics.Tracing
 #if FEATURE_MANAGED_ETW
 #if FEATURE_PERFTRACING
             // Set the activity id via EventPipe.
-            EventPipeInternal.EventActivityIdControl(
-                (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
+            EventPipeEventProvider.EventActivityIdControl(
+                Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
                 ref activityId);
 #endif // FEATURE_PERFTRACING
 #if TARGET_WINDOWS
@@ -580,8 +580,8 @@ namespace System.Diagnostics.Tracing
                     Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
                     ref retVal);
 #elif FEATURE_PERFTRACING
-                EventPipeInternal.EventActivityIdControl(
-                    (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
+                EventPipeEventProvider.EventActivityIdControl(
+                    Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
                     ref retVal);
 #endif // TARGET_WINDOWS
 #endif // FEATURE_MANAGED_ETW
@@ -622,12 +622,12 @@ namespace System.Diagnostics.Tracing
             // Note we can't access m_throwOnWrites because this is a static method.
 
 #if FEATURE_PERFTRACING && TARGET_WINDOWS
-            EventPipeInternal.EventActivityIdControl(
-                (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
+            EventPipeEventProvider.EventActivityIdControl(
+                Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_SET_ID,
                     ref oldActivityThatWillContinue);
 #elif FEATURE_PERFTRACING
-            EventPipeInternal.EventActivityIdControl(
-                (uint)Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID,
+            EventPipeEventProvider.EventActivityIdControl(
+                Interop.Advapi32.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID,
                     ref oldActivityThatWillContinue);
 #endif // FEATURE_PERFTRACING && TARGET_WINDOWS
 

--- a/src/mono/mono/metadata/icall-eventpipe.c
+++ b/src/mono/mono/metadata/icall-eventpipe.c
@@ -341,7 +341,7 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_EventActivityIdControl (
 	/* GUID * */uint8_t *activity_id)
 {
 	int32_t result = 0;
-	EventPipeThread *thread = ep_thread_get ();
+	EventPipeThread *thread = ep_thread_get_or_create ();
 
 	if (thread == NULL)
 		return 1;
@@ -359,9 +359,14 @@ ves_icall_System_Diagnostics_Tracing_EventPipeInternal_EventActivityIdControl (
 		ep_thread_create_activity_id (activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	case EP_ACTIVITY_CONTROL_GET_SET_ID:
+		ep_thread_get_activity_id (thread, current_activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
+		memcpy (activity_id, current_activity_id, EP_ACTIVITY_ID_SIZE);
+		break;
+	case EP_ACTIVITY_CONTROL_CREATE_SET_ID:
 		ep_thread_get_activity_id (thread, activity_id, EP_ACTIVITY_ID_SIZE);
-		ep_thread_create_activity_id (current_activity_id, G_N_ELEMENTS (current_activity_id));
-		ep_thread_set_activity_id (thread, current_activity_id, G_N_ELEMENTS (current_activity_id));
+		ep_thread_create_activity_id (current_activity_id, EP_ACTIVITY_ID_SIZE);
+		ep_thread_set_activity_id (thread, current_activity_id, EP_ACTIVITY_ID_SIZE);
 		break;
 	default:
 		result = 1;

--- a/src/tests/tracing/eventactivityidcontrol/EventActivityIdControl.cs
+++ b/src/tests/tracing/eventactivityidcontrol/EventActivityIdControl.cs
@@ -24,7 +24,6 @@ namespace Tracing.Tests
         private const uint NumTasks = 20;
 
         private static MethodInfo s_EventActivityIdControl;
-        private static object s_EventPipeEventProvider;
         private static bool s_FailureEncountered = false;
 
         static int Main(string[] args)
@@ -181,7 +180,7 @@ namespace Tracing.Tests
             };
 
             int retCode = (int) s_EventActivityIdControl.Invoke(
-                s_EventPipeEventProvider,
+                null,
                 parameters);
 
             // Copy the by ref activityid out of the parameters array.
@@ -204,18 +203,11 @@ namespace Tracing.Tests
                 Console.WriteLine("Failed to get System.Diagnostics.Tracing.EventPipeEventProvider type.");
                 return false;
             }
-            s_EventActivityIdControl = eventPipeEventProviderType.GetMethod("System.Diagnostics.Tracing.IEventProvider.EventActivityIdControl", BindingFlags.NonPublic | BindingFlags.Instance );
+            s_EventActivityIdControl = eventPipeEventProviderType.GetMethod("EventActivityIdControl", BindingFlags.NonPublic | BindingFlags.Static );
             if(s_EventActivityIdControl == null)
             {
                 Console.WriteLine("Failed to get EventActivityIdControl method.");
                 return false;
-            }
-
-            // Create an instance of EventPipeEventProvider.
-            s_EventPipeEventProvider = Activator.CreateInstance(eventPipeEventProviderType);
-            if(s_EventPipeEventProvider == null)
-            {
-                Console.WriteLine("Failed to create EventPipeEventProvider instance.");
             }
 
             return true;


### PR DESCRIPTION
Make EventSource call static version of EventActivityIdControl in EventPipeEventProvider instead of direct calling low level
EventPipeInternal (now only called from EventPipe* sources). Doing it that way will also keep EventPipeEventProvider.EventActivityIdControl in S.P.C meaning that tests like eventactivityidcontrol won't risk
of using methods that has been trimmed away by linker.

Added missing case into Mono's EventPipeInternal::EventActivityIdControl implementations.

Enabled eventactivityidcontrol test on Mono runtime. Adjusted test to use static EventPipeEventProvider.EventActivityIdControl version.