### PR TITLE
MemoryCache: Size calculation with expired Entries

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -215,8 +215,11 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
                 else
                 {
-                    // Entry could not be added due to being expired, reset cache size
-                    Interlocked.Add(ref _cacheSize, -entry.Size.Value);
+                    if (_options.SizeLimit.HasValue)
+                    {
+                        // Entry could not be added due to being expired, reset cache size
+                        Interlocked.Add(ref _cacheSize, -entry.Size.Value);
+                    }
                 }
 
                 entry.InvokeEvictionCallbacks();

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -213,6 +213,11 @@ namespace Microsoft.Extensions.Caching.Memory
 
                     TriggerOvercapacityCompaction();
                 }
+                else
+                {
+                    // Entry could not be added due to being expired, reset cache size
+                    Interlocked.Add(ref _cacheSize, -entry.Size.Value);
+                }
 
                 entry.InvokeEvictionCallbacks();
                 if (priorEntry != null)

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -345,11 +345,12 @@ namespace Microsoft.Extensions.Caching.Memory
         public void TryingToAddExpiredEntryDoesNotIncreaseCacheSize()
         {
             var testClock = new TestClock();
-            var cache = new MemoryCache(new MemoryCacheOptions {Clock = testClock, SizeLimit = 10});
+            var cache = new MemoryCache(new MemoryCacheOptions { Clock = testClock, SizeLimit = 10 });
 
             var entryOptions = new MemoryCacheEntryOptions
             {
-                Size = 5, AbsoluteExpiration = testClock.UtcNow.Add(TimeSpan.FromMinutes(-1))
+                Size = 5,
+                AbsoluteExpiration = testClock.UtcNow.Add(TimeSpan.FromMinutes(-1))
             };
 
             cache.Set("key", "value", entryOptions);
@@ -361,11 +362,12 @@ namespace Microsoft.Extensions.Caching.Memory
         [Fact]
         public void TryingToAddEntryWithExpiredTokenDoesNotIncreaseCacheSize()
         {
-            var cache = new MemoryCache(new MemoryCacheOptions {SizeLimit = 10});
+            var cache = new MemoryCache(new MemoryCacheOptions { SizeLimit = 10 });
             var testExpirationToken = new TestExpirationToken { HasChanged = true };
             var entryOptions = new MemoryCacheEntryOptions
             {
-                Size = 5, ExpirationTokens = { testExpirationToken }
+                Size = 5,
+                ExpirationTokens = { testExpirationToken }
             };
 
             cache.Set("key", "value", entryOptions);

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -342,6 +342,23 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/36037")]
+        public void TryingToAddExpiredEntryDoesNotIncreaseCacheSize()
+        {
+            var testClock = new TestClock();
+            var cache = new MemoryCache(new MemoryCacheOptions {Clock = testClock, SizeLimit = 10});
+
+            var entryOptions = new MemoryCacheEntryOptions
+            {
+                Size = 5, AbsoluteExpiration = testClock.UtcNow.Add(TimeSpan.FromMinutes(-1))
+            };
+
+            cache.Set("key", "value", entryOptions);
+
+            Assert.Equal(0, cache.Size);
+        }
+
+        [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/33993")]
         public async Task CompactsToLessThanLowWatermarkUsingLRUWhenHighWatermarkExceeded()
         {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/CapacityTests.cs
@@ -342,7 +342,6 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/36037")]
         public void TryingToAddExpiredEntryDoesNotIncreaseCacheSize()
         {
             var testClock = new TestClock();
@@ -354,7 +353,24 @@ namespace Microsoft.Extensions.Caching.Memory
             };
 
             cache.Set("key", "value", entryOptions);
+            
+            Assert.Null(cache.Get("key"));
+            Assert.Equal(0, cache.Size);
+        }
 
+        [Fact]
+        public void TryingToAddEntryWithExpiredTokenDoesNotIncreaseCacheSize()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions {SizeLimit = 10});
+            var testExpirationToken = new TestExpirationToken { HasChanged = true };
+            var entryOptions = new MemoryCacheEntryOptions
+            {
+                Size = 5, ExpirationTokens = { testExpirationToken }
+            };
+
+            cache.Set("key", "value", entryOptions);
+            
+            Assert.Null(cache.Get("key"));
             Assert.Equal(0, cache.Size);
         }
 


### PR DESCRIPTION
Trying to add an already expired entry to the cache no longer
permanently increases the cache size

Fix #36037