### PR TITLE
Remove unused locals in System.IO.Ports

### DIFF
--- a/src/libraries/System.IO.Ports/tests/SerialPort/BaudRate.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/BaudRate.cs
@@ -260,7 +260,6 @@ namespace System.IO.Ports.Tests
             using (SerialPort com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
             {
                 double expectedTime, actualTime, percentageDifference;
-                int numBytes = 0;
 
                 //Generate some random byte to read/write at this baudrate
                 for (int i = 0; i < xmitBytes.Length; i++)
@@ -316,7 +315,7 @@ namespace System.IO.Ports.Tests
                 if (MAX_ACCEPTABLE_PERCENTAGE_DIFFERENCE < percentageDifference)
                 {
                     Assert.True(false, string.Format("ERROR!!! BuadRate not used Expected time:{0}, actual time:{1} percentageDifference:{2}",
-                        expectedTime, actualTime, percentageDifference, numBytes));
+                        expectedTime, actualTime, percentageDifference));
                 }
 
                 com2.Read(rcvBytes, 0, rcvBytes.Length);

--- a/src/libraries/System.IO.Ports/tests/SerialPort/Encoding.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/Encoding.cs
@@ -175,7 +175,7 @@ namespace System.IO.Ports.Tests
                 if (ThrowAt.Open == throwAt)
                     com.Open();
 
-                object myEncoding = com.Encoding;
+                _ = com.Encoding;
 
                 com.Encoding = origEncoding;
 

--- a/src/libraries/System.IO.Ports/tests/SerialPort/Handshake.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/Handshake.cs
@@ -591,7 +591,6 @@ namespace System.IO.Ports.Tests
         {
             int com1BaudRate = com1.BaudRate;
             int com2BaudRate = com2.BaudRate;
-            int com1ReadBufferSize = com1.ReadBufferSize;
             int bufferSize = com1.ReadBufferSize;
             int upperLimit = (3 * bufferSize) / 4;
             int lowerLimit = bufferSize / 4;
@@ -695,7 +694,6 @@ namespace System.IO.Ports.Tests
         {
             int com1BaudRate = com1.BaudRate;
             int com2BaudRate = com2.BaudRate;
-            int com1ReadBufferSize = com1.ReadBufferSize;
             bool com2RtsEnable = com2.RtsEnable;
             int bufferSize = com1.ReadBufferSize;
             int upperLimit = bufferSize - 1024;

--- a/src/libraries/System.IO.Ports/tests/SerialPort/ReadBufferSize.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/ReadBufferSize.cs
@@ -299,7 +299,6 @@ namespace System.IO.Ports.Tests
                 SerialPortProperties serPortProp = new SerialPortProperties();
                 Random rndGen = new Random(-55);
                 int bytesToRead = readBufferSize < 4096 ? 4096 : readBufferSize;
-                int origBaudRate = com1.BaudRate;
                 int origReadTimeout = com1.ReadTimeout;
                 int bytesRead;
 

--- a/src/libraries/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/Read_char_int_int_Generic.cs
@@ -276,8 +276,6 @@ namespace System.IO.Ports.Tests
         [ConditionalFact(nameof(HasNullModem))]
         public void BytesToRead_Equal_Buffer_Size()
         {
-            Random rndGen = new Random(-55);
-
             VerifyBytesToRead(numRndBytesToRead);
         }
         #endregion

--- a/src/libraries/System.IO.Ports/tests/SerialPort/RtsEnable.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/RtsEnable.cs
@@ -190,7 +190,7 @@ namespace System.IO.Ports.Tests
 
                 Assert.Throws<InvalidOperationException>(() =>
                 {
-                    bool rtsEnable = com1.RtsEnable;
+                    _ = com1.RtsEnable;
                 });
             }
         }
@@ -208,7 +208,7 @@ namespace System.IO.Ports.Tests
 
                 Assert.Throws<InvalidOperationException>(() =>
                 {
-                    bool rtsEnable = com1.RtsEnable;
+                    _ = com1.RtsEnable;
                 });
             }
         }

--- a/src/libraries/System.IO.Ports/tests/SerialPort/WriteLine.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/WriteLine.cs
@@ -29,35 +29,35 @@ namespace System.IO.Ports.Tests
 
         #region Test Cases
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void ASCIIEncoding()
+        public void ASCIIEncoding()
         {
             Debug.WriteLine("Verifying write method with ASCIIEncoding");
             VerifyWrite(new ASCIIEncoding(), ENCODING_STRING_SIZE, GenRandomNewLine(true));
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void UTF8Encoding()
+        public void UTF8Encoding()
         {
             Debug.WriteLine("Verifying write method with UTF8Encoding");
             VerifyWrite(new UTF8Encoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void UTF32Encoding()
+        public void UTF32Encoding()
         {
             Debug.WriteLine("Verifying write method with UTF32Encoding");
             VerifyWrite(new UTF32Encoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void UnicodeEncoding()
+        public void UnicodeEncoding()
         {
             Debug.WriteLine("Verifying write method with UnicodeEncoding");
             VerifyWrite(new UnicodeEncoding(), ENCODING_STRING_SIZE, GenRandomNewLine(false));
         }
 
         [ConditionalFact(nameof(HasOneSerialPort))]
-        private void NullString()
+        public void NullString()
         {
             using (SerialPort com = new SerialPort(TCSupport.LocalMachineSerialInfo.FirstAvailablePortName))
             {
@@ -75,7 +75,7 @@ namespace System.IO.Ports.Tests
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void EmptyString()
+        public void EmptyString()
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -92,7 +92,7 @@ namespace System.IO.Ports.Tests
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void String_Null_Char()
+        public void String_Null_Char()
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -110,7 +110,7 @@ namespace System.IO.Ports.Tests
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void LargeString()
+        public void LargeString()
         {
             Debug.WriteLine("Verifying write method with a large string size");
             VerifyWrite(new UnicodeEncoding(), LARGE_STRING_SIZE, DEFAULT_NEW_LINE, 1);
@@ -118,7 +118,7 @@ namespace System.IO.Ports.Tests
 
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void StrContains_NewLine_RND()
+        public void StrContains_NewLine_RND()
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -145,7 +145,7 @@ namespace System.IO.Ports.Tests
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void StrContains_NewLine_CRLF()
+        public void StrContains_NewLine_CRLF()
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -172,7 +172,7 @@ namespace System.IO.Ports.Tests
         }
 
         [ConditionalFact(nameof(HasLoopbackOrNullModem))]
-        private void StrContains_NewLine_null()
+        public void StrContains_NewLine_null()
         {
             using (SerialPort com1 = TCSupport.InitFirstSerialPort())
             using (SerialPort com2 = TCSupport.InitSecondSerialPort(com1))
@@ -239,7 +239,6 @@ namespace System.IO.Ports.Tests
             int byteRead;
             int index = 0;
             int numNewLineBytes;
-            char[] newLineChars = com1.NewLine.ToCharArray();
             StringBuilder expectedStrBldr = new StringBuilder();
             string expectedString;
 

--- a/src/libraries/System.IO.Ports/tests/SerialPort/Write_byte_int_int.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialPort/Write_byte_int_int.cs
@@ -134,7 +134,6 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = rndGen.Next(0, bufferLength - 1);
             int count = bufferLength - offset;
-            Type expectedException = typeof(ArgumentException);
 
             VerifyWrite(new byte[bufferLength], offset, count);
         }
@@ -146,7 +145,6 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = bufferLength - 1;
             int count = 1;
-            Type expectedException = typeof(ArgumentException);
 
             VerifyWrite(new byte[bufferLength], offset, count);
         }
@@ -158,7 +156,6 @@ namespace System.IO.Ports.Tests
             int bufferLength = rndGen.Next(1, MAX_BUFFER_SIZE);
             int offset = 0;
             int count = bufferLength;
-            Type expectedException = typeof(ArgumentException);
 
             VerifyWrite(new byte[bufferLength], offset, count);
         }
@@ -299,12 +296,6 @@ namespace System.IO.Ports.Tests
                 VerifyWriteByteArray(buffer, offset, count, com1, com2, numWrites);
             }
         }
-
-        private void VerifyWriteByteArray(byte[] buffer, int offset, int count, SerialPort com1, SerialPort com2)
-        {
-            VerifyWriteByteArray(buffer, offset, count, com1, com2, DEFAULT_NUM_WRITES);
-        }
-
 
         private void VerifyWriteByteArray(byte[] buffer, int offset, int count, SerialPort com1, SerialPort com2, int numWrites)
         {

--- a/src/libraries/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialStream/BeginRead_Generic.cs
@@ -13,13 +13,6 @@ namespace System.IO.Ports.Tests
 {
     public class SerialStream_BeginRead_Generic : PortsTest
     {
-        // Set bounds fore random timeout values.
-        // If the min is to low read will not timeout accurately and the testcase will fail
-        private const int minRandomTimeout = 250;
-
-        // If the max is to large then the testcase will take forever to run
-        private const int maxRandomTimeout = 2000;
-
         // If the percentage difference between the expected timeout and the actual timeout
         // found through Stopwatch is greater then 10% then the timeout value was not correctly
         // to the read method and the testcase fails.
@@ -38,10 +31,6 @@ namespace System.IO.Ports.Tests
         // create an byte array to pass into the method the following is the size of the
         // byte array used in this situation
         private const int defaultByteArraySize = 1;
-
-        private const int NUM_TRYS = 5;
-
-        private const int MAX_WAIT_THREAD = 1000;
 
         #region Test Cases
 
@@ -99,25 +88,6 @@ namespace System.IO.Ports.Tests
                 com1.BaseStream.EndRead(ar);
 
                 Assert.True(mre.WaitOne(200));
-            }
-        }
-
-        private void WriteToCom1()
-        {
-            using (var com2 = new SerialPort(TCSupport.LocalMachineSerialInfo.SecondAvailablePortName))
-            {
-                var rndGen = new Random(-55);
-                var xmitBuffer = new byte[1];
-                int sleepPeriod = rndGen.Next(minRandomTimeout, maxRandomTimeout / 2);
-
-                // Sleep some random period with of a maximum duration of half the largest possible timeout value for a read method on COM1
-                Thread.Sleep(sleepPeriod);
-
-                com2.Open();
-                com2.Write(xmitBuffer, 0, xmitBuffer.Length);
-
-                if (com2.IsOpen)
-                    com2.Close();
             }
         }
 
@@ -236,8 +206,6 @@ namespace System.IO.Ports.Tests
         [ConditionalFact(nameof(HasNullModem))]
         public void BytesToRead_Equal_Buffer_Size()
         {
-            var rndGen = new Random(-55);
-
             VerifyBytesToRead(numRndBytesToRead, new UTF8Encoding());
         }
         #endregion

--- a/src/libraries/System.IO.Ports/tests/SerialStream/Length.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialStream/Length.cs
@@ -64,7 +64,7 @@ namespace System.IO.Ports.Tests
         {
             Assert.Throws(expectedException, () =>
             {
-                long lengthTest = serialStream.Length;
+                _ = serialStream.Length;
             });
         }
         #endregion

--- a/src/libraries/System.IO.Ports/tests/SerialStream/Position.cs
+++ b/src/libraries/System.IO.Ports/tests/SerialStream/Position.cs
@@ -78,7 +78,7 @@ namespace System.IO.Ports.Tests
             Assert.Throws(expectedException, () => serialStream.Position = value);
             Assert.Throws(expectedException, () =>
             {
-                long positionTest = serialStream.Position;
+                _ = serialStream.Position;
             });
         }
         #endregion


### PR DESCRIPTION
Also changed visibility in some tests from `private` to `public` to
follow the other code in the project and prevent the compiler from
thinking the tests are unused.

Fixes part of #30457