### PR TITLE
Implement IComparable on Rune

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -3757,6 +3757,9 @@
   <data name="Arg_MustBeHalf" xml:space="preserve">
     <value>Object must be of type Half.</value>
   </data>
+  <data name="Arg_MustBeRune" xml:space="preserve">
+    <value>Object must be of type Rune.</value>
+  </data>
   <data name="BinaryFormatter_SerializationDisallowed" xml:space="preserve">
     <value>BinaryFormatter serialization and deserialization are disabled within this application. See https://aka.ms/binaryformatter for more information.</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -269,13 +269,7 @@ namespace System.Text
         }
 #endif
 
-        public int CompareTo(Rune other)
-        {
-            // Since Unicode scalar values don't span the entire 32-bit domain, we can get away with using a
-            // simple subtraction without worrying about integer overflow.
-
-            return this.Value - other.Value;
-        }
+        public int CompareTo(Rune other) => this.Value - other.Value; // values don't span entire 32-bit domain; won't integer overflow
 
         /// <summary>
         /// Decodes the <see cref="Rune"/> at the beginning of the provided UTF-16 source buffer.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -1444,6 +1444,7 @@ namespace System.Text
 #endif
         }
 
+        /// <inheritdoc cref="IComparable.CompareTo" />
         int IComparable.CompareTo(object? obj)
         {
             if (obj is null)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10565,7 +10565,7 @@ namespace System.Text
         FormKC = 5,
         FormKD = 6,
     }
-    public readonly partial struct Rune : System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>
+    public readonly partial struct Rune : System.IComparable, System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>
     {
         private readonly int _dummyPrimitive;
         public Rune(char ch) { throw null; }
@@ -10630,6 +10630,7 @@ namespace System.Text
         public bool TryEncodeToUtf16(System.Span<char> destination, out int charsWritten) { throw null; }
         public bool TryEncodeToUtf8(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public static bool TryGetRuneAt(string input, int index, out System.Text.Rune value) { throw null; }
+        int System.IComparable.CompareTo(object? obj) { throw null; }
     }
     public sealed partial class StringBuilder : System.Runtime.Serialization.ISerializable
     {

--- a/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
@@ -157,6 +157,7 @@ namespace System.Text.Tests
             Rune b = new Rune(other);
 
             Assert.Equal(expectedSign, Math.Sign(a.CompareTo(b)));
+            Assert.Equal(expectedSign, Math.Sign(((IComparable)a).CompareTo(b)));
             Assert.Equal(expectedSign < 0, a < b);
             Assert.Equal(expectedSign <= 0, a <= b);
             Assert.Equal(expectedSign > 0, a > b);
@@ -474,7 +475,24 @@ namespace System.Text.Tests
             Assert.Equal(scalarValueLeft <= scalarValueRight, left <= right);
             Assert.Equal(scalarValueLeft > scalarValueRight, left > right);
             Assert.Equal(scalarValueLeft >= scalarValueRight, left >= right);
-            Assert.Equal(scalarValueLeft.CompareTo(scalarValueRight), left.CompareTo(right));
+            Assert.Equal(Math.Sign(scalarValueLeft.CompareTo(scalarValueRight)), Math.Sign(left.CompareTo(right)));
+            Assert.Equal(Math.Sign(((IComparable)scalarValueLeft).CompareTo(scalarValueRight)), Math.Sign(((IComparable)left).CompareTo(right)));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(0x10FFFF)]
+        public static void NonGenericCompareTo_NonNullAlwaysGreaterThanNull(uint scalarValue)
+        {
+            Assert.Equal(1, Math.Sign(((IComparable)new Rune(scalarValue)).CompareTo(null)));
+        }
+
+        [Fact]
+        public static void NonGenericCompareTo_GivenNonRuneArgument_ThrowsArgumentException()
+        {
+            IComparable rune = new Rune(0);
+
+            Assert.Throws<ArgumentException>(() => rune.CompareTo(0 /* int32 */));
         }
 
         [Fact]

--- a/src/libraries/System.Utf8String.Experimental/ref/System.Utf8String.Experimental.Rune.cs
+++ b/src/libraries/System.Utf8String.Experimental/ref/System.Utf8String.Experimental.Rune.cs
@@ -6,7 +6,7 @@
 
 namespace System.Text
 {
-    public readonly partial struct Rune : System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>
+    public readonly partial struct Rune : System.IComparable, System.IComparable<System.Text.Rune>, System.IEquatable<System.Text.Rune>
     {
         private readonly int _dummyPrimitive;
         public Rune(char ch) { throw null; }
@@ -71,5 +71,6 @@ namespace System.Text
         public bool TryEncodeToUtf16(System.Span<char> destination, out int charsWritten) { throw null; }
         public bool TryEncodeToUtf8(System.Span<byte> destination, out int bytesWritten) { throw null; }
         public static bool TryGetRuneAt(string input, int index, out System.Text.Rune value) { throw null; }
+        int IComparable.CompareTo(object? obj) { throw null; }
     }
 }

--- a/src/libraries/System.Utf8String.Experimental/src/Resources/Strings.resx
+++ b/src/libraries/System.Utf8String.Experimental/src/Resources/Strings.resx
@@ -165,4 +165,7 @@
   <data name="Utf8String_InputContainedMalformedUtf8" xml:space="preserve">
     <value>The input buffer contained ill-formed UTF-8 data.</value>
   </data>
+  <data name="Arg_MustBeRune" xml:space="preserve">
+    <value>Object must be of type Rune.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/2340.

Adds the `IComparable` interface to `System.Text.Rune`. Follows the same implementation used by `int.CompareTo(object)` and similar methods: _null_ always compares as "less than" _non-null_, and if _obj_ is not null and not a `Rune` an exception is thrown.