### PR TITLE
Remove unused locals and fix tests in System.ServiceModel.Syndication

### DIFF
--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10CategoriesDocumentFormatterTests.cs
@@ -49,7 +49,6 @@ namespace System.ServiceModel.Syndication.Tests
         [InlineData(typeof(InlineCategoriesDocumentSubclass), typeof(ReferencedCategoriesDocumentSubclass))]
         public void Ctor_Type_Type(Type inlineDocumentType, Type referencedDocumentType)
         {
-            var document = new InlineCategoriesDocument();
             var formatter = new AtomPub10CategoriesDocumentFormatter(inlineDocumentType, referencedDocumentType);
             Assert.Null(formatter.Document);
             Assert.Equal("http://www.w3.org/2007/app", formatter.Version);

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
@@ -255,7 +255,6 @@ namespace System.ServiceModel.Syndication.Tests
                 writer.WriteEndElement();
             });
 
-            var genericFormatter = new AtomPub10ServiceDocumentFormatter<ServiceDocument>(document);
             CompareHelper.AssertEqualWriteOutput(expected, writer => formatter.WriteTo(writer));
             CompareHelper.AssertEqualWriteOutput(expected, writer => document.Save(writer));
             CompareHelper.AssertEqualWriteOutput(expected, writer =>
@@ -490,7 +489,7 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Equal("category_scheme", secondDocumentSecondCategory.Scheme);
                 Assert.Equal("category_label", secondDocumentSecondCategory.Label);
 
-                InlineCategoriesDocument thirdDocument = Assert.IsType<InlineCategoriesDocument>(secondCollection.Categories[2]);
+                Assert.IsType<InlineCategoriesDocument>(secondCollection.Categories[2]);
                 Assert.Empty(secondDocumentFirstCategory.AttributeExtensions);
                 Assert.Empty(secondDocumentFirstCategory.ElementExtensions);
                 Assert.Empty(secondDocumentFirstCategory.Name);
@@ -516,7 +515,7 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Null(fifthDocument.Language);
                 Assert.Equal(new Uri("http://emptyelement_link.com"), fifthDocument.Link);
 
-                ReferencedCategoriesDocument sixthDocument = Assert.IsType<ReferencedCategoriesDocument>(secondCollection.Categories[5]);
+                Assert.IsType<ReferencedCategoriesDocument>(secondCollection.Categories[5]);
                 Assert.Empty(fifthDocument.AttributeExtensions);
                 Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/relative_link"), fifthDocument.BaseUri);
                 Assert.Empty(fifthDocument.ElementExtensions);
@@ -666,7 +665,7 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Equal("category_scheme", secondDocumentSecondCategory.Scheme);
                 Assert.Equal("category_label", secondDocumentSecondCategory.Label);
 
-                InlineCategoriesDocumentTryParseTrueSubclass thirdDocument = Assert.IsType<InlineCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[2]);
+                Assert.IsType<InlineCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[2]);
                 Assert.Empty(secondDocumentFirstCategory.AttributeExtensions);
                 Assert.Empty(secondDocumentFirstCategory.ElementExtensions);
                 Assert.Empty(secondDocumentFirstCategory.Name);
@@ -687,7 +686,7 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Null(fifthDocument.Language);
                 Assert.Equal(new Uri("http://emptyelement_link.com"), fifthDocument.Link);
 
-                ReferencedCategoriesDocumentTryParseTrueSubclass sixthDocument = Assert.IsType<ReferencedCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[5]);
+                Assert.IsType<ReferencedCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[5]);
                 Assert.Empty(fifthDocument.AttributeExtensions);
                 Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/relative_link"), fifthDocument.BaseUri);
                 Assert.Empty(fifthDocument.ElementExtensions);
@@ -944,7 +943,7 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Empty(document.Workspaces);
 
             var typedFormatter = new GenericFormatter<ServiceDocumentSubclass>();
-            ServiceDocumentSubclass item = Assert.IsType<ServiceDocumentSubclass>(typedFormatter.CreateDocumentInstanceEntryPoint());
+            Assert.IsType<ServiceDocumentSubclass>(typedFormatter.CreateDocumentInstanceEntryPoint());
             Assert.Empty(document.AttributeExtensions);
             Assert.Null(document.BaseUri);
             Assert.Empty(document.ElementExtensions);

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
@@ -947,12 +947,12 @@ namespace System.ServiceModel.Syndication.Tests
             Assert.Empty(document.Workspaces);
 
             var typedFormatter = new GenericFormatter<ServiceDocumentSubclass>();
-            Assert.IsType<ServiceDocumentSubclass>(typedFormatter.CreateDocumentInstanceEntryPoint());
-            Assert.Empty(document.AttributeExtensions);
-            Assert.Null(document.BaseUri);
-            Assert.Empty(document.ElementExtensions);
-            Assert.Null(document.Language);
-            Assert.Empty(document.Workspaces);
+            ServiceDocumentSubclass item = Assert.IsType<ServiceDocumentSubclass>(typedFormatter.CreateDocumentInstanceEntryPoint());
+            Assert.Empty(item.AttributeExtensions);
+            Assert.Null(item.BaseUri);
+            Assert.Empty(item.ElementExtensions);
+            Assert.Null(item.Language);
+            Assert.Empty(item.Workspaces);
         }
 
         public class ServiceDocumentSubclass : ServiceDocument { }

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
@@ -517,12 +517,12 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Null(fifthDocument.Language);
                 Assert.Equal(new Uri("http://emptyelement_link.com"), fifthDocument.Link);
 
-                Assert.IsType<ReferencedCategoriesDocument>(secondCollection.Categories[5]);
-                Assert.Empty(fifthDocument.AttributeExtensions);
-                Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/relative_link"), fifthDocument.BaseUri);
-                Assert.Empty(fifthDocument.ElementExtensions);
-                Assert.Null(fifthDocument.Language);
-                Assert.Equal(new Uri("http://emptyelement_link.com"), fifthDocument.Link);
+                ReferencedCategoriesDocument sixthDocument = Assert.IsType<ReferencedCategoriesDocument>(secondCollection.Categories[5]);
+                Assert.Empty(sixthDocument.AttributeExtensions);
+                Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/relative_link"), sixthDocument.BaseUri);
+                Assert.Empty(sixthDocument.ElementExtensions);
+                Assert.Null(sixthDocument.Language);
+                Assert.Equal(new Uri("http://emptyelement_link.com"), sixthDocument.Link);
             });
         }
 
@@ -690,12 +690,12 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Null(fifthDocument.Language);
                 Assert.Equal(new Uri("http://emptyelement_link.com"), fifthDocument.Link);
 
-                Assert.IsType<ReferencedCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[5]);
-                Assert.Empty(fifthDocument.AttributeExtensions);
-                Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/relative_link"), fifthDocument.BaseUri);
-                Assert.Empty(fifthDocument.ElementExtensions);
-                Assert.Null(fifthDocument.Language);
-                Assert.Equal(new Uri("http://emptyelement_link.com"), fifthDocument.Link);
+                ReferencedCategoriesDocumentTryParseTrueSubclass sixthDocument = Assert.IsType<ReferencedCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[5]);
+                Assert.Empty(sixthDocument.AttributeExtensions);
+                Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/relative_link"), sixthDocument.BaseUri);
+                Assert.Empty(sixthDocument.ElementExtensions);
+                Assert.Null(sixthDocument.Language);
+                Assert.Equal(new Uri("http://emptyelement_link.com"), sixthDocument.Link);
             }
         }
 

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/AtomPub10ServiceDocumentFormatterTests.cs
@@ -489,12 +489,14 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Equal("category_scheme", secondDocumentSecondCategory.Scheme);
                 Assert.Equal("category_label", secondDocumentSecondCategory.Label);
 
-                Assert.IsType<InlineCategoriesDocument>(secondCollection.Categories[2]);
-                Assert.Empty(secondDocumentFirstCategory.AttributeExtensions);
-                Assert.Empty(secondDocumentFirstCategory.ElementExtensions);
-                Assert.Empty(secondDocumentFirstCategory.Name);
-                Assert.Equal("inlinecategories_scheme", secondDocumentFirstCategory.Scheme);
-                Assert.Null(secondDocumentFirstCategory.Label);
+                InlineCategoriesDocument thirdDocument = Assert.IsType<InlineCategoriesDocument>(secondCollection.Categories[2]);
+                Assert.Empty(thirdDocument.AttributeExtensions);
+                Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/"), thirdDocument.BaseUri);
+                Assert.Empty(thirdDocument.Categories);
+                Assert.Empty(thirdDocument.ElementExtensions);
+                Assert.False(thirdDocument.IsFixed);
+                Assert.Null(thirdDocument.Language);
+                Assert.Null(thirdDocument.Scheme);
 
                 ReferencedCategoriesDocument fourthDocument = Assert.IsType<ReferencedCategoriesDocument>(secondCollection.Categories[3]);
                 Assert.Equal(4, fourthDocument.AttributeExtensions.Count);
@@ -665,12 +667,14 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Equal("category_scheme", secondDocumentSecondCategory.Scheme);
                 Assert.Equal("category_label", secondDocumentSecondCategory.Label);
 
-                Assert.IsType<InlineCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[2]);
-                Assert.Empty(secondDocumentFirstCategory.AttributeExtensions);
-                Assert.Empty(secondDocumentFirstCategory.ElementExtensions);
-                Assert.Empty(secondDocumentFirstCategory.Name);
-                Assert.Equal("inlinecategories_scheme", secondDocumentFirstCategory.Scheme);
-                Assert.Null(secondDocumentFirstCategory.Label);
+                InlineCategoriesDocumentTryParseTrueSubclass thirdDocument = Assert.IsType<InlineCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[2]);
+                Assert.Empty(thirdDocument.AttributeExtensions);
+                Assert.Equal(new Uri("http://resourcecollectioninfo_url.com/"), thirdDocument.BaseUri);
+                Assert.Empty(thirdDocument.Categories);
+                Assert.Empty(thirdDocument.ElementExtensions);
+                Assert.False(thirdDocument.IsFixed);
+                Assert.Null(thirdDocument.Language);
+                Assert.Null(thirdDocument.Scheme);
 
                 ReferencedCategoriesDocumentTryParseTrueSubclass fourthDocument = Assert.IsType<ReferencedCategoriesDocumentTryParseTrueSubclass>(secondCollection.Categories[3]);
                 Assert.Empty(fourthDocument.AttributeExtensions);

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20FeedFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20FeedFormatterTests.cs
@@ -449,7 +449,8 @@ namespace System.ServiceModel.Syndication.Tests
                 writer.WriteEndElement();
             });
 
-            CompareHelper.AssertEqualWriteOutput(expectedFull, writer => formatter.WriteTo(writer));
+            var genericFormatter = new Rss20FeedFormatter<SyndicationFeed>(feed);
+            CompareHelper.AssertEqualWriteOutput(expectedFull, writer => genericFormatter.WriteTo(writer));
             CompareHelper.AssertEqualWriteOutput(expectedFull, writer => feed.SaveAsRss20(writer));
         }
 

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20FeedFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20FeedFormatterTests.cs
@@ -449,7 +449,6 @@ namespace System.ServiceModel.Syndication.Tests
                 writer.WriteEndElement();
             });
 
-            var genericFormatter = new Rss20FeedFormatter<SyndicationFeed>(feed);
             CompareHelper.AssertEqualWriteOutput(expectedFull, writer => formatter.WriteTo(writer));
             CompareHelper.AssertEqualWriteOutput(expectedFull, writer => feed.SaveAsRss20(writer));
         }

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20ItemFormatterTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/Rss20ItemFormatterTests.cs
@@ -746,11 +746,11 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Equal("author_uri", thirdAuthor.Uri);
 
                 SyndicationPerson fourthAuthor = item.Authors[3];
-                Assert.Empty(firstAuthor.AttributeExtensions);
-                Assert.Empty(firstAuthor.ElementExtensions);
-                Assert.Null(firstAuthor.Email);
-                Assert.Null(firstAuthor.Name);
-                Assert.Null(firstAuthor.Uri);
+                Assert.Empty(fourthAuthor.AttributeExtensions);
+                Assert.Empty(fourthAuthor.ElementExtensions);
+                Assert.Null(fourthAuthor.Email);
+                Assert.Null(fourthAuthor.Name);
+                Assert.Null(fourthAuthor.Uri);
 
                 SyndicationPerson fifthAuthor = item.Authors[4];
                 Assert.Empty(fifthAuthor.AttributeExtensions);
@@ -1150,11 +1150,11 @@ namespace System.ServiceModel.Syndication.Tests
                 Assert.Equal("author_uri", thirdAuthor.Uri);
 
                 SyndicationPerson fourthAuthor = item.Authors[3];
-                Assert.Empty(firstAuthor.AttributeExtensions);
-                Assert.Empty(firstAuthor.ElementExtensions);
-                Assert.Null(firstAuthor.Email);
-                Assert.Null(firstAuthor.Name);
-                Assert.Null(firstAuthor.Uri);
+                Assert.Empty(fourthAuthor.AttributeExtensions);
+                Assert.Empty(fourthAuthor.ElementExtensions);
+                Assert.Null(fourthAuthor.Email);
+                Assert.Null(fourthAuthor.Name);
+                Assert.Null(fourthAuthor.Uri);
 
                 SyndicationPerson fifthAuthor = item.Authors[4];
                 Assert.Empty(fifthAuthor.AttributeExtensions);

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationElementExtensionCollectionTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationElementExtensionCollectionTests.cs
@@ -205,6 +205,10 @@ namespace System.ServiceModel.Syndication.Tests
         public void Clone_NoExtensions_ReturnsExpected()
         {
             var category = new SyndicationCategory();
+
+            SyndicationElementExtensionCollection elementExtensions = category.ElementExtensions;
+            Assert.Empty(elementExtensions);
+
             SyndicationElementExtensionCollection clone = category.Clone().ElementExtensions;
             Assert.Empty(clone);
         }

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationElementExtensionCollectionTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationElementExtensionCollectionTests.cs
@@ -108,7 +108,6 @@ namespace System.ServiceModel.Syndication.Tests
         [Fact]
         public void ItemSet_Null_ThrowsArgumentNullException()
         {
-            var extension = new SyndicationElementExtension(new ExtensionObject { Value = 10 });
             SyndicationElementExtensionCollection elementExtensions = new SyndicationCategory().ElementExtensions;
             elementExtensions.Add(new ExtensionObject { Value = 9 });
 
@@ -206,8 +205,6 @@ namespace System.ServiceModel.Syndication.Tests
         public void Clone_NoExtensions_ReturnsExpected()
         {
             var category = new SyndicationCategory();
-            SyndicationElementExtensionCollection elementExtensions = category.ElementExtensions;
-
             SyndicationElementExtensionCollection clone = category.Clone().ElementExtensions;
             Assert.Empty(clone);
         }

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationElementExtensionTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationElementExtensionTests.cs
@@ -17,7 +17,6 @@ namespace System.ServiceModel.Syndication.Tests
         [Fact]
         public void Ctor_Reader()
         {
-            var extensionObject = new ExtensionObject { Value = 10 };
             var extension = new SyndicationElementExtension(new XElement("ExtensionObject", new XElement("Value", 10)).CreateReader());
             Assert.Equal("ExtensionObject", extension.OuterName);
             Assert.Empty(extension.OuterNamespace);
@@ -215,7 +214,6 @@ namespace System.ServiceModel.Syndication.Tests
         [Fact]
         public void GetReader_WithReader_ReturnsExpected()
         {
-            var extensionObject = new ExtensionObject { Value = 10 };
             var extension = new SyndicationElementExtension(new XElement("ExtensionObject", new XElement("Value", 10)).CreateReader());
             XmlReader reader = extension.GetReader();
             Assert.Equal(@"<ExtensionObject><Value>10</Value></ExtensionObject>", reader.ReadOuterXml());

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationFeedTests.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationFeedTests.cs
@@ -209,7 +209,6 @@ namespace System.ServiceModel.Syndication.Tests
         [Fact]
         public void Ctor_NullSource_ThrowsArgumentNullException()
         {
-            var feed = new SyndicationFeed();
             AssertExtensions.Throws<ArgumentNullException>("source", () => new SyndicationFeedSubclass(null, true));
         }
 
@@ -469,8 +468,6 @@ namespace System.ServiceModel.Syndication.Tests
             public SyndicationFeedSubclass(SyndicationFeed source, bool cloneItems) : base(source, cloneItems) { }
 
             public SyndicationCategory CreateCategoryEntryPoint() => CreateCategory();
-
-            public SyndicationItem CreateItemEntryPoint() => CreateItem();
 
             public SyndicationLink CreateLinkEntryPoint() => CreateLink();
 

--- a/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationFeedTests.netcoreapp.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/System/ServiceModel/Syndication/SyndicationFeedTests.netcoreapp.cs
@@ -96,7 +96,6 @@ namespace System.ServiceModel.Syndication.Tests
         [Fact]
         public void Ctor_NoNetcoreappProperties_Success()
         {
-            var input = new SyndicationTextInput();
             var feed = new SyndicationFeed();
             var clone = new SyndicationFeedSubclass(feed, cloneItems: false);
             Assert.Null(clone.Documentation);

--- a/src/libraries/System.ServiceModel.Syndication/tests/Utils/XmlDiffDocument.cs
+++ b/src/libraries/System.ServiceModel.Syndication/tests/Utils/XmlDiffDocument.cs
@@ -667,7 +667,6 @@ namespace System.ServiceModel.Syndication.Tests
         {
             if (elem.FirstChild != null)
             {
-                XmlDiffNode _first = elem.FirstChild;
                 XmlDiffNode _current = elem.FirstChild;
                 XmlDiffNode _last = elem.LastChild;
                 elem._firstChild = null;


### PR DESCRIPTION
Remove unused locals in System.ServiceModel.Syndication.

While refactoring I found two places where unit tests appear to have a
copy/paste error and were asserting the wrong value.

This fixes part of #30457.