### PR TITLE
Fix libraries run-test-job dependencies

### DIFF
--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -53,7 +53,7 @@ jobs:
       - ${{ if notIn(parameters.framework, 'allConfigurations', 'net472') }}:
         - ${{ format('libraries_build_{0}{1}_{2}_{3}', parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.buildConfig) }}
         # tests are built as part of product build
-        - ${{ if and(ne(parameters.archType, parameters.dependsOnTestArchitecture), ne(parameters.buildConfig, parameters.dependsOnTestBuildConfiguration)) }}:
+        - ${{ if or(ne(parameters.archType, parameters.dependsOnTestArchitecture), ne(parameters.buildConfig, parameters.dependsOnTestBuildConfiguration)) }}:
           - ${{ format('libraries_build_{0}_{1}_{2}', parameters.osGroup, parameters.dependsOnTestArchitecture, parameters.dependsOnTestBuildConfiguration) }}
       - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
         - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/39535
Before this change the run test jobs didn't have a dependency to libraries-build-job which builds the tests if the test architecture or test build config was the same as the run-test-job architecture, which is wrong, if any of those is different we need to add a dependency to the libraries build job.

#### Before:
```yml
    dependsOn:
    - checkout
    - libraries_build_Linux_arm64_Debug
    - mono__product_build_Linux_arm64_release
```

#### After: 
```yml
    dependsOn:
    - checkout
    - libraries_build_Linux_arm64_Release
    - libraries_build_Linux_x64_Release
    - mono__product_build_Linux_arm64_release
```

This was causing a race, that if the `Linux_arm64` mono and libraries build finished before the `Linux_x64` libraries build, we would try and download the test assets to run them and they wouldn't be found cause the build that produces them hasn't finish, hence no present in the artifacts.