### PR TITLE
Add breaking change version DAC API (ISOSDacInterface9 interface)

### DIFF
--- a/src/coreclr/src/debug/daccess/daccess.cpp
+++ b/src/coreclr/src/debug/daccess/daccess.cpp
@@ -3293,6 +3293,10 @@ ClrDataAccess::QueryInterface(THIS_
     {
         ifaceRet = static_cast<ISOSDacInterface8*>(this);
     }
+    else if (IsEqualIID(interfaceId, __uuidof(ISOSDacInterface9)))
+    {
+        ifaceRet = static_cast<ISOSDacInterface9*>(this);
+    }
     else
     {
         *iface = NULL;

--- a/src/coreclr/src/debug/daccess/dacimpl.h
+++ b/src/coreclr/src/debug/daccess/dacimpl.h
@@ -840,7 +840,8 @@ class ClrDataAccess
       public ISOSDacInterface5,
       public ISOSDacInterface6,
       public ISOSDacInterface7,
-      public ISOSDacInterface8
+      public ISOSDacInterface8,
+      public ISOSDacInterface9
 {
 public:
     ClrDataAccess(ICorDebugDataTarget * pTarget, ICLRDataTarget * pLegacyTarget=0);
@@ -1204,6 +1205,9 @@ public:
     virtual HRESULT STDMETHODCALLTYPE GetFinalizationFillPointersSvr(CLRDATA_ADDRESS heapAddr, unsigned int cFillPointers, CLRDATA_ADDRESS *pFinalizationFillPointers, unsigned int *pNeeded);
 
     virtual HRESULT STDMETHODCALLTYPE GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDATA_ADDRESS* assemblyLoadContext);
+
+    // ISOSDacInterface9
+    virtual HRESULT STDMETHODCALLTYPE GetBreakingChangeVersion(int* pVersion);
 
     //
     // ClrDataAccess.

--- a/src/coreclr/src/debug/daccess/request.cpp
+++ b/src/coreclr/src/debug/daccess/request.cpp
@@ -4732,3 +4732,12 @@ HRESULT ClrDataAccess::GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDA
     SOSDacLeave();
     return hr;
 }
+
+HRESULT ClrDataAccess::GetBreakingChangeVersion(int* pVersion)
+{
+    if (pVersion == nullptr)
+        return E_INVALIDARG;
+
+    *pVersion = SOS_BREAKING_CHANGE_VERSION;
+    return S_OK;
+}

--- a/src/coreclr/src/inc/sospriv.idl
+++ b/src/coreclr/src/inc/sospriv.idl
@@ -409,3 +409,18 @@ interface ISOSDacInterface8 : IUnknown
 
     HRESULT GetAssemblyLoadContext(CLRDATA_ADDRESS methodTable, CLRDATA_ADDRESS* assemblyLoadContext);
 }
+
+// Increment anytime there is a change in the data structures that SOS depends on like
+// stress log structs (StressMsg, StressLogChunck, ThreadStressLog, etc), exception
+// stack traces (StackTraceElement), the PredefinedTlsSlots enums, etc.
+cpp_quote("#define SOS_BREAKING_CHANGE_VERSION 1")
+
+[
+    object,
+    local,
+    uuid(4eca42d8-7e7b-4c8a-a116-7bfbf6929267)
+]
+interface ISOSDacInterface9 : IUnknown
+{
+    HRESULT GetBreakingChangeVersion(int* pVersion);
+}

--- a/src/coreclr/src/pal/prebuilt/idl/sospriv_i.cpp
+++ b/src/coreclr/src/pal/prebuilt/idl/sospriv_i.cpp
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 
 
 /* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
@@ -8,7 +5,17 @@
 /* link this file in with the server and any clients */
 
 
- /* File created by MIDL compiler version 8.00.0613 */
+ /* File created by MIDL compiler version 8.01.0622 */
+/* at Mon Jan 18 19:14:07 2038
+ */
+/* Compiler settings for C:/ssd/runtime/src/coreclr/src/inc/sospriv.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.01.0622 
+    protocol : dce , ms_ext, c_ext, robust
+    error checks: allocation ref bounds_check enum stub_data 
+    VC __declspec() decoration level: 
+         __declspec(uuid()), __declspec(selectany), __declspec(novtable)
+         DECLSPEC_UUID(), MIDL_INTERFACE()
+*/
 /* @@MIDL_FILE_HEADING(  ) */
 
 #pragma warning( disable: 4049 )  /* more than 64k source lines */
@@ -94,6 +101,9 @@ MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface7,0xc1020dde,0xfe98,0x4536,0xa5,0x3b,0
 
 
 MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface8,0xc12f35a9,0xe55c,0x4520,0xa8,0x94,0xb3,0xdc,0x51,0x65,0xdf,0xce);
+
+
+MIDL_DEFINE_GUID(IID, IID_ISOSDacInterface9,0x4eca42d8,0x7e7b,0x4c8a,0xa1,0x16,0x7b,0xfb,0xf6,0x92,0x92,0x67);
 
 #undef MIDL_DEFINE_GUID
 

--- a/src/coreclr/src/pal/prebuilt/inc/sospriv.h
+++ b/src/coreclr/src/pal/prebuilt/inc/sospriv.h
@@ -2644,7 +2644,7 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 #define ISOSDacInterface8_GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) \
     ( (This)->lpVtbl -> GetFinalizationFillPointersSvr(This,heapAddr,cFillPointers,pFinalizationFillPointers,pNeeded) )
 
-#define ISOSDacInterface8_GetAssemblyLoadContext(This,methodTable,assemblyLoadContext)	\
+#define ISOSDacInterface8_GetAssemblyLoadContext(This,methodTable,assemblyLoadContext) \
     ( (This)->lpVtbl -> GetAssemblyLoadContext(This,methodTable,assemblyLoadContext) )
 
 #endif /* COBJMACROS */
@@ -2658,6 +2658,93 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 #endif  /* __ISOSDacInterface8_INTERFACE_DEFINED__ */
 
 
+/* interface __MIDL_itf_sospriv_0000_0012 */
+/* [local] */ 
+
+#define SOS_BREAKING_CHANGE_VERSION 1
+
+
+extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_c_ifspec;
+extern RPC_IF_HANDLE __MIDL_itf_sospriv_0000_0012_v0_0_s_ifspec;
+
+#ifndef __ISOSDacInterface9_INTERFACE_DEFINED__
+#define __ISOSDacInterface9_INTERFACE_DEFINED__
+
+/* interface ISOSDacInterface9 */
+/* [uuid][local][object] */ 
+
+
+EXTERN_C const IID IID_ISOSDacInterface9;
+
+#if defined(__cplusplus) && !defined(CINTERFACE)
+    
+    MIDL_INTERFACE("4eca42d8-7e7b-4c8a-a116-7bfbf6929267")
+    ISOSDacInterface9 : public IUnknown
+    {
+    public:
+        virtual HRESULT STDMETHODCALLTYPE GetBreakingChangeVersion( 
+            int *pVersion) = 0;
+        
+    };
+    
+    
+#else  /* C style interface */
+
+    typedef struct ISOSDacInterface9Vtbl
+    {
+        BEGIN_INTERFACE
+        
+        HRESULT ( STDMETHODCALLTYPE *QueryInterface )( 
+            ISOSDacInterface9 * This,
+            /* [in] */ REFIID riid,
+            /* [annotation][iid_is][out] */ 
+            _COM_Outptr_  void **ppvObject);
+        
+        ULONG ( STDMETHODCALLTYPE *AddRef )( 
+            ISOSDacInterface9 * This);
+        
+        ULONG ( STDMETHODCALLTYPE *Release )( 
+            ISOSDacInterface9 * This);
+        
+        HRESULT ( STDMETHODCALLTYPE *GetBreakingChangeVersion )( 
+            ISOSDacInterface9 * This,
+            int *pVersion);
+        
+        END_INTERFACE
+    } ISOSDacInterface9Vtbl;
+
+    interface ISOSDacInterface9
+    {
+        CONST_VTBL struct ISOSDacInterface9Vtbl *lpVtbl;
+    };
+
+    
+
+#ifdef COBJMACROS
+
+
+#define ISOSDacInterface9_QueryInterface(This,riid,ppvObject) \
+    ( (This)->lpVtbl -> QueryInterface(This,riid,ppvObject) ) 
+
+#define ISOSDacInterface9_AddRef(This) \
+    ( (This)->lpVtbl -> AddRef(This) ) 
+
+#define ISOSDacInterface9_Release(This) \
+    ( (This)->lpVtbl -> Release(This) ) 
+
+
+#define ISOSDacInterface9_GetBreakingChangeVersion(This,pVersion) \
+    ( (This)->lpVtbl -> GetBreakingChangeVersion(This,pVersion) ) 
+
+#endif /* COBJMACROS */
+
+
+#endif  /* C style interface */
+
+
+#endif  /* __ISOSDacInterface9_INTERFACE_DEFINED__ */
+
+
 /* Additional Prototypes for ALL interfaces */
 
 /* end of Additional Prototypes */
@@ -2667,5 +2754,4 @@ EXTERN_C const IID IID_ISOSDacInterface8;
 #endif
 
 #endif
-
 


### PR DESCRIPTION
GetBreakingChangeVersion(int* version)

Used in SOS to check if any of the runtime data structures it depends on has changed.

Issue: https://github.com/dotnet/runtime/issues/27309