### PR TITLE
ensure we can cancel a write operation while we are waiting for a write on the HTTP2 connection to complete

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -861,28 +861,32 @@ namespace System.Net.Http
                 {
                     while (_writeChannel.Reader.TryRead(out WriteQueueEntry? writeEntry))
                     {
-                        if (writeEntry.TryDisableCancellation())
+                        if (_abortException is not null)
                         {
-                            if (_abortException is not null)
+                            if (writeEntry.TryDisableCancellation())
                             {
                                 writeEntry.SetException(_abortException);
                             }
-                            else
+                        }
+                        else
+                        {
+                            int writeBytes = writeEntry.WriteBytes;
+
+                            // If the buffer has already grown to 32k, does not have room for the next request,
+                            // and is non-empty, flush the current contents to the wire.
+                            int totalBufferLength = _outgoingBuffer.Capacity;
+                            if (totalBufferLength >= UnflushedOutgoingBufferSize)
                             {
-                                int writeBytes = writeEntry.WriteBytes;
-
-                                // If the buffer has already grown to 32k, does not have room for the next request,
-                                // and is non-empty, flush the current contents to the wire.
-                                int totalBufferLength = _outgoingBuffer.Capacity;
-                                if (totalBufferLength >= UnflushedOutgoingBufferSize)
+                                int activeBufferLength = _outgoingBuffer.ActiveLength;
+                                if (writeBytes >= totalBufferLength - activeBufferLength)
                                 {
-                                    int activeBufferLength = _outgoingBuffer.ActiveLength;
-                                    if (writeBytes >= totalBufferLength - activeBufferLength)
-                                    {
-                                        await FlushOutgoingBytesAsync().ConfigureAwait(false);
-                                    }
+                                    await FlushOutgoingBytesAsync().ConfigureAwait(false);
                                 }
+                            }
 
+                            // We are ready to process the write, so disable write cancellation now.
+                            if (writeEntry.TryDisableCancellation())
+                            {
                                 _outgoingBuffer.EnsureAvailableSpace(writeBytes);
 
                                 try
@@ -902,7 +906,6 @@ namespace System.Net.Http
                                     writeEntry.SetException(e);
                                 }
                             }
-
                         }
                     }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -3116,6 +3116,46 @@ namespace System.Net.Http.Functional.Tests
                 });
         }
 
+        [Fact]
+        [OuterLoop("Uses Task.Delay")]
+        public async Task SocketSendQueueFull_RequestCanceled_ThrowsOperationCanceled()
+        {
+            TaskCompletionSource clientComplete = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            await Http2LoopbackServer.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+                    using HttpClient client = CreateHttpClient();
+
+                    // Post a large request, large enough to fill the socket send buffer
+                    Task postTask = client.PostAsync(uri, new StringContent(new string('a', 16 * 1024 * 1024)), cancellationTokenSource.Token);
+
+                    // Wait a while to hopefully ensure that the send buffer has been completely filled
+                    await Task.Delay(3000);
+
+                    Assert.False(postTask.IsCompleted);
+
+                    // Ensure that the request can be cancelled
+                    cancellationTokenSource.Cancel();
+                    await Assert.ThrowsAnyAsync<OperationCanceledException>(() => postTask);
+
+                    // Allow server to exit
+                    clientComplete.SetResult();
+                },
+                async server =>
+                {
+                    // Establish the connection and ensure client is not blocked on windows
+                    Http2LoopbackConnection connection = await server.EstablishConnectionAsync(new SettingsEntry { SettingId = SettingId.InitialWindowSize, Value = 128 * 1024 * 1024 });
+                    await connection.WriteFrameAsync(new WindowUpdateFrame(128 * 1024 * 1024, 0));
+
+                    // Now, don't process any frames. Let the client's send buffer fill up.
+                    // When the client is done, it will signal us.
+                    await clientComplete.Task;
+                });
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
Fixes #1577 

We need to wait to disable cancellation until after we flush the write buffer, otherwise we could wait indefinitely on the connection write without cancelling the write operation.

@dotnet/ncl @JamesNK 