### PR TITLE
Fix lcl fld addr.

### DIFF
--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -815,11 +815,14 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                     // so update 'source' to point this GT_LCL_VAR_ADDR node
                     // and continue to the codegen for the LCL_VAR node below
                     //
+                    assert(addrNode->isContained());
                     varNode  = addrNode->AsLclVarCommon();
                     addrNode = nullptr;
                 }
                 else // addrNode is used
                 {
+                    // TODO-Cleanup: `Lowering::NewPutArg` marks only `LCL_VAR_ADDR` as contained nowadays,
+                    // but we use `genConsumeAddress` as a precaution, use `genConsumeReg()` instead.
                     assert(!addrNode->isContained());
                     // Generate code to load the address that we need into a register
                     genConsumeAddress(addrNode);
@@ -1254,6 +1257,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
 
         if (varNode != nullptr)
         {
+            assert(varNode->isContained());
             srcVarNum = varNode->GetLclNum();
             assert(srcVarNum < compiler->lvaCount);
 
@@ -1271,6 +1275,8 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
         else // addrNode is used
         {
             assert(addrNode != nullptr);
+            // TODO-Cleanup: `Lowering::NewPutArg` marks only `LCL_VAR_ADDR` as contained nowadays,
+            // but we use `genConsumeAddress` as a precaution, use `genConsumeReg()` instead.
             assert(!addrNode->isContained());
 
             // Generate code to load the address that we need into a register

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -820,6 +820,7 @@ void CodeGen::genPutArgStk(GenTreePutArgStk* treeNode)
                 }
                 else // addrNode is used
                 {
+                    assert(!addrNode->isContained());
                     // Generate code to load the address that we need into a register
                     genConsumeAddress(addrNode);
                     addrReg = addrNode->GetRegNum();
@@ -1270,6 +1271,7 @@ void CodeGen::genPutArgSplit(GenTreePutArgSplit* treeNode)
         else // addrNode is used
         {
             assert(addrNode != nullptr);
+            assert(!addrNode->isContained());
 
             // Generate code to load the address that we need into a register
             genConsumeAddress(addrNode);

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -6938,14 +6938,7 @@ void CodeGen::genSSE41RoundOp(GenTreeOp* treeNode)
                 {
                     assert(memBase->isContained());
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
-                    if (memBase->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = memBase->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = memBase->AsLclVarCommon()->GetLclOffs();
 
                     // Ensure that all the GenTreeIndir values are set to their defaults.
                     assert(memBase->GetRegNum() == REG_NA);

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -6940,7 +6940,6 @@ void CodeGen::genSSE41RoundOp(GenTreeOp* treeNode)
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
                     if (memBase->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = memBase->AsLclFld()->GetLclOffs();
                     }
                     else

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -6934,10 +6934,19 @@ void CodeGen::genSSE41RoundOp(GenTreeOp* treeNode)
             switch (memBase->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(memBase->isContained());
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (memBase->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = memBase->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
 
                     // Ensure that all the GenTreeIndir values are set to their defaults.
                     assert(memBase->GetRegNum() == REG_NA);

--- a/src/coreclr/src/jit/codegenxarch.cpp
+++ b/src/coreclr/src/jit/codegenxarch.cpp
@@ -6935,6 +6935,7 @@ void CodeGen::genSSE41RoundOp(GenTreeOp* treeNode)
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(memBase->isContained());
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
                     offset = 0;
 

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3601,8 +3601,7 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
 {
     GenTree* addr = storeInd->Addr();
     addr          = addr->gtSkipReloadOrCopy();
-    assert(addr->OperGet() == GT_LCL_VAR || addr->OperGet() == GT_LCL_VAR_ADDR || addr->OperGet() == GT_LEA ||
-           addr->OperGet() == GT_CLS_VAR_ADDR || addr->OperGet() == GT_CNS_INT);
+    assert(addr->OperIs(GT_LCL_VAR, GT_LCL_VAR_ADDR, GT_LEA, GT_CLS_VAR_ADDR, GT_CNS_INT));
 
     instrDesc*     id = nullptr;
     UNATIVE_OFFSET sz;
@@ -3681,8 +3680,7 @@ void emitter::emitInsRMW(instruction ins, emitAttr attr, GenTreeStoreInd* storeI
 {
     GenTree* addr = storeInd->Addr();
     addr          = addr->gtSkipReloadOrCopy();
-    assert(addr->OperGet() == GT_LCL_VAR || addr->OperGet() == GT_LCL_VAR_ADDR || addr->OperGet() == GT_CLS_VAR_ADDR ||
-           addr->OperGet() == GT_LEA || addr->OperGet() == GT_CNS_INT);
+    assert(addr->OperIs(GT_LCL_VAR, GT_LCL_VAR_ADDR, GT_CLS_VAR_ADDR, GT_LEA, GT_CNS_INT));
 
     ssize_t offset = 0;
     if (addr->OperGet() != GT_CLS_VAR_ADDR)

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -2973,7 +2973,7 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
             assert(amIndxReg != REG_NA);
         }
 
-        assert((amBaseReg != REG_NA) || (amIndxReg != REG_NA)); // At least one should be set.
+        assert((amBaseReg != REG_NA) || (amIndxReg != REG_NA) || (indir->Offset() != 0)); // At least one should be set.
         id->idAddr()->iiaAddrMode.amBaseReg = amBaseReg;
         id->idAddr()->iiaAddrMode.amIndxReg = amIndxReg;
         id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(indir->Scale());

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3291,10 +3291,19 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
             switch (memBase->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(memBase->isContained());
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (memBase->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = memBase->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
 
                     // Ensure that all the GenTreeIndir values are set to their defaults.
                     assert(!memIndir->HasIndex());

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3292,6 +3292,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(memBase->isContained());
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
                     offset = 0;
 

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3046,11 +3046,7 @@ void emitter::emitInsLoadInd(instruction ins, emitAttr attr, regNumber dstReg, G
     if (addr->OperIs(GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR))
     {
         GenTreeLclVarCommon* varNode = addr->AsLclVarCommon();
-        unsigned             offset  = 0;
-        if (addr->OperIs(GT_LCL_FLD_ADDR))
-        {
-            offset = varNode->AsLclFld()->GetLclOffs();
-        }
+        unsigned             offset  = varNode->GetLclOffs();
         emitIns_R_S(ins, attr, dstReg, varNode->GetLclNum(), offset);
 
         // Updating variable liveness after instruction was emitted
@@ -3295,14 +3291,7 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
                 {
                     assert(memBase->isContained());
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
-                    if (memBase->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = memBase->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = memBase->AsLclVarCommon()->GetLclOffs();
 
                     // Ensure that all the GenTreeIndir values are set to their defaults.
                     assert(!memIndir->HasIndex());

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -2956,24 +2956,27 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
     }
     else
     {
+        regNumber amBaseReg = REG_NA;
         if (memBase != nullptr)
         {
-            id->idAddr()->iiaAddrMode.amBaseReg = memBase->GetRegNum();
-        }
-        else
-        {
-            id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
+            assert(!memBase->isContained());
+            amBaseReg = memBase->GetRegNum();
+            assert(amBaseReg != REG_NA);
         }
 
+        regNumber amIndxReg = REG_NA;
         if (indir->HasIndex())
         {
-            id->idAddr()->iiaAddrMode.amIndxReg = indir->Index()->GetRegNum();
+            GenTree* index = indir->Index();
+            assert(!index->isContained());
+            amIndxReg = index->GetRegNum();
+            assert(amIndxReg != REG_NA);
         }
-        else
-        {
-            id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
-        }
-        id->idAddr()->iiaAddrMode.amScale = emitEncodeScale(indir->Scale());
+
+        assert((amBaseReg != REG_NA) || (amIndxReg != REG_NA)); // At least one should be set.
+        id->idAddr()->iiaAddrMode.amBaseReg = amBaseReg;
+        id->idAddr()->iiaAddrMode.amIndxReg = amIndxReg;
+        id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(indir->Scale());
 
         id->idInsFmt(emitMapFmtForIns(fmt, ins));
 

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -3297,7 +3297,6 @@ regNumber emitter::emitInsBinary(instruction ins, emitAttr attr, GenTree* dst, G
                     varNum = memBase->AsLclVarCommon()->GetLclNum();
                     if (memBase->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = memBase->AsLclFld()->GetLclOffs();
                     }
                     else

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -475,7 +475,6 @@ void CodeGen::genHWIntrinsic_R_RM(
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     if (addr->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = addr->AsLclFld()->GetLclOffs();
                     }
                     else
@@ -714,7 +713,6 @@ void CodeGen::genHWIntrinsic_R_R_RM_I(GenTreeHWIntrinsic* node, instruction ins,
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     if (addr->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = addr->AsLclFld()->GetLclOffs();
                     }
                     else

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -473,14 +473,7 @@ void CodeGen::genHWIntrinsic_R_RM(
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    if (addr->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = addr->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = addr->AsLclVarCommon()->GetLclOffs();
                     break;
                 }
 
@@ -711,14 +704,7 @@ void CodeGen::genHWIntrinsic_R_R_RM_I(GenTreeHWIntrinsic* node, instruction ins,
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    if (addr->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = addr->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = addr->AsLclVarCommon()->GetLclOffs();
                     break;
                 }
 
@@ -883,14 +869,7 @@ void CodeGen::genHWIntrinsic_R_R_RM_R(GenTreeHWIntrinsic* node, instruction ins)
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    if (addr->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = addr->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = addr->AsLclVarCommon()->GetLclOffs();
                     break;
                 }
 
@@ -1017,14 +996,7 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    if (addr->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = addr->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = addr->AsLclVarCommon()->GetLclOffs();
                     break;
                 }
 

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -885,7 +885,6 @@ void CodeGen::genHWIntrinsic_R_R_RM_R(GenTreeHWIntrinsic* node, instruction ins)
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     if (addr->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = addr->AsLclFld()->GetLclOffs();
                     }
                     else
@@ -1020,7 +1019,6 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     if (addr->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = addr->AsLclFld()->GetLclOffs();
                     }
                     else

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -470,6 +470,7 @@ void CodeGen::genHWIntrinsic_R_RM(
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
                     break;
@@ -699,6 +700,7 @@ void CodeGen::genHWIntrinsic_R_R_RM_I(GenTreeHWIntrinsic* node, instruction ins,
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
                     break;
@@ -862,6 +864,7 @@ void CodeGen::genHWIntrinsic_R_R_RM_R(GenTreeHWIntrinsic* node, instruction ins)
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
                     break;
@@ -987,6 +990,7 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
                     break;

--- a/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
+++ b/src/coreclr/src/jit/hwintrinsiccodegenxarch.cpp
@@ -469,10 +469,19 @@ void CodeGen::genHWIntrinsic_R_RM(
             switch (addr->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (addr->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = addr->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
                     break;
                 }
 
@@ -699,10 +708,19 @@ void CodeGen::genHWIntrinsic_R_R_RM_I(GenTreeHWIntrinsic* node, instruction ins,
             switch (addr->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (addr->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = addr->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
                     break;
                 }
 
@@ -863,10 +881,19 @@ void CodeGen::genHWIntrinsic_R_R_RM_R(GenTreeHWIntrinsic* node, instruction ins)
             switch (addr->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (addr->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = addr->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
                     break;
                 }
 
@@ -989,10 +1016,19 @@ void CodeGen::genHWIntrinsic_R_R_R_RM(
             switch (addr->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (addr->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = addr->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
                     break;
                 }
 

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -1023,14 +1023,7 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    if (addr->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = addr->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = addr->AsLclVarCommon()->GetLclOffs();
                     break;
                 }
 
@@ -1159,14 +1152,7 @@ void CodeGen::inst_RV_RV_TT(
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    if (addr->OperIs(GT_LCL_FLD_ADDR))
-                    {
-                        offset = addr->AsLclFld()->GetLclOffs();
-                    }
-                    else
-                    {
-                        offset = 0;
-                    }
+                    offset = addr->AsLclVarCommon()->GetLclOffs();
                     break;
                 }
 

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -1019,10 +1019,19 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
             switch (addr->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (addr->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = addr->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
                     break;
                 }
 
@@ -1147,10 +1156,19 @@ void CodeGen::inst_RV_RV_TT(
             switch (addr->OperGet())
             {
                 case GT_LCL_VAR_ADDR:
+                case GT_LCL_FLD_ADDR:
                 {
                     assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
-                    offset = 0;
+                    if (addr->OperIs(GT_LCL_FLD_ADDR))
+                    {
+                        assert(!"don't expect GT_LCL_FLD_ADDR");
+                        offset = addr->AsLclFld()->GetLclOffs();
+                    }
+                    else
+                    {
+                        offset = 0;
+                    }
                     break;
                 }
 

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -478,7 +478,7 @@ void CodeGen::inst_IV_handle(instruction ins, int val)
 void CodeGen::inst_set_SV_var(GenTree* tree)
 {
 #ifdef DEBUG
-    assert(tree && (tree->gtOper == GT_LCL_VAR || tree->gtOper == GT_LCL_VAR_ADDR || tree->gtOper == GT_STORE_LCL_VAR));
+    assert((tree != nullptr) && tree->OperIs(GT_LCL_VAR, GT_LCL_VAR_ADDR, GT_STORE_LCL_VAR));
     assert(tree->AsLclVarCommon()->GetLclNum() < compiler->lvaCount);
 
     GetEmitter()->emitVarRefOffs = tree->AsLclVar()->gtLclILoffs;

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -1020,6 +1020,7 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
                     break;
@@ -1147,6 +1148,7 @@ void CodeGen::inst_RV_RV_TT(
             {
                 case GT_LCL_VAR_ADDR:
                 {
+                    assert(addr->isContained());
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     offset = 0;
                     break;

--- a/src/coreclr/src/jit/instr.cpp
+++ b/src/coreclr/src/jit/instr.cpp
@@ -1025,7 +1025,6 @@ void CodeGen::inst_RV_TT_IV(instruction ins, emitAttr attr, regNumber reg1, GenT
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     if (addr->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = addr->AsLclFld()->GetLclOffs();
                     }
                     else
@@ -1162,7 +1161,6 @@ void CodeGen::inst_RV_RV_TT(
                     varNum = addr->AsLclVarCommon()->GetLclNum();
                     if (addr->OperIs(GT_LCL_FLD_ADDR))
                     {
-                        assert(!"don't expect GT_LCL_FLD_ADDR");
                         offset = addr->AsLclFld()->GetLclOffs();
                     }
                     else

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -5136,7 +5136,7 @@ void Lowering::ContainCheckHWIntrinsicAddr(GenTreeHWIntrinsic* node, GenTree* ad
 {
     assert((addr->TypeGet() == TYP_I_IMPL) || (addr->TypeGet() == TYP_BYREF));
     TryCreateAddrMode(addr, true);
-    if ((addr->OperIs(GT_CLS_VAR_ADDR, GT_LCL_VAR_ADDR, GT_LEA) ||
+    if ((addr->OperIs(GT_CLS_VAR_ADDR, GT_LCL_VAR_ADDR, GT_LCL_FLD_ADDR, GT_LEA) ||
          (addr->IsCnsIntOrI() && addr->AsIntConCommon()->FitsInAddrBase(comp))) &&
         IsSafeToContainMem(node, addr))
     {

--- a/src/coreclr/src/jit/lowerxarch.cpp
+++ b/src/coreclr/src/jit/lowerxarch.cpp
@@ -3439,8 +3439,7 @@ bool Lowering::IsRMWMemOpRootedAtStoreInd(GenTree* tree, GenTree** outIndirCandi
     assert(storeInd->IsRMWStatusUnknown());
 
     // Early out if indirDst is not one of the supported memory operands.
-    if (indirDst->OperGet() != GT_LEA && indirDst->OperGet() != GT_LCL_VAR && indirDst->OperGet() != GT_LCL_VAR_ADDR &&
-        indirDst->OperGet() != GT_CLS_VAR_ADDR && indirDst->OperGet() != GT_CNS_INT)
+    if (!indirDst->OperIs(GT_LEA, GT_LCL_VAR, GT_LCL_VAR_ADDR, GT_CLS_VAR_ADDR, GT_CNS_INT))
     {
         storeInd->SetRMWStatus(STOREIND_RMW_UNSUPPORTED_ADDR);
         return false;
@@ -4452,14 +4451,13 @@ bool Lowering::LowerRMWMemOp(GenTreeIndir* storeInd)
     }
     else
     {
-        assert(indirCandidateChild->OperGet() == GT_LCL_VAR || indirCandidateChild->OperGet() == GT_LCL_VAR_ADDR ||
-               indirCandidateChild->OperGet() == GT_CLS_VAR_ADDR || indirCandidateChild->OperGet() == GT_CNS_INT);
+        assert(indirCandidateChild->OperIs(GT_LCL_VAR, GT_LCL_VAR_ADDR, GT_CLS_VAR_ADDR, GT_CNS_INT));
 
         // If it is a GT_LCL_VAR, it still needs the reg to hold the address.
         // We would still need a reg for GT_CNS_INT if it doesn't fit within addressing mode base.
         // For GT_CLS_VAR_ADDR, we don't need a reg to hold the address, because field address value is known at jit
         // time. Also, we don't need a reg for GT_CLS_VAR_ADDR.
-        if (indirCandidateChild->OperGet() == GT_LCL_VAR_ADDR || indirCandidateChild->OperGet() == GT_CLS_VAR_ADDR)
+        if (indirCandidateChild->OperIs(GT_LCL_VAR_ADDR, GT_CLS_VAR_ADDR))
         {
             indirDst->SetContained();
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39403/Runtime_39403.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39403/Runtime_39403.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+// The test was showing silence bad codegen for a `LclFldAddr` node under HWINSTRINSIC(IND).
+
+class Runtime_39403
+{
+    struct Container
+    {
+        public Vector<int> Vector;
+        public int Integer;
+    }
+
+    static Vector<int> DoAThingByRef(ref Vector<int> s)
+    {
+        return s + Vector<int>.Zero;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe Vector<int> TestLclFldAddr()
+    {
+        Container container = default;
+        return DoAThingByRef(ref container.Vector);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe Vector<int> TestLclVarAddr()
+    {
+        Container container = default;
+        return DoAThingByRef(ref Unsafe.As<Container, Vector<int>>(ref container));
+    }
+
+    public static int Main()
+    {
+        Vector<int> v1 = TestLclFldAddr();
+        Vector<int> v2 = TestLclVarAddr();
+        System.Diagnostics.Debug.Assert(v1 == v2);
+        return 100;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39403/Runtime_39403.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39403/Runtime_39403.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType />
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.il
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.il
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+// The test was showing some rare cases of `IND(LCL_FLD_ADDR)` under HW intrinsic nodes.
+
+.assembly extern System.Runtime {}
+.assembly extern System.Runtime.Intrinsics {}
+.assembly extern System.Runtime.Extensions {}
+.assembly extern System.Numerics.Vectors {}
+.assembly extern System.Numerics.Extensions {}
+.assembly extern System.Runtime.CompilerServices.Unsafe {}
+
+.assembly Runtime_39424.exe {}
+
+.class private auto ansi beforefieldinit Runtime_39424
+       extends [System.Runtime]System.Object
+{
+  .class sequential ansi sealed nested private beforefieldinit Container
+         extends [System.Runtime]System.ValueType
+  {
+    .field public valuetype [System.Numerics.Vectors]System.Numerics.Vector`1<int32> Vector
+    .field public float64 Double
+  } // end of class Container
+
+  .method private hidebysig static float64 
+          TestLclFldAddrIntrinsicsRound(float64 d) cil managed noinlining
+  {
+    // Code size       30 (0x1e)
+    .maxstack  2
+    .locals init (valuetype Runtime_39424/Container V_0)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    Runtime_39424/Container
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldarg.0
+    IL_000b:  stfld      float64 Runtime_39424/Container::Double
+    IL_0010:  ldloca.s   V_0
+    IL_0012:  ldflda     float64 Runtime_39424/Container::Double
+    IL_0017:  volatile. ldind.r8
+    IL_0018:  call       float64 [System.Runtime.Extensions]System.Math::Round(float64)
+    IL_001d:  ret
+  } // end of method Runtime_39424::TestLclFldAddrIntrinsicsRound
+  
+  .class sequential ansi sealed nested private beforefieldinit Vector128Wrapped
+         extends [System.Runtime]System.ValueType
+  {
+    .field public int8 i1
+    .field public int8 i2
+    .field public int8 i3
+    .field public int8 i4
+    .field public valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> 'vector'
+  } // end of class Vector128Wrapped
+  
+  
+  .class sequential ansi sealed nested private beforefieldinit Vector128WrappedDouble
+         extends [System.Runtime]System.ValueType
+  {
+    .field private bool i1
+    .field private bool i2
+    .field private bool i3
+    .field private bool i4
+    .field public valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> 'vector'
+  } // end of class Vector128WrappedDouble
+  
+  .method private hidebysig static float64 
+          TestLclFldAddrIntrinsicsSSE41_BlendVariable(float64 d) cil managed noinlining
+  {
+    // Code size       78 (0x4e)
+    .maxstack  3
+    .locals init (valuetype Runtime_39424/Vector128Wrapped V_0,
+             valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32>& V_1,
+             valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> V_2)
+    IL_0000:  call       bool [System.Runtime.Intrinsics]System.Runtime.Intrinsics.X86.Sse41::get_IsSupported()
+    IL_0005:  brfalse.s  IL_0044
+
+    IL_0007:  ldc.i4.1
+    IL_0008:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::Create(int32)
+    IL_000d:  ldloca.s   V_0
+    IL_000f:  initobj    Runtime_39424/Vector128Wrapped
+    IL_0015:  ldloca.s   V_0
+    IL_0017:  ldc.i4.2
+    IL_0018:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::Create(int32)
+    IL_001d:  stfld      valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> Runtime_39424/Vector128Wrapped::'vector'
+    IL_002a:  ldc.i4.3
+    IL_002b:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::Create(int32)
+    IL_0030:  stloc.2
+    IL_0022:  ldloca.s   V_0
+    IL_0024:  ldflda     valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> Runtime_39424/Vector128Wrapped::'vector'
+    IL_0032:  volatile. ldobj      valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32>
+    IL_0037:  ldloc.2
+    IL_0038:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.X86.Sse41::BlendVariable(valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32>,
+                                                                                                                                                                                         valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32>,
+                                                                                                                                                                                         valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<int32>)
+    IL_003d:  call       !!0 [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::ToScalar<int32>(valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<!!0>)
+    IL_0042:  conv.r8
+    IL_0043:  ret
+
+    IL_0044:  ldc.r8     100.
+    IL_004d:  ret
+  } // end of method Runtime_39424::TestLclFldAddrIntrinsicsSSE41_BlendVariable
+  
+  .method private hidebysig static float64 
+          TestLclFldAddrIntrinsicsFMA_MulipluAddScalar() cil managed noinlining
+  {
+    // Code size       101 (0x65)
+    .maxstack  3
+    .locals init (valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> V_0,
+             valuetype Runtime_39424/Vector128WrappedDouble V_1,
+             valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64>& V_2)
+    IL_0000:  call       bool [System.Runtime.Intrinsics]System.Runtime.Intrinsics.X86.Fma::get_IsSupported()
+    IL_0005:  brfalse.s  IL_005b
+
+    IL_0007:  ldc.r8     1.
+    IL_0010:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::Create(float64)
+    IL_0015:  ldc.r8     3.
+    IL_001e:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::Create(float64)
+    IL_0023:  stloc.0
+    IL_0024:  ldloca.s   V_1
+    IL_0026:  initobj    Runtime_39424/Vector128WrappedDouble
+    IL_002c:  ldloca.s   V_1
+    IL_002e:  ldc.r8     2.
+    IL_0037:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::Create(float64)
+    IL_003c:  stfld      valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> Runtime_39424/Vector128WrappedDouble::'vector'
+    IL_0049:  ldloc.0
+    IL_0041:  ldloca.s   V_1
+    IL_0043:  ldflda     valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> Runtime_39424/Vector128WrappedDouble::'vector'
+    IL_004b:  ldobj      valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64>
+    IL_0050:  call       valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64> [System.Runtime.Intrinsics]System.Runtime.Intrinsics.X86.Fma::MultiplyAddScalar(valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64>,
+                                                                                                                                                                                             valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64>,
+                                                                                                                                                                                             valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<float64>)
+    IL_0055:  call       !!0 [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128::ToScalar<float64>(valuetype [System.Runtime.Intrinsics]System.Runtime.Intrinsics.Vector128`1<!!0>)
+    IL_005a:  ret
+
+    IL_005b:  ldc.r8     100.
+    IL_0064:  ret
+  } // end of method Runtime_39424::TestLclFldAddrIntrinsicsFMA_MulipluAddScalar
+
+
+  .class sequential ansi sealed nested private beforefieldinit IntsWrapped
+         extends [System.Runtime]System.ValueType
+  {
+    .field public int32 i1
+    .field public int32 i2
+    .field public int32 i3
+    .field public int32 i4
+    .field public int32 i5
+  } // end of class IntsWrapped
+
+  .method public hidebysig static int32  TestLclFldAddr_BinOp(int32 a) cil managed noinlining
+  {
+    // Code size       21 (0x15)
+    .maxstack  2
+    .locals init (valuetype Runtime_39424/IntsWrapped V_0,
+             int32& V_1)
+    IL_0000:  ldloca.s   V_0
+    IL_0002:  initobj    Runtime_39424/IntsWrapped
+    IL_0010:  ldarg.0
+    IL_0008:  ldloca.s   V_0
+    IL_000a:  ldflda     int32 Runtime_39424/IntsWrapped::i4
+    IL_0012:  volatile. ldind.i4
+    IL_0013:  add
+    IL_0014:  ret
+  } // end of method Runtime_39424::TestLclFldAddr_BinOp
+
+  .method public hidebysig static int32  Main() cil managed
+  {
+    .entrypoint
+    // Code size       18 (0x12)
+    .maxstack  8
+    IL_0000:  ldc.r8     1.
+    IL_0009:  call       float64 Runtime_39424::TestLclFldAddrIntrinsicsRound(float64)
+    IL_000e:  pop
+    IL_0010:  ldc.r8     2.
+    IL_0011:  call       float64 Runtime_39424::TestLclFldAddrIntrinsicsSSE41_BlendVariable(float64)
+    IL_0012:  pop
+    IL_0013:  call       float64 Runtime_39424::TestLclFldAddrIntrinsicsFMA_MulipluAddScalar()
+    IL_0014:  pop
+              ldc.i4.1
+              call       int32 Runtime_39424::TestLclFldAddr_BinOp(int32)
+              pop
+    
+    IL_0015:  ldc.i4.s   100
+    IL_0016:  ret
+  } // end of method Runtime_39424::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Runtime_39424::.ctor
+
+} // end of class Runtime_39424

--- a/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.ilproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_39424/Runtime_39424.ilproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <PropertyGroup>
+  <!-- Disable CSE to protect fragile `OBJ(ADDR(LCL_FIELD)` constructions. -->
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_JitNoCSE=1
+]]></CLRTestBatchPreCommands>
+    <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_JitNoCSE=1
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).il" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR fixes https://github.com/dotnet/runtime/issues/39403 introduced by https://github.com/dotnet/runtime/pull/38316 (first two commits).

The safest solution would be to revert https://github.com/dotnet/runtime/commit/eefeb7e7b1485f48c2c3d65d119c7fa7693b0943 and https://github.com/dotnet/runtime/commit/ceec9c8fd43d5b938f5bc5ad610075aa44498b44 but it will lead to significant regressions, like 


  | Total size diff, bytes | Methods imrpoved | Methods regressed
-- | -- | -- | --
arm64 Windows crossgen | 18912 | 0 | 1156


so after advising with Carol I have decided to fix the optimization rather than disable it.

The two bad things about the issue were:
1. we did not catch it with our testing;
2. Jit was producing bad code instead of failing with an assert;

so the main goal in the fix was to add as many relevant asserts as possible. 

I recommend reviewing by commits.

Changes:
https://github.com/dotnet/runtime/pull/39424/commits/aaf2e99c566d8beff28851f330bb4dfe09f6e1a6: Add a repro test.

https://github.com/dotnet/runtime/pull/39424/commits/69d33fb52d427019cd89243f9dd0118839446b31: Small ref.

Combine long chains of `addr->OperGet() == GT_* ||` with `GT_LCL_VAR_ADDR` using `OperIs` to simplify future changes.

https://github.com/dotnet/runtime/pull/39424/commits/f8d8cacec293d41b63e9c2f9588fb6efd69fba2e: Add an assert that would fire in the repro test.

`emitter::emitHandleMemOp` has special logic for contained `memBase` but the last else does not
expect a contained node. A contained node doesn't produce a register so it is not correct to use the result
of `GetRegNum()` from a contained node as a valid register.
However, adding an assert to `GetRegNum()` that `!this->isContained` is a bigger task that is out of this PR.

https://github.com/dotnet/runtime/pull/39424/commits/578d0ed1194fbfa2732215c8f8d416f18071a2e5: Assert that `LCL_FLD_ADDR` is not contained in `genPutArgStk(Split)`

We have contained `LCL_VAR_ADDR` support there but make sure that contained `LCL_FLD_ADDR` can't reach it.

https://github.com/dotnet/runtime/pull/39424/commits/cd9d0b3eff500c97731291749f4304f472d31181: Contain `GT_LCL_FLD_ADDR` under HW_INTRINSIC.

This is an additional optimization that makes future changes simpler.

https://github.com/dotnet/runtime/pull/39424/commits/7d68d3f25289c3ad126f3b39ca82ba0119ba907f: Add contained checks.

In all these places we expect `LCL_VAR_ADDR` to be contained.
If we had gotten a `LCL_VAR_ADDR` that is not contained we would have instantiated `LCL_VAR_ADDR` twice:
in the register and the parent instruction.
The register value would have been unused.

https://github.com/dotnet/runtime/pull/39424/commits/1865d2943f15d3b00523597f519b546f4dea936f: Support `FLD_ADDR` where `LCL_ADDR` is supported.

However, fire an assert if we think that this path is unreachable for now.

https://github.com/dotnet/runtime/pull/39424/commits/69ecffc6a1c0d67b59f3c87fb914ef5cd48efa40: Delete asserts in the reachable blocks.

We have coverage for this asserts in the following tests:
hwintrinsic 478: Ssse3_ro
instr 11645: Runtime_39403
instr 1028 : Aes_ro
hwintrinsic 716: pmi of Microsoft.Diagnostics.Tracing.TraceEvent


From HWIntrinsic support we have some improvements (x64 Pmi):
```
Total bytes of diff: -2267 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -604 : JIT\HardwareIntrinsics\X86\Sse2\Sse2_r\Sse2_r.dasm (-0.02% of base)
        -500 : JIT\HardwareIntrinsics\X86\Avx2\Avx2_r\Avx2_r.dasm (-0.01% of base)
        -364 : JIT\HardwareIntrinsics\X86\Avx\Avx_r\Avx_r.dasm (-0.02% of base)
        -300 : JIT\HardwareIntrinsics\X86\Sse41\Sse41_r\Sse41_r.dasm (-0.02% of base)
        -208 : JIT\HardwareIntrinsics\X86\Sse\Sse_r\Sse_r.dasm (-0.02% of base)
         -80 : JIT\HardwareIntrinsics\X86\Fma_Vector128\Fma_r\Fma_r.dasm (-0.02% of base)
         -64 : JIT\HardwareIntrinsics\X86\Ssse3\Ssse3_r\Ssse3_r.dasm (-0.01% of base)
         -48 : JIT\HardwareIntrinsics\X86\Fma_Vector256\Fma_r\Fma_r.dasm (-0.02% of base)
         -32 : JIT\HardwareIntrinsics\X86\Sse41_Overloaded\Sse41_Overloaded_r\Sse41_Overloaded_r.dasm (-0.03% of base)
         -24 : JIT\HardwareIntrinsics\X86\Aes\Aes_r\Aes_r.dasm (-0.03% of base)
         -24 : JIT\HardwareIntrinsics\X86\Sse3\Sse3_r\Sse3_r.dasm (-0.02% of base)
          -8 : JIT\HardwareIntrinsics\X86\Avx_Vector128\Avx_r\Avx_r.dasm (-0.01% of base)
          -4 : JIT\HardwareIntrinsics\X86\Avx2_Vector128\Avx2_r\Avx2_r.dasm (-0.00% of base)
          -4 : JIT\HardwareIntrinsics\X86\Sse42\Sse42_r\Sse42_r.dasm (-0.02% of base)
          -3 : JIT\Regression\JitBlue\Runtime_39403\Runtime_39403\Runtime_39403.dasm (-1.03% of base)
15 total files with Code Size differences (15 improved, 0 regressed), 3365 unchanged.
```

crossgen linuxnonjit:
```
Top file improvements (bytes):
        -662 : System.Private.CoreLib.dasm (-0.01% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 261 unchanged.
Top method improvements (bytes):
        -184 (-20.54% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_Multiply(Matrix4x4,Matrix4x4):Matrix4x4 (2 methods)
         -70 (-15.84% of base) : System.Private.CoreLib.dasm - Matrix4x4:Lerp(Matrix4x4,Matrix4x4,float):Matrix4x4 (2 methods)
         -70 (-23.33% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_Addition(Matrix4x4,Matrix4x4):Matrix4x4 (2 methods)
         -70 (-23.33% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_Subtraction(Matrix4x4,Matrix4x4):Matrix4x4 (2 methods)
         -70 (-27.34% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_Equality(Matrix4x4,Matrix4x4):bool (2 methods)
         -70 (-26.72% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_Inequality(Matrix4x4,Matrix4x4):bool (2 methods)
         -32 (-11.76% of base) : System.Private.CoreLib.dasm - Matrix4x4:Transpose(Matrix4x4):Matrix4x4 (2 methods)
         -32 (-10.06% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_UnaryNegation(Matrix4x4):Matrix4x4 (2 methods)
         -32 (-10.06% of base) : System.Private.CoreLib.dasm - Matrix4x4:op_Multiply(Matrix4x4,float):Matrix4x4 (2 methods)
         -32 (-1.24% of base) : System.Private.CoreLib.dasm - Matrix4x4:<Invert>g__SseImpl|59_0(Matrix4x4,byref):bool (2 methods)

```

I am planning to write repro cases for the rest of `assert(!"don't expect GT_LCL_FLD_ADDR")` before I finish this PR.