### PR TITLE
Make ContentType(string) constructor throw FormatException instead of IndexOutOfRangeException

### DIFF
--- a/src/libraries/Common/src/System/Net/Mail/MailBnfHelper.cs
+++ b/src/libraries/Common/src/System/Net/Mail/MailBnfHelper.cs
@@ -267,9 +267,9 @@ namespace System.Net.Mime
                 }
             }
 
-            if (start == offset)
+            if (start == offset && offset < data.Length)
             {
-                throw new FormatException(SR.ContentTypeInvalid);
+                throw new FormatException(SR.Format(SR.MailHeaderFieldInvalidCharacter, data[offset]));
             }
 
             return data.Substring(start, offset - start);

--- a/src/libraries/Common/src/System/Net/Mail/MailBnfHelper.cs
+++ b/src/libraries/Common/src/System/Net/Mail/MailBnfHelper.cs
@@ -269,7 +269,7 @@ namespace System.Net.Mime
 
             if (start == offset)
             {
-                throw new FormatException(SR.Format(SR.MailHeaderFieldInvalidCharacter, data[offset]));
+                throw new FormatException(SR.ContentTypeInvalid);
             }
 
             return data.Substring(start, offset - start);

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -264,9 +264,6 @@
   <data name="net_http_value_must_be_greater_than" xml:space="preserve">
     <value>The specified value must be greater than {0}.</value>
   </data>
-  <data name="ContentTypeInvalid" xml:space="preserve">
-    <value>The specified content type is invalid.</value>
-  </data>
   <data name="MailHeaderFieldInvalidCharacter" xml:space="preserve">
     <value>An invalid character was found in the mail header: '{0}'.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -264,6 +264,9 @@
   <data name="net_http_value_must_be_greater_than" xml:space="preserve">
     <value>The specified value must be greater than {0}.</value>
   </data>
+  <data name="ContentTypeInvalid" xml:space="preserve">
+    <value>The specified content type is invalid.</value>
+  </data>
   <data name="MailHeaderFieldInvalidCharacter" xml:space="preserve">
     <value>An invalid character was found in the mail header: '{0}'.</value>
   </data>

--- a/src/libraries/System.Net.Mail/tests/Functional/ContentTypeTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/ContentTypeTest.cs
@@ -53,7 +53,7 @@ namespace System.Net.Mime.Tests
         [InlineData(typeof(FormatException), "text/plain; charset=utf-8 ,")]
         [InlineData(typeof(FormatException), "text/plain; charset=utf-8,")]
         [InlineData(typeof(FormatException), "textplain")]
-        [InlineData(typeof(IndexOutOfRangeException), "text/")]
+        [InlineData(typeof(FormatException), "text/")]
         [InlineData(typeof(FormatException), ",, , ,,text/plain; charset=iso-8859-1; q=1.0,\r\n */xml; charset=utf-8; q=0.5,,,")]
         [InlineData(typeof(FormatException), "text/plain; charset=iso-8859-1; q=1.0, */xml; charset=utf-8; q=0.5")]
         [InlineData(typeof(FormatException), " , */xml; charset=utf-8; q=0.5 ")]


### PR DESCRIPTION
Fix #39337 