### PR TITLE
Get index of first non ascii byte

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -43,7 +43,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetIndexOfFirstNonAsciiByteInLane(Vector128<byte> value, Vector128<byte> bitmask)
+        private static int GetIndexOfFirstNonAsciiByteInLane(Vector128<byte> value, Vector128<byte> bitmask)
         {
             if (!AdvSimd.Arm64.IsSupported || !BitConverter.IsLittleEndian)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -90,7 +90,7 @@ namespace System.Text
             // this method is running.
 
             return (Sse2.IsSupported || AdvSimd.Arm64.IsSupported && BitConverter.IsLittleEndian)
-                ? GetIndexOfFirstNonAsciiByte_Sse2OrArm64(pBuffer, bufferLength)
+                ? GetIndexOfFirstNonAsciiByte_Intrinsified(pBuffer, bufferLength)
                 : GetIndexOfFirstNonAsciiByte_Default(pBuffer, bufferLength);
         }
 
@@ -249,7 +249,7 @@ namespace System.Text
             }
         }
 
-        private static unsafe nuint GetIndexOfFirstNonAsciiByte_Sse2OrArm64(byte* pBuffer, nuint bufferLength)
+        private static unsafe nuint GetIndexOfFirstNonAsciiByte_Intrinsified(byte* pBuffer, nuint bufferLength)
         {
             // JIT turns the below into constants
 
@@ -259,7 +259,9 @@ namespace System.Text
             Debug.Assert(Sse2.IsSupported || AdvSimd.Arm64.IsSupported, "Sse2 or AdvSimd64 required.");
             Debug.Assert(BitConverter.IsLittleEndian, "This SSE2/Arm64 implementation assumes little-endian.");
 
-            Vector128<byte> bitmask = Vector128.Create((ushort)0x1001).AsByte();
+            Vector128<byte> bitmask = BitConverter.IsLittleEndian ?
+            Vector128.Create((ushort)0x1001).AsByte() :
+            Vector128.Create((ushort)0x0110).AsByte();
 
             uint currentMask, secondMask;
             byte* pOriginalBuffer = pBuffer;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -264,8 +264,8 @@ namespace System.Text
             Debug.Assert(BitConverter.IsLittleEndian, "This SSE2/Arm64 implementation assumes little-endian.");
 
             Vector128<byte> bitmask = BitConverter.IsLittleEndian ?
-            Vector128.Create((ushort)0x1001).AsByte() :
-            Vector128.Create((ushort)0x0110).AsByte();
+                Vector128.Create((ushort)0x1001).AsByte() :
+                Vector128.Create((ushort)0x0110).AsByte();
 
             uint currentMask, secondMask;
             byte* pOriginalBuffer = pBuffer;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -355,7 +355,7 @@ namespace System.Text
                         throw new PlatformNotSupportedException();
                     }
 
-                    if (ContainsNonAsciiByte(currentMask | secondMask))
+                    if (ContainsNonAsciiByte(currentMask) || ContainsNonAsciiByte(secondMask))
                     {
                         goto FoundNonAsciiDataInInnerLoop;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -476,7 +476,7 @@ namespace System.Text
                 if (!ContainsNonAsciiByte_AdvSimd(currentAdvSimdIndex))
                 {
                     pBuffer += SizeOfVector128;
-                    currentAdvSimdIndex = secondSseMask;
+                    currentAdvSimdIndex = secondAdvSimdIndex;
                 }
             }
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -243,9 +243,13 @@ namespace System.Text
             {
                 return currentMask != 0;
             }
-            else
+            else if (AdvSimd.IsSupported)
             {
                 return currentMask < 16;
+            }
+            else
+            {
+                throw new PlatformNotSupportedException();
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -450,7 +450,7 @@ namespace System.Text
             // Tzcnt is the correct operation to count the number of zero bits quickly. If this instruction isn't
             // available, we'll fall back to a normal loop.
 
-            Debug.Assert(currentMask != 0, "Shouldn't be here unless we see non-ASCII data.");
+            Debug.Assert(ContainsNonAsciiByte(currentMask), "Shouldn't be here unless we see non-ASCII data.");
             if (Sse2.IsSupported)
             {
                 pBuffer += (uint)BitOperations.TrailingZeroCount(currentMask);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -43,7 +43,7 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int GetIndexOfFirstNonAsciiByteInLane(Vector128<byte> value, Vector128<byte> bitmask)
+        private static int GetIndexOfFirstNonAsciiByteInLane_AdvSimd(Vector128<byte> value, Vector128<byte> bitmask)
         {
             if (!AdvSimd.Arm64.IsSupported || !BitConverter.IsLittleEndian)
             {
@@ -296,7 +296,7 @@ namespace System.Text
             }
             else if (AdvSimd.Arm64.IsSupported)
             {
-                currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane(AdvSimd.LoadVector128(pBuffer), bitmask); // unaligned load
+                currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane_AdvSimd(AdvSimd.LoadVector128(pBuffer), bitmask); // unaligned load
                 if (ContainsNonAsciiByte_AdvSimd(currentSseMaskOrAdvSimdIndex))
                 {
                     goto FoundNonAsciiDataInCurrentMask;
@@ -358,8 +358,8 @@ namespace System.Text
                         Vector128<byte> firstVector = AdvSimd.LoadVector128(pBuffer);
                         Vector128<byte> secondVector = AdvSimd.LoadVector128(pBuffer + SizeOfVector128);
 
-                        currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane(firstVector, bitmask);
-                        secondSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane(secondVector, bitmask);
+                        currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane_AdvSimd(firstVector, bitmask);
+                        secondSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane_AdvSimd(secondVector, bitmask);
                         if (ContainsNonAsciiByte_AdvSimd(currentSseMaskOrAdvSimdIndex) || ContainsNonAsciiByte_AdvSimd(secondSseMaskOrAdvSimdIndex))
                         {
                             goto FoundNonAsciiDataInInnerLoop;
@@ -401,7 +401,7 @@ namespace System.Text
             }
             else if (AdvSimd.Arm64.IsSupported)
             {
-                currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane(AdvSimd.LoadVector128(pBuffer), bitmask);
+                currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane_AdvSimd(AdvSimd.LoadVector128(pBuffer), bitmask);
                 if (ContainsNonAsciiByte_AdvSimd(currentSseMaskOrAdvSimdIndex))
                 {
                     goto FoundNonAsciiDataInCurrentMask;
@@ -436,7 +436,7 @@ namespace System.Text
                 }
                 else if (AdvSimd.Arm64.IsSupported)
                 {
-                    currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane(AdvSimd.LoadVector128(pBuffer), bitmask); // unaligned load
+                    currentSseMaskOrAdvSimdIndex = (uint)GetIndexOfFirstNonAsciiByteInLane_AdvSimd(AdvSimd.LoadVector128(pBuffer), bitmask); // unaligned load
                     if (ContainsNonAsciiByte_AdvSimd(currentSseMaskOrAdvSimdIndex))
                     {
                         goto FoundNonAsciiDataInCurrentMask;


### PR DESCRIPTION
Can be reviewed now. I'll add perf numbers in a bit.

Implements `GetIndexOfFirstNonAsciiByte` from https://github.com/dotnet/runtime/issues/35034