### PR TITLE
WIP Add ICLRDebuggingLibraryProvider3

### DIFF
--- a/src/coreclr/src/debug/shim/debugshim.cpp
+++ b/src/coreclr/src/debug/shim/debugshim.cpp
@@ -50,6 +50,31 @@ typedef HRESULT (STDAPICALLTYPE  *OpenVirtualProcess2FnPtr)(ULONG64 clrInstanceI
 
 typedef HMODULE (STDAPICALLTYPE  *LoadLibraryWFnPtr)(LPCWSTR lpLibFileName);
 
+static bool IsTargetWindows(ICorDebugDataTarget* pDataTarget)
+{
+    CorDebugPlatform targetPlatform;
+
+    HRESULT result = pDataTarget->GetPlatform(&targetPlatform);
+
+    if(FAILED(result))
+    {
+        _ASSERTE(!"Unexpected error");
+        return false;
+    }
+
+    switch (targetPlatform)
+    {
+        case CORDB_PLATFORM_WINDOWS_X86:
+        case CORDB_PLATFORM_WINDOWS_AMD64:
+        case CORDB_PLATFORM_WINDOWS_IA64:
+        case CORDB_PLATFORM_WINDOWS_ARM:
+        case CORDB_PLATFORM_WINDOWS_ARM64:
+            return true;
+        default:
+            return false;
+    }
+}
+
 // Implementation of ICLRDebugging::OpenVirtualProcess
 //
 // Arguments:
@@ -410,192 +435,197 @@ HRESULT CLRDebuggingImpl::GetCLRInfo(ICorDebugDataTarget* pDataTarget,
                                      DWORD  dwDacNameCharCount)
 {
 #ifndef TARGET_UNIX
-    WORD imageFileMachine = 0;
-    DWORD resourceSectionRVA = 0;
-    HRESULT hr = GetMachineAndResourceSectionRVA(pDataTarget, moduleBaseAddress, &imageFileMachine, &resourceSectionRVA);
-
-    // We want the version resource which has type = RT_VERSION = 16, name = 1, language = 0x409
-    DWORD versionResourceRVA = 0;
-    DWORD versionResourceSize = 0;
-    if(SUCCEEDED(hr))
+    if(IsTargetWindows(pDataTarget))
     {
-        hr = GetResourceRvaFromResourceSectionRva(pDataTarget, moduleBaseAddress, resourceSectionRVA, 16, 1, 0x409,
-                 &versionResourceRVA, &versionResourceSize);
-    }
+        WORD imageFileMachine = 0;
+        DWORD resourceSectionRVA = 0;
+        HRESULT hr = GetMachineAndResourceSectionRVA(pDataTarget, moduleBaseAddress, &imageFileMachine, &resourceSectionRVA);
 
-    // At last we get our version info
-    VS_FIXEDFILEINFO fixedFileInfo = {0};
-    if(SUCCEEDED(hr))
-    {
-        // The version resource has 3 words, then the unicode string "VS_VERSION_INFO"
-        // (16 WCHARS including the null terminator)
-        // then padding to a 32-bit boundary, then the VS_FIXEDFILEINFO struct
-        DWORD fixedFileInfoRVA = ((versionResourceRVA + 3*2 + 16*2 + 3)/4)*4;
-        hr = ReadFromDataTarget(pDataTarget, moduleBaseAddress + fixedFileInfoRVA, (BYTE*)&fixedFileInfo, sizeof(fixedFileInfo));
-    }
-
-    //Verify the signature on the version resource
-    if(SUCCEEDED(hr) && fixedFileInfo.dwSignature != PE_FIXEDFILEINFO_SIGNATURE)
-    {
-        hr = CORDBG_E_NOT_CLR;
-    }
-
-    // Record the version information
-    if(SUCCEEDED(hr))
-    {
-        pVersion->wMajor = (WORD) (fixedFileInfo.dwProductVersionMS >> 16);
-        pVersion->wMinor = (WORD) (fixedFileInfo.dwProductVersionMS & 0xFFFF);
-        pVersion->wBuild = (WORD) (fixedFileInfo.dwProductVersionLS >> 16);
-        pVersion->wRevision = (WORD) (fixedFileInfo.dwProductVersionLS & 0xFFFF);
-    }
-
-    // Now grab the special clr debug info resource
-    // We may need to scan a few different names searching though...
-    // 1) CLRDEBUGINFO<host_os><host_arch> where host_os = 'WINDOWS' or 'CORESYS' and host_arch = 'X86' or 'ARM' or 'AMD64'
-    // 2) For back-compat if the host os is windows and the host architecture matches the target then CLRDEBUGINFO is used with no suffix.
-    DWORD debugResourceRVA = 0;
-    DWORD debugResourceSize = 0;
-    BOOL useCrossPlatformNaming = FALSE;
-    if(SUCCEEDED(hr))
-    {
-        // the initial state is that we haven't found a proper resource
-        HRESULT hrGetResource = E_FAIL;
-
-        // First check for the resource which has type = RC_DATA = 10, name = "CLRDEBUGINFO<host_os><host_arch>", language = 0
-#if defined (HOST_WINDOWS) && defined(HOST_X86)
-        const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSX86");
-#endif
-
-#if !defined (HOST_WINDOWS) && defined(HOST_X86)
-        const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSX86");
-#endif
-
-#if defined (HOST_WINDOWS) && defined(HOST_AMD64)
-        const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSAMD64");
-#endif
-
-#if !defined (HOST_WINDOWS) && defined(HOST_AMD64)
-        const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSAMD64");
-#endif
-
-#if defined (HOST_WINDOWS) && defined(HOST_ARM64)
-        const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSARM64");
-#endif
-
-#if !defined (HOST_WINDOWS) && defined(HOST_ARM64)
-        const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSARM64");
-#endif
-
-#if defined (HOST_WINDOWS) && defined(HOST_ARM)
-        const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSARM");
-#endif
-
-#if !defined (HOST_WINDOWS) && defined(HOST_ARM)
-        const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSARM");
-#endif
-
-        hrGetResource = GetResourceRvaFromResourceSectionRvaByName(pDataTarget, moduleBaseAddress, resourceSectionRVA, 10, resourceName, 0,
-                 &debugResourceRVA, &debugResourceSize);
-        useCrossPlatformNaming = SUCCEEDED(hrGetResource);
-
-
-#if defined(HOST_WINDOWS) && (defined(HOST_X86) || defined(HOST_AMD64) || defined(HOST_ARM))
-  #if defined(HOST_X86)
-    #define _HOST_MACHINE_TYPE IMAGE_FILE_MACHINE_I386
-  #elif defined(HOST_AMD64)
-    #define _HOST_MACHINE_TYPE IMAGE_FILE_MACHINE_AMD64
-  #elif defined(HOST_ARM)
-    #define _HOST_MACHINE_TYPE IMAGE_FILE_MACHINE_ARMNT
-  #endif
-
-        // if this is windows, and if host_arch matches target arch then we can fallback to searching for CLRDEBUGINFO on failure
-        if(FAILED(hrGetResource) && (imageFileMachine == _HOST_MACHINE_TYPE))
+        // We want the version resource which has type = RT_VERSION = 16, name = 1, language = 0x409
+        DWORD versionResourceRVA = 0;
+        DWORD versionResourceSize = 0;
+        if(SUCCEEDED(hr))
         {
-            hrGetResource = GetResourceRvaFromResourceSectionRvaByName(pDataTarget, moduleBaseAddress, resourceSectionRVA, 10, W("CLRDEBUGINFO"), 0,
-                 &debugResourceRVA, &debugResourceSize);
+            hr = GetResourceRvaFromResourceSectionRva(pDataTarget, moduleBaseAddress, resourceSectionRVA, 16, 1, 0x409,
+                     &versionResourceRVA, &versionResourceSize);
         }
 
-  #undef _HOST_MACHINE_TYPE
-#endif
-        // if the search failed, we don't recognize the CLR
-        if(FAILED(hrGetResource))
+        // At last we get our version info
+        VS_FIXEDFILEINFO fixedFileInfo = {0};
+        if(SUCCEEDED(hr))
+        {
+            // The version resource has 3 words, then the unicode string "VS_VERSION_INFO"
+            // (16 WCHARS including the null terminator)
+            // then padding to a 32-bit boundary, then the VS_FIXEDFILEINFO struct
+            DWORD fixedFileInfoRVA = ((versionResourceRVA + 3*2 + 16*2 + 3)/4)*4;
+            hr = ReadFromDataTarget(pDataTarget, moduleBaseAddress + fixedFileInfoRVA, (BYTE*)&fixedFileInfo, sizeof(fixedFileInfo));
+        }
+
+        //Verify the signature on the version resource
+        if(SUCCEEDED(hr) && fixedFileInfo.dwSignature != PE_FIXEDFILEINFO_SIGNATURE)
+        {
             hr = CORDBG_E_NOT_CLR;
-    }
+        }
 
-    CLR_DEBUG_RESOURCE debugResource;
-    if(SUCCEEDED(hr) && debugResourceSize != sizeof(debugResource))
-    {
-        hr = CORDBG_E_NOT_CLR;
-    }
+        // Record the version information
+        if(SUCCEEDED(hr))
+        {
+            pVersion->wMajor = (WORD) (fixedFileInfo.dwProductVersionMS >> 16);
+            pVersion->wMinor = (WORD) (fixedFileInfo.dwProductVersionMS & 0xFFFF);
+            pVersion->wBuild = (WORD) (fixedFileInfo.dwProductVersionLS >> 16);
+            pVersion->wRevision = (WORD) (fixedFileInfo.dwProductVersionLS & 0xFFFF);
+        }
 
-    // Get the special debug resource from the image and return the results
-    if(SUCCEEDED(hr))
-    {
-        hr = ReadFromDataTarget(pDataTarget, moduleBaseAddress + debugResourceRVA, (BYTE*)&debugResource, sizeof(debugResource));
-    }
-    if(SUCCEEDED(hr) && (debugResource.dwVersion != 0))
-    {
-        hr = CORDBG_E_NOT_CLR;
-    }
+        // Now grab the special clr debug info resource
+        // We may need to scan a few different names searching though...
+        // 1) CLRDEBUGINFO<host_os><host_arch> where host_os = 'WINDOWS' or 'CORESYS' and host_arch = 'X86' or 'ARM' or 'AMD64'
+        // 2) For back-compat if the host os is windows and the host architecture matches the target then CLRDEBUGINFO is used with no suffix.
+        DWORD debugResourceRVA = 0;
+        DWORD debugResourceSize = 0;
+        BOOL useCrossPlatformNaming = FALSE;
+        if(SUCCEEDED(hr))
+        {
+            // the initial state is that we haven't found a proper resource
+            HRESULT hrGetResource = E_FAIL;
 
-    // The signature needs to match m_skuId exactly, except for m_skuId=CLR_ID_ONECORE_CLR which is
-    // also compatible with the older CLR_ID_PHONE_CLR signature.
-    if(SUCCEEDED(hr) &&
-       (debugResource.signature != m_skuId) &&
-       !( (debugResource.signature == CLR_ID_PHONE_CLR) && (m_skuId == CLR_ID_ONECORE_CLR) ))
-    {
-        hr = CORDBG_E_NOT_CLR;
-    }
+            // First check for the resource which has type = RC_DATA = 10, name = "CLRDEBUGINFO<host_os><host_arch>", language = 0
+    #if defined (HOST_WINDOWS) && defined(HOST_X86)
+            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSX86");
+    #endif
 
-    if(SUCCEEDED(hr) &&
-       (debugResource.signature != CLR_ID_ONECORE_CLR) &&
-       useCrossPlatformNaming)
-    {
-        FormatLongDacModuleName(pDacName, dwDacNameCharCount, imageFileMachine, &fixedFileInfo);
-        swprintf_s(pDbiName, dwDbiNameCharCount, W("%s_%s.dll"), MAIN_DBI_MODULE_NAME_W, W("x86"));
-    }
-    else
-    {
-        if(m_skuId == CLR_ID_V4_DESKTOP)
-            swprintf_s(pDacName, dwDacNameCharCount, W("%s.dll"), CLR_DAC_MODULE_NAME_W);
+    #if !defined (HOST_WINDOWS) && defined(HOST_X86)
+            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSX86");
+    #endif
+
+    #if defined (HOST_WINDOWS) && defined(HOST_AMD64)
+            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSAMD64");
+    #endif
+
+    #if !defined (HOST_WINDOWS) && defined(HOST_AMD64)
+            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSAMD64");
+    #endif
+
+    #if defined (HOST_WINDOWS) && defined(HOST_ARM64)
+            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSARM64");
+    #endif
+
+    #if !defined (HOST_WINDOWS) && defined(HOST_ARM64)
+            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSARM64");
+    #endif
+
+    #if defined (HOST_WINDOWS) && defined(HOST_ARM)
+            const WCHAR * resourceName = W("CLRDEBUGINFOWINDOWSARM");
+    #endif
+
+    #if !defined (HOST_WINDOWS) && defined(HOST_ARM)
+            const WCHAR * resourceName = W("CLRDEBUGINFOCORESYSARM");
+    #endif
+
+            hrGetResource = GetResourceRvaFromResourceSectionRvaByName(pDataTarget, moduleBaseAddress, resourceSectionRVA, 10, resourceName, 0,
+                     &debugResourceRVA, &debugResourceSize);
+            useCrossPlatformNaming = SUCCEEDED(hrGetResource);
+
+
+    #if defined(HOST_WINDOWS) && (defined(HOST_X86) || defined(HOST_AMD64) || defined(HOST_ARM))
+      #if defined(HOST_X86)
+        #define _HOST_MACHINE_TYPE IMAGE_FILE_MACHINE_I386
+      #elif defined(HOST_AMD64)
+        #define _HOST_MACHINE_TYPE IMAGE_FILE_MACHINE_AMD64
+      #elif defined(HOST_ARM)
+        #define _HOST_MACHINE_TYPE IMAGE_FILE_MACHINE_ARMNT
+      #endif
+
+            // if this is windows, and if host_arch matches target arch then we can fallback to searching for CLRDEBUGINFO on failure
+            if(FAILED(hrGetResource) && (imageFileMachine == _HOST_MACHINE_TYPE))
+            {
+                hrGetResource = GetResourceRvaFromResourceSectionRvaByName(pDataTarget, moduleBaseAddress, resourceSectionRVA, 10, W("CLRDEBUGINFO"), 0,
+                     &debugResourceRVA, &debugResourceSize);
+            }
+
+      #undef _HOST_MACHINE_TYPE
+    #endif
+            // if the search failed, we don't recognize the CLR
+            if(FAILED(hrGetResource))
+                hr = CORDBG_E_NOT_CLR;
+        }
+
+        CLR_DEBUG_RESOURCE debugResource;
+        if(SUCCEEDED(hr) && debugResourceSize != sizeof(debugResource))
+        {
+            hr = CORDBG_E_NOT_CLR;
+        }
+
+        // Get the special debug resource from the image and return the results
+        if(SUCCEEDED(hr))
+        {
+            hr = ReadFromDataTarget(pDataTarget, moduleBaseAddress + debugResourceRVA, (BYTE*)&debugResource, sizeof(debugResource));
+        }
+        if(SUCCEEDED(hr) && (debugResource.dwVersion != 0))
+        {
+            hr = CORDBG_E_NOT_CLR;
+        }
+
+        // The signature needs to match m_skuId exactly, except for m_skuId=CLR_ID_ONECORE_CLR which is
+        // also compatible with the older CLR_ID_PHONE_CLR signature.
+        if(SUCCEEDED(hr) &&
+           (debugResource.signature != m_skuId) &&
+           !( (debugResource.signature == CLR_ID_PHONE_CLR) && (m_skuId == CLR_ID_ONECORE_CLR) ))
+        {
+            hr = CORDBG_E_NOT_CLR;
+        }
+
+        if(SUCCEEDED(hr) &&
+           (debugResource.signature != CLR_ID_ONECORE_CLR) &&
+           useCrossPlatformNaming)
+        {
+            FormatLongDacModuleName(pDacName, dwDacNameCharCount, imageFileMachine, &fixedFileInfo);
+            swprintf_s(pDbiName, dwDbiNameCharCount, W("%s_%s.dll"), MAIN_DBI_MODULE_NAME_W, W("x86"));
+        }
         else
-            swprintf_s(pDacName, dwDacNameCharCount, W("%s.dll"), CORECLR_DAC_MODULE_NAME_W);
-        swprintf_s(pDbiName, dwDbiNameCharCount, W("%s.dll"), MAIN_DBI_MODULE_NAME_W);
-    }
+        {
+            if(m_skuId == CLR_ID_V4_DESKTOP)
+                swprintf_s(pDacName, dwDacNameCharCount, W("%s.dll"), CLR_DAC_MODULE_NAME_W);
+            else
+                swprintf_s(pDacName, dwDacNameCharCount, W("%s.dll"), CORECLR_DAC_MODULE_NAME_W);
+            swprintf_s(pDbiName, dwDbiNameCharCount, W("%s.dll"), MAIN_DBI_MODULE_NAME_W);
+        }
 
-    if(SUCCEEDED(hr))
-    {
-        *pdwDbiTimeStamp = debugResource.dwDbiTimeStamp;
-        *pdwDbiSizeOfImage = debugResource.dwDbiSizeOfImage;
-        *pdwDacTimeStamp = debugResource.dwDacTimeStamp;
-        *pdwDacSizeOfImage = debugResource.dwDacSizeOfImage;
-    }
+        if(SUCCEEDED(hr))
+        {
+            *pdwDbiTimeStamp = debugResource.dwDbiTimeStamp;
+            *pdwDbiSizeOfImage = debugResource.dwDbiSizeOfImage;
+            *pdwDacTimeStamp = debugResource.dwDacTimeStamp;
+            *pdwDacSizeOfImage = debugResource.dwDacSizeOfImage;
+        }
 
-    // any failure should be interpreted as this module not being a CLR
-    if(FAILED(hr))
-    {
-        return CORDBG_E_NOT_CLR;
+        // any failure should be interpreted as this module not being a CLR
+        if(FAILED(hr))
+        {
+            return CORDBG_E_NOT_CLR;
+        }
+        else
+        {
+            return S_OK;
+        }
     }
     else
+#endif // !TARGET_UNIX
     {
+        swprintf_s(pDacName, dwDacNameCharCount, W("%s"), MAKEDLLNAME_W(CORECLR_DAC_MODULE_NAME_W));
+        swprintf_s(pDbiName, dwDbiNameCharCount, W("%s"), MAKEDLLNAME_W(MAIN_DBI_MODULE_NAME_W));
+
+        pVersion->wMajor = 0;
+        pVersion->wMinor = 0;
+        pVersion->wBuild = 0;
+        pVersion->wRevision = 0;
+
+        *pdwDbiTimeStamp = 0;
+        *pdwDbiSizeOfImage = 0;
+        *pdwDacTimeStamp = 0;
+        *pdwDacSizeOfImage = 0;
+
         return S_OK;
     }
-#else
-    swprintf_s(pDacName, dwDacNameCharCount, W("%s"), MAKEDLLNAME_W(CORECLR_DAC_MODULE_NAME_W));
-    swprintf_s(pDbiName, dwDbiNameCharCount, W("%s"), MAKEDLLNAME_W(MAIN_DBI_MODULE_NAME_W));
-
-    pVersion->wMajor = 0;
-    pVersion->wMinor = 0;
-    pVersion->wBuild = 0;
-    pVersion->wRevision = 0;
-
-    *pdwDbiTimeStamp = 0;
-    *pdwDbiSizeOfImage = 0;
-    *pdwDacTimeStamp = 0;
-    *pdwDacSizeOfImage = 0;
-
-    return S_OK;
-#endif // TARGET_UNIX
 }
 
 // Formats the long name for DAC

--- a/src/coreclr/src/inc/metahost.idl
+++ b/src/coreclr/src/inc/metahost.idl
@@ -37,6 +37,10 @@ import "mscoree.idl";
 
 cpp_quote("#include <winapifamily.h>")
 
+#if !DEFINITIONS_FROM_NON_IMPORTABLE_PLACES
+typedef BYTE *LPBYTE;
+#endif
+
 cpp_quote("STDAPI CLRCreateInstance(REFCLSID clsid, REFIID riid, /*iid_is(riid)*/ LPVOID *ppInterface);")
 
 // IID ICLRMetaHost : uuid(D332DB9E-B9B3-4125-8207-A14884F53216)

--- a/src/coreclr/src/inc/metahost.idl
+++ b/src/coreclr/src/inc/metahost.idl
@@ -290,6 +290,49 @@ interface ICLRDebuggingLibraryProvider2 : IUnknown
         [out] LPWSTR* ppResolvedModulePath);
 }
 
+ /**************************************************************************************
+ ** ICLRDebuggingLibraryProvider3                                                     **
+ ** Implemented by API user                                                           **
+ ** This interface allows the debugger to provide module paths which are needed for   **
+ ** debugging a particular CLR such as mscordbi and mscordacwks.                      **
+ **************************************************************************************/
+[
+    uuid(5C3BACDF-4024-488E-B413-DC0CAA8ABA73),
+    version(1.0),
+    helpstring("CLR debugging LibraryProvider callback interface"),
+    local
+]
+interface ICLRDebuggingLibraryProvider3 : IUnknown
+{
+    /**********************************************************************************
+    ** The goal of this method is to allow the debugger to provide a module path     **
+    ** which is needed for debugging. The debugger may use any available means to    **
+    ** locate and/or procure the module. See the security note below for important   **
+    ** information about implementing this method securely.                          **
+    ** Arguments:                                                                    **
+    ** pwzFileName - The name of the module being requested                          **
+    ** inBuildId - The buildId of the module being requested                         **
+    ** inBuildIdSize - The size of the buildId for the module being requested        **
+    ** ppResolvedModulePath - Where *ppResolvedModulePath is a null terminated       **
+    **                        path to the module dll. On Windows it should be        **
+    **                        allocated with CoTaskMemAlloc. On Unix it should be    **
+    **                        allocated with malloc. Failure leave it untouched. See **
+    **                        security note below!                                   **
+    **                                                                               **
+    ** Return value - S_OK if the module was provided, or any other convenient       **
+    **                error HRESULT if the module could not be provided              **
+    **                                                                               **
+    **                               !!!!!!!!!!!!!!                                  **
+    ** SECURITY NOTE: Anything the caller would not be willing to execute itself, it **
+    ** should not provide to the this API call                                       **
+    ***********************************************************************************/
+    HRESULT ProvideLibrary3(
+        [in] const WCHAR* pwszFileName,
+        [in] ULONG32 inBuildIdSize,
+        [in, size_is(inBuildIdSize)] LPBYTE inBuildId,
+        [out] LPWSTR* ppResolvedModulePath);
+}
+
 /**************************************************************************************
  ** ICLRDebugging                                                                    **
  ** Activated using mscoree!CLRCreateInstance.                                       **

--- a/src/coreclr/src/pal/prebuilt/inc/metahost.h
+++ b/src/coreclr/src/pal/prebuilt/inc/metahost.h
@@ -66,6 +66,13 @@ typedef interface ICLRDebuggingLibraryProvider2 ICLRDebuggingLibraryProvider2;
 #endif 	/* __ICLRDebuggingLibraryProvider2_FWD_DEFINED__ */
 
 
+#ifndef __ICLRDebuggingLibraryProvider3_FWD_DEFINED__
+#define __ICLRDebuggingLibraryProvider3_FWD_DEFINED__
+typedef interface ICLRDebuggingLibraryProvider3 ICLRDebuggingLibraryProvider3;
+
+#endif 	/* __ICLRDebuggingLibraryProvider3_FWD_DEFINED__ */
+
+
 #ifndef __ICLRDebugging_FWD_DEFINED__
 #define __ICLRDebugging_FWD_DEFINED__
 typedef interface ICLRDebugging ICLRDebugging;
@@ -95,6 +102,8 @@ extern "C"{
 /* [local] */ 
 
 #include <winapifamily.h>
+typedef BYTE *LPBYTE;
+
 STDAPI CLRCreateInstance(REFCLSID clsid, REFIID riid, /*iid_is(riid)*/ LPVOID *ppInterface);
 EXTERN_GUID(IID_ICLRMetaHost, 0xD332DB9E, 0xB9B3, 0x4125, 0x82, 0x07, 0xA1, 0x48, 0x84, 0xF5, 0x32, 0x16);
 EXTERN_GUID(CLSID_CLRMetaHost, 0x9280188d, 0xe8e, 0x4867, 0xb3, 0xc, 0x7f, 0xa8, 0x38, 0x84, 0xe8, 0xde);
@@ -466,6 +475,92 @@ EXTERN_C const IID IID_ICLRDebuggingLibraryProvider2;
 
 
 #endif 	/* __ICLRDebuggingLibraryProvider2_INTERFACE_DEFINED__ */
+
+
+#ifndef __ICLRDebuggingLibraryProvider3_INTERFACE_DEFINED__
+#define __ICLRDebuggingLibraryProvider3_INTERFACE_DEFINED__
+
+/* interface ICLRDebuggingLibraryProvider3 */
+/* [object][local][helpstring][version][uuid] */ 
+
+
+EXTERN_C const IID IID_ICLRDebuggingLibraryProvider3;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("5C3BACDF-4024-488E-B413-DC0CAA8ABA73")
+    ICLRDebuggingLibraryProvider3 : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE ProvideLibrary3( 
+            /* [in] */ const WCHAR *pwszFileName,
+            /* [in] */ ULONG32 inBuildIdSize,
+            /* [size_is][in] */ LPBYTE inBuildId,
+            /* [out] */ LPWSTR *ppResolvedModulePath) = 0;
+        
+    };
+    
+    
+#else 	/* C style interface */
+
+    typedef struct ICLRDebuggingLibraryProvider3Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ICLRDebuggingLibraryProvider3 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ICLRDebuggingLibraryProvider3 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ICLRDebuggingLibraryProvider3 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *ProvideLibrary3 )( 
+            ICLRDebuggingLibraryProvider3 * This,
+            /* [in] */ const WCHAR *pwszFileName,
+            /* [in] */ ULONG32 inBuildIdSize,
+            /* [size_is][in] */ LPBYTE inBuildId,
+            /* [out] */ LPWSTR *ppResolvedModulePath);
+        
+        END_INTERFACE
+    } ICLRDebuggingLibraryProvider3Vtbl;
+
+    interface ICLRDebuggingLibraryProvider3
+    {
+        CONST_VTBL struct ICLRDebuggingLibraryProvider3Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ICLRDebuggingLibraryProvider3_QueryInterface(This,riid,ppvObject)	\
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ICLRDebuggingLibraryProvider3_AddRef(This)	\
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ICLRDebuggingLibraryProvider3_Release(This)	\
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ICLRDebuggingLibraryProvider3_ProvideLibrary3(This,pwszFileName,inBuildIdSize,inBuildId,ppResolvedModulePath)	\
+    ( (This)->lpVtbl -> ProvideLibrary3(This,pwszFileName,inBuildIdSize,inBuildId,ppResolvedModulePath) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif 	/* C style interface */
+
+
+
+
+#endif 	/* __ICLRDebuggingLibraryProvider3_INTERFACE_DEFINED__ */
 
 
 #ifndef __ICLRDebugging_INTERFACE_DEFINED__


### PR DESCRIPTION
In order to enable the debug shim to locate Linux and MacOS binaries we need to add new interface to pass the build-ids.

