### PR TITLE
Sprinkle SuppressGCTransition across Unix shim P/Invokes

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.Errors.cs
@@ -193,9 +193,11 @@ internal static partial class Interop
         private static extern unsafe byte* StrErrorR(int platformErrno, byte* buffer, int bufferSize);
 #else
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
+        [SuppressGCTransition]
         internal static extern Error ConvertErrorPlatformToPal(int platformErrno);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPalToPlatform")]
+        [SuppressGCTransition]
         internal static extern int ConvertErrorPalToPlatform(Error error);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StrErrorR")]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Fcntl.Pipe.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.Fcntl.Pipe.cs
@@ -20,6 +20,7 @@ internal static partial class Interop
             internal static extern int SetPipeSz(SafePipeHandle fd, int size);
 
             [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlCanGetSetPipeSz")]
+            [SuppressGCTransition]
             private static extern int FcntlCanGetSetPipeSz();
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDomainSocketSizes.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetDomainSocketSizes.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetDomainSocketSizes")]
+        [SuppressGCTransition]
         internal static extern void GetDomainSocketSizes(out int pathOffset, out int pathSize, out int addressSize);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetMaximumAddressSize.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.GetMaximumAddressSize.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetMaximumAddressSize")]
+        [SuppressGCTransition]
         internal static extern int GetMaximumAddressSize();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetControlMessageBufferSize")]
         [SuppressGCTransition]
-        internal static extern int GetControlMessageBufferSize(bool isIPv4, bool isIPv6);
+        internal static extern int GetControlMessageBufferSize(int isIPv4, int isIPv6);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryGetIPPacketInformation")]
         internal static extern unsafe bool TryGetIPPacketInformation(MessageHeader* messageHeader, bool isIPv4, IPPacketInformation* packetInfo);

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetControlMessageBufferSize")]
+        [SuppressGCTransition]
         internal static extern int GetControlMessageBufferSize(bool isIPv4, bool isIPv6);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryGetIPPacketInformation")]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LChflags.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.LChflags.cs
@@ -20,6 +20,7 @@ internal static partial class Interop
         internal static readonly bool CanSetHiddenFlag = (LChflagsCanSetHiddenFlag() != 0);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LChflagsCanSetHiddenFlag")]
+        [SuppressGCTransition]
         private static extern int LChflagsCanSetHiddenFlag();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MapTcpState.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MapTcpState.cs
@@ -9,6 +9,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MapTcpState")]
+        [SuppressGCTransition]
         internal static extern TcpState MapTcpState(int nativeState);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PlatformSocketSupport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PlatformSocketSupport.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PlatformSupportsDualModeIPv4PacketInfo")]
+        [SuppressGCTransition]
         internal static extern bool PlatformSupportsDualModeIPv4PacketInfo();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PlatformSocketSupport.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.PlatformSocketSupport.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PlatformSupportsDualModeIPv4PacketInfo")]
         [SuppressGCTransition]
-        internal static extern bool PlatformSupportsDualModeIPv4PacketInfo();
+        internal static extern int PlatformSupportsDualModeIPv4PacketInfo();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -57,6 +57,7 @@ internal static partial class Interop
         internal static extern IntPtr OpenDir(string path);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetReadDirRBufferSize", SetLastError = false)]
+        [SuppressGCTransition]
         internal static extern int GetReadDirRBufferSize();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadDirR", SetLastError = false)]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
@@ -16,9 +16,11 @@ internal partial class Interop
         internal delegate void CtrlCallback(CtrlCode ctrlCode);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RegisterForCtrl")]
+        [SuppressGCTransition]
         internal static extern void RegisterForCtrl(CtrlCallback handler);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UnregisterForCtrl")]
+        [SuppressGCTransition]
         internal static extern void UnregisterForCtrl();
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetSignalForBreak.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetSignalForBreak.cs
@@ -8,6 +8,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSignalForBreak")]
+        [SuppressGCTransition]
         internal static extern bool GetSignalForBreak();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSignalForBreak")]

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetSignalForBreak.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetSignalForBreak.cs
@@ -9,9 +9,9 @@ internal static partial class Interop
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSignalForBreak")]
         [SuppressGCTransition]
-        internal static extern bool GetSignalForBreak();
+        internal static extern int GetSignalForBreak();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSignalForBreak")]
-        internal static extern bool SetSignalForBreak(bool signalForBreak);
+        internal static extern int SetSignalForBreak(int signalForBreak);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetTerminalInvalidationHandler.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SetTerminalInvalidationHandler.cs
@@ -10,6 +10,7 @@ internal partial class Interop
         internal delegate void TerminalInvalidationCallback();
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetTerminalInvalidationHandler")]
+        [SuppressGCTransition]
         internal static extern void SetTerminalInvalidationHandler(TerminalInvalidationCallback handler);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -38,11 +38,9 @@ internal static partial class Interop
         internal static extern unsafe Error SetIPv4Address(byte* socketAddress, int socketAddressLen, uint address);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6Address")]
-        [SuppressGCTransition]
         internal static extern unsafe Error GetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint* scopeId);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6Address")]
-        [SuppressGCTransition]
         internal static extern unsafe Error SetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint scopeId);
     }
 }

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -10,30 +10,39 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPSocketAddressSizes")]
+        [SuppressGCTransition]
         internal static extern unsafe Error GetIPSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAddressFamily")]
+        [SuppressGCTransition]
         internal static extern unsafe Error GetAddressFamily(byte* socketAddress, int socketAddressLen, int* addressFamily);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetAddressFamily")]
+        [SuppressGCTransition]
         internal static extern unsafe Error SetAddressFamily(byte* socketAddress, int socketAddressLen, int addressFamily);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPort")]
+        [SuppressGCTransition]
         internal static extern unsafe Error GetPort(byte* socketAddress, int socketAddressLen, ushort* port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetPort")]
+        [SuppressGCTransition]
         internal static extern unsafe Error SetPort(byte* socketAddress, int socketAddressLen, ushort port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4Address")]
+        [SuppressGCTransition]
         internal static extern unsafe Error GetIPv4Address(byte* socketAddress, int socketAddressLen, uint* address);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4Address")]
+        [SuppressGCTransition]
         internal static extern unsafe Error SetIPv4Address(byte* socketAddress, int socketAddressLen, uint address);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6Address")]
+        [SuppressGCTransition]
         internal static extern unsafe Error GetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint* scopeId);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6Address")]
+        [SuppressGCTransition]
         internal static extern unsafe Error SetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint scopeId);
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -370,7 +370,7 @@ int32_t SystemNative_GetReadDirRBufferSize(void)
 {
 #if HAVE_READDIR_R
     // dirent should be under 2k in size
-    assert(sizeof(struct dirent) < 2048);
+    static_assert(sizeof(struct dirent) < 2048);
     // add some extra space so we can align the buffer to dirent.
     return sizeof(struct dirent) + dirent_alignment - 1;
 #else

--- a/src/libraries/Native/Unix/System.Native/pal_io.c
+++ b/src/libraries/Native/Unix/System.Native/pal_io.c
@@ -370,7 +370,7 @@ int32_t SystemNative_GetReadDirRBufferSize(void)
 {
 #if HAVE_READDIR_R
     // dirent should be under 2k in size
-    static_assert(sizeof(struct dirent) < 2048);
+    assert(sizeof(struct dirent) < 2048);
     // add some extra space so we can align the buffer to dirent.
     return sizeof(struct dirent) + dirent_alignment - 1;
 #else

--- a/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/libraries/System.Console/src/System/ConsolePal.Unix.cs
@@ -143,14 +143,14 @@ namespace System
                     return false;
 
                 EnsureConsoleInitialized();
-                return !Interop.Sys.GetSignalForBreak();
+                return Interop.Sys.GetSignalForBreak() == 0;
             }
             set
             {
                 if (!Console.IsInputRedirected)
                 {
                     EnsureConsoleInitialized();
-                    if (!Interop.Sys.SetSignalForBreak(signalForBreak: !value))
+                    if (Interop.Sys.SetSignalForBreak(Convert.ToInt32(value)) == 0)
                         throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo());
                 }
             }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -22,10 +22,8 @@ namespace System.Net.Sockets
         // that get stackalloced in the Linux kernel.
         private const int IovStackThreshold = 8;
 
-        private static bool GetPlatformSupportsDualModeIPv4PacketInfo()
-        {
-            return Interop.Sys.PlatformSupportsDualModeIPv4PacketInfo();
-        }
+        private static bool GetPlatformSupportsDualModeIPv4PacketInfo() =>
+            Interop.Sys.PlatformSupportsDualModeIPv4PacketInfo() != 0;
 
         public static void Initialize()
         {
@@ -422,8 +420,8 @@ namespace System.Net.Sockets
         {
             Debug.Assert(socketAddress != null, "Expected non-null socketAddress");
 
-            int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(isIPv4, isIPv6);
-            var cmsgBuffer = stackalloc byte[cmsgBufferLen];
+            int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(Convert.ToInt32(isIPv4), Convert.ToInt32(isIPv6));
+            byte* cmsgBuffer = stackalloc byte[cmsgBufferLen];
 
             int sockAddrLen = socketAddressLen;
 
@@ -498,8 +496,8 @@ namespace System.Net.Sockets
                 fixed (byte* sockAddr = socketAddress)
                 fixed (Interop.Sys.IOVector* iov = iovecs)
                 {
-                    int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(isIPv4, isIPv6);
-                    var cmsgBuffer = stackalloc byte[cmsgBufferLen];
+                    int cmsgBufferLen = Interop.Sys.GetControlMessageBufferSize(Convert.ToInt32(isIPv4), Convert.ToInt32(isIPv6));
+                    byte* cmsgBuffer = stackalloc byte[cmsgBufferLen];
 
                     var messageHeader = new Interop.Sys.MessageHeader
                     {


### PR DESCRIPTION
Did a quick audit and added it to all the trivial functions that just return a constant or return some static or map one value to another or such things.

@AaronRobinsonMSFT, can you help:
1. Confirm that we actually want to do this, i.e. that it's beneficial even for functions invoked rarely or even once and worth any maintenance headache.
2. That the ones I attributed look approriate.

Thanks.