### PR TITLE
Allow platform-specific attributes on Fields

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/MinimumOSPlatformAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/MinimumOSPlatformAttribute.cs
@@ -17,6 +17,7 @@ namespace System.Runtime.Versioning
                     AttributeTargets.Class |
                     AttributeTargets.Constructor |
                     AttributeTargets.Event |
+                    AttributeTargets.Field |
                     AttributeTargets.Method |
                     AttributeTargets.Module |
                     AttributeTargets.Property |

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/ObsoletedInOSPlatformAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/ObsoletedInOSPlatformAttribute.cs
@@ -13,6 +13,7 @@ namespace System.Runtime.Versioning
                     AttributeTargets.Class |
                     AttributeTargets.Constructor |
                     AttributeTargets.Event |
+                    AttributeTargets.Field |
                     AttributeTargets.Method |
                     AttributeTargets.Module |
                     AttributeTargets.Property |

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/RemovedInOSPlatformAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Versioning/RemovedInOSPlatformAttribute.cs
@@ -14,6 +14,7 @@ namespace System.Runtime.Versioning
                     AttributeTargets.Class |
                     AttributeTargets.Constructor |
                     AttributeTargets.Event |
+                    AttributeTargets.Field |
                     AttributeTargets.Method |
                     AttributeTargets.Module |
                     AttributeTargets.Property |

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9923,12 +9923,12 @@ namespace System.Runtime.Versioning
         public static bool operator !=(System.Runtime.Versioning.FrameworkName? left, System.Runtime.Versioning.FrameworkName? right) { throw null; }
         public override string ToString() { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     public sealed class MinimumOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
     {
         public MinimumOSPlatformAttribute(string platformName) : base(platformName) { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     public sealed class ObsoletedInOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
     {
         public ObsoletedInOSPlatformAttribute(string platformName) : base(platformName) { }
@@ -9941,7 +9941,7 @@ namespace System.Runtime.Versioning
         private protected OSPlatformAttribute(string platformName) { }
         public string PlatformName { get; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Event | System.AttributeTargets.Field | System.AttributeTargets.Method | System.AttributeTargets.Module | System.AttributeTargets.Property | System.AttributeTargets.Struct, AllowMultiple = true, Inherited = false)]
     public sealed class RemovedInOSPlatformAttribute : System.Runtime.Versioning.OSPlatformAttribute
     {
         public RemovedInOSPlatformAttribute(string platformName) : base(platformName) { }


### PR DESCRIPTION
Per https://github.com/dotnet/designs/pull/138#discussion_r452869905, we want to be able to mark Enum members (and other Fields) as platform-specific.