### PR TITLE
Add info to templates about area-, os-, arch- labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.md
@@ -9,6 +9,18 @@ assignees: ''
 
 <!--This is just a template - feel free to delete any and all of it and replace as appropriate.-->
 
+<!--
+     Labels on your issue are optional but can help it get routed quickly.
+
+     "area-" labels help route your issue to the right expert. Please no more than one "area-" label.
+     https://github.com/dotnet/runtime/labels?q=area-
+     https://github.com/dotnet/runtime/blob/master/docs/area-owners.md
+
+     "os-" and "arch-" labels are useful for issues specific to certain platforms or architectures.
+     https://github.com/dotnet/runtime/labels?q=arch-
+     https://github.com/dotnet/runtime/labels?q=os-
+-->
+
 ### Description
 
 <!--

--- a/.github/ISSUE_TEMPLATE/03_performance_issue.md
+++ b/.github/ISSUE_TEMPLATE/03_performance_issue.md
@@ -26,6 +26,18 @@ assignees: ''
 * If relevant, what are the specs of the machine?
   -->
 
+ <!--
+     Labels on your issue are optional but can help it get routed quickly.
+
+     "area-" labels help route your issue to the right expert. Please no more than one "area-" label.
+     https://github.com/dotnet/runtime/labels?q=area-
+     https://github.com/dotnet/runtime/blob/master/docs/area-owners.md
+
+     "os-" and "arch-" labels are useful for issues specific to certain platforms or architectures.
+     https://github.com/dotnet/runtime/labels?q=arch-
+     https://github.com/dotnet/runtime/labels?q=os-
+-->
+
 ### Regression?
 
 <!--


### PR DESCRIPTION
This may help reduce the number of guesses that the bot has to make.