### PR TITLE
WASM: Enable System.Reflection.MetadataLoadContext tests

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -132,9 +132,6 @@
       <WasmFilesToIncludeInFileSystem Include="@(ContentWithTargetPath)" />
       <WasmFilesToIncludeInFileSystem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.BuildReference)' == 'true' and !$([System.String]::new('%(ReferenceCopyLocalPaths.Identity)').EndsWith('.resources.dll'))" />
       <WasmFilesToIncludeInFileSystem Include="@(WasmSatelliteAssemblies)" TargetPath="%(WasmSatelliteAssemblies.CultureName)\%(WasmSatelliteAssemblies.Filename)%(WasmSatelliteAssemblies.Extension)" />
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Private.CoreLib.dll" Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'" />
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.MetadataLoadContext.Tests.dll" Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'" />
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)mscorlib.dll" Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'" />
       <ExtraAssemblies Include="$(PublishDir)$(AssemblyName).dll" />
       <!-- we need to preserve these facades for BinaryFormatter tests -->
       <ExtraAssemblies Include="$(PublishDir)mscorlib.dll" />
@@ -149,6 +146,11 @@
       <ExtraAssemblies Include="$(PublishDir)System.Transactions.dll" />
       <ExtraAssemblies Include="$(PublishDir)System.Xml.dll" />
       <ExtraAssemblies Include="$(PublishDir)WindowsBase.dll" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'">
+      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Private.CoreLib.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.MetadataLoadContext.Tests.dll" />
+      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)mscorlib.dll" />
     </ItemGroup>
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <WasmAppBuilder

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -132,6 +132,9 @@
       <WasmFilesToIncludeInFileSystem Include="@(ContentWithTargetPath)" />
       <WasmFilesToIncludeInFileSystem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.BuildReference)' == 'true' and !$([System.String]::new('%(ReferenceCopyLocalPaths.Identity)').EndsWith('.resources.dll'))" />
       <WasmFilesToIncludeInFileSystem Include="@(WasmSatelliteAssemblies)" TargetPath="%(WasmSatelliteAssemblies.CultureName)\%(WasmSatelliteAssemblies.Filename)%(WasmSatelliteAssemblies.Extension)" />
+      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Private.CoreLib.dll" Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'" />
+      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.MetadataLoadContext.Tests.dll" Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'" />
+      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)mscorlib.dll" Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'" />
       <ExtraAssemblies Include="$(PublishDir)$(AssemblyName).dll" />
       <!-- we need to preserve these facades for BinaryFormatter tests -->
       <ExtraAssemblies Include="$(PublishDir)mscorlib.dll" />

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/MetadataLoadContext/PathAssemblyResolver.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/MetadataLoadContext/PathAssemblyResolver.cs
@@ -62,6 +62,12 @@ namespace System.Reflection.Tests
             // Obtain this test class
             string thisAssemblyPath = typeof(MetadataLoadContextTests).Assembly.Location;
 
+            if (PlatformDetection.IsBrowser)
+            {
+                // prepends slash as Assembly.Location only contains the file name on browser (https://github.com/dotnet/runtime/issues/39650)
+                thisAssemblyPath = "/" + thisAssemblyPath;
+            }
+
             var resolver = new PathAssemblyResolver(new string[] { coreAssemblyPath, thisAssemblyPath });
             using (MetadataLoadContext lc = new MetadataLoadContext(resolver, TestUtils.GetNameOfCoreAssembly()))
             {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -42,7 +42,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSerializer\ReflectionOnly\System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSerializer\System.Xml.XmlSerializer.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.Metadata\tests\System.Reflection.Metadata.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.MetadataLoadContext\tests\System.Reflection.MetadataLoadContext.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\CoreCLR\System.Reflection.CoreCLR.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection\tests\System.Reflection.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Permissions\tests\System.Security.Permissions.Tests.csproj" />


### PR DESCRIPTION
`Tests run: 559, Errors: 0, Failures: 0, Skipped: 0. Time: 5.4221639s`