### PR TITLE
Fix `fgOptimizeBranch` when run late.

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -15333,6 +15333,12 @@ bool Compiler::fgOptimizeBranch(BasicBlock* bJump)
         // Clone/substitute the expression.
         Statement* stmt = gtCloneStmt(curStmt);
 
+        if (fgStmtListThreaded)
+        {
+            gtSetStmtInfo(stmt);
+            fgSetStmtSeq(stmt);
+        }
+
         // cloneExpr doesn't handle everything.
         if (stmt == nullptr)
         {


### PR DESCRIPTION
`fgOptimizeBranch` can now run during `fgInsertGCPolls` so
it needs additional processing for newly-created statements.

Fixes #39308.