### PR TITLE
ARM64: Eliminate redundant ldr/str instruction

### DIFF
--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -15503,8 +15503,8 @@ bool emitter::IsRedundantLdStr(instruction ins, regNumber dst, regNumber src, ss
         return false;
     }
 
-    regNumber prevDst = emitLastIns->idReg1();
-    regNumber prevSrc = emitLastIns->idReg2();
+    regNumber prevDst    = emitLastIns->idReg1();
+    regNumber prevSrc    = emitLastIns->idReg2();
     insFormat lastInsfmt = emitLastIns->idInsFmt();
     ssize_t prevImm = emitLastIns->idIsLargeCns() ? ((instrDescCns*)emitLastIns)->idcCnsVal : emitLastIns->idSmallCns();
 

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -15521,10 +15521,14 @@ bool emitter::IsRedundantLdStr(
     regNumber prevReg1   = emitLastIns->idReg1();
     regNumber prevReg2   = emitLastIns->idReg2();
     insFormat lastInsfmt = emitLastIns->idInsFmt();
+    emitAttr  prevSize   = emitLastIns->idOpSize();
     ssize_t prevImm = emitLastIns->idIsLargeCns() ? ((instrDescCns*)emitLastIns)->idcCnsVal : emitLastIns->idSmallCns();
 
-    // Only optimize for "base" or "base plus immediate offset" addressing modes.
-    if (((fmt != IF_LS_2A) && (fmt != IF_LS_2B)) || fmt != lastInsfmt)
+    // Only optimize if:
+    // 1. "base" or "base plus immediate offset" addressing modes.
+    // 2. Addressing mode matches with previous instruction.
+    // 3. The operand size matches with previous instruction
+    if (((fmt != IF_LS_2A) && (fmt != IF_LS_2B)) || (fmt != lastInsfmt) || (prevSize != size))
     {
         return false;
     }

--- a/src/coreclr/src/jit/emitarm64.cpp
+++ b/src/coreclr/src/jit/emitarm64.cpp
@@ -5541,6 +5541,9 @@ void emitter::emitIns_R_R_I(
         }
 
         // Is the ldr/str even necessary?
+        // For volatile load/store, there will be memory barrier instruction before/after the load/store
+        // and in such case, IsRedundantLdStr() returns false, because the method just checks for load/store
+        // pair next to each other.
         if (emitComp->opts.OptimizationEnabled() && IsRedundantLdStr(ins, reg1, reg2, imm, size, fmt))
         {
             return;
@@ -15538,7 +15541,7 @@ bool emitter::IsRedundantLdStr(
         // If reg1 is of size less than 8-bytes, then eliminating the 'ldr'
         // will not zero the upper bits of reg1.
 
-        // Make sure operand size is not 4-bytes
+        // Make sure operand size is 8-bytes
         //  str w0, [x1, #4]
         //  ldr w0, [x1, #4]  <-- can't eliminate because upper-bits of x0 won't get set.
         if (size != EA_8BYTE)

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -119,6 +119,7 @@ static UINT64 Replicate_helper(UINT64 value, unsigned width, emitAttr size);
 // Method to do check if mov is redundant with respect to the last instruction.
 // If yes, the caller of this method can choose to omit current mov instruction.
 bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src);
+bool IsRedundantLdStr(instruction ins, regNumber dst, regNumber src, ssize_t imm);
 
 /************************************************************************
 *

--- a/src/coreclr/src/jit/emitarm64.h
+++ b/src/coreclr/src/jit/emitarm64.h
@@ -119,7 +119,7 @@ static UINT64 Replicate_helper(UINT64 value, unsigned width, emitAttr size);
 // Method to do check if mov is redundant with respect to the last instruction.
 // If yes, the caller of this method can choose to omit current mov instruction.
 bool IsRedundantMov(instruction ins, emitAttr size, regNumber dst, regNumber src);
-bool IsRedundantLdStr(instruction ins, regNumber dst, regNumber src, ssize_t imm);
+bool IsRedundantLdStr(instruction ins, regNumber reg1, regNumber reg2, ssize_t imm, emitAttr size, insFormat fmt);
 
 /************************************************************************
 *


### PR DESCRIPTION
Added optimizer to check if we can eliminate ldr/str instruction based on previous instruction.

```
PMI CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  protononjit.dll
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -22704 (-0.041% of base)
    diff is an improvement.
Top file improvements (bytes):
       -4064 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.065% of base)
       -3296 : Microsoft.CodeAnalysis.dasm (-0.160% of base)
       -2376 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.068% of base)
       -1836 : Microsoft.CodeAnalysis.CSharp.dasm (-0.037% of base)
        -920 : System.Private.CoreLib.dasm (-0.016% of base)
        -704 : System.ComponentModel.TypeConverter.dasm (-0.199% of base)
        -692 : System.Private.Xml.dasm (-0.017% of base)
        -648 : System.Collections.Immutable.dasm (-0.052% of base)
        -400 : System.Data.Common.dasm (-0.023% of base)
        -328 : System.Security.Cryptography.Pkcs.dasm (-0.063% of base)
        -320 : System.Private.DataContractSerialization.dasm (-0.035% of base)
        -304 : System.Threading.Tasks.Parallel.dasm (-0.177% of base)
        -292 : System.Text.Json.dasm (-0.038% of base)
        -288 : Microsoft.VisualBasic.Core.dasm (-0.053% of base)
        -276 : System.Threading.Tasks.Dataflow.dasm (-0.026% of base)
        -204 : System.Linq.Expressions.dasm (-0.022% of base)
        -200 : System.Reflection.Metadata.dasm (-0.039% of base)
        -196 : System.Drawing.Common.dasm (-0.062% of base)
        -184 : System.ComponentModel.Composition.dasm (-0.047% of base)
        -180 : System.DirectoryServices.dasm (-0.037% of base)
152 total files with Code Size differences (152 improved, 0 regressed), 112 unchanged.
Top method improvements (bytes):
       -1824 (-1.745% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ApplicationServerTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -676 (-2.242% of base) : System.ComponentModel.TypeConverter.dasm - CultureInfoMapper:CreateMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
        -288 (-3.304% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.PeWriter:WriteHeaders(System.IO.Stream,Microsoft.Cci.NtHeader,Microsoft.Cci.CoffHeader,System.Collections.Generic.List`1[[Microsoft.Cci.SectionHeader, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref):this
        -140 (-1.079% of base) : System.Data.Common.dasm - System.Data.XmlTreeGen:HandleTable(System.Data.DataTable,System.Xml.XmlDocument,System.Xml.XmlElement,bool):System.Xml.XmlElement:this
        -124 (-0.191% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.CtfTraceEventSource:InitEventMap():System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.ETWMapping, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]
        -124 (-0.821% of base) : System.Private.Xml.dasm - System.Xml.Serialization.XmlReflectionImporter:ImportAccessorMapping(System.Xml.Serialization.MemberMapping,System.Xml.Serialization.FieldModel,System.Xml.Serialization.XmlAttributes,System.String,System.Type,bool,bool,System.Xml.Serialization.RecursionLimiter):this
        -116 (-0.373% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.ClrPrivateTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
        -112 (-1.194% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:DecodeModifiers(Microsoft.CodeAnalysis.SyntaxTokenList,int,int,int,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.MemberModifiers:this
        -108 (-1.395% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:DecodeParameterList(Microsoft.CodeAnalysis.VisualBasic.Symbol,bool,int,Microsoft.CodeAnalysis.SeparatedSyntaxList`1[[Microsoft.CodeAnalysis.VisualBasic.Syntax.ParameterSyntax, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],Microsoft.CodeAnalysis.ArrayBuilder`1[[Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],CheckParameterModifierDelegate,Microsoft.CodeAnalysis.DiagnosticBag):this
        -100 (-0.688% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:ReportOverloadResolutionFailureForASingleCandidate(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.Location,int,byref,System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.BoundExpression, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],System.Collections.Immutable.ImmutableArray`1[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],bool,bool,bool,bool,Microsoft.CodeAnalysis.DiagnosticBag,Microsoft.CodeAnalysis.VisualBasic.Symbol,bool,Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxNode,Microsoft.CodeAnalysis.VisualBasic.Symbol):this
         -92 (-0.201% of base) : Microsoft.Diagnostics.Tracing.TraceEvent.dasm - Microsoft.Diagnostics.Tracing.Parsers.KernelTraceEventParser:EnumerateTemplates(System.Func`3[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[Microsoft.Diagnostics.Tracing.EventFilterResponse, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]],System.Action`1[[Microsoft.Diagnostics.Tracing.TraceEvent, Microsoft.Diagnostics.Tracing.TraceEvent, Version=2.0.49.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]):this
         -76 (-4.600% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Symbols.MethodSignatureComparer:DetailedParameterCompare(System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref,System.Collections.Immutable.ImmutableArray`1[[Microsoft.CodeAnalysis.VisualBasic.Symbols.ParameterSymbol, Microsoft.CodeAnalysis.VisualBasic, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref,int,int):int
         -72 (-3.147% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.PeWriter:WriteCorHeader(System.IO.Stream,Microsoft.Cci.CorHeader)
         -72 (-0.965% of base) : System.Text.Json.dasm - System.Text.Json.JsonDocument:Parse(System.ReadOnlySpan`1[Byte],System.Text.Json.JsonReaderOptions,byref,byref)
         -68 (-1.700% of base) : System.Private.DataContractSerialization.dasm - CriticalHelper:WriteMembers(System.Runtime.Serialization.ClassDataContract,System.Reflection.Emit.LocalBuilder,System.Runtime.Serialization.ClassDataContract):int:this (2 methods)
         -60 (-2.083% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.PeWriter:WriteDirectory(Directory,Microsoft.Cci.BlobBuilder,int,int,int,int,Microsoft.Cci.BlobBuilder):this
         -60 (-0.192% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineParser:Parse(System.Collections.Generic.IEnumerable`1[[System.String, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]],System.String,System.String,System.String):Microsoft.CodeAnalysis.VisualBasic.VisualBasicCommandLineArguments:this
         -60 (-1.304% of base) : System.Private.Uri.dasm - System.Uri:ReCreateParts(int,ushort,int):System.String:this
         -56 (-1.007% of base) : Microsoft.CodeAnalysis.VisualBasic.dasm - Microsoft.CodeAnalysis.VisualBasic.Binder:BindAttribute(Microsoft.CodeAnalysis.VisualBasic.Syntax.AttributeSyntax,Microsoft.CodeAnalysis.VisualBasic.Symbols.NamedTypeSymbol,Microsoft.CodeAnalysis.DiagnosticBag):Microsoft.CodeAnalysis.VisualBasic.BoundAttribute:this
         -56 (-0.440% of base) : System.Formats.Asn1.dasm - System.Formats.Asn1.AsnWriter:WriteGeneralizedTimeCore(System.Formats.Asn1.Asn1Tag,System.DateTimeOffset,bool):this
Top method improvements (percentages):
         -12 (-30.000% of base) : System.Private.Xml.dasm - MS.Internal.Xml.Cache.XPathNodeInfoAtom:.ctor(System.String,System.String,System.String,System.String,MS.Internal.Xml.Cache.XPathNode[],MS.Internal.Xml.Cache.XPathNode[],MS.Internal.Xml.Cache.XPathNode[],System.Xml.XPath.XPathDocument,int,int):this
         -12 (-27.273% of base) : System.DirectoryServices.Protocols.dasm - System.DirectoryServices.Protocols.LdapPal:SearchDirectory(System.DirectoryServices.Protocols.ConnectionHandle,System.String,int,System.String,long,bool,long,long,int,int,byref):int
          -8 (-22.222% of base) : System.Data.Common.dasm - System.Data.SqlTypes.SqlInt16:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlInt16
          -8 (-22.222% of base) : System.Data.Common.dasm - System.Data.SqlTypes.SqlByte:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlByte
          -4 (-16.667% of base) : System.Private.CoreLib.dasm - System.ValueTuple:Create(double):System.ValueTuple`1[Double]
          -4 (-16.667% of base) : System.Private.DataContractSerialization.dasm - XmlTextNode:.ctor(int,System.Xml.PrefixHandle,System.Xml.StringHandle,System.Xml.ValueHandle,int,int,XmlAttributeTextNode,int):this
          -4 (-14.286% of base) : Microsoft.CodeAnalysis.dasm - Roslyn.Utilities.ImmutableArrayInterop:DangerousGetUnderlyingArray(System.Collections.Immutable.ImmutableArray`1[Byte]):System.Byte[]
          -4 (-14.286% of base) : System.Console.dasm - System.Console:MoveBufferArea(int,int,int,int,int,int,ushort,int,int)
         -12 (-14.286% of base) : System.Drawing.Common.dasm - System.Windows.Forms.DpiHelper:CreateScaledBitmap(System.Drawing.Bitmap):System.Drawing.Bitmap
          -4 (-14.286% of base) : System.Private.CoreLib.dasm - System.TupleExtensions:ToValueTuple(System.Tuple`1[Double]):System.ValueTuple`1[Double]
          -4 (-14.286% of base) : System.Reflection.Metadata.dasm - System.Reflection.Internal.ImmutableByteArrayInterop:DangerousGetUnderlyingArray(System.Collections.Immutable.ImmutableArray`1[Byte]):System.Byte[]
          -4 (-12.500% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.BlobWriter:ToImmutableArray(int,int):System.Collections.Immutable.ImmutableArray`1[Byte]:this
          -4 (-12.500% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.BlobWriter:WriteBytes(System.Collections.Immutable.ImmutableArray`1[Byte],int,int):this
          -4 (-12.500% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.BlobBuilder:WriteBytes(System.Collections.Immutable.ImmutableArray`1[Byte],int,int):this
          -4 (-12.500% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.BlobBuilder:ToImmutableArray(int,int):System.Collections.Immutable.ImmutableArray`1[Byte]:this
          -4 (-12.500% of base) : System.Linq.Parallel.dasm - System.Linq.Parallel.GroupByGrouping`2[Double,Int64][System.Double,System.Int64]:System.Linq.IGrouping<TGroupKey,TElement>.get_Key():double:this
          -4 (-12.500% of base) : System.Private.CoreLib.dasm - System.Globalization.JapaneseCalendar:ToDateTime(int,int,int,int,int,int,int,int):System.DateTime:this
          -4 (-12.500% of base) : System.Private.CoreLib.dasm - System.Globalization.KoreanCalendar:ToDateTime(int,int,int,int,int,int,int,int):System.DateTime:this
          -4 (-12.500% of base) : System.Private.CoreLib.dasm - System.Globalization.TaiwanCalendar:ToDateTime(int,int,int,int,int,int,int,int):System.DateTime:this
          -4 (-12.500% of base) : System.Private.CoreLib.dasm - System.Globalization.ThaiBuddhistCalendar:ToDateTime(int,int,int,int,int,int,int,int):System.DateTime:this
3308 total methods with Code Size differences (3308 improved, 0 regressed), 307138 unchanged.
```

```
Crossgen CodeSize Diffs for System.Private.CoreLib.dll, framework assemblies for  protononjit.dll
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -32520 (-0.031% of base)
    diff is an improvement.
Top file improvements (bytes):
      -11272 : Microsoft.CodeAnalysis.dasm (-0.287% of base)
       -6808 : System.Private.CoreLib.dasm (-0.063% of base)
       -3232 : Microsoft.CodeAnalysis.VisualBasic.dasm (-0.027% of base)
       -1744 : Microsoft.CodeAnalysis.CSharp.dasm (-0.016% of base)
       -1296 : System.Security.Cryptography.Pkcs.dasm (-0.179% of base)
        -808 : System.Private.Xml.dasm (-0.009% of base)
        -472 : System.Linq.Expressions.dasm (-0.020% of base)
        -376 : System.Data.Common.dasm (-0.012% of base)
        -352 : Microsoft.VisualBasic.Core.dasm (-0.029% of base)
        -336 : System.Collections.Immutable.dasm (-0.036% of base)
        -320 : System.Security.Cryptography.Algorithms.dasm (-0.047% of base)
        -304 : System.Drawing.Common.dasm (-0.035% of base)
        -304 : System.Reflection.Metadata.dasm (-0.032% of base)
        -272 : System.Private.Uri.dasm (-0.137% of base)
        -248 : Microsoft.Diagnostics.Tracing.TraceEvent.dasm (-0.003% of base)
        -232 : System.Security.Cryptography.X509Certificates.dasm (-0.066% of base)
        -224 : System.Security.Cryptography.Cng.dasm (-0.055% of base)
        -224 : System.Text.Encoding.CodePages.dasm (-0.112% of base)
        -200 : System.DirectoryServices.dasm (-0.018% of base)
        -200 : System.Private.DataContractSerialization.dasm (-0.009% of base)
100 total files with Code Size differences (100 improved, 0 regressed), 164 unchanged.
Top method improvements (bytes):
       -4416 (-3.291% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.CodeAnalysis.DesktopAssemblyIdentityComparer:.cctor() (4 methods)
       -1072 (-4.257% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.PeWriter:WriteHeaders(System.IO.Stream,Microsoft.Cci.NtHeader,Microsoft.Cci.CoffHeader,System.Collections.Generic.List`1[[Microsoft.Cci.SectionHeader, Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]],byref):this (4 methods)
        -528 (-4.215% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]:GetHashCode():int:this (4 methods)
        -360 (-0.903% of base) : System.Private.Xml.dasm - System.Xml.Serialization.XmlReflectionImporter:ImportAccessorMapping(System.Xml.Serialization.MemberMapping,System.Xml.Serialization.FieldModel,System.Xml.Serialization.XmlAttributes,System.String,System.Type,bool,bool,System.Xml.Serialization.RecursionLimiter):this (2 methods)
        -224 (-2.288% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.PeWriter:WriteDirectory(Directory,Microsoft.Cci.BlobBuilder,int,int,int,int,Microsoft.Cci.BlobBuilder):this (4 methods)
        -216 (-4.103% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`1[System.__Canon]]]:GetHashCode():int:this (2 methods)
        -216 (-4.079% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`2[System.__Canon,System.__Canon]]]:GetHashCode():int:this (2 methods)
        -216 (-4.079% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`3[System.__Canon,System.__Canon,System.__Canon]]]:GetHashCode():int:this (2 methods)
        -216 (-4.066% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`4[System.__Canon,System.__Canon,System.__Canon,System.__Canon]]]:GetHashCode():int:this (2 methods)
        -216 (-4.066% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`5[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]]]:GetHashCode():int:this (2 methods)
        -216 (-4.054% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`6[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]]]:GetHashCode():int:this (2 methods)
        -216 (-4.054% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,ValueTuple`8][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`8[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.ValueTuple`7[System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]]]:GetHashCode():int:this (2 methods)
        -208 (-3.009% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.MetadataWriter:SerializeAssemblyRefTable(Microsoft.Cci.BlobBuilder,Microsoft.Cci.MetadataSizes):this (4 methods)
        -192 (-3.133% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.MetadataWriter:SerializeAssemblyTable(Microsoft.Cci.BlobBuilder,Microsoft.Cci.MetadataSizes):this (4 methods)
        -192 (-2.098% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]:ToString():System.String:this (4 methods)
        -192 (-2.174% of base) : System.Private.CoreLib.dasm - System.ValueTuple`8[__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon,__Canon][System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon,System.__Canon]:System.IValueTupleInternal.ToStringEnd():System.String:this (4 methods)
        -176 (-3.134% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.MetadataWriter:SerializeTypeDefTable(Microsoft.Cci.BlobBuilder,Microsoft.Cci.MetadataSizes):this (4 methods)
        -160 (-3.367% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.MetadataWriter:SerializeExceptionRegion(Microsoft.Cci.ExceptionHandlerRegion,bool,Microsoft.Cci.BlobBuilder):this (4 methods)
        -160 (-3.311% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.MetadataWriter:SerializeMethodDefTable(Microsoft.Cci.BlobBuilder,Microsoft.Cci.MetadataSizes,int):this (4 methods)
        -144 (-1.571% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.BlobWriterImpl:WriteConstant(Microsoft.Cci.BlobBuilder,System.Object) (4 methods)
Top method improvements (percentages):
          -8 (-14.286% of base) : System.Reflection.Metadata.dasm - System.Reflection.Internal.ImmutableByteArrayInterop:DangerousGetUnderlyingArray(System.Collections.Immutable.ImmutableArray`1[Byte]):System.Byte[] (2 methods)
         -16 (-12.500% of base) : System.Data.Common.dasm - System.Data.SqlTypes.SqlInt16:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlInt16 (2 methods)
         -16 (-12.500% of base) : System.Data.Common.dasm - System.Data.SqlTypes.SqlByte:op_Explicit(System.Data.SqlTypes.SqlDecimal):System.Data.SqlTypes.SqlByte (2 methods)
          -8 (-10.000% of base) : System.Private.CoreLib.dasm - System.Runtime.Intrinsics.Vector128:AsVector2(System.Runtime.Intrinsics.Vector128`1[Single]):System.Numerics.Vector2 (2 methods)
         -24 (-9.677% of base) : System.Drawing.Common.dasm - System.Windows.Forms.DpiHelper:CreateScaledBitmap(System.Drawing.Bitmap):System.Drawing.Bitmap (2 methods)
         -16 (-9.091% of base) : Microsoft.CodeAnalysis.dasm - Microsoft.Cci.BlobBuilder:ToImmutableArray(int,int):System.Collections.Immutable.ImmutableArray`1[Byte]:this (4 methods)
          -8 (-9.091% of base) : System.Reflection.Metadata.dasm - System.Reflection.BlobUtilities:ReadImmutableBytes(long,int):System.Collections.Immutable.ImmutableArray`1[Byte] (2 methods)
          -8 (-9.091% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.BlobWriter:ToImmutableArray(int,int):System.Collections.Immutable.ImmutableArray`1[Byte]:this (2 methods)
          -8 (-9.091% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.BlobBuilder:ToImmutableArray(int,int):System.Collections.Immutable.ImmutableArray`1[Byte]:this (2 methods)
          -8 (-9.091% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.BlobBuilder:WriteBytes(System.Collections.Immutable.ImmutableArray`1[Byte],int,int):this (2 methods)
          -8 (-9.091% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.BlobContentId:.ctor(System.Collections.Immutable.ImmutableArray`1[Byte]):this (2 methods)
          -8 (-9.091% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.BlobContentId:FromHash(System.Collections.Immutable.ImmutableArray`1[Byte]):System.Reflection.Metadata.BlobContentId (2 methods)
         -16 (-8.000% of base) : System.Data.Common.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlByte():System.Data.SqlTypes.SqlByte:this (2 methods)
         -16 (-8.000% of base) : System.Data.Common.dasm - System.Data.SqlTypes.SqlDecimal:ToSqlInt16():System.Data.SqlTypes.SqlInt16:this (2 methods)
          -8 (-7.692% of base) : System.Private.CoreLib.dasm - TIME_DYNAMIC_ZONE_INFORMATION:GetTimeZoneKeyName():System.String:this (2 methods)
          -8 (-7.692% of base) : System.Private.CoreLib.dasm - TIME_ZONE_INFORMATION:GetStandardName():System.String:this (2 methods)
          -8 (-7.692% of base) : System.Private.CoreLib.dasm - TIME_ZONE_INFORMATION:GetDaylightName():System.String:this (2 methods)
          -8 (-7.692% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.MetadataReader:GetBlobContent(System.Reflection.Metadata.BlobHandle):System.Collections.Immutable.ImmutableArray`1[Byte]:this (2 methods)
         -16 (-7.407% of base) : Newtonsoft.Json.dasm - Newtonsoft.Json.JsonReader:ReadAsInt32Async(System.Threading.CancellationToken):System.Threading.Tasks.Task`1[Nullable`1]:this (2 methods)
          -8 (-6.667% of base) : System.Reflection.Metadata.dasm - System.Reflection.Metadata.BlobWriter:ToImmutableArray():System.Collections.Immutable.ImmutableArray`1[Byte]:this (2 methods)
1442 total methods with Code Size differences (1442 improved, 0 regressed), 198346 unchanged.
```


Fixes: #35613 and #35614