### PR TITLE
WASM: Fix System.Diagnostics.TraceSource tests

### DIFF
--- a/src/libraries/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -337,7 +337,7 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.IndentLevel = 0;
             Trace.WriteLine("Message end.");
             textTL.Flush();
-            var testRunnerAssemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
+            string testRunnerAssemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
             string newLine = Environment.NewLine;
             var expected =
                 string.Format(

--- a/src/libraries/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/TraceClassTests.cs
@@ -11,8 +11,6 @@ namespace System.Diagnostics.TraceSourceTests
 
     public class TraceClassTests : IDisposable
     {
-        private readonly string TestRunnerAssemblyName = Assembly.GetEntryAssembly().GetName().Name;
-
         void IDisposable.Dispose()
         {
             TraceTestHelper.ResetState();
@@ -339,11 +337,12 @@ namespace System.Diagnostics.TraceSourceTests
             Trace.IndentLevel = 0;
             Trace.WriteLine("Message end.");
             textTL.Flush();
+            var testRunnerAssemblyName = Assembly.GetEntryAssembly()?.GetName().Name ?? string.Empty;
             string newLine = Environment.NewLine;
             var expected =
                 string.Format(
                     "Message start." + newLine + "    This message should be indented.{0} Error: 0 : This error not be indented." + newLine + "    {0} Error: 0 : This error is indented" + newLine + "    {0} Warning: 0 : This warning is indented" + newLine + "    {0} Warning: 0 : This warning is also indented" + newLine + "    {0} Information: 0 : This information in indented" + newLine + "    {0} Information: 0 : This information is also indented" + newLine + "Message end." + newLine + "",
-                    TestRunnerAssemblyName
+                    testRunnerAssemblyName
                 );
 
             Assert.Equal(expected, textTL.Output);

--- a/src/libraries/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
@@ -48,6 +48,7 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         public void CallstackTest_NotEmpty()
         {
             var cache = new TraceEventCache();
@@ -55,6 +56,7 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         public void CallstackTest_ContainsExpectedFrames()
         {
             var cache = new TraceEventCache();

--- a/src/libraries/System.Diagnostics.TraceSource/tests/TraceListenerClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/TraceListenerClassTests.cs
@@ -313,6 +313,7 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void WriteFooterTest_Callstack()
         {

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -68,7 +68,7 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/38995", TestPlatforms.Browser)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         public void StackTraceDoesNotStartWithInternalFrame()
         {
              string stackTrace = Environment.StackTrace;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -31,7 +31,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TextWriterTraceListener\tests\System.Diagnostics.TextWriterTraceListener.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TraceSource\tests\System.Diagnostics.TraceSource.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\CalendarTestWithConfigSwitch\System.Globalization.CalendarsWithConfigSwitch.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\System.Globalization.Calendars.Tests.csproj" />


### PR DESCRIPTION
One test was using `Assembly.GetEntryAssembly()` which returns null on WebAssembly.
Others are testing that the output contains the stacktrace but it is empty on WASM right now.