### PR TITLE
add OSPlatform.macOS, switch to OrdinalIgnoreCase for OSPlatform comparisons

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/ref/System.Runtime.InteropServices.RuntimeInformation.cs
@@ -23,6 +23,8 @@ namespace System.Runtime.InteropServices
         public static System.Runtime.InteropServices.OSPlatform FreeBSD { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform iOS { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform Linux { get { throw null; } }
+        public static System.Runtime.InteropServices.OSPlatform macOS { get { throw null; } }
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static System.Runtime.InteropServices.OSPlatform OSX { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform tvOS { get { throw null; } }
         public static System.Runtime.InteropServices.OSPlatform watchOS { get { throw null; } }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -48,10 +48,9 @@ namespace System.Runtime.InteropServices
             return Equals(other._osPlatform);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool Equals(string? other)
         {
-            return other?.Length == _osPlatform?.Length && string.Equals(_osPlatform, other, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(_osPlatform, other, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj)

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -60,7 +60,7 @@ namespace System.Runtime.InteropServices
 
         public override bool Equals(object? obj)
         {
-            return obj is OSPlatform oSPlatform && Equals(oSPlatform);
+            return obj is OSPlatform osPlatform && Equals(osPlatform);
         }
 
         public override int GetHashCode()

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -48,17 +48,17 @@ namespace System.Runtime.InteropServices
 
         internal bool Equals(string? other)
         {
-            return string.Equals(_osPlatform, other, StringComparison.Ordinal);
+            return string.Equals(_osPlatform, other, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj)
         {
-            return obj is OSPlatform && Equals((OSPlatform)obj);
+            return obj is OSPlatform oSPlatform && Equals(oSPlatform);
         }
 
         public override int GetHashCode()
         {
-            return _osPlatform == null ? 0 : _osPlatform.GetHashCode();
+            return _osPlatform == null ? 0 : _osPlatform.GetHashCode(StringComparison.OrdinalIgnoreCase);
         }
 
         public override string ToString()

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -15,6 +15,9 @@ namespace System.Runtime.InteropServices
 
         public static OSPlatform Linux { get; } = new OSPlatform("LINUX");
 
+        public static OSPlatform macOS { get; } = new OSPlatform("MACOS");
+
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
         public static OSPlatform OSX { get; } = new OSPlatform("OSX");
 
         public static OSPlatform iOS { get; } = new OSPlatform("IOS");

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -28,7 +28,7 @@ namespace System.Runtime.InteropServices
 
         public static OSPlatform Windows { get; } = new OSPlatform("WINDOWS");
 
-        internal bool IsCurrent { get; }
+        internal bool IsCurrent { get; } // this information is cached because it's frequently used
 
         private OSPlatform(string osPlatform)
         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 namespace System.Runtime.InteropServices
 {
     public readonly struct OSPlatform : IEquatable<OSPlatform>
@@ -17,7 +19,7 @@ namespace System.Runtime.InteropServices
 
         public static OSPlatform macOS { get; } = new OSPlatform("MACOS");
 
-        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Never)] // superseded by macOS
         public static OSPlatform OSX { get; } = new OSPlatform("OSX");
 
         public static OSPlatform iOS { get; } = new OSPlatform("IOS");
@@ -46,9 +48,10 @@ namespace System.Runtime.InteropServices
             return Equals(other._osPlatform);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool Equals(string? other)
         {
-            return string.Equals(_osPlatform, other, StringComparison.OrdinalIgnoreCase);
+            return other?.Length == _osPlatform?.Length && string.Equals(_osPlatform, other, StringComparison.OrdinalIgnoreCase);
         }
 
         public override bool Equals(object? obj)

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/OSPlatform.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.CompilerServices;
-
 namespace System.Runtime.InteropServices
 {
     public readonly struct OSPlatform : IEquatable<OSPlatform>
@@ -30,14 +28,21 @@ namespace System.Runtime.InteropServices
 
         public static OSPlatform Windows { get; } = new OSPlatform("WINDOWS");
 
+        internal bool IsCurrent { get; }
+
         private OSPlatform(string osPlatform)
         {
             if (osPlatform == null) throw new ArgumentNullException(nameof(osPlatform));
             if (osPlatform.Length == 0) throw new ArgumentException(SR.Argument_EmptyValue, nameof(osPlatform));
 
             _osPlatform = osPlatform;
+            IsCurrent = RuntimeInformation.IsCurrentOSPlatform(osPlatform);
         }
 
+        /// <summary>
+        /// Creates a new OSPlatform instance.
+        /// </summary>
+        /// <remarks>If you plan to call this method frequently, please consider caching its result.</remarks>
         public static OSPlatform Create(string osPlatform)
         {
             return new OSPlatform(osPlatform);

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Browser.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Browser.cs
@@ -5,7 +5,7 @@ namespace System.Runtime.InteropServices
 {
     public static partial class RuntimeInformation
     {
-        public static bool IsOSPlatform(OSPlatform osPlatform) => osPlatform.Equals(OSPlatform.Browser);
+        internal static bool IsCurrentOSPlatform(string osPlatform) => osPlatform.Equals("BROWSER", StringComparison.OrdinalIgnoreCase);
 
         public static string OSDescription => "Browser";
 

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -17,15 +17,9 @@ namespace System.Runtime.InteropServices
         internal static bool IsCurrentOSPlatform(string osPlatform)
         {
             string name = s_osPlatformName ??= Interop.Sys.GetUnixName();
-            if (osPlatform.Equals(name, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-            else if (name == "OSX")
-            {
-                return osPlatform.Equals("MACOS", StringComparison.OrdinalIgnoreCase);
-            }
-            return false;
+
+            return osPlatform.Equals(name, StringComparison.OrdinalIgnoreCase)
+                || (name == "OSX" && osPlatform.Equals("MACOS", StringComparison.OrdinalIgnoreCase)); // GetUnixName returns OSX on macOS
         }
 
         public static string OSDescription => s_osDescription ??= Interop.Sys.GetUnixVersion();

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -17,7 +17,15 @@ namespace System.Runtime.InteropServices
         public static bool IsOSPlatform(OSPlatform osPlatform)
         {
             string name = s_osPlatformName ??= Interop.Sys.GetUnixName();
-            return osPlatform.Equals(name);
+            if (osPlatform.Equals(name))
+            {
+                return true;
+            }
+            else if (name.Length == 3 && name[0] == 'O' && name[1] == 'S' && name[2] == 'X')
+            {
+                return osPlatform.Equals("MACOS");
+            }
+            return false;
         }
 
         public static string OSDescription => s_osDescription ??= Interop.Sys.GetUnixVersion();

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -14,16 +14,16 @@ namespace System.Runtime.InteropServices
         private static Architecture? s_osArch;
         private static Architecture? s_processArch;
 
-        public static bool IsOSPlatform(OSPlatform osPlatform)
+        internal static bool IsCurrentOSPlatform(string osPlatform)
         {
             string name = s_osPlatformName ??= Interop.Sys.GetUnixName();
-            if (osPlatform.Equals(name))
+            if (osPlatform.Equals(name, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
             else if (name.Length == 3 && name[0] == 'O' && name[1] == 'S' && name[2] == 'X')
             {
-                return osPlatform.Equals("MACOS");
+                return osPlatform.Equals("MACOS", StringComparison.OrdinalIgnoreCase);
             }
             return false;
         }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -21,7 +21,7 @@ namespace System.Runtime.InteropServices
             {
                 return true;
             }
-            else if (name.Length == 3 && name[0] == 'O' && name[1] == 'S' && name[2] == 'X')
+            else if (name == "OSX")
             {
                 return osPlatform.Equals("MACOS", StringComparison.OrdinalIgnoreCase);
             }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Windows.cs
@@ -13,10 +13,7 @@ namespace System.Runtime.InteropServices
         private static Architecture? s_osArch;
         private static Architecture? s_processArch;
 
-        public static bool IsOSPlatform(OSPlatform osPlatform)
-        {
-            return OSPlatform.Windows == osPlatform;
-        }
+        internal static bool IsCurrentOSPlatform(string osPlatform) => osPlatform.Equals("WINDOWS", StringComparison.OrdinalIgnoreCase);
 
         public static string OSDescription
         {

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
@@ -48,5 +48,10 @@ namespace System.Runtime.InteropServices
         /// </remarks>
         public static string RuntimeIdentifier =>
             s_runtimeIdentifier ??= AppContext.GetData("RUNTIME_IDENTIFIER") as string ?? "unknown";
+
+        /// <summary>
+        /// Indicates whether the current application is running on the specified platform.
+        /// </summary>
+        public static bool IsOSPlatform(OSPlatform osPlatform) => osPlatform.IsCurrent;
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Runtime.InteropServices.RuntimeInformationTests
@@ -13,10 +12,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("LINUX")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("linux")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("DARWIN")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
-            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("linux")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NetBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("netbsd")));
@@ -31,9 +30,9 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         public void CheckNetBSD()
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NetBSD")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("netbsd")));
 
-            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NetBSD")));
-            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("netbsd")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("DARWIN")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("LINUX")));
@@ -51,12 +50,12 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("OSX")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("osx")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NetBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("netbsd")));
-            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("osx")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("mac")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("DARWIN")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACOSX")));
@@ -70,6 +69,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.iOS));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("IOS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("iOS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("ios")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
@@ -89,6 +90,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.tvOS));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("TVOS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("tvOS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("tvos")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
@@ -108,6 +111,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Android));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("android")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
@@ -127,6 +131,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Browser));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("browser")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
@@ -146,6 +151,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
         {
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("WINDOWS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("windows")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
@@ -153,6 +159,7 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("netbsd")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("windows")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("Windows NT")));
+            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("win")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD));
@@ -212,6 +219,18 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.Equal(winObj.GetHashCode(), winProp.GetHashCode());
             Assert.Equal(0, defaultObj.GetHashCode());
             Assert.Equal(defaultObj.GetHashCode(), conObj.GetHashCode());
+        }
+
+        [Fact]
+        public void StringComparisonOrdinalIgnoreCaseIsUsed()
+        {
+            Assert.Equal(OSPlatform.Create("A"), OSPlatform.Create("a"));
+            Assert.Equal(OSPlatform.Create("A"), OSPlatform.Create("A"));
+            Assert.Equal(OSPlatform.Create("a"), OSPlatform.Create("a"));
+
+            Assert.Equal(OSPlatform.Create("A").GetHashCode(), OSPlatform.Create("a").GetHashCode());
+            Assert.Equal(OSPlatform.Create("A").GetHashCode(), OSPlatform.Create("A").GetHashCode());
+            Assert.Equal(OSPlatform.Create("a").GetHashCode(), OSPlatform.Create("a").GetHashCode());
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckPlatformTests.cs
@@ -51,6 +51,10 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.OSX));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("OSX")));
             Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("osx")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.macOS));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("MACOS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("macOS")));
+            Assert.True(RuntimeInformation.IsOSPlatform(OSPlatform.Create("macos")));
 
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
@@ -157,7 +161,6 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("NetBSD")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("netbsd")));
-            Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("windows")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("Windows NT")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Create("win")));
             Assert.False(RuntimeInformation.IsOSPlatform(OSPlatform.Linux));

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/PlatformVersionTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/PlatformVersionTests.cs
@@ -14,6 +14,11 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             yield return new object[] { OSPlatform.Linux };
             yield return new object[] { OSPlatform.OSX };
             yield return new object[] { OSPlatform.Browser };
+            yield return new object[] { OSPlatform.macOS };
+            yield return new object[] { OSPlatform.iOS };
+            yield return new object[] { OSPlatform.tvOS };
+            yield return new object[] { OSPlatform.watchOS };
+            yield return new object[] { OSPlatform.Android };
         }
 
         [Fact]
@@ -49,6 +54,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Version current = Environment.OSVersion.Version;
 
             Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater($"{osPlatform}{current}"));
+            Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater($"{osPlatform.ToString().ToLower()}{current}"));
+            Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater($"{osPlatform.ToString().ToUpper()}{current}"));
 
             Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater(osPlatform, current.Major));
 
@@ -78,6 +85,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             Version newer = new Version(currentVersion.Major + 1, 0);
             Assert.False(RuntimeInformation.IsOSPlatformOrLater($"{osPlatform}{newer}"));
+            Assert.False(RuntimeInformation.IsOSPlatformOrLater($"{osPlatform.ToString().ToLower()}{newer}"));
+            Assert.False(RuntimeInformation.IsOSPlatformOrLater($"{osPlatform.ToString().ToUpper()}{newer}"));
             Assert.False(RuntimeInformation.IsOSPlatformOrLater(osPlatform, newer.Major));
 
             newer = new Version(currentVersion.Major, currentVersion.Minor + 1);
@@ -104,6 +113,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             Version older = new Version(current.Major - 1, 0);
             Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater($"{osPlatform}{older}"));
+            Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater($"{osPlatform.ToString().ToLower()}{older}"));
+            Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater($"{osPlatform.ToString().ToUpper()}{older}"));
             Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformOrLater(osPlatform, older.Major));
 
             if (current.Minor > 0)
@@ -160,6 +171,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Version current = Environment.OSVersion.Version;
 
             Assert.False(RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform}{current}"));
+            Assert.False(RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform.ToString().ToLower()}{current}"));
+            Assert.False(RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform.ToString().ToUpper()}{current}"));
 
             Assert.False(RuntimeInformation.IsOSPlatformEarlierThan(osPlatform, current.Major));
 
@@ -190,6 +203,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             Version newer = new Version(current.Major + 1, 0);
             Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform}{newer}"));
+            Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform.ToString().ToLower()}{newer}"));
+            Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform.ToString().ToUpper()}{newer}"));
             Assert.Equal(isCurrentPlatfom, RuntimeInformation.IsOSPlatformEarlierThan(osPlatform, newer.Major));
 
             newer = new Version(current.Major, current.Minor + 1);
@@ -215,6 +230,8 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
 
             Version older = new Version(current.Major - 1, 0);
             Assert.False(RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform}{older}"));
+            Assert.False(RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform.ToString().ToLower()}{older}"));
+            Assert.False(RuntimeInformation.IsOSPlatformEarlierThan($"{osPlatform.ToString().ToUpper()}{older}"));
             Assert.False(RuntimeInformation.IsOSPlatformEarlierThan(osPlatform, older.Major));
 
             if (current.Minor > 0)


### PR DESCRIPTION
I tried to introduce as small overhead as possible.

On Windows, there is basically no difference. On OSX there is no difference for "OSX" (old check), but the "macOS" check takes twice the time because we need two comparisons.

I've added the test cases that were missing in #39005 (ignore case comparison was not enabled then)

## Windows

```cs
private readonly OSPlatform _notCurrent = OSPlatform.Create("NOPE");
private readonly OSPlatform _current = OSPlatform.Windows;

[Benchmark]
public bool IsOSPlatform_True() => RuntimeInformation.IsOSPlatform(_current);

[Benchmark]
public bool IsOSPlatform_False() => RuntimeInformation.IsOSPlatform(_notCurrent);
```

```ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.18363.900 (1909/November2018Update/19H2)
Intel Xeon CPU E5-1650 v4 3.60GHz, 1 CPU, 12 logical and 6 physical cores
```

Before:

|             Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|------:|------:|----------:|
|  IsOSPlatform_True | 3.160 ns | 0.0116 ns | 0.0103 ns | 3.158 ns | 3.145 ns | 3.183 ns |     - |     - |     - |         - |
| IsOSPlatform_False | 4.592 ns | 0.0139 ns | 0.0130 ns | 4.590 ns | 4.571 ns | 4.613 ns |     - |     - |     - |         - |

After:

|             Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|------:|------:|----------:|
|  IsOSPlatform_True | 3.177 ns | 0.0210 ns | 0.0197 ns | 3.171 ns | 3.152 ns | 3.213 ns |     - |     - |     - |         - |
| IsOSPlatform_False | 4.739 ns | 0.0126 ns | 0.0112 ns | 4.741 ns | 4.722 ns | 4.761 ns |     - |     - |     - |         - |

### OSX

```ini
BenchmarkDotNet=v0.12.1, OS=macOS Mojave 10.14.5 (18F132) [Darwin 18.6.0]
Intel Core i7-5557U CPU 3.10GHz (Broadwell), 1 CPU, 4 logical and 2 physical cores
```

```cs
private readonly OSPlatform _notCurrent = OSPlatform.Create("NOPE");
private readonly OSPlatform _current = OSPlatform.OSX;
private readonly OSPlatform _macOS = OSPlatform.macOS;

[Benchmark]
public bool IsOSPlatform_True() => RuntimeInformation.IsOSPlatform(_current);

[Benchmark]
public bool IsOSPlatform_macOS() => RuntimeInformation.IsOSPlatform(_macOS );

[Benchmark]
public bool IsOSPlatform_False() => RuntimeInformation.IsOSPlatform(_notCurrent);
```

Before:

|             Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|------:|------:|----------:|
|  IsOSPlatform_True | 2.901 ns | 0.0071 ns | 0.0063 ns | 2.901 ns | 2.892 ns | 2.915 ns |     - |     - |     - |         - |
| IsOSPlatform_macOS | 4.091 ns | 0.0092 ns | 0.0077 ns | 4.089 ns | 4.081 ns | 4.106 ns |     - |     - |     - |         - |
| IsOSPlatform_False | 4.415 ns | 0.0209 ns | 0.0163 ns | 4.411 ns | 4.402 ns | 4.463 ns |     - |     - |     - |         - |

After:

|             Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|------:|------:|----------:|
|  IsOSPlatform_True | 2.887 ns | 0.0057 ns | 0.0048 ns | 2.886 ns | 2.880 ns | 2.897 ns |     - |     - |     - |         - |
| IsOSPlatform_macOS | 7.972 ns | 0.0146 ns | 0.0130 ns | 7.968 ns | 7.956 ns | 7.996 ns |     - |     - |     - |         - |
| IsOSPlatform_False | 9.689 ns | 0.0378 ns | 0.0335 ns | 9.682 ns | 9.627 ns | 9.751 ns |     - |     - |     - |         - |
