### PR TITLE
[wasm] Address System.Text.RegularExpressions.Tests Failures

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/Regex.Groups.Tests.cs
@@ -856,8 +856,11 @@ namespace System.Text.RegularExpressions.Tests
 
         public static IEnumerable<object[]> Groups_CustomCulture_TestData_AzeriLatin()
         {
-            yield return new object[] { "az-Latn-AZ", "\u0131", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
-            yield return new object[] { "az-Latn-AZ", "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
+            if (PlatformDetection.IsNotBrowser)
+            {
+                yield return new object[] { "az-Latn-AZ", "\u0131", "\u0049", RegexOptions.IgnoreCase, new string[] { "\u0049" } };
+                yield return new object[] { "az-Latn-AZ", "\u0130", "\u0069", RegexOptions.IgnoreCase, new string[] { "\u0069" } };
+            }
         }
 
         [Theory]

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexMatchTimeoutExceptionTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexMatchTimeoutExceptionTests.cs
@@ -43,7 +43,7 @@ namespace System.Text.RegularExpressions.Tests
             Assert.Equal(timeout, e.MatchTimeout);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public void SerializationRoundtrip()
         {
             const string Input = "abcdef";

--- a/src/libraries/System.Text.RegularExpressions/tests/RegexParserTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/RegexParserTests.cs
@@ -813,7 +813,7 @@ namespace System.Text.RegularExpressions.Tests
             Parse(pattern, options, error);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework)]
         public void RegexParseException_Serializes()
         {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -49,7 +49,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.Extensions\tests\System.Resources.Extensions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.ResourceManager\tests\System.Resources.ResourceManager.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Permissions\tests\System.Security.Permissions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ValueTuple\tests\System.ValueTuple.Tests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Contributes to #38422 
`Tests run: 6671, Errors: 0, Failures: 0, Skipped: 12. Time: 15.42393s`