### PR TITLE
Fix sync ConnectHelper.Connect

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs
@@ -96,14 +96,14 @@ namespace System.Net.Http
                 {
                     socket.Connect(new DnsEndPoint(host, port));
                 }
+
+                return new NetworkStream(socket, ownsSocket: true);
             }
             catch (Exception e)
             {
                 socket.Dispose();
                 throw CreateWrappedException(e, host, port, cancellationToken);
             }
-
-            return new NetworkStream(socket, ownsSocket: true);
         }
 
         /// <summary>SocketAsyncEventArgs that carries with it additional state for a Task builder and a CancellationToken.</summary>


### PR DESCRIPTION
During synchronous creation of a new [`NetworkStream`](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectHelper.cs#L87-L107), the `Socket.Connect` passed successfully and then cancellation disposed the socket. Then `NetworkStream` ctor checked the socket state and thrown an `IOException`. This exception should have been handled the same way as exceptions from `Connect` and mapped to `OperationCanceledException`.

Fixes #39279