### PR TITLE
WASM: Fix System.IO.MemoryMappedFiles tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -47,9 +47,9 @@ namespace System
         public static bool IsNotFedoraOrRedHatFamily => !IsFedora && !IsRedHatFamily;
         public static bool IsNotDebian10 => !IsDebian10;
 
-        public static bool IsSuperUser => !IsWindows ?
+        public static bool IsSuperUser => IsBrowser ? false : (!IsWindows ?
             libc.geteuid() == 0 :
-            throw new PlatformNotSupportedException();
+            throw new PlatformNotSupportedException());
 
         public static Version OpenSslVersion => !IsOSXLike && !IsWindows ?
             GetOpenSslVersion() :

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -614,6 +614,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test exceptional behavior when trying to create a map for a non-shared file that's currently in use.
         /// </summary>
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // the emscripten implementation ignores FileShare.None
         public void FileInUse_CreateFromFile_FailsWithExistingNoShareFile()
         {
             // Already opened with a FileStream
@@ -696,13 +697,13 @@ namespace System.IO.MemoryMappedFiles.Tests
         public void WriteToReadOnlyFile_ReadWrite(MemoryMappedFileAccess access)
         {
             WriteToReadOnlyFile(access, access == MemoryMappedFileAccess.Read ||
-                            (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && geteuid() == 0));
+                            (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && PlatformDetection.IsSuperUser));
         }
 
         [Fact]
         public void WriteToReadOnlyFile_CopyOnWrite()
         {
-            WriteToReadOnlyFile(MemoryMappedFileAccess.CopyOnWrite, (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && geteuid() == 0));
+            WriteToReadOnlyFile(MemoryMappedFileAccess.CopyOnWrite, (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && PlatformDetection.IsSuperUser));
         }
 
         /// <summary>
@@ -768,6 +769,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test to validate we can create multiple maps from the same FileStream.
         /// </summary>
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // the emscripten implementation doesn't share data
         public void MultipleMapsForTheSameFileStream()
         {
             const int Capacity = 4096;

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.Unix.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedFilesTestsBase.Unix.cs
@@ -14,6 +14,9 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// <summary>Gets the system's page size.</summary>
         protected static Lazy<int> s_pageSize = new Lazy<int>(() =>
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Browser))
+                return Environment.SystemPageSize;
+
             int pageSize;
             const int _SC_PAGESIZE_FreeBSD = 47;
             const int _SC_PAGESIZE_Linux = 30;
@@ -30,9 +33,6 @@ namespace System.IO.MemoryMappedFiles.Tests
 
         [DllImport("libc", SetLastError = true)]
         private static extern int sysconf(int name);
-
-        [DllImport("libc", SetLastError = true)]
-        protected static extern int geteuid();
 
         /// <summary>Asserts that the handle's inheritability matches the specified value.</summary>
         protected static void AssertInheritability(SafeHandle handle, HandleInheritability inheritability)

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewAccessor.Tests.cs
@@ -334,6 +334,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test to validate that multiple accessors over the same map share data appropriately.
         /// </summary>
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // the emscripten implementation doesn't share data
         public void ViewsShareData()
         {
             const int MapLength = 256;

--- a/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
+++ b/src/libraries/System.IO.MemoryMappedFiles/tests/MemoryMappedViewStream.Tests.cs
@@ -264,6 +264,7 @@ namespace System.IO.MemoryMappedFiles.Tests
         /// Test to validate that multiple accessors over the same map share data appropriately.
         /// </summary>
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // the emscripten implementation doesn't share data
         public void ViewsShareData()
         {
             const int MapLength = 256;

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -32,7 +32,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Extensions\tests\System.Globalization.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization\tests\System.Globalization.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.MemoryMappedFiles\tests\System.IO.MemoryMappedFiles.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Packaging\tests\System.IO.Packaging.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Parallel\tests\System.Linq.Parallel.Tests.csproj" />


### PR DESCRIPTION
Allows the tests to run on WebAssembly: `Tests run: 329, Errors: 0, Failures: 0, Skipped: 5. Time: 1.0009759s`