### PR TITLE
Fix Crossgen2 compilation in case input files are on different drives

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -311,7 +311,7 @@ namespace ILCompiler
                     foreach (string inputFile in _inputFiles)
                     {
                         string relativeMsilPath = Path.GetRelativePath(_compositeRootPath, inputFile);
-                        if (relativeMsilPath == inputFile || relativeMsilPath.StartsWith(s_folderUpPrefix))
+                        if (relativeMsilPath == inputFile || relativeMsilPath.StartsWith(s_folderUpPrefix, StringComparison.Ordinal))
                         {
                             // Input file not under the composite root, emit to root output folder
                             relativeMsilPath = Path.GetFileName(inputFile);

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -311,9 +311,9 @@ namespace ILCompiler
                     foreach (string inputFile in _inputFiles)
                     {
                         string relativeMsilPath = Path.GetRelativePath(_compositeRootPath, inputFile);
-                        if (relativeMsilPath.StartsWith(s_folderUpPrefix))
+                        if (relativeMsilPath == inputFile || relativeMsilPath.StartsWith(s_folderUpPrefix))
                         {
-                            // Input file not in the composite root, emit to root output folder
+                            // Input file not under the composite root, emit to root output folder
                             relativeMsilPath = Path.GetFileName(inputFile);
                         }
                         string standaloneMsilOutputFile = Path.Combine(outputDirectory, relativeMsilPath);


### PR DESCRIPTION
Crossgen2 would try to override _input_ files if they are on a different drive or a share with respect to `_compositeRootPath`. @dotnet/crossgen-contrib