### PR TITLE
[wasm] Fail right away in interp_create_method_pointer () when trying to create a function pointer to a native-to-managed wrapper.

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -2975,6 +2975,14 @@ interp_create_method_pointer (MonoMethod *method, gboolean compile, MonoError *e
 			imethod->jit_entry = addr;
 			return addr;
 		}
+
+		/*
+		 * The runtime expects a function pointer unique to method and
+		 * the native caller expects a function pointer with the
+		 * right signature, so fail right away.
+		 */
+		mono_error_set_platform_not_supported (error, "No native to managed transitions on this platform.");
+		return NULL;
 	}
 #endif
 	return (gpointer)interp_no_native_to_managed;


### PR DESCRIPTION
The previous method of returning interp_no_native_to_managed doesn't work:
* The runtime expects different function pointers for different methods, returning
  the same pointer leads to all kinds of weird errors.
* On wasm, the native caller expects the function to have the right signature, so
  calling interp_no_native_managed () will leads a to signature mismatch error which is
  hard to debug.