### PR TITLE
WASM: Disable tests on System.Diagnostics.StackTrace that fail

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackFrameExtensionsTests
     {
         public static IEnumerable<object[]> StackFrame_TestData()

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackFrameTests
     {
         [Fact]

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace System.Diagnostics.SymbolStore.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackTraceSymbolsTests
     {
         [Fact]

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -29,6 +29,7 @@ namespace System.Diagnostics
 
 namespace System.Diagnostics.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackTraceTests
     {
         [Fact]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -29,7 +29,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter\tests\System.ComponentModel.TypeConverter.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common\tests\System.Data.Common.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TextWriterTraceListener\tests\System.Diagnostics.TextWriterTraceListener.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TraceSource\tests\System.Diagnostics.TraceSource.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />


### PR DESCRIPTION
Failing due to https://github.com/dotnet/runtime/issues/39223