### PR TITLE
Move wasm queue to one that has more capacity and condition it

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -138,6 +138,6 @@ jobs:
 
     # WebAssembly
     - ${{ if eq(parameters.platform, 'Browser_wasm') }}:
-      - Ubuntu.2004.Amd64.Open
+      - Ubuntu.1804.Amd64.Open
 
     ${{ insert }}: ${{ parameters.jobParameters }}

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -129,11 +129,6 @@ jobs:
       - eng/pipelines/coreclr/*
       - eng/pipelines/mono/*
       - eng/pipelines/libraries/*
-    
-    # Temporary workaround to: https://github.com/dotnet/runtime/issues/39238
-    - subset: testsproj
-      include:
-      - src/libraries/tests.proj
 
 #
 # Build CoreCLR checked
@@ -318,8 +313,8 @@ jobs:
     - Browser_wasm
     variables:
       # map dependencies variables to local variables
-      - name: testsProjContainsChange
-        value: $[ dependencies.checkout.outputs['SetPathVars_testsproj.containsChange'] ]
+      - name: librariesContainsChange
+        value: $[ dependencies.checkout.outputs['SetPathVars_libraries.containsChange'] ]
       - name: monoContainsChange
         value: $[ dependencies.checkout.outputs['SetPathVars_mono.containsChange'] ]
     jobParameters:
@@ -338,10 +333,9 @@ jobs:
       extraStepsParameters:
         creator: dotnet-bot
         testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-        # update once: https://github.com/dotnet/runtime/issues/39238 is fixed
         condition: >-
           or(
-          eq(variables['testsProjContainsChange'], true),
+          eq(variables['librariesContainsChange'], true),
           eq(variables['monoContainsChange'], true),
           eq(variables['isFullMatrix'], true))
 


### PR DESCRIPTION
This new queue has v8 and more capacity, so remove the workaround and run the tests when libraries or mono are changed.

Fixes: https://github.com/dotnet/runtime/issues/39238
Fixes: https://github.com/dotnet/runtime/issues/38400

cc: @akoeplinger @steveisok @MattGal @directhex 