### PR TITLE
Assembly.Location should return empty string for assemblies loaded from single-file bundle

### DIFF
--- a/src/coreclr/src/binder/assemblybinder.cpp
+++ b/src/coreclr/src/binder/assemblybinder.cpp
@@ -396,9 +396,9 @@ namespace BINDER_SPACE
         BundleFileLocation bundleFileLocation = Bundle::ProbeAppBundle(sCoreLibName, /*pathIsBundleRelative */ true);
         if (!bundleFileLocation.IsValid())
         {
-            sCoreLib.Set(systemDirectory);
             pathSource = BinderTracing::PathSource::ApplicationAssemblies;
         }
+        sCoreLib.Set(systemDirectory);
         CombinePath(sCoreLib, sCoreLibName, sCoreLib);
 
         IF_FAIL_GO(AssemblyBinder::GetAssembly(sCoreLib,

--- a/src/coreclr/src/vm/pefile.inl
+++ b/src/coreclr/src/vm/pefile.inl
@@ -180,7 +180,7 @@ inline const SString &PEFile::GetPath()
     }
     CONTRACTL_END;
 
-    if (IsDynamic())
+    if (IsDynamic() || m_identity->IsInBundle ())
     {
         return SString::Empty();
     }

--- a/src/coreclr/src/vm/peimage.h
+++ b/src/coreclr/src/vm/peimage.h
@@ -237,9 +237,7 @@ private:
     // Private routines
     // ------------------------------------------------------------
 
-    void  Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation);
-    void  Init(IStream* pStream, UINT64 uStreamAsmId,
-               DWORD dwModuleId, BOOL resourceFile);
+    void Init(LPCWSTR pPath, BundleFileLocation bundleFileLocation);
 
     void VerifyIsILOrNIAssembly(BOOL fIL);
 


### PR DESCRIPTION
Changes made to PEFile to report empty string for path when it comes directly from the bundle.

I experimented with changing the PEImage m_path to empty string, but way too many things break. It is valid for the m_path to be empty, but we only use it to memory-loaded assemblies where the assembly loaded via PEImage::LoadFlat which does things very differently. The bundle still relies on opening the assembly as a file (file handle and offset).

The end result is that internally the assembly's PEImage has a non-existent m_path (it points to the base directory and the file name of the assembly, but no such file will normally exist). I don't think anything will actually use the path to access the file though.

Also changed how we load CoreLib from bundle. We used to give it path "System.Private.CoreLib.dll" which causes asserts in the runtime in couple of places (the one I hit was when trying to load assembly from memory - it gets CoreLib as its creator and we call GetPath on the creator and then validate the path in debug builds). As far as I can tell this change should not make any observable effect, other than fixing the fact that we expect the m_path of a PEImage to be either empty or absolute path.

Fixes https://github.com/dotnet/runtime/issues/39184.

I have to still look at how to add tests - we don't have any infra to run tests in the runtime repo from a single-file bundle. Not sure how much is that going to be...