### PR TITLE
Fix DebuggerTypeProxy on ObjectCollection

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/ObjectCollection.cs
@@ -9,7 +9,7 @@ namespace System.Net.Http.Headers
 {
     /// <summary>An <see cref="ICollection{T}"/> list that prohibits null elements and that is optimized for a small number of elements.</summary>
     [DebuggerDisplay("Count = {Count}")]
-    [DebuggerTypeProxy(nameof(DebugView))]
+    [DebuggerTypeProxy(typeof(ObjectCollection<>.DebugView))]
     internal sealed class ObjectCollection<T> : ICollection<T> where T : class
     {
         private const int DefaultSize = 4;


### PR DESCRIPTION
Using `nameof(DebugView)` doesn't work because DebugView is a nested type, so this isn't the full name of the type. Fixing to use typeof instead.