### PR TITLE
Remove unused locals in System.Net.*

### DIFF
--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/HttpListener.Windows.cs
@@ -682,7 +682,6 @@ namespace System.Net
             stoleBlob = false;
 
             // Some things we need right away.  Lift them out now while it's convenient.
-            string verb = Interop.HttpApi.GetVerb(memoryBlob.RequestBlob);
             string authorizationHeader = Interop.HttpApi.GetKnownHeader(memoryBlob.RequestBlob, (int)HttpRequestHeader.Authorization);
             ulong connectionId = memoryBlob.RequestBlob->ConnectionId;
             ulong requestId = memoryBlob.RequestBlob->RequestId;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketProtocolComponent.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Windows/WebSockets/WebSocketProtocolComponent.cs
@@ -248,7 +248,6 @@ namespace System.Net.WebSockets
 
             ThrowOnError(errorCode);
 
-            Interop.WebSocket.HttpHeader[] responseHeaders = MarshalHttpHeaders(responseHeadersPtr, (int)responseHeaderCount);
             errorCode = Interop.WebSocket.WebSocketEndServerHandshake(webSocketHandle);
 
             ThrowOnError(errorCode);

--- a/src/libraries/System.Net.HttpListener/tests/GetContextHelper.cs
+++ b/src/libraries/System.Net.HttpListener/tests/GetContextHelper.cs
@@ -24,7 +24,7 @@ namespace System.Net.Tests
         public async Task<HttpListenerResponse> GetResponse()
         {
             // We need to create a mock request to give the HttpListener a context.
-            Task<string> clientTask = _client.GetStringAsync(_listeningUrl);
+            _ = _client.GetStringAsync(_listeningUrl);
             HttpListenerContext context = await _listener.GetContextAsync();
             return context.Response;
         }

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerAuthenticationTests.cs
@@ -269,7 +269,7 @@ namespace System.Net.Tests
 
             using (var client = new HttpClient())
             {
-                HttpResponseMessage response = await AuthenticationFailure(client, HttpStatusCode.InternalServerError);
+                await AuthenticationFailure(client, HttpStatusCode.InternalServerError);
             }
         }
 
@@ -281,7 +281,7 @@ namespace System.Net.Tests
 
             using (var client = new HttpClient())
             {
-                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+                _ = client.GetStringAsync(_factory.ListeningUrl);
                 Assert.Throws<OutOfMemoryException>(() => _listener.GetContext());
             }
         }
@@ -450,7 +450,7 @@ namespace System.Net.Tests
                     Basic,
                     Convert.ToBase64String(Encoding.ASCII.GetBytes(string.Format("{0}:{1}", TestUser, TestPassword))));
 
-                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+                _ = client.GetStringAsync(_factory.ListeningUrl);
                 HttpListenerContext listenerContext = await serverContextTask;
 
                 Assert.Null(listenerContext.User);
@@ -469,7 +469,7 @@ namespace System.Net.Tests
                     Basic,
                     Convert.ToBase64String(Encoding.ASCII.GetBytes(authHeader)));
 
-                Task <string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+                _ = client.GetStringAsync(_factory.ListeningUrl);
                 HttpListenerContext listenerContext = await serverContextTask;
 
                 Assert.Equal(expectedUsername, listenerContext.User.Identity.Name);

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -108,7 +108,6 @@ namespace System.Net.Tests
             Assert.Equal("user", context.User.Identity.Name);
 
             HttpListenerWebSocketContext webSocketContext = await context.AcceptWebSocketAsync(null);
-            IPrincipal user = webSocketContext.User;
 
             // Should be copied as User gets disposed when HttpListenerContext is closed.
             Assert.NotSame(context.User, webSocketContext.User);

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerPrefixCollectionTests.cs
@@ -272,7 +272,6 @@ namespace System.Net.Tests
         {
             using (var factory1 = new HttpListenerFactory(host, path: string.Empty))
             {
-                HttpListener listener1 = factory1.GetListener();
                 using (var listener2 = new HttpListener())
                 {
                     string prefixWithSubPath = $"{factory1.ListeningUrl}sub_path/";

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -410,7 +410,6 @@ namespace System.Net.Tests
         public async Task CloseResponseEntity_SendToClosedConnection_DoesNotThrow(bool willBlock)
         {
             const string Text = "Some-String";
-            byte[] buffer = Encoding.UTF8.GetBytes(Text);
 
             using (HttpListenerFactory factory = new HttpListenerFactory())
             using (Socket client = factory.GetConnectedSocket())

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTests.cs
@@ -148,7 +148,7 @@ namespace System.Net.Tests
                 HttpListener listener = listenerFactory.GetListener();
                 listener.Start();
 
-                Task<string> clientTask = client.GetStringAsync(listenerFactory.ListeningUrl);
+                _ = client.GetStringAsync(listenerFactory.ListeningUrl);
 
                 IAsyncResult beginGetContextResult = listener.BeginGetContext(null, null);
                 listener.EndGetContext(beginGetContextResult);

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerTimeoutManagerTests.cs
@@ -369,10 +369,7 @@ namespace System.Net.Tests
 
         private unsafe void GetUrlGroupProperty(ulong urlGroupId, HTTP_SERVER_PROPERTY property, IntPtr info, uint infosize)
         {
-            uint statusCode = 0;
-
-            statusCode = HttpQueryUrlGroupProperty(urlGroupId, HTTP_SERVER_PROPERTY.HttpServerTimeoutsProperty, info, infosize, IntPtr.Zero);
-
+            uint statusCode = HttpQueryUrlGroupProperty(urlGroupId, HTTP_SERVER_PROPERTY.HttpServerTimeoutsProperty, info, infosize, IntPtr.Zero);
             if (statusCode != 0)
             {
                 throw new Exception("HttpQueryUrlGroupProperty failed with " + (int)statusCode);

--- a/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -302,7 +302,7 @@ namespace System.Net.Tests
         {
             using (HttpClient client = new HttpClient())
             {
-                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+                _ = client.GetStringAsync(_factory.ListeningUrl);
 
                 HttpListenerContext serverContext = await _listener.GetContextAsync();
                 using (HttpListenerResponse response = serverContext.Response)
@@ -330,7 +330,7 @@ namespace System.Net.Tests
         {
             using (HttpClient client = new HttpClient())
             {
-                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+                _ = client.GetStringAsync(_factory.ListeningUrl);
 
                 HttpListenerContext serverContext = await _listener.GetContextAsync();
                 using (HttpListenerResponse response = serverContext.Response)
@@ -356,7 +356,7 @@ namespace System.Net.Tests
         {
             using (HttpClient client = new HttpClient())
             {
-                Task<string> clientTask = client.GetStringAsync(_factory.ListeningUrl);
+                _ = client.GetStringAsync(_factory.ListeningUrl);
 
                 HttpListenerContext serverContext = await _listener.GetContextAsync();
                 using (HttpListenerResponse response = serverContext.Response)

--- a/src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/FileWebRequestTest.cs
@@ -188,7 +188,6 @@ namespace System.Net.Tests
             string path = Path.GetTempFileName();
             try
             {
-                var data = new byte[1024];
                 WebRequest request = WebRequest.Create("file://" + path);
                 request.Method = WebRequestMethods.File.UploadFile;
                 using (WebResponse response = await GetResponseAsync(request))

--- a/src/libraries/System.Net.Requests/tests/FtpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/FtpWebRequestTest.cs
@@ -61,7 +61,7 @@ namespace System.Net.Tests
         {
             string serverUrl = string.Format("ftp://www.{0}.com/", Guid.NewGuid().ToString());
             FtpWebRequest request = (FtpWebRequest)WebRequest.Create(serverUrl);
-            WebException ex = Assert.Throws<WebException>(() => request.GetResponse());
+            Assert.Throws<WebException>(() => request.GetResponse());
         }
 
         [OuterLoop]

--- a/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -1164,7 +1164,7 @@ namespace System.Net.Tests
             HttpWebRequest request = HttpWebRequest.CreateHttp(remoteServer);
             request.Method = "POST";
 
-            IAsyncResult asyncResult = request.BeginGetRequestStream(null, null);
+            request.BeginGetRequestStream(null, null);
             Assert.Throws<InvalidOperationException>(() =>
             {
                 request.BeginGetRequestStream(null, null);
@@ -1178,7 +1178,7 @@ namespace System.Net.Tests
             {
                 HttpWebRequest request = HttpWebRequest.CreateHttp(url);
 
-                IAsyncResult asyncResult = request.BeginGetResponse(null, null);
+                request.BeginGetResponse(null, null);
                 Assert.Throws<ProtocolViolationException>(() =>
                 {
                     request.BeginGetRequestStream(null, null);
@@ -1194,7 +1194,7 @@ namespace System.Net.Tests
             await LoopbackServer.CreateServerAsync((server, url) =>
             {
                 HttpWebRequest request = WebRequest.CreateHttp(url);
-                IAsyncResult asyncResult = request.BeginGetResponse(null, null);
+                request.BeginGetResponse(null, null);
                 Assert.Throws<InvalidOperationException>(() => request.BeginGetResponse(null, null));
                 return Task.FromResult<object>(null);
             });
@@ -1324,7 +1324,6 @@ namespace System.Net.Tests
         public void CookieContainer_Count_Add(Uri remoteServer)
         {
             HttpWebRequest request = WebRequest.CreateHttp(remoteServer);
-            DateTime now = DateTime.UtcNow;
             request.CookieContainer = new CookieContainer();
             request.CookieContainer.Add(remoteServer, new Cookie("1", "cookie1"));
             request.CookieContainer.Add(remoteServer, new Cookie("2", "cookie2"));
@@ -1457,7 +1456,6 @@ namespace System.Net.Tests
                 request.ContentType = HeadersPartialContent;
 
                 using WebResponse response = await GetResponseAsync(request);
-                string headersString = response.Headers.ToString();
                 Assert.Equal(HeadersPartialContent, response.Headers[HttpResponseHeader.ContentType]);
             }, async server =>
             {

--- a/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
+++ b/src/libraries/System.Net.Requests/tests/HttpWebResponseHeaderTest.cs
@@ -28,8 +28,7 @@ namespace System.Net.Tests
                 request.Method = HttpMethod.Get.Method;
                 HttpContinueDelegate continueDelegate = new HttpContinueDelegate(HttpContinueMethod);
                 request.ContinueDelegate = continueDelegate;
-                Task<WebResponse> getResponse = request.GetResponseAsync();
-                DateTimeOffset utcNow = DateTimeOffset.UtcNow;
+                _ = request.GetResponseAsync();
                 await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Content-Type: application/json;charset=UTF-8\r\n", "12345");
                 Assert.Equal(continueDelegate, request.ContinueDelegate);
             });
@@ -44,7 +43,6 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                DateTimeOffset utcNow = DateTimeOffset.UtcNow;
                 await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Content-Type: application/json;charset=UTF-8\r\n", "12345");
 
                 using (WebResponse response = await getResponse)
@@ -71,7 +69,6 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                DateTimeOffset utcNow = DateTimeOffset.UtcNow;
                 await server.AcceptConnectionSendResponseAndCloseAsync(HttpStatusCode.OK, "Content-Type: application/json;charset=UTF-8\r\n", "12345");
                 WebResponse response = await getResponse;
                 HttpWebResponse httpResponse = (HttpWebResponse)response;
@@ -104,7 +101,6 @@ namespace System.Net.Tests
         [Fact]
         public async Task LastModified_InvalidDate_Throws()
         {
-            DateTime expected = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(2018, 4, 10, 3, 4, 5, DateTimeKind.Utc), TimeZoneInfo.Local);
             await LoopbackServer.CreateServerAsync(async (server, url) =>
             {
                 HttpWebRequest request = WebRequest.CreateHttp(url);
@@ -126,12 +122,10 @@ namespace System.Net.Tests
                 HttpWebRequest request = WebRequest.CreateHttp(url);
                 request.Method = HttpMethod.Get.Method;
                 Task<WebResponse> getResponse = request.GetResponseAsync();
-                DateTimeOffset utcNow = DateTimeOffset.UtcNow;
                 await server.AcceptConnectionSendResponseAndCloseAsync();
 
                 using (WebResponse response = await getResponse)
                 {
-                    HttpWebResponse httpResponse = (HttpWebResponse)response;
                     using (MemoryStream fs = new MemoryStream())
                     {
                         BinaryFormatter formatter = new BinaryFormatter();

--- a/src/libraries/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/libraries/System.Net.Requests/tests/RequestStreamTest.cs
@@ -70,7 +70,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { Task t = stream.WriteAsync(null, 0, 1); });
+                AssertExtensions.Throws<ArgumentNullException>("buffer", () => { stream.WriteAsync(null, 0, 1); });
             });
         }
 
@@ -79,7 +79,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, -1, buffer.Length); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { stream.WriteAsync(buffer, -1, buffer.Length); });
             });
         }
 
@@ -88,7 +88,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => { Task t = stream.WriteAsync(buffer, 0, -1); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => { stream.WriteAsync(buffer, 0, -1); });
             });
         }
 
@@ -97,7 +97,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => { Task t = stream.WriteAsync(buffer, 0, buffer.Length + 1); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("count", "size", () => { stream.WriteAsync(buffer, 0, buffer.Length + 1); });
             });
         }
 
@@ -106,7 +106,7 @@ namespace System.Net.Tests
         {
             await GetRequestStream((stream) =>
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("offset", () => { stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
             });
         }
 

--- a/src/libraries/System.Net.Requests/tests/WebRequestTest.cs
+++ b/src/libraries/System.Net.Requests/tests/WebRequestTest.cs
@@ -82,7 +82,7 @@ namespace System.Net.Tests
         public void Create_ValidWebRequestUriScheme_Success(string scheme)
         {
             var uri = new Uri($"{scheme}://example.com/folder/resource.txt");
-            WebRequest request = WebRequest.Create(uri);
+            WebRequest.Create(uri);
         }
 
         [Theory]

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -56,7 +56,7 @@ namespace System.Net
             SafeFreeCertContext? remoteContext = null;
             try
             {
-                int errorCode = QueryContextRemoteCertificate(securityContext, out remoteContext);
+                QueryContextRemoteCertificate(securityContext, out remoteContext);
 
                 if (remoteContext != null && !remoteContext.IsInvalid)
                 {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -561,7 +561,6 @@ namespace System.Net.Security
             }
 
             // Following can underflow but it is ok due to equality check below
-            int hostNameStructLength = BinaryPrimitives.ReadUInt16BigEndian(serverName) - sizeof(NameType);
             NameType nameType = (NameType)serverName[NameTypeOffset];
             ReadOnlySpan<byte> hostNameStruct = serverName.Slice(HostNameStructOffset);
             if (nameType != NameType.HostName)

--- a/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/Fakes/FakeSslStream.Implementation.cs
@@ -49,21 +49,7 @@ namespace System.Net.Security
 
         private ValueTask<int> ReadAsyncInternal<TReadAdapter>(TReadAdapter adapter, Memory<byte> buffer) => default;
 
-        private Task CheckEnqueueWriteAsync() => default;
-
-        private void CheckEnqueueWrite()
-        {
-        }
-
-        private ValueTask<int> CheckEnqueueReadAsync(Memory<byte> buffer) => default;
-
-        private int CheckEnqueueRead(Memory<byte> buffer) => default;
-
         private bool RemoteCertRequired => default;
-
-        private void CheckThrow(bool authSuccessCheck, bool shutdownCheck = false)
-        {
-        }
 
         private void CloseInternal()
         {


### PR DESCRIPTION
Remove unused local variables and methods in:

- System.Net.HttpListener
- System.Net.Requests
- System.Net.Security

This fixes a part of #30457.