### PR TITLE
[Test] EventPipe test enhancements

### DIFF
--- a/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
+++ b/src/tests/tracing/eventpipe/buffersize/buffersize.csproj
@@ -7,6 +7,7 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
+++ b/src/tests/tracing/eventpipe/common/IpcTraceTest.cs
@@ -378,22 +378,6 @@ namespace Tracing.Tests.Common
                         }
                     }
                 }
-
-                // validate we cleaned everything up
-                (currentIpcs, currentPids) = getPidsAndSockets();
-
-                // if there are pipes for processses that don't exist anymore,
-                // or a process has multiple pipes, we failed.
-                foreach (IGrouping<int,FileInfo> group in currentIpcs)
-                {
-                    if (!currentPids.Contains(group.Key) || group.Count() > 1)
-                    {
-                        Logger.logger.Log("Environment is dirty.");
-                        return false;
-                    }
-                }
-                Logger.logger.Log("Environment is clean.");
-
             }
 
             return true;


### PR DESCRIPTION
Fixes #39171

Marks buffersize test as gcstress sensitive.

Removes an attempt to validate that the environment is clean before running IPC tests.  It will still attempt to clean the environment, but validating a clean environment was susceptible to a race with process creation that would force a test failure when the test would have been fine.