### PR TITLE
Use system default ciphers on Fedora/RHEL/CentOS

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/CipherSuitesPolicyPal.Linux.cs
@@ -14,9 +14,6 @@ namespace System.Net.Security
 {
     internal class CipherSuitesPolicyPal
     {
-        private static readonly byte[] RequireEncryptionDefault =
-            Encoding.ASCII.GetBytes("DEFAULT\0");
-
         private static readonly byte[] AllowNoEncryptionDefault =
             Encoding.ASCII.GetBytes("ALL:eNULL\0");
 
@@ -171,12 +168,12 @@ namespace System.Net.Security
             return policy.Pal._tls13CipherSuites;
         }
 
-        private static byte[] CipherListFromEncryptionPolicy(EncryptionPolicy policy)
+        private static byte[]? CipherListFromEncryptionPolicy(EncryptionPolicy policy)
         {
             switch (policy)
             {
                 case EncryptionPolicy.RequireEncryption:
-                    return RequireEncryptionDefault;
+                    return null;
                 case EncryptionPolicy.AllowNoEncryption:
                     return AllowNoEncryptionDefault;
                 case EncryptionPolicy.NoEncryption:


### PR DESCRIPTION
@bartonjs ptal

I've implemented it so it applies only to non-portable builds.
If desired, I can change it into a runtime check for the OS (Fedora, RHEL, CentOS) in order to make it apply also for portable builds.

cc @omajid 