### PR TITLE
Remove unused locals in System.Security namespaces

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -610,7 +610,7 @@ namespace System.Security.Cryptography.Rsa.Tests
                 byte[] crypt = Encrypt(rsa, TestData.HelloBytes, RSAEncryptionPadding.OaepSHA1);
 
                 // Export the key, this should not clear/destroy the key.
-                RSAParameters ignored = rsa.ExportParameters(true);
+                rsa.ExportParameters(true);
                 output = Decrypt(rsa, crypt, RSAEncryptionPadding.OaepSHA1);
             }
 

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ACL.cs
@@ -587,7 +587,6 @@ namespace System.Security.AccessControl
 
         public void RemoveAce(int index)
         {
-            GenericAce ace = _aces[index];
             _aces.RemoveAt(index);
         }
 

--- a/src/libraries/System.Security.AccessControl/tests/RawAcl/RawAcl_RemoveAce.cs
+++ b/src/libraries/System.Security.AccessControl/tests/RawAcl/RawAcl_RemoveAce.cs
@@ -41,6 +41,13 @@ namespace System.Security.AccessControl.Tests
                 rawAcl.RemoveAce(index);
             });
 
+            //test remove at value too large
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                index = int.MaxValue;
+                rawAcl.RemoveAce(index);
+            });
+
             //test remove at 0, only need to catch ArgumentOutOfRangeException if Count = 0
             index = 0;
             try

--- a/src/libraries/System.Security.AccessControl/tests/RawAcl/RawAcl_RemoveAce.cs
+++ b/src/libraries/System.Security.AccessControl/tests/RawAcl/RawAcl_RemoveAce.cs
@@ -35,18 +35,22 @@ namespace System.Security.AccessControl.Tests
             count = rawAcl.Count;
 
             //test remove at -1
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                index = -1;
-                rawAcl.RemoveAce(index);
-            });
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                "index",
+                () =>
+                {
+                    index = -1;
+                    rawAcl.RemoveAce(index);
+                });
 
             //test remove at value too large
-            Assert.Throws<ArgumentOutOfRangeException>(() =>
-            {
-                index = int.MaxValue;
-                rawAcl.RemoveAce(index);
-            });
+            AssertExtensions.Throws<ArgumentOutOfRangeException>(
+                "index",
+                () =>
+                {
+                    index = int.MaxValue;
+                    rawAcl.RemoveAce(index);
+                });
 
             //test remove at 0, only need to catch ArgumentOutOfRangeException if Count = 0
             index = 0;


### PR DESCRIPTION
Remove unused locals in the System.Security namespaces.

Fixes a part of #30457.