### PR TITLE
Bump Intellisense nupkg version to Preview7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -114,7 +114,7 @@
     <NewtonsoftJsonVersion>12.0.3</NewtonsoftJsonVersion>
     <MoqVersion>4.12.0</MoqVersion>
     <!-- Docs -->
-    <MicrosoftPrivateIntellisenseVersion>3.0.0-preview-20200602.3</MicrosoftPrivateIntellisenseVersion>
+    <MicrosoftPrivateIntellisenseVersion>3.0.0-preview-20200715.1</MicrosoftPrivateIntellisenseVersion>
     <!-- ILLink -->
     <MicrosoftNETILLinkTasksVersion>5.0.0-preview.3.20363.5</MicrosoftNETILLinkTasksVersion>
     <!-- ICU -->


### PR DESCRIPTION
Bumping Microsoft.Private.Intellisense to the latest generated version for Preview7 (Intellisense is always one version behind).

Here's the [Docs job](https://apidrop.visualstudio.com/Content%20CI/_build/results?buildId=150735&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b&t=11e7ea89-affe-5194-cdc6-0171c3394706) that generated it and pushed it.

Note: I already requested the Docs eng team to rename the package to 5.0.0. It's not an issue, though. It's just for clarity in the future.