### PR TITLE
Fix tiering assertion failures from concurrent or reentering JIT of the same native code version

### DIFF
--- a/src/coreclr/src/vm/callcounting.cpp
+++ b/src/coreclr/src/vm/callcounting.cpp
@@ -479,7 +479,7 @@ void CallCountingManager::DisableCallCounting(NativeCodeVersion codeVersion)
     {
         // Call counting may already have been disabled due to the possibility of concurrent or reentering JIT of the same
         // native code version of a method. The call counting info is created with call counting enabled or disabled and it
-        // cannot be changed thereafter for consistency in dependencies of the info.
+        // cannot be changed thereafter for consistency in dependents of the info.
         _ASSERTE(callCountingInfo->GetStage() == CallCountingInfo::Stage::Disabled);
         return;
     }

--- a/src/coreclr/src/vm/callcounting.cpp
+++ b/src/coreclr/src/vm/callcounting.cpp
@@ -474,7 +474,16 @@ void CallCountingManager::DisableCallCounting(NativeCodeVersion codeVersion)
 
     CodeVersionManager::LockHolder codeVersioningLockHolder;
 
-    _ASSERTE(m_callCountingInfoByCodeVersionHash.Lookup(codeVersion) == nullptr);
+    CallCountingInfo *callCountingInfo = m_callCountingInfoByCodeVersionHash.Lookup(codeVersion);
+    if (callCountingInfo != nullptr)
+    {
+        // Call counting may already have been disabled due to the possibility of concurrent or reentering JIT of the same
+        // native code version of a method. The call counting info is created with call counting enabled or disabled and it
+        // cannot be changed thereafter for consistency in dependencies of the info.
+        _ASSERTE(callCountingInfo->GetStage() == CallCountingInfo::Stage::Disabled);
+        return;
+    }
+
     NewHolder<CallCountingInfo> callCountingInfoHolder = CallCountingInfo::CreateWithCallCountingDisabled(codeVersion);
     m_callCountingInfoByCodeVersionHash.Add(callCountingInfoHolder);
     callCountingInfoHolder.SuppressRelease();

--- a/src/coreclr/src/vm/prestub.cpp
+++ b/src/coreclr/src/vm/prestub.cpp
@@ -1071,7 +1071,7 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
             // Call counting may already have been disabled due to the possibility of concurrent or reentering JIT of the same
             // native code version of a method. The current optimization tier should be consistent with the change being made
             // (Tier 0 to Optimized), such that the tier is not changed in an unexpected way or at an unexpected time. Since
-            // changes to the optimziation tier are unlocked, this assertion is just a speculative check on possible values.
+            // changes to the optimization tier are unlocked, this assertion is just a speculative check on possible values.
             NativeCodeVersion::OptimizationTier previousOptimizationTier = pConfig->GetCodeVersion().GetOptimizationTier();
             _ASSERTE(
                 previousOptimizationTier == NativeCodeVersion::OptimizationTier0 ||

--- a/src/coreclr/src/vm/prestub.cpp
+++ b/src/coreclr/src/vm/prestub.cpp
@@ -1063,11 +1063,21 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
     bool shouldCountCalls = false;
     if (pFlags->IsSet(CORJIT_FLAGS::CORJIT_FLAG_TIER0))
     {
-        _ASSERTE(pConfig->GetCodeVersion().GetOptimizationTier() == NativeCodeVersion::OptimizationTier0);
         _ASSERTE(pConfig->GetMethodDesc()->IsEligibleForTieredCompilation());
 
         if (pConfig->JitSwitchedToOptimized())
         {
+#ifdef _DEBUG
+            // Call counting may already have been disabled due to the possibility of concurrent or reentering JIT of the same
+            // native code version of a method. The current optimization tier should be consistent with the change being made
+            // (Tier 0 to Optimized), such that the tier is not changed in an unexpected way or at an unexpected time. Since
+            // changes to the optimziation tier are unlocked, this assertion is just a speculative check on possible values.
+            NativeCodeVersion::OptimizationTier previousOptimizationTier = pConfig->GetCodeVersion().GetOptimizationTier();
+            _ASSERTE(
+                previousOptimizationTier == NativeCodeVersion::OptimizationTier0 ||
+                previousOptimizationTier == NativeCodeVersion::OptimizationTierOptimized);
+#endif // _DEBUG
+
             // Update the tier in the code version. The JIT may have decided to switch from tier 0 to optimized, in which case
             // call counting would have to be disabled for the method.
             NativeCodeVersion codeVersion = pConfig->GetCodeVersion();
@@ -1082,7 +1092,7 @@ PCODE MethodDesc::JitCompileCodeLocked(PrepareCodeConfig* pConfig, JitListLockEn
             shouldCountCalls = true;
         }
     }
-#endif
+#endif // FEATURE_TIERED_COMPILATION
 
     // Aside from rejit, performing a SetNativeCodeInterlocked at this point
     // generally ensures that there is only one winning version of the native


### PR DESCRIPTION
Allowed disabling call counting multiple times.

Fixes https://github.com/dotnet/runtime/issues/39604