### PR TITLE
One-shot hash feedback

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHash.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptHash.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Win32.SafeHandles;
+
+internal partial class Interop
+{
+    internal partial class BCrypt
+    {
+        [DllImport(Libraries.BCrypt, CharSet = CharSet.Unicode)]
+        internal static unsafe extern NTSTATUS BCryptHash(SafeBCryptAlgorithmHandle hAlgorithm, byte* pbSecret, int cbSecret, byte* pbInput, int cbInput, byte* pbOutput, int cbOutput);
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Unix.cs
@@ -11,6 +11,12 @@ namespace Internal.Cryptography
 {
     internal static partial class HashProviderDispenser
     {
+        private static volatile IntPtr s_evpMd5;
+        private static volatile IntPtr s_evpSha1;
+        private static volatile IntPtr s_evpSha256;
+        private static volatile IntPtr s_evpSha384;
+        private static volatile IntPtr s_evpSha512;
+
         public static HashProvider CreateHashProvider(string hashAlgorithmId)
         {
             IntPtr evpType = HashAlgorithmToEvp(hashAlgorithmId);
@@ -24,11 +30,11 @@ namespace Internal.Cryptography
         }
 
         private static IntPtr HashAlgorithmToEvp(string hashAlgorithmId) => hashAlgorithmId switch {
-            HashAlgorithmNames.SHA1 => Interop.Crypto.EvpSha1(),
-            HashAlgorithmNames.SHA256 => Interop.Crypto.EvpSha256(),
-            HashAlgorithmNames.SHA384 => Interop.Crypto.EvpSha384(),
-            HashAlgorithmNames.SHA512 => Interop.Crypto.EvpSha512(),
-            HashAlgorithmNames.MD5 => Interop.Crypto.EvpMd5(),
+            HashAlgorithmNames.SHA1 => s_evpSha1 == IntPtr.Zero ? (s_evpSha1 = Interop.Crypto.EvpSha1()) : s_evpSha1,
+            HashAlgorithmNames.SHA256 => s_evpSha256 == IntPtr.Zero ? (s_evpSha256 = Interop.Crypto.EvpSha256()) : s_evpSha256,
+            HashAlgorithmNames.SHA384 => s_evpSha384 == IntPtr.Zero ? (s_evpSha384 = Interop.Crypto.EvpSha384()) : s_evpSha384,
+            HashAlgorithmNames.SHA512 => s_evpSha512 == IntPtr.Zero ? (s_evpSha512 = Interop.Crypto.EvpSha512()) : s_evpSha512,
+            HashAlgorithmNames.MD5 => s_evpMd5 == IntPtr.Zero ? (s_evpMd5 = Interop.Crypto.EvpMd5()) : s_evpMd5,
             _ => throw new CryptographicException(SR.Format(SR.Cryptography_UnknownHashAlgorithm, hashAlgorithmId))
         };
 

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -29,7 +29,7 @@ namespace Internal.Cryptography
 
         public static class OneShotHashProvider
         {
-            private static volatile bool s_UseCompatOneShot;
+            private static volatile bool s_useCompatOneShot;
 
             public static unsafe int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
             {
@@ -54,7 +54,7 @@ namespace Internal.Cryptography
                 if (destination.Length < hashSize)
                     throw new CryptographicException();
 
-                if (!s_UseCompatOneShot)
+                if (!s_useCompatOneShot)
                 {
                     try
                     {
@@ -71,7 +71,7 @@ namespace Internal.Cryptography
                     }
                     catch (EntryPointNotFoundException)
                     {
-                        s_UseCompatOneShot = true;
+                        s_useCompatOneShot = true;
                         HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
                     }
                 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -4,6 +4,11 @@
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+using NTSTATUS = Interop.BCrypt.NTSTATUS;
+using BCryptOpenAlgorithmProviderFlags = Interop.BCrypt.BCryptOpenAlgorithmProviderFlags;
+using BCryptCreateHashFlags = Interop.BCrypt.BCryptCreateHashFlags;
+using BCryptAlgorithmCache = Interop.BCrypt.BCryptAlgorithmCache;
 
 namespace Internal.Cryptography
 {
@@ -24,12 +29,86 @@ namespace Internal.Cryptography
 
         public static class OneShotHashProvider
         {
+            private static volatile bool s_UseCompatOneShot;
+
             public static unsafe int HashData(string hashAlgorithmId, ReadOnlySpan<byte> source, Span<byte> destination)
             {
-                using (HashProviderCng hashProvider = new HashProviderCng(hashAlgorithmId, null))
+                // Shared handle, no using or dispose.
+                SafeBCryptAlgorithmHandle cachedAlgorithmHandle = BCryptAlgorithmCache.GetCachedBCryptAlgorithmHandle(
+                    hashAlgorithmId,
+                    BCryptOpenAlgorithmProviderFlags.None);
+
+                int hashSize;
+
+                NTSTATUS ntStatus = Interop.BCrypt.BCryptGetProperty(
+                    cachedAlgorithmHandle,
+                    Interop.BCrypt.BCryptPropertyStrings.BCRYPT_HASH_LENGTH,
+                    &hashSize,
+                    sizeof(int),
+                    out _,
+                    0);
+
+                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                    throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+
+                if (destination.Length < hashSize)
+                    throw new CryptographicException();
+
+                if (!s_UseCompatOneShot)
                 {
-                    hashProvider.AppendHashData(source);
-                    return hashProvider.FinalizeHashAndReset(destination);
+                    try
+                    {
+                        fixed (byte* pSource = source)
+                        fixed (byte* pDestination = destination)
+                        {
+                            ntStatus = Interop.BCrypt.BCryptHash(cachedAlgorithmHandle, null, 0, pSource, source.Length, pDestination, hashSize);
+
+                            if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                            {
+                                throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+                            }
+                        }
+                    }
+                    catch (EntryPointNotFoundException)
+                    {
+                        s_UseCompatOneShot = true;
+                        HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
+                    }
+                }
+                else
+                {
+                    HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
+                }
+
+                return hashSize;
+            }
+
+            private static void HashUpdateAndFinish(
+                SafeBCryptAlgorithmHandle algHandle,
+                int hashSize,
+                ReadOnlySpan<byte> source,
+                Span<byte> destination)
+            {
+                NTSTATUS ntStatus = Interop.BCrypt.BCryptCreateHash(
+                    algHandle,
+                    out SafeBCryptHashHandle hHash,
+                    IntPtr.Zero,
+                    0,
+                    default,
+                    0,
+                    BCryptCreateHashFlags.None);
+
+                if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                    throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+
+                using (hHash)
+                {
+                    ntStatus = Interop.BCrypt.BCryptHashData(hHash, source, source.Length, 0);
+
+                    if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                        throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+
+                    Interop.BCrypt.BCryptFinishHash(hHash, destination, hashSize, 0);
                 }
             }
         }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/HashProviderDispenser.Windows.cs
@@ -49,10 +49,14 @@ namespace Internal.Cryptography
                     0);
 
                 if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                {
                     throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+                }
 
                 if (destination.Length < hashSize)
+                {
                     throw new CryptographicException();
+                }
 
                 if (!s_useCompatOneShot)
                 {
@@ -68,17 +72,17 @@ namespace Internal.Cryptography
                                 throw Interop.BCrypt.CreateCryptographicException(ntStatus);
                             }
                         }
+
+                        return hashSize;
                     }
                     catch (EntryPointNotFoundException)
                     {
                         s_useCompatOneShot = true;
-                        HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
                     }
                 }
-                else
-                {
-                    HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
-                }
+
+                Debug.Assert(s_useCompatOneShot);
+                HashUpdateAndFinish(cachedAlgorithmHandle, hashSize, source, destination);
 
                 return hashSize;
             }
@@ -99,14 +103,18 @@ namespace Internal.Cryptography
                     BCryptCreateHashFlags.None);
 
                 if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                {
                     throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+                }
 
                 using (hHash)
                 {
                     ntStatus = Interop.BCrypt.BCryptHashData(hHash, source, source.Length, 0);
 
                     if (ntStatus != NTSTATUS.STATUS_SUCCESS)
+                    {
                         throw Interop.BCrypt.CreateCryptographicException(ntStatus);
+                    }
 
                     Interop.BCrypt.BCryptFinishHash(hHash, destination, hashSize, 0);
                 }

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -323,6 +323,8 @@
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptDestroyHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptDuplicateHash.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptDuplicateHash.cs" />
+    <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptHash.cs"
+             Link="Common\Interop\Windows\BCrypt\Interop.BCryptHash.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptHashData.cs"
              Link="Common\Interop\Windows\BCrypt\Interop.BCryptHashData.cs" />
     <Compile Include="$(CommonPath)Interop\Windows\BCrypt\Interop.BCryptFinishHash.cs"


### PR DESCRIPTION
This addresses the feedback from #17590.

I wasn't able to find any good examples of "Use this Win32 API if it's available, otherwise emulate it". If there is a example to model that off of other than what I did, happy to re-do the approach.

Fixes #17590.