### PR TITLE
Ensure Firing Activity Stop event before setting the current Activity

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -624,9 +624,9 @@ namespace System.Diagnostics
                     SetEndTime(GetUtcNow());
                 }
 
-                SetCurrent(Parent);
-
                 Source.NotifyActivityStop(this);
+
+                SetCurrent(Parent);
             }
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityListener.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityListener.cs
@@ -50,6 +50,9 @@ namespace System.Diagnostics
         /// <summary>
         /// Determine if the listener automatically generates a new trace Id before sampling when there is no parent context.
         /// </summary>
+        /// <remarks>
+        /// If this property is set to true and caused generating a new trace Id, the created <see cref="Activity"/> object from such call will have the same generated trace Id.
+        /// </remarks>
         public bool AutoGenerateRootContextTraceId { get; set;}
 
         /// <summary>


### PR DESCRIPTION
Fixing https://github.com/dotnet/runtime/issues/39179

When firing the Stop activity event when the Activit get disposed we notify all listeners with that event and we set the Current activity back to the parent culture. currently we set the Current activity first then we notify the listeners. That cause inconsistent result with DiagnosticSource. The linked issue has the broken scenario. The fix is simply notify the event first and then set the current activity.