### PR TITLE
Update MSBuild Traversal SDK that contains StopOnFirstFailure support

### DIFF
--- a/global.json
+++ b/global.json
@@ -19,6 +19,6 @@
     "Microsoft.FIX-85B6-MERGE-9C38-CONFLICT": "1.0.0",
     "Microsoft.NET.Sdk.IL": "5.0.0-preview.8.20359.4",
     "Microsoft.Build.NoTargets": "1.0.53",
-    "Microsoft.Build.Traversal": "2.0.34"
+    "Microsoft.Build.Traversal": "2.0.52"
   }
 }


### PR DESCRIPTION
This adds support for: https://github.com/microsoft/MSBuildSdks/pull/186

This fixes the issue in our traversal builds where if I run `build.cmd libs.native+libs.ref` and `libs.native` fails, we keep going and build refs as well, causing cryptic un-diagnosable issues.

I remember we had an issue opened for this but I can't find it.

