### PR TITLE
don't always aquite lock when calling RuntimeInformation.OSArchitecture and OSArchitecture.ProcessArchitecture

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetOSArchitecture.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetOSArchitecture.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
+        [SuppressGCTransition]
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetOSArchitecture")]
         internal static extern int GetOSArchitecture();
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetProcessArchitecture.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetProcessArchitecture.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
+        [SuppressGCTransition]
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetProcessArchitecture")]
         internal static extern int GetProcessArchitecture();
     }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -11,8 +11,8 @@ namespace System.Runtime.InteropServices
         private static readonly object s_processLock = new object();
         private static string? s_osPlatformName;
         private static string? s_osDescription;
-        private static Architecture? s_osArch;
-        private static Architecture? s_processArch;
+        private static int s_osArch = -1;
+        private static int s_processArch = -1;
 
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
@@ -26,34 +26,39 @@ namespace System.Runtime.InteropServices
         {
             get
             {
-                lock (s_osLock)
+                Debug.Assert(sizeof(Architecture) == sizeof(int));
+
+                if (s_osArch == -1)
                 {
-                    if (null == s_osArch)
+                    lock (s_osLock)
                     {
-                        Interop.Sys.ProcessorArchitecture arch = (Interop.Sys.ProcessorArchitecture)Interop.Sys.GetOSArchitecture();
-                        switch (arch)
+                        if (s_osArch == -1)
                         {
-                            case Interop.Sys.ProcessorArchitecture.ARM:
-                                s_osArch = Architecture.Arm;
-                                break;
+                            Interop.Sys.ProcessorArchitecture arch = (Interop.Sys.ProcessorArchitecture)Interop.Sys.GetOSArchitecture();
+                            switch (arch)
+                            {
+                                case Interop.Sys.ProcessorArchitecture.ARM:
+                                    s_osArch = (int)Architecture.Arm;
+                                    break;
 
-                            case Interop.Sys.ProcessorArchitecture.x64:
-                                s_osArch = Architecture.X64;
-                                break;
+                                case Interop.Sys.ProcessorArchitecture.x64:
+                                    s_osArch = (int)Architecture.X64;
+                                    break;
 
-                            case Interop.Sys.ProcessorArchitecture.x86:
-                                s_osArch = Architecture.X86;
-                                break;
+                                case Interop.Sys.ProcessorArchitecture.x86:
+                                    s_osArch = (int)Architecture.X86;
+                                    break;
 
-                            case Interop.Sys.ProcessorArchitecture.ARM64:
-                                s_osArch = Architecture.Arm64;
-                                break;
+                                case Interop.Sys.ProcessorArchitecture.ARM64:
+                                    s_osArch = (int)Architecture.Arm64;
+                                    break;
+                            }
                         }
                     }
                 }
 
-                Debug.Assert(s_osArch != null);
-                return s_osArch.Value;
+                Debug.Assert(s_osArch != -1);
+                return (Architecture)s_osArch;
             }
         }
 
@@ -61,34 +66,39 @@ namespace System.Runtime.InteropServices
         {
             get
             {
-                lock (s_processLock)
+                Debug.Assert(sizeof(Architecture) == sizeof(int));
+
+                if (s_processArch == -1)
                 {
-                    if (null == s_processArch)
+                    lock (s_processLock)
                     {
-                        Interop.Sys.ProcessorArchitecture arch = (Interop.Sys.ProcessorArchitecture)Interop.Sys.GetProcessArchitecture();
-                        switch (arch)
+                        if (s_processArch == -1)
                         {
-                            case Interop.Sys.ProcessorArchitecture.ARM:
-                                s_processArch = Architecture.Arm;
-                                break;
+                            Interop.Sys.ProcessorArchitecture arch = (Interop.Sys.ProcessorArchitecture)Interop.Sys.GetProcessArchitecture();
+                            switch (arch)
+                            {
+                                case Interop.Sys.ProcessorArchitecture.ARM:
+                                    s_processArch = (int)Architecture.Arm;
+                                    break;
 
-                            case Interop.Sys.ProcessorArchitecture.x64:
-                                s_processArch = Architecture.X64;
-                                break;
+                                case Interop.Sys.ProcessorArchitecture.x64:
+                                    s_processArch = (int)Architecture.X64;
+                                    break;
 
-                            case Interop.Sys.ProcessorArchitecture.x86:
-                                s_processArch = Architecture.X86;
-                                break;
+                                case Interop.Sys.ProcessorArchitecture.x86:
+                                    s_processArch = (int)Architecture.X86;
+                                    break;
 
-                            case Interop.Sys.ProcessorArchitecture.ARM64:
-                                s_processArch = Architecture.Arm64;
-                                break;
+                                case Interop.Sys.ProcessorArchitecture.ARM64:
+                                    s_processArch = (int)Architecture.Arm64;
+                                    break;
+                            }
                         }
-                    }
+                }
                 }
 
-                Debug.Assert(s_processArch != null);
-                return s_processArch.Value;
+                Debug.Assert(s_processArch != -1);
+                return (Architecture)s_processArch;
             }
         }
     }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -9,8 +9,6 @@ namespace System.Runtime.InteropServices
     {
         private static string? s_osPlatformName;
         private static string? s_osDescription;
-        private static readonly Architecture s_osArch = Map((Interop.Sys.ProcessorArchitecture)Interop.Sys.GetOSArchitecture());
-        private static readonly Architecture s_processArch = Map((Interop.Sys.ProcessorArchitecture)Interop.Sys.GetProcessArchitecture());
 
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
@@ -20,9 +18,9 @@ namespace System.Runtime.InteropServices
 
         public static string OSDescription => s_osDescription ??= Interop.Sys.GetUnixVersion();
 
-        public static Architecture OSArchitecture => s_osArch;
+        public static Architecture OSArchitecture { get; } = Map((Interop.Sys.ProcessorArchitecture)Interop.Sys.GetOSArchitecture());
 
-        public static Architecture ProcessArchitecture => s_processArch;
+        public static Architecture ProcessArchitecture { get; } = Map((Interop.Sys.ProcessorArchitecture)Interop.Sys.GetProcessArchitecture());
 
         private static Architecture Map(Interop.Sys.ProcessorArchitecture arch)
         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -7,8 +7,7 @@ namespace System.Runtime.InteropServices
 {
     public static partial class RuntimeInformation
     {
-        private static readonly object s_osLock = new object();
-        private static readonly object s_processLock = new object();
+        private static readonly object s_lock = new object();
         private static string? s_osPlatformName;
         private static string? s_osDescription;
         private static volatile int s_osArch = -1;
@@ -30,7 +29,7 @@ namespace System.Runtime.InteropServices
 
                 if (s_osArch == -1)
                 {
-                    lock (s_osLock)
+                    lock (s_lock)
                     {
                         if (s_osArch == -1)
                         {
@@ -70,7 +69,7 @@ namespace System.Runtime.InteropServices
 
                 if (s_processArch == -1)
                 {
-                    lock (s_processLock)
+                    lock (s_lock)
                     {
                         if (s_processArch == -1)
                         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -11,8 +11,8 @@ namespace System.Runtime.InteropServices
         private static readonly object s_processLock = new object();
         private static string? s_osPlatformName;
         private static string? s_osDescription;
-        private static int s_osArch = -1;
-        private static int s_processArch = -1;
+        private static volatile int s_osArch = -1;
+        private static volatile int s_processArch = -1;
 
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -10,8 +10,8 @@ namespace System.Runtime.InteropServices
         private static string? s_osDescription;
         private static readonly object s_osLock = new object();
         private static readonly object s_processLock = new object();
-        private static int s_osArch = -1;
-        private static int s_processArch = -1;
+        private static volatile int s_osArch = -1;
+        private static volatile int s_processArch = -1;
 
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -8,8 +8,7 @@ namespace System.Runtime.InteropServices
     public static partial class RuntimeInformation
     {
         private static string? s_osDescription;
-        private static readonly object s_osLock = new object();
-        private static readonly object s_processLock = new object();
+        private static readonly object s_lock = new object();
         private static volatile int s_osArch = -1;
         private static volatile int s_processArch = -1;
 
@@ -46,7 +45,7 @@ namespace System.Runtime.InteropServices
 
                 if (s_osArch == -1)
                 {
-                    lock (s_osLock)
+                    lock (s_lock)
                     {
                         if (s_osArch == -1)
                         {
@@ -85,7 +84,7 @@ namespace System.Runtime.InteropServices
 
                 if (s_processArch == -1)
                 {
-                    lock (s_processLock)
+                    lock (s_lock)
                     {
                         if (s_processArch == -1)
                         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -49,29 +49,13 @@ namespace System.Runtime.InteropServices
                     {
                         if (s_osArch == -1)
                         {
-                            Interop.Kernel32.SYSTEM_INFO sysInfo;
-                            Interop.Kernel32.GetNativeSystemInfo(out sysInfo);
+                            Interop.Kernel32.GetNativeSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
 
-                            switch ((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
-                            {
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
-                                    s_osArch = (int)Architecture.Arm64;
-                                    break;
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
-                                    s_osArch = (int)Architecture.Arm;
-                                    break;
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
-                                    s_osArch = (int)Architecture.X64;
-                                    break;
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
-                                    s_osArch = (int)Architecture.X86;
-                                    break;
-                            }
+                            s_osArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
                         }
                     }
                 }
 
-                Debug.Assert(s_osArch != -1);
                 return (Architecture)s_osArch;
             }
         }
@@ -88,30 +72,31 @@ namespace System.Runtime.InteropServices
                     {
                         if (s_processArch == -1)
                         {
-                            Interop.Kernel32.SYSTEM_INFO sysInfo;
-                            Interop.Kernel32.GetSystemInfo(out sysInfo);
+                            Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
 
-                            switch ((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
-                            {
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
-                                    s_processArch = (int)Architecture.Arm64;
-                                    break;
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
-                                    s_processArch = (int)Architecture.Arm;
-                                    break;
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
-                                    s_processArch = (int)Architecture.X64;
-                                    break;
-                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
-                                    s_processArch = (int)Architecture.X86;
-                                    break;
-                            }
+                            s_processArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
                         }
                     }
                 }
 
-                Debug.Assert(s_processArch != -1);
                 return (Architecture)s_processArch;
+            }
+        }
+
+        private static Architecture Map(Interop.Kernel32.ProcessorArchitecture processorArchitecture)
+        {
+            switch (processorArchitecture)
+            {
+                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
+                    return Architecture.Arm64;
+                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
+                    return Architecture.Arm;
+                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
+                    return Architecture.X64;
+                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
+                default:
+                    Debug.Assert(processorArchitecture == Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL, "Unidentified Architecture");
+                    return Architecture.X86;
             }
         }
     }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -8,7 +8,6 @@ namespace System.Runtime.InteropServices
     public static partial class RuntimeInformation
     {
         private static string? s_osDescription;
-        private static readonly object s_lock = new object();
         private static volatile int s_osArch = -1;
         private static volatile int s_processArch = -1;
 
@@ -43,20 +42,15 @@ namespace System.Runtime.InteropServices
             {
                 Debug.Assert(sizeof(Architecture) == sizeof(int));
 
-                if (s_osArch == -1)
-                {
-                    lock (s_lock)
-                    {
-                        if (s_osArch == -1)
-                        {
-                            Interop.Kernel32.GetNativeSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
+                int osArch = s_osArch;
 
-                            s_osArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
-                        }
-                    }
+                if (osArch == -1)
+                {
+                    Interop.Kernel32.GetNativeSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
+                    osArch = s_osArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
                 }
 
-                return (Architecture)s_osArch;
+                return (Architecture)osArch;
             }
         }
 
@@ -66,20 +60,15 @@ namespace System.Runtime.InteropServices
             {
                 Debug.Assert(sizeof(Architecture) == sizeof(int));
 
-                if (s_processArch == -1)
-                {
-                    lock (s_lock)
-                    {
-                        if (s_processArch == -1)
-                        {
-                            Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
+                int processArch = s_processArch;
 
-                            s_processArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
-                        }
-                    }
+                if (processArch == -1)
+                {
+                    Interop.Kernel32.GetSystemInfo(out Interop.Kernel32.SYSTEM_INFO sysInfo);
+                    processArch = s_processArch = (int)Map((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture);
                 }
 
-                return (Architecture)s_processArch;
+                return (Architecture)processArch;
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -10,8 +10,8 @@ namespace System.Runtime.InteropServices
         private static string? s_osDescription;
         private static readonly object s_osLock = new object();
         private static readonly object s_processLock = new object();
-        private static Architecture? s_osArch;
-        private static Architecture? s_processArch;
+        private static int s_osArch = -1;
+        private static int s_processArch = -1;
 
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
@@ -42,34 +42,38 @@ namespace System.Runtime.InteropServices
         {
             get
             {
-                lock (s_osLock)
+                Debug.Assert(sizeof(Architecture) == sizeof(int));
+
+                if (s_osArch == -1)
                 {
-                    if (null == s_osArch)
+                    lock (s_osLock)
                     {
-                        Interop.Kernel32.SYSTEM_INFO sysInfo;
-                        Interop.Kernel32.GetNativeSystemInfo(out sysInfo);
-
-                        switch ((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
+                        if (s_osArch == -1)
                         {
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
-                                s_osArch = Architecture.Arm64;
-                                break;
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
-                                s_osArch = Architecture.Arm;
-                                break;
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
-                                s_osArch = Architecture.X64;
-                                break;
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
-                                s_osArch = Architecture.X86;
-                                break;
-                        }
+                            Interop.Kernel32.SYSTEM_INFO sysInfo;
+                            Interop.Kernel32.GetNativeSystemInfo(out sysInfo);
 
+                            switch ((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
+                            {
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
+                                    s_osArch = (int)Architecture.Arm64;
+                                    break;
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
+                                    s_osArch = (int)Architecture.Arm;
+                                    break;
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
+                                    s_osArch = (int)Architecture.X64;
+                                    break;
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
+                                    s_osArch = (int)Architecture.X86;
+                                    break;
+                            }
+                        }
                     }
                 }
 
-                Debug.Assert(s_osArch != null);
-                return s_osArch.Value;
+                Debug.Assert(s_osArch != -1);
+                return (Architecture)s_osArch;
             }
         }
 
@@ -77,33 +81,38 @@ namespace System.Runtime.InteropServices
         {
             get
             {
-                lock (s_processLock)
-                {
-                    if (null == s_processArch)
-                    {
-                        Interop.Kernel32.SYSTEM_INFO sysInfo;
-                        Interop.Kernel32.GetSystemInfo(out sysInfo);
+                Debug.Assert(sizeof(Architecture) == sizeof(int));
 
-                        switch ((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
+                if (s_processArch == -1)
+                {
+                    lock (s_processLock)
+                    {
+                        if (s_processArch == -1)
                         {
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
-                                s_processArch = Architecture.Arm64;
-                                break;
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
-                                s_processArch = Architecture.Arm;
-                                break;
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
-                                s_processArch = Architecture.X64;
-                                break;
-                            case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
-                                s_processArch = Architecture.X86;
-                                break;
+                            Interop.Kernel32.SYSTEM_INFO sysInfo;
+                            Interop.Kernel32.GetSystemInfo(out sysInfo);
+
+                            switch ((Interop.Kernel32.ProcessorArchitecture)sysInfo.wProcessorArchitecture)
+                            {
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM64:
+                                    s_processArch = (int)Architecture.Arm64;
+                                    break;
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_ARM:
+                                    s_processArch = (int)Architecture.Arm;
+                                    break;
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_AMD64:
+                                    s_processArch = (int)Architecture.X64;
+                                    break;
+                                case Interop.Kernel32.ProcessorArchitecture.Processor_Architecture_INTEL:
+                                    s_processArch = (int)Architecture.X86;
+                                    break;
+                            }
                         }
                     }
                 }
 
-                Debug.Assert(s_processArch != null);
-                return s_processArch.Value;
+                Debug.Assert(s_processArch != -1);
+                return (Architecture)s_processArch;
             }
         }
     }


### PR DESCRIPTION
```cs
[Benchmark]
public Architecture OSArchitecture() => RuntimeInformation.OSArchitecture;

[Benchmark]
public Architecture ProcessArchitecture() => RuntimeInformation.ProcessArchitecture;
```

BEFORE:

|              Method |      Mean |     Error |    StdDev |    Median |       Min |       Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |----------:|----------:|----------:|----------:|----------:|----------:|------:|------:|------:|----------:|
|      OSArchitecture | 16.202 ns | 0.1181 ns | 0.1105 ns | 16.184 ns | 16.073 ns | 16.362 ns |     - |     - |     - |         - |
| ProcessArchitecture | 16.221 ns | 0.0320 ns | 0.0267 ns | 16.217 ns | 16.180 ns | 16.288 ns |     - |     - |     - |         - |

AFTER:

|              Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|------:|------:|----------:|
|      OSArchitecture | 1.059 ns | 0.0073 ns | 0.0065 ns | 1.059 ns | 1.049 ns | 1.070 ns |     - |     - |     - |         - |
| ProcessArchitecture | 1.331 ns | 0.0129 ns | 0.0120 ns | 1.328 ns | 1.314 ns | 1.354 ns |     - |     - |     - |         - |