### PR TITLE
[preview8] Linking native libraries into superhost (#38684)

### DIFF
--- a/src/coreclr/src/pal/src/loader/module.cpp
+++ b/src/coreclr/src/pal/src/loader/module.cpp
@@ -603,6 +603,13 @@ PAL_LoadLibraryDirect(
           lpLibFileName ? lpLibFileName : W16_NULLSTRING,
           lpLibFileName ? lpLibFileName : W16_NULLSTRING);
 
+    // Getting nullptr as name indicates redirection to current library
+    if (lpLibFileName == nullptr)
+    {
+        dl_handle = dlopen(NULL, RTLD_LAZY);
+        goto done;
+    }
+
     if (!LOADVerifyLibraryPath(lpLibFileName))
     {
         goto done;
@@ -1436,18 +1443,6 @@ static LPWSTR LOADGetModuleFileName(MODSTRUCT *module)
     return module->lib_name;
 }
 
-static bool ShouldRedirectToCurrentLibrary(LPCSTR libraryNameOrPath)
-{
-    if (!g_running_in_exe)
-        return false;
-
-    // Getting nullptr as name indicates redirection to current library
-    if (libraryNameOrPath == nullptr)
-        return true;
-
-    return false;
-}
-
 /*
 Function:
     LOADLoadLibraryDirect [internal]
@@ -1464,7 +1459,8 @@ static NATIVE_LIBRARY_HANDLE LOADLoadLibraryDirect(LPCSTR libraryNameOrPath)
 {
     NATIVE_LIBRARY_HANDLE dl_handle;
 
-    if (ShouldRedirectToCurrentLibrary(libraryNameOrPath))
+    // Getting nullptr as name indicates redirection to current library
+    if (libraryNameOrPath == nullptr)
     {
         dl_handle = dlopen(NULL, RTLD_LAZY);
     }

--- a/src/installer/corehost/Windows/gen-buildsys-win.bat
+++ b/src/installer/corehost/Windows/gen-buildsys-win.bat
@@ -43,7 +43,8 @@ popd
 :DoGen
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_SYSTEM_VERSION=10.0" "-DCLI_CMAKE_HOST_VER=%__HostVersion%" "-DCLI_CMAKE_COMMON_HOST_VER=%__AppHostVersion%" "-DCLI_CMAKE_HOST_FXR_VER=%__HostFxrVersion%"
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_HOST_POLICY_VER=%__HostPolicyVersion%" "-DCLI_CMAKE_PKG_RID=%cm_BaseRid%" "-DCLI_CMAKE_COMMIT_HASH=%__LatestCommit%" "-DCLR_CMAKE_HOST_ARCH=%__Arch%"
-set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR=%__ResourcesDir%" "-DCLR_ENG_NATIVE_DIR="%__sourceDir%\..\..\..\eng\native"
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCORECLR_ARTIFACTS=%__CoreClrArtifacts% " "-DNATIVE_LIBS_ARTIFACTS=%__NativeLibsArtifacts%" 
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_INSTALL_PREFIX=%__CMakeBinDir%" "-DCLI_CMAKE_RESOURCE_DIR=%__ResourcesDir%" "-DCLR_ENG_NATIVE_DIR=%__sourceDir%\..\..\..\eng\native"
 
 echo "%CMakePath%" %__sourceDir% -G "Visual Studio %__VSString%" %__ExtraCmakeParams%
 "%CMakePath%" %__sourceDir% -G "Visual Studio %__VSString%" %__ExtraCmakeParams%

--- a/src/installer/corehost/build.cmd
+++ b/src/installer/corehost/build.cmd
@@ -39,6 +39,7 @@ if /i [%1] == [commit]      (set __CommitSha=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [incremental-native-build] ( set __IncrementalNativeBuild=1&&shift&goto Arg_Loop)
 if /i [%1] == [rootDir]     ( set __rootDir=%2&&shift&&shift&goto Arg_Loop)
 if /i [%1] == [coreclrartifacts]  (set __CoreClrArtifacts=%2&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [nativelibsartifacts]  (set __NativeLibsArtifacts=%2&&shift&&shift&goto Arg_Loop)
 
 
 shift

--- a/src/installer/corehost/build.proj
+++ b/src/installer/corehost/build.proj
@@ -34,6 +34,7 @@
       <BuildArgs Condition="'$(Compiler)' != ''">$(BuildArgs) $(Compiler)</BuildArgs>
       <BuildArgs Condition="'$(CMakeArgs)' != ''">$(BuildArgs) $(CMakeArgs)</BuildArgs>
       <BuildArgs>$(BuildArgs) -coreclrartifacts $(CoreCLRArtifactsPath)</BuildArgs>
+      <BuildArgs>$(BuildArgs) -nativelibsartifacts $(LibrariesArtifactsPath)/bin/native/$(NetCoreAppCurrent)-$(TargetOS)-$(LibrariesConfiguration)-$(TargetArchitecture)</BuildArgs>
     </PropertyGroup>
 
     <!--
@@ -87,6 +88,7 @@
       <BuildArgs Condition="'$(IncrementalNativeBuild)' == 'true'">$(BuildArgs) incremental-native-build</BuildArgs>
       <BuildArgs>$(BuildArgs) rootdir $(RepoRoot)</BuildArgs>
       <BuildArgs>$(BuildArgs) coreclrartifacts $(CoreCLRArtifactsPath)</BuildArgs>
+      <BuildArgs>$(BuildArgs) nativelibsartifacts $(LibrariesArtifactsPath)/bin/native/$(NetCoreAppCurrent)-$(TargetOS)-$(LibrariesConfiguration)-$(TargetArchitecture)</BuildArgs>
     </PropertyGroup>
 
     <!--

--- a/src/installer/corehost/build.sh
+++ b/src/installer/corehost/build.sh
@@ -66,6 +66,11 @@ handle_arguments() {
             __ShiftArgs=1
             ;;
 
+        nativelibsartifacts|-nativelibsartifacts)
+            __NativeLibsArtifacts="$2"
+            __ShiftArgs=1
+            ;;
+
         *)
             __UnprocessedBuildArgs="$__UnprocessedBuildArgs $1"
     esac
@@ -82,10 +87,11 @@ __DistroRidLower="$(echo $__DistroRid | tr '[:upper:]' '[:lower:]')"
 __BinDir="$__RootBinDir/bin/$__DistroRidLower.$__BuildType"
 __IntermediatesDir="$__RootBinDir/obj/$__DistroRidLower.$__BuildType"
 
-export __BinDir __IntermediatesDir __CoreClrArtifacts
+export __BinDir __IntermediatesDir __CoreClrArtifacts __NativeLibsArtifacts
 
 __CMakeArgs="-DCLI_CMAKE_HOST_VER=\"$__host_ver\" -DCLI_CMAKE_COMMON_HOST_VER=\"$__apphost_ver\" -DCLI_CMAKE_HOST_FXR_VER=\"$__fxr_ver\" $__CMakeArgs"
 __CMakeArgs="-DCLI_CMAKE_HOST_POLICY_VER=\"$__policy_ver\" -DCLI_CMAKE_PKG_RID=\"$__DistroRid\" -DCLI_CMAKE_COMMIT_HASH=\"$__commit_hash\" $__CMakeArgs"
+__CMakeArgs="-DCORECLR_ARTIFACTS=\"$__CoreClrArtifacts\" -DNATIVE_LIBS_ARTIFACTS=\"$__NativeLibsArtifacts\" $__CMakeArgs"
 
 if [[ "$__PortableBuild" == 1 ]]; then
     __CMakeArgs="-DCLI_CMAKE_PORTABLE_BUILD=1 $__CMakeArgs"

--- a/src/installer/corehost/cli/apphost/static/CMakeLists.txt
+++ b/src/installer/corehost/cli/apphost/static/CMakeLists.txt
@@ -39,6 +39,7 @@ if(CLR_CMAKE_TARGET_WIN32)
 endif()
 
 include(../../exe.cmake)
+include(configure.cmake)
 
 add_definitions(-DFEATURE_APPHOST=1)
 add_definitions(-DFEATURE_STATIC_HOST=1)
@@ -57,7 +58,7 @@ endif()
 
 # Path like: artifacts/bin/coreclr/Windows_NT.x64.Release/lib  or
 #            /root/runtime/artifacts/transport/coreclr/lib
-set(CORECLR_STATIC_LIB_LOCATION "$ENV{__CoreClrArtifacts}/lib")
+set(CORECLR_STATIC_LIB_LOCATION "${CORECLR_ARTIFACTS}/lib")
 
 message ("Looking for coreclr_static lib at location: '${CORECLR_STATIC_LIB_LOCATION}'.")
 
@@ -78,7 +79,7 @@ if(CLR_CMAKE_TARGET_WIN32)
         bcrypt.lib
         RuntimeObject.lib
     )
-else()
+elseif(CLR_CMAKE_TARGET_LINUX)
     set(CORECLR_LIBRARIES
         ${CORECLR_STATIC_LIB_LOCATION}/libcoreclr_static.a
         ${CORECLR_STATIC_LIB_LOCATION}/libcoreclrpal.a
@@ -86,54 +87,114 @@ else()
         ${CORECLR_STATIC_LIB_LOCATION}/libeventprovider.a
         ${CORECLR_STATIC_LIB_LOCATION}/libnativeresourcestring.a
     )
+
+    # currently linking coreclr into the singlefilehost is only supported on linux
+    # the following code here would be needed if/when BSD and OSX are supported too
+    #
+    # if(CLR_CMAKE_TARGET_OSX)
+    #   find_library(COREFOUNDATION CoreFoundation)
+    #   find_library(CORESERVICES CoreServices)
+    #   find_library(SECURITY Security)
+    #   find_library(SYSTEM System)
+    # 
+    #   LIST(APPEND CORECLR_LIBRARIES
+    #     ${COREFOUNDATION}
+    #     ${CORESERVICES}
+    #     ${SECURITY}
+    #     ${SYSTEM}
+    #   )
+    # endif(CLR_CMAKE_TARGET_OSX)
+    # 
+    # # On OSX and *BSD, we use the libunwind that's part of the OS
+    # if(CLR_CMAKE_TARGET_FREEBSD)
+    #     find_unwind_libs(UNWIND_LIBS)
+    # 
+    #     LIST(APPEND CORECLR_LIBRARIES
+    #       ${UNWIND_LIBS}
+    #     )
+    # endif(CLR_CMAKE_TARGET_FREEBSD)
+    # 
+    # if(CLR_CMAKE_TARGET_NETBSD)
+    #     find_library(KVM kvm)
+    # 
+    #     LIST(APPEND CORECLR_LIBRARIES
+    #       ${KVM}
+    #     )
+    # endif(CLR_CMAKE_TARGET_NETBSD)
 endif(CLR_CMAKE_TARGET_WIN32)
 
-if(CLR_CMAKE_TARGET_OSX)
-  find_library(COREFOUNDATION CoreFoundation)
-  find_library(CORESERVICES CoreServices)
-  find_library(SECURITY Security)
-  find_library(SYSTEM System)
+# Path like: artifacts/bin/native/net5.0-Linux-Release-arm/
+set(NATIVE_LIBS_LOCATION "${NATIVE_LIBS_ARTIFACTS}")
+message ("Looking for native libs at location: '${NATIVE_LIBS_LOCATION}'.")
 
-  LIST(APPEND CORECLR_LIBRARIES
-    ${COREFOUNDATION}
-    ${CORESERVICES}
-    ${SECURITY}
-    ${SYSTEM}
-  )
-endif(CLR_CMAKE_TARGET_OSX)
-
-# On OSX and *BSD, we use the libunwind that's part of the OS
-if(CLR_CMAKE_TARGET_FREEBSD)
-    find_unwind_libs(UNWIND_LIBS)
-
-    LIST(APPEND CORECLR_LIBRARIES
-      ${UNWIND_LIBS}
+if(NOT CLR_CMAKE_TARGET_LINUX)
+    set(NATIVE_LIBS
+        # Native libs linked into singlefilehost is supported only on Linux for now.
+        # if/when BSD and OSX are supported too, consider the commented code sections below.
     )
-endif(CLR_CMAKE_TARGET_FREEBSD)
-
-if(CLR_CMAKE_TARGET_NETBSD)
-    find_library(KVM kvm)
-
-    LIST(APPEND CORECLR_LIBRARIES
-      ${KVM}
+else()
+    set(NATIVE_LIBS
+      ${NATIVE_LIBS_LOCATION}/libSystem.IO.Compression.Native.a
+      ${NATIVE_LIBS_LOCATION}/libSystem.Native.a
+      ${NATIVE_LIBS_LOCATION}/libSystem.Net.Security.Native.a
+      ${NATIVE_LIBS_LOCATION}/libSystem.Security.Cryptography.Native.OpenSsl.a
     )
-endif(CLR_CMAKE_TARGET_NETBSD)
 
-if(NOT CLR_CMAKE_TARGET_WIN32)
-    set(DEF_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/singlefilehost_unixexports.src)
-    set(EXPORTS_FILE ${CMAKE_CURRENT_BINARY_DIR}/singlefilehost.exports)
-    generate_exports_file(${DEF_SOURCES} ${EXPORTS_FILE})
+    find_package(ZLIB REQUIRED)
 
-    set_exports_linker_option(${EXPORTS_FILE})
-endif(NOT CLR_CMAKE_TARGET_WIN32)
+    # Additional requirements for System.System.IO.Compression.Native
+    #
+    # if (CLR_CMAKE_TARGET_SUNOS)
+    #     set(ZLIB_LIBRARIES z m)
+    # elseif (CLR_CMAKE_TARGET_UNIX)
+    #     find_package(ZLIB REQUIRED)
+    # endif ()
+    
+    # Additional requirements for System.Net.Security.Native
+    if (HAVE_GSSFW_HEADERS)
+       find_library(LIBGSS NAMES GSS)
+       if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
+         message(FATAL_ERROR "Cannot find GSS.Framework and System.Net.Security.Native cannot build without it. Try installing GSS.Framework (or the appropriate package for your platform)")
+       endif()
+    elseif(HAVE_HEIMDAL_HEADERS)
+       find_library(LIBGSS NAMES gssapi)
+       if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
+         message(FATAL_ERROR "Cannot find libgssapi and System.Net.Security.Native cannot build without it. Try installing heimdal (or the appropriate package for your platform)")
+       endif()
+    else()
+       find_library(LIBGSS NAMES gssapi_krb5)
+       if(LIBGSS STREQUAL LIBGSS-NOTFOUND)
+         message(FATAL_ERROR "Cannot find libgssapi_krb5 and System.Net.Security.Native cannot build without it. Try installing libkrb5-dev (or the appropriate package for your platform)")
+       endif()
+    endif()
+    
+    # Additional requirements for System.Native
+    if (CLR_CMAKE_TARGET_LINUX AND NOT CLR_CMAKE_TARGET_ANDROID)
+        set(NATIVE_LIBS_EXTRA
+          rt
+        )
+    # elseif (CLR_CMAKE_TARGET_FREEBSD)
+    #     set(NATIVE_LIBS_EXTRA
+    #       pthread
+    #     )
+    #     find_library(INOTIFY_LIBRARY inotify HINTS /usr/local/lib)
+    #     if(NOT (INOTIFY_LIBRARY STREQUAL INOTIFY_LIBRARY-NOTFOUND))
+    #       LIST(APPEND NATIVE_LIBS_EXTRA
+    #         ${INOTIFY_LIBRARY}
+    #       )
+    #     endif ()
+    # elseif (CLR_CMAKE_TARGET_SUNOS)
+    #     set(NATIVE_LIBS_EXTRA
+    #         socket
+    #     )
+    endif ()
 
-if(CLR_CMAKE_HOST_UNIX)
-    add_custom_target(singlefilehost_exports DEPENDS ${EXPORTS_FILE})
-    add_dependencies(singlefilehost singlefilehost_exports)
-
-    set_property(TARGET singlefilehost APPEND_STRING PROPERTY LINK_FLAGS ${EXPORTS_LINKER_OPTION})
-    set_property(TARGET singlefilehost APPEND_STRING PROPERTY LINK_DEPENDS ${EXPORTS_FILE})
-endif(CLR_CMAKE_HOST_UNIX)
+    if(CLR_CMAKE_TARGET_LINUX OR CLR_CMAKE_TARGET_FREEBSD OR CLR_CMAKE_TARGET_NETBSD OR CLR_CMAKE_TARGET_SUNOS)
+        # These options are used to force every object to be included even if it's unused.
+        set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
+        set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive)
+    endif(CLR_CMAKE_TARGET_LINUX OR CLR_CMAKE_TARGET_FREEBSD OR CLR_CMAKE_TARGET_NETBSD OR CLR_CMAKE_TARGET_SUNOS)
+endif(NOT CLR_CMAKE_TARGET_LINUX)
 
 set_property(TARGET singlefilehost PROPERTY ENABLE_EXPORTS 1)
 
@@ -142,4 +203,12 @@ target_link_libraries(singlefilehost
     libhostpolicy_static
     libhostcommon
     ${CORECLR_LIBRARIES}
+
+    ${ZLIB_LIBRARIES}
+    ${LIBGSS}
+    ${NATIVE_LIBS_EXTRA}
+
+    ${START_WHOLE_ARCHIVE}
+    ${NATIVE_LIBS}
+    ${END_WHOLE_ARCHIVE}
 )

--- a/src/installer/corehost/cli/apphost/static/configure.cmake
+++ b/src/installer/corehost/cli/apphost/static/configure.cmake
@@ -1,0 +1,12 @@
+include(CheckIncludeFiles)
+
+check_include_files(
+    GSS/GSS.h
+    HAVE_GSSFW_HEADERS)
+
+option(HeimdalGssApi "use heimdal implementation of GssApi" OFF)
+if (HeimdalGssApi)
+   check_include_files(
+       gssapi/gssapi.h
+       HAVE_HEIMDAL_HEADERS)
+endif()

--- a/src/installer/corehost/cli/apphost/static/singlefilehost_unixexports.src
+++ b/src/installer/corehost/cli/apphost/static/singlefilehost_unixexports.src
@@ -1,8 +1,0 @@
-; Licensed to the .NET Foundation under one or more agreements.
-; The .NET Foundation licenses this file to you under the MIT license.
-
-DllMain
-
-; the following two exports are needed for FreeBSD where overwise they will be implicitly hidden and cause linker issues.
-__progname
-environ

--- a/src/installer/corehost/cli/hostpolicy/static/coreclr_resolver.cpp
+++ b/src/installer/corehost/cli/hostpolicy/static/coreclr_resolver.cpp
@@ -42,7 +42,7 @@ extern "C"
 }
 
 
-#if defined(_WIN32)
+#if !defined(TARGET_LINUX)
 
 bool coreclr_resolver_t::resolve_coreclr(const pal::string_t& libcoreclr_path, coreclr_resolver_contract_t& coreclr_resolver_contract)
 {

--- a/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Directory.Build.props
@@ -13,11 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- UNIX -->
-    <SingleFileHostIncludeFilename Include="libSystem.IO.Compression.Native.so" />
-    <SingleFileHostIncludeFilename Include="libSystem.Native.so" />
-    <SingleFileHostIncludeFilename Include="libSystem.Net.Security.Native.so" />
-    <SingleFileHostIncludeFilename Include="libSystem.Security.Cryptography.Native.OpenSsl.so" />
+    <!-- LINUX -->
 
     <!-- OSX -->
     <SingleFileHostIncludeFilename Include="libSystem.IO.Compression.Native.dylib" />
@@ -25,7 +21,9 @@
     <SingleFileHostIncludeFilename Include="libSystem.Net.Security.Native.dylib" />
     <SingleFileHostIncludeFilename Include="libSystem.Security.Cryptography.Native.Apple.dylib" />
     <SingleFileHostIncludeFilename Include="libSystem.Security.Cryptography.Native.OpenSsl.dylib" />
-
+    <SingleFileHostIncludeFilename Include="libclrjit.dylib" />
+    <SingleFileHostIncludeFilename Include="libcoreclr.dylib" />
+    
     <!-- Windows -->
     <SingleFileHostIncludeFilename Include="clrcompression.dll" />
     <SingleFileHostIncludeFilename Include="clrjit.dll" />


### PR DESCRIPTION

Porting https://github.com/dotnet/runtime/pull/38684  to Preview 8

---

Related to: https://github.com/dotnet/runtime/issues/37119

This change results in singlefilehost to embed the following native libraries on Linux:
- libSystem.Native
- libSystem.IO.Compression.Native
- libSystem.Net.Security.Native
- libSystem.Security.Cryptography.Native.OpenSsl