### PR TITLE
Fix source build (CLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE)

### DIFF
--- a/src/coreclr/src/pal/src/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/CMakeLists.txt
@@ -41,6 +41,10 @@ include_directories(include)
 
 # Compile options
 
+if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+  add_definitions(-DFEATURE_USE_SYSTEM_LIBUNWIND)
+endif(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+
 if(CLR_CMAKE_TARGET_OSX)
   add_definitions(-DTARGET_OSX)
   add_definitions(-DXSTATE_SUPPORTED)


### PR DESCRIPTION
Fixes issue #https://github.com/dotnet/runtime/issues/2014

Adds back ELF unwind info parsing code that has been around since 3.0 so it is fairly well tested. It is conditional on CLR_CMAKE_USE_SYSTEM_LIBUNWIND, otherwise, PAL_VirtualUnwindOutOfProc uses the new libunwind8 _OOP_find_proc_info function.