### PR TITLE
Throw when Rfc2898DeriveBytes extract limit has been exceeded

### DIFF
--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -351,4 +351,7 @@
   <data name="Cryptography_PlatformNotSupported_Browser" xml:space="preserve">
     <value>System.Security.Cryptography is not supported on Browser.</value>
   </data>
+  <data name="Cryptography_ExceedKdfExtractLimit" xml:space="preserve">
+    <value>The total number of bytes extracted cannot exceed (2^32 - 1) * hash length.</value>
+  </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -352,6 +352,6 @@
     <value>System.Security.Cryptography is not supported on Browser.</value>
   </data>
   <data name="Cryptography_ExceedKdfExtractLimit" xml:space="preserve">
-    <value>The total number of bytes extracted cannot exceed (2^32 - 1) * hash length.</value>
+    <value>The total number of bytes extracted cannot exceed UInt32.MaxValue * hash length.</value>
   </data>
 </root>


### PR DESCRIPTION
Fixes #39277