### PR TITLE
Interpret DOTNET_BUNDLE_EXTRACT_BASE_DIR without dir separator as relative path

### DIFF
--- a/src/installer/corehost/cli/bundle/extractor.cpp
+++ b/src/installer/corehost/cli/bundle/extractor.cpp
@@ -31,6 +31,11 @@ pal::string_t& extractor_t::extraction_dir()
         }
 
         pal::string_t host_name = strip_executable_ext(get_filename(m_bundle_path));
+        if (m_extraction_dir[0] != DIR_SEPARATOR)
+        {
+            m_extraction_dir.insert(0, { '.', DIR_SEPARATOR });
+        }
+
         append_path(&m_extraction_dir, host_name.c_str());
         append_path(&m_extraction_dir, m_bundle_id.c_str());
 

--- a/src/installer/corehost/cli/bundle/extractor.cpp
+++ b/src/installer/corehost/cli/bundle/extractor.cpp
@@ -31,9 +31,12 @@ pal::string_t& extractor_t::extraction_dir()
         }
 
         pal::string_t host_name = strip_executable_ext(get_filename(m_bundle_path));
-        if (m_extraction_dir[0] != DIR_SEPARATOR)
+        if (!pal::is_path_rooted(m_extraction_dir))
         {
-            m_extraction_dir.insert(0, { '.', DIR_SEPARATOR });
+            pal::string_t current_dir = _X(".");
+            pal::string_t relative_path(m_extraction_dir);
+            m_extraction_dir = pal::realpath(&current_dir);
+            append_path(&m_extraction_dir, relative_path.c_str());
         }
 
         append_path(&m_extraction_dir, host_name.c_str());

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/AppHost.Bundle.Tests/BundleExtractToSpecificPath.cs
@@ -57,6 +57,28 @@ namespace AppHost.Bundle.Tests
             extractDir.Should().NotHaveFiles(BundleHelper.GetFilesNeverExtracted(fixture));
         }
 
+        [InlineData("./foo")]
+        [InlineData("../foo")]
+        [InlineData("foo")]
+        [InlineData("foo/bar")]
+        [Theory]
+        private void Bundle_Extraction_To_Relative_Path_Succeeds (string relativePath)
+        {
+            var fixture = sharedTestState.TestFixture.Copy();
+            var singleFile = BundleHelper.BundleApp(fixture, BundleOptions.None);
+
+            // Run the bundled app (extract files to <path>)
+            Command.Create(singleFile)
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .EnvironmentVariable(BundleHelper.DotnetBundleExtractBaseEnvVariable, relativePath)
+                .Execute()
+                .Should()
+                .Pass()
+                .And
+                .HaveStdOutContaining("Hello World");
+        }
+
         [Fact]
         private void Bundle_extraction_is_reused()
         {


### PR DESCRIPTION
Should fix #36804