### PR TITLE
Keep weak gc handle for EventPipe delegate callback in provider.

### DIFF
--- a/src/mono/mono/eventpipe/ep-config-internals.h
+++ b/src/mono/mono/eventpipe/ep-config-internals.h
@@ -30,6 +30,7 @@ config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue);
 

--- a/src/mono/mono/eventpipe/ep-config.c
+++ b/src/mono/mono/eventpipe/ep-config.c
@@ -168,7 +168,7 @@ ep_config_init (EventPipeConfiguration *config)
 
 	ep_requires_lock_not_held ();
 
-	config->config_provider = ep_create_provider (ep_config_get_default_provider_name_utf8 (), NULL, NULL);
+	config->config_provider = ep_create_provider (ep_config_get_default_provider_name_utf8 (), NULL, NULL, NULL);
 	ep_raise_error_if_nok (config->config_provider != NULL);
 
 	// Create the metadata event.
@@ -225,6 +225,7 @@ ep_config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue)
 {
@@ -235,7 +236,7 @@ ep_config_create_provider (
 
 	EventPipeProvider *provider = NULL;
 	EP_LOCK_ENTER (section1)
-		provider = config_create_provider (config, provider_name, callback_func, callback_data, provider_callback_data_queue);
+		provider = config_create_provider (config, provider_name, callback_func, callback_data_free_func, callback_data, provider_callback_data_queue);
 		ep_raise_error_if_nok_holding_lock (provider != NULL, section1);
 	EP_LOCK_EXIT (section1)
 
@@ -448,6 +449,7 @@ config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue)
 {
@@ -456,7 +458,7 @@ config_create_provider (
 
 	ep_requires_lock_held ();
 	
-	EventPipeProvider *provider = ep_provider_alloc (config, provider_name, callback_func, callback_data);
+	EventPipeProvider *provider = ep_provider_alloc (config, provider_name, callback_func, callback_data_free_func, callback_data);
 	ep_raise_error_if_nok (provider != NULL);
 	ep_raise_error_if_nok (config_register_provider (config, provider, provider_callback_data_queue) == true);
 

--- a/src/mono/mono/eventpipe/ep-config.h
+++ b/src/mono/mono/eventpipe/ep-config.h
@@ -80,6 +80,7 @@ ep_config_create_provider (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data,
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue);
 

--- a/src/mono/mono/eventpipe/ep-event-source.c
+++ b/src/mono/mono/eventpipe/ep-event-source.c
@@ -91,7 +91,7 @@ ep_event_source_init (EventPipeEventSource *event_source)
 
 	EP_ASSERT (event_source != NULL);
 
-	event_source->provider = ep_create_provider (ep_provider_get_default_name_utf8 (), NULL, NULL);
+	event_source->provider = ep_create_provider (ep_provider_get_default_name_utf8 (), NULL, NULL, NULL);
 	ep_raise_error_if_nok (event_source->provider != NULL);
 
 	event_source->provider_name = ep_provider_get_default_name_utf8 ();

--- a/src/mono/mono/eventpipe/ep-provider.c
+++ b/src/mono/mono/eventpipe/ep-provider.c
@@ -168,6 +168,7 @@ ep_provider_alloc (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data)
 {
 	EP_ASSERT (config != NULL);
@@ -185,6 +186,7 @@ ep_provider_alloc (
 	instance->keywords = 0;
 	instance->provider_level = EP_EVENT_LEVEL_CRITICAL;
 	instance->callback_func = callback_func;
+	instance->callback_data_free_func = callback_data_free_func;
 	instance->callback_data = callback_data;
 	instance->config = config;
 	instance->delete_deferred = false;
@@ -203,6 +205,9 @@ void
 ep_provider_free (EventPipeProvider * provider)
 {
 	ep_return_void_if_nok (provider != NULL);
+
+	if (provider->callback_data_free_func)
+		provider->callback_data_free_func (provider->callback_func, provider->callback_data);
 
 	ep_rt_event_list_free (&provider->event_list, event_free_func);
 	ep_rt_utf16_string_free (provider->provider_name_utf16);

--- a/src/mono/mono/eventpipe/ep-provider.h
+++ b/src/mono/mono/eventpipe/ep-provider.h
@@ -32,8 +32,10 @@ struct _EventPipeProvider_Internal {
 	// List of every event currently associated with the provider.
 	// New events can be added on-the-fly.
 	ep_rt_event_list_t event_list;
-	// The optional provider callback.
+	// The optional provider callback function.
 	EventPipeCallback callback_func;
+	// The optional provider callback_data free callback function.
+	EventPipeCallbackDataFree callback_data_free_func;
 	// The optional provider callback data pointer.
 	void *callback_data;
 	// The configuration object.
@@ -96,6 +98,7 @@ ep_provider_alloc (
 	EventPipeConfiguration *config,
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data);
 
 void

--- a/src/mono/mono/eventpipe/ep-types.h
+++ b/src/mono/mono/eventpipe/ep-types.h
@@ -177,7 +177,11 @@ typedef void (*EventPipeCallback)(
 	uint64_t match_any_keywords,
 	uint64_t match_all_keywords,
 	EventFilterDescriptor *filter_data,
-	void *callback_context);
+	void *callback_data);
+
+typedef void (*EventPipeCallbackDataFree)(
+	EventPipeCallback callback,
+	void *callback_data);
 
 /*
  * EventFilterDescriptor.

--- a/src/mono/mono/eventpipe/ep.c
+++ b/src/mono/mono/eventpipe/ep.c
@@ -1073,6 +1073,7 @@ EventPipeProvider *
 ep_create_provider (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data)
 {
 	ep_return_null_if_nok (provider_name != NULL);
@@ -1085,7 +1086,7 @@ ep_create_provider (
 	EventPipeProviderCallbackDataQueue *provider_callback_data_queue = ep_provider_callback_data_queue_init (&data_queue);
 
 	EP_LOCK_ENTER (section1)
-		provider = config_create_provider (ep_config_get (), provider_name, callback_func, callback_data, provider_callback_data_queue);
+		provider = config_create_provider (ep_config_get (), provider_name, callback_func, callback_data_free_func, callback_data, provider_callback_data_queue);
 		ep_raise_error_if_nok_holding_lock (provider != NULL, section1);
 	EP_LOCK_EXIT (section1)
 

--- a/src/mono/mono/eventpipe/ep.h
+++ b/src/mono/mono/eventpipe/ep.h
@@ -211,6 +211,7 @@ EventPipeProvider *
 ep_create_provider (
 	const ep_char8_t *provider_name,
 	EventPipeCallback callback_func,
+	EventPipeCallbackDataFree callback_data_free_func,
 	void *callback_data);
 
 void

--- a/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-manager-tests.c
@@ -110,7 +110,7 @@ buffer_manager_init (
 
 	test_location = 3;
 
-	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (*provider != NULL);
 
 	test_location = 4;

--- a/src/mono/mono/eventpipe/test/ep-buffer-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-buffer-tests.c
@@ -93,7 +93,7 @@ load_buffer_with_events_init (
 
 	test_location = 2;
 
-	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	*provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (*provider != NULL);
 
 	test_location = 3;

--- a/src/mono/mono/eventpipe/test/ep-fastserializer-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-fastserializer-tests.c
@@ -76,7 +76,7 @@ test_fast_serializer_object_fast_serialize (void)
 
 	test_location = 2;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 3;

--- a/src/mono/mono/eventpipe/test/ep-file-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-file-tests.c
@@ -79,7 +79,7 @@ test_file_write_event (EventPipeSerializationFormat format, bool write_event, bo
 	test_location = 2;
 
 	if (write_event) {
-		provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+		provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 		ep_raise_error_if_nok (provider != NULL);
 
 		test_location = 3;

--- a/src/mono/mono/eventpipe/test/ep-tests.c
+++ b/src/mono/mono/eventpipe/test/ep-tests.c
@@ -33,7 +33,7 @@ test_create_delete_provider (void)
 	RESULT result = NULL;
 	uint32_t test_location = 0;
 
-	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	if (!test_provider) {
 		result = FAILED ("Failed to create provider %s, ep_create_provider returned NULL", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -59,7 +59,7 @@ test_stress_create_delete_provider (void)
 
 	for (uint32_t i = 0; i < 1000; ++i) {
 		char *provider_name = g_strdup_printf (TEST_PROVIDER_NAME "_%i", i);
-		test_providers [i] = ep_create_provider (provider_name, NULL, NULL);
+		test_providers [i] = ep_create_provider (provider_name, NULL, NULL, NULL);
 		g_free (provider_name);
 
 		if (!test_providers [i]) {
@@ -87,7 +87,7 @@ test_get_provider (void)
 	RESULT result = NULL;
 	uint32_t test_location = 0;
 
-	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	if (!test_provider) {
 		result = FAILED ("Failed to create provider %s, ep_create_provider returned NULL", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -128,7 +128,7 @@ test_create_same_provider_twice (void)
 	RESULT result = NULL;
 	uint32_t test_location = 0;
 
-	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	EventPipeProvider *test_provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	if (!test_provider) {
 		result = FAILED ("Failed to create provider %s, ep_create_provider returned NULL", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -144,7 +144,7 @@ test_create_same_provider_twice (void)
 
 	test_location = 2;
 
-	EventPipeProvider *test_provider2 = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	EventPipeProvider *test_provider2 = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	if (test_provider2) {
 		result = FAILED ("Creating an already existing provider %s, succeeded", TEST_PROVIDER_NAME);
 		ep_raise_error ();
@@ -523,7 +523,7 @@ test_create_delete_provider_with_callback (void)
 
 	ep_start_streaming (session_id);
 
-	test_provider = ep_create_provider (TEST_PROVIDER_NAME, provider_callback, &provider_callback_data);
+	test_provider = ep_create_provider (TEST_PROVIDER_NAME, provider_callback, NULL, &provider_callback_data);
 	ep_raise_error_if_nok (test_provider != NULL);
 
 	test_location = 3;
@@ -556,7 +556,7 @@ test_build_event_metadata (void)
 	EventPipeEventInstance *ep_event_instance = NULL;
 	EventPipeEventMetadataEvent *metadata_event = NULL;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 1;
@@ -652,7 +652,7 @@ test_session_write_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -705,7 +705,7 @@ test_session_write_event_seq_point (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -762,7 +762,7 @@ test_session_write_wait_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -827,7 +827,7 @@ test_session_write_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -904,7 +904,7 @@ test_session_write_suspend_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -966,7 +966,7 @@ test_write_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1017,7 +1017,7 @@ test_write_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1076,7 +1076,7 @@ test_write_wait_get_next_event (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;
@@ -1153,7 +1153,7 @@ test_write_event_perf (void)
 
 	test_location = 1;
 
-	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL);
+	provider = ep_create_provider (TEST_PROVIDER_NAME, NULL, NULL, NULL);
 	ep_raise_error_if_nok (provider != NULL);
 
 	test_location = 2;


### PR DESCRIPTION
Delegate callback can be held in native event pipe provider instance and called multiple times during provider lifetime (enable/disable sessions). Store a weak GC reference to delegate to correctly handle case where delegate gets moved by GC. It should not be collected since delegate should be held alive by managed event pipe class.