### PR TITLE
Limit arm32 Windows testing.

### DIFF
--- a/eng/pipelines/coreclr/jitstress.yml
+++ b/eng/pipelines/coreclr/jitstress.yml
@@ -28,7 +28,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -56,7 +55,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstress2-jitstressregs.yml
@@ -28,7 +28,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -56,7 +55,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/jitstressregs.yml
+++ b/eng/pipelines/coreclr/jitstressregs.yml
@@ -28,7 +28,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
     jobParameters:
@@ -56,7 +55,6 @@ jobs:
     - Linux_x64
     - Windows_NT_x64
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     helixQueueGroup: ci
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -682,7 +682,6 @@ jobs:
     platforms:
     - Linux_arm
     - Windows_NT_x86
-    - Windows_NT_arm
     - Windows_NT_arm64
     helixQueueGroup: pr
     helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -850,7 +849,6 @@ jobs:
     platforms:
     - Windows_NT_x86
     - ${{ if eq(variables['isFullMatrix'], true) }}:
-      - Windows_NT_arm
       - Windows_NT_arm64
     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
     jobParameters:


### PR DESCRIPTION
Remove Windows arm32 testing from PRs. Builds are not removed.
Remove Windows arm32 jitstress testing.
Remove Windows arm32 builds from official builds.

Outerloop still has Windows arm32 builds and testing.

Resolves #38570.