### PR TITLE
Add .cfi annotation to CONTEXT_CaptureContext and RtlCaptureContext

### DIFF
--- a/src/coreclr/src/pal/src/arch/arm64/context2.S
+++ b/src/coreclr/src/pal/src/arch/arm64/context2.S
@@ -14,7 +14,9 @@
 //  x0: Context*
 //
 LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
-    sub sp, sp, #32
+    PROLOG_STACK_ALLOC 32
+    .cfi_adjust_cfa_offset 32
+
     // save x1, x2 and x3 on stack so we can use them as scratch
     stp x1, x2, [sp]
     str x3, [sp, 16]
@@ -104,7 +106,7 @@ LOCAL_LABEL(Done_CONTEXT_INTEGER):
 
 LOCAL_LABEL(Done_CONTEXT_FLOATING_POINT):
 
-    add sp, sp, #32
+    EPILOG_STACK_FREE 32
     ret
 LEAF_END CONTEXT_CaptureContext, _TEXT
 
@@ -112,7 +114,8 @@ LEAF_END CONTEXT_CaptureContext, _TEXT
 //  x0: Context*
 
 LEAF_ENTRY RtlCaptureContext, _TEXT
-    sub sp, sp, #16
+    PROLOG_STACK_ALLOC 16
+    .cfi_adjust_cfa_offset 16
     str x1, [sp]
     // same as above, clang doesn't like mov with #imm32
     // keep this in sync if CONTEXT_FULL changes
@@ -123,7 +126,7 @@ LEAF_ENTRY RtlCaptureContext, _TEXT
     orr w1, w1, #0x8
     str w1, [x0, CONTEXT_ContextFlags]
     ldr x1, [sp]
-    add sp, sp, #16
+    EPILOG_STACK_FREE 16
     b C_FUNC(CONTEXT_CaptureContext)
 LEAF_END RtlCaptureContext, _TEXT
 


### PR DESCRIPTION
This change ensures correct unwinding of stack when stepping through
these methods under a debugger.

Close #33470