### PR TITLE
Fix inadvertently case sensitive Boyer-Moore

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1337,7 +1337,7 @@ namespace System.Text.RegularExpressions
                 // ch = runtext[runtextpos];
                 // if (ch == lastChar) goto partialMatch;
                 Rightchar();
-                if (_boyerMoorePrefix.CaseInsensitive && ParticipatesInCaseConversion(chLast))
+                if (_boyerMoorePrefix.CaseInsensitive)
                 {
                     CallToLower();
                 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -1335,7 +1335,6 @@ namespace System.Text.RegularExpressions
                 }
 
                 // ch = runtext[runtextpos];
-                // if (ch == lastChar) goto partialMatch;
                 Rightchar();
                 if (_boyerMoorePrefix.CaseInsensitive)
                 {
@@ -1349,6 +1348,7 @@ namespace System.Text.RegularExpressions
                     Ldloc(chLocal);
                     Ldc(chLast);
 
+                    // if (ch == lastChar) goto partialMatch;
                     BeqFar(lPartialMatch);
 
                     // ch -= lowAscii;

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -16,7 +16,7 @@ namespace System.Text.RegularExpressions.Tests
         {
             // pattern, input, options, beginning, length, expectedSuccess, expectedValue
             yield return new object[] { @"H#", "#H#", RegexOptions.IgnoreCase, 0, 3, true, "H#" }; // https://github.com/dotnet/runtime/issues/39390
-            yield return new object[] { @"H#", "#H#", RegexOptions.None, 1, 2, true, "H#" };
+            yield return new object[] { @"H#", "#H#", RegexOptions.None, 0, 3, true, "H#" };
 
             // Testing octal sequence matches: "\\060(\\061)?\\061"
             // Octal \061 is ASCII 49 ('1')

--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Match.Tests.cs
@@ -15,6 +15,8 @@ namespace System.Text.RegularExpressions.Tests
         public static IEnumerable<object[]> Match_Basic_TestData()
         {
             // pattern, input, options, beginning, length, expectedSuccess, expectedValue
+            yield return new object[] { @"H#", "#H#", RegexOptions.IgnoreCase, 0, 3, true, "H#" }; // https://github.com/dotnet/runtime/issues/39390
+            yield return new object[] { @"H#", "#H#", RegexOptions.None, 1, 2, true, "H#" };
 
             // Testing octal sequence matches: "\\060(\\061)?\\061"
             // Octal \061 is ASCII 49 ('1')


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/39390

In this case the pattern "H#" would not match "#H#" iff RegexOptions.IgnoreCase | RegexOptions.Compiled.

Because the pattern contains a literal prefix (indeed it is the entire pattern) we will use Boyer-Moore to find the first instance of it. (One could imagine a more efficient way to search for a 2-character prefix.) Because the IgnoreCase was passed, we lowercase the pattern immediately to "h#", and when we match against a character in the text, we must lower case that character to compare it. 

As a performance optimization, in the Compiled path, we avoid calling ToLower on the text candidate if we can cheaply verify that the character we are searching for is not be affected by case conversion. In this case, for example, we need not bother to lower case the text candidate character when we are searching for "#" because it is in a UnicodeCategory ("OtherPunctuation") which we know is not affected by case conversion. This optimization, like many others, does not exist in the non Compiled path.

The bug was that when deciding whether to lowercase the text candidate, instead of examining the character we were searching for, we were examining the last character of the prefix instead. In this repro case that is "#" so when searching for "H" we would not lower case it.

I added a test that fails without this fix.