### PR TITLE
[System.Console] Fix manual test

### DIFF
--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -254,11 +254,6 @@ namespace System.IO
                 case '\r':
                     return ConsoleKey.Enter;
 
-                case '\n':
-                    // Windows compatibility; LF is Ctrl+Enter
-                    isCtrl = true;
-                    return ConsoleKey.Enter;
-
                 case (char)(0x1B):
                     return ConsoleKey.Escape;
 

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -67,17 +69,9 @@ namespace System
         }
 
         [ConditionalTheory(nameof(ManualTestsEnabled))]
-        [InlineData('\x01', ConsoleKey.A, ConsoleModifiers.Control)]
-        [InlineData('\x01', ConsoleKey.A, ConsoleModifiers.Control | ConsoleModifiers.Alt)]
-        [InlineData('\r', ConsoleKey.Enter, (ConsoleModifiers)0)]
-        [InlineData('\n', ConsoleKey.Enter, ConsoleModifiers.Control)]
-        public static void ReadKey_KeyChords(char keyChar, ConsoleKey key, ConsoleModifiers modifiers)
+        [MemberData(nameof(GetKeyChords))]
+        public static void ReadKey_KeyChords(ConsoleKeyInfo expected)
         {
-            var expected = new ConsoleKeyInfo(keyChar, key, 
-                control: modifiers.HasFlag(ConsoleModifiers.Control),
-                alt: modifiers.HasFlag(ConsoleModifiers.Alt),
-                shift: modifiers.HasFlag(ConsoleModifiers.Shift));
-
             Console.Write($"Please type key chord {RenderKeyChord(expected)}: ");
             var actual = Console.ReadKey(intercept: true);
             Console.WriteLine();
@@ -93,6 +87,34 @@ namespace System
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Alt)) modifiers += "Alt+";
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Shift)) modifiers += "Shift+";
                 return modifiers + key.Key;
+            }
+        }
+
+        public static IEnumerable<object[]> GetKeyChords()
+        {
+            yield return MkConsoleKeyInfo('\x01', ConsoleKey.A, ConsoleModifiers.Control);
+            yield return MkConsoleKeyInfo('\x01', ConsoleKey.A, ConsoleModifiers.Control | ConsoleModifiers.Alt);
+            yield return MkConsoleKeyInfo('\r', ConsoleKey.Enter, (ConsoleModifiers)0);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // windows will report '\n' as 'Ctrl+Enter', which is typically not picked up by Unix terminals
+                yield return MkConsoleKeyInfo('\n', ConsoleKey.Enter, ConsoleModifiers.Control);
+            }
+            else
+            {
+                yield return MkConsoleKeyInfo('\n', ConsoleKey.J, ConsoleModifiers.Control);
+            }
+
+            static object[] MkConsoleKeyInfo (char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
+            {
+                return new object[]
+                {
+                    new ConsoleKeyInfo(keyChar, consoleKey, 
+                        control: modifiers.HasFlag(ConsoleModifiers.Control),
+                        alt: modifiers.HasFlag(ConsoleModifiers.Alt),
+                        shift: modifiers.HasFlag(ConsoleModifiers.Shift))
+                };
             }
         }
 

--- a/src/libraries/System.Console/tests/ManualTests/Readme.md
+++ b/src/libraries/System.Console/tests/ManualTests/Readme.md
@@ -7,3 +7,9 @@ To run the suite, follow these steps:
 2. Using a terminal, navigate to the current folder.
 3. Enable manual testing by defining the `MANUAL_TESTS` environment variable (e.g. on bash `export MANUAL_TESTS=true`).
 4. Run `dotnet test` and follow the instructions in the command prompt.
+
+## Instructions for MacOS testers
+
+By default, Alt-Key does not work on the MacOS terminal.
+Before running the tests, navigate to `Terminal > Preferences > Settings > Keyboard`
+and check "Use option as meta key" at the bottom.

--- a/src/libraries/System.Console/tests/ManualTests/Readme.md
+++ b/src/libraries/System.Console/tests/ManualTests/Readme.md
@@ -8,6 +8,17 @@ To run the suite, follow these steps:
 3. Enable manual testing by defining the `MANUAL_TESTS` environment variable (e.g. on bash `export MANUAL_TESTS=true`).
 4. Run `dotnet test` and follow the instructions in the command prompt.
 
+## Instructions for Windows testers
+
+VsTest on Windows redirects console input, so in order to properly execute the manual tests, 
+`xunit-console` must be invoked directly. To do this first run
+
+```
+> dotnet build -t:Test
+```
+
+And then copy and execute the commands logged under the `To repro directly:` section of the output logs.
+
 ## Instructions for MacOS testers
 
 By default, Alt-Key does not work on the MacOS terminal.


### PR DESCRIPTION
Fixes a bug/bad manual test introduced in #37491. In that particular change I mapped the `\n` character to the `Ctrl + Enter` keychord. However, the `Ctrl + Enter` chord is picked up on Windows terminal emulators but others do not recognize it. So in this PR:

* I've reverted mapping `\n` back to the `Ctrl + J` keychord for Unix.
* Updated the manual test so that `Ctrl + J` is tested on non-Windows systems instead of `Ctrl + Enter`.

Fixes #39351. Contributes to #802.