### PR TITLE
Apply missing obsolete attributes in src; fix attribute ordering

### DIFF
--- a/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
+++ b/src/libraries/System.Security.Permissions/ref/System.Security.Permissions.cs
@@ -31,10 +31,10 @@ namespace System.Configuration
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.All, AllowMultiple=true, Inherited=false)]
     public sealed partial class ConfigurationPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public ConfigurationPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -402,10 +402,10 @@ namespace System.Net
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
     public sealed partial class SocketPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public SocketPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -444,10 +444,10 @@ namespace System.Net
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
     public sealed partial class WebPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public WebPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -885,10 +885,10 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-    [System.FlagsAttribute]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.FlagsAttribute]
     public enum EnvironmentPermissionAccess
     {
         NoAccess = 0,
@@ -896,10 +896,10 @@ namespace System.Security.Permissions
         Write = 2,
         AllAccess = 3,
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
     public sealed partial class EnvironmentPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public EnvironmentPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -1199,10 +1199,10 @@ namespace System.Security.Permissions
         public bool MoveNext() { throw null; }
         public void Reset() { }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
     public sealed partial class KeyContainerPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public KeyContainerPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -1253,10 +1253,10 @@ namespace System.Security.Permissions
         public override System.Security.SecurityElement ToXml() { throw null; }
         public override System.Security.IPermission Union(System.Security.IPermission target) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.Assembly | System.AttributeTargets.Class | System.AttributeTargets.Constructor | System.AttributeTargets.Method | System.AttributeTargets.Struct, AllowMultiple=true, Inherited=false)]
     public sealed partial class MediaPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
         public MediaPermissionAttribute(System.Security.Permissions.SecurityAction action) : base (default(System.Security.Permissions.SecurityAction)) { }
@@ -1337,10 +1337,10 @@ namespace System.Security.Permissions
         public System.Security.SecurityElement ToXml() { throw null; }
         public System.Security.IPermission Union(System.Security.IPermission other) { throw null; }
     }
-    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
 #if NET50_OBSOLETIONS
     [System.ObsoleteAttribute("Code Access Security is not supported or honored by the runtime.", DiagnosticId = "SYSLIB0003", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
 #endif
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Method, AllowMultiple=true, Inherited=false)]
     public sealed partial class PrincipalPermissionAttribute : System.Security.Permissions.CodeAccessSecurityAttribute
     {
 #if NET50_OBSOLETIONS

--- a/src/libraries/System.Security.Permissions/src/System/Configuration/ConfigurationPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Configuration/ConfigurationPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Configuration
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
     public sealed class ConfigurationPermissionAttribute : CodeAccessSecurityAttribute
     {

--- a/src/libraries/System.Security.Permissions/src/System/Data/Common/DBDataPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/Common/DBDataPermissionAttribute.cs
@@ -5,6 +5,9 @@ using System.Security.Permissions;
 
 namespace System.Data.Common
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor| AttributeTargets.Method,
         AllowMultiple =true, Inherited =false)]
     public abstract class DBDataPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Data/OracleClient/OraclePermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Data/OracleClient/OraclePermissionAttribute.cs
@@ -5,6 +5,9 @@ using System.Security.Permissions;
 
 namespace System.Data.OracleClient
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct |
         AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public sealed class OraclePermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Diagnostics/EventLogPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Diagnostics/EventLogPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Diagnostics
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct
         | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Event, AllowMultiple = true, Inherited = false)]
     public class EventLogPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Diagnostics/PerformanceCounterPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Diagnostics/PerformanceCounterPermissionAttribute.cs
@@ -5,6 +5,9 @@ using System.Security;
 using System.Security.Permissions;
 namespace System.Diagnostics
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Event,
     AllowMultiple = true, Inherited = false)]
     public class PerformanceCounterPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Drawing/Printing/PrintingPermissionAttribute.cs
@@ -5,6 +5,9 @@ using System.Security.Permissions;
 
 namespace System.Drawing.Printing
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
     public sealed class PrintingPermissionAttribute : CodeAccessSecurityAttribute
     {

--- a/src/libraries/System.Security.Permissions/src/System/Net/DnsPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/DnsPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |
         AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class DnsPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Net/Mail/SmtpPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/Mail/SmtpPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net.Mail
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |
         AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class SmtpPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Net/NetworkInformation/NetworkInformationPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/NetworkInformation/NetworkInformationPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net.NetworkInformation
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class NetworkInformationPermissionAttribute : CodeAccessSecurityAttribute
     {

--- a/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/Collaboration/PeerCollaborationPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/Collaboration/PeerCollaborationPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net.PeerToPeer.Collaboration
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct |
        AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public sealed class PeerCollaborationPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/PnrpPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/PeerToPeer/PnrpPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net.PeerToPeer
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Assembly | AttributeTargets.Class | AttributeTargets.Struct |
          AttributeTargets.Constructor | AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public sealed class PnrpPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Net/SocketPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/SocketPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |
         AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class SocketPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Net/WebPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Net/WebPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Net
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class |
         AttributeTargets.Struct | AttributeTargets.Assembly, AllowMultiple = true, Inherited = false)]
     public sealed class WebPermissionAttribute : CodeAccessSecurityAttribute

--- a/src/libraries/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/CodeAccessPermission.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public abstract partial class CodeAccessPermission : IPermission, ISecurityEncodable, IStackWalk
     {
         protected CodeAccessPermission() { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/NamedPermissionSet.cs
@@ -5,6 +5,9 @@ using System.Security.Permissions;
 
 namespace System.Security
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class NamedPermissionSet : PermissionSet
     {
         public NamedPermissionSet(NamedPermissionSet permSet) : base(default(PermissionState)) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/GacInstalled.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class GacInstalled : EvidenceBase, IIdentityPermissionFactory
     {
         public GacInstalled() { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/IIdentityPermissionFactory.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public partial interface IIdentityPermissionFactory
     {
         IPermission CreateIdentityPermission(Evidence evidence);

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyLevel.cs
@@ -19,18 +19,33 @@ namespace System.Security.Policy
         public void AddFullTrustAssembly(StrongName sn) { }
         [Obsolete("Because all GAC assemblies always get full trust, the full trust list is no longer meaningful. You should install any assemblies that are used in security policy in the GAC to ensure they are trusted.")]
         public void AddFullTrustAssembly(StrongNameMembershipCondition snMC) { }
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public void AddNamedPermissionSet(NamedPermissionSet permSet) { }
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public NamedPermissionSet ChangeNamedPermissionSet(string name, PermissionSet pSet) { return default(NamedPermissionSet); }
         [Obsolete("AppDomain policy levels are obsolete. See https://go.microsoft.com/fwlink/?LinkID=155570 for more information.")]
         public static PolicyLevel CreateAppDomainLevel() { return default(PolicyLevel); }
         public void FromXml(SecurityElement e) { }
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public NamedPermissionSet GetNamedPermissionSet(string name) { return default(NamedPermissionSet); }
         public void Recover() { }
         [Obsolete("Because all GAC assemblies always get full trust, the full trust list is no longer meaningful. You should install any assemblies that are used in security policy in the GAC to ensure they are trusted.")]
         public void RemoveFullTrustAssembly(StrongName sn) { }
         [Obsolete("Because all GAC assemblies always get full trust, the full trust list is no longer meaningful. You should install any assemblies that are used in security policy in the GAC to ensure they are trusted.")]
         public void RemoveFullTrustAssembly(StrongNameMembershipCondition snMC) { }
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public NamedPermissionSet RemoveNamedPermissionSet(NamedPermissionSet permSet) { return default(NamedPermissionSet); }
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public NamedPermissionSet RemoveNamedPermissionSet(string name) { return default(NamedPermissionSet); }
         public void Reset() { }
         public PolicyStatement Resolve(Evidence evidence) { return default(PolicyStatement); }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class PolicyStatement : ISecurityEncodable, ISecurityPolicyEncodable
     {
         public PolicyStatement(PermissionSet permSet) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/PolicyStatement.cs
@@ -3,12 +3,15 @@
 
 namespace System.Security.Policy
 {
-#if NET50_OBSOLETIONS
-    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-#endif
     public sealed partial class PolicyStatement : ISecurityEncodable, ISecurityPolicyEncodable
     {
+#if NET50_OBSOLETIONS
+        [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public PolicyStatement(PermissionSet permSet) { }
+#if NET50_OBSOLETIONS
+        [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
         public PolicyStatement(PermissionSet permSet, PolicyStatementAttribute attributes) { }
         public PolicyStatementAttribute Attributes { get; set; }
         public string AttributeString { get { return null; } }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Publisher.cs
@@ -5,6 +5,9 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class Publisher : EvidenceBase, IIdentityPermissionFactory
     {
         public Publisher(X509Certificate cert) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Site.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Site.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class Site : EvidenceBase, IIdentityPermissionFactory
     {
         public Site(string name) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Url.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Url.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class Url : EvidenceBase, IIdentityPermissionFactory
     {
         public Url(string name) { }

--- a/src/libraries/System.Security.Permissions/src/System/Security/Policy/Zone.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Security/Policy/Zone.cs
@@ -3,6 +3,9 @@
 
 namespace System.Security.Policy
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     public sealed partial class Zone : EvidenceBase, IIdentityPermissionFactory
     {
         public Zone(SecurityZone zone) { }

--- a/src/libraries/System.Security.Permissions/src/System/ServiceProcess/ServiceControllerPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/ServiceProcess/ServiceControllerPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.ServiceProcess
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Constructor | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Assembly | AttributeTargets.Event, AllowMultiple = true, Inherited = false )]
     public class ServiceControllerPermissionAttribute : CodeAccessSecurityAttribute
     {

--- a/src/libraries/System.Security.Permissions/src/System/Transactions/DistributedTransactionPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Transactions/DistributedTransactionPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Transactions
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
     public sealed class DistributedTransactionPermissionAttribute : CodeAccessSecurityAttribute
     {

--- a/src/libraries/System.Security.Permissions/src/System/Web/AspNetHostingPermissionAttribute.cs
+++ b/src/libraries/System.Security.Permissions/src/System/Web/AspNetHostingPermissionAttribute.cs
@@ -6,6 +6,9 @@ using System.Security.Permissions;
 
 namespace System.Web
 {
+#if NET50_OBSOLETIONS
+    [Obsolete(Obsoletions.CodeAccessSecurityMessage, DiagnosticId = Obsoletions.CodeAccessSecurityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+#endif
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false )]
     public sealed class AspNetHostingPermissionAttribute : CodeAccessSecurityAttribute
     {


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/39269, I missed some of the `src` files for `System.Security.Permissions`; this PR applies the `[Obsolete]` attributes to the APIs missed--the attributes were correctly applied to the `ref` assembly source already.

Additionally, this PR fixes small inconsistencies in the `ref` assembly source regarding the ordering of the attributes, keeping the `[Obsolete]` attribute first.