### PR TITLE
Obsolete BinaryFormatter.Serialize and BinaryFormatter.Deserialize

### DIFF
--- a/docs/project/list-of-obsoletions.md
+++ b/docs/project/list-of-obsoletions.md
@@ -15,3 +15,4 @@ Currently the identifiers `MSLIB0001` through `MSLIB0999` are carved out for obs
 | :--------------- | :---------- |
 |  __`MSLIB0001`__ | The UTF-7 encoding is insecure and should not be used. Consider using UTF-8 instead. |
 |  __`MSLIB0002`__ | `PrincipalPermissionAttribute` is not honored by the runtime and must not be used. |
+|  __`MSLIB0003`__ | `BinaryFormatter` serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for recommended alternatives. |

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -60,6 +60,12 @@
     <IsShipping Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">false</IsShipping>
   </PropertyGroup>
 
+  <!-- Warnings that should be disabled in our test projects. -->
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">
+    <!-- don't warn on usage of BinaryFormatter from test projects -->
+    <NoWarn>$(NoWarn);MSLIB0003</NoWarn>
+  </PropertyGroup>
+
   <!-- Common repo directories -->
   <PropertyGroup>
     <!-- Need to try and keep the same logic as the native builds as we need this for packaging -->

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
@@ -25,15 +25,20 @@ namespace System.ComponentModel.Design
         /// </summary>
         public static void Serialize(Stream o, string cryptoKey, DesigntimeLicenseContext context)
         {
+            // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
             IFormatter formatter = new BinaryFormatter();
+#pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
             formatter.Serialize(o, new object[] { cryptoKey, context._savedLicenseKeys });
+#pragma warning restore MSLIB0003
         }
 
         internal static void Deserialize(Stream o, string cryptoKey, RuntimeLicenseContext context)
         {
+#pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
             IFormatter formatter = new BinaryFormatter();
 
             object obj = formatter.Deserialize(o);
+#pragma warning restore MSLIB0003
 
             if (obj is object[] value)
             {

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/Design/DesigntimeLicenseContextSerializer.cs
@@ -25,7 +25,6 @@ namespace System.ComponentModel.Design
         /// </summary>
         public static void Serialize(Stream o, string cryptoKey, DesigntimeLicenseContext context)
         {
-            // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
             IFormatter formatter = new BinaryFormatter();
 #pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39293 tracks finding an alternative to BinaryFormatter
             formatter.Serialize(o, new object[] { cryptoKey, context._savedLicenseKeys });

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingsPropertyValue.cs
@@ -98,6 +98,7 @@ namespace System.Configuration
                     {
                         using (MemoryStream ms = new MemoryStream((byte[])SerializedValue))
                         {
+                            // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
                             value = (new BinaryFormatter()).Deserialize(ms);
                         }
                     }
@@ -195,6 +196,7 @@ namespace System.Configuration
                     byte[] buffer = Convert.FromBase64String(serializedValue);
                     using (MemoryStream ms = new MemoryStream(buffer))
                     {
+                        // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
                         return (new BinaryFormatter()).Deserialize(ms);
                     }
                 case SettingsSerializeAs.Xml:
@@ -221,6 +223,7 @@ namespace System.Configuration
 
             using (MemoryStream ms = new MemoryStream())
             {
+                // Issue https://github.com/dotnet/runtime/issues/39295 tracks finding an alternative to BinaryFormatter
                 BinaryFormatter bf = new BinaryFormatter();
                 bf.Serialize(ms, _value);
                 return ms.ToArray();

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -301,9 +301,12 @@ namespace System.Data
                     //Tables, Columns, Rows
                     for (int i = 0; i < Tables.Count; i++)
                     {
+                        // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter
                         BinaryFormatter bf = new BinaryFormatter(null, new StreamingContext(context.State, false));
                         MemoryStream memStream = new MemoryStream();
+#pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter
                         bf.Serialize(memStream, Tables[i]);
+#pragma warning restore MSLIB0003
                         memStream.Position = 0;
                         info.AddValue(string.Format(CultureInfo.InvariantCulture, "DataSet.Tables_{0}", i), memStream.GetBuffer());
                     }
@@ -380,8 +383,10 @@ namespace System.Data
                         byte[] buffer = (byte[])info.GetValue(string.Format(CultureInfo.InvariantCulture, "DataSet.Tables_{0}", i), typeof(byte[]));
                         MemoryStream memStream = new MemoryStream(buffer);
                         memStream.Position = 0;
+#pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter
                         BinaryFormatter bf = new BinaryFormatter(null, new StreamingContext(context.State, false));
                         DataTable dt = (DataTable)bf.Deserialize(memStream);
+#pragma warning restore MSLIB0003
                         Tables.Add(dt);
                     }
 

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -301,7 +301,6 @@ namespace System.Data
                     //Tables, Columns, Rows
                     for (int i = 0; i < Tables.Count; i++)
                     {
-                        // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter
                         BinaryFormatter bf = new BinaryFormatter(null, new StreamingContext(context.State, false));
                         MemoryStream memStream = new MemoryStream();
 #pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter

--- a/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataSet.cs
@@ -382,8 +382,8 @@ namespace System.Data
                         byte[] buffer = (byte[])info.GetValue(string.Format(CultureInfo.InvariantCulture, "DataSet.Tables_{0}", i), typeof(byte[]));
                         MemoryStream memStream = new MemoryStream(buffer);
                         memStream.Position = 0;
-#pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter
                         BinaryFormatter bf = new BinaryFormatter(null, new StreamingContext(context.State, false));
+#pragma warning disable MSLIB0003 // Issue https://github.com/dotnet/runtime/issues/39289 tracks finding an alternative to BinaryFormatter
                         DataTable dt = (DataTable)bf.Deserialize(memStream);
 #pragma warning restore MSLIB0003
                         Tables.Add(dt);

--- a/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/libraries/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <NoWarn>0168,0169,0414,0219,0649</NoWarn>
+    <NoWarn>$(NoWarn),0168,0169,0414,0219,0649</NoWarn>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
   </PropertyGroup>

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.Core.cs
@@ -64,6 +64,7 @@ namespace System.Resources
             return graph;
         }
 
+        // Issue https://github.com/dotnet/runtime/issues/39290 tracks finding an alternative to BinaryFormatter
         private void InitializeBinaryFormatter()
         {
             LazyInitializer.EnsureInitialized(ref s_binaryFormatterType, () =>

--- a/src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/DeserializingResourceReader.cs
+++ b/src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/DeserializingResourceReader.cs
@@ -34,6 +34,7 @@ namespace System.Resources.Extensions
             return false;
         }
 
+        // Issue https://github.com/dotnet/runtime/issues/39292 tracks finding an alternative to BinaryFormatter
         private object ReadBinaryFormattedObject()
         {
             if (_formatter == null)

--- a/src/libraries/System.Runtime.Serialization.Formatters/ref/System.Runtime.Serialization.Formatters.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/ref/System.Runtime.Serialization.Formatters.cs
@@ -15,9 +15,11 @@ namespace System.Runtime.Serialization
         public abstract System.Runtime.Serialization.SerializationBinder? Binder { get; set; }
         public abstract System.Runtime.Serialization.StreamingContext Context { get; set; }
         public abstract System.Runtime.Serialization.ISurrogateSelector? SurrogateSelector { get; set; }
+        [System.ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId = "MSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public abstract object Deserialize(System.IO.Stream serializationStream);
         protected virtual object? GetNext(out long objID) { throw null; }
         protected virtual long Schedule(object? obj) { throw null; }
+        [System.ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId = "MSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public abstract void Serialize(System.IO.Stream serializationStream, object graph);
         protected abstract void WriteArray(object obj, string name, System.Type memberType);
         protected abstract void WriteBoolean(bool val, string name);
@@ -85,7 +87,9 @@ namespace System.Runtime.Serialization
         System.Runtime.Serialization.SerializationBinder? Binder { get; set; }
         System.Runtime.Serialization.StreamingContext Context { get; set; }
         System.Runtime.Serialization.ISurrogateSelector? SurrogateSelector { get; set; }
+        [System.ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId = "MSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         object Deserialize(System.IO.Stream serializationStream);
+        [System.ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId = "MSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         void Serialize(System.IO.Stream serializationStream, object graph);
     }
     public partial interface ISerializationSurrogate
@@ -179,7 +183,9 @@ namespace System.Runtime.Serialization.Formatters.Binary
         public System.Runtime.Serialization.Formatters.TypeFilterLevel FilterLevel { get { throw null; } set { } }
         public System.Runtime.Serialization.ISurrogateSelector? SurrogateSelector { get { throw null; } set { } }
         public System.Runtime.Serialization.Formatters.FormatterTypeStyle TypeFormat { get { throw null; } set { } }
+        [System.ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId = "MSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public object Deserialize(System.IO.Stream serializationStream) { throw null; }
+        [System.ObsoleteAttribute("BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.", DiagnosticId = "MSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
         public void Serialize(System.IO.Stream serializationStream, object graph) { }
     }
 }

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
@@ -17,6 +17,7 @@
     <Compile Include="System\Runtime\Serialization\MemberHolder.cs" />
     <Compile Include="System\Runtime\Serialization\ObjectIDGenerator.cs" />
     <Compile Include="System\Runtime\Serialization\ObjectManager.cs" />
+    <Compile Include="System\Runtime\Serialization\Obsoletions.cs" />
     <Compile Include="System\Runtime\Serialization\SerializationBinder.cs" />
     <Compile Include="System\Runtime\Serialization\SerializationEventsCache.cs" />
     <Compile Include="System\Runtime\Serialization\SerializationFieldInfo.cs" />

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatter.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatter.cs
@@ -20,6 +20,7 @@ namespace System.Runtime.Serialization
             m_idGenerator = new ObjectIDGenerator();
         }
 
+        [Obsolete(Obsoletions.InsecureSerializationMessage, DiagnosticId = Obsoletions.InsecureSerializationDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public abstract object Deserialize(Stream serializationStream);
 
         protected virtual object? GetNext(out long objID)
@@ -59,6 +60,7 @@ namespace System.Runtime.Serialization
             return id;
         }
 
+        [Obsolete(Obsoletions.InsecureSerializationMessage, DiagnosticId = Obsoletions.InsecureSerializationDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public abstract void Serialize(Stream serializationStream, object graph);
 
         protected abstract void WriteArray(object obj, string name, Type memberType);

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.cs
@@ -37,6 +37,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             _context = context;
         }
 
+        [Obsolete(Obsoletions.InsecureSerializationMessage, DiagnosticId = Obsoletions.InsecureSerializationDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public object Deserialize(Stream serializationStream) => Deserialize(serializationStream, true);
 
         internal object Deserialize(Stream serializationStream, bool check)
@@ -77,6 +78,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             }
         }
 
+        [Obsolete(Obsoletions.InsecureSerializationMessage, DiagnosticId = Obsoletions.InsecureSerializationDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public void Serialize(Stream serializationStream, object graph) =>
             Serialize(serializationStream, graph, true);
 

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/IFormatter.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/IFormatter.cs
@@ -7,7 +7,9 @@ namespace System.Runtime.Serialization
 {
     public interface IFormatter
     {
+        [Obsolete(Obsoletions.InsecureSerializationMessage, DiagnosticId = Obsoletions.InsecureSerializationDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         object Deserialize(Stream serializationStream);
+        [Obsolete(Obsoletions.InsecureSerializationMessage, DiagnosticId = Obsoletions.InsecureSerializationDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         void Serialize(Stream serializationStream, object graph);
         ISurrogateSelector? SurrogateSelector { get; set; }
         SerializationBinder? Binder { get; set; }

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Obsoletions.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Obsoletions.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Runtime.Serialization
+{
+    internal static class Obsoletions
+    {
+        internal const string SharedUrlFormat = "https://aka.ms/dotnet-warnings/{0}";
+
+        internal const string InsecureSerializationMessage = "BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.";
+        internal const string InsecureSerializationDiagId = "MSLIB0003";
+    }
+}

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/FormatterTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/FormatterTests.cs
@@ -140,8 +140,10 @@ namespace System.Runtime.Serialization.Formatters.Tests
             public override SerializationBinder Binder { get; set; }
             public override StreamingContext Context { get; set; }
             public override ISurrogateSelector SurrogateSelector { get; set; }
+#pragma warning disable CS0672 // Member overrides obsolete member
             public override object Deserialize(Stream serializationStream) => null;
             public override void Serialize(Stream serializationStream, object graph) { }
+#pragma warning restore CS0672 // Member overrides obsolete member
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>1718</NoWarn>
+    <NoWarn>$(NoWarn),1718</NoWarn>
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-Unix;$(NetCoreAppCurrent)-Browser</TargetFrameworks>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/designs/pull/141.

Once this goes through we'll need to update WinForms, WPF, etc. The easiest thing for them to do now would be to suppress the new warning to allow the merge to commence, then `pragma warning suppress` the individual call sites and open individual tracking issues. https://github.com/dotnet/runtime/issues/39287 can be used to track them.