### PR TITLE
Create and add instance reference inside ResolveMetadata*

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -137,7 +137,7 @@ namespace System.Text.Json.Serialization.Converters
                 bool preserveReferences = options.ReferenceHandler != null;
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadataForJsonObject(this, ref reader, ref state, options))
+                    if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
@@ -297,7 +297,7 @@ namespace System.Text.Json.Serialization.Converters
             return success;
         }
 
-        public sealed override void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        internal sealed override void CreateInstanceForReferenceResolver(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
             => CreateCollection(ref reader, ref state);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -137,7 +137,7 @@ namespace System.Text.Json.Serialization.Converters
                 bool preserveReferences = options.ReferenceHandler != null;
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadata(this, ref reader, ref state))
+                    if (JsonSerializer.ResolveMetadataForJsonObject(this, ref reader, ref state, options))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
@@ -156,18 +156,6 @@ namespace System.Text.Json.Serialization.Converters
                 if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
                 {
                     CreateCollection(ref reader, ref state);
-
-                    if (state.Current.MetadataId != null)
-                    {
-                        Debug.Assert(CanHaveIdMetadata);
-
-                        value = (TCollection)state.Current.ReturnValue!;
-                        state.ReferenceResolver.AddReference(state.Current.MetadataId, value);
-                        // Clear metadata name, if the next read fails
-                        // we want to point the JSON path to the property's object.
-                        state.Current.JsonPropertyName = null;
-                    }
-
                     state.Current.ObjectState = StackFrameObjectState.CreatedObject;
                 }
 
@@ -308,5 +296,8 @@ namespace System.Text.Json.Serialization.Converters
 
             return success;
         }
+
+        public sealed override void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+            => CreateCollection(ref reader, ref state);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -113,7 +113,7 @@ namespace System.Text.Json.Serialization.Converters
                 // Handle the metadata properties.
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadata(this, ref reader, ref state))
+                    if (JsonSerializer.ResolveMetadataForJsonArray(this, ref reader, ref state, options))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
@@ -131,23 +131,6 @@ namespace System.Text.Json.Serialization.Converters
                 if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
                 {
                     CreateCollection(ref reader, ref state, options);
-
-                    if (state.Current.MetadataId != null)
-                    {
-                        value = (TCollection)state.Current.ReturnValue!;
-
-                        // TODO: https://github.com/dotnet/runtime/issues/37168
-                        //Separate logic for IEnumerable to call AddReference when the reader is at `$id`, in order to avoid remembering the last metadata.
-
-                        // Remember the prior metadata and temporarily use '$id' to write it in the path in case AddReference throws
-                        // in this case, the last property seen will be '$values' when we reach this point.
-                        byte[]? lastMetadataProperty = state.Current.JsonPropertyName;
-                        state.Current.JsonPropertyName = JsonSerializer.s_idPropertyName;
-
-                        state.ReferenceResolver.AddReference(state.Current.MetadataId, value);
-                        state.Current.JsonPropertyName = lastMetadataProperty;
-                    }
-
                     state.Current.JsonPropertyInfo = state.Current.JsonClassInfo.ElementClassInfo!.PropertyInfoForClassInfo;
                     state.Current.ObjectState = StackFrameObjectState.CreatedObject;
                 }
@@ -203,34 +186,25 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     state.Current.ObjectState = StackFrameObjectState.EndToken;
 
-                    // Read the EndObject for $values.
-                    if (state.Current.MetadataId != null)
+                    // Read the EndObject token for an array with preserve semantics.
+                    if (state.Current.ValidateEndTokenOnArray)
                     {
                         if (!reader.Read())
                         {
                             value = default;
                             return false;
                         }
-
-                        if (reader.TokenType != JsonTokenType.EndObject)
-                        {
-                            if (reader.TokenType == JsonTokenType.PropertyName)
-                            {
-                                state.Current.JsonPropertyName = reader.GetSpan().ToArray();
-                            }
-
-                            ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(typeToConvert, reader);
-                        }
                     }
                 }
 
                 if (state.Current.ObjectState < StackFrameObjectState.EndTokenValidation)
                 {
-                    if (state.Current.MetadataId != null)
+                    if (state.Current.ValidateEndTokenOnArray)
                     {
                         if (reader.TokenType != JsonTokenType.EndObject)
                         {
-                            ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(typeToConvert, reader);
+                            Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
+                            ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(ref state, typeToConvert, reader);
                         }
                     }
                 }
@@ -299,5 +273,8 @@ namespace System.Text.Json.Serialization.Converters
         }
 
         protected abstract bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state);
+
+        public sealed override void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+            => CreateCollection(ref reader, ref state, options);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -113,7 +113,7 @@ namespace System.Text.Json.Serialization.Converters
                 // Handle the metadata properties.
                 if (preserveReferences && state.Current.ObjectState < StackFrameObjectState.PropertyValue)
                 {
-                    if (JsonSerializer.ResolveMetadataForJsonArray(this, ref reader, ref state, options))
+                    if (JsonSerializer.ResolveMetadataForJsonArray(ref reader, ref state, options))
                     {
                         if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                         {
@@ -274,7 +274,7 @@ namespace System.Text.Json.Serialization.Converters
 
         protected abstract bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state);
 
-        public sealed override void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        internal sealed override void CreateInstanceForReferenceResolver(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
             => CreateCollection(ref reader, ref state, options);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableOfTConverter.cs
@@ -18,7 +18,7 @@ namespace System.Text.Json.Serialization.Converters
             ((List<TElement>)state.Current.ReturnValue!).Add(value);
         }
 
-        protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state,  JsonSerializerOptions options)
+        protected override void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             if (!TypeToConvert.IsAssignableFrom(RuntimeType))
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -77,7 +77,7 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     if (options.ReferenceHandler != null)
                     {
-                        if (JsonSerializer.ResolveMetadata(this, ref reader, ref state))
+                        if (JsonSerializer.ResolveMetadataForJsonObject(this, ref reader, ref state, options))
                         {
                             if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                             {
@@ -91,8 +91,6 @@ namespace System.Text.Json.Serialization.Converters
                             return false;
                         }
                     }
-
-                    state.Current.ObjectState = StackFrameObjectState.PropertyValue;
                 }
 
                 if (state.Current.ObjectState < StackFrameObjectState.CreatedObject)
@@ -103,13 +101,6 @@ namespace System.Text.Json.Serialization.Converters
                     }
 
                     obj = state.Current.JsonClassInfo.CreateObject!()!;
-                    if (state.Current.MetadataId != null)
-                    {
-                        state.ReferenceResolver.AddReference(state.Current.MetadataId, obj);
-                        // Clear metadata name, if the next read fails
-                        // we want to point the JSON path to the property's object.
-                        state.Current.JsonPropertyName = null;
-                    }
 
                     state.Current.ReturnValue = obj;
                     state.Current.ObjectState = StackFrameObjectState.CreatedObject;
@@ -415,6 +406,17 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             return true;
+        }
+
+        public sealed override void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        {
+            if (state.Current.JsonClassInfo.CreateObject == null)
+            {
+                ThrowHelper.ThrowNotSupportedException_DeserializeNoConstructor(state.Current.JsonClassInfo.Type, ref reader, ref state);
+            }
+
+            object obj = state.Current.JsonClassInfo.CreateObject!()!;
+            state.Current.ReturnValue = obj;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -77,7 +77,7 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     if (options.ReferenceHandler != null)
                     {
-                        if (JsonSerializer.ResolveMetadataForJsonObject(this, ref reader, ref state, options))
+                        if (JsonSerializer.ResolveMetadataForJsonObject(ref reader, ref state, options))
                         {
                             if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
                             {
@@ -408,7 +408,7 @@ namespace System.Text.Json.Serialization.Converters
             return true;
         }
 
-        public sealed override void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
+        internal sealed override void CreateInstanceForReferenceResolver(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options)
         {
             if (state.Current.JsonClassInfo.CreateObject == null)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -81,5 +81,10 @@ namespace System.Text.Json.Serialization
         internal ConstructorInfo? ConstructorInfo { get; set; }
 
         internal virtual void Initialize(JsonSerializerOptions options) { }
+
+        /// <summary>
+        /// Creates the instance and assigns it to state.Current.ReturnValue.
+        /// </summary>
+        internal virtual void CreateInstanceForReferenceResolver(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options) { }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -41,7 +41,5 @@ namespace System.Text.Json.Serialization
         }
 
         public sealed override bool HandleNull => false;
-
-        public abstract void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonResumableConverterOfT.cs
@@ -41,5 +41,7 @@ namespace System.Text.Json.Serialization
         }
 
         public sealed override bool HandleNull => false;
+
+        public abstract void CreateInstance(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options);
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -12,17 +12,22 @@ namespace System.Text.Json
         internal static readonly byte[] s_idPropertyName
             = new byte[] { (byte)'$', (byte)'i', (byte)'d' };
 
-        internal static ReadOnlySpan<byte> s_refPropertyName
-            => new byte[] { (byte)'$', (byte)'r', (byte)'e', (byte)'f' };
+        internal static readonly byte[] s_refPropertyName
+            = new byte[] { (byte)'$', (byte)'r', (byte)'e', (byte)'f' };
+
+        internal static readonly byte[] s_valuesPropertyName
+            = new byte[] { (byte)'$', (byte)'v', (byte)'a', (byte)'l', (byte)'u', (byte)'e', (byte)'s' };
 
         /// <summary>
         /// Returns true if successful, false is the reader ran out of buffer.
-        /// Sets state.Current.ReturnValue to the $ref target for MetadataRefProperty cases.
+        /// Sets state.Current.ReturnValue to the reference target for $ref cases;
+        /// Sets state.Current.ReturnValue to a new instance for $id cases.
         /// </summary>
-        internal static bool ResolveMetadata(
-            JsonConverter converter,
+        internal static bool ResolveMetadataForJsonObject<T>(
+            JsonResumableConverter<T> converter,
             ref Utf8JsonReader reader,
-            ref ReadStack state)
+            ref ReadStack state,
+            JsonSerializerOptions options)
         {
             if (state.Current.ObjectState < StackFrameObjectState.ReadAheadNameOrEndObject)
             {
@@ -37,18 +42,10 @@ namespace System.Text.Json
             {
                 if (reader.TokenType != JsonTokenType.PropertyName)
                 {
-                    // An enumerable needs metadata since it starts with StartObject.
-                    if (converter.ClassType == ClassType.Enumerable)
-                    {
-                        ThrowHelper.ThrowJsonException_MetadataPreservedArrayValuesNotFound(converter.TypeToConvert);
-                    }
-
-                    // The reader should have detected other invalid cases.
-                    Debug.Assert(reader.TokenType == JsonTokenType.EndObject);
-
+                    // Since this was an empty object, we are done reading metadata.
+                    state.Current.ObjectState = StackFrameObjectState.PropertyValue;
                     // Skip the read of the first property name, since we already read it above.
                     state.Current.PropertyState = StackFramePropertyState.ReadName;
-
                     return true;
                 }
 
@@ -56,7 +53,8 @@ namespace System.Text.Json
                 MetadataPropertyName metadata = GetMetadataPropertyName(propertyName);
                 if (metadata == MetadataPropertyName.Id)
                 {
-                    state.Current.JsonPropertyName = propertyName.ToArray();
+                    state.Current.JsonPropertyName = s_idPropertyName;
+
                     if (!converter.CanHaveIdMetadata)
                     {
                         ThrowHelper.ThrowJsonException_MetadataCannotParsePreservedObjectIntoImmutable(converter.TypeToConvert);
@@ -66,7 +64,8 @@ namespace System.Text.Json
                 }
                 else if (metadata == MetadataPropertyName.Ref)
                 {
-                    state.Current.JsonPropertyName = propertyName.ToArray();
+                    state.Current.JsonPropertyName = s_refPropertyName;
+
                     if (converter.IsValueType)
                     {
                         ThrowHelper.ThrowJsonException_MetadataInvalidReferenceToValueType(converter.TypeToConvert);
@@ -76,30 +75,155 @@ namespace System.Text.Json
                 }
                 else if (metadata == MetadataPropertyName.Values)
                 {
-                    state.Current.JsonPropertyName = propertyName.ToArray();
-                    if (converter.ClassType == ClassType.Enumerable)
+                    ThrowHelper.ThrowJsonException_MetadataInvalidPropertyWithLeadingDollarSign(propertyName, ref state, reader);
+                }
+                else
+                {
+                    Debug.Assert(metadata == MetadataPropertyName.NoMetadata);
+                    // We are done reading metadata, the object didn't contain any.
+                    state.Current.ObjectState = StackFrameObjectState.PropertyValue;
+                    // Skip the read of the first property name, since we already read it above.
+                    state.Current.PropertyState = StackFramePropertyState.ReadName;
+                    return true;
+                }
+            }
+
+            if (state.Current.ObjectState == StackFrameObjectState.ReadAheadRefValue)
+            {
+                if (!TryReadAheadMetadataAndSetState(ref reader, ref state, StackFrameObjectState.ReadRefValue))
+                {
+                    return false;
+                }
+            }
+            else if (state.Current.ObjectState == StackFrameObjectState.ReadAheadIdValue)
+            {
+                if (!TryReadAheadMetadataAndSetState(ref reader, ref state, StackFrameObjectState.ReadIdValue))
+                {
+                    return false;
+                }
+            }
+
+            if (state.Current.ObjectState == StackFrameObjectState.ReadRefValue)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                {
+                    ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
+                }
+
+                string referenceId = reader.GetString()!;
+
+                // todo: https://github.com/dotnet/runtime/issues/32354
+                state.Current.ReturnValue = state.ReferenceResolver.ResolveReference(referenceId);
+
+                state.Current.ObjectState = StackFrameObjectState.ReadAheadRefEndObject;
+            }
+            else if (state.Current.ObjectState == StackFrameObjectState.ReadIdValue)
+            {
+                if (reader.TokenType != JsonTokenType.String)
+                {
+                    ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
+                }
+
+                converter.CreateInstance(ref reader, ref state, options);
+
+                string referenceId = reader.GetString()!;
+                state.ReferenceResolver.AddReference(referenceId, state.Current.ReturnValue!);
+
+                // We are done reading metadata plus we instantiated the object.
+                state.Current.ObjectState = StackFrameObjectState.CreatedObject;
+            }
+
+            // Clear the metadata property name that was set in case of failure on ResolveReference/AddReference.
+            state.Current.JsonPropertyName = null;
+
+            if (state.Current.ObjectState == StackFrameObjectState.ReadAheadRefEndObject)
+            {
+                if (!TryReadAheadMetadataAndSetState(ref reader, ref state, StackFrameObjectState.ReadRefEndObject))
+                {
+                    return false;
+                }
+            }
+
+            if (state.Current.ObjectState == StackFrameObjectState.ReadRefEndObject)
+            {
+                if (reader.TokenType != JsonTokenType.EndObject)
+                {
+                    // We just read a property. The only valid next tokens are EndObject and PropertyName.
+                    Debug.Assert(reader.TokenType == JsonTokenType.PropertyName);
+
+                    ThrowHelper.ThrowJsonException_MetadataReferenceObjectCannotContainOtherProperties(reader.GetSpan(), ref state);
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns true if successful, false is the reader ran out of buffer.
+        /// Sets state.Current.ReturnValue to the reference target for $ref cases;
+        /// Sets state.Current.ReturnValue to a new instance for $id cases.
+        /// </summary>
+        internal static bool ResolveMetadataForJsonArray<T>(
+            JsonResumableConverter<T> converter,
+            ref Utf8JsonReader reader,
+            ref ReadStack state,
+            JsonSerializerOptions options)
+        {
+            if (state.Current.ObjectState < StackFrameObjectState.ReadAheadNameOrEndObject)
+            {
+                // Read the first metadata property name.
+                if (!TryReadAheadMetadataAndSetState(ref reader, ref state, StackFrameObjectState.ReadNameOrEndObject))
+                {
+                    return false;
+                }
+            }
+
+            if (state.Current.ObjectState == StackFrameObjectState.ReadNameOrEndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    // The reader should have detected other invalid cases.
+                    Debug.Assert(reader.TokenType == JsonTokenType.EndObject);
+
+                    // An enumerable needs metadata since it starts with StartObject.
+                    ThrowHelper.ThrowJsonException_MetadataPreservedArrayValuesNotFound(ref state, converter.TypeToConvert);
+                }
+
+
+                ReadOnlySpan<byte> propertyName = reader.GetSpan();
+                MetadataPropertyName metadata = GetMetadataPropertyName(propertyName);
+                if (metadata == MetadataPropertyName.Id)
+                {
+                    state.Current.JsonPropertyName = s_idPropertyName;
+
+                    if (!converter.CanHaveIdMetadata)
                     {
-                        ThrowHelper.ThrowJsonException_MetadataMissingIdBeforeValues();
+                        ThrowHelper.ThrowJsonException_MetadataCannotParsePreservedObjectIntoImmutable(converter.TypeToConvert);
                     }
-                    else
+
+                    state.Current.ObjectState = StackFrameObjectState.ReadAheadIdValue;
+                }
+                else if (metadata == MetadataPropertyName.Ref)
+                {
+                    state.Current.JsonPropertyName = s_refPropertyName;
+
+                    if (converter.IsValueType)
                     {
-                        ThrowHelper.ThrowJsonException_MetadataInvalidPropertyWithLeadingDollarSign(propertyName, ref state, reader);
+                        ThrowHelper.ThrowJsonException_MetadataInvalidReferenceToValueType(converter.TypeToConvert);
                     }
+
+                    state.Current.ObjectState = StackFrameObjectState.ReadAheadRefValue;
+                }
+                else if (metadata == MetadataPropertyName.Values)
+                {
+                    ThrowHelper.ThrowJsonException_MetadataMissingIdBeforeValues(ref state, propertyName);
                 }
                 else
                 {
                     Debug.Assert(metadata == MetadataPropertyName.NoMetadata);
 
                     // Having a StartObject without metadata properties is not allowed.
-                    if (converter.ClassType == ClassType.Enumerable)
-                    {
-                        state.Current.JsonPropertyName = propertyName.ToArray();
-                        ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(converter.TypeToConvert, reader);
-                    }
-
-                    // Skip the read of the first property name, since we already read it above.
-                    state.Current.PropertyState = StackFramePropertyState.ReadName;
-                    return true;
+                    ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(ref state, converter.TypeToConvert, reader);
                 }
             }
 
@@ -138,20 +262,17 @@ namespace System.Text.Json
                     ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
                 }
 
-                state.Current.MetadataId = reader.GetString();
+                converter.CreateInstance(ref reader, ref state, options);
 
-                if (converter.ClassType == ClassType.Enumerable)
-                {
-                    // Need to Read $values property name.
-                    state.Current.ObjectState = StackFrameObjectState.ReadAheadValuesName;
-                }
-                else
-                {
-                    // We are done reading metadata.
-                    state.Current.ObjectState = StackFrameObjectState.PropertyValue;
-                    return true;
-                }
+                string referenceId = reader.GetString()!;
+                state.ReferenceResolver.AddReference(referenceId, state.Current.ReturnValue!);
+
+                // Need to Read $values property name.
+                state.Current.ObjectState = StackFrameObjectState.ReadAheadValuesName;
             }
+
+            // Clear the metadata property name that was set in case of failure on ResolverReference/AddReference.
+            state.Current.JsonPropertyName = null;
 
             if (state.Current.ObjectState == StackFrameObjectState.ReadAheadRefEndObject)
             {
@@ -186,20 +307,18 @@ namespace System.Text.Json
             {
                 if (reader.TokenType != JsonTokenType.PropertyName)
                 {
-                    // Missing $values, JSON path should point to the property's object.
-                    state.Current.JsonPropertyName = null;
-                    ThrowHelper.ThrowJsonException_MetadataPreservedArrayValuesNotFound(converter.TypeToConvert);
+                    ThrowHelper.ThrowJsonException_MetadataPreservedArrayValuesNotFound(ref state, converter.TypeToConvert);
                 }
 
                 ReadOnlySpan<byte> propertyName = reader.GetSpan();
 
-                // Remember the property in case we get an exception.
-                state.Current.JsonPropertyName = propertyName.ToArray();
-
                 if (GetMetadataPropertyName(propertyName) != MetadataPropertyName.Values)
                 {
-                    ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(converter.TypeToConvert, reader);
+                    ThrowHelper.ThrowJsonException_MetadataPreservedArrayInvalidProperty(ref state, converter.TypeToConvert, reader);
                 }
+
+                // Remember the property in case we get an exception in one of the array elements.
+                state.Current.JsonPropertyName = s_valuesPropertyName;
 
                 state.Current.ObjectState = StackFrameObjectState.ReadAheadValuesStartArray;
             }
@@ -218,8 +337,8 @@ namespace System.Text.Json
                 {
                     ThrowHelper.ThrowJsonException_MetadataValuesInvalidToken(reader.TokenType);
                 }
-
-                state.Current.ObjectState = StackFrameObjectState.PropertyValue;
+                state.Current.ValidateEndTokenOnArray = true;
+                state.Current.ObjectState = StackFrameObjectState.CreatedObject;
             }
 
             return true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandleMetadata.cs
@@ -23,12 +23,13 @@ namespace System.Text.Json
         /// Sets state.Current.ReturnValue to the reference target for $ref cases;
         /// Sets state.Current.ReturnValue to a new instance for $id cases.
         /// </summary>
-        internal static bool ResolveMetadataForJsonObject<T>(
-            JsonResumableConverter<T> converter,
+        internal static bool ResolveMetadataForJsonObject(
             ref Utf8JsonReader reader,
             ref ReadStack state,
             JsonSerializerOptions options)
         {
+            JsonConverter converter = state.Current.JsonClassInfo.PropertyInfoForClassInfo.ConverterBase;
+
             if (state.Current.ObjectState < StackFrameObjectState.ReadAheadNameOrEndObject)
             {
                 // Read the first metadata property name.
@@ -124,7 +125,7 @@ namespace System.Text.Json
                     ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
                 }
 
-                converter.CreateInstance(ref reader, ref state, options);
+                converter.CreateInstanceForReferenceResolver(ref reader, ref state, options);
 
                 string referenceId = reader.GetString()!;
                 state.ReferenceResolver.AddReference(referenceId, state.Current.ReturnValue!);
@@ -163,12 +164,13 @@ namespace System.Text.Json
         /// Sets state.Current.ReturnValue to the reference target for $ref cases;
         /// Sets state.Current.ReturnValue to a new instance for $id cases.
         /// </summary>
-        internal static bool ResolveMetadataForJsonArray<T>(
-            JsonResumableConverter<T> converter,
+        internal static bool ResolveMetadataForJsonArray(
             ref Utf8JsonReader reader,
             ref ReadStack state,
             JsonSerializerOptions options)
         {
+            JsonConverter converter = state.Current.JsonClassInfo.PropertyInfoForClassInfo.ConverterBase;
+
             if (state.Current.ObjectState < StackFrameObjectState.ReadAheadNameOrEndObject)
             {
                 // Read the first metadata property name.
@@ -262,7 +264,7 @@ namespace System.Text.Json
                     ThrowHelper.ThrowJsonException_MetadataValueWasNotString(reader.TokenType);
                 }
 
-                converter.CreateInstance(ref reader, ref state, options);
+                converter.CreateInstanceForReferenceResolver(ref reader, ref state, options);
 
                 string referenceId = reader.GetString()!;
                 state.ReferenceResolver.AddReference(referenceId, state.Current.ReturnValue!);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.HandleMetadata.cs
@@ -28,7 +28,6 @@ namespace System.Text.Json
             }
             else
             {
-
                 string referenceId = state.ReferenceResolver.GetReference(currentValue, out bool alreadyExists);
                 Debug.Assert(referenceId != null);
 
@@ -65,10 +64,10 @@ namespace System.Text.Json
             else
             {
                 string referenceId = state.ReferenceResolver.GetReference(currentValue, out bool alreadyExists);
+                Debug.Assert(referenceId != null);
 
                 if (alreadyExists)
                 {
-                    Debug.Assert(referenceId != null);
                     writer.WriteStartObject();
                     writer.WriteString(s_metadataRef, referenceId);
                     writer.WriteEndObject();
@@ -76,7 +75,6 @@ namespace System.Text.Json
                 }
                 else
                 {
-                    Debug.Assert(referenceId != null);
                     writer.WriteStartObject();
                     writer.WriteString(s_metadataId, referenceId);
                     writer.WriteStartArray(s_metadataValues);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -32,8 +32,8 @@ namespace System.Text.Json
         public JsonClassInfo JsonClassInfo;
         public StackFrameObjectState ObjectState; // State tracking the current object.
 
-        // Preserve reference.
-        public string? MetadataId;
+        // Validate EndObject token on array with preserve semantics.
+        public bool ValidateEndTokenOnArray;
 
         // For performance, we order the properties by the first deserialize and PropertyIndex helps find the right slot quicker.
         public int PropertyIndex;
@@ -59,7 +59,7 @@ namespace System.Text.Json
             JsonPropertyName = null;
             JsonPropertyNameAsString = null;
             PropertyState = StackFramePropertyState.None;
-            MetadataId = null;
+            ValidateEndTokenOnArray = false;
 
             // No need to clear these since they are overwritten each time:
             //  UseExtensionProperty

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -505,8 +506,9 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_MetadataMissingIdBeforeValues()
+        public static void ThrowJsonException_MetadataMissingIdBeforeValues(ref ReadStack state, ReadOnlySpan<byte> propertyName)
         {
+            state.Current.JsonPropertyName = propertyName.ToArray();
             ThrowJsonException(SR.MetadataPreservedArrayPropertyNotFound);
         }
 
@@ -543,19 +545,23 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_MetadataPreservedArrayInvalidProperty(Type propertyType, in Utf8JsonReader reader)
+        public static void ThrowJsonException_MetadataPreservedArrayInvalidProperty(ref ReadStack state, Type propertyType, in Utf8JsonReader reader)
         {
-            string propertyName = reader.GetString()!;
+            state.Current.JsonPropertyName = reader.HasValueSequence ? reader.ValueSequence.ToArray() : reader.ValueSpan.ToArray();
+            string propertyNameAsString = reader.GetString()!;
 
             ThrowJsonException(SR.Format(SR.MetadataPreservedArrayFailed,
-                SR.Format(SR.MetadataPreservedArrayInvalidProperty, propertyName),
+                SR.Format(SR.MetadataPreservedArrayInvalidProperty, propertyNameAsString),
                 SR.Format(SR.DeserializeUnableToConvertValue, propertyType)));
         }
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public static void ThrowJsonException_MetadataPreservedArrayValuesNotFound(Type propertyType)
+        public static void ThrowJsonException_MetadataPreservedArrayValuesNotFound(ref ReadStack state, Type propertyType)
         {
+            // Missing $values, JSON path should point to the property's object.
+            state.Current.JsonPropertyName = null;
+
             ThrowJsonException(SR.Format(SR.MetadataPreservedArrayFailed,
                 SR.MetadataPreservedArrayPropertyNotFound,
                 SR.Format(SR.DeserializeUnableToConvertValue, propertyType)));


### PR DESCRIPTION
...in order to remove workaround described in https://github.com/dotnet/runtime/issues/37168 used to correctly build the JSON path in case of error.

This PR adds a new method `CreateInstance` to `JsonResumableConverter<T>` that is used to instantiate the object at the time that `ReferenceResolver.AddReference` is called.

It also splits `ResolveMetadata` into two methods: `ResolveMetadataForJsonObject` (Used on POCOs and dictionaries) and `ResolveMetadataForJsonArray` (Used for collections such as `List<T>`).

This makes the code more mantainable, reduces the amount of if checks and allow us to remove the string field `ReadStackFrame.MetadataId` from the state.

Fixes https://github.com/dotnet/runtime/issues/37168.