### PR TITLE
Disable slow tests under GCStress

### DIFF
--- a/src/tests/baseservices/threading/interlocked/compareexchange/CompareExchangeTString.csproj
+++ b/src/tests/baseservices/threading/interlocked/compareexchange/CompareExchangeTString.csproj
@@ -5,6 +5,11 @@
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <CLRTestPriority>1</CLRTestPriority>
     <CLRTestExecutionArguments>"hello"</CLRTestExecutionArguments>
+    <!-- This test isn't technically incompatible with GCStress, but it ends up running very slowly
+         in some configurations, e.g., GCStress=3 on Linux/arm32 measured at over 30 minutes (on
+         Windows x64, just over one minute).
+    -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compareexchangetstring.cs" />

--- a/src/tests/baseservices/threading/regressions/beta2/437044.csproj
+++ b/src/tests/baseservices/threading/regressions/beta2/437044.csproj
@@ -2,6 +2,10 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <CLRTestPriority>1</CLRTestPriority>
+    <!-- This test isn't technically incompatible with GCStress, but it ends up running very slowly
+         in some configurations, e.g. GCStress=3 on Linux/arm32 measured at 20 minutes.
+    -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="437044.cs" />

--- a/src/tests/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
+++ b/src/tests/tracing/eventpipe/eventsvalidation/ExceptionThrown_V1.csproj
@@ -7,6 +7,10 @@
     <CLRTestPriority>1</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- This test isn't technically incompatible with GCStress, but it ends up running very slowly
+         in some configurations, e.g. GCStress=3 on Linux/arm32 measured at 15 minutes.
+    -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ExceptionThrown_V1.cs" />


### PR DESCRIPTION
Some tests are very slow under GCStress for some platforms, especially
Linux arm32 and for GCStress=3. Disable these tests under GCStress.

https://github.com/dotnet/runtime/issues/2231