### PR TITLE
[Console.ReadKey] Return the correct KeyChar on Alt+Symbol chords

### DIFF
--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -358,7 +358,7 @@ namespace System.IO
         private bool IsPotentialKeyCharacter(char keyChar)
         {
             // symbol or punctuation ascii characters
-            return keyChar < '\x00ff' && (char.IsSymbol(keyChar) || char.IsPunctuation(keyChar));
+            return keyChar < '\x0080' && (char.IsSymbol(keyChar) || char.IsPunctuation(keyChar));
         }
 
         internal bool MapBufferToConsoleKey(out ConsoleKey key, out char ch, out bool isShift, out bool isAlt, out bool isCtrl)

--- a/src/libraries/System.Console/src/System/IO/StdInReader.cs
+++ b/src/libraries/System.Console/src/System/IO/StdInReader.cs
@@ -355,6 +355,12 @@ namespace System.IO
             return default(ConsoleKey);
         }
 
+        private bool IsPotentialKeyCharacter(char keyChar)
+        {
+            // symbol or punctuation ascii characters
+            return keyChar < '\x00ff' && (char.IsSymbol(keyChar) || char.IsPunctuation(keyChar));
+        }
+
         internal bool MapBufferToConsoleKey(out ConsoleKey key, out char ch, out bool isShift, out bool isAlt, out bool isCtrl)
         {
             Debug.Assert(!IsUnprocessedBufferEmpty());
@@ -382,6 +388,14 @@ namespace System.IO
                 _startIndex++;
                 if (MapBufferToConsoleKey(out key, out ch, out isShift, out isAlt, out isCtrl))
                 {
+                    isAlt = true;
+                    return true;
+                }
+                else if (IsPotentialKeyCharacter(ch))
+                {
+                    // The char following Esc is a potential key character
+                    // which however cannot be conclusively mapped to a key chord.
+                    // Just return the keyChar with `isAlt` enabled and no ConsoleKey association.
                     isAlt = true;
                     return true;
                 }

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -116,7 +116,6 @@ namespace System
         {
             yield return MkConsoleKeyInfo('b', ConsoleKey.B, default);
             yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control);
-            yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
             yield return MkConsoleKeyInfo(OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
 
             yield return MkConsoleKeyInfo(',', OperatingSystem.IsWindows() ? ConsoleKey.OemComma : default, default);

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -114,13 +114,17 @@ namespace System
 
         public static IEnumerable<object[]> GetKeyChords()
         {
+            yield return MkConsoleKeyInfo('b', ConsoleKey.B, default);
             yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control);
             yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
             yield return MkConsoleKeyInfo(OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
+
+            yield return MkConsoleKeyInfo(',', OperatingSystem.IsWindows() ? ConsoleKey.OemComma : default, default);
+            yield return MkConsoleKeyInfo(',', OperatingSystem.IsWindows() ? ConsoleKey.OemComma : default, ConsoleModifiers.Alt);
+
             yield return MkConsoleKeyInfo('\r', ConsoleKey.Enter, (ConsoleModifiers)0);
             // windows will report '\n' as 'Ctrl+Enter', which is typically not picked up by Unix terminals
             yield return MkConsoleKeyInfo('\n', OperatingSystem.IsWindows() ? ConsoleKey.Enter : ConsoleKey.J, ConsoleModifiers.Control);
-            yield return MkConsoleKeyInfo(',', OperatingSystem.IsWindows() ? ConsoleKey.OemComma : default, ConsoleModifiers.Alt);
 
             static object[] MkConsoleKeyInfo (char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
             {

--- a/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
+++ b/src/libraries/System.Console/tests/ManualTests/ManualTests.cs
@@ -107,17 +107,20 @@ namespace System
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Control)) modifiers += "Ctrl+";
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Alt)) modifiers += "Alt+";
                 if (key.Modifiers.HasFlag(ConsoleModifiers.Shift)) modifiers += "Shift+";
-                return modifiers + key.Key;
+                string keyId = (key.Key == default) ? key.KeyChar.ToString() : key.Key.ToString();
+                return modifiers + keyId;
             }
         }
 
         public static IEnumerable<object[]> GetKeyChords()
         {
             yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control);
+            yield return MkConsoleKeyInfo('\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
             yield return MkConsoleKeyInfo(OperatingSystem.IsWindows() ? '\x00' : '\x02', ConsoleKey.B, ConsoleModifiers.Control | ConsoleModifiers.Alt);
             yield return MkConsoleKeyInfo('\r', ConsoleKey.Enter, (ConsoleModifiers)0);
             // windows will report '\n' as 'Ctrl+Enter', which is typically not picked up by Unix terminals
             yield return MkConsoleKeyInfo('\n', OperatingSystem.IsWindows() ? ConsoleKey.Enter : ConsoleKey.J, ConsoleModifiers.Control);
+            yield return MkConsoleKeyInfo(',', OperatingSystem.IsWindows() ? ConsoleKey.OemComma : default, ConsoleModifiers.Alt);
 
             static object[] MkConsoleKeyInfo (char keyChar, ConsoleKey consoleKey, ConsoleModifiers modifiers)
             {

--- a/src/libraries/System.Console/tests/ManualTests/System.Console.Manual.Tests.csproj
+++ b/src/libraries/System.Console/tests/ManualTests/System.Console.Manual.Tests.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="ManualTests.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="Readme.md" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Contributes to #802.

Attempts to address an issue on Unix where using `Console.ReadKey()` to read <kbd>Alt</kbd> + symbol chords will return the Escape character. For example:
```
$ dotnet fsi

> System.Console.ReadKey() ;; // Alt + #
val it : System.ConsoleKeyInfo = System.ConsoleKeyInfo {Key = Escape;
                                                        KeyChar = '\027';
                                                        Modifiers = 0;}
```
The current behaviour is by design, escape is returned whenever the trailing character cannot be conclusively mapped to a keychord. However this often results in loss of information in otherwise legal key chords.

This PR adds a conservative change, where if the trailing character is an ASCII symbol, then that character will be returned instead of Escape:
```
> System.Console.ReadKey() ;; // Alt + #
#val it : System.ConsoleKeyInfo = System.ConsoleKeyInfo {Key = 0;
                                                        KeyChar = '#';
                                                        Modifiers = Alt;}
```

Note that this change will still drop valid keychords (e.g. <kbd>Alt</kbd> + <kbd>£</kbd> in UK keyboard layouts).

Should be merged after #39460.