### PR TITLE
Disable Add_TakeFromAnotherThread_ExpectedItemsTaken for TailcallStress

### DIFF
--- a/src/libraries/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ProducerConsumerCollectionTests.cs
@@ -98,6 +98,7 @@ namespace System.Collections.Concurrent.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [SkipOnCoreClr("https://github.com/dotnet/runtime/issues/39398", RuntimeTestModes.TailcallStress)]
         public void Add_TakeFromAnotherThread_ExpectedItemsTaken()
         {
             IProducerConsumerCollection<int> c = CreateProducerConsumerCollection();


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/39398