### PR TITLE
In mono_wasm_invoke_js_marshalled, pass through treatResultAsVoid param

### DIFF
--- a/src/mono/wasm/runtime/dotnet_support.js
+++ b/src/mono/wasm/runtime/dotnet_support.js
@@ -29,7 +29,7 @@ var DotNetSupportLib = {
 			return MONO.string_decoder.copy (mono_obj);
 		}
 	},
-	mono_wasm_invoke_js_marshalled: function(exceptionMessage, asyncHandleLongPtr, functionName, argsJson) {
+	mono_wasm_invoke_js_marshalled: function(exceptionMessage, asyncHandleLongPtr, functionName, argsJson, treatResultAsVoid) {
 
 		var mono_string = DOTNET._dotnet_get_global()._mono_string_cached
 			|| (DOTNET._dotnet_get_global()._mono_string_cached = Module.cwrap('mono_wasm_string_from_js', 'number', ['string']));
@@ -54,10 +54,10 @@ var DotNetSupportLib = {
 			}
 
 			if (asyncHandleJsNumber) {
-				dotNetExports.jsCallDispatcher.beginInvokeJSFromDotNet(asyncHandleJsNumber, funcNameJsString, argsJsonJsString);
+				dotNetExports.jsCallDispatcher.beginInvokeJSFromDotNet(asyncHandleJsNumber, funcNameJsString, argsJsonJsString, treatResultAsVoid);
 				return 0;
 			} else {
-				var resultJson = dotNetExports.jsCallDispatcher.invokeJSFromDotNet(funcNameJsString, argsJsonJsString);
+				var resultJson = dotNetExports.jsCallDispatcher.invokeJSFromDotNet(funcNameJsString, argsJsonJsString, treatResultAsVoid);
 				return resultJson === null ? 0 : mono_string(resultJson);
 			}
 		} catch (ex) {


### PR DESCRIPTION
When invoking JS functions, sometimes they return values that aren't JSON serializable. This would then result in a JSON serialization exception.

But this doesn't make sense in the case where the developer made the call using `InvokeVoid` or `InvokeVoidAsync`. In these cases, we know they don't want the response, so why would we even try serializing and sending it?

This PR adds a new parameter that Blazor can use to control whether the result value is to be JSON-serialized or just discarded. The real implementation of the rest of the functionality will happen in the aspnetcore repo.