### PR TITLE
Make Comments In SortedList Match Code Behavior

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -526,9 +526,8 @@ namespace System.Collections.Generic
         private const int MaxArrayLength = 0X7FEFFFFF;
 
         // Ensures that the capacity of this sorted list is at least the given
-        // minimum value. If the current capacity of the list is less than
-        // min, the capacity is increased to twice the current capacity or
-        // to min, whichever is larger.
+        // minimum value. The capacity is increased to twice the current capacity
+        // or to min, whichever is larger.
         private void EnsureCapacity(int min)
         {
             int newCapacity = keys.Length == 0 ? DefaultCapacity : keys.Length * 2;


### PR DESCRIPTION
The method "EnsureCapacity" does not check whether resizing
is necessary, thus the comments should not contain the conditional
clause.

Fix #39526