### PR TITLE
Fix issue with Trimming tests on Windows

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -59,7 +59,7 @@ jobs:
     jobTemplate: /eng/pipelines/common/global-build-job.yml
     buildConfig: release
     platforms:
-#    - Windows_NT_x64
+    - Windows_NT_x64
     - OSX_x64
     - Linux_x64
     jobParameters:

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -106,6 +106,12 @@
       <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFrameworkName)" />
     </ItemGroup>
 
+    <ItemGroup>
+      <!-- Remove pdbs form RuntimeList.xml as they shouldn't be there -->
+      <_runtimePackLibFiles Remove="@(_runtimePackLibFiles)" Condition="'%(Extension)' == '.pdb'" />
+      <_runtimePackNativeFiles Remove="@(_runtimePackNativeFiles)" Condition="'%(Extension)' == '.pdb'" />
+    </ItemGroup>
+
     <CreateFrameworkListFile Files="@(_refPackLibFile)"
                              TargetFile="$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml"
                              TargetFilePrefixes="ref/;runtimes/"

--- a/src/libraries/pretest.proj
+++ b/src/libraries/pretest.proj
@@ -87,11 +87,9 @@
     <ItemGroup>
       <_refPackLibFile Include="$(MicrosoftNetCoreAppRefPackRefDir)*.*">
         <TargetPath>ref/$(NetCoreAppCurrent)</TargetPath>
-        <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
       </_refPackLibFile>
       <_runtimePackLibFiles Include="$(MicrosoftNetCoreAppRuntimePackRidLibTfmDir)*.*">
         <TargetPath>runtimes/$(PackageRID)/lib/$(NetCoreAppCurrent)</TargetPath>
-        <IsSymbolFile Condition="$([System.String]::Copy('%(Identity)').EndsWith('pdb'))">true</IsSymbolFile>
       </_runtimePackLibFiles>
       <_runtimePackNativeFiles Include="$(MicrosoftNetCoreAppRuntimePackNativeDir)*.*">
         <TargetPath>runtimes/$(PackageRID)/native</TargetPath>
@@ -106,10 +104,18 @@
       <FrameworkListRootAttributes Include="FrameworkName" Value="$(SharedFrameworkName)" />
     </ItemGroup>
 
+    <!-- We need to set this metadata in a separate ItemGroup than when the Items are initially populated in order to
+    have access to the Extension metadata. -->
     <ItemGroup>
-      <!-- Remove pdbs form RuntimeList.xml as they shouldn't be there -->
-      <_runtimePackLibFiles Remove="@(_runtimePackLibFiles)" Condition="'%(Extension)' == '.pdb'" />
-      <_runtimePackNativeFiles Remove="@(_runtimePackNativeFiles)" Condition="'%(Extension)' == '.pdb'" />
+      <_refPackLibFile>
+        <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
+      </_refPackLibFile>
+      <_runtimePackLibFiles>
+        <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
+      </_runtimePackLibFiles>
+      <_runtimePackNativeFiles>
+        <IsSymbolFile Condition="'%(Extension)' == '.pdb'">true</IsSymbolFile>
+      </_runtimePackNativeFiles>
     </ItemGroup>
 
     <CreateFrameworkListFile Files="@(_refPackLibFile)"


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39288

RuntimeList.xml file was incorrectly also listing .pdbs so this PR is fixing that and will fix the issue that caused the tests to be disabled.

cc: @eerhardt @marek-safar @safern @ViktorHofer 