### PR TITLE
[mono] Base ALC unloadability functionality

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -2050,7 +2050,7 @@ AM_CONDITIONAL(ENABLE_PERFTRACING, test x$enable_perftracing = xyes)
 
 if test "x$mono_feature_disable_alc_unloadability" = "xyes"; then
 	AC_DEFINE(DISABLE_ALC_UNLOADABILITY, 1, [Disable ALC unloadability in netcore])
-	AC_MSG_NOTICE([Didsabled ALC unloadability])
+	AC_MSG_NOTICE([Disabled ALC unloadability])
 fi
 
 if test "x$mono_feature_disable_domain_code_memory" = "xyes"; then

--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -1406,6 +1406,9 @@ if test x$with_runtime_preset = xnetcore; then
    mono_feature_disable_perfcounters='yes'
    mono_feature_disable_attach='yes'
    mono_feature_disable_cfgdir_config='yes'
+   mono_feature_disable_alc_unloadability='yes'
+   # For debugging; merge this in with ALC unloadability once JIT and AOT allocations are moved over
+   # mono_feature_disable_domain_code_memory='yes'
    if test "x$enable_monodroid" = "x" -a "x$enable_monotouch" = "x"; then
      mono_feature_disable_dllmap='yes' # FIXME: the mobile products use this
    fi
@@ -2044,6 +2047,16 @@ if test x$enable_perftracing = xyes; then
 	AC_DEFINE(ENABLE_PERFTRACING,1,[Enables support for eventpipe library])
 fi
 AM_CONDITIONAL(ENABLE_PERFTRACING, test x$enable_perftracing = xyes)
+
+if test "x$mono_feature_disable_alc_unloadability" = "xyes"; then
+	AC_DEFINE(DISABLE_ALC_UNLOADABILITY, 1, [Disable ALC unloadability in netcore])
+	AC_MSG_NOTICE([Didsabled ALC unloadability])
+fi
+
+if test "x$mono_feature_disable_domain_code_memory" = "xyes"; then
+	AC_DEFINE(DISABLE_DOMAIN_CODE_MEMORY, 1, [Disable domain code memory in netcore])
+	AC_MSG_NOTICE([Disabled domain code memory for debugging])
+fi
 
 AC_ARG_ENABLE(executables, [  --disable-executables disable the build of the runtime executables], enable_executables=$enableval, enable_executables=yes)
 AM_CONDITIONAL(DISABLE_EXECUTABLES, test x$enable_executables = xno)

--- a/src/mono/mono/eglib/eglib-remap.h
+++ b/src/mono/mono/eglib/eglib-remap.h
@@ -159,6 +159,7 @@
 #define g_ptr_array_sized_new monoeg_g_ptr_array_sized_new
 #define g_ptr_array_sort monoeg_g_ptr_array_sort
 #define g_ptr_array_sort_with_data monoeg_g_ptr_array_sort_with_data
+#define g_ptr_array_find monoeg_g_ptr_array_find
 #define g_qsort_with_data monoeg_g_qsort_with_data
 #define g_queue_free monoeg_g_queue_free
 #define g_queue_is_empty monoeg_g_queue_is_empty

--- a/src/mono/mono/eglib/glib.h
+++ b/src/mono/mono/eglib/glib.h
@@ -726,6 +726,7 @@ void       g_ptr_array_set_size           (GPtrArray *array, gint length);
 gpointer  *g_ptr_array_free               (GPtrArray *array, gboolean free_seg);
 void       g_ptr_array_foreach            (GPtrArray *array, GFunc func, gpointer user_data);
 guint      g_ptr_array_capacity           (GPtrArray *array);
+gboolean   g_ptr_array_find               (GPtrArray *array, gconstpointer needle, guint *index);
 #define    g_ptr_array_index(array,index) (array)->pdata[(index)]
 //FIXME previous missing parens
 

--- a/src/mono/mono/eglib/gptrarray.c
+++ b/src/mono/mono/eglib/gptrarray.c
@@ -229,3 +229,18 @@ g_ptr_array_capacity (GPtrArray *array)
 {
 	return ((GPtrArrayPriv *)array)->size;
 }
+
+gboolean
+g_ptr_array_find (GPtrArray *array, gconstpointer needle, guint *index)
+{
+	g_assert (array);
+	for (int i = 0; i < array->len; i++) {
+		if (array->pdata [i] == needle) {
+			if (index)
+				*index = i;
+			return TRUE;
+		}
+	}
+
+	return FALSE;
+}

--- a/src/mono/mono/metadata/Makefile.am
+++ b/src/mono/mono/metadata/Makefile.am
@@ -427,6 +427,7 @@ common_sources = \
 	callspec.h	\
 	callspec.c	\
 	abi.c	\
+	memory-manager.c \
 	native-library.c \
 	native-library.h \
 	native-library-qcall.c \

--- a/src/mono/mono/metadata/appdomain.c
+++ b/src/mono/mono/metadata/appdomain.c
@@ -1054,7 +1054,7 @@ mono_domain_owns_vtable_slot (MonoDomain *domain, gpointer vtable_slot)
 	gboolean res;
 
 	mono_domain_lock (domain);
-	res = mono_mempool_contains_addr (domain->memory_manager->mp, vtable_slot);
+	res = mono_mempool_contains_addr (mono_domain_ambient_memory_manager (domain)->mp, vtable_slot);
 	mono_domain_unlock (domain);
 	return res;
 }
@@ -3229,7 +3229,7 @@ unload_thread_main (void *arg)
 {
 	unload_data *data = (unload_data*)arg;
 	MonoDomain *domain = data->domain;
-	MonoMemoryManager *memory_manager = domain->memory_manager;
+	MonoMemoryManager *memory_manager = mono_domain_default_memory_manager (domain);
 	int i;
 	gsize result = 1; // failure
 

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -286,9 +286,10 @@ mono_alc_is_default (MonoAssemblyLoadContext *alc)
 MonoAssemblyLoadContext *
 mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 {
+	HANDLE_FUNCTION_ENTER ();
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
 	MonoAssemblyLoadContext *alc = MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
-	return alc;
+	HANDLE_FUNCTION_RETURN_VAL (alc);
 }
 
 MonoGCHandle

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -14,6 +14,31 @@
 #include "mono/utils/mono-logger-internals.h"
 
 GENERATE_GET_CLASS_WITH_CACHE (assembly_load_context, "System.Runtime.Loader", "AssemblyLoadContext");
+static GENERATE_GET_CLASS_WITH_CACHE (reference_tracker, "System.Reflection", "ReferenceTracker");
+
+static void
+mono_alc_free (MonoAssemblyLoadContext *alc);
+
+static MonoAssemblyLoadContext *
+mono_domain_create_alc (MonoDomain *domain, gboolean is_default, gboolean collectible)
+{
+	MonoAssemblyLoadContext *alc = NULL;
+
+	mono_domain_alcs_lock (domain);
+	if (is_default && domain->default_alc)
+		goto leave;
+
+	alc = g_new0 (MonoAssemblyLoadContext, 1);
+	mono_alc_init (alc, domain, collectible);
+
+	domain->alcs = g_slist_prepend (domain->alcs, alc);
+	if (is_default)
+		domain->default_alc = alc;
+
+leave:
+	mono_domain_alcs_unlock (domain);
+	return alc;
+}
 
 void
 mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collectible)
@@ -23,6 +48,9 @@ mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collec
 	alc->domain = domain;
 	alc->loaded_images = li;
 	alc->loaded_assemblies = NULL;
+	alc->memory_manager = mono_memory_manager_create_singleton (alc, collectible);
+	alc->generic_memory_managers = g_ptr_array_new ();
+	mono_coop_mutex_init (&alc->memory_managers_lock);
 	alc->unloading = FALSE;
 	alc->collectible = collectible;
 	alc->pinvoke_scopes = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, NULL);
@@ -31,34 +59,50 @@ mono_alc_init (MonoAssemblyLoadContext *alc, MonoDomain *domain, gboolean collec
 }
 
 void
-mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+mono_domain_create_default_alc (MonoDomain *domain)
+{
+	if (domain->default_alc)
+		return;
+	mono_domain_create_alc (domain, TRUE, FALSE);
+}
+
+MonoAssemblyLoadContext *
+mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandle, gboolean collectible, MonoError *error)
+{
+	MonoAssemblyLoadContext *alc = mono_domain_create_alc (domain, FALSE, collectible);
+
+	if (collectible) {
+		// Create managed ReferenceTracker
+		// TODO: handle failure case
+		MonoClass *ref_tracker_class = mono_class_get_reference_tracker_class ();
+		MonoObjectHandle ref_tracker = mono_object_new_handle (domain, ref_tracker_class, error); // need to actually call ctor properly
+		alc->ref_tracker = mono_gchandle_from_handle (ref_tracker, FALSE);
+	}
+
+	alc->gchandle = this_gchandle;
+
+	return alc;
+}
+
+static void
+mono_alc_cleanup_assemblies (MonoAssemblyLoadContext *alc)
 {
 	/*
-	 * This is still very much WIP. It needs to be split up into various other functions and adjusted to work with the 
-	 * managed LoaderAllocator design. For now, I've put it all in this function, but don't look at it too closely.
-	 * 
-	 * Of particular note: the minimum refcount on assemblies is 2: one for the domain and one for the ALC. 
+	 * The minimum refcount on assemblies is 2: one for the domain and one for the ALC.
 	 * The domain refcount might be less than optimal on netcore, but its removal is too likely to cause issues for now.
 	 */
 	GSList *tmp;
 	MonoDomain *domain = alc->domain;
 
-	g_assert (alc != mono_domain_default_alc (domain));
-	g_assert (alc->collectible == TRUE);
-
-	// FIXME: alc unloading profiler event
-
 	// Remove the assemblies from domain_assemblies
 	mono_domain_assemblies_lock (domain);
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
 		MonoAssembly *assembly = (MonoAssembly *)tmp->data;
-		g_slist_remove (domain->domain_assemblies, assembly);
-		mono_atomic_dec_i32 (&assembly->ref_count);
+		domain->domain_assemblies = g_slist_remove (domain->domain_assemblies, assembly);
+		mono_assembly_decref (assembly);
 		mono_trace (G_LOG_LEVEL_DEBUG, MONO_TRACE_ASSEMBLY, "Unloading ALC [%p], removing assembly %s[%p] from domain_assemblies, ref_count=%d\n", alc, assembly->aname.name, assembly, assembly->ref_count);
 	}
 	mono_domain_assemblies_unlock (domain);
-
-	// Some equivalent to mono_gc_clear_domain? I guess in our case we just have to assert that we have no lingering references?
 
 	// Release the GC roots
 	for (tmp = alc->loaded_assemblies; tmp; tmp = tmp->next) {
@@ -99,15 +143,40 @@ mono_alc_cleanup (MonoAssemblyLoadContext *alc)
 	g_slist_free (alc->loaded_assemblies);
 	alc->loaded_assemblies = NULL;
 
-	// FIXME: alc unloaded profiler event
-
-	g_hash_table_destroy (alc->pinvoke_scopes);
 	mono_coop_mutex_destroy (&alc->assemblies_lock);
-	mono_coop_mutex_destroy (&alc->pinvoke_lock);
 
 	mono_loaded_images_free (alc->loaded_images);
+	alc->loaded_images = NULL;
+}
 
-	// TODO: free mempool stuff/jit info tables, see domain freeing for an example
+void
+mono_alc_cleanup (MonoAssemblyLoadContext *alc)
+{
+	MonoDomain *domain = alc->domain;
+
+	g_assert (alc != mono_domain_default_alc (domain));
+	g_assert (alc->collectible == TRUE);
+
+	// Remove from domain list
+	mono_domain_alcs_lock (domain);
+	domain->alcs = g_slist_remove (domain->alcs, alc);
+	mono_domain_alcs_unlock (domain);
+
+	mono_alc_cleanup_assemblies (alc);
+
+	mono_memory_manager_free_singleton (alc->memory_manager, FALSE);
+	alc->memory_manager = NULL;
+
+	// clean up generic memory managers
+
+	mono_gchandle_free_internal (alc->gchandle);
+	alc->gchandle = NULL;
+
+	g_hash_table_destroy (alc->pinvoke_scopes);
+	alc->pinvoke_scopes = NULL;
+	mono_coop_mutex_destroy (&alc->pinvoke_lock);
+
+	// TODO: alc unloaded profiler event
 }
 
 void
@@ -120,6 +189,13 @@ void
 mono_alc_assemblies_unlock (MonoAssemblyLoadContext *alc)
 {
 	mono_coop_mutex_unlock (&alc->assemblies_lock);
+}
+
+static void
+mono_alc_free (MonoAssemblyLoadContext *alc)
+{
+	mono_alc_cleanup (alc);
+	g_free (alc);
 }
 
 gpointer
@@ -136,10 +212,9 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_InternalInitializeNativeALC 
 		g_assert (alc);
 		if (!alc->gchandle)
 			alc->gchandle = this_gchandle;
-	} else {
-		/* create it */
+	} else
 		alc = mono_domain_create_individual_alc (domain, this_gchandle, collectible, error);
-	}
+
 	return alc;
 }
 
@@ -149,13 +224,29 @@ ves_icall_System_Runtime_Loader_AssemblyLoadContext_PrepareForAssemblyLoadContex
 	MonoGCHandle strong_gchandle = (MonoGCHandle)strong_gchandle_ptr;
 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_pointer;
 
-	g_assert (alc->collectible == TRUE);
-	g_assert (alc->unloading == FALSE);
+	g_assert (alc->collectible);
+	g_assert (!alc->unloading);
+	g_assert (alc->gchandle);
+	g_assert (alc->ref_tracker);
+
 	alc->unloading = TRUE;
 
+	// Replace the weak gchandle with the new strong one to keep the managed ALC alive
 	MonoGCHandle weak_gchandle = alc->gchandle;
 	alc->gchandle = strong_gchandle;
 	mono_gchandle_free_internal (weak_gchandle);
+
+	// Destroy the strong handle to the ReferenceTracker to let it reach its finalizer
+	mono_gchandle_free_internal (alc->ref_tracker);
+	alc->ref_tracker = NULL;
+}
+
+void
+ves_icall_System_Reflection_ReferenceTracker_Destroy (gpointer alc_pointer, MonoError *error)
+{
+	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_pointer;
+
+	mono_alc_free (alc);
 }
 
 gpointer

--- a/src/mono/mono/metadata/assembly-load-context.c
+++ b/src/mono/mono/metadata/assembly-load-context.c
@@ -75,8 +75,9 @@ mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandl
 		// Create managed ReferenceTracker
 		// TODO: handle failure case
 		MonoClass *ref_tracker_class = mono_class_get_reference_tracker_class ();
-		MonoObjectHandle ref_tracker = mono_object_new_handle (domain, ref_tracker_class, error); // need to actually call ctor properly
-		alc->ref_tracker = mono_gchandle_from_handle (ref_tracker, FALSE);
+		MonoManagedReferenceTrackerHandle ref_tracker = MONO_HANDLE_CAST (MonoManagedReferenceTracker, mono_object_new_handle (domain, ref_tracker_class, error));
+		MONO_HANDLE_SETVAL (ref_tracker, native_assembly_load_context, MonoAssemblyLoadContext *, alc); 
+		alc->ref_tracker = mono_gchandle_from_handle (MONO_HANDLE_CAST (MonoObject, ref_tracker), FALSE);
 	}
 
 	alc->gchandle = this_gchandle;
@@ -245,7 +246,6 @@ void
 ves_icall_System_Reflection_ReferenceTracker_Destroy (gpointer alc_pointer, MonoError *error)
 {
 	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)alc_pointer;
-
 	mono_alc_free (alc);
 }
 
@@ -268,7 +268,7 @@ MonoAssemblyLoadContext *
 mono_alc_from_gchandle (MonoGCHandle alc_gchandle)
 {
 	MonoManagedAssemblyLoadContextHandle managed_alc = MONO_HANDLE_CAST (MonoManagedAssemblyLoadContext, mono_gchandle_get_target_handle (alc_gchandle));
-	MonoAssemblyLoadContext *alc = (MonoAssemblyLoadContext *)MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
+	MonoAssemblyLoadContext *alc = MONO_HANDLE_GETVAL (managed_alc, native_assembly_load_context);
 	return alc;
 }
 

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -1308,10 +1308,16 @@ assemblyref_public_tok_checked (MonoImage *image, guint32 key_index, guint32 fla
  * The reference count is reduced every time the method mono_assembly_close() is
  * invoked.
  */
-void
+gint32
 mono_assembly_addref (MonoAssembly *assembly)
 {
-	mono_atomic_inc_i32 (&assembly->ref_count);
+	return mono_atomic_inc_i32 (&assembly->ref_count);
+}
+
+gint32
+mono_assembly_decref (MonoAssembly *assembly)
+{
+	return mono_atomic_dec_i32 (&assembly->ref_count);
 }
 
 /*
@@ -4243,6 +4249,7 @@ assembly_binding_info_parsed (MonoAssemblyBindingInfo *info, void *user_data)
 	GSList *tmp;
 	MonoAssemblyBindingInfo *info_tmp;
 	MonoDomain *domain = (MonoDomain*)user_data;
+	MonoMemoryManager *memory_manager = domain->memory_manager;
 
 	if (!domain)
 		return;
@@ -4259,14 +4266,14 @@ assembly_binding_info_parsed (MonoAssemblyBindingInfo *info, void *user_data)
 			return;
 	}
 
-	info_copy = (MonoAssemblyBindingInfo *)mono_mempool_alloc0 (domain->mp, sizeof (MonoAssemblyBindingInfo));
+	info_copy = (MonoAssemblyBindingInfo *)mono_mempool_alloc0 (memory_manager->mp, sizeof (MonoAssemblyBindingInfo));
 	memcpy (info_copy, info, sizeof (MonoAssemblyBindingInfo));
 	if (info->name)
-		info_copy->name = mono_mempool_strdup (domain->mp, info->name);
+		info_copy->name = mono_mempool_strdup (memory_manager->mp, info->name);
 	if (info->culture)
-		info_copy->culture = mono_mempool_strdup (domain->mp, info->culture);
+		info_copy->culture = mono_mempool_strdup (memory_manager->mp, info->culture);
 
-	domain->assembly_bindings = g_slist_append_mempool (domain->mp, domain->assembly_bindings, info_copy);
+	domain->assembly_bindings = g_slist_append_mempool (memory_manager->mp, domain->assembly_bindings, info_copy);
 }
 
 static int

--- a/src/mono/mono/metadata/assembly.c
+++ b/src/mono/mono/metadata/assembly.c
@@ -4249,7 +4249,7 @@ assembly_binding_info_parsed (MonoAssemblyBindingInfo *info, void *user_data)
 	GSList *tmp;
 	MonoAssemblyBindingInfo *info_tmp;
 	MonoDomain *domain = (MonoDomain*)user_data;
-	MonoMemoryManager *memory_manager = domain->memory_manager;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
 	if (!domain)
 		return;

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -721,10 +721,21 @@ mono_domain_ambient_alc (MonoDomain *domain)
 
 static inline
 MonoMemoryManager *
+mono_domain_default_memory_manager (MonoDomain *domain)
+{
+#ifdef ENABLE_NETCORE
+	return (MonoMemoryManager *)mono_domain_default_alc (domain)->memory_manager;
+#else
+	return domain->memory_manager;
+#endif
+}
+
+static inline
+MonoMemoryManager *
 mono_domain_ambient_memory_manager (MonoDomain *domain)
 {
 	// FIXME: All the callers of mono_domain_ambient_memory_manager should get a MemoryManager passed to them from their callers
-	return domain->memory_manager;
+	return mono_domain_default_memory_manager (domain);
 }
 
 G_END_DECLS

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -339,8 +339,7 @@ struct _MonoDomain {
 	 * must taken first.
 	 */
 	MonoCoopMutex    lock;
-	MonoMemPool        *mp;
-	MonoCodeManager    *code_mp;
+
 	/*
 	 * keep all the managed objects close to each other for the precise GC
 	 * For the Boehm GC we additionally keep close also other GC-tracked pointers.
@@ -366,14 +365,7 @@ struct _MonoDomain {
 #define MONO_DOMAIN_FIRST_GC_TRACKED env
 	MonoGHashTable     *env;
 	MonoGHashTable     *ldstr_table;
-	/* hashtables for Reflection handles */
-	MonoGHashTable     *type_hash;
-	MonoConcGHashTable     *refobject_hash;
-	/* maps class -> type initialization exception object */
-	MonoGHashTable    *type_init_exception_hash;
-	/* maps delegate trampoline addr -> delegate object */
-	MonoGHashTable     *delegate_hash_table;
-#define MONO_DOMAIN_LAST_GC_TRACKED delegate_hash_table
+#define MONO_DOMAIN_LAST_GC_TRACKED ldstr_table
 	guint32            state;
 	/* Needed by Thread:GetDomainID() */
 	gint32             domain_id;
@@ -388,7 +380,6 @@ struct _MonoDomain {
 	GSList             *domain_assemblies;
 	MonoAssembly       *entry_assembly;
 	char               *friendly_name;
-	GPtrArray          *class_vtable_array;
 	/* maps remote class key -> MonoRemoteClass */
 	GHashTable         *proxy_vtable_hash;
 	/* Protected by 'jit_code_hash_lock' */
@@ -414,14 +405,7 @@ struct _MonoDomain {
 	MonoMethod         *private_invoke_method;
 	/* Used to store offsets of thread and context static fields */
 	GHashTable         *special_static_fields;
-	/* 
-	 * This must be a GHashTable, since these objects can't be finalized
-	 * if the hashtable contains a GC visible reference to them.
-	 */
-	GHashTable         *finalizable_objects_hash;
 
-	/* Protects the three hashes above */
-	mono_mutex_t   finalizable_objects_hash_lock;
 	/* Used when accessing 'domain_assemblies' */
 	MonoCoopMutex  assemblies_lock;
 
@@ -455,7 +439,7 @@ struct _MonoDomain {
 
 	/* Cache function pointers for architectures  */
 	/* that require wrappers */
-	GHashTable *ftnptrs_hash;
+	GHashTable *ftnptrs_hash; // TODO: need to move?
 
 	/* Maps MonoMethod* to weak links to DynamicMethod objects */
 	GHashTable *method_to_dyn_method;
@@ -467,9 +451,15 @@ struct _MonoDomain {
 
 #ifdef ENABLE_NETCORE
 	GSList *alcs;
+	GPtrArray *generic_memory_managers;
 	MonoAssemblyLoadContext *default_alc;
-	MonoCoopMutex alcs_lock; /* Used when accessing 'alcs' */
+	MonoCoopMutex alcs_lock; /* Used when accessing 'alcs' and 'generic_memory_managers' */
 #endif
+
+//#ifndef ENABLE_NETCORE // TODO: re-add this define
+	// Holds domain code memory
+	MonoMemoryManager *memory_manager;
+//#endif
 };
 
 typedef struct  {
@@ -699,8 +689,23 @@ MonoAssemblyLoadContext *
 mono_domain_default_alc (MonoDomain *domain);
 
 #ifdef ENABLE_NETCORE
+void
+mono_domain_create_default_alc (MonoDomain *domain);
+
 MonoAssemblyLoadContext *
 mono_domain_create_individual_alc (MonoDomain *domain, MonoGCHandle this_gchandle, gboolean collectible, MonoError *error);
+
+static inline void
+mono_domain_alcs_lock (MonoDomain *domain)
+{
+	mono_coop_mutex_lock (&domain->alcs_lock);
+}
+
+static inline void
+mono_domain_alcs_unlock (MonoDomain *domain)
+{
+	mono_coop_mutex_unlock (&domain->alcs_lock);
+}
 #endif
 
 static inline
@@ -712,6 +717,14 @@ mono_domain_ambient_alc (MonoDomain *domain)
 	 * passed to them from their callers.
 	 */
 	return mono_domain_default_alc (domain);
+}
+
+static inline
+MonoMemoryManager *
+mono_domain_ambient_memory_manager (MonoDomain *domain)
+{
+	// FIXME: All the callers of mono_domain_ambient_memory_manager should get a MemoryManager passed to them from their callers
+	return domain->memory_manager;
 }
 
 G_END_DECLS

--- a/src/mono/mono/metadata/domain-internals.h
+++ b/src/mono/mono/metadata/domain-internals.h
@@ -451,15 +451,14 @@ struct _MonoDomain {
 
 #ifdef ENABLE_NETCORE
 	GSList *alcs;
-	GPtrArray *generic_memory_managers;
 	MonoAssemblyLoadContext *default_alc;
-	MonoCoopMutex alcs_lock; /* Used when accessing 'alcs' and 'generic_memory_managers' */
+	MonoCoopMutex alcs_lock; /* Used when accessing 'alcs' */
 #endif
 
-//#ifndef ENABLE_NETCORE // TODO: re-add this define
+#if !defined(ENABLE_NETCORE) || !defined(DISABLE_DOMAIN_CODE_MEMORY)
 	// Holds domain code memory
 	MonoMemoryManager *memory_manager;
-//#endif
+#endif
 };
 
 typedef struct  {
@@ -555,6 +554,7 @@ mono_make_shadow_copy (const char *filename, MonoError *error);
 gboolean
 mono_is_shadow_copy_enabled (MonoDomain *domain, const gchar *dir_name);
 
+#if !defined(ENABLE_NETCORE) || !defined(DISABLE_DOMAIN_CODE_MEMORY)
 gpointer
 mono_domain_alloc  (MonoDomain *domain, guint size);
 
@@ -564,11 +564,6 @@ gpointer
 mono_domain_alloc0 (MonoDomain *domain, guint size);
 
 #define mono_domain_alloc0(domain, size) (g_cast (mono_domain_alloc0 ((domain), (size))))
-
-gpointer
-mono_domain_alloc0_lock_free (MonoDomain *domain, guint size);
-
-#define mono_domain_alloc0_lock_free(domain, size) (g_cast (mono_domain_alloc0_lock_free ((domain), (size))))
 
 void*
 mono_domain_code_reserve (MonoDomain *domain, int size);
@@ -585,6 +580,12 @@ mono_domain_code_commit (MonoDomain *domain, void *data, int size, int newsize);
 
 void
 mono_domain_code_foreach (MonoDomain *domain, MonoCodeManagerFunc func, void *user_data);
+#endif
+
+gpointer
+mono_domain_alloc0_lock_free (MonoDomain *domain, guint size);
+
+#define mono_domain_alloc0_lock_free(domain, size) (g_cast (mono_domain_alloc0_lock_free ((domain), (size))))
 
 void
 mono_domain_unset (void);

--- a/src/mono/mono/metadata/gc-internals.h
+++ b/src/mono/mono/metadata/gc-internals.h
@@ -20,8 +20,8 @@
 #include <mono/metadata/icalls.h>
 
 // TODO: MemoryManager specific locking
-#define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain->memory_manager)->finalizable_objects_hash_lock);
-#define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain->memory_manager)->finalizable_objects_hash_lock);
+#define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&mono_domain_default_memory_manager (domain)->finalizable_objects_hash_lock);
+#define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&mono_domain_default_memory_manager (domain)->finalizable_objects_hash_lock);
 
 /* Register a memory area as a conservatively scanned GC root */
 #define MONO_GC_REGISTER_ROOT_PINNING(x,src,key,msg) mono_gc_register_root ((char*)&(x), sizeof(x), MONO_GC_DESCRIPTOR_NULL, (src), (key), (msg))

--- a/src/mono/mono/metadata/gc-internals.h
+++ b/src/mono/mono/metadata/gc-internals.h
@@ -19,8 +19,9 @@
 #include <mono/sgen/gc-internal-agnostic.h>
 #include <mono/metadata/icalls.h>
 
-#define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain)->finalizable_objects_hash_lock);
-#define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain)->finalizable_objects_hash_lock);
+// TODO: MemoryManager specific locking
+#define mono_domain_finalizers_lock(domain) mono_os_mutex_lock (&(domain->memory_manager)->finalizable_objects_hash_lock);
+#define mono_domain_finalizers_unlock(domain) mono_os_mutex_unlock (&(domain->memory_manager)->finalizable_objects_hash_lock);
 
 /* Register a memory area as a conservatively scanned GC root */
 #define MONO_GC_REGISTER_ROOT_PINNING(x,src,key,msg) mono_gc_register_root ((char*)&(x), sizeof(x), MONO_GC_DESCRIPTOR_NULL, (src), (key), (msg))

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -220,7 +220,7 @@ mono_gc_run_finalize (void *obj, void *data)
 #ifndef HAVE_SGEN_GC
 	mono_domain_finalizers_lock (domain);
 
-	o2 = (MonoObject *)g_hash_table_lookup (domain->finalizable_objects_hash, o);
+	o2 = (MonoObject *)g_hash_table_lookup (domain->memory_manager->finalizable_objects_hash, o);
 
 	mono_domain_finalizers_unlock (domain);
 
@@ -374,9 +374,9 @@ object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*))
 	mono_domain_finalizers_lock (domain);
 
 	if (callback)
-		g_hash_table_insert (domain->finalizable_objects_hash, obj, obj);
+		g_hash_table_insert (domain->memory_manager->finalizable_objects_hash, obj, obj);
 	else
-		g_hash_table_remove (domain->finalizable_objects_hash, obj);
+		g_hash_table_remove (domain->memory_manager->finalizable_objects_hash, obj);
 
 	mono_domain_finalizers_unlock (domain);
 
@@ -878,7 +878,7 @@ finalize_domain_objects (void)
 	mono_gc_invoke_finalizers ();
 
 #ifdef HAVE_BOEHM_GC
-	while (g_hash_table_size (domain->finalizable_objects_hash) > 0) {
+	while (g_hash_table_size (domain->memory_manager->finalizable_objects_hash) > 0) {
 		int i;
 		GPtrArray *objs;
 		/* 
@@ -887,7 +887,7 @@ finalize_domain_objects (void)
 		 * remove entries from the hash table, so we make a copy.
 		 */
 		objs = g_ptr_array_new ();
-		g_hash_table_foreach (domain->finalizable_objects_hash, collect_objects, objs);
+		g_hash_table_foreach (domain->memory_manager->finalizable_objects_hash, collect_objects, objs);
 		/* printf ("FINALIZING %d OBJECTS.\n", objs->len); */
 
 		for (i = 0; i < objs->len; ++i) {

--- a/src/mono/mono/metadata/gc.c
+++ b/src/mono/mono/metadata/gc.c
@@ -220,7 +220,7 @@ mono_gc_run_finalize (void *obj, void *data)
 #ifndef HAVE_SGEN_GC
 	mono_domain_finalizers_lock (domain);
 
-	o2 = (MonoObject *)g_hash_table_lookup (domain->memory_manager->finalizable_objects_hash, o);
+	o2 = (MonoObject *)g_hash_table_lookup (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, o);
 
 	mono_domain_finalizers_unlock (domain);
 
@@ -374,9 +374,9 @@ object_register_finalizer (MonoObject *obj, void (*callback)(void *, void*))
 	mono_domain_finalizers_lock (domain);
 
 	if (callback)
-		g_hash_table_insert (domain->memory_manager->finalizable_objects_hash, obj, obj);
+		g_hash_table_insert (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, obj, obj);
 	else
-		g_hash_table_remove (domain->memory_manager->finalizable_objects_hash, obj);
+		g_hash_table_remove (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, obj);
 
 	mono_domain_finalizers_unlock (domain);
 
@@ -878,7 +878,7 @@ finalize_domain_objects (void)
 	mono_gc_invoke_finalizers ();
 
 #ifdef HAVE_BOEHM_GC
-	while (g_hash_table_size (domain->memory_manager->finalizable_objects_hash) > 0) {
+	while (g_hash_table_size (mono_domain_default_memory_manager (domain)->finalizable_objects_hash) > 0) {
 		int i;
 		GPtrArray *objs;
 		/* 
@@ -887,7 +887,7 @@ finalize_domain_objects (void)
 		 * remove entries from the hash table, so we make a copy.
 		 */
 		objs = g_ptr_array_new ();
-		g_hash_table_foreach (domain->memory_manager->finalizable_objects_hash, collect_objects, objs);
+		g_hash_table_foreach (mono_domain_default_memory_manager (domain)->finalizable_objects_hash, collect_objects, objs);
 		/* printf ("FINALIZING %d OBJECTS.\n", objs->len); */
 
 		for (i = 0; i < objs->len; ++i) {

--- a/src/mono/mono/metadata/icall-def-netcore.h
+++ b/src/mono/mono/metadata/icall-def-netcore.h
@@ -251,6 +251,9 @@ HANDLES(MMETHI_1, "get_method_info", ves_icall_get_method_info, void, 2, (MonoMe
 HANDLES(MMETHI_2, "get_parameter_info", ves_icall_System_Reflection_MonoMethodInfo_get_parameter_info, MonoArray, 2, (MonoMethod_ptr, MonoReflectionMethod))
 HANDLES(MMETHI_3, "get_retval_marshal", ves_icall_System_MonoMethodInfo_get_retval_marshal, MonoReflectionMarshalAsAttribute, 1, (MonoMethod_ptr))
 
+ICALL_TYPE(REFTRACKER, "System.Reflection.ReferenceTracker", REFTRACKER_1)
+HANDLES(REFTRACKER_1, "Destroy", ves_icall_System_Reflection_ReferenceTracker_Destroy, void, 1, (gpointer))
+
 ICALL_TYPE(RASSEM, "System.Reflection.RuntimeAssembly", RASSEM_1)
 HANDLES(RASSEM_1, "GetExportedTypes", ves_icall_System_Reflection_RuntimeAssembly_GetExportedTypes, MonoArray, 1, (MonoReflectionAssembly))
 HANDLES(RASSEM_1a, "GetFilesInternal", ves_icall_System_Reflection_RuntimeAssembly_GetFilesInternal, MonoObject, 3, (MonoReflectionAssembly, MonoString, MonoBoolean))

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -1814,7 +1814,7 @@ type_from_parsed_name (MonoTypeNameParse *info, MonoStackCrawlMark *stack_mark, 
 	MonoAssembly *assembly = NULL;
 	gboolean type_resolve = FALSE;
 	MonoImage *rootimage = NULL;
-	MonoAssemblyLoadContext *alc = mono_domain_ambient_alc (mono_domain_get ());
+	MonoAssemblyLoadContext *alc = mono_domain_ambient_alc (mono_domain_get ()); // This is wrong
 
 	error_init (error);
 

--- a/src/mono/mono/metadata/loader-internals.h
+++ b/src/mono/mono/metadata/loader-internals.h
@@ -92,7 +92,7 @@ struct _MonoMemoryManager {
 
 	GPtrArray *class_vtable_array;
 
-#define MONO_MEMORY_MANAGER_FIRST_GC_TRACKED type_hash // TODO: make this actually matter
+	// !!! REGISTERED AS GC ROOTS !!!
 	// Hashtables for Reflection handles
 	MonoGHashTable *type_hash;
 	MonoConcGHashTable *refobject_hash;
@@ -100,7 +100,7 @@ struct _MonoMemoryManager {
 	MonoGHashTable *type_init_exception_hash;
 	// Maps delegate trampoline addr -> delegate object
 	//MonoGHashTable *delegate_hash_table;
-#define MONO_MEMORY_MANAGER_LAST_GC_TRACKED type_init_exception_hash
+	// End of gc roots
 
 	// This must be a GHashTable, since these objects can't be finalized
 	// if the hashtable contains a GC visible reference to them.

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -7,6 +7,8 @@ memory_manager_init (MonoMemoryManager *memory_manager, gboolean collectible)
 {
 	MonoDomain *domain = mono_domain_get (); // this is quite possibly wrong on legacy?
 
+	memory_manager->freeing = FALSE;
+
 	mono_coop_mutex_init_recursive (&memory_manager->lock);
 
 	memory_manager->mp = mono_mempool_new ();
@@ -14,7 +16,7 @@ memory_manager_init (MonoMemoryManager *memory_manager, gboolean collectible)
 
 	memory_manager->class_vtable_array = g_ptr_array_new ();
 
-	// TODO: make these not linked to the domain
+	// TODO: make these not linked to the domain for debugging
 	memory_manager->type_hash = mono_g_hash_table_new_type_internal ((GHashFunc)mono_metadata_type_hash, (GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
 	memory_manager->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
 	memory_manager->type_init_exception_hash = mono_g_hash_table_new_type_internal (mono_aligned_addr_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Type Initialization Exception Table");
@@ -36,53 +38,95 @@ mono_memory_manager_create_singleton (MonoAssemblyLoadContext *alc, gboolean col
 }
 
 #ifdef ENABLE_NETCORE
-// LOCKING: assumes domain alcs_lock is held
 static MonoGenericMemoryManager *
-memory_manager_create_generic (MonoAssemblyLoadContext **alcs, int n_alcs, gboolean collectible)
+memory_manager_create_generic (MonoAssemblyLoadContext **alcs, int n_alcs)
 {
-	MonoGenericMemoryManager *mem_manager = g_new0 (MonoGenericMemoryManager, 1);
-	memory_manager_init ((MonoMemoryManager *)mem_manager, collectible);
+	gboolean collectible = FALSE;
 
+	MonoGenericMemoryManager *mem_manager = g_new0 (MonoGenericMemoryManager, 1);
 	mem_manager->memory_manager.is_generic = TRUE;
 
-	for (int i = 0; i < n_alcs; i++)
-		g_assert (!alcs [i]->unloading);
+	for (int i = 0; i < n_alcs; i++) {
+		MonoAssemblyLoadContext *alc = alcs [i];
+		g_assert (!alc->unloading);
+		if (alc->collectible) {
+			collectible = TRUE;
+			break;
+		}
+	}
 
+	memory_manager_init ((MonoMemoryManager *)mem_manager, collectible);
 	mem_manager->n_alcs = n_alcs;
 	mem_manager->alcs = (MonoAssemblyLoadContext **)g_new (MonoAssemblyLoadContext *, n_alcs);
 	memcpy (mem_manager->alcs, alcs, n_alcs * sizeof (MonoAssemblyLoadContext *));
 
 	for (int i = 0; i < n_alcs; i++) {
-		//MonoAssemblyLoadContext *alc = alcs [i];
-		// add to alc generic memory manager array
+		MonoAssemblyLoadContext *alc = alcs [i];
+		mono_alc_memory_managers_lock (alc);
+		g_ptr_array_add (alc->generic_memory_managers, mem_manager);
+		mono_alc_memory_managers_unlock (alc);
 	}
-	// add to domain generic memory manager array
 
 	return mem_manager;
+}
+
+static gboolean
+compare_memory_manager (MonoGenericMemoryManager *memory_manager, MonoAssemblyLoadContext **alcs, int n_alcs)
+{
+	int i, j;
+
+	if (memory_manager->n_alcs != n_alcs)
+		return FALSE;
+
+	for (i = 0; i < n_alcs; i++) {
+		for (j = 0; j < n_alcs; j++) {
+			if (memory_manager->alcs [j] == alcs [i])
+				break; // break on match
+		}
+
+		if (j == n_alcs)
+			break; // break on not found
+	}
+
+	// If we made it all the way through, all items were found
+	return i == n_alcs;
 }
 
 MonoGenericMemoryManager *
-mono_memory_manager_get_generic (MonoAssemblyLoadContext **alcs, int n_alcs, gboolean collectible)
+mono_memory_manager_get_generic (MonoAssemblyLoadContext **alcs, int n_alcs)
 {
-	MonoGenericMemoryManager *mem_manager;
-	MonoDomain *domain = mono_domain_get ();
+	g_assert (n_alcs > 0);
+	g_assert (alcs [0]);
 
-	mono_domain_alcs_lock (domain);
+	// TODO: consider a cache
 
-	// generate hash
-	// search domain or 1st alc generic memory manager array
+	// TODO: maybe we need a global lock here
 
-	mem_manager = memory_manager_create_generic (alcs, n_alcs, collectible);
+	// Look through first ALC's memory managers for a match
+	MonoAssemblyLoadContext *alc = alcs [0];
 
-//leave:
-	mono_domain_alcs_unlock (domain);
-	return mem_manager;
+	mono_alc_memory_managers_lock (alc);
+
+	GPtrArray *generic_mms = alc->generic_memory_managers;
+	for (int i = 0; i < generic_mms->len; i++) {
+		MonoGenericMemoryManager *test_memory_manager = (MonoGenericMemoryManager *)generic_mms->pdata [i];
+		if (compare_memory_manager (test_memory_manager, alcs, n_alcs)) {
+			mono_alc_memory_managers_unlock (alc);
+			return test_memory_manager;
+		}
+	}
+
+	mono_alc_memory_managers_unlock (alc);
+
+	// Not found, create it
+	return memory_manager_create_generic (alcs, n_alcs);
 }
+#endif
 
 static void
 cleanup_refobject_hash (gpointer key, gpointer value, gpointer user_data)
 {
-	free_reflected_entry ((ReflectedEntry*)key);
+	free_reflected_entry ((ReflectedEntry *)key);
 }
 
 static void
@@ -144,14 +188,183 @@ mono_memory_manager_free_singleton (MonoSingletonMemoryManager *memory_manager, 
 	g_free (memory_manager);
 }
 
+#ifdef ENABLE_NETCORE
 void
 mono_memory_manager_free_generic (MonoGenericMemoryManager *memory_manager, gboolean debug_unload)
 {
 	g_assert (memory_manager->memory_manager.is_generic);
 
+	// This should be an atomic read/write, but I'm sure it's fine
+	if (memory_manager->memory_manager.freeing)
+		return;
+
+	memory_manager->memory_manager.freeing = TRUE;
+
+	// Remove from composing ALCs
+	for (int i = 0; i < memory_manager->n_alcs; i++) {
+		MonoAssemblyLoadContext *alc = memory_manager->alcs [i];
+		mono_alc_memory_managers_lock (alc);
+		g_ptr_array_remove (alc->generic_memory_managers, memory_manager);
+		mono_alc_memory_managers_unlock (alc);
+	}
+	g_free (memory_manager->alcs);
+
 	memory_manager_delete ((MonoMemoryManager *)memory_manager, debug_unload);
-	// asdf
 	g_free (memory_manager);
 }
 #endif
+
+gpointer
+mono_memory_manager_alloc (MonoMemoryManager *memory_manager, guint size)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+#ifndef DISABLE_PERFCOUNTERS
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
+#endif
+	res = mono_mempool_alloc (memory_manager->mp, size);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+gpointer
+mono_memory_manager_alloc0 (MonoMemoryManager *memory_manager, guint size)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+#ifndef DISABLE_PERFCOUNTERS
+	mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, size);
+#endif
+	res = mono_mempool_alloc0 (memory_manager->mp, size);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+void*
+mono_memory_manager_code_reserve (MonoMemoryManager *memory_manager, int size)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+	res = mono_code_manager_reserve (memory_manager->code_mp, size);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+void*
+mono_memory_manager_code_reserve_align (MonoMemoryManager *memory_manager, int size, int alignment)
+{
+	gpointer res;
+
+	mono_memory_manager_lock (memory_manager);
+	res = mono_code_manager_reserve_align (memory_manager->code_mp, size, alignment);
+	mono_memory_manager_unlock (memory_manager);
+
+	return res;
+}
+
+void
+mono_memory_manager_code_commit (MonoMemoryManager *memory_manager, void *data, int size, int newsize)
+{
+	mono_memory_manager_lock (memory_manager);
+	mono_code_manager_commit (memory_manager->code_mp, data, size, newsize);
+	mono_memory_manager_unlock (memory_manager);
+}
+
+void
+mono_memory_manager_code_foreach (MonoMemoryManager *memory_manager, MonoCodeManagerFunc func, void *user_data)
+{
+	mono_memory_manager_lock (memory_manager);
+	mono_code_manager_foreach (memory_manager->code_mp, func, user_data);
+	mono_memory_manager_unlock (memory_manager);
+}
+
+void *
+mono_method_alloc_code (MonoDomain *domain, MonoMethod *method, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_method (domain, method);
+	return mono_memory_manager_alloc (memory_manager, size);
+}
+
+void *
+mono_method_alloc0_code (MonoDomain *domain, MonoMethod *method, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_method (domain, method);
+	return mono_memory_manager_alloc0 (memory_manager, size);
+}
+
+void *
+mono_class_alloc_code (MonoDomain *domain, MonoClass *klass, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
+	return mono_memory_manager_alloc (memory_manager, size);
+}
+
+void *
+mono_class_alloc0_code (MonoDomain *domain, MonoClass *klass, int size)
+{
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
+	return mono_memory_manager_alloc0 (memory_manager, size);
+}
+
+static MonoAssemblyLoadContext **
+get_alcs_from_image_set (MonoImageSet *set, int *n_alcs)
+{
+	GPtrArray *alcs_dym = g_ptr_array_new ();
+	for (int i = 0; i < set->nimages; i++) {
+		MonoImage *image = set->images [i];
+		MonoAssemblyLoadContext *alc = image->alc;
+		if (alc && !g_ptr_array_find (alcs_dym, alc, NULL))
+			g_ptr_array_add (alcs_dym, alc);
+	}
+	MonoAssemblyLoadContext **alcs = (MonoAssemblyLoadContext **)alcs_dym->pdata;
+	*n_alcs = alcs_dym->len;
+	g_ptr_array_free (alcs_dym, FALSE);
+	return alcs;
+}
+
+static MonoMemoryManager *
+memory_manager_from_set (MonoImageSet *set)
+{
+	if (set->nimages == 1)
+		return (MonoMemoryManager *)set->images [0]->alc->memory_manager;
+
+	int n_alcs;
+	MonoAssemblyLoadContext **alcs = get_alcs_from_image_set (set, &n_alcs);
+	MonoMemoryManager *memory_manager = (MonoMemoryManager *)mono_memory_manager_get_generic (alcs, n_alcs);
+	g_free (alcs);
+	return memory_manager;
+}
+
+MonoMemoryManager *
+mono_memory_manager_from_class (MonoDomain *domain, MonoClass *klass)
+{
+#if defined(ENABLE_NETCORE) && !defined(DISABLE_ALC_UNLOADABILITY)
+	if (klass == NULL) // this happens in startup, apparently
+		return (MonoMemoryManager *)mono_domain_default_alc (domain)->memory_manager;
+	// TODO: blatant hack, this needs to be way cheaper, probably by setting the MemoryManager in the vtable
+	MonoImageSet *set = mono_metadata_get_image_set_for_class (klass);
+	return memory_manager_from_set (set);
+#else
+	return domain->memory_manager;
+#endif
+}
+
+MonoMemoryManager *
+mono_memory_manager_from_method (MonoDomain *domain, MonoMethod *method)
+{
+#if defined(ENABLE_NETCORE) && !defined(DISABLE_ALC_UNLOADABILITY)
+	// TODO: blatant hack, this needs to be way cheaper, probably by setting the MemoryManager in the vtable
+	// TODO: actually get inflated method properly
+	MonoImageSet *set = mono_metadata_get_image_set_for_method ((MonoMethodInflated *)method);
+	return memory_manager_from_set (set);
+#else
+	return domain->memory_manager;
+#endif
+}
 

--- a/src/mono/mono/metadata/memory-manager.c
+++ b/src/mono/mono/metadata/memory-manager.c
@@ -1,0 +1,157 @@
+#include <mono/metadata/loader-internals.h>
+#include <mono/metadata/reflection-cache.h>
+#include <mono/metadata/mono-hash-internals.h>
+
+static void
+memory_manager_init (MonoMemoryManager *memory_manager, gboolean collectible)
+{
+	MonoDomain *domain = mono_domain_get (); // this is quite possibly wrong on legacy?
+
+	mono_coop_mutex_init_recursive (&memory_manager->lock);
+
+	memory_manager->mp = mono_mempool_new ();
+	memory_manager->code_mp = mono_code_manager_new ();
+
+	memory_manager->class_vtable_array = g_ptr_array_new ();
+
+	// TODO: make these not linked to the domain
+	memory_manager->type_hash = mono_g_hash_table_new_type_internal ((GHashFunc)mono_metadata_type_hash, (GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
+	memory_manager->refobject_hash = mono_conc_g_hash_table_new_type (mono_reflected_hash, mono_reflected_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Object Table");
+	memory_manager->type_init_exception_hash = mono_g_hash_table_new_type_internal (mono_aligned_addr_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Type Initialization Exception Table");
+
+	memory_manager->finalizable_objects_hash = g_hash_table_new (mono_aligned_addr_hash, NULL);
+	mono_os_mutex_init_recursive (&memory_manager->finalizable_objects_hash_lock);
+}
+
+MonoSingletonMemoryManager *
+mono_memory_manager_create_singleton (MonoAssemblyLoadContext *alc, gboolean collectible)
+{
+	MonoSingletonMemoryManager *mem_manager = g_new0 (MonoSingletonMemoryManager, 1);
+	memory_manager_init ((MonoMemoryManager *)mem_manager, collectible);
+
+	mem_manager->memory_manager.is_generic = FALSE;
+	mem_manager->alc = alc;
+
+	return mem_manager;
+}
+
+#ifdef ENABLE_NETCORE
+// LOCKING: assumes domain alcs_lock is held
+static MonoGenericMemoryManager *
+memory_manager_create_generic (MonoAssemblyLoadContext **alcs, int n_alcs, gboolean collectible)
+{
+	MonoGenericMemoryManager *mem_manager = g_new0 (MonoGenericMemoryManager, 1);
+	memory_manager_init ((MonoMemoryManager *)mem_manager, collectible);
+
+	mem_manager->memory_manager.is_generic = TRUE;
+
+	for (int i = 0; i < n_alcs; i++)
+		g_assert (!alcs [i]->unloading);
+
+	mem_manager->n_alcs = n_alcs;
+	mem_manager->alcs = (MonoAssemblyLoadContext **)g_new (MonoAssemblyLoadContext *, n_alcs);
+	memcpy (mem_manager->alcs, alcs, n_alcs * sizeof (MonoAssemblyLoadContext *));
+
+	for (int i = 0; i < n_alcs; i++) {
+		//MonoAssemblyLoadContext *alc = alcs [i];
+		// add to alc generic memory manager array
+	}
+	// add to domain generic memory manager array
+
+	return mem_manager;
+}
+
+MonoGenericMemoryManager *
+mono_memory_manager_get_generic (MonoAssemblyLoadContext **alcs, int n_alcs, gboolean collectible)
+{
+	MonoGenericMemoryManager *mem_manager;
+	MonoDomain *domain = mono_domain_get ();
+
+	mono_domain_alcs_lock (domain);
+
+	// generate hash
+	// search domain or 1st alc generic memory manager array
+
+	mem_manager = memory_manager_create_generic (alcs, n_alcs, collectible);
+
+//leave:
+	mono_domain_alcs_unlock (domain);
+	return mem_manager;
+}
+
+static void
+cleanup_refobject_hash (gpointer key, gpointer value, gpointer user_data)
+{
+	free_reflected_entry ((ReflectedEntry*)key);
+}
+
+static void
+unregister_vtable_reflection_type (MonoVTable *vtable)
+{
+	MonoObject *type = (MonoObject *)vtable->type;
+
+	if (type->vtable->klass != mono_defaults.runtimetype_class)
+		MONO_GC_UNREGISTER_ROOT_IF_MOVING (vtable->type);
+}
+
+static void
+memory_manager_delete (MonoMemoryManager *memory_manager, gboolean debug_unload)
+{
+	// Scan here to assert no lingering references in vtables?
+
+	mono_coop_mutex_destroy (&memory_manager->lock);
+
+	if (debug_unload) {
+		mono_mempool_invalidate (memory_manager->mp);
+		mono_code_manager_invalidate (memory_manager->code_mp);
+	} else {
+#ifndef DISABLE_PERFCOUNTERS
+		/* FIXME: use an explicit subtraction method as soon as it's available */
+		mono_atomic_fetch_add_i32 (&mono_perfcounters->loader_bytes, -1 * mono_mempool_get_allocated (memory_manager->mp));
+#endif
+		mono_mempool_destroy (memory_manager->mp);
+		memory_manager->mp = NULL;
+		mono_code_manager_destroy (memory_manager->code_mp);
+		memory_manager->code_mp = NULL;
+	}
+
+	g_ptr_array_free (memory_manager->class_vtable_array, TRUE);
+	memory_manager->class_vtable_array = NULL;
+
+	// Must be done before type_hash is freed
+	for (int i = 0; i < memory_manager->class_vtable_array->len; i++)
+		unregister_vtable_reflection_type ((MonoVTable *)g_ptr_array_index (memory_manager->class_vtable_array, i));
+
+	mono_g_hash_table_destroy (memory_manager->type_hash);
+	memory_manager->type_hash = NULL;
+	mono_conc_g_hash_table_foreach (memory_manager->refobject_hash, cleanup_refobject_hash, NULL);
+	mono_conc_g_hash_table_destroy (memory_manager->refobject_hash);
+	memory_manager->refobject_hash = NULL;
+	mono_g_hash_table_destroy (memory_manager->type_init_exception_hash);
+	memory_manager->type_init_exception_hash = NULL;
+
+	g_hash_table_destroy (memory_manager->finalizable_objects_hash);
+	memory_manager->finalizable_objects_hash = NULL;
+	mono_os_mutex_destroy (&memory_manager->finalizable_objects_hash_lock);
+}
+
+void
+mono_memory_manager_free_singleton (MonoSingletonMemoryManager *memory_manager, gboolean debug_unload)
+{
+	g_assert (!memory_manager->memory_manager.is_generic);
+
+	memory_manager_delete ((MonoMemoryManager *)memory_manager, debug_unload);
+	g_free (memory_manager);
+}
+
+void
+mono_memory_manager_free_generic (MonoGenericMemoryManager *memory_manager, gboolean debug_unload)
+{
+	g_assert (memory_manager->memory_manager.is_generic);
+
+	memory_manager_delete ((MonoMemoryManager *)memory_manager, debug_unload);
+	// asdf
+	g_free (memory_manager);
+}
+#endif
+

--- a/src/mono/mono/metadata/metadata-internals.h
+++ b/src/mono/mono/metadata/metadata-internals.h
@@ -216,7 +216,7 @@ struct _MonoAssembly {
 	 * the additional reference, they can be freed at any time.
 	 * The ref_count is initially 0.
 	 */
-	int ref_count; /* use atomic operations only */
+	gint32 ref_count; /* use atomic operations only */
 	char *basedir;
 	MonoAssemblyName aname;
 	MonoImage *image;
@@ -1011,9 +1011,13 @@ gboolean
 mono_metadata_generic_param_equal (MonoGenericParam *p1, MonoGenericParam *p2);
 
 void mono_dynamic_stream_reset  (MonoDynamicStream* stream);
-MONO_API void mono_assembly_addref       (MonoAssembly *assembly);
 void mono_assembly_load_friends (MonoAssembly* ass);
 gboolean mono_assembly_has_skip_verification (MonoAssembly* ass);
+
+MONO_API gint32
+mono_assembly_addref (MonoAssembly *assembly);
+gint32
+mono_assembly_decref (MonoAssembly *assembly);
 
 void mono_assembly_release_gc_roots (MonoAssembly *assembly);
 gboolean mono_assembly_close_except_image_pools (MonoAssembly *assembly);

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -323,6 +323,30 @@ mono_string_builder_string_length (MonoStringBuilderHandle sbh)
 	return sb->chunkOffset + sb->chunkLength;
 }
 
+#ifdef ENABLE_NETCORE
+// Keep in sync with System.Runtime.Loader.AssemblyLoadContext.InternalState
+typedef enum {
+	ALIVE = 0,
+	UNLOADING = 1
+} MonoManagedAssemblyLoadContextInternalState;
+
+// Keep in sync with System.Runtime.Loader.AssemblyLoadContext
+typedef struct {
+	MonoObject object;
+	MonoObject *unload_lock;
+	MonoEvent *resolving_unmanaged_dll;
+	MonoEvent *resolving;
+	MonoEvent *unloading;
+	MonoString *name;
+	gpointer *native_assembly_load_context;
+	gint64 id;
+	gint32 internal_state;
+	MonoBoolean is_collectible;
+} MonoManagedAssemblyLoadContext;
+
+TYPED_HANDLE_DECL (MonoManagedAssemblyLoadContext);
+#endif
+
 typedef struct {
 	MonoType *type;
 	gpointer  value;
@@ -1647,30 +1671,6 @@ typedef struct {
 	MonoClassField *field;
 	MonoProperty *prop;
 } CattrNamedArg;
-
-#ifdef ENABLE_NETCORE
-// Keep in sync with System.Runtime.Loader.AssemblyLoadContext.InternalState
-typedef enum {
-	ALIVE = 0,
-	UNLOADING = 1
-} MonoManagedAssemblyLoadContextInternalState;
-
-// Keep in sync with System.Runtime.Loader.AssemblyLoadContext
-typedef struct {
-	MonoObject object;
-	MonoObject *unload_lock;
-	MonoEvent *resolving_unmaned_dll;
-	MonoEvent *resolving;
-	MonoEvent *unloading;
-	MonoString *name;
-	gpointer *native_assembly_load_context;
-	gint64 id;
-	gint32 internal_state;
-	MonoBoolean is_collectible;
-} MonoManagedAssemblyLoadContext;
-
-TYPED_HANDLE_DECL (MonoManagedAssemblyLoadContext);
-#endif
 
 /* All MonoInternalThread instances should be pinned, so it's safe to use the raw ptr.  However
  * for uniformity, icall wrapping will make handles anyway.  So this is the method for getting the payload.

--- a/src/mono/mono/metadata/object-internals.h
+++ b/src/mono/mono/metadata/object-internals.h
@@ -338,13 +338,20 @@ typedef struct {
 	MonoEvent *resolving;
 	MonoEvent *unloading;
 	MonoString *name;
-	gpointer *native_assembly_load_context;
+	MonoAssemblyLoadContext *native_assembly_load_context;
 	gint64 id;
 	gint32 internal_state;
 	MonoBoolean is_collectible;
 } MonoManagedAssemblyLoadContext;
 
 TYPED_HANDLE_DECL (MonoManagedAssemblyLoadContext);
+
+typedef struct {
+	MonoObject object;
+	MonoAssemblyLoadContext *native_assembly_load_context;
+} MonoManagedReferenceTracker;
+
+TYPED_HANDLE_DECL (MonoManagedReferenceTracker);
 #endif
 
 typedef struct {

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -329,9 +329,8 @@ get_type_init_exception_for_vtable (MonoVTable *vtable)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	ERROR_DECL (error);
-	MonoDomain *domain = vtable->domain;
 	MonoClass *klass = vtable->klass;
-	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (vtable->domain, vtable->klass);
 	MonoException *ex;
 	gchar *full_name;
 
@@ -439,7 +438,6 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoDomain *domain = vtable->domain;
-	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
 	error_init (error);
 
@@ -447,6 +445,7 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 		return TRUE;
 
 	MonoClass *klass = vtable->klass;
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 
 	MonoImage *klass_image = m_class_get_image (klass);
 	if (!mono_runtime_run_module_cctor(klass_image, vtable->domain, error)) {
@@ -1837,7 +1836,7 @@ mono_method_add_generic_virtual_invocation (MonoDomain *domain, MonoVTable *vtab
 
 	/* If not found, make a new one */
 	if (!gvc) {
-		gvc = (GenericVirtualCase *)mono_domain_alloc (domain, sizeof (GenericVirtualCase));
+		gvc = (GenericVirtualCase *)mono_method_alloc_code (domain, method, sizeof (GenericVirtualCase));
 		gvc->method = method;
 		gvc->code = code;
 		gvc->count = 0;
@@ -1964,7 +1963,7 @@ mono_class_try_get_vtable (MonoDomain *domain, MonoClass *klass)
 }
 
 static gpointer*
-alloc_vtable (MonoDomain *domain, size_t vtable_size, size_t imt_table_bytes)
+alloc_vtable (MonoDomain *domain, MonoClass *klass, size_t vtable_size, size_t imt_table_bytes)
 {
 	MONO_REQ_GC_NEUTRAL_MODE;
 
@@ -1983,7 +1982,7 @@ alloc_vtable (MonoDomain *domain, size_t vtable_size, size_t imt_table_bytes)
 		alloc_offset = 0;
 	}
 
-	return (gpointer*) ((char*)mono_domain_alloc0 (domain, vtable_size) + alloc_offset);
+	return (gpointer*) ((char*)mono_class_alloc0_code (domain, klass, vtable_size) + alloc_offset);
 }
 
 static MonoVTable *
@@ -2089,7 +2088,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 	UnlockedIncrement (&mono_stats.used_class_count);
 	UnlockedAdd (&mono_stats.class_vtable_size, vtable_size);
 
-	interface_offsets = alloc_vtable (domain, vtable_size, imt_table_bytes);
+	interface_offsets = alloc_vtable (domain, klass, vtable_size, imt_table_bytes);
 	vt = (MonoVTable*) ((char*)interface_offsets + imt_table_bytes);
 	/* If on interp, skip the interp interface table */
 	if (use_interpreter)
@@ -2150,7 +2149,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 			if (bitmap != default_bitmap)
 				g_free (bitmap);
 		} else {
-			vt->vtable [m_class_get_vtable_size (klass)] = mono_domain_alloc0 (domain, class_size);
+			vt->vtable [m_class_get_vtable_size (klass)] = mono_class_alloc0_code (domain, klass, class_size);
 		}
 		vt->has_static_fields = TRUE;
 		UnlockedAdd (&mono_stats.class_static_data_size, class_size);
@@ -2282,7 +2281,7 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 
 	/*  class_vtable_array keeps an array of created vtables
 	 */
-	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 	mono_memory_manager_lock (memory_manager);
 	g_ptr_array_add (memory_manager->class_vtable_array, vt);
 	mono_memory_manager_unlock (memory_manager);

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -1735,7 +1735,7 @@ gpointer
 	}
 	generic_virtual_trampolines_size += size;
 
-	return mono_domain_code_reserve (domain, size);
+	return mono_memory_manager_code_reserve (mono_domain_ambient_memory_manager (domain), size);
 }
 
 typedef struct _GenericVirtualCase {
@@ -2707,7 +2707,7 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	MonoRemoteClass *rc;
 	gpointer* key, *mp_key;
 	char *name;
-	MonoMemoryManager *memory_manager = domain->memory_manager;
+	MonoMemoryManager *memory_manager = mono_domain_default_memory_manager (domain);
 	
 	error_init (error);
 

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -331,6 +331,7 @@ get_type_init_exception_for_vtable (MonoVTable *vtable)
 	ERROR_DECL (error);
 	MonoDomain *domain = vtable->domain;
 	MonoClass *klass = vtable->klass;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 	MonoException *ex;
 	gchar *full_name;
 
@@ -342,10 +343,9 @@ get_type_init_exception_for_vtable (MonoVTable *vtable)
 	 * in the hash.
 	 */
 	ex = NULL;
-	mono_domain_lock (domain);
-	if (domain->type_init_exception_hash)
-		ex = (MonoException *)mono_g_hash_table_lookup (domain->type_init_exception_hash, klass);
-	mono_domain_unlock (domain);
+	mono_memory_manager_lock (memory_manager);
+	ex = (MonoException *)mono_g_hash_table_lookup (memory_manager->type_init_exception_hash, klass);
+	mono_memory_manager_unlock (memory_manager);
 
 	if (!ex) {
 		const char *klass_name_space = m_class_get_name_space (klass);
@@ -439,6 +439,7 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoDomain *domain = vtable->domain;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
 	error_init (error);
 
@@ -593,11 +594,9 @@ mono_runtime_class_init_full (MonoVTable *vtable, MonoError *error)
 			 * Store the exception object so it could be thrown on subsequent
 			 * accesses.
 			 */
-			mono_domain_lock (domain);
-			if (!domain->type_init_exception_hash)
-				domain->type_init_exception_hash = mono_g_hash_table_new_type_internal (mono_aligned_addr_hash, NULL, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Type Initialization Exception Table");
-			mono_g_hash_table_insert_internal (domain->type_init_exception_hash, klass, exc_to_throw);
-			mono_domain_unlock (domain);
+			mono_memory_manager_lock (memory_manager);
+			mono_g_hash_table_insert_internal (memory_manager->type_init_exception_hash, klass, exc_to_throw);
+			mono_memory_manager_unlock (memory_manager);
 		}
 
 		if (last_domain)
@@ -2283,7 +2282,10 @@ mono_class_create_runtime_vtable (MonoDomain *domain, MonoClass *klass, MonoErro
 
 	/*  class_vtable_array keeps an array of created vtables
 	 */
-	g_ptr_array_add (domain->class_vtable_array, vt);
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
+	mono_memory_manager_lock (memory_manager);
+	g_ptr_array_add (memory_manager->class_vtable_array, vt);
+	mono_memory_manager_unlock (memory_manager);
 	/* klass->runtime_info is protected by the loader lock, both when
 	 * it it enlarged and when it is stored info.
 	 */
@@ -2705,6 +2707,7 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 	MonoRemoteClass *rc;
 	gpointer* key, *mp_key;
 	char *name;
+	MonoMemoryManager *memory_manager = domain->memory_manager;
 	
 	error_init (error);
 
@@ -2719,7 +2722,9 @@ mono_remote_class (MonoDomain *domain, MonoStringHandle class_name, MonoClass *p
 		return rc;
 	}
 
-	name = mono_string_to_utf8_mp (domain->mp, MONO_HANDLE_RAW (class_name), error);
+	mono_memory_manager_lock (memory_manager);
+	name = mono_string_to_utf8_mp (memory_manager->mp, MONO_HANDLE_RAW (class_name), error);
+	mono_memory_manager_unlock (memory_manager);
 	if (!is_ok (error)) {
 		g_free (key);
 		mono_domain_unlock (domain);

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -184,36 +184,22 @@ mono_reflected_hash (gconstpointer a) {
 static void
 clear_cached_object (MonoDomain *domain, gpointer o, MonoClass *klass)
 {
-	mono_domain_lock (domain);
-	if (domain->refobject_hash) {
-        ReflectedEntry pe;
-		gpointer orig_pe, orig_value;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
-		pe.item = o;
-		pe.refclass = klass;
+	mono_memory_manager_lock (memory_manager);
 
-		if (mono_conc_g_hash_table_lookup_extended (domain->refobject_hash, &pe, &orig_pe, &orig_value)) {
-			mono_conc_g_hash_table_remove (domain->refobject_hash, &pe);
-			free_reflected_entry ((ReflectedEntry*)orig_pe);
-		}
+	ReflectedEntry pe;
+	gpointer orig_pe, orig_value;
+
+	pe.item = o;
+	pe.refclass = klass;
+
+	if (mono_conc_g_hash_table_lookup_extended (memory_manager->refobject_hash, &pe, &orig_pe, &orig_value)) {
+		mono_conc_g_hash_table_remove (memory_manager->refobject_hash, &pe);
+		free_reflected_entry ((ReflectedEntry*)orig_pe);
 	}
-	mono_domain_unlock (domain);
-}
 
-static void
-cleanup_refobject_hash (gpointer key, gpointer value, gpointer user_data)
-{
-	free_reflected_entry ((ReflectedEntry*)key);
-}
-
-void
-mono_reflection_cleanup_domain (MonoDomain *domain)
-{
-	if (domain->refobject_hash) {
-		mono_conc_g_hash_table_foreach (domain->refobject_hash, cleanup_refobject_hash, NULL);
-		mono_conc_g_hash_table_destroy (domain->refobject_hash);
-		domain->refobject_hash = NULL;
-	}
+	mono_memory_manager_unlock (memory_manager);
 }
 
 /**
@@ -454,6 +440,7 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	MonoType *norm_type;
 	MonoReflectionType *res;
 	MonoClass *klass;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
 	error_init (error);
 
@@ -500,15 +487,10 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	}
 
 	mono_loader_lock (); /*FIXME mono_class_init_internal and mono_class_vtable acquire it*/
-	mono_domain_lock (domain);
-	if (!domain->type_hash)
-		domain->type_hash = mono_g_hash_table_new_type_internal ((GHashFunc)mono_metadata_type_hash, 
-				(GCompareFunc)mono_metadata_type_equal, MONO_HASH_VALUE_GC, MONO_ROOT_SOURCE_DOMAIN, domain, "Domain Reflection Type Table");
-	if ((res = (MonoReflectionType *)mono_g_hash_table_lookup (domain->type_hash, type))) {
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return res;
-	}
+	mono_memory_manager_lock (memory_manager);
+
+	if ((res = (MonoReflectionType *)mono_g_hash_table_lookup (memory_manager->type_hash, type)))
+		goto leave;
 
 	/*Types must be normalized so a generic instance of the GTD get's the same inner type.
 	 * For example in: Foo<A,B>; Bar<A> : Foo<A, Bar<A>>
@@ -521,14 +503,12 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	if (norm_type != type) {
 		res = mono_type_get_object_checked (domain, norm_type, error);
 		if (!is_ok (error)) {
-			mono_domain_unlock (domain);
-			mono_loader_unlock ();
-			return NULL;
+			res = NULL;
+			goto leave;
 		}
-		mono_g_hash_table_insert_internal (domain->type_hash, type, res);
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return res;
+
+		mono_g_hash_table_insert_internal (memory_manager->type_hash, type, res);
+		goto leave;
 	}
 
 	if ((type->type == MONO_TYPE_GENERICINST) && type->data.generic_class->is_dynamic && !m_class_was_typebuilder (type->data.generic_class->container_class)) {
@@ -549,31 +529,29 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 		/* I would have expected ReflectionTypeLoadException, but evidently .NET throws TLE in this case. */
 		mono_error_set_type_load_class (error, klass, "TypeBuilder.CreateType() not called for generic class %s", full_name);
 		g_free (full_name);
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return NULL;
+		res = NULL;
+		goto leave;
 	}
 
 	if (mono_class_has_ref_info (klass) && !m_class_was_typebuilder (klass) && !type->byref) {
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return &mono_class_get_ref_info_raw (klass)->type; /* FIXME use handles */
+		res = &mono_class_get_ref_info_raw (klass)->type; /* FIXME use handles */
+		goto leave;
 	}
 	/* This is stored in vtables/JITted code so it has to be pinned */
 	res = (MonoReflectionType *)mono_object_new_pinned (domain, mono_defaults.runtimetype_class, error);
 	if (!is_ok (error)) {
-		mono_domain_unlock (domain);
-		mono_loader_unlock ();
-		return NULL;
+		res = NULL;
+		goto leave;
 	}
 
 	res->type = type;
-	mono_g_hash_table_insert_internal (domain->type_hash, type, res);
+	mono_g_hash_table_insert_internal (memory_manager->type_hash, type, res);
 
 	if (type->type == MONO_TYPE_VOID)
 		domain->typeof_void = (MonoObject*)res;
 
-	mono_domain_unlock (domain);
+leave:
+	mono_memory_manager_unlock (memory_manager);
 	mono_loader_unlock ();
 	return res;
 }

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -184,7 +184,7 @@ mono_reflected_hash (gconstpointer a) {
 static void
 clear_cached_object (MonoDomain *domain, gpointer o, MonoClass *klass)
 {
-	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 
 	mono_memory_manager_lock (memory_manager);
 
@@ -440,12 +440,12 @@ mono_type_get_object_checked (MonoDomain *domain, MonoType *type, MonoError *err
 	MonoType *norm_type;
 	MonoReflectionType *res;
 	MonoClass *klass;
-	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 
 	error_init (error);
 
 	g_assert (type != NULL);
 	klass = mono_class_from_mono_type_internal (type);
+	MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 
 	/*we must avoid using @type as it might have come
 	 * from a mono_metadata_type_dup and the caller

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -4041,7 +4041,7 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 	 * Together with this we must ensure the contents of all instances to match the created type.
 	 */
 	if (mono_class_is_gtd (klass)) {
-		MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
+		MonoMemoryManager *memory_manager = mono_memory_manager_from_class (domain, klass);
 		struct remove_instantiations_user_data data;
 		data.klass = klass;
 		data.error = error;

--- a/src/mono/mono/metadata/sre.c
+++ b/src/mono/mono/metadata/sre.c
@@ -4040,12 +4040,15 @@ ves_icall_TypeBuilder_create_runtime_class (MonoReflectionTypeBuilderHandle ref_
 	 *
 	 * Together with this we must ensure the contents of all instances to match the created type.
 	 */
-	if (domain->type_hash && mono_class_is_gtd (klass)) {
+	if (mono_class_is_gtd (klass)) {
+		MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (domain);
 		struct remove_instantiations_user_data data;
 		data.klass = klass;
 		data.error = error;
 		mono_error_assert_ok (error);
-		mono_g_hash_table_foreach_remove (domain->type_hash, remove_instantiations_of_and_ensure_contents, &data);
+		mono_memory_manager_lock (memory_manager);
+		mono_g_hash_table_foreach_remove (memory_manager->type_hash, remove_instantiations_of_and_ensure_contents, &data);
+		mono_memory_manager_unlock (memory_manager);
 		goto_if_nok (error, failure);
 	}
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6884,7 +6884,7 @@ generate_compacted_code (TransformData *td)
 	}
 
 	// Generate the compacted stream of instructions
-	td->new_code = ip = (guint16*)mono_domain_alloc0 (td->rtm->domain, size * sizeof (guint16));
+	td->new_code = ip = (guint16*)mono_method_alloc0_code (td->rtm->domain, td->method, size * sizeof (guint16));
 	ins = td->first_ins;
 	while (ins) {
 		ip = emit_compacted_instruction (td, ip, ins);
@@ -7847,7 +7847,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 	code_len_u8 = (guint8 *) td->new_code_end - (guint8 *) td->new_code;
 	code_len_u16 = td->new_code_end - td->new_code;
 
-	rtm->clauses = (MonoExceptionClause*)mono_domain_alloc0 (domain, header->num_clauses * sizeof (MonoExceptionClause));
+	rtm->clauses = (MonoExceptionClause*)mono_method_alloc0_code (domain, method, header->num_clauses * sizeof (MonoExceptionClause));
 	memcpy (rtm->clauses, header->clauses, header->num_clauses * sizeof(MonoExceptionClause));
 	rtm->code = (gushort*)td->new_code;
 	rtm->init_locals = header->init_locals;
@@ -7870,7 +7870,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 	rtm->vt_stack_size = td->max_vt_sp;
 	rtm->total_locals_size = ALIGN_TO (td->total_locals_size, MINT_VT_ALIGNMENT);
 	rtm->alloca_size = ALIGN_TO (rtm->total_locals_size + rtm->vt_stack_size + rtm->stack_size, 8);
-	rtm->data_items = (gpointer*)mono_domain_alloc0 (domain, td->n_data_items * sizeof (td->data_items [0]));
+	rtm->data_items = (gpointer*)mono_method_alloc0_code (domain, method, td->n_data_items * sizeof (td->data_items [0]));
 	memcpy (rtm->data_items, td->data_items, td->n_data_items * sizeof (td->data_items [0]));
 
 	/* Save debug info */
@@ -7880,7 +7880,7 @@ generate (MonoMethod *method, MonoMethodHeader *header, InterpMethod *rtm, MonoG
 	int jinfo_len;
 	jinfo_len = mono_jit_info_size ((MonoJitInfoFlags)0, header->num_clauses, 0);
 	MonoJitInfo *jinfo;
-	jinfo = (MonoJitInfo *)mono_domain_alloc0 (domain, jinfo_len);
+	jinfo = (MonoJitInfo *)mono_method_alloc0_code (domain, method, jinfo_len);
 	jinfo->is_interp = 1;
 	rtm->jinfo = jinfo;
 	mono_jit_info_init (jinfo, method, (guint8*)rtm->code, code_len_u8, (MonoJitInfoFlags)0, header->num_clauses, 0);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -854,8 +854,9 @@ static void
 interp_generate_ipe_throw_with_msg (TransformData *td, MonoError *error_msg)
 {
 	MonoJitICallInfo *info = &mono_get_jit_icall_info ()->mono_throw_invalid_program;
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (td->rtm->domain);
 
-	char *msg = mono_mempool_strdup (td->rtm->domain->mp, mono_error_get_message (error_msg));
+	char *msg = mono_mempool_strdup (memory_manager->mp, mono_error_get_message (error_msg));
 
 	interp_add_ins (td, MINT_MONO_LDPTR);
 	td->last_ins->data [0] = get_data_item_index (td, msg);

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -2317,7 +2317,8 @@ static void
 emit_invalid_program_with_msg (MonoCompile *cfg, MonoError *error_msg, MonoMethod *caller, MonoMethod *callee)
 {
 	g_assert (!is_ok (error_msg));
-	char *str = mono_mempool_strdup (cfg->domain->mp, mono_error_get_message (error_msg));
+	MonoMemoryManager *memory_manager = mono_domain_ambient_memory_manager (cfg->domain);
+	char *str = mono_mempool_strdup (memory_manager->mp, mono_error_get_message (error_msg));
 	MonoInst *iargs[1];
 	if (cfg->compile_aot)
 		EMIT_NEW_LDSTRLITCONST (cfg, iargs [0], str);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -119,7 +119,6 @@ static gpointer throw_corlib_exception_func;
 
 static MonoFtnPtrEHCallback ftnptr_eh_callback;
 
-static void mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context);
 static void mono_raise_exception_with_ctx (MonoException *exc, MonoContext *ctx);
 static void mono_runtime_walk_stack_with_ctx (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data);
 static gboolean mono_current_thread_has_handle_block_guard (void);
@@ -1242,7 +1241,7 @@ mono_walk_stack (MonoJitStackWalk func, MonoUnwindOptions options, void *user_da
  * function is called with the relevant info. The walk ends when no more
  * managed stack frames are found or when the callback returns a TRUE value.
  */
-static void
+void
 mono_walk_stack_full (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context)
 {
 	gint il_offset;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4546,7 +4546,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 	if (mono_aot_only) {
 		/* This helps catch code allocation requests */
-		mono_code_manager_set_read_only (domain->code_mp);
+		mono_code_manager_set_read_only (domain->memory_manager->code_mp);
 		mono_marshal_use_aot_wrappers (TRUE);
 	}
 

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4546,7 +4546,7 @@ mini_init (const char *filename, const char *runtime_version)
 
 	if (mono_aot_only) {
 		/* This helps catch code allocation requests */
-		mono_code_manager_set_read_only (domain->memory_manager->code_mp);
+		mono_code_manager_set_read_only (mono_domain_ambient_memory_manager (domain)->code_mp);
 		mono_marshal_use_aot_wrappers (TRUE);
 	}
 

--- a/src/mono/mono/mini/mini.h
+++ b/src/mono/mono/mini/mini.h
@@ -2525,6 +2525,7 @@ MONO_API void     mono_print_thread_dump_from_ctx        (MonoContext *ctx);
 void     mono_walk_stack_with_ctx               (MonoJitStackWalk func, MonoContext *start_ctx, MonoUnwindOptions unwind_options, void *user_data);
 void     mono_walk_stack_with_state             (MonoJitStackWalk func, MonoThreadUnwindState *state, MonoUnwindOptions unwind_options, void *user_data);
 void     mono_walk_stack                        (MonoJitStackWalk func, MonoUnwindOptions options, void *user_data);
+void     mono_walk_stack_full                   (MonoJitStackWalk func, MonoContext *start_ctx, MonoDomain *domain, MonoJitTlsData *jit_tls, MonoLMF *lmf, MonoUnwindOptions unwind_options, gpointer user_data, gboolean crash_context);
 gboolean mono_thread_state_init_from_sigctx     (MonoThreadUnwindState *ctx, void *sigctx);
 void     mono_thread_state_init                 (MonoThreadUnwindState *ctx);
 gboolean mono_thread_state_init_from_current    (MonoThreadUnwindState *ctx);

--- a/src/mono/mono/sgen/sgen-scan-object.h
+++ b/src/mono/mono/sgen/sgen-scan-object.h
@@ -43,6 +43,10 @@
 	sgen_binary_protocol_scan_vtype_begin (start + SGEN_CLIENT_OBJECT_HEADER_SIZE, size);
 #endif
 #endif
+#if defined(ENABLE_NETCORE) && !defined(DISABLE_ALC_UNLOADABILITY)
+	// Scan RefTracker for collectible MemoryManagers
+	// This is expensive, and should probably be optimized by putting the RefTracker handle in the vtables when appropriate so we can just check there
+#endif
 	switch (desc & DESC_TYPE_MASK) {
 	case DESC_TYPE_RUN_LENGTH:
 #define SCAN OBJ_RUN_LEN_FOREACH_PTR (desc, ((GCObject*)start))

--- a/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
+++ b/src/mono/netcore/System.Private.CoreLib/System.Private.CoreLib.csproj
@@ -215,6 +215,7 @@
       <Compile Include="$(BclSourcesRoot)\System\Reflection\FieldInfo.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\MemberInfo.Mono.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\MethodBase.Mono.cs" />
+      <Compile Include="$(BclSourcesRoot)\System\Reflection\ReferenceTracker.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\RuntimeAssembly.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\RuntimeEventInfo.cs" />
       <Compile Include="$(BclSourcesRoot)\System\Reflection\RuntimeFieldInfo.cs" />

--- a/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -541,7 +541,7 @@
 		</type>
 
 		<!-- assembly-load-context.c: mono_domain_create_individual_alc -->
-		<type fullname="System.Reflection.RefTracker" preserve="fields" >
+		<type fullname="System.Reflection.ReferenceTracker" preserve="fields" >
 			<method name=".ctor" />
 		</type>
 

--- a/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -540,6 +540,11 @@
 			<method signature="System.Void .ctor()" />
 		</type>
 
+		<!-- assembly-load-context.c: mono_domain_create_individual_alc -->
+		<type fullname="System.Reflection.RefTracker" preserve="fields" >
+			<method name=".ctor" />
+		</type>
+
 		<!-- domain.c: mono_defaults.method_info_class -->
 		<type fullname="System.Reflection.MethodInfo" preserve="nothing" />
 

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/ReferenceTracker.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/ReferenceTracker.cs
@@ -9,19 +9,17 @@ namespace System.Reflection
 {
     internal sealed class ReferenceTracker
     {
+#pragma warning disable CA1823, 414, 169
         private IntPtr NativeALC;
+#pragma warning restore CA1823, 414, 169
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         private static extern void Destroy(IntPtr NativeALC);
 
-        private ReferenceTracker(IntPtr native_alc)
-        {
-            this.NativeALC = native_alc;
-        }
-
         ~ReferenceTracker()
         {
-            Destroy(NativeALC);
+            if (NativeALC != IntPtr.Zero)
+                Destroy(NativeALC);
         }
     }
 }

--- a/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/ReferenceTracker.cs
+++ b/src/mono/netcore/System.Private.CoreLib/src/System/Reflection/ReferenceTracker.cs
@@ -1,0 +1,27 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+namespace System.Reflection
+{
+    internal sealed class ReferenceTracker
+    {
+        private IntPtr NativeALC;
+
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private static extern void Destroy(IntPtr NativeALC);
+
+        private ReferenceTracker(IntPtr native_alc)
+        {
+            this.NativeALC = native_alc;
+        }
+
+        ~ReferenceTracker()
+        {
+            Destroy(NativeALC);
+        }
+    }
+}


### PR DESCRIPTION
Various functionality is behind build defines due to both stability and performance concerns.

Remaining work for this PR:
* Scan RefTracker from objects
* Scan RefTracker from stack walk
* Get inflated method properly in `mono_memory_manager_from_method`
* Rebase

Remaining long-term work:
* Add and populate `keepalive` field with RefTracker for reflection types
* Update remaining code memory allocations (mostly JIT and AOT)
* Put MemoryManager/RefTracker pointers directly in vtables
* Update docs
* Add MONO_ROOT_SOURCE_MEMORY_MANAGER (or something like that)
* Add exclusions for creating certain types within collectible ALCs
* Turn on by default for netcore