### PR TITLE
[wasm] Enable System.Resources.Extensions.Tests and System.Resources.ResourceManager.Tests test suites

### DIFF
--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -262,7 +262,7 @@ namespace System.Resources.Extensions.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34495", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34008", TestPlatforms.Linux, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public static void BinaryFormattedResources()
@@ -300,7 +300,7 @@ namespace System.Resources.Extensions.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34495", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34008", TestPlatforms.Linux, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public static void BinaryFormattedResourcesWithoutTypeName()
@@ -436,7 +436,7 @@ namespace System.Resources.Extensions.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public static void CanReadViaResourceManager()
         {
             ResourceManager resourceManager = new ResourceManager(typeof(TestData));
@@ -474,7 +474,7 @@ namespace System.Resources.Extensions.Tests
             Assert.IsType<DeserializingResourceReader>(reader);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         public static void EmbeddedResourcesAreUpToDate()
         {
             // this is meant to catch a case where our embedded test resources are out of date with respect to the current writer.

--- a/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
+++ b/src/libraries/System.Resources.ResourceManager/tests/ResourceManagerTests.cs
@@ -228,7 +228,7 @@ namespace System.Resources.Tests
             yield return new object[] { "Size", new Size(20, 30), true };
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(EnglishNonStringResourceData))]
         public static void GetObject(string key, object expectedValue, bool requiresBinaryFormatter)
         {
@@ -299,7 +299,7 @@ namespace System.Resources.Tests
             Assert.Equal(expectedValue, set.GetString(key));
         }
 
-        [Theory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [MemberData(nameof(EnglishNonStringResourceData))]
         public static void GetResourceSet_NonStrings(string key, object expectedValue, bool requiresBinaryFormatter)
         {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -46,8 +46,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\CoreCLR\System.Reflection.CoreCLR.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.Extensions\tests\System.Resources.Extensions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Resources.ResourceManager\tests\System.Resources.ResourceManager.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Permissions\tests\System.Security.Permissions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.RegularExpressions\tests\System.Text.RegularExpressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

Tests failures are ones with `System.NotSupportedException : BinaryFormatter serialization and deserialization are disabled within this application. See https://aka.ms/binaryformatter for more information.` message. (see https://github.com/dotnet/runtime/pull/38963) 