### PR TITLE
Remove SELECTANY usage

### DIFF
--- a/src/coreclr/src/debug/inc/amd64/primitives.h
+++ b/src/coreclr/src/debug/inc/amd64/primitives.h
@@ -53,7 +53,7 @@ inline CORDB_ADDRESS GetPatchEndAddr(CORDB_ADDRESS patchAddr)
     CORDbgInsertBreakpoint((CORDB_ADDRESS_TYPE *)((_buffer) + ((_patchAddr) - (_requestedAddr))));
 
 
-SELECTANY const CorDebugRegister g_JITToCorDbgReg[] =
+constexpr CorDebugRegister g_JITToCorDbgReg[] =
 {
     REGISTER_AMD64_RAX,
     REGISTER_AMD64_RCX,

--- a/src/coreclr/src/debug/inc/arm/primitives.h
+++ b/src/coreclr/src/debug/inc/arm/primitives.h
@@ -63,7 +63,7 @@ inline T _ClearThumbBit(T addr)
     CORDbgInsertBreakpointExImpl((CORDB_ADDRESS_TYPE *)((_buffer) + (_ClearThumbBit(_patchAddr) - (_requestedAddr))));
 
 
-SELECTANY const CorDebugRegister g_JITToCorDbgReg[] =
+constexpr CorDebugRegister g_JITToCorDbgReg[] =
 {
     REGISTER_ARM_R0,
     REGISTER_ARM_R1,

--- a/src/coreclr/src/debug/inc/arm64/primitives.h
+++ b/src/coreclr/src/debug/inc/arm64/primitives.h
@@ -56,7 +56,7 @@ inline CORDB_ADDRESS GetPatchEndAddr(CORDB_ADDRESS patchAddr)
     CORDbgInsertBreakpointExImpl((CORDB_ADDRESS_TYPE *)((_buffer) + (_patchAddr) - (_requestedAddr)));
 
 
-SELECTANY const CorDebugRegister g_JITToCorDbgReg[] =
+constexpr CorDebugRegister g_JITToCorDbgReg[] =
 {
     REGISTER_ARM64_X0,
     REGISTER_ARM64_X1,

--- a/src/coreclr/src/debug/inc/dbgipcevents.h
+++ b/src/coreclr/src/debug/inc/dbgipcevents.h
@@ -984,7 +984,7 @@ struct MSLAYOUT IPCEventTypeNameMapping
             const char *            eventName;
 };
 
-extern const IPCEventTypeNameMapping DECLSPEC_SELECTANY DbgIPCEventTypeNames[] =
+constexpr IPCEventTypeNameMapping DbgIPCEventTypeNames[] =
 {
     #define IPC_EVENT_TYPE0(type, val)  { type, #type },
     #define IPC_EVENT_TYPE1(type, val)  { type, #type },

--- a/src/coreclr/src/debug/inc/i386/primitives.h
+++ b/src/coreclr/src/debug/inc/i386/primitives.h
@@ -48,7 +48,7 @@ inline CORDB_ADDRESS GetPatchEndAddr(CORDB_ADDRESS patchAddr)
     CORDbgInsertBreakpoint((CORDB_ADDRESS_TYPE *)((_buffer) + ((_patchAddr) - (_requestedAddr))));
 
 
-SELECTANY const CorDebugRegister g_JITToCorDbgReg[] =
+constexpr CorDebugRegister g_JITToCorDbgReg[] =
 {
     REGISTER_X86_EAX,
     REGISTER_X86_ECX,

--- a/src/coreclr/src/dlls/mscorpe/stubs.h
+++ b/src/coreclr/src/dlls/mscorpe/stubs.h
@@ -28,7 +28,7 @@
 // fixed up by the loader when the image is paged in.
 //*****************************************************************************
 
-SELECTANY const BYTE ExeMainX86Template[] =
+constexpr BYTE ExeMainX86Template[] =
 {
 	// Jump through IAT to _CorExeMain
 	0xFF, 0x25,				// jmp [iat:_CorDllMain entry]
@@ -51,7 +51,7 @@ SELECTANY const BYTE ExeMainX86Template[] =
 // fixed up by the loader when the image is paged in.
 //*****************************************************************************
 
-SELECTANY const BYTE DllMainX86Template[] =
+constexpr BYTE DllMainX86Template[] =
 {
 	// Jump through IAT to CorDllMain
 	0xFF, 0x25,				// jmp [iat:_CorDllMain entry]
@@ -74,7 +74,7 @@ SELECTANY const BYTE DllMainX86Template[] =
 // fixed up by the loader when the image is paged in.
 //*****************************************************************************
 
-SELECTANY const BYTE ExeMainAMD64Template[] =
+constexpr BYTE ExeMainAMD64Template[] =
 {
 	// Jump through IAT to _CorExeMain
 	0x48, 0xA1,				// rex.w rex.b mov rax,[following address]
@@ -98,7 +98,7 @@ SELECTANY const BYTE ExeMainAMD64Template[] =
 // fixed up by the loader when the image is paged in.
 //*****************************************************************************
 
-SELECTANY const BYTE DllMainAMD64Template[] =
+constexpr BYTE DllMainAMD64Template[] =
 {
 	// Jump through IAT to CorDllMain
 	0x48, 0xA1,				// rex.w rex.b mov rax,[following address]
@@ -120,7 +120,7 @@ SELECTANY const BYTE DllMainAMD64Template[] =
 // We set the value of gp to point at the iat table entry for _CorExeMain
 //*****************************************************************************
 
-SELECTANY const BYTE ExeMainIA64Template[] =
+constexpr BYTE ExeMainIA64Template[] =
 {
     // ld8    r9  = [gp]    ;;
     // ld8    r10 = [r9],8
@@ -148,7 +148,7 @@ SELECTANY const BYTE ExeMainIA64Template[] =
 // We set the value of gp to point at the iat table entry for _CorExeMain
 //*****************************************************************************
 
-SELECTANY const BYTE DllMainIA64Template[] =
+constexpr BYTE DllMainIA64Template[] =
 {
     // ld8    r9  = [gp]    ;;
     // ld8    r10 = [r9],8

--- a/src/coreclr/src/inc/clr/fs/path.h
+++ b/src/coreclr/src/inc/clr/fs/path.h
@@ -9,7 +9,6 @@
 #define _clr_fs_Path_h_
 
 #include "clrtypes.h"
-#include "cor.h" // SELECTANY
 
 #include "strsafe.h"
 

--- a/src/coreclr/src/inc/cor.h
+++ b/src/coreclr/src/inc/cor.h
@@ -2093,15 +2093,7 @@ inline ULONG CorSigUncompressData(      // return number of bytes of that compre
 }
 
 
-#if !defined(SELECTANY)
-#if defined(__GNUC__)
-    #define SELECTANY extern __attribute__((weak))
-#else
-    #define SELECTANY extern __declspec(selectany)
-#endif
-#endif
-
-SELECTANY const mdToken g_tkCorEncodeToken[4] ={mdtTypeDef, mdtTypeRef, mdtTypeSpec, mdtBaseType};
+constexpr mdToken g_tkCorEncodeToken[4] ={mdtTypeDef, mdtTypeRef, mdtTypeSpec, mdtBaseType};
 
 // uncompress a token
 inline mdToken CorSigUncompressToken(   // return the token.

--- a/src/coreclr/src/inc/corinfo.h
+++ b/src/coreclr/src/inc/corinfo.h
@@ -208,15 +208,7 @@ TODO: Talk about initializing strutures before use
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#if !defined(SELECTANY)
-#if defined(__GNUC__)
-    #define SELECTANY extern __attribute__((weak))
-#else
-    #define SELECTANY extern __declspec(selectany)
-#endif
-#endif
-
-SELECTANY const GUID JITEEVersionIdentifier = { /* 7af97117-55be-4c76-afb2-e26261cb140e */
+constexpr GUID JITEEVersionIdentifier = { /* 7af97117-55be-4c76-afb2-e26261cb140e */
     0x7af97117,
     0x55be,
     0x4c76,

--- a/src/coreclr/src/inc/delayloadhelpers.h
+++ b/src/coreclr/src/inc/delayloadhelpers.h
@@ -49,7 +49,7 @@ namespace DelayLoad
 #define DELAY_LOADED_MODULE(DLL_NAME) \
     namespace DelayLoad { \
         namespace Modules { \
-            SELECTANY Module DLL_NAME = { L#DLL_NAME W(".dll"), nullptr, S_OK, false }; \
+            constexpr Module DLL_NAME = { L#DLL_NAME W(".dll"), nullptr, S_OK, false }; \
         } \
     }
 
@@ -104,7 +104,7 @@ namespace DelayLoad
     DELAY_LOADED_MODULE(DLL_NAME) \
     namespace DelayLoad { \
         namespace DLL_NAME { \
-            SELECTANY Function FUNC_NAME = { &Modules::##DLL_NAME, #FUNC_NAME, nullptr, S_OK, false }; \
+            constexpr Function FUNC_NAME = { &Modules::##DLL_NAME, #FUNC_NAME, nullptr, S_OK, false }; \
         } \
     }
 

--- a/src/coreclr/src/inc/palclr.h
+++ b/src/coreclr/src/inc/palclr.h
@@ -485,26 +485,6 @@
 #define PAL_CPP_CATCH_EXCEPTION_NOARG catch (Exception *)
 
 
-//  SELECTANY macro is intended to prevent duplication of static const
-//  arrays declared in .h files in binary modules.
-//  The problem is that const variables have static internal linkage
-//  in C++.  That means that if a const variable is declared in a .h file
-//  the compiler will emit it into every translation unit that uses that .h file.
-//  That will cause duplication of the data when those translation units
-//  are linked into a binary module.
-//  SELECTANY declares a variable as extern to give it external linkage
-//  and it provides __declspec(selectany) to instruct the linker to merge
-//  duplicate external const static data copies into one.
-//
-#if defined(SOURCE_FORMATTING)
-#define SELECTANY extern
-#else
-#if defined(__GNUC__)
-#define SELECTANY extern __attribute__((weak))
-#else
-#define SELECTANY extern __declspec(selectany)
-#endif
-#endif
 #if defined(SOURCE_FORMATTING)
 #define __annotation(x)
 #endif

--- a/src/coreclr/src/inc/simplerhash.h
+++ b/src/coreclr/src/inc/simplerhash.h
@@ -68,8 +68,8 @@ public:
 class PrimeInfo
 {
 public:
-    PrimeInfo() : prime(0), magic(0), shift(0) {}
-    PrimeInfo(unsigned p, unsigned m, unsigned s) : prime(p), magic(m), shift(s) {}
+    constexpr PrimeInfo() : prime(0), magic(0), shift(0) {}
+    constexpr PrimeInfo(unsigned p, unsigned m, unsigned s) : prime(p), magic(m), shift(s) {}
     unsigned prime;
     unsigned magic;
     unsigned shift;

--- a/src/coreclr/src/inc/simplerhash.inl
+++ b/src/coreclr/src/inc/simplerhash.inl
@@ -303,7 +303,7 @@ void SimplerHashTable<Key,KeyFuncs,Value,Behavior>::Reallocate(unsigned newTable
 // 32-bit magic numbers, (because the algorithm for using 33-bit magic numbers is slightly slower).
 //
 
-SELECTANY const PrimeInfo primeInfo[] =
+constexpr PrimeInfo primeInfo[] =
 {
     PrimeInfo(9,         0x38e38e39, 1),
     PrimeInfo(23,        0xb21642c9, 4),

--- a/src/coreclr/src/inc/utilcode.h
+++ b/src/coreclr/src/inc/utilcode.h
@@ -4071,13 +4071,13 @@ HRESULT GetImageRuntimeVersionString(PVOID pMetaData, LPCSTR* pString);
 // The registry keys and values that contain the information regarding
 // the default registered unmanaged debugger.
 //*****************************************************************************
-SELECTANY const WCHAR kDebugApplicationsPoliciesKey[] = W("SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Error Reporting\\DebugApplications");
-SELECTANY const WCHAR kDebugApplicationsKey[] = W("SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\DebugApplications");
+constexpr WCHAR kDebugApplicationsPoliciesKey[] = W("SOFTWARE\\Policies\\Microsoft\\Windows\\Windows Error Reporting\\DebugApplications");
+constexpr WCHAR kDebugApplicationsKey[] = W("SOFTWARE\\Microsoft\\Windows\\Windows Error Reporting\\DebugApplications");
 
-SELECTANY const WCHAR kUnmanagedDebuggerKey[] = W("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug");
-SELECTANY const WCHAR kUnmanagedDebuggerValue[] = W("Debugger");
-SELECTANY const WCHAR kUnmanagedDebuggerAutoValue[] = W("Auto");
-SELECTANY const WCHAR kUnmanagedDebuggerAutoExclusionListKey[] = W("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\AutoExclusionList");
+constexpr WCHAR kUnmanagedDebuggerKey[] = W("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug");
+constexpr WCHAR kUnmanagedDebuggerValue[] = W("Debugger");
+constexpr WCHAR kUnmanagedDebuggerAutoValue[] = W("Auto");
+constexpr WCHAR kUnmanagedDebuggerAutoExclusionListKey[] = W("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug\\AutoExclusionList");
 
 BOOL GetRegistryLongValue(HKEY    hKeyParent,              // Parent key.
                           LPCWSTR szKey,                   // Key name to look at.

--- a/src/coreclr/src/jit/_typeinfo.h
+++ b/src/coreclr/src/jit/_typeinfo.h
@@ -42,7 +42,7 @@ enum ti_types
 namespace
 {
 #endif // _MSC_VER
-SELECTANY const char* g_ti_type_names_map[] = {
+constexpr char* g_ti_type_names_map[] = {
 #define DEF_TI(ti, nm) nm,
 #include "titypes.h"
 #undef DEF_TI
@@ -57,7 +57,7 @@ SELECTANY const char* g_ti_type_names_map[] = {
 namespace
 {
 #endif //  _MSC_VER
-SELECTANY const ti_types g_jit_types_map[] = {
+constexpr ti_types g_jit_types_map[] = {
 #define DEF_TP(tn, nm, jitType, verType, sz, sze, asze, st, al, tf, howUsed) verType,
 #include "typelist.h"
 #undef DEF_TP
@@ -92,7 +92,7 @@ inline ti_types varType2tiType(var_types type)
 namespace
 {
 #endif // _MSC_VER
-SELECTANY const ti_types g_ti_types_map[CORINFO_TYPE_COUNT] = {
+constexpr ti_types g_ti_types_map[CORINFO_TYPE_COUNT] = {
     // see the definition of enum CorInfoType in file inc/corinfo.h
     TI_ERROR,  // CORINFO_TYPE_UNDEF           = 0x0,
     TI_ERROR,  // CORINFO_TYPE_VOID            = 0x1,

--- a/src/coreclr/src/jit/jithashtable.h
+++ b/src/coreclr/src/jit/jithashtable.h
@@ -57,10 +57,10 @@ public:
 class JitPrimeInfo
 {
 public:
-    JitPrimeInfo() : prime(0), magic(0), shift(0)
+    constexpr JitPrimeInfo() : prime(0), magic(0), shift(0)
     {
     }
-    JitPrimeInfo(unsigned p, unsigned m, unsigned s) : prime(p), magic(m), shift(s)
+    constexpr JitPrimeInfo(unsigned p, unsigned m, unsigned s) : prime(p), magic(m), shift(s)
     {
     }
     unsigned prime;
@@ -92,7 +92,7 @@ public:
 // 32-bit magic numbers, (because the algorithm for using 33-bit magic numbers is slightly slower).
 
 // clang-format off
-SELECTANY const JitPrimeInfo jitPrimeInfo[]
+constexpr JitPrimeInfo jitPrimeInfo[]
 {
     JitPrimeInfo(9,         0x38e38e39, 1),
     JitPrimeInfo(23,        0xb21642c9, 4),

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -441,10 +441,10 @@ typedef unsigned char   regNumberSmall;
   #define REG_ARG_0                REG_ECX
   #define REG_ARG_1                REG_EDX
 
-  SELECTANY const regNumber intArgRegs [] = {REG_ECX, REG_EDX};
-  SELECTANY const regMaskTP intArgMasks[] = {RBM_ECX, RBM_EDX};
-  SELECTANY const regNumber fltArgRegs [] = {REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3};
-  SELECTANY const regMaskTP fltArgMasks[] = {RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3};
+  constexpr regNumber intArgRegs [] = {REG_ECX, REG_EDX};
+  constexpr regMaskTP intArgMasks[] = {RBM_ECX, RBM_EDX};
+  constexpr regNumber fltArgRegs [] = {REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3};
+  constexpr regMaskTP fltArgMasks[] = {RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3};
 
   #define RBM_ARG_0                RBM_ECX
   #define RBM_ARG_1                RBM_EDX
@@ -779,10 +779,10 @@ typedef unsigned char   regNumberSmall;
   #define REG_ARG_4                REG_R8
   #define REG_ARG_5                REG_R9
 
-  SELECTANY const regNumber intArgRegs [] = { REG_EDI, REG_ESI, REG_EDX, REG_ECX, REG_R8, REG_R9 };
-  SELECTANY const regMaskTP intArgMasks[] = { RBM_EDI, RBM_ESI, RBM_EDX, RBM_ECX, RBM_R8, RBM_R9 };
-  SELECTANY const regNumber fltArgRegs [] = { REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3, REG_XMM4, REG_XMM5, REG_XMM6, REG_XMM7 };
-  SELECTANY const regMaskTP fltArgMasks[] = { RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3, RBM_XMM4, RBM_XMM5, RBM_XMM6, RBM_XMM7 };
+  constexpr regNumber intArgRegs [] = { REG_EDI, REG_ESI, REG_EDX, REG_ECX, REG_R8, REG_R9 };
+  constexpr regMaskTP intArgMasks[] = { RBM_EDI, RBM_ESI, RBM_EDX, RBM_ECX, RBM_R8, RBM_R9 };
+  constexpr regNumber fltArgRegs [] = { REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3, REG_XMM4, REG_XMM5, REG_XMM6, REG_XMM7 };
+  constexpr regMaskTP fltArgMasks[] = { RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3, RBM_XMM4, RBM_XMM5, RBM_XMM6, RBM_XMM7 };
 
   #define RBM_ARG_0                RBM_RDI
   #define RBM_ARG_1                RBM_RSI
@@ -802,10 +802,10 @@ typedef unsigned char   regNumberSmall;
   #define REG_ARG_2                REG_R8
   #define REG_ARG_3                REG_R9
 
-  SELECTANY const regNumber intArgRegs [] = { REG_ECX, REG_EDX, REG_R8, REG_R9 };
-  SELECTANY const regMaskTP intArgMasks[] = { RBM_ECX, RBM_EDX, RBM_R8, RBM_R9 };
-  SELECTANY const regNumber fltArgRegs [] = { REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3 };
-  SELECTANY const regMaskTP fltArgMasks[] = { RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3 };
+  constexpr regNumber intArgRegs [] = { REG_ECX, REG_EDX, REG_R8, REG_R9 };
+  constexpr regMaskTP intArgMasks[] = { RBM_ECX, RBM_EDX, RBM_R8, RBM_R9 };
+  constexpr regNumber fltArgRegs [] = { REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3 };
+  constexpr regMaskTP fltArgMasks[] = { RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3 };
 
   #define RBM_ARG_0                RBM_ECX
   #define RBM_ARG_1                RBM_EDX
@@ -1152,8 +1152,8 @@ typedef unsigned char   regNumberSmall;
   #define REG_ARG_2                REG_R2
   #define REG_ARG_3                REG_R3
 
-  SELECTANY const regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3};
-  SELECTANY const regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3};
+  constexpr regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3};
+  constexpr regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3};
 
   #define RBM_ARG_0                RBM_R0
   #define RBM_ARG_1                RBM_R1
@@ -1164,8 +1164,8 @@ typedef unsigned char   regNumberSmall;
   #define RBM_FLTARG_REGS         (RBM_F0|RBM_F1|RBM_F2|RBM_F3|RBM_F4|RBM_F5|RBM_F6|RBM_F7|RBM_F8|RBM_F9|RBM_F10|RBM_F11|RBM_F12|RBM_F13|RBM_F14|RBM_F15)
   #define RBM_DBL_REGS            RBM_ALLDOUBLE
 
-  SELECTANY const regNumber fltArgRegs [] = {REG_F0, REG_F1, REG_F2, REG_F3, REG_F4, REG_F5, REG_F6, REG_F7, REG_F8, REG_F9, REG_F10, REG_F11, REG_F12, REG_F13, REG_F14, REG_F15 };
-  SELECTANY const regMaskTP fltArgMasks[] = {RBM_F0, RBM_F1, RBM_F2, RBM_F3, RBM_F4, RBM_F5, RBM_F6, RBM_F7, RBM_F8, RBM_F9, RBM_F10, RBM_F11, RBM_F12, RBM_F13, RBM_F14, RBM_F15 };
+  constexpr regNumber fltArgRegs [] = {REG_F0, REG_F1, REG_F2, REG_F3, REG_F4, REG_F5, REG_F6, REG_F7, REG_F8, REG_F9, REG_F10, REG_F11, REG_F12, REG_F13, REG_F14, REG_F15 };
+  constexpr regMaskTP fltArgMasks[] = {RBM_F0, RBM_F1, RBM_F2, RBM_F3, RBM_F4, RBM_F5, RBM_F6, RBM_F7, RBM_F8, RBM_F9, RBM_F10, RBM_F11, RBM_F12, RBM_F13, RBM_F14, RBM_F15 };
 
   #define LBL_DIST_SMALL_MAX_NEG  (0)
   #define LBL_DIST_SMALL_MAX_POS  (+1020)
@@ -1486,8 +1486,8 @@ typedef unsigned char   regNumberSmall;
   #define REG_ARG_6                REG_R6
   #define REG_ARG_7                REG_R7
 
-  SELECTANY const regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3, REG_R4, REG_R5, REG_R6, REG_R7};
-  SELECTANY const regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3, RBM_R4, RBM_R5, RBM_R6, RBM_R7};
+  constexpr regNumber intArgRegs [] = {REG_R0, REG_R1, REG_R2, REG_R3, REG_R4, REG_R5, REG_R6, REG_R7};
+  constexpr regMaskTP intArgMasks[] = {RBM_R0, RBM_R1, RBM_R2, RBM_R3, RBM_R4, RBM_R5, RBM_R6, RBM_R7};
 
   #define RBM_ARG_0                RBM_R0
   #define RBM_ARG_1                RBM_R1
@@ -1519,8 +1519,8 @@ typedef unsigned char   regNumberSmall;
   #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3|RBM_ARG_4|RBM_ARG_5|RBM_ARG_6|RBM_ARG_7)
   #define RBM_FLTARG_REGS         (RBM_FLTARG_0|RBM_FLTARG_1|RBM_FLTARG_2|RBM_FLTARG_3|RBM_FLTARG_4|RBM_FLTARG_5|RBM_FLTARG_6|RBM_FLTARG_7)
 
-  SELECTANY const regNumber fltArgRegs [] = {REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7 };
-  SELECTANY const regMaskTP fltArgMasks[] = {RBM_V0, RBM_V1, RBM_V2, RBM_V3, RBM_V4, RBM_V5, RBM_V6, RBM_V7 };
+  constexpr regNumber fltArgRegs [] = {REG_V0, REG_V1, REG_V2, REG_V3, REG_V4, REG_V5, REG_V6, REG_V7 };
+  constexpr regMaskTP fltArgMasks[] = {RBM_V0, RBM_V1, RBM_V2, RBM_V3, RBM_V4, RBM_V5, RBM_V6, RBM_V7 };
 
   #define LBL_DIST_SMALL_MAX_NEG  (-1048576)
   #define LBL_DIST_SMALL_MAX_POS  (+1048575)

--- a/src/coreclr/src/pal/inc/rt/guiddef.h
+++ b/src/coreclr/src/pal/inc/rt/guiddef.h
@@ -17,7 +17,7 @@
 
 #ifdef INITGUID
 #define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
-        EXTERN_C DLLEXPORT const GUID DECLSPEC_SELECTANY name \
+        EXTERN_C DLLEXPORT constexpr GUID name \
                 = { l, w1, w2, { b1, b2,  b3,  b4,  b5,  b6,  b7,  b8 } }
 #else
 #define DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \

--- a/src/coreclr/src/pal/inc/rt/palrt.h
+++ b/src/coreclr/src/pal/inc/rt/palrt.h
@@ -223,7 +223,6 @@ inline void *__cdecl operator new(size_t, void *_P)
 #define THIS                void
 
 #define DECLSPEC_NOVTABLE
-#define DECLSPEC_SELECTANY  __attribute__((weak))
 
 #define DECLARE_INTERFACE(iface)    interface DECLSPEC_NOVTABLE iface
 #define DECLARE_INTERFACE_(iface, baseiface)    interface DECLSPEC_NOVTABLE iface : public baseiface

--- a/src/coreclr/src/pal/inc/rt/rpc.h
+++ b/src/coreclr/src/pal/inc/rt/rpc.h
@@ -25,7 +25,7 @@
 #define MIDL_INTERFACE(x)   struct DECLSPEC_UUID(x) DECLSPEC_NOVTABLE
 
 #define EXTERN_GUID(itf,l1,s1,s2,c1,c2,c3,c4,c5,c6,c7,c8) \
-    EXTERN_C const IID DECLSPEC_SELECTANY itf = {l1,s1,s2,{c1,c2,c3,c4,c5,c6,c7,c8}}
+    constexpr IID itf = {l1,s1,s2,{c1,c2,c3,c4,c5,c6,c7,c8}}
 
 interface IRpcStubBuffer;
 interface IRpcChannelBuffer;

--- a/src/coreclr/src/scripts/genEtwProvider.py
+++ b/src/coreclr/src/scripts/genEtwProvider.py
@@ -164,7 +164,7 @@ def genEtwMacroHeader(manifest, exclusion_filename, intermediate):
 
         header_file.write("#define NO_OF_ETW_PROVIDERS " + str(numOfProviders) + "\n")
         header_file.write("#define MAX_BYTES_PER_ETW_PROVIDER " + str(nMaxEventBytesPerProvider) + "\n")
-        header_file.write("EXTERN_C SELECTANY const BYTE etwStackSupportedEvents[NO_OF_ETW_PROVIDERS][MAX_BYTES_PER_ETW_PROVIDER] = \n{\n")
+        header_file.write("EXTERN_C constexpr BYTE etwStackSupportedEvents[NO_OF_ETW_PROVIDERS][MAX_BYTES_PER_ETW_PROVIDER] = \n{\n")
 
         for providerNode in tree.getElementsByTagName('provider'):
             stackSupportedEvents = [0]*nMaxEventBytesPerProvider

--- a/src/coreclr/src/scripts/genEventing.py
+++ b/src/coreclr/src/scripts/genEventing.py
@@ -627,7 +627,7 @@ typedef struct _DOTNET_TRACE_CONTEXT
 
             if is_windows:
                 eventpipeProviderCtxName = providerSymbol + "_EVENTPIPE_Context"
-                Clrallevents.write('SELECTANY EVENTPIPE_TRACE_CONTEXT const ' + eventpipeProviderCtxName + ' = { W("' + providerName + '"), 0, false, 0 };\n')
+                Clrallevents.write('constexpr EVENTPIPE_TRACE_CONTEXT ' + eventpipeProviderCtxName + ' = { W("' + providerName + '"), 0, false, 0 };\n')
 
     if write_xplatheader:
         clrproviders = os.path.join(incDir, "clrproviders.h")
@@ -676,14 +676,14 @@ typedef struct _EVENT_DESCRIPTOR
                     symbolName = eventNode.getAttribute('symbol')
                     keywords = eventNode.getAttribute('keywords')
                     level = convertToLevelId(levelName)
-                    Clrproviders.write("SELECTANY EVENT_DESCRIPTOR const " + symbolName + " = { " + str(level) + ", " + hex(getKeywordsMaskCombined(keywords, keywordsToMask)) + " };\n")
+                    Clrproviders.write("constexpr EVENT_DESCRIPTOR " + symbolName + " = { " + str(level) + ", " + hex(getKeywordsMaskCombined(keywords, keywordsToMask)) + " };\n")
 
                 allProviders.append("&" + providerSymbol + "_LTTNG_Context")
 
             # define and initialize runtime providers' DOTNET_TRACE_CONTEXT depending on the platform
             if not is_windows:
                 Clrproviders.write('#define NB_PROVIDERS ' + str(nbProviders) + '\n')
-                Clrproviders.write('SELECTANY LTTNG_TRACE_CONTEXT * const ALL_LTTNG_PROVIDERS_CONTEXT[NB_PROVIDERS] = { ')
+                Clrproviders.write('constexpr LTTNG_TRACE_CONTEXT * ALL_LTTNG_PROVIDERS_CONTEXT[NB_PROVIDERS] = { ')
                 Clrproviders.write(', '.join(allProviders))
                 Clrproviders.write(' };\n')
 

--- a/src/coreclr/src/vm/stdinterfaces.cpp
+++ b/src/coreclr/src/vm/stdinterfaces.cpp
@@ -56,7 +56,7 @@ static const GUID LIBID_STDOLE2 = { 0x00020430, 0x0000, 0x0000, { 0xc0, 0x00, 0x
 
 // Until the Windows SDK is updated, just hard-code the IAgileObject IID
 #ifndef __IAgileObject_INTERFACE_DEFINED__
-EXTERN_C SELECTANY const GUID IID_IAgileObject = { 0x94ea2b94, 0xe9cc, 0x49e0, { 0xc0, 0xff, 0xee, 0x64, 0xca, 0x8f, 0x5b, 0x90 } };
+EXTERN_C constexpr GUID IID_IAgileObject = { 0x94ea2b94, 0xe9cc, 0x49e0, { 0xc0, 0xff, 0xee, 0x64, 0xca, 0x8f, 0x5b, 0x90 } };
 #endif // !__IAgileObject_INTERFACE_DEFINED__
 
 // Until the Windows SDK is updated, just hard-code the INoMarshal IID


### PR DESCRIPTION
This change replaces SELECTANY by using constexpr. It results in major
reduction of the native binaries size (3.2MB in the libcoreclr.so case)

Close #39281