### PR TITLE
Fix 2 noRetypingRegressions.

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -5622,6 +5622,8 @@ private:
     GenTree* fgMorphToEmulatedFP(GenTree* tree);
     GenTree* fgMorphConst(GenTree* tree);
 
+    GenTreeLclVar* fgMorphTryFoldObjAsLclVar(GenTreeObj* obj);
+
 public:
     GenTree* fgMorphTree(GenTree* tree, MorphAddrContext* mac = nullptr);
 

--- a/src/coreclr/src/jit/layout.cpp
+++ b/src/coreclr/src/jit/layout.cpp
@@ -410,3 +410,64 @@ ClassLayout* ClassLayout::GetPPPQuirkLayout(CompAllocator alloc)
     return m_pppQuirkLayout;
 }
 #endif // TARGET_AMD64
+
+//------------------------------------------------------------------------
+// AreMatching: check if 2 layouts are the same for copying.
+//
+// Arguments:
+//    layout1 - the first layout;
+//    layout2 - the second layout.
+//
+// Return value:
+//    true if matching, false otherwise.
+//
+// Notes:
+//    Layouts are called matching if they are equal or if
+//    they have the same size and the same GC slots.
+//
+// static
+bool ClassLayout::AreMatching(const ClassLayout* layout1, const ClassLayout* layout2)
+{
+    CORINFO_CLASS_HANDLE clsHnd1 = layout1->GetClassHandle();
+    CORINFO_CLASS_HANDLE clsHnd2 = layout2->GetClassHandle();
+    assert(clsHnd1 != NO_CLASS_HANDLE);
+    assert(clsHnd2 != NO_CLASS_HANDLE);
+
+    if (clsHnd1 == clsHnd2)
+    {
+        return true;
+    }
+
+    if (layout1->GetSize() != layout2->GetSize())
+    {
+        return false;
+    }
+
+    if (layout1->HasGCPtr() != layout2->HasGCPtr())
+    {
+        return false;
+    }
+
+    if (!layout1->HasGCPtr() && !layout2->HasGCPtr())
+    {
+        return false;
+    }
+
+    assert(layout1->HasGCPtr() && layout2->HasGCPtr());
+    if (layout1->GetGCPtrCount() != layout2->GetGCPtrCount())
+    {
+        return false;
+    }
+
+    assert(layout1->GetSlotCount() == layout2->GetSlotCount());
+    unsigned slotsCount = layout1->GetSlotCount();
+
+    for (unsigned i = 0; i < slotsCount; ++i)
+    {
+        if (layout1->GetGCPtrType(i) != layout2->GetGCPtrType(i))
+        {
+            return false;
+        }
+    }
+    return true;
+}

--- a/src/coreclr/src/jit/layout.cpp
+++ b/src/coreclr/src/jit/layout.cpp
@@ -412,21 +412,21 @@ ClassLayout* ClassLayout::GetPPPQuirkLayout(CompAllocator alloc)
 #endif // TARGET_AMD64
 
 //------------------------------------------------------------------------
-// AreMatching: check if 2 layouts are the same for copying.
+// AreCompatible: check if 2 layouts are the same for copying.
 //
 // Arguments:
 //    layout1 - the first layout;
 //    layout2 - the second layout.
 //
 // Return value:
-//    true if matching, false otherwise.
+//    true if compatible, false otherwise.
 //
 // Notes:
-//    Layouts are called matching if they are equal or if
+//    Layouts are called compatible if they are equal or if
 //    they have the same size and the same GC slots.
 //
 // static
-bool ClassLayout::AreMatching(const ClassLayout* layout1, const ClassLayout* layout2)
+bool ClassLayout::AreCompatible(const ClassLayout* layout1, const ClassLayout* layout2)
 {
     CORINFO_CLASS_HANDLE clsHnd1 = layout1->GetClassHandle();
     CORINFO_CLASS_HANDLE clsHnd2 = layout2->GetClassHandle();
@@ -450,7 +450,7 @@ bool ClassLayout::AreMatching(const ClassLayout* layout1, const ClassLayout* lay
 
     if (!layout1->HasGCPtr() && !layout2->HasGCPtr())
     {
-        return false;
+        return true;
     }
 
     assert(layout1->HasGCPtr() && layout2->HasGCPtr());

--- a/src/coreclr/src/jit/layout.h
+++ b/src/coreclr/src/jit/layout.h
@@ -195,6 +195,8 @@ public:
         }
     }
 
+    static bool AreMatching(const ClassLayout* layout1, const ClassLayout* layout2);
+
 private:
     const BYTE* GetGCPtrs() const
     {

--- a/src/coreclr/src/jit/layout.h
+++ b/src/coreclr/src/jit/layout.h
@@ -195,7 +195,7 @@ public:
         }
     }
 
-    static bool AreMatching(const ClassLayout* layout1, const ClassLayout* layout2);
+    static bool AreCompatible(const ClassLayout* layout1, const ClassLayout* layout2);
 
 private:
     const BYTE* GetGCPtrs() const

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -10907,23 +10907,23 @@ GenTree* Compiler::fgMorphCopyBlock(GenTree* tree)
                     addrSpill = gtCloneExpr(destAddr); // addrSpill represents the 'destAddr'
                     noway_assert(addrSpill != nullptr);
                 }
+            }
+        }
 
-                // TODO-CQ: this should be based on a more general
-                // "BaseAddress" method, that handles fields of structs, before or after
-                // morphing.
-                if (addrSpill != nullptr && addrSpill->OperGet() == GT_ADDR)
-                {
-                    if (addrSpill->AsOp()->gtOp1->IsLocal())
-                    {
-                        // We will *not* consider this to define the local, but rather have each individual field assign
-                        // be a definition.
-                        addrSpill->AsOp()->gtOp1->gtFlags &= ~(GTF_LIVENESS_MASK);
-                        assert(lvaGetPromotionType(addrSpill->AsOp()->gtOp1->AsLclVarCommon()->GetLclNum()) !=
-                               PROMOTION_TYPE_INDEPENDENT);
-                        addrSpillIsStackDest = true; // addrSpill represents the address of LclVar[varNum] in our
-                                                     // local stack frame
-                    }
-                }
+        // TODO-CQ: this should be based on a more general
+        // "BaseAddress" method, that handles fields of structs, before or after
+        // morphing.
+        if ((addrSpill != nullptr) && addrSpill->OperIs(GT_ADDR))
+        {
+            GenTree* addrSpillOp = addrSpill->AsOp()->gtGetOp1();
+            if (addrSpillOp->IsLocal())
+            {
+                // We will *not* consider this to define the local, but rather have each individual field assign
+                // be a definition.
+                addrSpillOp->gtFlags &= ~(GTF_LIVENESS_MASK);
+                assert(lvaGetPromotionType(addrSpillOp->AsLclVarCommon()->GetLclNum()) != PROMOTION_TYPE_INDEPENDENT);
+                addrSpillIsStackDest = true; // addrSpill represents the address of LclVar[varNum] in our
+                                             // local stack frame
             }
         }
 

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -9161,16 +9161,16 @@ GenTreeLclVar* Compiler::fgMorphTryFoldObjAsLclVar(GenTreeObj* obj)
 
                 ClassLayout* lclVarLayout = lvaGetDesc(lclVar)->GetLayout();
                 ClassLayout* objLayout    = obj->GetLayout();
-                if (ClassLayout::AreMatching(lclVarLayout, objLayout))
+                if (ClassLayout::AreCompatible(lclVarLayout, objLayout))
                 {
-#ifdef DEUBUG
+#ifdef DEBUG
                     CORINFO_CLASS_HANDLE objClsHandle = obj->GetLayout()->GetClassHandle();
                     assert(objClsHandle != NO_CLASS_HANDLE);
-                    if (canFoldAsLclVar && verbose)
+                    if (verbose)
                     {
                         CORINFO_CLASS_HANDLE lclClsHnd = gtGetStructHandle(lclVar);
-                        printf("fold OBJ(ADDR(X)) [%06u] into X [%06u], ", dspTreeID(tree), dspTreeID(addrOp));
-                        printf("with %s handles\n", (lclClsHnd == objClsHandle) ? "matching", "different");
+                        printf("fold OBJ(ADDR(X)) [%06u] into X [%06u], ", dspTreeID(obj), dspTreeID(lclVar));
+                        printf("with %s handles\n", ((lclClsHnd == objClsHandle) ? "matching" : "different"));
                     }
 #endif
                     // Keep the DONT_CSE flag in sync


### PR DESCRIPTION
This PR fixes 2 regressions that appeared after `NoRetyping` by default, I hope to get it in before the snap.



  | Total size diff, bytes | Methods imrpoved | Methods regressed
-- | -- | -- | --
x64 Windows crossgen | -544 | 96 | 4
x64 Windows PMI | -5021 | 613 | 28
x64 Linux crossgen | -1858 | 125 | 3
x64 Linux PMI | -4714 | 626 | 24
arm64 Windows crossgen | -2192 | 108 | 2
arm64 Windows PMI | -5588 | 660 | 26
x86 Windows crossgen | -525 | 106 | 7
x86 Windows PMI | -4313 | 592 | 38
x86 Linux crossgen | -1330 | 107 | 7
x86 Linux PMI | -4756 | 597 | 30
arm Windows crossgen | -1132 | 105 | 3
arm Windows PMI | -3300 | 602 | 24

Changes:
dab238d3bc6: don't mark stack indir as 'X'.
We were doing it for a dstAddr spill, but not for the source.

701956fe7ee: Fold OBJ(ADDR(x)) under ASG when possible.
Improvements are mostly for PMI that uses many Canon/Exact `OBJ(ADDR(LCL_VAR)` casts.