### PR TITLE
Fix crash on invariant mode when calling GetCultureInfo(name, true)

### DIFF
--- a/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
+++ b/src/libraries/System.Globalization/tests/Invariant/InvariantMode.cs
@@ -1029,6 +1029,12 @@ namespace System.Globalization.Tests
             Assert.Equal(expectedToLower, Rune.ToLower(originalRune, CultureInfo.GetCultureInfo("tr-TR")).Value);
         }
 
+        [Fact]
+        public void TestGetCultureInfo_PredefinedOnly_ReturnsSame()
+        {
+            Assert.Equal(CultureInfo.GetCultureInfo("en-US"), CultureInfo.GetCultureInfo("en-US", predefinedOnly: true));
+        }
+
         private static byte[] GetExpectedInvariantOrdinalSortKey(ReadOnlySpan<char> input)
         {
             MemoryStream memoryStream = new MemoryStream();

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -1130,7 +1130,7 @@ namespace System.Globalization
                 throw new ArgumentNullException(nameof(name));
             }
 
-            if (predefinedOnly)
+            if (predefinedOnly && !GlobalizationMode.Invariant)
             {
                 return GlobalizationMode.UseNls ?
                     NlsGetPredefinedCultureInfo(name) :


### PR DESCRIPTION
`IcuGetPredefinedCultureInfo` calls into ICU and in invariant mode ICU is not initialized so it crashes.

@marek-safar would the linker trim this code with this check?