### PR TITLE
Fix Mono RuntimeType to handle conversion between enums of same underlying type.

### DIFF
--- a/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/RuntimeType.Mono.cs
@@ -2002,7 +2002,7 @@ namespace System
                 Type? type = Enum.GetUnderlyingType(this);
                 if (type == value.GetType())
                     return value;
-                object? res = IsConvertibleToPrimitiveType(value, this);
+                object? res = IsConvertibleToPrimitiveType(value, type);
                 if (res != null)
                     return res;
             }


### PR DESCRIPTION
runtime\src\tests\tracing\common\TraceConfiguration.cs tries to call a constructor of using type System.Diagnostics.Tracing.EventPipeSerializationFormat with a different (but compatbile) enum type using reflection. Both enums are of underlying type, Int32, but the call fails on Mono since it fails to recognize that the two enums are compatible in RuntimeType.CheckValue.

Fix will make sure call to IsConvertibleToPrimitiveType uses underlying type as target type when checking if current value is convertible to a primitive compatible type.