### PR TITLE
Fix rare case of 'Reading is already in progress' after canceling another Read

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs
@@ -852,6 +852,10 @@ namespace System.IO.Pipelines
             finally
             {
                 cancellationTokenRegistration.Dispose();
+            }
+
+            if (result.IsCanceled)
+            {
                 cancellationToken.ThrowIfCancellationRequested();
             }
 


### PR DESCRIPTION
There is a race where a `ReadAsync(someToken)` could have a valid `ReadResult` that it is going to return and then the token passed in could cancel and cause the method to throw an exception after the result was already prepared.
https://github.com/dotnet/runtime/blob/ee41d4a5e84681cb5d8f0e61501385ceb7abf96f/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs#L855

The preparation of the result sets some internal state which would cause future `ReadAsync`'s to throw with "Reading is already in progress".
https://github.com/dotnet/runtime/blob/ee41d4a5e84681cb5d8f0e61501385ceb7abf96f/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs#L886

The change is to move the throw to only happen if the `ReadResult` is canceled, which only happens if the cancellation token is observed before creating a successful `ReadResult`.
https://github.com/dotnet/runtime/blob/ee41d4a5e84681cb5d8f0e61501385ceb7abf96f/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.cs#L864

There are no new tests because I don't believe this race is testable without a stress test like shown in the linked issue.

Fix https://github.com/dotnet/runtime/issues/1296