### PR TITLE
Test EmbeddedSignatureData api

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/Signature.il
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILTestAssembly/Signature.il
@@ -1,6 +1,31 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+.class public auto ansi beforefieldinit ModOptTester
+       extends [CoreTestAssembly]System.Object
+{
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [CoreTestAssembly]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method I::.ctor
+
+  .method public hidebysig instance int32 modopt([CoreTestAssembly]System.Void) modopt([CoreTestAssembly]System.Char) Method(int32 modopt(FooModifier)) cil managed
+  {
+     ret
+  }
+
+  .method public hidebysig instance int32 modopt([CoreTestAssembly]System.Void) & modopt([CoreTestAssembly]System.Char) Method2(int32 modopt(FooModifier)) cil managed
+  {
+     ret
+  }
+}
+
 .class private auto ansi beforefieldinit Atom
        extends [CoreTestAssembly]System.Object
 {

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
@@ -37,7 +37,7 @@ namespace TypeSystemTests
             {
                 sb.Append(data.kind.ToString());
                 sb.Append(data.index);
-                sb.Append(data.type.ToString());
+                sb.Append(((MetaDataType)data.type).Name);
             }
             return sb.ToString();
         }
@@ -50,7 +50,10 @@ namespace TypeSystemTests
 
             // All modopts that are at the very beginning of the signature are given index 0.1.1.1
             // Both the index and the order in the modopt array are significant for signature comparison
-            Assert.Equal("OptionalCustomModifier0.1.1.1charOptionalCustomModifier0.1.1.1voidOptionalCustomModifier0.1.2.1[ILTestAssembly]FooModifier", GetModOptMethodSignatureInfo(methodWith2ModOptsAtStartOfSig));
+            Assert.Equal(MethodSignature.IndexOfCustomModifiersOnReturnType, methodWith2ModOptsAtStartOfSig.GetEmbeddedSignatureData()[0].index);
+            Assert.Equal(MethodSignature.IndexOfCustomModifiersOnReturnType, methodWith2ModOptsAtStartOfSig.GetEmbeddedSignatureData()[1].index);
+            Assert.NotEqual(MethodSignature.IndexOfCustomModifiersOnReturnType, methodWith2ModOptsAtStartOfSig.GetEmbeddedSignatureData()[2].index);
+            Assert.Equal("OptionalCustomModifier0.1.1.1CharOptionalCustomModifier0.1.1.1VoidOptionalCustomModifier0.1.2.1FooModifier", GetModOptMethodSignatureInfo(methodWith2ModOptsAtStartOfSig));
         }
 
         [Fact]
@@ -60,7 +63,10 @@ namespace TypeSystemTests
             MethodSignature methodWithModOptAtStartOfSigAndAfterByRef = modOptTester.GetMethods().Single(m => string.Equals(m.Name, "Method2")).Signature;
 
             // A modopts after an E_T_BYREF will look like 0.1.1.2.1.1
-            Assert.Equal("OptionalCustomModifier0.1.1.1charOptionalCustomModifier0.1.1.2.1.1voidOptionalCustomModifier0.1.2.1[ILTestAssembly]FooModifier", GetModOptMethodSignatureInfo(methodWithModOptAtStartOfSigAndAfterByRef));
+            Assert.Equal(MethodSignature.IndexOfCustomModifiersOnReturnType, methodWithModOptAtStartOfSigAndAfterByRef.GetEmbeddedSignatureData()[0].index);
+            Assert.NotEqual(MethodSignature.IndexOfCustomModifiersOnReturnType, methodWithModOptAtStartOfSigAndAfterByRef.GetEmbeddedSignatureData()[1].index);
+            Assert.NotEqual(MethodSignature.IndexOfCustomModifiersOnReturnType, methodWithModOptAtStartOfSigAndAfterByRef.GetEmbeddedSignatureData()[2].index);
+            Assert.Equal("OptionalCustomModifier0.1.1.1CharOptionalCustomModifier0.1.1.2.1.1VoidOptionalCustomModifier0.1.2.1FooModifier", GetModOptMethodSignatureInfo(methodWithModOptAtStartOfSigAndAfterByRef));
         }
 
         [Fact]

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/SignatureTests.cs
@@ -37,7 +37,7 @@ namespace TypeSystemTests
             {
                 sb.Append(data.kind.ToString());
                 sb.Append(data.index);
-                sb.Append(((MetaDataType)data.type).Name);
+                sb.Append(((MetadataType)data.type).Name);
             }
             return sb.ToString();
         }


### PR DESCRIPTION
- Add test to provide clarity about the behavior of the EmbeddedSignatureData api when examining the start of the signature for custom modifiers
