### PR TITLE
Fix hosted crossgen2 build on arm64

### DIFF
--- a/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
+++ b/src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj
@@ -42,7 +42,7 @@
 
   <PropertyGroup>
     <CrossHostArch></CrossHostArch>
-    <CrossHostArch Condition="'$(TargetArchitecture)' == 'arm64'">x64</CrossHostArch>
+    <CrossHostArch Condition="'$(TargetArchitecture)' == 'arm64' and '$(BuildArchitecture)' == 'x64'">x64</CrossHostArch>
 
     <TargetOSComponent>unix</TargetOSComponent>
     <TargetOSComponent Condition="'$(TargetOS)' == 'Windows_NT'">win</TargetOSComponent>


### PR DESCRIPTION
crossgen2 (and by extension, runtime) fails to build on an arm64 box. This is the error I see on Fedora 32 aarch64:

    ./build.sh
    ...
    crossgen2 -> artifacts/bin/coreclr/Linux.arm64.Debug/crossgen2/crossgen2.dll
    src/coreclr/src/tools/aot/crossgen2/crossgen2.csproj(87,5): error MSB3030: Could not copy the file "artifacts/bin/coreclr/Linux.arm64.Debug//x64/libjitinterface.so" because it was not found.

The file is there, just not under the `x64` directory:

    $ find -iname libjitinterface.so
    ./artifacts/bin/coreclr/Linux.arm64.Debug/libjitinterface.so
    ./artifacts/bin/coreclr/Linux.arm64.Debug/crossgen2/libjitinterface.so
    ./artifacts/obj/coreclr/Linux.arm64.Debug/src/tools/aot/jitinterface/libjitinterface.so

The actual bug is that crossgen2 seems to assume that if the build is for an `arm64` RID, it's a cross-build, not a hosted build. Fix that by explicitly checking `BuildArchitecture` as well.

Please see https://github.com/dotnet/corefx/pull/40453 and https://github.com/dotnet/core-setup/pull/8468 for related fixes enabling building for arm64 on an arm64 machine.

I have *not* verified this change in Visual Studio.