### PR TITLE
Allow Debugger attributes to be trimmed in Mono

### DIFF
--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -3448,7 +3448,7 @@ mono_class_from_name (MonoImage *image, const char* name_space, const char *name
  *
  * This function works exactly like mono_class_from_name but it will abort if the class is not found.
  * This function should be used by the runtime for critical types to which there's no way to recover but crash
- * If they are missing. Thing of System.Object or System.String.
+ * if they are missing. For example, System.Object or System.String.
  */
 MonoClass *
 mono_class_load_from_name (MonoImage *image, const char* name_space, const char *name)

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -3612,9 +3612,9 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 		return;
 
 	// NOTE: The following Debugger attributes may not exist if they are trimmed away by the ILLinker
-    MonoClass *hidden_klass = mono_class_try_get_hidden_klass_class ();
-    MonoClass *step_through_klass = mono_class_try_get_step_through_klass_class ();
-    MonoClass *non_user_klass = mono_class_try_get_non_user_klass_class ();
+	MonoClass *hidden_klass = mono_class_try_get_hidden_klass_class ();
+	MonoClass *step_through_klass = mono_class_try_get_step_through_klass_class ();
+	MonoClass *non_user_klass = mono_class_try_get_non_user_klass_class ();
 
 	ainfo = mono_custom_attrs_from_method_checked (jinfo_get_method (ji), error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -3607,27 +3607,27 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 	if (ji->dbg_attrs_inited)
 		return;
 
+	// NOTE: The following Debugger attributes may not exist if they are trimmed away by the ILLinker
 	MONO_STATIC_POINTER_INIT (MonoClass, hidden_klass)
-		hidden_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
+		hidden_klass = mono_class_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
 	MONO_STATIC_POINTER_INIT_END (MonoClass, hidden_klass)
 
-
 	MONO_STATIC_POINTER_INIT (MonoClass, step_through_klass)
-		step_through_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
+		step_through_klass = mono_class_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
 	MONO_STATIC_POINTER_INIT_END (MonoClass, step_through_klass)
 
 	MONO_STATIC_POINTER_INIT (MonoClass, non_user_klass)
-		non_user_klass = mono_class_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
+		non_user_klass = mono_class_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
 	MONO_STATIC_POINTER_INIT_END (MonoClass, non_user_klass)
 
 	ainfo = mono_custom_attrs_from_method_checked (jinfo_get_method (ji), error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */
 	if (ainfo) {
-		if (mono_custom_attrs_has_attr (ainfo, hidden_klass))
+		if (hidden_klass && mono_custom_attrs_has_attr (ainfo, hidden_klass))
 			ji->dbg_hidden = TRUE;
-		if (mono_custom_attrs_has_attr (ainfo, step_through_klass))
+		if (step_through_klass && mono_custom_attrs_has_attr (ainfo, step_through_klass))
 			ji->dbg_step_through = TRUE;
-		if (mono_custom_attrs_has_attr (ainfo, non_user_klass))
+		if (non_user_klass && mono_custom_attrs_has_attr (ainfo, non_user_klass))
 			ji->dbg_non_user_code = TRUE;
 		mono_custom_attrs_free (ainfo);
 	}
@@ -3635,9 +3635,9 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 	ainfo = mono_custom_attrs_from_class_checked (jinfo_get_method (ji)->klass, error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */
 	if (ainfo) {
-		if (mono_custom_attrs_has_attr (ainfo, step_through_klass))
+		if (step_through_klass && mono_custom_attrs_has_attr (ainfo, step_through_klass))
 			ji->dbg_step_through = TRUE;
-		if (mono_custom_attrs_has_attr (ainfo, non_user_klass))
+		if (non_user_klass && mono_custom_attrs_has_attr (ainfo, non_user_klass))
 			ji->dbg_non_user_code = TRUE;
 		mono_custom_attrs_free (ainfo);
 	}

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -3609,15 +3609,15 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 
 	// NOTE: The following Debugger attributes may not exist if they are trimmed away by the ILLinker
 	MONO_STATIC_POINTER_INIT (MonoClass, hidden_klass)
-		hidden_klass = mono_class_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
+		hidden_klass = mono_class_try_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
 	MONO_STATIC_POINTER_INIT_END (MonoClass, hidden_klass)
 
 	MONO_STATIC_POINTER_INIT (MonoClass, step_through_klass)
-		step_through_klass = mono_class_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
+		step_through_klass = mono_class_try_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
 	MONO_STATIC_POINTER_INIT_END (MonoClass, step_through_klass)
 
 	MONO_STATIC_POINTER_INIT (MonoClass, non_user_klass)
-		non_user_klass = mono_class_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
+		non_user_klass = mono_class_try_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
 	MONO_STATIC_POINTER_INIT_END (MonoClass, non_user_klass)
 
 	ainfo = mono_custom_attrs_from_method_checked (jinfo_get_method (ji), error);

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -3598,6 +3598,10 @@ dbg_path_get_basename (const char *filename)
 	return g_strdup (&r[1]);
 }
 
+GENERATE_TRY_GET_CLASS_WITH_CACHE(hidden_klass, "System.Diagnostics", "DebuggerHiddenAttribute")
+GENERATE_TRY_GET_CLASS_WITH_CACHE(step_through_klass, "System.Diagnostics", "DebuggerStepThroughAttribute")
+GENERATE_TRY_GET_CLASS_WITH_CACHE(non_user_klass, "System.Diagnostics", "DebuggerNonUserCodeAttribute")
+
 static void
 init_jit_info_dbg_attrs (MonoJitInfo *ji)
 {
@@ -3608,17 +3612,9 @@ init_jit_info_dbg_attrs (MonoJitInfo *ji)
 		return;
 
 	// NOTE: The following Debugger attributes may not exist if they are trimmed away by the ILLinker
-	MONO_STATIC_POINTER_INIT (MonoClass, hidden_klass)
-		hidden_klass = mono_class_try_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerHiddenAttribute");
-	MONO_STATIC_POINTER_INIT_END (MonoClass, hidden_klass)
-
-	MONO_STATIC_POINTER_INIT (MonoClass, step_through_klass)
-		step_through_klass = mono_class_try_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerStepThroughAttribute");
-	MONO_STATIC_POINTER_INIT_END (MonoClass, step_through_klass)
-
-	MONO_STATIC_POINTER_INIT (MonoClass, non_user_klass)
-		non_user_klass = mono_class_try_load_from_name (mono_defaults.corlib, "System.Diagnostics", "DebuggerNonUserCodeAttribute");
-	MONO_STATIC_POINTER_INIT_END (MonoClass, non_user_klass)
+    MonoClass *hidden_klass = mono_class_try_get_hidden_klass_class ();
+    MonoClass *step_through_klass = mono_class_try_get_step_through_klass_class ();
+    MonoClass *non_user_klass = mono_class_try_get_non_user_klass_class ();
 
 	ainfo = mono_custom_attrs_from_method_checked (jinfo_get_method (ji), error);
 	mono_error_cleanup (error); /* FIXME don't swallow the error? */

--- a/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+++ b/src/mono/netcore/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
@@ -142,11 +142,6 @@
 			<method signature="System.Void .ctor()" />
 		</type>
 
-		<!-- debugger-agent.c: create_event_list -->
-		<type fullname="System.Diagnostics.DebuggerNonUserCodeAttribute"/>
-		<type fullname="System.Diagnostics.DebuggerHiddenAttribute"/>
-		<type fullname="System.Diagnostics.DebuggerStepThroughAttribute"/>
-
 		<!-- exception.c (mono_get_exception_divide_by_zero) -->
 		<type fullname="System.DivideByZeroException">
 			<!-- mono_exception_from_name -->


### PR DESCRIPTION
* Changed debugger-agent to allow for the Debugger Attributes to not exist.
* Removed the Debugger Attributes entries from the Descriptors.xml file.

Fix mono/linker#1355