### PR TITLE
WASM: Enable System.Memory tests

### DIFF
--- a/src/libraries/System.Memory/tests/Span/Reflection.cs
+++ b/src/libraries/System.Memory/tests/Span/Reflection.cs
@@ -40,6 +40,7 @@ namespace System.SpanTests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39311", TestPlatforms.Browser)]
         public static void BinaryPrimitives_StaticWithSpanArgument()
         {
             Type type = typeof(BinaryPrimitives);

--- a/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
+++ b/src/libraries/System.Memory/tests/System.Memory.Tests.csproj
@@ -171,8 +171,6 @@
     <Compile Include="ReadOnlySpan\ToArray.cs" />
     <Compile Include="ReadOnlySpan\ToString.cs" />
     <Compile Include="ReadOnlySpan\ToUpperLower.cs" />
-    <Compile Include="$(CommonTestPath)Tests\System\StringTests.cs"
-             Link="ReadOnlySpan\StringTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Memory\AsMemory.cs" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -38,7 +38,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Packaging\tests\System.IO.Packaging.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Parallel\tests\System.Linq.Parallel.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\PalTests\System.Net.Primitives.Pal.Tests.csproj" />


### PR DESCRIPTION
One test failed with an issue: https://github.com/dotnet/runtime/issues/39311

Also noticed that StringTests.cs is included from the CommonTestPath, this is a historical artifact from when System.Memory built for netfx/netstandard so we could run tests on those configs.
We no longer need it since StringTests.cs is already ran in System.Runtime.Tests.