### PR TITLE
improve diag for GetNetworkInterfaces failures

### DIFF
--- a/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
+++ b/src/libraries/Native/Unix/System.Native/pal_interfaceaddresses.c
@@ -236,6 +236,7 @@ int32_t SystemNative_GetNetworkInterfaces(int32_t * interfaceCount, NetworkInter
 
     if (getifaddrs(&head) == -1)
     {
+        assert(errno != 0);
         return -1;
     }
 
@@ -262,6 +263,7 @@ int32_t SystemNative_GetNetworkInterfaces(int32_t * interfaceCount, NetworkInter
     void * memoryBlock = calloc((size_t)count, sizeof(NetworkInterfaceInfo));
     if (memoryBlock == NULL)
     {
+        errno = ENOMEM;
         return -1;
     }
 


### PR DESCRIPTION
In #39242 we failed to get network interfaces without any useful info. getifaddrs() _should_ set errno according to man page.
This PR aims to get better info if we see another failure.   

contributes to #39242 