### PR TITLE
Fix source build (CLR_CMAKE_USE_SYSTEM_LIBUNWIND=TRUE)

### DIFF
--- a/src/coreclr/src/pal/src/CMakeLists.txt
+++ b/src/coreclr/src/pal/src/CMakeLists.txt
@@ -41,6 +41,10 @@ include_directories(include)
 
 # Compile options
 
+if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+  add_definitions(-DFEATURE_USE_SYSTEM_LIBUNWIND)
+endif(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)
+
 if(CLR_CMAKE_TARGET_OSX)
   add_definitions(-DTARGET_OSX)
   add_definitions(-DXSTATE_SUPPORTED)


### PR DESCRIPTION
**Summary**
Fix #2014

Adds back ELF unwind info parsing code that has been around since 3.0 so it is fairly well tested. It is conditional on CLR_CMAKE_USE_SYSTEM_LIBUNWIND, otherwise, PAL_VirtualUnwindOutOfProc uses the new libunwind8 _OOP_find_proc_info function.

**Customer Impact**
The source build for RHEL will fail if they want to use the system libunwind instead of the one in our sources.

**Regression**
N/A

**Risk**
Very low. The code added back was in the product since 3.0.


Fixes issue #https://github.com/dotnet/runtime/issues/2014

@hoyosjs Yes. This is for sourcebuild. The impact is that RedHat has requested that we use the local system's libunwind for portable builds. See dotnet/source-build#391 The OS that I'm using to build this is CentOS.

Adds back ELF unwind info parsing code that has been around since 3.0 so it is fairly well tested. It is conditional on CLR_CMAKE_USE_SYSTEM_LIBUNWIND, otherwise, PAL_VirtualUnwindOutOfProc uses the new libunwind8 _OOP_find_proc_info function.