### PR TITLE
WASM: Fix System.IO.FileSystem.DriveInfo and Microsoft.VisualBasic.Core tests

### DIFF
--- a/src/libraries/Microsoft.VisualBasic.Core/tests/FinancialTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/FinancialTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.VisualBasic.Tests
 
         // The accuracy to which we can validate some numeric test cases depends on the platform.
         private static readonly int s_precision = IsArmOrArm64OrAlpine ? 12 :
-            PlatformDetection.IsNetFramework ? 14 : 15;
+            (PlatformDetection.IsBrowser || PlatformDetection.IsNetFramework) ? 14 : 15;
 
         [Theory]
         [InlineData(0, 1.0, 1.0, 1.0, 1.0, 0, 0)]

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/ObjectTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/ObjectTypeTests.cs
@@ -342,8 +342,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { "a", "a", 0, 0 };
             yield return new object[] { "a", "b", -1, -1 };
             yield return new object[] { "b", "a", 1, 1 };
-            yield return new object[] { "a", "ABC", 32, -1 };
-            yield return new object[] { "ABC", "a", -32, 1 };
+            yield return new object[] { "a", "ABC", 32, PlatformDetection.IsInvariantGlobalization ? -2 : -1 };
+            yield return new object[] { "ABC", "a", -32, PlatformDetection.IsInvariantGlobalization ? 2 : 1 };
             yield return new object[] { "abc", "ABC", 32, 0 };
         }
     }

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
@@ -383,8 +383,8 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
             yield return new object[] { "a", "a", 0, 0 };
             yield return new object[] { "a", "b", -1, -1 };
             yield return new object[] { "b", "a", 1, 1 };
-            yield return new object[] { "a", "ABC", 32, PlatformDetection.IsInvariantGlobalization ? -2 : 1 };
-            yield return new object[] { "ABC", "a", -32, PlatformDetection.IsInvariantGlobalization ? 2 : -1 };
+            yield return new object[] { "a", "ABC", 32, PlatformDetection.IsInvariantGlobalization ? -2 : -1 };
+            yield return new object[] { "ABC", "a", -32, PlatformDetection.IsInvariantGlobalization ? 2 : 1 };
             yield return new object[] { "abc", "ABC", 32, 0 };
         }
 

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringTypeTests.cs
@@ -364,23 +364,28 @@ namespace Microsoft.VisualBasic.CompilerServices.Tests
         }
 
         [Theory]
-        [InlineData(null, null, 0, 0)]
-        [InlineData(null, "", 0, 0)]
-        [InlineData("", null, 0, 0)]
-        [InlineData(null, "a", -1, -1)]
-        [InlineData("a", null, 1, 1)]
-        [InlineData("", "a", -97, -1)]
-        [InlineData("a", "", 97, 1)]
-        [InlineData("a", "a", 0, 0)]
-        [InlineData("a", "b", -1, -1)]
-        [InlineData("b", "a", 1, 1)]
-        [InlineData("a", "ABC", 32, -1)]
-        [InlineData("ABC", "a", -32, 1)]
-        [InlineData("abc", "ABC", 32, 0)]
+        [MemberData(nameof(StrCmp_TestData))]
         public void StrCmp(string left, string right, int expectedBinaryCompare, int expectedTextCompare)
         {
             Assert.Equal(expectedBinaryCompare, StringType.StrCmp(left, right, TextCompare: false));
             Assert.Equal(expectedTextCompare, StringType.StrCmp(left, right, TextCompare: true));
+        }
+
+        public static IEnumerable<object[]> StrCmp_TestData()
+        {
+            yield return new object[] { null, null, 0, 0 };
+            yield return new object[] { null, "", 0, 0 };
+            yield return new object[] { "", null, 0, 0 };
+            yield return new object[] { null, "a", -1, -1 };
+            yield return new object[] { "a", null, 1, 1 };
+            yield return new object[] { "", "a", -97, -1 };
+            yield return new object[] { "a", "", 97, 1 };
+            yield return new object[] { "a", "a", 0, 0 };
+            yield return new object[] { "a", "b", -1, -1 };
+            yield return new object[] { "b", "a", 1, 1 };
+            yield return new object[] { "a", "ABC", 32, PlatformDetection.IsInvariantGlobalization ? -2 : 1 };
+            yield return new object[] { "ABC", "a", -32, PlatformDetection.IsInvariantGlobalization ? 2 : -1 };
+            yield return new object[] { "abc", "ABC", 32, 0 };
         }
 
         [Theory]

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/StringsTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/StringsTests.cs
@@ -129,7 +129,7 @@ namespace Microsoft.VisualBasic.Tests
         }
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/30419", TargetFrameworkMonikers.NetFramework)]
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotInvariantGlobalization))]
         [InlineData(0, 0)]
         [InlineData(33, 33)]
         [InlineData(172, 0)]

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.csproj
@@ -49,7 +49,8 @@
     <Compile Include="$(CommonPath)System\IO\PathInternal.Windows.cs"
              Link="Common\System\IO\PathInternal.Windows.cs" />
   </ItemGroup>
-  <ItemGroup Condition="('$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true') And '$(TargetFramework)' == '$(NetCoreAppCurrent)' ">
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true' And '$(TargetFramework)' == '$(NetCoreAppCurrent)' ">
+    <Compile Include="System\IO\DriveInfo.UnixOrBrowser.cs" />
     <Compile Include="System\IO\DriveInfo.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
@@ -65,6 +66,10 @@
              Link="Common\Interop\Unix\Interop.MountPoints.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.MountPoints.FormatInfo.cs"
              Link="Common\Interop\Unix\Interop.MountPoints.FormatInfo.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' == 'true' And '$(TargetFramework)' == '$(NetCoreAppCurrent)' ">
+    <Compile Include="System\IO\DriveInfo.UnixOrBrowser.cs" />
+    <Compile Include="System\IO\DriveInfo.Browser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.IO.FileSystem" />

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Browser.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Browser.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security;
+
+namespace System.IO
+{
+    public sealed partial class DriveInfo
+    {
+        public DriveType DriveType => DriveType.Unknown;
+        public string DriveFormat => "memfs";
+        public long AvailableFreeSpace => 0;
+        public long TotalFreeSpace => 0;
+        public long TotalSize => 0;
+
+        private static string[] GetMountPoints() => Environment.GetLogicalDrives();
+    }
+}

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Unix.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Unix.cs
@@ -9,31 +9,6 @@ namespace System.IO
 {
     public sealed partial class DriveInfo
     {
-        public static DriveInfo[] GetDrives()
-        {
-            string[] mountPoints = Interop.Sys.GetAllMountPoints();
-            DriveInfo[] info = new DriveInfo[mountPoints.Length];
-            for (int i = 0; i < info.Length; i++)
-            {
-                info[i] = new DriveInfo(mountPoints[i]);
-            }
-
-            return info;
-        }
-
-        private static string NormalizeDriveName(string driveName)
-        {
-            if (driveName.Contains("\0")) // string.Contains(char) is .NetCore2.1+ specific
-            {
-                throw new ArgumentException(SR.Format(SR.Arg_InvalidDriveChars, driveName), nameof(driveName));
-            }
-            if (driveName.Length == 0)
-            {
-                throw new ArgumentException(SR.Arg_MustBeNonEmptyDriveName, nameof(driveName));
-            }
-            return driveName;
-        }
-
         public DriveType DriveType
         {
             get
@@ -104,19 +79,6 @@ namespace System.IO
             }
         }
 
-        [AllowNull]
-        public string VolumeLabel
-        {
-            get
-            {
-                return Name;
-            }
-            set
-            {
-                throw new PlatformNotSupportedException();
-            }
-        }
-
         private void CheckStatfsResultAndThrowIfNecessary(int result)
         {
             if (result != 0)
@@ -132,5 +94,7 @@ namespace System.IO
                 }
             }
         }
+
+        private static string[] GetMountPoints() => Interop.Sys.GetAllMountPoints();
     }
 }

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.UnixOrBrowser.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.UnixOrBrowser.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Security;
+
+namespace System.IO
+{
+    public sealed partial class DriveInfo
+    {
+        public static DriveInfo[] GetDrives()
+        {
+            string[] mountPoints = GetMountPoints();
+            DriveInfo[] info = new DriveInfo[mountPoints.Length];
+            for (int i = 0; i < info.Length; i++)
+            {
+                info[i] = new DriveInfo(mountPoints[i]);
+            }
+
+            return info;
+        }
+
+        private static string NormalizeDriveName(string driveName)
+        {
+            if (driveName.Contains("\0")) // string.Contains(char) is .NetCore2.1+ specific
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_InvalidDriveChars, driveName), nameof(driveName));
+            }
+            if (driveName.Length == 0)
+            {
+                throw new ArgumentException(SR.Arg_MustBeNonEmptyDriveName, nameof(driveName));
+            }
+            return driveName;
+        }
+
+        [AllowNull]
+        public string VolumeLabel
+        {
+            get
+            {
+                return Name;
+            }
+            set
+            {
+                throw new PlatformNotSupportedException();
+            }
+        }
+    }
+}

--- a/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Unix.Tests.cs
@@ -41,7 +41,7 @@ namespace System.IO.FileSystem.DriveInfoTests
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [PlatformSpecific(TestPlatforms.AnyUnix & ~TestPlatforms.Browser)]
         public void PropertiesOfInvalidDrive()
         {
             string invalidDriveName = "NonExistentDriveName";
@@ -64,16 +64,26 @@ namespace System.IO.FileSystem.DriveInfoTests
         public void PropertiesOfValidDrive()
         {
             var root = new DriveInfo("/");
-            Assert.True(root.AvailableFreeSpace > 0);
             var format = root.DriveFormat;
-            Assert.Equal(DriveType.Fixed, root.DriveType);
+            Assert.Equal(PlatformDetection.IsBrowser ? DriveType.Unknown : DriveType.Fixed, root.DriveType);
             Assert.True(root.IsReady);
             Assert.Equal("/", root.Name);
             Assert.Equal("/", root.ToString());
             Assert.Equal("/", root.RootDirectory.FullName);
-            Assert.True(root.TotalFreeSpace > 0);
-            Assert.True(root.TotalSize > 0);
             Assert.Equal("/", root.VolumeLabel);
+
+            if (PlatformDetection.IsBrowser)
+            {
+                Assert.True(root.AvailableFreeSpace == 0);
+                Assert.True(root.TotalFreeSpace == 0);
+                Assert.True(root.TotalSize == 0);
+            }
+            else
+            {
+                Assert.True(root.AvailableFreeSpace > 0);
+                Assert.True(root.TotalFreeSpace > 0);
+                Assert.True(root.TotalSize > 0);
+            }
         }
 
         [Fact]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -34,7 +34,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\System.Globalization.Calendars.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Extensions\tests\System.Globalization.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem.DriveInfo\tests\System.IO.FileSystem.DriveInfo.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.MemoryMappedFiles\tests\System.IO.MemoryMappedFiles.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Packaging\tests\System.IO.Packaging.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -22,7 +22,6 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">
     <!-- Builds currently do not pass -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.CodeDom\tests\System.CodeDom.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.Primitives\tests\System.ComponentModel.Primitives.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter\tests\System.ComponentModel.TypeConverter.Tests.csproj" />

--- a/src/mono/wasm/wasm.targets
+++ b/src/mono/wasm/wasm.targets
@@ -17,7 +17,6 @@
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Runtime\$(NetCoreAppCurrent)-$(Configuration)\System.Runtime.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Console\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Console.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.IO.FileSystem\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.IO.FileSystem.dll"/>
-    <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.IO.FileSystem.DriveInfo\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.IO.FileSystem.DriveInfo.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.IO.MemoryMappedFiles\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.IO.MemoryMappedFiles.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Net.Sockets\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Net.Sockets.dll"/>
     <WasmPInvokeAssemblies Include="$(ArtifactsBinDir)\System.Net.Primitives\$(NetCoreAppCurrent)-Browser-$(Configuration)\System.Net.Primitives.dll"/>


### PR DESCRIPTION
Some of the VB tests need culture data.

For DriveInfo we provide an implementation for Browser that returns stub values.