### PR TITLE
Fix ManagedWebSocket ordering of releasing send buffer and semaphore

### DIFF
--- a/src/libraries/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/Common/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -384,7 +384,7 @@ namespace System.Net.WebSockets
             // If we get here, the cancellation token is not cancelable so we don't have to worry about it,
             // and we own the semaphore, so we don't need to asynchronously wait for it.
             ValueTask writeTask = default;
-            bool releaseSemaphoreAndSendBuffer = true;
+            bool releaseSendBufferAndSemaphore = true;
             try
             {
                 // Write the payload synchronously to the buffer, then write that buffer out to the network.
@@ -402,7 +402,7 @@ namespace System.Net.WebSockets
                 // Up until this point, if an exception occurred (such as when accessing _stream or when
                 // calling GetResult), we want to release the semaphore and the send buffer. After this point,
                 // both need to be held until writeTask completes.
-                releaseSemaphoreAndSendBuffer = false;
+                releaseSendBufferAndSemaphore = false;
             }
             catch (Exception exc)
             {
@@ -413,10 +413,10 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                if (releaseSemaphoreAndSendBuffer)
+                if (releaseSendBufferAndSemaphore)
                 {
-                    _sendFrameAsyncLock.Release();
                     ReleaseSendBuffer();
+                    _sendFrameAsyncLock.Release();
                 }
             }
 
@@ -437,8 +437,8 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                _sendFrameAsyncLock.Release();
                 ReleaseSendBuffer();
+                _sendFrameAsyncLock.Release();
             }
         }
 
@@ -461,8 +461,8 @@ namespace System.Net.WebSockets
             }
             finally
             {
-                _sendFrameAsyncLock.Release();
                 ReleaseSendBuffer();
+                _sendFrameAsyncLock.Release();
             }
         }
 
@@ -1277,6 +1277,8 @@ namespace System.Net.WebSockets
         /// <summary>Releases the send buffer to the pool.</summary>
         private void ReleaseSendBuffer()
         {
+            Debug.Assert(_sendFrameAsyncLock.CurrentCount == 0, "Caller should hold the _sendFrameAsyncLock");
+
             byte[]? old = _sendBuffer;
             if (old != null)
             {


### PR DESCRIPTION
Once we release the semaphore, we no longer have ownership over _sendBuffer, so we have to release the latter before not after releasing the semaphore.

Fixes https://github.com/dotnet/runtime/issues/39198