### PR TITLE
Remove unused locals in System.IO.FileSystem.*

### DIFF
--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -478,7 +478,7 @@ namespace System.IO
             string path = Path.Combine(directory.Path, "createMe");
 
             DirectorySecurity basicSecurity = new DirectorySecurity();
-            DirectoryInfo basicDirInfo = basicSecurity.CreateDirectory(path);
+            basicSecurity.CreateDirectory(path);
 
             Assert.True(Directory.Exists(path));
 
@@ -534,7 +534,7 @@ namespace System.IO
             using var directory = new TempDirectory();
             string path = Path.Combine(directory.Path, "createMe");
 
-            DirectoryInfo createdInfo = expectedSecurity.CreateDirectory(path);
+            expectedSecurity.CreateDirectory(path);
 
             Assert.True(Directory.Exists(path));
 

--- a/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/tests/FileSystemSecurityTests.cs
@@ -423,7 +423,7 @@ namespace System.IO
             // - NetCore: a valid name because long paths are correctly handled, and non-existent, as expected
             AssertExtensions.Throws<DirectoryNotFoundException, ArgumentException>(() =>
             {
-                var security = new DirectorySecurity(longDir, AccessControlSections.Owner);
+                new DirectorySecurity(longDir, AccessControlSections.Owner);
             });
             
         }
@@ -440,7 +440,7 @@ namespace System.IO
             // - NetCore: a valid name because long paths are correctly handled, and non-existent, as expected
             AssertExtensions.Throws<FileNotFoundException, ArgumentException>(() =>
             {
-                var security = new FileSecurity(filePath, AccessControlSections.Owner);
+                new FileSecurity(filePath, AccessControlSections.Owner);
             });
         }
 

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -59,7 +59,7 @@ namespace System.IO
                 finally
                 {
                     if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
+                        Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
                 return userBytes;
             }
@@ -81,7 +81,7 @@ namespace System.IO
                 finally
                 {
                     if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
+                        Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
                 return freeBytes;
             }
@@ -95,7 +95,7 @@ namespace System.IO
                 // or other various removable media drives.
                 long userBytes, totalBytes, freeBytes;
                 uint oldMode;
-                bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
+                Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
                 try
                 {
                     bool r = Interop.Kernel32.GetDiskFreeSpaceEx(Name, out userBytes, out totalBytes, out freeBytes);
@@ -104,7 +104,7 @@ namespace System.IO
                 }
                 finally
                 {
-                    Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
+                    Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
                 return totalBytes;
             }
@@ -159,7 +159,7 @@ namespace System.IO
                 finally
                 {
                     if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out oldMode);
+                        Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
             }
         }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableAPIs.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/EnumerableAPIs.cs
@@ -94,8 +94,8 @@ namespace System.IO.Tests
         public void Delete_Directory_After_Creating_Enumerable()
         {
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            DirectoryInfo subDir1 = Directory.CreateDirectory(Path.Combine(testDir.FullName, "a"));
-            DirectoryInfo subDir2 = Directory.CreateDirectory(Path.Combine(testDir.FullName, "b"));
+            Directory.CreateDirectory(Path.Combine(testDir.FullName, "a"));
+            Directory.CreateDirectory(Path.Combine(testDir.FullName, "b"));
             var enumerator = Directory.EnumerateDirectories(testDir.FullName);
             foreach (var dir in enumerator)
             {
@@ -110,8 +110,8 @@ namespace System.IO.Tests
         {
             // A searchpattern of c:\temp\ will become c:\temp\* internally
             DirectoryInfo testDir = Directory.CreateDirectory(GetTestFilePath());
-            DirectoryInfo subDir1 = Directory.CreateDirectory(Path.Combine(testDir.FullName, "a"));
-            DirectoryInfo subDir2 = Directory.CreateDirectory(Path.Combine(testDir.FullName, "b"));
+            Directory.CreateDirectory(Path.Combine(testDir.FullName, "a"));
+            Directory.CreateDirectory(Path.Combine(testDir.FullName, "b"));
             var enumerator = Directory.EnumerateDirectories(testDir.FullName, "a" + Path.DirectorySeparatorChar);
             Assert.Equal(0, enumerator.ToArray().Length);
         }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -44,7 +44,7 @@ namespace System.IO.Tests
         public void ValidPathExists_ReturnsTrue(string component)
         {
             string path = Path.Combine(TestDirectory, component);
-            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Directory.CreateDirectory(path);
             Assert.True(Exists(path));
         }
 
@@ -73,7 +73,7 @@ namespace System.IO.Tests
         public void PathAlreadyExistsAsDirectory()
         {
             string path = GetTestFilePath();
-            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             Assert.True(Exists(IOServices.RemoveTrailingSlash(path)));
             Assert.True(Exists(IOServices.RemoveTrailingSlash(IOServices.RemoveTrailingSlash(path))));
@@ -177,7 +177,7 @@ namespace System.IO.Tests
         public void ValidExtendedPathExists_ReturnsTrue(string component)
         {
             string path = IOInputs.ExtendedPrefix + Path.Combine(TestDirectory, "extended", component);
-            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Directory.CreateDirectory(path);
             Assert.True(Exists(path));
         }
 
@@ -198,7 +198,7 @@ namespace System.IO.Tests
         public void ExtendedPathAlreadyExistsAsDirectory()
         {
             string path = IOInputs.ExtendedPrefix + GetTestFilePath();
-            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             Assert.True(Exists(IOServices.RemoveTrailingSlash(path)));
             Assert.True(Exists(IOServices.RemoveTrailingSlash(IOServices.RemoveTrailingSlash(path))));
@@ -278,7 +278,7 @@ namespace System.IO.Tests
         {
             // Windows trims spaces
             string path = GetTestFilePath();
-            DirectoryInfo testDir = Directory.CreateDirectory(path + component);
+            Directory.CreateDirectory(path + component);
             Assert.True(Exists(path), "can find without space");
             Assert.True(Exists(path + component), "can find with space");
         }

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str.cs
@@ -682,7 +682,7 @@ namespace System.IO.Tests
         {
             string testDir1Str = GetTestFileName();
             DirectoryInfo testDir = new DirectoryInfo(TestDirectory);
-            DirectoryInfo testDir1 = testDir.CreateSubdirectory(testDir1Str);
+            testDir.CreateSubdirectory(testDir1Str);
 
             using (File.Create(Path.Combine(TestDirectory, testDir1Str, GetTestFileName())))
             using (File.Create(Path.Combine(TestDirectory, GetTestFileName())))

--- a/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/GetFileSystemEntries_str_str_so.cs
@@ -32,7 +32,7 @@ namespace System.IO.Tests
         {
             string testDir1Str = GetTestFileName();
             DirectoryInfo testDir = new DirectoryInfo(TestDirectory);
-            DirectoryInfo testDir1 = testDir.CreateSubdirectory(testDir1Str);
+            testDir.CreateSubdirectory(testDir1Str);
 
             using (File.Create(Path.Combine(TestDirectory, testDir1Str, GetTestFileName())))
             using (File.Create(Path.Combine(TestDirectory, GetTestFileName())))

--- a/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Directory/SetCurrentDirectory.cs
@@ -64,8 +64,6 @@ namespace System.IO.Tests
                     Assert.True(Directory.Exists(linkPath), "linkPath should exist");
 
                     // Set Current Directory to symlink
-                    string currentDir = Directory.GetCurrentDirectory();
-
                     Directory.SetCurrentDirectory(linkPath);
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                     {

--- a/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/Exists.cs
@@ -104,7 +104,7 @@ namespace System.IO.Tests
         public void PathAlreadyExistsAsDirectory()
         {
             string path = GetTestFilePath();
-            DirectoryInfo testDir = Directory.CreateDirectory(path);
+            Directory.CreateDirectory(path);
 
             Assert.False(Exists(IOServices.RemoveTrailingSlash(path)));
             Assert.False(Exists(IOServices.RemoveTrailingSlash(IOServices.RemoveTrailingSlash(path))));

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytes.cs
@@ -22,7 +22,6 @@ namespace System.IO.Tests
         [Fact]
         public void InvalidParameters()
         {
-            string path = GetTestFilePath();
             Assert.Throws<ArgumentException>(() => File.WriteAllBytes(string.Empty, new byte[0]));
             Assert.Throws<ArgumentException>(() => File.ReadAllBytes(string.Empty));
         }

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllBytesAsync.cs
@@ -24,7 +24,6 @@ namespace System.IO.Tests
         [Fact]
         public async Task InvalidParametersAsync()
         {
-            string path = GetTestFilePath();
             await Assert.ThrowsAsync<ArgumentException>("path", async () => await File.WriteAllBytesAsync(string.Empty, new byte[0]));
             await Assert.ThrowsAsync<ArgumentException>("path", async () => await File.ReadAllBytesAsync(string.Empty));
         }

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllText.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllText.cs
@@ -28,7 +28,6 @@ namespace System.IO.Tests
         [Fact]
         public void NullParameters()
         {
-            string path = GetTestFilePath();
             Assert.Throws<ArgumentNullException>(() => Write(null, "Text"));
             Assert.Throws<ArgumentNullException>(() => Read(null));
         }
@@ -58,7 +57,6 @@ namespace System.IO.Tests
         [Fact]
         public void InvalidParameters()
         {
-            string path = GetTestFilePath();
             Assert.Throws<ArgumentException>(() => Write(string.Empty, "Text"));
             Assert.Throws<ArgumentException>(() => Read(""));
         }

--- a/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllTextAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/File/ReadWriteAllTextAsync.cs
@@ -26,7 +26,6 @@ namespace System.IO.Tests
         [Fact]
         public async Task NullParametersAsync()
         {
-            string path = GetTestFilePath();
             await Assert.ThrowsAsync<ArgumentNullException>("path", async () => await WriteAsync(null, "Text"));
             await Assert.ThrowsAsync<ArgumentNullException>("path", async () => await ReadAsync(null));
         }
@@ -54,7 +53,6 @@ namespace System.IO.Tests
         [Fact]
         public async Task InvalidParametersAsync()
         {
-            string path = GetTestFilePath();
             await Assert.ThrowsAsync<ArgumentException>("path", async () => await WriteAsync(string.Empty, "Text"));
             await Assert.ThrowsAsync<ArgumentException>("path", async () => await ReadAsync(""));
         }

--- a/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileInfo/GetSetTimes.cs
@@ -186,12 +186,9 @@ namespace System.IO.Tests
         public void DeleteAfterEnumerate_TimesStillSet()
         {
             // When enumerating we populate the state as we already have it.
-            DateTime beforeTime = DateTime.UtcNow.AddSeconds(-1);
             string filePath = GetTestFilePath();
             File.Create(filePath).Dispose();
             FileInfo info = new DirectoryInfo(TestDirectory).EnumerateFiles().First();
-
-            DateTime afterTime = DateTime.UtcNow.AddSeconds(1);
 
             info.Delete();
             Assert.Equal(DateTime.FromFileTimeUtc(0), info.LastAccessTimeUtc);

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/CopyToAsync.cs
@@ -104,7 +104,7 @@ namespace System.IO.Tests
                 // If configured to expose the handle, do so.  This influences the stream's need to ensure the position is in sync.
                 if (exposeHandle)
                 {
-                    var ignored = src.SafeFileHandle;
+                    _ = src.SafeFileHandle;
                 }
 
                 // If configured to "preWrite", do a write before we start reading.

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/Dispose.cs
@@ -193,7 +193,7 @@ namespace System.IO.Tests
 
             Action act = () => // separate method to avoid JIT lifetime-extension issues
             {
-                var fs2 = new MyFileStream(GetTestFilePath(), FileMode.Create)
+                new MyFileStream(GetTestFilePath(), FileMode.Create)
                 {
                     DisposeMethod = (disposing) =>
                     {

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -52,7 +52,7 @@ namespace System.IO.Tests
                 // other handle doesn't yet see the change
                 Assert.Equal(0, fsr.Length);
 
-                SafeFileHandle handle = fs.SafeFileHandle;
+                _ = fs.SafeFileHandle;
 
                 // expect the handle to be flushed
                 Assert.Equal(TestBuffer.Length, fsr.Length);

--- a/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/libraries/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -311,7 +311,7 @@ namespace System.IO.Tests
                 }
                 if (exposeHandle)
                 {
-                    var ignored = fs.SafeFileHandle;
+                    _ = fs.SafeFileHandle;
                 }
 
                 Task[] writes = new Task[numWrites];

--- a/src/libraries/System.IO.FileSystem/tests/PortedCommon/CommonUtilities.cs
+++ b/src/libraries/System.IO.FileSystem/tests/PortedCommon/CommonUtilities.cs
@@ -262,9 +262,6 @@ public class ManageFileSystem : IDisposable
         //we will not include this directory
         //        m_listOfAllDirs.Add(m_startDir);
 
-        string currentWorkingDir = _startDir;
-        string parentDir = _startDir;
-
         _allDirs = new Dictionary<int, Dictionary<string, List<string>>>();
         //        List<String> dirsForOneLevel = new List<String>();
         //        List<String> tempDirsForOneLevel;
@@ -386,72 +383,4 @@ public class TestInfo
     }
 
     public static string CurrentDirectory { get; set; }
-
-    private delegate void ExceptionCode();
-
-    private void DeleteFile(string fileName)
-    {
-        if (File.Exists(fileName))
-            File.Delete(fileName);
-    }
-
-
-    //Checks for error
-    private static bool Eval(bool expression, string msg, params object[] values)
-    {
-        return Eval(expression, string.Format(msg, values));
-    }
-
-    private static bool Eval<T>(T actual, T expected, string errorMsg)
-    {
-        bool retValue = expected == null ? actual == null : expected.Equals(actual);
-
-        if (!retValue)
-            Eval(retValue, errorMsg +
-            " Expected:" + (null == expected ? "<null>" : expected.ToString()) +
-            " Actual:" + (null == actual ? "<null>" : actual.ToString()));
-
-        return retValue;
-    }
-
-    private static bool Eval(bool expression, string msg)
-    {
-        if (!expression)
-        {
-            Console.WriteLine(msg);
-        }
-        return expression;
-    }
-
-    //Checks for a particular type of exception
-    private static void CheckException<E>(ExceptionCode test, string error)
-    {
-        CheckException<E>(test, error, null);
-    }
-
-    //Checks for a particular type of exception and an Exception msg
-    private static void CheckException<E>(ExceptionCode test, string error, string msgExpected)
-    {
-        bool exception = false;
-        try
-        {
-            test();
-            error = string.Format("{0} Exception NOT thrown ", error);
-        }
-        catch (Exception e)
-        {
-            if (e.GetType() == typeof(E))
-            {
-                exception = true;
-                if (System.Globalization.CultureInfo.CurrentUICulture.Name == "en-US" && msgExpected != null && e.Message != msgExpected)
-                {
-                    exception = false;
-                    error = string.Format("{0} Message Different: <{1}>", error, e.Message);
-                }
-            }
-            else
-                error = string.Format("{0} Exception type: {1}", error, e.GetType().Name);
-        }
-        Eval(exception, error);
-    }
 }


### PR DESCRIPTION
Remove unused locals in:

- System.IO.FileSystem.AccessControl
- System.IO.FileSystem.DriveInfo
- System.IO.FileSystem

Fixes part of #30457