### PR TITLE
Remove unused locals in System.Configuration.ConfigurationManager

### DIFF
--- a/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/GenericEnumConverterTest.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/Mono/GenericEnumConverterTest.cs
@@ -49,9 +49,9 @@ namespace MonoTests.System.Configuration
         }
 
         [Fact]
-        public void Ctor_TypeError()
+        public void Ctor_Object()
         {
-            GenericEnumConverter cv = new GenericEnumConverter(typeof(object));
+            Assert.NotNull(new GenericEnumConverter(typeof(object)));
         }
 
         [Fact]

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/CallBackValidatorAttributeTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/CallBackValidatorAttributeTests.cs
@@ -56,7 +56,7 @@ namespace System.Configuration
                 Type = typeof(CallBackValidatorAttributeTests),
                 CallbackMethodName = "CallBackValidatorTestMethod"
             };
-            var response = testCallBackValidatorAttribute.ValidatorInstance;
+            _ = testCallBackValidatorAttribute.ValidatorInstance;
             Assert.IsType<CallbackValidator>(testCallBackValidatorAttribute.ValidatorInstance);
         }
 

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingElementTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingElementTests.cs
@@ -74,7 +74,8 @@ namespace System.Configuration.Tests
                 }
             };
 
-            Assert.NotEqual(new SettingElement().Value.GetHashCode(), Element.Value.GetHashCode());
+            // Validate the getting the hash code doesn't throw
+            _ = Element.GetHashCode();
         }
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingElementTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/SettingElementTests.cs
@@ -73,6 +73,8 @@ namespace System.Configuration.Tests
                     }
                 }
             };
+
+            Assert.NotEqual(new SettingElement().Value.GetHashCode(), Element.Value.GetHashCode());
         }
     }
 }

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/StringValidatorTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/StringValidatorTests.cs
@@ -42,7 +42,7 @@ namespace System.ConfigurationTests
         public void Validate_StringTooBig()
         {
             StringValidator validator = new StringValidator(5, 10);
-            ArgumentException thrownException = AssertExtensions.Throws<ArgumentException>(null, () => validator.Validate("This is more than ten"));
+            AssertExtensions.Throws<ArgumentException>(null, () => validator.Validate("This is more than ten"));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace System.ConfigurationTests
         public void Validate_UsinginvalidCharacters(string stringToValidate)
         {
             StringValidator validator = new StringValidator(1, 20, "_-");
-            ArgumentException result = AssertExtensions.Throws<ArgumentException>(null, () => validator.Validate(stringToValidate));
+            AssertExtensions.Throws<ArgumentException>(null, () => validator.Validate(stringToValidate));
         }
 
         [Fact]

--- a/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/tests/System/Configuration/UrlPathTests.cs
@@ -14,7 +14,7 @@ namespace System.ConfigurationTests
         public void GetDirectoryOrRootName_Null()
         {
             string test = UrlPath.GetDirectoryOrRootName(null);
-            Assert.Null(null);
+            Assert.Null(test);
         }
 
         [Fact]


### PR DESCRIPTION
Removed unused locals in System.Configuration.ConfigurationManager. In a few places tests needed to be updated as they had no asserts, or asserted things that were always true.

Fixes a part of #30457