### PR TITLE
WASM: Disable thread related tests on System.IO.Compression

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/CompressionStreamUnitTestBase.cs
@@ -14,7 +14,7 @@ namespace System.IO.Compression
     {
         private const int TaskTimeout = 30 * 1000; // Generous timeout for official test runs
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public virtual void FlushAsync_DuringWriteAsync()
         {
             if (FlushNoOps)
@@ -49,7 +49,7 @@ namespace System.IO.Compression
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task FlushAsync_DuringReadAsync()
         {
             if (FlushNoOps)
@@ -78,7 +78,7 @@ namespace System.IO.Compression
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task FlushAsync_DuringFlushAsync()
         {
             if (FlushNoOps)
@@ -121,7 +121,7 @@ namespace System.IO.Compression
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public virtual void WriteAsync_DuringWriteAsync()
         {
             byte[] buffer = new byte[100000];
@@ -154,7 +154,7 @@ namespace System.IO.Compression
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public async Task ReadAsync_DuringReadAsync()
         {
             byte[] buffer = new byte[32];
@@ -179,7 +179,7 @@ namespace System.IO.Compression
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
         public virtual async Task Dispose_WithUnfinishedReadAsync()
         {
             string compressedPath = CompressedTestFile(UncompressedTestFile());

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -37,7 +37,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\System.Globalization.Calendars.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Extensions\tests\System.Globalization.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression\tests\System.IO.Compression.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem.DriveInfo\tests\System.IO.FileSystem.DriveInfo.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.MemoryMappedFiles\tests\System.IO.MemoryMappedFiles.Tests.csproj" />


### PR DESCRIPTION
They try to test various conditions that only work if you have multiple threads which is not the case on WebAssembly.