### PR TITLE
Guard SseImpl method body with IsSupported check

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.cs
@@ -1338,6 +1338,13 @@ namespace System.Numerics
 
             static unsafe bool SseImpl(Matrix4x4 matrix, out Matrix4x4 result)
             {
+                // Redundant test so we won't prejit remainder of this method
+                // on platforms without SSE.
+                if (!Sse.IsSupported)
+                {
+                    throw new PlatformNotSupportedException();
+                }
+
                 // This implementation is based on the DirectX Math Library XMMInverse method
                 // https://github.com/microsoft/DirectXMath/blob/master/Inc/DirectXMathMatrix.inl
 


### PR DESCRIPTION
Though this method is only ever callable by code that's already done the right
IsSupported check, add a redundant check to the method itself, so that when
crossgenning SPC on non-xarch platforms we won't try and compile the xarch
specific parts of this method.  This should save some time and a bit of file
size for non-xarch SPCs.

See notes on #38894 for context.