### PR TITLE
Add space after "Other" in OperatingSystem.VersionString

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs
@@ -65,7 +65,7 @@ namespace System
                         case PlatformID.Unix: os = "Unix "; break;
                         case PlatformID.Xbox: os = "Xbox "; break;
                         case PlatformID.MacOSX: os = "Mac OS X "; break;
-                        case PlatformID.Other: os = "Other"; break;
+                        case PlatformID.Other: os = "Other "; break;
                         default:
                             Debug.Fail($"Unknown platform {_platform}");
                             os = "<unknown> "; break;

--- a/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/EnvironmentTests.cs
@@ -142,7 +142,7 @@ namespace System.Tests
 
             Assert.Contains(version.ToString(2), versionString);
 
-            string expectedOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Windows" : RuntimeInformation.IsOSPlatform(OSPlatform.Browser) ? "Other" : "Unix";
+            string expectedOS = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Windows " : RuntimeInformation.IsOSPlatform(OSPlatform.Browser) ? "Other " : "Unix ";
             Assert.Contains(expectedOS, versionString);
         }
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/runtime/pull/39130