### PR TITLE
Fix liveness of FrameListRoot

### DIFF
--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -1903,9 +1903,9 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
                     // Removing a call does not affect liveness unless it is a tail call in a nethod with P/Invokes or
                     // is itself a P/Invoke, in which case it may affect the liveness of the frame root variable.
                     if (!opts.MinOpts() && !opts.ShouldUsePInvokeHelpers() &&
-                        lvaTable[info.compLvFrameListRoot].lvTracked &&
                         ((call->IsTailCall() && compMethodRequiresPInvokeFrame()) ||
-                         (call->IsUnmanaged() && !call->IsSuppressGCTransition())))
+                         (call->IsUnmanaged() && !call->IsSuppressGCTransition())) &&
+                        lvaTable[info.compLvFrameListRoot].lvTracked)
                     {
                         fgStmtRemoved = true;
                     }

--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -1900,7 +1900,7 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
 
                     blockRange.Remove(node);
 
-                    // Removing a call does not affect liveness unless it is a tail call in a nethod with P/Invokes or
+                    // Removing a call does not affect liveness unless it is a tail call in a method with P/Invokes or
                     // is itself a P/Invoke, in which case it may affect the liveness of the frame root variable.
                     if (!opts.MinOpts() && !opts.ShouldUsePInvokeHelpers() &&
                         ((call->IsTailCall() && compMethodRequiresPInvokeFrame()) ||


### PR DESCRIPTION
The FrameListRoot variable isn't used if `call->IsSuppressGCTransition()`, but liveness wasn't checking this.

Fix #39221