### PR TITLE
Fix TableOutOfRangeException in Crossgen2

### DIFF
--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedFieldRvaNode.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedFieldRvaNode.cs
@@ -67,7 +67,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 int currentFieldRid;
                 if (compressedFieldRef)
                 {
-                    currentFieldRid = metadataBlob.ReadInt16();
+                    currentFieldRid = metadataBlob.ReadUInt16();
                 }
                 else
                 {

--- a/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMetadataBlobNode.cs
+++ b/src/coreclr/src/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMetadataBlobNode.cs
@@ -84,7 +84,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 int fieldToken;
                 if (compressedFieldRef)
                 {
-                    fieldToken = reader.ReadInt16();
+                    fieldToken = reader.ReadUInt16();
                 }
                 else
                 {


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/39493

Turns out the compilation failure here wasn't caused by Managed C++,
it was due to a simple bug in the field RVA copy loop - reading
compressed 16-bit field indices as signed, not unsigned, from the
FieldRVA ECMA metadata table.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib 