### PR TITLE
add SupportsTls11 and SupportsTls12 to PlatformDetection avoid OS versions in tests

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -125,6 +125,9 @@ namespace System
 
         public static bool SupportsClientAlpn => SupportsAlpn || IsOSX || IsiOS || IstvOS;
 
+        // TLS 1.1 and 1.2 can work on Windows7 but it is not enabled by default.
+        public static bool SupportsTls11 => !IsWindows7 && !IsDebian10;
+        public static bool SupportsTls12 => !IsWindows7;
         // OpenSSL 1.1.1 and above.
         public static bool SupportsTls13 => GetTls13Support();
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -251,7 +251,7 @@ namespace System.Net.Security.Tests
                 yield return new object[] { SslProtocols.Tls11 };
             }
 
-            if (!PlatformDetection.SupportsTls12)
+            if (PlatformDetection.SupportsTls12)
             {
                 yield return new object[] { SslProtocols.Tls12 };
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -23,8 +23,6 @@ namespace System.Net.Security.Tests
         private readonly ITestOutputHelper _logVerbose;
         private readonly X509Certificate2 _serverCertificate;
 
-        public static bool SupportsTls11 => PlatformDetection.SupportsTls11;
-
         public ServerAsyncAuthenticateTest(ITestOutputHelper output)
         {
             _log = output;
@@ -99,9 +97,8 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ConditionalTheory(nameof(SupportsTls11))]
-        [InlineData(SslProtocols.Tls11)]
-        [InlineData(SslProtocols.Tls12)]
+        [Theory]
+        [MemberData(nameof(SupportedProtocolData))]
         public async Task ServerAsyncAuthenticate_SniSetVersion_Success(SslProtocols version)
         {
             var serverOptions = new SslServerAuthenticationOptions() { ServerCertificate = _serverCertificate, EnabledSslProtocols = version };
@@ -247,6 +244,18 @@ namespace System.Net.Security.Tests
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls11, typeof(AuthenticationException) };
         }
 
+        public static IEnumerable<Object[]> SupportedProtocolData()
+        {
+            if (PlatformDetection.SupportsTls11)
+            {
+                yield return new object[] { SslProtocols.Tls11 };
+            }
+
+            if (!PlatformDetection.SupportsTls12)
+            {
+                yield return new object[] { SslProtocols.Tls12 };
+            }
+        }
         #region Helpers
 
         private async Task ServerAsyncSslHelper(

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -23,7 +23,7 @@ namespace System.Net.Security.Tests
         private readonly ITestOutputHelper _logVerbose;
         private readonly X509Certificate2 _serverCertificate;
 
-        public static bool IsNotWindows7 => !PlatformDetection.IsWindows7;
+        public static bool SupportsTls11 => PlatformDetection.SupportsTls11;
 
         public ServerAsyncAuthenticateTest(ITestOutputHelper output)
         {
@@ -99,7 +99,7 @@ namespace System.Net.Security.Tests
             }
         }
 
-        [ConditionalTheory(nameof(IsNotWindows7))]
+        [ConditionalTheory(nameof(SupportsTls11))]
         [InlineData(SslProtocols.Tls11)]
         [InlineData(SslProtocols.Tls12)]
         public async Task ServerAsyncAuthenticate_SniSetVersion_Success(SslProtocols version)


### PR DESCRIPTION
It seems like Debian10 does not want to do TLS1.1 by default. We may see more of the in the future.

fixes #39445