### PR TITLE
Force bindingRedirect for System.Resources.Extensions (#39386)

### DIFF
--- a/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
+++ b/src/libraries/System.Resources.Extensions/src/System.Resources.Extensions.csproj
@@ -37,4 +37,30 @@
     <Reference Include="mscorlib" />
     <Reference Include="System" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <_packageTargetsFile>$(IntermediateOutputPath)$(AssemblyName).targets</_packageTargetsFile>
+  </PropertyGroup>
+
+  <Target Name="GeneratePackageTargetsFile" 
+          Condition="'$(TargetFramework)' == 'net461'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(_packageTargetsFile)"
+          BeforeTargets="GetFilesToPackage">
+    <PropertyGroup>
+      <_packageTargetsFileContent><![CDATA[<Project>
+  <!-- ResolveAssemblyReferences will never see the assembly reference embedded in the resources type,
+       force a binding redirect ourselves so that we'll always unify to the System.Resources.Extensions
+       version provided by this package -->
+  <ItemGroup>
+    <SuggestedBindingRedirects Include="$(AssemblyName), Culture=neutral, PublicKeyToken=$(PublicKeyToken)" MaxVersion="$(AssemblyVersion)" />
+  </ItemGroup>
+</Project>
+]]></_packageTargetsFileContent>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(_packageTargetsFile)" Overwrite="true" Lines="$(_packageTargetsFileContent)" />
+    <ItemGroup>
+      <FilesToPackage Include="$(_packageTargetsFile)" TargetPath="build/$(TargetFramework)" TargetFramework="$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
System.Resources.Extensions writes a type-reference into the .resources
file it writes but RAR will never see this when considering conflicts
for bindingRedirects.

Force a bindingRedirect whenever this package is used.

Porting to preview8 to get it out to get feedback.