### PR TITLE
Trim more Http DiagnosticsHandler code

### DIFF
--- a/docs/workflow/trimming/feature-switches.md
+++ b/docs/workflow/trimming/feature-switches.md
@@ -13,7 +13,7 @@ configurations but their defaults might vary as any SDK can set the defaults dif
 | EventSourceSupport | System.Diagnostics.Tracing.EventSource.IsSupported | Any EventSource related code or logic is trimmed when set to false |
 | InvariantGlobalization | System.Globalization.Invariant | All globalization specific code and data is trimmed when set to true |
 | UseSystemResourceKeys | System.Resources.UseSystemResourceKeys |  Any localizable resources for system assemblies is trimmed when set to true |
-| - | System.Net.Http.EnableActivityPropagation | Any dependency related to diagnostics support for System.Net.Http is trimmed when set to false |
+| HttpActivityPropagationSupport | System.Net.Http.EnableActivityPropagation | Any dependency related to diagnostics support for System.Net.Http is trimmed when set to false |
 
 Any feature-switch which defines property can be set in csproj file or
 on the command line as any other MSBuild property. Those without predefined property name

--- a/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.xml
+++ b/src/libraries/System.Net.Http/src/ILLink/ILLink.Substitutions.xml
@@ -1,7 +1,7 @@
 <linker>
   <assembly fullname="System.Net.Http">
     <type fullname="System.Net.Http.DiagnosticsHandler">
-      <method signature="System.Boolean IsEnabled()" body="stub" value="false" feature="System.Net.Http.EnableActivityPropagation" featurevalue="false" />
+      <method signature="System.Boolean IsGloballyEnabled()" body="stub" value="false" feature="System.Net.Http.EnableActivityPropagation" featurevalue="false" />
     </type>
   </assembly>
 </linker>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DiagnosticsHandler.cs
@@ -27,7 +27,12 @@ namespace System.Net.Http
         {
             // check if there is a parent Activity (and propagation is not suppressed)
             // or if someone listens to HttpHandlerDiagnosticListener
-            return Settings.s_activityPropagationEnabled && (Activity.Current != null || Settings.s_diagnosticListener.IsEnabled());
+            return IsGloballyEnabled() && (Activity.Current != null || Settings.s_diagnosticListener.IsEnabled());
+        }
+
+        internal static bool IsGloballyEnabled()
+        {
+            return Settings.s_activityPropagationEnabled;
         }
 
         // SendAsyncCore returns already completed ValueTask for when async: false is passed.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -18,7 +18,7 @@ namespace System.Net.Http
 #else
         private readonly SocketsHttpHandler _underlyingHandler;
 #endif
-        private readonly DiagnosticsHandler _diagnosticsHandler;
+        private readonly DiagnosticsHandler? _diagnosticsHandler;
         private ClientCertificateOption _clientCertificateOptions;
 
         private volatile bool _disposed;
@@ -30,7 +30,10 @@ namespace System.Net.Http
 #else
             _underlyingHandler = new SocketsHttpHandler();
 #endif
-            _diagnosticsHandler = new DiagnosticsHandler(_underlyingHandler);
+            if (DiagnosticsHandler.IsGloballyEnabled())
+            {
+                _diagnosticsHandler = new DiagnosticsHandler(_underlyingHandler);
+            }
             ClientCertificateOptions = ClientCertificateOption.Manual;
         }
 
@@ -273,7 +276,7 @@ namespace System.Net.Http
         protected internal override HttpResponseMessage Send(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            return DiagnosticsHandler.IsEnabled() ?
+            return DiagnosticsHandler.IsEnabled() && _diagnosticsHandler != null ?
                 _diagnosticsHandler.Send(request, cancellationToken) :
                 _underlyingHandler.Send(request, cancellationToken);
         }
@@ -281,7 +284,7 @@ namespace System.Net.Http
         protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            return DiagnosticsHandler.IsEnabled() ?
+            return DiagnosticsHandler.IsEnabled() && _diagnosticsHandler != null ?
                 _diagnosticsHandler.SendAsync(request, cancellationToken) :
                 _underlyingHandler.SendAsync(request, cancellationToken);
         }


### PR DESCRIPTION
Since the DiagnosticsHandler still gets instantiated in the HttpClientHandler, none of its overriden methods are getting trimmed. This leads to System.Diagnostics.DiagnosticListener still being preserved in a linked application.

This fix is split DiagnosticsHandler.IsEnabled() into two methods:

* IsGloballyEnabled() - checks the AppContext switch, and is replaced by the linker by a feature swtich.
* IsEnabled() - which checks IsGloballyEnabled() and if there is an Activity or listener available.

This allows all but the IsEnabled and IsGloballyEnabled methods to get trimmed on DiagnosticsHandler.

Contributes to #38765

This allows for ~20KB savings in the default Blazor WASM template app:

| Build          | Size     |
|-------------|----------|
| master       | 2,420,736 bytes |
| PR              | 2,400,768 bytes |
