### PR TITLE
Add support for examining arm32 R2R files with R2RDump

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
@@ -68,6 +68,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case Machine.Amd64:
                     return ((Amd64.Registers)regnum).ToString();
                 case Machine.Arm:
+                case Machine.ArmThumb2:
                     return ((Arm.Registers)regnum).ToString();
                 case Machine.Arm64:
                     return ((Arm64.Registers)regnum).ToString();


### PR DESCRIPTION
- We already had support for nearly everything, but the names of the registers were not handled correctly
