### PR TITLE
Micro optimizations for serialization

### DIFF
--- a/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
+++ b/src/libraries/System.Text.Encodings.Web/src/System/Text/Encodings/Web/DefaultJavaScriptEncoderBasicLatin.cs
@@ -99,18 +99,11 @@ namespace System.Text.Encodings.Web
 #endif
             Debug.Assert(textLength > 0 && ptr < end);
 
-            // For performance on certain platforms, avoid referencing the static table for every value.
-            ReadOnlySpan<byte> allowList = AllowList;
             do
             {
                 Debug.Assert(text <= ptr && ptr < (text + textLength));
 
-                char value = *(char*)ptr;
-
-                // NeedsEscaping() is manually inlined below for perf; verify semantics remain consistent.
-                Debug.Assert((value > LastAsciiCharacter || allowList[value] == 0) == NeedsEscaping(value));
-
-                if (value > LastAsciiCharacter || allowList[value] == 0)
+                if (NeedsEscaping(*(char*)ptr))
                 {
                     goto Return;
                 }
@@ -242,6 +235,7 @@ namespace System.Text.Encodings.Web
                 byte* end = ptr + textLength;
 
 #if NETCOREAPP
+
                 if (Sse2.IsSupported && textLength >= Vector128<sbyte>.Count)
                 {
                     goto Vectorized;
@@ -251,16 +245,11 @@ namespace System.Text.Encodings.Web
 #endif
                 Debug.Assert(textLength > 0 && ptr < end);
 
-                // For performance on certain platforms, avoid referencing the static table for every value.
-                ReadOnlySpan<byte> allowList = AllowList;
                 do
                 {
                     Debug.Assert(pValue <= ptr && ptr < (pValue + utf8Text.Length));
 
-                    // NeedsEscaping() is manually inlined below for perf; verify semantics remain consistent.
-                    Debug.Assert((allowList[*ptr] == 0) == NeedsEscaping(*ptr));
-
-                    if (allowList[*ptr] == 0)
+                    if (NeedsEscaping(*ptr))
                     {
                         goto Return;
                     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
@@ -14,7 +14,8 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, short value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(value);
+            // For performance, lift up the writer implementation.
+            writer.WriteNumberValue((long)value);
         }
 
         internal override short ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
@@ -12,7 +12,8 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(value);
+            // For performance, lift up the writer implementation.
+            writer.WriteNumberValue((long)value);
         }
 
         internal override int ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -14,7 +14,15 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value);
+            // For performance, lift up the writer implementation.
+            if (value == null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                writer.WriteStringValue(value.AsSpan());
+            }
         }
 
         internal override string ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
@@ -12,7 +12,8 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, ushort value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(value);
+            // For performance, lift up the writer implementation.
+            writer.WriteNumberValue((long)value);
         }
 
         internal override ushort ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
@@ -12,7 +12,8 @@ namespace System.Text.Json.Serialization.Converters
 
         public override void Write(Utf8JsonWriter writer, uint value, JsonSerializerOptions options)
         {
-            writer.WriteNumberValue(value);
+            // For performance, lift up the writer implementation.
+            writer.WriteNumberValue((ulong)value);
         }
 
         internal override uint ReadWithQuotes(ref Utf8JsonReader reader)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Bytes.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Bytes.cs
@@ -18,10 +18,8 @@ namespace System.Text.Json
         /// Thrown if this would result in invalid JSON being written (while validation is enabled).
         /// </exception>
         public void WriteBase64String(JsonEncodedText propertyName, ReadOnlySpan<byte> bytes)
-            => WriteBase64StringHelper(propertyName.EncodedUtf8Bytes, bytes);
-
-        private void WriteBase64StringHelper(ReadOnlySpan<byte> utf8PropertyName, ReadOnlySpan<byte> bytes)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             JsonWriterHelper.ValidateBytes(bytes);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTime.cs
@@ -22,10 +22,8 @@ namespace System.Text.Json
         /// The property name should already be escaped when the instance of <see cref="JsonEncodedText"/> was created.
         /// </remarks>
         public void WriteString(JsonEncodedText propertyName, DateTime value)
-            => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteStringHelper(ReadOnlySpan<byte> utf8PropertyName, DateTime value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteStringByOptions(utf8PropertyName, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.DateTimeOffset.cs
@@ -21,10 +21,8 @@ namespace System.Text.Json
         /// Writes the <see cref="DateTimeOffset"/> using the round-trippable ('O') <see cref="StandardFormat"/> , for example: 2017-06-12T05:30:45.7680000-07:00.
         /// </remarks>
         public void WriteString(JsonEncodedText propertyName, DateTimeOffset value)
-            => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteStringHelper(ReadOnlySpan<byte> utf8PropertyName, DateTimeOffset value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteStringByOptions(utf8PropertyName, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Decimal.cs
@@ -21,10 +21,8 @@ namespace System.Text.Json
         /// Writes the <see cref="decimal"/> using the default <see cref="StandardFormat"/> (that is, 'G').
         /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, decimal value)
-            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, decimal value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteNumberByOptions(utf8PropertyName, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Double.cs
@@ -21,10 +21,8 @@ namespace System.Text.Json
         /// Writes the <see cref="double"/> using the default <see cref="StandardFormat"/> (that is, 'G').
         /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, double value)
-            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, double value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             JsonWriterHelper.ValidateDouble(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Float.cs
@@ -21,10 +21,8 @@ namespace System.Text.Json
         /// Writes the <see cref="float"/> using the default <see cref="StandardFormat"/> (that is, 'G').
         /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, float value)
-            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, float value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             JsonWriterHelper.ValidateSingle(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.Guid.cs
@@ -21,10 +21,8 @@ namespace System.Text.Json
         /// Writes the <see cref="Guid"/> using the default <see cref="StandardFormat"/> (that is, 'D'), as the form: nnnnnnnn-nnnn-nnnn-nnnn-nnnnnnnnnnnn.
         /// </remarks>
         public void WriteString(JsonEncodedText propertyName, Guid value)
-            => WriteStringHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteStringHelper(ReadOnlySpan<byte> utf8PropertyName, Guid value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteStringByOptions(utf8PropertyName, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.SignedNumber.cs
@@ -21,10 +21,8 @@ namespace System.Text.Json
         /// Writes the <see cref="long"/> using the default <see cref="StandardFormat"/> (that is, 'G'), for example: 32767.
         /// </remarks>
         public void WriteNumber(JsonEncodedText propertyName, long value)
-            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, long value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteNumberByOptions(utf8PropertyName, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteProperties.UnsignedNumber.cs
@@ -22,10 +22,8 @@ namespace System.Text.Json
         /// </remarks>
         [CLSCompliant(false)]
         public void WriteNumber(JsonEncodedText propertyName, ulong value)
-            => WriteNumberHelper(propertyName.EncodedUtf8Bytes, value);
-
-        private void WriteNumberHelper(ReadOnlySpan<byte> utf8PropertyName, ulong value)
         {
+            ReadOnlySpan<byte> utf8PropertyName = propertyName.EncodedUtf8Bytes;
             Debug.Assert(utf8PropertyName.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteNumberByOptions(utf8PropertyName, value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Bytes.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Bytes.cs
@@ -33,7 +33,10 @@ namespace System.Text.Json
 
         private void WriteBase64ByOptions(ReadOnlySpan<byte> bytes)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
 
             if (_options.Indented)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTime.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTime.cs
@@ -21,7 +21,11 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteStringValue(DateTime value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteStringValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTimeOffset.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.DateTimeOffset.cs
@@ -22,7 +22,11 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteStringValue(DateTimeOffset value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteStringValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Decimal.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Decimal.cs
@@ -21,7 +21,11 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteNumberValue(decimal value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteNumberValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
@@ -25,7 +25,11 @@ namespace System.Text.Json
         {
             JsonWriterHelper.ValidateDouble(value);
 
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteNumberValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
@@ -25,7 +25,11 @@ namespace System.Text.Json
         {
             JsonWriterHelper.ValidateSingle(value);
 
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteNumberValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.FormattedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.FormattedNumber.cs
@@ -25,7 +25,11 @@ namespace System.Text.Json
         {
             JsonWriterHelper.ValidateValue(utf8FormattedNumber);
             JsonWriterHelper.ValidateNumber(utf8FormattedNumber);
-            ValidateWritingValue();
+
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
 
             if (_options.Indented)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Guid.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Guid.cs
@@ -21,7 +21,11 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteStringValue(Guid value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteStringValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Helpers.cs
@@ -12,25 +12,24 @@ namespace System.Text.Json
     {
         private void ValidateWritingValue()
         {
-            if (!_options.SkipValidation)
-            {
-                if (_inObject)
-                {
-                    if (_tokenType != JsonTokenType.PropertyName)
-                    {
-                        Debug.Assert(_tokenType != JsonTokenType.None && _tokenType != JsonTokenType.StartArray);
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueWithinObject, currentDepth: default, token: default, _tokenType);
-                    }
-                }
-                else
-                {
-                    Debug.Assert(_tokenType != JsonTokenType.PropertyName);
+            Debug.Assert(!_options.SkipValidation);
 
-                    // It is more likely for CurrentDepth to not equal 0 when writing valid JSON, so check that first to rely on short-circuiting and return quickly.
-                    if (CurrentDepth == 0 && _tokenType != JsonTokenType.None)
-                    {
-                        ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
-                    }
+            if (_inObject)
+            {
+                if (_tokenType != JsonTokenType.PropertyName)
+                {
+                    Debug.Assert(_tokenType != JsonTokenType.None && _tokenType != JsonTokenType.StartArray);
+                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueWithinObject, currentDepth: default, token: default, _tokenType);
+                }
+            }
+            else
+            {
+                Debug.Assert(_tokenType != JsonTokenType.PropertyName);
+
+                // It is more likely for CurrentDepth to not equal 0 when writing valid JSON, so check that first to rely on short-circuiting and return quickly.
+                if (CurrentDepth == 0 && _tokenType != JsonTokenType.None)
+                {
+                    ThrowHelper.ThrowInvalidOperationException(ExceptionResource.CannotWriteValueAfterPrimitiveOrClose, currentDepth: default, token: default, _tokenType);
                 }
             }
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Literal.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Literal.cs
@@ -46,7 +46,11 @@ namespace System.Text.Json
 
         private void WriteLiteralByOptions(ReadOnlySpan<byte> utf8Value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteLiteralIndented(utf8Value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.SignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.SignedNumber.cs
@@ -34,7 +34,11 @@ namespace System.Text.Json
         /// </remarks>
         public void WriteNumberValue(long value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteNumberValueIndented(value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
@@ -16,10 +16,8 @@ namespace System.Text.Json
         /// Thrown if this would result in invalid JSON being written (while validation is enabled).
         /// </exception>
         public void WriteStringValue(JsonEncodedText value)
-            => WriteStringValueHelper(value.EncodedUtf8Bytes);
-
-        private void WriteStringValueHelper(ReadOnlySpan<byte> utf8Value)
         {
+            ReadOnlySpan<byte> utf8Value = value.EncodedUtf8Bytes;
             Debug.Assert(utf8Value.Length <= JsonConstants.MaxUnescapedTokenSize);
 
             WriteStringByOptions(utf8Value);
@@ -99,7 +97,11 @@ namespace System.Text.Json
 
         private void WriteStringByOptions(ReadOnlySpan<char> value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteStringIndented(value);
@@ -242,7 +244,11 @@ namespace System.Text.Json
 
         private void WriteStringByOptions(ReadOnlySpan<byte> utf8Value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteStringIndented(utf8Value);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.UnsignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.UnsignedNumber.cs
@@ -36,7 +36,11 @@ namespace System.Text.Json
         [CLSCompliant(false)]
         public void WriteNumberValue(ulong value)
         {
-            ValidateWritingValue();
+            if (!_options.SkipValidation)
+            {
+                ValidateWritingValue();
+            }
+
             if (_options.Indented)
             {
                 WriteNumberValueIndented(value);


### PR DESCRIPTION
Primarily this helps with Blazor performance on the Mono interpreter during serialization.

The writer tests are ~1.4x faster and serialization (which uses the writer) are ~1.25x faster. This is an existing benchmark we have been using that represents a large object graph. These timings taken from Edge browser:
```
Before:
Serialization took 1383 ms	Deserialization took 4074 ms	Writer took 1146 ms

After:
Serialization took 1117 ms	Deserialization took 4055 ms	Writer took 804 ms
```

The main perf benefit is due to avoiding accessing the `static ReadOnlySpan<byte>` table when checking to see if we need to escaper each characters. Instead, a local stack variable is made once. This performance may be able to be fixed in the interpreter @BrzVlad; not sure why this is much slower on Mono interpreter, although it could be taking a lock to ensure the static table is properly initialized.

The non-Mono (core) numbers are a bit faster as well (about 2-3%) due to micro optimizations in the writer and serializer code and was not affected by the escaping change mentioned above. Here's a generic writer test:
```
Before:

|          Method | Formatted | SkipValidation | DataSize |     Mean |   Error |  StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------- |--------------- |--------- |---------:|--------:|--------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|  WriteBasicUtf8 |     False |          False |       10 | 642.9 ns | 4.94 ns | 4.62 ns | 641.7 ns | 636.7 ns | 650.4 ns | 0.0179 |     - |     - |     120 B |
| WriteBasicUtf16 |     False |          False |       10 | 705.0 ns | 5.50 ns | 5.15 ns | 705.6 ns | 697.5 ns | 715.5 ns | 0.0167 |     - |     - |     120 B |

After:
|          Method | Formatted | SkipValidation | DataSize |     Mean |   Error |  StdDev |   Median |      Min |      Max |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------- |---------- |--------------- |--------- |---------:|--------:|--------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|  WriteBasicUtf8 |     False |          False |       10 | 630.2 ns | 5.96 ns | 5.58 ns | 631.0 ns | 616.8 ns | 636.9 ns | 0.0174 |     - |     - |     120 B |
| WriteBasicUtf16 |     False |          False |       10 | 692.4 ns | 7.38 ns | 6.90 ns | 693.7 ns | 682.4 ns | 705.0 ns | 0.0168 |     - |     - |     120 B |
```
