### PR TITLE
WASM: Add PNSE for System.Net.NameResolution and disable tests

### DIFF
--- a/src/libraries/System.Net.NameResolution/src/ExcludeApiList.PNSE.Browser.txt
+++ b/src/libraries/System.Net.NameResolution/src/ExcludeApiList.PNSE.Browser.txt
@@ -1,0 +1,1 @@
+M:System.Net.Dns.GetHostName

--- a/src/libraries/System.Net.NameResolution/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.NameResolution/src/Resources/Strings.resx
@@ -72,4 +72,7 @@
   <data name="net_invalid_ip_addr" xml:space="preserve">
     <value>IPv4 address 0.0.0.0 and IPv6 address ::0 are unspecified addresses that cannot be used as a target address.</value>
   </data>
+  <data name="NameResolution_PlatformNotSupported" xml:space="preserve">
+    <value>System.Net.NameResolution is not supported on this platform.</value>
+  </data>
 </root>

--- a/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -5,7 +5,11 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <ItemGroup>
+  <PropertyGroup>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.NameResolution_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAdditionalParameters Condition="'$(TargetsBrowser)' == 'true'">--exclude-api-list ExcludeApiList.PNSE.Browser.txt</GeneratePlatformNotSupportedAdditionalParameters>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
     <Compile Include="System\Net\Dns.cs" />
     <Compile Include="System\Net\IPHostEntry.cs" />
     <Compile Include="System\Net\NetEventSource.NameResolution.cs" />
@@ -69,7 +73,7 @@
     <Compile Include="$(CommonPath)Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs"
              Link="Common\Interop\Windows\WinSock\Interop.GetAddrInfoExW.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true' ">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
     <Compile Include="System\Net\NameResolutionPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\InteropIPAddressExtensions.Unix.cs"
              Link="Common\System\Net\InteropIPAddressExtensions.Unix.cs" />
@@ -101,6 +105,9 @@
              Link="Common\Interop\Unix\System.Native\Interop.Socket.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs"
              Link="Common\Interop\Unix\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
+    <Compile Include="System\Net\Dns.Browser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.Browser.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.Browser.cs
@@ -1,0 +1,15 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace System.Net
+{
+    public static partial class Dns
+    {
+        public static string GetHostName()
+        {
+            return Environment.MachineName;
+        }
+    }
+}

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+[assembly: SkipOnMono("System.Net.NameResolution is not supported on wasm.", TestPlatforms.Browser)]

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/System.Net.NameResolution.Functional.Tests.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
+    <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="GetHostByAddressTest.cs" />
     <Compile Include="GetHostByNameTest.cs" />
     <Compile Include="ResolveTest.cs" />

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+[assembly: SkipOnMono("System.Net.NameResolution is not supported on wasm.", TestPlatforms.Browser)]

--- a/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -4,6 +4,7 @@
     <StringResourcesPath>../../src/Resources/Strings.resx</StringResourcesPath>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <Nullable>annotations</Nullable>
+    <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
   </PropertyGroup>
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
   <ItemGroup>
@@ -13,6 +14,7 @@
     <Compile Include="..\..\src\System\Net\IPHostEntry.cs"
              Link="ProductionCode\System\Net\IPHostEntry.cs" />
     <Compile Include="Fakes\FakeContextAwareResult.cs" />
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="NameResolutionPalTests.cs" />
     <Compile Include="Fakes\DnsFake.cs" />
     <Compile Include="Fakes\IPAddressFakeExtensions.cs" />

--- a/src/libraries/System.Net.NameResolution/tests/UnitTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.NameResolution/tests/UnitTests/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+[assembly: SkipOnMono("System.Net.NameResolution is not supported on wasm.", TestPlatforms.Browser)]

--- a/src/libraries/System.Net.NameResolution/tests/UnitTests/System.Net.NameResolution.Unit.Tests.csproj
+++ b/src/libraries/System.Net.NameResolution/tests/UnitTests/System.Net.NameResolution.Unit.Tests.csproj
@@ -6,6 +6,7 @@
     <NoWarn>0436</NoWarn>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>
     <Nullable>annotations</Nullable>
+    <IgnoreForCI Condition="'$(TargetOS)' == 'Browser'">true</IgnoreForCI>
   </PropertyGroup>
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
   <ItemGroup>
@@ -18,6 +19,7 @@
              Link="ProductionCode\System\Net\Dns.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="InitializationTest.cs" />
     <Compile Include="XunitTestAssemblyAtrributes.cs" />
     <!-- Fakes -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -46,8 +46,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\UnitTests\System.Net.Http.Unit.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NameResolution\tests\FunctionalTests\System.Net.NameResolution.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.NameResolution\tests\PalTests\System.Net.NameResolution.Pal.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Security\tests\FunctionalTests\System.Net.Security.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Sockets\tests\FunctionalTests\System.Net.Sockets.Tests.csproj" />

--- a/src/mono/wasm/wasm.targets
+++ b/src/mono/wasm/wasm.targets
@@ -21,7 +21,6 @@
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.IO.MemoryMappedFiles\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.IO.MemoryMappedFiles.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Net.Sockets\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Net.Sockets.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Net.Primitives\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Net.Primitives.dll"/>
-    <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Net.NameResolution\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Net.NameResolution.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Security.Cryptography.Algorithms\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Security.Cryptography.Algorithms.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.IO.Compression\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.IO.Compression.dll"/>
     <!--<WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.IO.Compression.Brotli\$(NetCoreAppCurrent)-Unix-$(Configuration)\System.IO.Compression.Brotli.dll"/>-->


### PR DESCRIPTION
We only support `Dns.GetHostName()` since that didn't throw in the older mono WebAssembly release and can be redirected to `Environment.MachineName`.