### PR TITLE
Narrow four utf16 chars to ascii and write to buffer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -1003,6 +1003,19 @@ namespace System.Text
                 Vector128<uint> vecNarrow = Sse2.PackUnsignedSaturate(vecWide, vecWide).AsUInt32();
                 Unsafe.WriteUnaligned<uint>(ref outputBuffer, Sse2.ConvertToUInt32(vecNarrow));
             }
+            else if (AdvSimd.Arm64.IsSupported)
+            {
+                // Narrows a vector of words [ w0 w1 w2 w3 ] to a vector of bytes
+                // [ b0 b1 b2 b3 b0 b1 b2 b3 ], then writes 4 bytes (32 bits) to the destination.
+
+                Vector128<short> vecWide = Vector128.CreateScalarUnsafe(value).AsInt16();
+                Vector64<byte> lower = AdvSimd.ExtractNarrowingSaturateUnsignedLower(vecWide);
+                unsafe
+                {
+                    AdvSimd.StoreSelectedScalar((byte*)Unsafe.AsPointer(ref outputBuffer), lower, 0);
+                }
+            }
+
             else
             {
                 if (BitConverter.IsLittleEndian)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -1006,14 +1006,11 @@ namespace System.Text
             else if (AdvSimd.Arm64.IsSupported)
             {
                 // Narrows a vector of words [ w0 w1 w2 w3 ] to a vector of bytes
-                // [ b0 b1 b2 b3 b0 b1 b2 b3 ], then writes 4 bytes (32 bits) to the destination.
+                // [ b0 b1 b2 b3 * * * * ], then writes 4 bytes (32 bits) to the destination.
 
                 Vector128<short> vecWide = Vector128.CreateScalarUnsafe(value).AsInt16();
                 Vector64<byte> lower = AdvSimd.ExtractNarrowingSaturateUnsignedLower(vecWide);
-                unsafe
-                {
-                    AdvSimd.StoreSelectedScalar((byte*)Unsafe.AsPointer(ref outputBuffer), lower, 0);
-                }
+                Unsafe.WriteUnaligned<uint>(ref outputBuffer, lower.AsUInt32().ToScalar());
             }
 
             else

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIUtility.cs
@@ -1003,7 +1003,7 @@ namespace System.Text
                 Vector128<uint> vecNarrow = Sse2.PackUnsignedSaturate(vecWide, vecWide).AsUInt32();
                 Unsafe.WriteUnaligned<uint>(ref outputBuffer, Sse2.ConvertToUInt32(vecNarrow));
             }
-            else if (AdvSimd.Arm64.IsSupported)
+            else if (AdvSimd.IsSupported)
             {
                 // Narrows a vector of words [ w0 w1 w2 w3 ] to a vector of bytes
                 // [ b0 b1 b2 b3 * * * * ], then writes 4 bytes (32 bits) to the destination.

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -9,6 +9,8 @@ namespace System.Runtime.Intrinsics
         public static Vector64<uint> CreateScalar(uint value) => throw new PlatformNotSupportedException();
         public static Vector64<byte> AsByte<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
+        public static Vector64<T> GetLower<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
+        public static Vector64<ulong> AsUInt64<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector64<T>
         where T : struct
@@ -21,6 +23,8 @@ namespace System.Runtime.Intrinsics
         public static Vector128<short> Create(short value) => throw new PlatformNotSupportedException();
         public static Vector128<ulong> Create(ulong value) => throw new PlatformNotSupportedException();
         public static Vector128<ushort> Create(ushort value) => throw new PlatformNotSupportedException();
+        public static Vector128<byte> Create(byte value) => throw new PlatformNotSupportedException();
+        public static Vector128<uint> Create(uint value) => throw new PlatformNotSupportedException();
         public static Vector128<ulong> CreateScalarUnsafe(ulong value) => throw new PlatformNotSupportedException();
         public static Vector128<byte> AsByte<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector128<short> AsInt16<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -11,7 +11,6 @@ namespace System.Runtime.Intrinsics
         public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector64<T> GetLower<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector64<ulong> AsUInt64<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
-        public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector64<T>
         where T : struct

--- a/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
+++ b/src/libraries/System.Utf8String.Experimental/src/System/Runtime/Intrinsics/Intrinsics.Shims.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.Intrinsics
         public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector64<T> GetLower<T>(this Vector128<T> vector) where T : struct => throw new PlatformNotSupportedException();
         public static Vector64<ulong> AsUInt64<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
+        public static Vector64<uint> AsUInt32<T>(this Vector64<T> vector) where T : struct => throw new PlatformNotSupportedException();
     }
     internal readonly struct Vector64<T>
         where T : struct


### PR DESCRIPTION
I decided to split up my single PR into multiple ones so I can isolate CI bugs better. I believe this change should be good to go in. 

In the process of splitting, I eventually found that the ARM64 CI legs seem to be broken currently. I opened https://github.com/dotnet/runtime/pull/39582 to test that claim. 

Perf results:
### Before and After Arm64 optimizations
calope@calopearm:~/performance/src/tools/ResultsComparer$ dotnet run --base ~/pgovind_before/ --diff ~/pgovind_after/ --threshold 0.01%
summary:
better: 1, geomean: 1.244
total diff: 1
No Slower results for the provided threshold = 0.01% and noise filter = 0.3ns.
| Faster                                   | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| ---------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| System.Text.Experimental.Perf.Intrinsics |      1.24 |         10433.00 |          8384.06 |         |
No file given