### PR TITLE
Get index of first non ascii char

### DIFF
--- a/src/libraries/System.Formats.Asn1/tests/Writer/WriteUtf8String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/WriteUtf8String.cs
@@ -10,16 +10,16 @@ namespace System.Formats.Asn1.Tests.Writer
     {
         public static IEnumerable<object[]> ShortValidCases { get; } = new object[][]
         {
-            //new object[]
-            //{
-            //    string.Empty,
-            //    "00",
-            //},
-            //new object[]
-            //{
-            //    "hi",
-            //    "026869",
-            //},
+            new object[]
+            {
+                string.Empty,
+                "00",
+            },
+            new object[]
+            {
+                "hi",
+                "026869",
+            },
             new object[]
             {
                 "Dr. & Mrs. Smith\u2010Jones \uFE60 children",

--- a/src/libraries/System.Formats.Asn1/tests/Writer/WriteUtf8String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/WriteUtf8String.cs
@@ -10,16 +10,16 @@ namespace System.Formats.Asn1.Tests.Writer
     {
         public static IEnumerable<object[]> ShortValidCases { get; } = new object[][]
         {
-            new object[]
-            {
-                string.Empty,
-                "00",
-            },
-            new object[]
-            {
-                "hi",
-                "026869",
-            },
+            //new object[]
+            //{
+            //    string.Empty,
+            //    "00",
+            //},
+            //new object[]
+            //{
+            //    "hi",
+            //    "026869",
+            //},
             new object[]
             {
                 "Dr. & Mrs. Smith\u2010Jones \uFE60 children",

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -490,7 +490,7 @@ namespace System.Text
             // this method is running.
 
             return (BitConverter.IsLittleEndian && (Sse2.IsSupported || AdvSimd.Arm64.IsSupported))
-                ? GetIndexOfFirstNonAsciiChar_Sse2OrArm64(pBuffer, bufferLength)
+                ? GetIndexOfFirstNonAsciiChar_Intrinsified(pBuffer, bufferLength)
                 : GetIndexOfFirstNonAsciiChar_Default(pBuffer, bufferLength);
         }
 
@@ -630,7 +630,7 @@ namespace System.Text
             goto Finish;
         }
 
-        private static unsafe nuint GetIndexOfFirstNonAsciiChar_Sse2OrArm64(char* pBuffer, nuint bufferLength /* in chars */)
+        private static unsafe nuint GetIndexOfFirstNonAsciiChar_Intrinsified(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // This method contains logic optimized for SSE2, SSE41 and ARM64. Much of the logic in this method
             // will be elided by JIT once we determine which specific ISAs we support.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -650,7 +650,10 @@ namespace System.Text
             Debug.Assert(Sse2.IsSupported || AdvSimd.Arm64.IsSupported, "Sse2 or AdvSimd64 required.");
             Debug.Assert(BitConverter.IsLittleEndian, "This SSE2/Arm64 implementation assumes little-endian.");
 
-            Vector128<byte> bitmask = Vector128.Create((ushort)0x1001).AsByte();
+            Vector128<byte> bitmask = BitConverter.IsLittleEndian ?
+                Vector128.Create(0x80402010_08040201).AsByte() :
+                Vector128.Create(0x01020408_10204080).AsByte();
+
             Vector128<ushort> firstVector, secondVector;
             uint currentMask;
             char* pOriginalBuffer = pBuffer;

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -486,7 +486,7 @@ namespace System.Text.Unicode
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static uint GetNonAsciiBytes(Vector128<byte> value, Vector128<byte> bitMask128)
+        internal static uint GetNonAsciiBytes(Vector128<byte> value, Vector128<byte> bitMask128)
         {
             Debug.Assert(AdvSimd.Arm64.IsSupported);
 


### PR DESCRIPTION
I think this is ready and can be reviewed now. 

Implements GetIndexOfFirstNonAsciiChar from #35034

Updated Perf:
```
| Faster                                                                 | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ---------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| System.Text.Experimental.Perf.IsNormalized_GetIndexOfFirstNonAsciiChar |      1.40 |        111784.29 |         79682.34 |         |
```