### PR TITLE
Unify resource strings used for Browser PNSE

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
+++ b/src/libraries/System.Diagnostics.Process/src/Resources/Strings.resx
@@ -246,7 +246,7 @@
     <value>The {0} property is not supported on this platform.</value>
   </data>
   <data name="Process_PlatformNotSupported" xml:space="preserve">
-    <value>System.Diagnostics.Process is not supported on this platform</value>
+    <value>System.Diagnostics.Process is not supported on this platform.</value>
   </data>
   <data name="RUsageFailure" xml:space="preserve">
     <value>Failed to set or retrieve rusage information. See the error code for OS-specific error information.</value>

--- a/src/libraries/System.IO.FileSystem.Watcher/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/Resources/Strings.resx
@@ -192,6 +192,6 @@
     <value>The path '{0}' is too long, or a component of the specified path is too long.</value>
   </data>
   <data name="FileSystemWatcher_PlatformNotSupported" xml:space="preserve">
-    <value>System.IO.FileSystem.Watcher is not supported on Browser.</value>
+    <value>System.IO.FileSystem.Watcher is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Pipes/src/Resources/Strings.resx
@@ -292,6 +292,6 @@
     <value>'pipeSecurity' must be null when 'options' contains 'PipeOptions.CurrentUserOnly'. </value>
   </data>
   <data name="Pipes_PlatformNotSupported" xml:space="preserve">
-    <value>System.IO.Pipes is not supported on this platform</value>
+    <value>System.IO.Pipes is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.Mail/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Mail/src/Resources/Strings.resx
@@ -334,7 +334,7 @@
   <data name="SmtpGetIisPickupDirectoryNotSupported" xml:space="preserve">
     <value>IIS delivery is not supported.</value>
   </data>
-  <data name="SystemNetMailNotSupported" xml:space="preserve">
+  <data name="SystemNetMail_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.Mail is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
+++ b/src/libraries/System.Net.Mail/src/System.Net.Mail.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetMailNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetMail_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
     <Compile Include="System\Net\Base64Stream.cs" />

--- a/src/libraries/System.Net.NameResolution/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.NameResolution/src/Resources/Strings.resx
@@ -72,7 +72,7 @@
   <data name="net_invalid_ip_addr" xml:space="preserve">
     <value>IPv4 address 0.0.0.0 and IPv6 address ::0 are unspecified addresses that cannot be used as a target address.</value>
   </data>
-  <data name="NameResolution_PlatformNotSupported" xml:space="preserve">
+  <data name="SystemNetNameResolution_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.NameResolution is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/libraries/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.NameResolution_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetNameResolution_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
     <GeneratePlatformNotSupportedAdditionalParameters Condition="'$(TargetsBrowser)' == 'true'">--exclude-api-list ExcludeApiList.PNSE.Browser.txt</GeneratePlatformNotSupportedAdditionalParameters>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">

--- a/src/libraries/System.Net.NetworkInformation/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.NetworkInformation/src/Resources/Strings.resx
@@ -90,7 +90,7 @@
   <data name="net_PInvokeError" xml:space="preserve">
     <value>An error was encountered while querying information from the operating system.</value>
   </data>
-  <data name="net_NetworkInformation_PlatformNotSupported" xml:space="preserve">
+  <data name="SystemNetNetworkInformation_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.NetworkInformation is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/libraries/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.net_NetworkInformation_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetNetworkInformation_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
     <Compile Include="System\Net\NetworkInformation\DuplicateAddressDetectionState.cs" />

--- a/src/libraries/System.Net.Ping/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Ping/src/Resources/Strings.resx
@@ -87,7 +87,7 @@
   <data name="net_ping_not_supported_uwp" xml:space="preserve">
     <value>Ping functionality is not currently supported in UWP.</value>
   </data>
-  <data name="Ping_PlatformNotSupported" xml:space="preserve">
+  <data name="SystemNetPing_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.Ping is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
+++ b/src/libraries/System.Net.Ping/src/System.Net.Ping.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Ping_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetPing_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
     <Compile Include="System\Net\NetworkInformation\IPStatus.cs" />

--- a/src/libraries/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Sockets/src/Resources/Strings.resx
@@ -262,7 +262,7 @@
   <data name="InvalidNullArgument" xml:space="preserve">
     <value>Null is not a valid value for {0}.</value>
   </data>
-  <data name="Sockets_PlatformNotSupported" xml:space="preserve">
+  <data name="SystemNetSockets_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.Sockets is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Sockets_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetSockets_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <PropertyGroup>
     <!-- SYSTEM_NET_SOCKETS_DLL is required to allow source-level code sharing for types defined within the

--- a/src/libraries/System.Net.WebClient/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebClient/src/Resources/Strings.resx
@@ -75,7 +75,7 @@
   <data name="net_webstatus_MessageLengthLimitExceeded" xml:space="preserve">
     <value>The message length limit was exceeded</value>
   </data>
-  <data name="net_webclient_PlatformNotSupported" xml:space="preserve">
+  <data name="SystemNetWebClient_PlatformNotSupported" xml:space="preserve">
     <value>System.Net.WebClient is not supported on this platform. Use System.Net.Http.HttpClient instead.</value>
   </data>
 </root>

--- a/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
+++ b/src/libraries/System.Net.WebClient/src/System.Net.WebClient.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.net_webclient_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemNetWebClient_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">
     <Compile Include="System\Net\WebClient.cs" />

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -348,8 +348,8 @@
   <data name="Cryptography_Okm_TooLarge" xml:space="preserve">
     <value>Output keying material length can be at most {0} bytes (255 * hash length).</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported_Browser" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on Browser.</value>
+  <data name="SystemSecurityCryptographyAlgorithms_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.Algorithms is not supported on this platform.</value>
   </data>
   <data name="Cryptography_ExceedKdfExtractLimit" xml:space="preserve">
     <value>The total number of bytes extracted cannot exceed UInt32.MaxValue * hash length.</value>

--- a/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/libraries/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -9,7 +9,7 @@
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" />
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Cryptography_PlatformNotSupported_Browser</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemSecurityCryptographyAlgorithms_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
     <GeneratePlatformNotSupportedAdditionalParameters Condition="'$(TargetsBrowser)' == 'true'">--exclude-api-list ExcludeApiList.PNSE.Browser.txt</GeneratePlatformNotSupportedAdditionalParameters>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsBrowser)' != 'true'">

--- a/src/libraries/System.Security.Cryptography.Csp/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Csp/src/Resources/Strings.resx
@@ -215,8 +215,8 @@
   <data name="CspParameter_invalid" xml:space="preserve">
     <value>CSPParameters cannot be null</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on this platform.</value>
+  <data name="SystemSecurityCryptographyCsp_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.Csp is not supported on this platform.</value>
   </data>
   <data name="Argument_DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>

--- a/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
+++ b/src/libraries/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsAnyOS)' == 'true'">
     <NoWarn>$(NoWarn);CS0809</NoWarn>
-    <GeneratePlatformNotSupportedAssemblyMessage>SR.Cryptography_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage>SR.SystemSecurityCryptographyCsp_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetsAnyOS)' != 'true'">
     <Compile Include="System\Security\Cryptography\AesCryptoServiceProvider.cs" />

--- a/src/libraries/System.Security.Cryptography.Encoding/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/Resources/Strings.resx
@@ -138,7 +138,7 @@
   <data name="ObjectDisposed_Generic" xml:space="preserve">
     <value>Cannot access a disposed object.</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on this platform.</value>
+  <data name="SystemSecurityCryptographyEncoding_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.Encoding is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
+++ b/src/libraries/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsAnyOS)' == 'true'">SR.Cryptography_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsAnyOS)' == 'true'">SR.SystemSecurityCryptographyEncoding_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition=" '$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" />
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition=" '$(TargetsOSX)' == 'true' or '$(TargetsiOS)' == 'true' or '$(TargetstvOS)' == 'true'" />

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Resources/Strings.resx
@@ -295,7 +295,7 @@
   <data name="Cryptography_Cms_CertificateAlreadyInCollection" xml:space="preserve">
     <value>Certificate already present in the collection.</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported_Browser" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on Browser.</value>
+  <data name="SystemSecurityCryptographyPkcs_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.Pkcs is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System.Security.Cryptography.Pkcs.csproj
@@ -17,7 +17,7 @@
     <AssemblyVersion Condition="$(TargetFramework.StartsWith('netstandard'))">4.0.4.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Cryptography_PlatformNotSupported_Browser</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemSecurityCryptographyPkcs_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" Condition="'$(IsPartialFacadeAssembly)' != 'true'" />

--- a/src/libraries/System.Security.Cryptography.Primitives/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/Resources/Strings.resx
@@ -129,7 +129,7 @@
   <data name="InvalidOperation_IncorrectImplementation" xml:space="preserve">
     <value>The algorithm's implementation is incorrect.</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported_Browser" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on Browser.</value>
+  <data name="SystemSecurityCryptographyPrimitives_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.Primitives is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
+++ b/src/libraries/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Cryptography_PlatformNotSupported_Browser</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemSecurityCryptographyPrimitives_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Security\Cryptography\AsymmetricAlgorithm.cs" />

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -427,7 +427,7 @@
   <data name="Cryptography_NotValidPrivateKey" xml:space="preserve">
     <value>Key is not a valid private key.</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on this platform.</value>
+  <data name="SystemSecurityCryptographyX509Certificates_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.X509Certificates is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/libraries/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetsAnyOS)' == 'true'">
     <NoWarn>$(NoWarn);CS8769</NoWarn>
-    <GeneratePlatformNotSupportedAssemblyMessage>SR.Cryptography_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage>SR.SystemSecurityCryptographyX509Certificates_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1\AsnXml.targets" />
   <Import Project="$(CommonPath)System\Security\Cryptography\Asn1Reader\System.Security.Cryptography.Asn1Reader.Shared.projitems" />

--- a/src/libraries/System.Security.Cryptography.Xml/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography.Xml/src/Resources/Strings.resx
@@ -377,7 +377,7 @@
   <data name="Log_UnsafeTransformMethod" xml:space="preserve">
     <value>Transform method "{0}" is not on the safe list. Safe transform methods are: {1}.</value>
   </data>
-  <data name="Cryptography_PlatformNotSupported_Browser" xml:space="preserve">
-    <value>System.Security.Cryptography is not supported on Browser.</value>
+  <data name="SystemSecurityCryptographyXml_PlatformNotSupported" xml:space="preserve">
+    <value>System.Security.Cryptography.Xml is not supported on this platform.</value>
   </data>
 </root>

--- a/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
+++ b/src/libraries/System.Security.Cryptography.Xml/src/System.Security.Cryptography.Xml.csproj
@@ -9,7 +9,7 @@
     <IsPartialFacadeAssembly Condition="$(TargetFramework.StartsWith('net4'))">true</IsPartialFacadeAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.Cryptography_PlatformNotSupported_Browser</GeneratePlatformNotSupportedAssemblyMessage>
+    <GeneratePlatformNotSupportedAssemblyMessage Condition="'$(TargetsBrowser)' == 'true'">SR.SystemSecurityCryptographyXml_PlatformNotSupported</GeneratePlatformNotSupportedAssemblyMessage>
   </PropertyGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
     <Compile Include="System\Security\Cryptography\Xml\AncestralNamespaceContextManager.cs" />


### PR DESCRIPTION
We sometimes used `... is not supported on Browser.` and elsewhere `... is not supported on this platform.`

Standardize on the latter one as it can potentially be reused for other targets.

Also unify the naming of the resource keys.