### PR TITLE
Fix IsPrerelease condition to be aligned with rest of utf8string code

### DIFF
--- a/src/libraries/System.Utf8String.Experimental/src/System.Utf8String.Experimental.csproj
+++ b/src/libraries/System.Utf8String.Experimental/src/System.Utf8String.Experimental.csproj
@@ -110,7 +110,7 @@
     <Compile Include="$(CoreLibSharedDir)\System\Text\Utf8Span.Searching.cs"
              Link="System\Text\Utf8Span.Searching.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'">
+  <ItemGroup Condition="'$(IsPrerelease)' != 'false' AND '$(TargetFramework)' == '$(NetCoreAppCurrent)'">
     <Compile Include="System\Net\Http\Utf8StringContent.netcoreapp.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR $(TargetFramework.StartsWith('net4'))">


### PR DESCRIPTION
During snapshot it shows there is no IsPrerelease check for newly added file. See #39416 for the failures.

