### PR TITLE
[preview8] Mmap R2R images at and non-page-boundary (#38951)

### DIFF
--- a/src/coreclr/src/pal/src/map/map.cpp
+++ b/src/coreclr/src/pal/src/map/map.cpp
@@ -2137,6 +2137,18 @@ MAPRecordMapping(
     return palError;
 }
 
+static size_t OffsetWithinPage(off_t addr)
+{
+    return addr & (GetVirtualPageSize() - 1);
+}
+
+static size_t RoundToPage(size_t size, off_t offset)
+{
+    size_t result = size + OffsetWithinPage(offset);
+    _ASSERTE(result >= size);
+    return result;
+}
+
 // Do the actual mmap() call, and record the mapping in the MappedViewList list.
 // This call assumes the mapping_critsec has already been taken.
 static PAL_ERROR
@@ -2155,9 +2167,13 @@ MAPmmapAndRecord(
     _ASSERTE(pPEBaseAddress != NULL);
 
     PAL_ERROR palError = NO_ERROR;
-    off_t adjust = offset & (GetVirtualPageSize() - 1);
+    off_t adjust = OffsetWithinPage(offset);
     LPVOID pvBaseAddress = static_cast<char *>(addr) - adjust;
 
+    // Ensure address and offset arguments mmap() are page-aligned.
+    _ASSERTE(OffsetWithinPage(offset - adjust) == 0);
+    _ASSERTE(OffsetWithinPage((off_t)pvBaseAddress) == 0);
+    
 #ifdef __APPLE__
     if ((prot & PROT_EXEC) != 0 && IsRunningOnMojaveHardenedRuntime())
     {
@@ -2176,7 +2192,7 @@ MAPmmapAndRecord(
     else
 #endif
     {
-        pvBaseAddress = mmap(static_cast<char *>(addr) - adjust, len + adjust, prot, flags, fd, offset - adjust);
+        pvBaseAddress = mmap(pvBaseAddress, len + adjust, prot, flags, fd, offset - adjust);
         if (MAP_FAILED == pvBaseAddress)
         {
             ERROR_(LOADER)( "mmap failed with code %d: %s.\n", errno, strerror( errno ) );
@@ -2360,7 +2376,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     // We're going to start adding mappings to the mapping list, so take the critical section
     InternalEnterCriticalSection(pThread, &mapping_critsec);
 
-    reserveSize = virtualSize;
+    reserveSize = RoundToPage(virtualSize, offset);
     if ((ntHeader.OptionalHeader.SectionAlignment) > GetVirtualPageSize())
     {
         reserveSize += ntHeader.OptionalHeader.SectionAlignment;
@@ -2441,11 +2457,19 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     //we have now reserved memory (potentially we got rebased).  Walk the PE sections and map each part
     //separately.
 
+    _ASSERTE(OffsetWithinPage((off_t)loadedBase) == 0);
 
     //first, map the PE header to the first page in the image.  Get pointers to the section headers
+    loadedHeader = (IMAGE_DOS_HEADER*)(static_cast<char*>(loadedBase) + OffsetWithinPage(offset));
+
+    LPVOID loadedHeaderBase;
+    // initialize this on a separate line to prevent a false error about the goto done; jumping over this
+    loadedHeaderBase = NULL;
+
+    _ASSERTE(OffsetWithinPage(offset) == OffsetWithinPage((off_t)loadedHeader));
     palError = MAPmmapAndRecord(pFileObject, loadedBase,
-                    loadedBase, headerSize, PROT_READ, readOnlyFlags, fd, offset,
-                    (void**)&loadedHeader);
+                    (LPVOID)loadedHeader, headerSize, PROT_READ, readOnlyFlags, fd, offset,
+                    &loadedHeaderBase);
     if (NO_ERROR != palError)
     {
         ERROR_(LOADER)( "mmap of PE header failed\n" );
@@ -2453,7 +2477,7 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     }
 
     TRACE_(LOADER)("PE header loaded @ %p\n", loadedHeader);
-    _ASSERTE(loadedHeader == loadedBase); // we already preallocated the space, and we used MAP_FIXED, so we should have gotten this address
+    _ASSERTE(loadedHeaderBase == loadedBase); // we already preallocated the space, and we used MAP_FIXED, so we should have gotten this address
     IMAGE_SECTION_HEADER * firstSection;
     firstSection = (IMAGE_SECTION_HEADER*)(((char *)loadedHeader)
                                            + loadedHeader->e_lfanew
@@ -2465,9 +2489,9 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     // Validation
     char* sectionHeaderEnd;
     sectionHeaderEnd = (char*)firstSection + numSections * sizeof(IMAGE_SECTION_HEADER);
-    if (   ((void*)firstSection < loadedBase)
+    if (   ((void*)firstSection < loadedHeader)
         || ((char*)firstSection > sectionHeaderEnd)
-        || (sectionHeaderEnd > (char*)loadedBase + virtualSize)
+        || (sectionHeaderEnd > (char*)loadedHeader + virtualSize)
         )
     {
         ERROR_(LOADER)( "image is corrupt\n" );
@@ -2476,7 +2500,8 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
     }
 
     void* prevSectionEnd;
-    prevSectionEnd = (char*)loadedBase + headerSize; // the first "section" for our purposes is the header
+    prevSectionEnd = (char*)loadedHeader + headerSize; // the first "section" for our purposes is the header
+
     for (unsigned i = 0; i < numSections; ++i)
     {
         //for each section, map the section of the file to the correct virtual offset.  Gather the
@@ -2485,13 +2510,13 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
         int prot = 0;
         IMAGE_SECTION_HEADER &currentHeader = firstSection[i];
 
-        void* sectionBase = (char*)loadedBase + currentHeader.VirtualAddress;
+        void* sectionBase = (char*)loadedHeader + currentHeader.VirtualAddress;
         void* sectionBaseAligned = ALIGN_DOWN(sectionBase, GetVirtualPageSize());
 
         // Validate the section header
-        if (   (sectionBase < loadedBase)                                                           // Did computing the section base overflow?
+        if (   (sectionBase < loadedHeader)                                                           // Did computing the section base overflow?
             || ((char*)sectionBase + currentHeader.SizeOfRawData < (char*)sectionBase)              // Does the section overflow?
-            || ((char*)sectionBase + currentHeader.SizeOfRawData > (char*)loadedBase + virtualSize) // Does the section extend past the end of the image as the header stated?
+            || ((char*)sectionBase + currentHeader.SizeOfRawData > (char*)loadedHeader + virtualSize) // Does the section extend past the end of the image as the header stated?
             || (prevSectionEnd > sectionBase)                                                       // Does this section overlap the previous one?
             )
         {
@@ -2499,9 +2524,17 @@ void * MAPMapPEFile(HANDLE hFile, off_t offset)
             palError = ERROR_INVALID_PARAMETER;
             goto doneReleaseMappingCriticalSection;
         }
+
         if (currentHeader.Misc.VirtualSize > currentHeader.SizeOfRawData)
         {
             ERROR_(LOADER)( "no support for zero-padded sections, section %d\n", i );
+            palError = ERROR_INVALID_PARAMETER;
+            goto doneReleaseMappingCriticalSection;
+        }
+
+        if (OffsetWithinPage((off_t)sectionBase) != OffsetWithinPage(offset + currentHeader.PointerToRawData))
+        {
+            ERROR_(LOADER)("can't map section if data and VA hint have different page alignment %d\n", i);
             palError = ERROR_INVALID_PARAMETER;
             goto doneReleaseMappingCriticalSection;
         }
@@ -2600,7 +2633,7 @@ done:
 
     if (palError == ERROR_SUCCESS)
     {
-        retval = loadedBase;
+        retval = loadedHeader;
         LOGEXIT("MAPMapPEFile returns %p\n", retval);
     }
     else

--- a/src/coreclr/src/utilcode/pedecoder.cpp
+++ b/src/coreclr/src/utilcode/pedecoder.cpp
@@ -288,9 +288,9 @@ CHECK PEDecoder::CheckNTHeaders() const
     if (IsMapped())
     {
         // Ideally we would require the layout address to honor the section alignment constraints.
-        // However, we do have 8K aligned IL only images which we load on 32 bit platforms. In this
-        // case, we can only guarantee OS page alignment (which after all, is good enough.)
-        CHECK(CheckAligned(m_base, GetOsPageSize()));
+        // However, we do have 8K aligned IL only images which we load on 32 bit platforms.
+        // Also in the case of files embedded within a single-file app, the default alignment for assemblies is 16 bytes.
+        CHECK(CheckAligned(m_base, 16));
     }
 
     // @todo: check NumberOfSections for overflow of SizeOfHeaders


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/38951   to Preview8

----
* Mmap R2R images at and non-page-boundary

Assemblies embedded within a single-file are aligned at 16 byte boundaries.

However, currently MappedImageLayout assumes that assemblies are mapped at 4K offsets.
This results in map failure and subsequent failure to load the image in a mapped layout.
Subsequently, the image was loaded as IL as a fallback.

The change fixes this problem by:

mmap() pages containing sections/headers using appropriate ROUND_DOWN and ROUND_UP operations
Load sections at unaligned offsets in MAPMapPEFile.

Fixes: #38061

* Relaxing map alignment check to 16 bytes

* do not round up header size

* asserts

* reject sections where data and VA hint have different page alignment

* PR feedback

* revert init of loadedHeaderBase and add a comment

Co-authored-by: Swaroop Sridhar <swaroop.sridhar@microsoft.com>