### PR TITLE
Console.Unix: make Console.OpenStandardInput Stream aware of terminal

### DIFF
--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -1435,7 +1435,7 @@ namespace System
                 base.Dispose(disposing);
             }
 
-            public unsafe override int Read(byte[] buffer, int offset, int count)
+            public override int Read(byte[] buffer, int offset, int count)
             {
                 ValidateRead(buffer, offset, count);
 

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -43,7 +43,8 @@ namespace System
 
         public static Stream OpenStandardInput()
         {
-            return new UnixConsoleStream(SafeFileHandleHelper.Open(() => Interop.Sys.Dup(Interop.Sys.FileDescriptors.STDIN_FILENO)), FileAccess.Read);
+            return new UnixConsoleStream(SafeFileHandleHelper.Open(() => Interop.Sys.Dup(Interop.Sys.FileDescriptors.STDIN_FILENO)), FileAccess.Read,
+                                         useReadLine: !Console.IsInputRedirected);
         }
 
         public static Stream OpenStandardOutput()
@@ -68,7 +69,7 @@ namespace System
 
         private static SyncTextReader? s_stdInReader;
 
-        private static SyncTextReader StdInReader
+        internal static SyncTextReader StdInReader
         {
             get
             {
@@ -1410,15 +1411,19 @@ namespace System
             /// <summary>The file descriptor for the opened file.</summary>
             private readonly SafeFileHandle _handle;
 
+            private readonly bool _useReadLine;
+
             /// <summary>Initialize the stream.</summary>
             /// <param name="handle">The file handle wrapped by this stream.</param>
             /// <param name="access">FileAccess.Read or FileAccess.Write.</param>
-            internal UnixConsoleStream(SafeFileHandle handle, FileAccess access)
+            /// <param name="useReadLine">Use ReadLine API for reading.</param>
+            internal UnixConsoleStream(SafeFileHandle handle, FileAccess access, bool useReadLine = false)
                 : base(access)
             {
                 Debug.Assert(handle != null, "Expected non-null console handle");
                 Debug.Assert(!handle.IsInvalid, "Expected valid console handle");
                 _handle = handle;
+                _useReadLine = useReadLine;
             }
 
             protected override void Dispose(bool disposing)
@@ -1430,11 +1435,18 @@ namespace System
                 base.Dispose(disposing);
             }
 
-            public override int Read(byte[] buffer, int offset, int count)
+            public unsafe override int Read(byte[] buffer, int offset, int count)
             {
                 ValidateRead(buffer, offset, count);
 
-                return ConsolePal.Read(_handle, buffer, offset, count);
+                if (_useReadLine)
+                {
+                    return ConsolePal.StdInReader.ReadLine(buffer, offset, count);
+                }
+                else
+                {
+                    return ConsolePal.Read(_handle, buffer, offset, count);
+                }
             }
 
             public override void Write(byte[] buffer, int offset, int count)

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -80,9 +80,6 @@ namespace System.IO
 
         public override string? ReadLine()
         {
-            // Don't carry over chars from ReadLine buffer method.
-            _readLineSB.Clear();
-
             bool isEnter = ReadLineCore(consumeKeys: true);
             string? line = null;
             if (isEnter || _readLineSB.Length > 0)
@@ -140,6 +137,10 @@ namespace System.IO
         private bool ReadLineCore(bool consumeKeys)
         {
             Debug.Assert(_tmpKeys.Count == 0);
+
+            // Don't carry over chars from previous ReadLine call.
+            _readLineSB.Clear();
+
             Interop.Sys.InitializeConsoleBeforeRead();
             try
             {

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -85,9 +85,6 @@ namespace System.IO
             if (isEnter || _readLineSB.Length > 0)
             {
                 line = _readLineSB.ToString();
-            }
-            else
-            {
                 _readLineSB.Clear();
             }
             return line;

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -22,6 +22,7 @@ namespace System.IO
         private readonly Stack<ConsoleKeyInfo> _tmpKeys = new Stack<ConsoleKeyInfo>(); // temporary working stack; should be empty outside of ReadLine
         private readonly Stack<ConsoleKeyInfo> _availableKeys = new Stack<ConsoleKeyInfo>(); // a queue of already processed key infos available for reading
         private readonly Encoding _encoding;
+        private Encoder? _bufferedReadEncoder;
 
         private char[] _unprocessedBufferToBeRead; // Buffer that might have already been read from stdin but not yet processed.
         private const int BytesToBeRead = 1024; // No. of bytes to be read from the stream at a time.
@@ -79,129 +80,184 @@ namespace System.IO
 
         public override string? ReadLine()
         {
-            return ReadLine(consumeKeys: true);
+            return ReadLine(consumeKeys: true).line;
         }
 
-        private string? ReadLine(bool consumeKeys)
+        public int ReadLine(byte[] buffer, int offset, int count)
         {
+            return ReadLine(consumeKeys: true, buffer, offset, count).bytesRead;
+        }
+
+        private (string? line, int bytesRead) ReadLine(bool consumeKeys, byte[]? buffer = null, int offset = 0, int count = 0)
+        {
+            // This method blocks until a line was read or EOF was reached.
+            // When buffer is null, and consumeKeys is true, the line is returned as a string.
+            // When buffer is not null, the line is encoded into the buffer.
+            // If the buffer is too small for the line, successive calls will return the remainder.
             Debug.Assert(_tmpKeys.Count == 0);
-            string? readLineStr = null;
 
-            Interop.Sys.InitializeConsoleBeforeRead();
-            try
+            // Don't carry over chars from buffer read followed by non-buffer read.
+            if (buffer == null)
             {
-                // Read key-by-key until we've read a line.
-                while (true)
-                {
-                    // Read the next key.  This may come from previously read keys, from previously read but
-                    // unprocessed data, or from an actual stdin read.
-                    bool previouslyProcessed;
-                    ConsoleKeyInfo keyInfo = ReadKey(out previouslyProcessed);
-                    if (!consumeKeys && keyInfo.Key != ConsoleKey.Backspace) // backspace is the only character not written out in the below if/elses.
-                    {
-                        _tmpKeys.Push(keyInfo);
-                    }
+                _readLineSB.Clear();
+            }
+            // read into emty buffer.
+            else if (count == 0)
+            {
+                return (null, 0);
+            }
 
-                    // Handle the next key.  Since for other functions we may have ended up reading some of the user's
-                    // input, we need to be able to handle manually processing that input, and so we do that processing
-                    // for all input.  As such, we need to special-case a few characters, e.g. recognizing when Enter is
-                    // pressed to end a line.  We also need to handle Backspace specially, to fix up both our buffer of
-                    // characters and the position of the cursor.  More advanced processing would be possible, but we
-                    // try to keep this very simple, at least for now.
-                    if (keyInfo.Key == ConsoleKey.Enter)
+            // For a buffer read, first use remaining chars from _readLineSB.
+            if (buffer == null || _readLineSB.Length == 0)
+            {
+                Interop.Sys.InitializeConsoleBeforeRead();
+                try
+                {
+                    // Read key-by-key until we've read a line.
+                    while (true)
                     {
-                        readLineStr = _readLineSB.ToString();
-                        _readLineSB.Clear();
-                        if (!previouslyProcessed)
+                        // Read the next key.  This may come from previously read keys, from previously read but
+                        // unprocessed data, or from an actual stdin read.
+                        bool previouslyProcessed;
+                        ConsoleKeyInfo keyInfo = ReadKey(out previouslyProcessed);
+                        if (!consumeKeys && keyInfo.Key != ConsoleKey.Backspace) // backspace is the only character not written out in the below if/elses.
                         {
-                            Console.WriteLine();
+                            _tmpKeys.Push(keyInfo);
                         }
-                        break;
-                    }
-                    else if (IsEol(keyInfo.KeyChar))
-                    {
-                        string line = _readLineSB.ToString();
-                        _readLineSB.Clear();
-                        if (line.Length > 0)
+
+                        // Handle the next key.  Since for other functions we may have ended up reading some of the user's
+                        // input, we need to be able to handle manually processing that input, and so we do that processing
+                        // for all input.  As such, we need to special-case a few characters, e.g. recognizing when Enter is
+                        // pressed to end a line.  We also need to handle Backspace specially, to fix up both our buffer of
+                        // characters and the position of the cursor.  More advanced processing would be possible, but we
+                        // try to keep this very simple, at least for now.
+                        if (keyInfo.Key == ConsoleKey.Enter)
                         {
-                            readLineStr = line;
-                        }
-                        break;
-                    }
-                    else if (keyInfo.Key == ConsoleKey.Backspace)
-                    {
-                        int len = _readLineSB.Length;
-                        if (len > 0)
-                        {
-                            _readLineSB.Length = len - 1;
+                            if (buffer != null)
+                            {
+                                _readLineSB.Append('\n');
+                            }
                             if (!previouslyProcessed)
                             {
-                                // The ReadLine input may wrap accross terminal rows and we need to handle that.
-                                // note: ConsolePal will cache the cursor position to avoid making many slow cursor position fetch operations.
-                                if (ConsolePal.TryGetCursorPosition(out int left, out int top, reinitializeForRead: true) &&
-                                    left == 0 && top > 0)
+                                Console.WriteLine();
+                            }
+                            break;
+                        }
+                        else if (IsEol(keyInfo.KeyChar))
+                        {
+                            if (_readLineSB.Length == 0)
+                            {
+                                return (null, 0);
+                            }
+                            break;
+                        }
+                        else if (keyInfo.Key == ConsoleKey.Backspace)
+                        {
+                            int len = _readLineSB.Length;
+                            if (len > 0)
+                            {
+                                _readLineSB.Length = len - 1;
+                                if (!previouslyProcessed)
                                 {
-                                    if (s_clearToEol == null)
+                                    // The ReadLine input may wrap accross terminal rows and we need to handle that.
+                                    // note: ConsolePal will cache the cursor position to avoid making many slow cursor position fetch operations.
+                                    if (ConsolePal.TryGetCursorPosition(out int left, out int top, reinitializeForRead: true) &&
+                                        left == 0 && top > 0)
                                     {
-                                        s_clearToEol = ConsolePal.TerminalFormatStrings.Instance.ClrEol ?? string.Empty;
-                                    }
+                                        if (s_clearToEol == null)
+                                        {
+                                            s_clearToEol = ConsolePal.TerminalFormatStrings.Instance.ClrEol ?? string.Empty;
+                                        }
 
-                                    // Move to end of previous line
-                                    ConsolePal.SetCursorPosition(ConsolePal.WindowWidth - 1, top - 1);
-                                    // Clear from cursor to end of the line
-                                    ConsolePal.WriteStdoutAnsiString(s_clearToEol, mayChangeCursorPosition: false);
-                                }
-                                else
-                                {
-                                    if (s_moveLeftString == null)
+                                        // Move to end of previous line
+                                        ConsolePal.SetCursorPosition(ConsolePal.WindowWidth - 1, top - 1);
+                                        // Clear from cursor to end of the line
+                                        ConsolePal.WriteStdoutAnsiString(s_clearToEol, mayChangeCursorPosition: false);
+                                    }
+                                    else
                                     {
-                                        string? moveLeft = ConsolePal.TerminalFormatStrings.Instance.CursorLeft;
-                                        s_moveLeftString = !string.IsNullOrEmpty(moveLeft) ? moveLeft + " " + moveLeft : string.Empty;
-                                    }
+                                        if (s_moveLeftString == null)
+                                        {
+                                            string? moveLeft = ConsolePal.TerminalFormatStrings.Instance.CursorLeft;
+                                            s_moveLeftString = !string.IsNullOrEmpty(moveLeft) ? moveLeft + " " + moveLeft : string.Empty;
+                                        }
 
-                                    Console.Write(s_moveLeftString);
+                                        Console.Write(s_moveLeftString);
+                                    }
                                 }
                             }
                         }
-                    }
-                    else if (keyInfo.Key == ConsoleKey.Tab)
-                    {
-                        _readLineSB.Append(keyInfo.KeyChar);
-                        if (!previouslyProcessed)
+                        else if (keyInfo.Key == ConsoleKey.Tab)
                         {
-                            Console.Write(' ');
+                            _readLineSB.Append(keyInfo.KeyChar);
+                            if (!previouslyProcessed)
+                            {
+                                Console.Write(' ');
+                            }
                         }
-                    }
-                    else if (keyInfo.Key == ConsoleKey.Clear)
-                    {
-                        _readLineSB.Clear();
-                        if (!previouslyProcessed)
+                        else if (keyInfo.Key == ConsoleKey.Clear)
                         {
-                            Console.Clear();
+                            _readLineSB.Clear();
+                            if (!previouslyProcessed)
+                            {
+                                Console.Clear();
+                            }
                         }
-                    }
-                    else if (keyInfo.KeyChar != '\0')
-                    {
-                        _readLineSB.Append(keyInfo.KeyChar);
-                        if (!previouslyProcessed)
+                        else if (keyInfo.KeyChar != '\0')
                         {
-                            Console.Write(keyInfo.KeyChar);
+                            _readLineSB.Append(keyInfo.KeyChar);
+                            if (!previouslyProcessed)
+                            {
+                                Console.Write(keyInfo.KeyChar);
+                            }
                         }
                     }
                 }
-            }
-            finally
-            {
-                Interop.Sys.UninitializeConsoleAfterRead();
-
-                // If we're not consuming the read input, make the keys available for a future read
-                while (_tmpKeys.Count > 0)
+                finally
                 {
-                    _availableKeys.Push(_tmpKeys.Pop());
+                    Interop.Sys.UninitializeConsoleAfterRead();
+
+                    // If we're not consuming the read input, make the keys available for a future read
+                    while (_tmpKeys.Count > 0)
+                    {
+                        _availableKeys.Push(_tmpKeys.Pop());
+                    }
                 }
             }
 
-            return readLineStr;
+            string? line = null;
+            int bytesUsedTotal = 0;
+            if (buffer == null)
+            {
+                if (consumeKeys)
+                {
+                    line = _readLineSB.ToString();
+                }
+                _readLineSB.Clear();
+            }
+            else
+            {
+                // Encode _readLineSB in buffer.
+                Encoder encoder = _bufferedReadEncoder ??= _encoding.GetEncoder();
+
+                int charsUsedTotal = 0;
+                Span<byte> destination = buffer.AsSpan(offset, count);
+                foreach (ReadOnlyMemory<char> chunk in _readLineSB.GetChunks())
+                {
+                    encoder.Convert(chunk.Span, destination, flush: false, out int charsUsed, out int bytesUsed, out bool completed);
+                    destination = destination.Slice(bytesUsed);
+                    bytesUsedTotal += bytesUsed;
+                    charsUsedTotal += charsUsed;
+
+                    if (charsUsed == 0)
+                    {
+                        break;
+                    }
+                }
+
+                _readLineSB.Remove(0, charsUsedTotal);
+            }
+            return (line, bytesUsedTotal);
         }
 
         public override int Read() => ReadOrPeek(peek: false);

--- a/src/libraries/System.Console/src/System/IO/SyncTextReader.Unix.cs
+++ b/src/libraries/System.Console/src/System/IO/SyncTextReader.Unix.cs
@@ -39,5 +39,8 @@ namespace System.IO
                 }
             }
         }
+
+        public int ReadLine(byte[] buffer, int offset, int count)
+            => Inner.ReadLine(buffer, offset, count);
     }
 }

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -57,6 +57,7 @@ namespace System
         }
 
         [ConditionalFact(nameof(ManualTestsEnabled))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40735", TestPlatforms.Windows)]
         public static void InPeek()
         {
             Console.WriteLine("Please type \"peek\" (without the quotes). You should see it as you type:");
@@ -112,19 +113,11 @@ namespace System
 
         public static IEnumerable<object[]> GetKeyChords()
         {
-            yield return MkConsoleKeyInfo('\x01', ConsoleKey.A, ConsoleModifiers.Control);
-            yield return MkConsoleKeyInfo('\x01', ConsoleKey.A, ConsoleModifiers.Control | ConsoleModifiers.Alt);
+            yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control);
+            yield return MkConsoleKeyInfo(OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
             yield return MkConsoleKeyInfo('\r', ConsoleKey.Enter, (ConsoleModifiers)0);
-
-            if (OperatingSystem.IsWindows())
-            {
-                // windows will report '\n' as 'Ctrl+Enter', which is typically not picked up by Unix terminals
-                yield return MkConsoleKeyInfo('\n', ConsoleKey.Enter, ConsoleModifiers.Control);
-            }
-            else
-            {
-                yield return MkConsoleKeyInfo('\n', ConsoleKey.J, ConsoleModifiers.Control);
-            }
+            // windows will report '\n' as 'Ctrl+Enter', which is typically not picked up by Unix terminals
+            yield return MkConsoleKeyInfo('\n', OperatingSystem.IsWindows() ? ConsoleKey.Enter : ConsoleKey.J, ConsoleModifiers.Control);
 
             static object[] MkConsoleKeyInfo (char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
             {
@@ -225,7 +218,7 @@ namespace System
                 }
             }
 
-            AssertUserExpectedResults("the arrow keys move around the screen as expected with no other bad artificts");
+            AssertUserExpectedResults("the arrow keys move around the screen as expected with no other bad artifacts");
         }
 
         [ConditionalFact(nameof(ManualTestsEnabled))]

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.IO;
 using Xunit;
 
 namespace System
@@ -19,6 +20,26 @@ namespace System
             string expectedLine = $"This is a test of Console.{(consoleIn ? "In." : "")}ReadLine.";
             Console.WriteLine($"Please type the sentence (without the quotes): \"{expectedLine}\"");
             string result = consoleIn ? Console.In.ReadLine() : Console.ReadLine();
+            Assert.Equal(expectedLine, result);
+            AssertUserExpectedResults("the characters you typed properly echoed as you typed");
+        }
+
+        [ConditionalFact(nameof(ManualTestsEnabled))]
+        public static void ReadLineFromOpenStandardInput()
+        {
+            string expectedLine = "aab";
+
+            // Use Console.ReadLine
+            Console.WriteLine($"Please type 'a' 3 times, press 'Backspace' to erase 1, then type a single 'b' and press 'Enter'.");
+            string result = Console.ReadLine();
+            Assert.Equal(expectedLine, result);
+            AssertUserExpectedResults("the characters you typed properly echoed as you typed");
+
+            // ReadLine from Console.OpenStandardInput
+            Console.WriteLine($"Please type 'a' 3 times, press 'Backspace' to erase 1, then type a single 'b' and press 'Enter'.");
+            using Stream inputStream = Console.OpenStandardInput();
+            using StreamReader reader = new StreamReader(inputStream);
+            result = reader.ReadLine();
             Assert.Equal(expectedLine, result);
             AssertUserExpectedResults("the characters you typed properly echoed as you typed");
         }
@@ -115,18 +136,6 @@ namespace System
                         shift: modifiers.HasFlag(ConsoleModifiers.Shift))
                 };
             }
-        }
-
-        [ConditionalFact(nameof(ManualTestsEnabled))]
-        public static void OpenStandardInput()
-        {
-            Console.WriteLine("Please type \"console\" (without the quotes). You shouldn't see it as you type:");
-            var stream = Console.OpenStandardInput();
-            var textReader = new System.IO.StreamReader(stream);
-            var result = textReader.ReadLine();
-
-            Assert.Equal("console", result);
-            AssertUserExpectedResults("\"console\" correctly not echoed as you typed it");
         }
 
         [ConditionalFact(nameof(ManualTestsEnabled))]


### PR DESCRIPTION
When performing OpenStandardInput against a terminal, perform Reads on a
line-by-line basis and perform appropriate processing and echoing.

Fixes https://github.com/dotnet/runtime/issues/39008

@eiriktsarpalis @stephentoub ptal