### PR TITLE
Fix up trimming tests for new SDK

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -19,14 +19,12 @@
     </ItemGroup>
   </Target>
 
-  <!-- This will need to change to AfterTargets=PrepareForILLink when we get a new SDK -->
   <Target Name="EnsureAllAssembliesAreLinked"
-          AfterTargets="_SetILLinkDefaults"> 
+          AfterTargets="PrepareForILLink"> 
     <ItemGroup>
-      <!-- This will need to change to ManagedAssemblyToLink and TrimMode=link when we get a new SDK -->
-      <_ManagedAssembliesToLink>
-        <action>link</action>
-      </_ManagedAssembliesToLink>
+      <ManagedAssemblyToLink>
+        <TrimMode>link</TrimMode>
+      </ManagedAssemblyToLink>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Now that we have a new SDK with the latest linker settings, we need to change how we invoke the linker during the trimming tests.

See #39126 and #39158 which came in hours apart. Fixing the conflict that occurred between them.