### PR TITLE
[debugger] Removing unhandled_exception which was used for android.

### DIFF
--- a/src/mono/mono/mini/debugger-agent-stubs.c
+++ b/src/mono/mono/mini/debugger-agent-stubs.c
@@ -74,12 +74,6 @@ stub_debugger_agent_debug_log_is_enabled (void)
 }
 
 static void
-stub_debugger_agent_unhandled_exception (MonoException *exc)
-{
-	g_assert_not_reached ();
-}
-
-static void
 stub_debugger_agent_single_step_from_context (MonoContext *ctx)
 {
 	g_assert_not_reached ();
@@ -110,7 +104,6 @@ mono_debugger_agent_stub_init (void)
 	cbs.single_step_from_context = stub_debugger_agent_single_step_from_context;
 	cbs.breakpoint_from_context = stub_debugger_agent_breakpoint_from_context;
 	cbs.free_domain_info = stub_debugger_agent_free_domain_info;
-	cbs.unhandled_exception = stub_debugger_agent_unhandled_exception;
 	cbs.handle_exception = stub_debugger_agent_handle_exception;
 	cbs.begin_exception_filter = stub_debugger_agent_begin_exception_filter;
 	cbs.end_exception_filter = stub_debugger_agent_end_exception_filter;

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -5291,26 +5291,6 @@ debugger_agent_debug_log_is_enabled (void)
 }
 
 static void
-debugger_agent_unhandled_exception (MonoException *exc)
-{
-	int suspend_policy;
-	GSList *events;
-	EventInfo ei;
-
-	if (!inited)
-		return;
-
-	memset (&ei, 0, sizeof (ei));
-	ei.exc = (MonoObject*)exc;
-
-	mono_loader_lock ();
-	events = create_event_list (EVENT_KIND_EXCEPTION, NULL, NULL, &ei, &suspend_policy);
-	mono_loader_unlock ();
-
-	process_event (EVENT_KIND_EXCEPTION, &ei, 0, NULL, events, suspend_policy);
-}
-
-static void
 debugger_agent_handle_exception (MonoException *exc, MonoContext *throw_ctx,
 									  MonoContext *catch_ctx, StackFrameInfo *catch_frame)
 {
@@ -10424,7 +10404,6 @@ mono_debugger_agent_init (void)
 	cbs.single_step_from_context = debugger_agent_single_step_from_context;
 	cbs.breakpoint_from_context = debugger_agent_breakpoint_from_context;
 	cbs.free_domain_info = debugger_agent_free_domain_info;
-	cbs.unhandled_exception = debugger_agent_unhandled_exception;
 	cbs.handle_exception = debugger_agent_handle_exception;
 	cbs.begin_exception_filter = debugger_agent_begin_exception_filter;
 	cbs.end_exception_filter = debugger_agent_end_exception_filter;

--- a/src/mono/mono/mini/debugger-agent.h
+++ b/src/mono/mono/mini/debugger-agent.h
@@ -21,7 +21,6 @@ struct _MonoDebuggerCallbacks {
 	void (*single_step_from_context) (MonoContext *ctx);
 	void (*breakpoint_from_context) (MonoContext *ctx);
 	void (*free_domain_info) (MonoDomain *domain);
-	void (*unhandled_exception) (MonoException *exc);
 	void (*handle_exception) (MonoException *exc, MonoContext *throw_ctx,
 							  MonoContext *catch_ctx, StackFrameInfo *catch_frame);
 	void (*begin_exception_filter) (MonoException *exc, MonoContext *ctx, MonoContext *orig_ctx);

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -2366,8 +2366,15 @@ handle_exception_first_pass (MonoContext *ctx, MonoObject *obj, gint32 *out_filt
 		if (method->wrapper_type == MONO_WRAPPER_NATIVE_TO_MANAGED && ftnptr_eh_callback) {
 			result = MONO_FIRST_PASS_CALLBACK_TO_NATIVE;
 		}
-				
-				
+
+#if defined(HOST_ANDROID) || defined(TARGET_ANDROID)
+		//ignore the try catch in the .. icall_wrapper call
+		if (method->wrapper_type == WRAPPER_SUBTYPE_ICALL_WRAPPER) {
+			*ctx = new_ctx;
+			continue;
+		}
+#endif
+
 		for (i = clause_index_start; i < ji->num_clauses; i++) {
 			MonoJitExceptionInfo *ei = &ji->clauses [i];
 			gboolean filtered = FALSE;

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4640,11 +4640,6 @@ register_icalls (void)
 	mono_add_internal_call_internal ("Mono.Runtime::mono_runtime_cleanup_handlers",
 				mono_runtime_cleanup_handlers);
 
-#if defined(HOST_ANDROID) || defined(TARGET_ANDROID)
-	mono_add_internal_call_internal ("System.Diagnostics.Debugger::Mono_UnhandledException_internal",
-							mini_get_dbg_callbacks ()->unhandled_exception);
-#endif
-
 	/*
 	 * It's important that we pass `TRUE` as the last argument here, as
 	 * it causes the JIT to omit a wrapper for these icalls. If the JIT


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20122,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Trying to remove the usage of unhandled_exception function to make debugger handle with an exception when running on android.
We should ignore the try catch that is in an WRAPPER_SUBTYPE_ICALL_WRAPPER, then we can walk through all the callstack and find any try catch in managed code if it exists.
