### PR TITLE
Remove unused local variables and methods from System.Drawing.Common

### DIFF
--- a/src/libraries/System.Drawing.Common/tests/BufferedGraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/BufferedGraphicsTests.cs
@@ -72,8 +72,6 @@ namespace System.Drawing.Tests
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Render_ParameterlessWithNullTargetGraphics_Success()
         {
-            Color color = Color.FromArgb(255, 0, 0, 0);
-
             using (var context = new BufferedGraphicsContext())
             using (var image = new Bitmap(3, 3))
             using (Graphics graphics = Graphics.FromImage(image))

--- a/src/libraries/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Drawing2D/GraphicsPathIteratorTests.cs
@@ -251,7 +251,6 @@ namespace System.Drawing.Drawing2D.Tests
                 gp.StartFigure();
                 gp.AddLine(20, 21, 22, 23);
                 gp.AddBezier(5, 6, 7, 8, 9, 10, 11, 12);
-                byte[] types = new byte[] { 0, 3, 3, 3, 1, 33, 0, 1 };
 
                 using (GraphicsPathIterator gpi = new GraphicsPathIterator(gp))
                 {

--- a/src/libraries/System.Drawing.Common/tests/FontTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/FontTests.cs
@@ -714,7 +714,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     var logFont = new UnblittableLOGFONT

--- a/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/GraphicsTests.cs
@@ -63,7 +63,7 @@ namespace System.Drawing.Tests
             using (var bitmap = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(bitmap))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.GetHdc());
@@ -416,7 +416,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.CompositingMode);
@@ -510,7 +510,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.CompositingQuality);
@@ -573,7 +573,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DpiX);
@@ -604,7 +604,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DpiX);
@@ -656,7 +656,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.Flush());
@@ -730,7 +730,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.InterpolationMode);
@@ -792,7 +792,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.PageScale);
@@ -864,7 +864,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.PageUnit);
@@ -935,7 +935,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.PixelOffsetMode);
@@ -1004,7 +1004,6 @@ namespace System.Drawing.Tests
         [MemberData(nameof(RenderingOrigin_TestData))]
         public void RenderingOrigin_SetToCustom_RendersExpected(Point renderingOrigin, Color[][] expectedRendering)
         {
-            Color empty = Color.FromArgb(255, 0, 0, 0);
             Color red = Color.FromArgb(Color.Red.ToArgb());
 
             using (var image = new Bitmap(3, 3))
@@ -1026,7 +1025,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.RenderingOrigin);
@@ -1097,7 +1096,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.SmoothingMode);
@@ -1156,7 +1155,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.TextContrast);
@@ -1218,7 +1217,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.TextRenderingHint);
@@ -1315,7 +1314,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var matrix = new Matrix())
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.Transform);
@@ -1364,7 +1363,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.ResetTransform());
@@ -1483,7 +1482,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var matrix = new Matrix())
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.MultiplyTransform(matrix));
@@ -1570,7 +1569,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.TranslateTransform(0, 0));
@@ -1664,7 +1663,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.ScaleTransform(0, 0));
@@ -1751,7 +1750,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.RotateTransform(0));
@@ -1814,8 +1813,6 @@ namespace System.Drawing.Tests
         [InlineData(1, 1, 2, 2, 3, 3)]
         public void CopyFromScreen_ValidRange_AffectsGraphics(int sourceX, int sourceY, int destinationX, int destinationY, int width, int height)
         {
-            Size screenSize = Helpers.GetHWndRect(IntPtr.Zero).Size;
-
             Color color = Color.FromArgb(2, 3, 4);
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
@@ -1934,7 +1931,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.CopyFromScreen(0, 0, 0, 0, Size.Empty));
@@ -2198,7 +2195,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.TransformPoints(CoordinateSpace.Page, CoordinateSpace.Page, new Point[] { Point.Empty }));
@@ -2250,7 +2247,7 @@ namespace System.Drawing.Tests
             using (var image = new Bitmap(10, 10))
             using (Graphics graphics = Graphics.FromImage(image))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.GetNearestColor(Color.Red));
@@ -2344,7 +2341,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawArc(pen, new Rectangle(0, 0, 1, 1), 0, 90));
@@ -2412,7 +2409,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawRectangle(pen, new Rectangle(0, 0, 1, 1)));
@@ -2498,7 +2495,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawRectangles(pen, new Rectangle[2]));
@@ -2563,7 +2560,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawEllipse(pen, new Rectangle(0, 0, 1, 1)));
@@ -2661,7 +2658,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawPie(pen, new Rectangle(0, 0, 1, 1), 0, 90));
@@ -2751,7 +2748,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawPolygon(pen, new Point[2]));
@@ -2837,7 +2834,7 @@ namespace System.Drawing.Tests
             using (var pen = new Pen(Color.Red))
             using (var graphicsPath = new GraphicsPath())
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawPath(pen, graphicsPath));
@@ -2961,7 +2958,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawCurve(pen, new Point[2]));
@@ -3066,7 +3063,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawClosedCurve(pen, new Point[3]));
@@ -3125,7 +3122,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.Clear(Color.Red));

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawBezierTests.cs
@@ -101,7 +101,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawBezier(pen, 1, 2, 3, 4, 5, 6, 7, 8));
@@ -190,7 +190,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawBeziers(pen, new Point[2]));

--- a/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Graphics_DrawLineTests.cs
@@ -76,7 +76,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawLine(pen, Point.Empty, Point.Empty));
@@ -166,7 +166,7 @@ namespace System.Drawing.Tests
             using (Graphics graphics = Graphics.FromImage(image))
             using (var pen = new Pen(Color.Red))
             {
-                IntPtr hdc = graphics.GetHdc();
+                graphics.GetHdc();
                 try
                 {
                     Assert.Throws<InvalidOperationException>(() => graphics.DrawLines(pen, new Point[2]));

--- a/src/libraries/System.Drawing.Common/tests/Imaging/ColorMatrixTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Imaging/ColorMatrixTests.cs
@@ -155,7 +155,7 @@ namespace System.Drawing.Imaging.Tests
                 new float[] { 4.0f, 4.1f, 4.2f, 4.3f, 4.4f, 4.5f },
                 new float[] { 5.0f, 5.1f, 5.2f, 5.3f, 5.4f, 5.5f }
             });
-            Assert.Throws<IndexOutOfRangeException>(() => { var x = cm[5, 5]; });
+            Assert.Throws<IndexOutOfRangeException>(() => _ = cm[5, 5]);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]

--- a/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -49,6 +49,7 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             bool canDuplex = printerSettings.CanDuplex;
+            Assert.True(canDuplex);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -56,6 +57,7 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             int copies = printerSettings.Copies;
+            Assert.Equal(1, copies);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -85,6 +87,7 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             bool collate = printerSettings.Collate;
+            Assert.True(collate);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -397,6 +400,7 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             bool supported = printerSettings.IsDirectPrintingSupported(imageFormat);
+            Assert.True(supported);
         }
 
         public static IEnumerable<object[]> IsDirectPrintingSupported_ImageFormatNotSupported_TestData()

--- a/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/Printing/PrinterSettingsTests.cs
@@ -49,7 +49,6 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             bool canDuplex = printerSettings.CanDuplex;
-            Assert.True(canDuplex);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -57,7 +56,6 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             int copies = printerSettings.Copies;
-            Assert.Equal(1, copies);
         }
 
         [ConditionalTheory(Helpers.IsDrawingSupported)]
@@ -87,7 +85,6 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             bool collate = printerSettings.Collate;
-            Assert.True(collate);
         }
 
         [ConditionalFact(Helpers.IsDrawingSupported)]
@@ -400,7 +397,6 @@ namespace System.Drawing.Printing.Tests
         {
             var printerSettings = new PrinterSettings();
             bool supported = printerSettings.IsDirectPrintingSupported(imageFormat);
-            Assert.True(supported);
         }
 
         public static IEnumerable<object[]> IsDirectPrintingSupported_ImageFormatNotSupported_TestData()

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/BitmapTests.cs
@@ -528,8 +528,6 @@ namespace MonoTests.System.Drawing
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void Rotate1bit4bit(string file, RotateFlipType type, string md5)
         {
-            StringBuilder md5s = new StringBuilder();
-
             using (Bitmap bmp = new Bitmap(Helpers.GetTestBitmapPath(file)))
             {
                 Assert.Equal(md5, RotateIndexedBmp(bmp, type));
@@ -885,20 +883,6 @@ namespace MonoTests.System.Drawing
                 bmp.UnlockBits(data);
                 bmp.Dispose();
             }
-        }
-
-        private Stream Serialize(object o)
-        {
-            MemoryStream ms = new MemoryStream();
-            IFormatter formatter = new BinaryFormatter();
-            formatter.Serialize(ms, o);
-            ms.Position = 0;
-            return ms;
-        }
-
-        private object Deserialize(Stream s)
-        {
-            return new BinaryFormatter().Deserialize(s);
         }
 
         static int[] palette1 = {

--- a/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
+++ b/src/libraries/System.Drawing.Common/tests/mono/System.Drawing/GraphicsTests.cs
@@ -687,15 +687,6 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        private void CheckBoundsInt(string msg, RectangleF bounds, int x, int y, int w, int h)
-        {
-            // currently bounds are rounded at 8 pixels (FIXME - we can go down to 1 pixel)
-            AssertEquals(msg + ".X", x, bounds.X, -1);
-            AssertEquals(msg + ".Y", y, bounds.Y, -1);
-            AssertEquals(msg + ".Width", w, bounds.Width, -1);
-            AssertEquals(msg + ".Height", h, bounds.Height, -1);
-        }
-
         [ConditionalFact(Helpers.IsDrawingSupported)]
         public void Clip_ScaleTransform_NoBoundsChange()
         {
@@ -777,7 +768,6 @@ namespace MonoTests.System.Drawing
             }
         }
 
-        static Point[] SmallCurve = new Point[3] { new Point(0, 0), new Point(15, 5), new Point(5, 15) };
         static PointF[] SmallCurveF = new PointF[3] { new PointF(0, 0), new PointF(15, 5), new PointF(5, 15) };
 
         static Point[] TooSmallCurve = new Point[2] { new Point(0, 0), new Point(15, 5) };


### PR DESCRIPTION
Remove unused locals, and update a few unit tests that had no asserts.

Fixes a part of #30457