### PR TITLE
Fix il verification tests

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Common/TypeSystemException.Resources.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/TypeSystemException.Resources.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Resources;
+using System.Reflection;
+
+// This partial file is designed to allow the runtime variant of the type system to not
+// need to support accessing these strings via the ResourceManager
+namespace Internal.TypeSystem
+{
+    partial class TypeSystemException : Exception
+    {
+        private static Lazy<ResourceManager> s_stringResourceManager =
+            new Lazy<ResourceManager>(() => new ResourceManager("Internal.TypeSystem.Strings", typeof(TypeSystemException).GetTypeInfo().Assembly));
+
+        public static string GetFormatString(ExceptionStringID id)
+        {
+            return s_stringResourceManager.Value.GetString(id.ToString(), CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/TypeSystemException.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/TypeSystemException.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Resources;
+using System.Reflection;
 
 namespace Internal.TypeSystem
 {
@@ -12,6 +15,9 @@ namespace Internal.TypeSystem
     public abstract class TypeSystemException : Exception
     {
         private string[] _arguments;
+
+        private static Lazy<ResourceManager> s_stringResourceManager =
+            new Lazy<ResourceManager>(() => new ResourceManager("Internal.TypeSystem.Strings", typeof(TypeSystemException).GetTypeInfo().Assembly));
 
         /// <summary>
         /// Gets the resource string identifier.
@@ -43,53 +49,22 @@ namespace Internal.TypeSystem
             _arguments = args;
         }
 
-        private static string GetFormatString(ExceptionStringID id)
+        public static string GetFormatString(ExceptionStringID id)
         {
-            switch (id)
-            {
-                case ExceptionStringID.ClassLoadGeneral: return SR.ClassLoadGeneral;
-                case ExceptionStringID.ClassLoadBadFormat: return SR.ClassLoadBadFormat;
-                case ExceptionStringID.ClassLoadExplicitGeneric: return SR.ClassLoadExplicitGeneric;
-                case ExceptionStringID.ClassLoadExplicitLayout: return SR.ClassLoadExplicitLayout;
-                case ExceptionStringID.ClassLoadValueClassTooLarge: return SR.ClassLoadValueClassTooLarge;
-                case ExceptionStringID.ClassLoadRankTooLarge: return SR.ClassLoadRankTooLarge;
-                case ExceptionStringID.MissingMethod: return SR.MissingMethod;
-                case ExceptionStringID.MissingField: return SR.MissingField;
-                case ExceptionStringID.InvalidProgramDefault: return SR.InvalidProgramDefault;
-                case ExceptionStringID.InvalidProgramSpecific: return SR.InvalidProgramSpecific;
-                case ExceptionStringID.InvalidProgramVararg: return SR.InvalidProgramVararg;
-                case ExceptionStringID.InvalidProgramCallVirtFinalize: return SR.InvalidProgramCallVirtFinalize;
-                case ExceptionStringID.InvalidProgramUnmanagedCallersOnly: return SR.InvalidProgramUnmanagedCallersOnly;
-                case ExceptionStringID.InvalidProgramCallAbstractMethod: return SR.InvalidProgramCallAbstractMethod;
-                case ExceptionStringID.InvalidProgramCallVirtStatic: return SR.InvalidProgramCallVirtStatic;
-                case ExceptionStringID.InvalidProgramNonStaticMethod: return SR.InvalidProgramNonStaticMethod;
-                case ExceptionStringID.InvalidProgramGenericMethod: return SR.InvalidProgramGenericMethod;
-                case ExceptionStringID.InvalidProgramNonBlittableTypes: return SR.InvalidProgramNonBlittableTypes;
-                case ExceptionStringID.BadImageFormatGeneric: return SR.BadImageFormatGeneric;
-                case ExceptionStringID.FileLoadErrorGeneric: return SR.FileLoadErrorGeneric;
-            }
-#if !DEBUG
-            throw new Exception($"Unknown Exception string id {id}");
-#else
-            return null;
-#endif
+            return s_stringResourceManager.Value.GetString(id.ToString(), CultureInfo.InvariantCulture);
         }
 
         private static string GetExceptionString(ExceptionStringID id, string[] args)
         {
             string formatString = GetFormatString(id);
-#if !DEBUG
             try
             {
-#endif
                 return String.Format(formatString, (object[])args);
-#if !DEBUG
             }
             catch
             {
                 return "[TEMPORARY EXCEPTION MESSAGE] " + id.ToString() + ": " + String.Join(", ", args);
             }
-#endif
         }
 
         /// <summary>

--- a/src/coreclr/src/tools/Common/TypeSystem/Common/TypeSystemException.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/TypeSystemException.cs
@@ -3,21 +3,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Resources;
-using System.Reflection;
 
 namespace Internal.TypeSystem
 {
     /// <summary>
     /// Base type for all type system exceptions.
     /// </summary>
-    public abstract class TypeSystemException : Exception
+    public abstract partial class TypeSystemException : Exception
     {
         private string[] _arguments;
-
-        private static Lazy<ResourceManager> s_stringResourceManager =
-            new Lazy<ResourceManager>(() => new ResourceManager("Internal.TypeSystem.Strings", typeof(TypeSystemException).GetTypeInfo().Assembly));
 
         /// <summary>
         /// Gets the resource string identifier.
@@ -49,22 +43,19 @@ namespace Internal.TypeSystem
             _arguments = args;
         }
 
-        public static string GetFormatString(ExceptionStringID id)
-        {
-            return s_stringResourceManager.Value.GetString(id.ToString(), CultureInfo.InvariantCulture);
-        }
-
         private static string GetExceptionString(ExceptionStringID id, string[] args)
         {
             string formatString = GetFormatString(id);
             try
             {
-                return String.Format(formatString, (object[])args);
+                if (formatString != null)
+                {
+                    return String.Format(formatString, (object[])args);
+                }
             }
-            catch
-            {
-                return "[TEMPORARY EXCEPTION MESSAGE] " + id.ToString() + ": " + String.Join(", ", args);
-            }
+            catch {}
+            
+            return "[TEMPORARY EXCEPTION MESSAGE] " + id.ToString() + ": " + String.Join(", ", args);
         }
 
         /// <summary>

--- a/src/coreclr/src/tools/ILVerification/ILVerification.projitems
+++ b/src/coreclr/src/tools/ILVerification/ILVerification.projitems
@@ -13,18 +13,17 @@
     <Compile Include="$(MSBuildThisFileDirectory)Verifier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)VerifierError.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <ToolsCommonPath>$(MSBuildThisFileDirectory)..\Common\</ToolsCommonPath>
+  </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Strings.resx">
       <LogicalName>ILVerification.Strings.resources</LogicalName>
     </EmbeddedResource>
-    <EmbeddedResource Include="..\Common\TypeSystem\Common\Properties\Resources.resx">
-      <GenerateSource>true</GenerateSource>
-      <ClassName>Internal.TypeSystem.SR</ClassName>
+    <EmbeddedResource Include="$(ToolsCommonPath)TypeSystem\Common\Properties\Resources.resx">
+      <LogicalName>Internal.TypeSystem.Strings.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
-  <PropertyGroup>
-    <ToolsCommonPath>$(MSBuildThisFileDirectory)..\Common\</ToolsCommonPath>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(ToolsCommonPath)TypeSystem\CodeGen\MethodDesc.CodeGen.cs">
       <Link>TypeSystem\CodeGen\MethodDesc.CodeGen.cs</Link>

--- a/src/coreclr/src/tools/ILVerification/ILVerification.projitems
+++ b/src/coreclr/src/tools/ILVerification/ILVerification.projitems
@@ -52,6 +52,9 @@
     <Compile Include="$(ToolsCommonPath)TypeSystem\Common\TypeSystemException.cs">
       <Link>TypeSystem\Common\TypeSystemException.cs</Link>
     </Compile>
+    <Compile Include="$(ToolsCommonPath)TypeSystem\Common\TypeSystemException.Resources.cs">
+      <Link>TypeSystem\Common\TypeSystemException.Resources.cs</Link>
+    </Compile>
     <Compile Include="$(ToolsCommonPath)TypeSystem\Common\Utilities\CustomAttributeTypeNameParser.cs">
       <Link>Utilities\CustomAttributeTypeNameParser.cs</Link>
     </Compile>

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ExceptionStringTests.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ExceptionStringTests.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Internal.TypeSystem;
+
+using Xunit;
+
+namespace TypeSystemTests
+{
+    public class ExceptionStringTests
+    {
+        public ExceptionStringTests()
+        {
+        }
+
+        [Fact]
+        public void TestAllExceptionIdsHaveMessages()
+        {
+            foreach(var exceptionId in (ExceptionStringID[])Enum.GetValues(typeof(ExceptionStringID)))
+            {
+                Assert.NotNull(TypeSystemException.GetFormatString(exceptionId));
+            }
+        }
+    }
+}

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun.Tests/ILCompiler.TypeSystem.ReadyToRun.Tests.csproj
@@ -56,5 +56,6 @@
     <Compile Include="StaticFieldLayoutTests.cs" />
     <Compile Include="TestTypeSystemContext.cs" />
     <Compile Include="WellKnownTypeTests.cs" />
+    <Compile Include="ExceptionStringTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -19,8 +19,7 @@
 
   <ItemGroup Label="Embedded Resources">
     <EmbeddedResource Include="..\..\Common\TypeSystem\Common\Properties\Resources.resx">
-      <GenerateSource>true</GenerateSource>
-      <ClassName>Internal.TypeSystem.SR</ClassName>
+      <LogicalName>Internal.TypeSystem.Strings.resources</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
+++ b/src/coreclr/src/tools/aot/ILCompiler.TypeSystem.ReadyToRun/ILCompiler.TypeSystem.ReadyToRun.csproj
@@ -152,6 +152,9 @@
     <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemException.cs">
       <Link>TypeSystem\Common\TypeSystemException.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\TypeSystemException.Resources.cs">
+      <Link>TypeSystem\Common\TypeSystemException.Resources.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ThrowHelper.cs">
       <Link>TypeSystem\Common\ThrowHelper.cs</Link>
     </Compile>

--- a/src/tests/ilverify/ILVerification.Tests.csproj
+++ b/src/tests/ilverify/ILVerification.Tests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <OutputPath>$(BaseOutputPathWithConfig)ilverify\</OutputPath>
+    <CLRTestPriority>1</CLRTestPriority>
+    <!-- The test uses xunit directly and it fails to find the test assembly for some reason -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="ILMethodTester.cs" />
+    <Compile Include="ILTypeVerificationTester.cs" />
+    <Compile Include="TestDataLoader.cs" />
+    <Compile Include="..\Common\XunitBase.cs" />
+  </ItemGroup>
+
+  <Import Project="..\..\coreclr\src\tools\ILVerification\ILVerification.projitems" />
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="$(XUnitVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="ILTests\*.ilproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/src/tests/ilverify/TestDataLoader.cs
+++ b/src/tests/ilverify/TestDataLoader.cs
@@ -27,7 +27,7 @@ namespace ILVerification.Tests
         /// <summary>
         /// The folder with the test binaries
         /// </summary>
-        private const string TestAssemblyPath = @"Tests\";
+        private const string TestAssemblyPath = @"Tests";
 
         private const string SpecialTestPrefix = "special.";
 
@@ -236,7 +236,7 @@ namespace ILVerification.Tests
 
             foreach (var fileName in GetAllTestDlls())
             {
-                simpleNameToPathMap.Add(Path.GetFileNameWithoutExtension(fileName), TestAssemblyPath + fileName);
+                simpleNameToPathMap.Add(Path.GetFileNameWithoutExtension(fileName), Path.Combine(TestAssemblyPath, fileName));
             }
 
             Assembly coreAssembly = typeof(object).GetTypeInfo().Assembly;


### PR DESCRIPTION
- Re-enable the test project build
- Change string resources in type system to directly use ResourceManager instead of SR abstraction which is unavaliable in the test build tree
- Add test to verify that all ExceptionStringID values have associated strings
- Use ToolsCommonPath property to successfully reference the correct resource file

Fixes #39504