### PR TITLE
[Infra] Add diagnostics output to xunit runner

### DIFF
--- a/src/coreclr/tests/helixpublishwitharcade.proj
+++ b/src/coreclr/tests/helixpublishwitharcade.proj
@@ -213,7 +213,7 @@
     <_XUnitParallelMode>collections</_XUnitParallelMode>
     <_XUnitParallelMode Condition=" '$(LongRunningGCTests)' == 'true' ">none</_XUnitParallelMode>
     <_XUnitParallelMode Condition=" '$(GcSimulatorTests)' == 'true' ">none</_XUnitParallelMode>
-    <XUnitRunnerArgs>-parallel $(_XUnitParallelMode) -nocolor -noshadow -xml testResults.xml</XUnitRunnerArgs>
+    <XUnitRunnerArgs>-parallel $(_XUnitParallelMode) -diagnostics -internaldiagnostics -nocolor -noshadow -xml testResults.xml</XUnitRunnerArgs>
   </PropertyGroup>
 
   <!-- WARNING: HelixPreCommand ItemGroup is intentionally minimal and should be kept that way. -->


### PR DESCRIPTION
This change turns on higher verbosity output from the XUnit runner for coreclr tests.  We've seen recurring timeouts of the PaylodGroup0 Helix WorkItem (#38284) which results in logs with effectively no information.  I'm turning this on in the hopes that the output is intelligible and able to give us more insight into these timeouts.

CC @jashook @jaredpar @hoyosjs  