### PR TITLE
Add events around type load and r2r usage

### DIFF
--- a/src/coreclr/src/inc/eventtrace.h
+++ b/src/coreclr/src/inc/eventtrace.h
@@ -172,6 +172,8 @@ namespace ETW
         static void Cleanup();
         static VOID DeleteTypeHashNoLock(AllLoggedTypes **ppAllLoggedTypes);
         static VOID FlushObjectAllocationEvents();
+        static UINT32 TypeLoadBegin();
+        static VOID TypeLoadEnd(UINT32 typeLoad, TypeHandle th, UINT16 loadLevel);
 
     private:
         static BOOL ShouldLogType(TypeHandle th);

--- a/src/coreclr/src/inc/eventtracebase.h
+++ b/src/coreclr/src/inc/eventtracebase.h
@@ -918,7 +918,7 @@ namespace ETW
         static const UINT8 MethodFlagsJitOptimizationTierShift = 7;
         static const unsigned int MethodFlagsJitOptimizationTierLowMask = 0x7;
 
-        static VOID GetR2RGetEntryPointStarted(MethodDesc *pMethodDesc);
+        static VOID GetR2RGetEntryPointStart(MethodDesc *pMethodDesc);
         static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint);
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);
@@ -929,7 +929,7 @@ namespace ETW
         static VOID DynamicMethodDestroyed(MethodDesc *pMethodDesc);
 #else // FEATURE_EVENT_TRACE
     public:
-        static VOID GetR2RGetEntryPointStarted(MethodDesc *pMethodDesc) {};
+        static VOID GetR2RGetEntryPointStart(MethodDesc *pMethodDesc) {};
         static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint) {};
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);

--- a/src/coreclr/src/inc/eventtracebase.h
+++ b/src/coreclr/src/inc/eventtracebase.h
@@ -918,6 +918,7 @@ namespace ETW
         static const UINT8 MethodFlagsJitOptimizationTierShift = 7;
         static const unsigned int MethodFlagsJitOptimizationTierLowMask = 0x7;
 
+        static VOID GetR2RGetEntryPointStarted(MethodDesc *pMethodDesc);
         static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint);
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);
@@ -928,6 +929,7 @@ namespace ETW
         static VOID DynamicMethodDestroyed(MethodDesc *pMethodDesc);
 #else // FEATURE_EVENT_TRACE
     public:
+        static VOID GetR2RGetEntryPointStarted(MethodDesc *pMethodDesc) {};
         static VOID GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPoint) {};
         static VOID MethodJitting(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature);
         static VOID MethodJitted(MethodDesc *pMethodDesc, SString *namespaceOrClassName, SString *methodName, SString *methodSignature, PCODE pNativeCodeStartAddress, PrepareCodeConfig *pConfig);

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -247,7 +247,6 @@
                             <opcode name="AssemblyUnload" message="$(string.RuntimePublisher.AssemblyUnloadOpcodeMessage)" symbol="CLR_ASSEMBLYUNLOAD_OPCODE" value="38"> </opcode>
                             <opcode name="AppDomainLoad" message="$(string.RuntimePublisher.AppDomainLoadOpcodeMessage)" symbol="CLR_APPDOMAINLOAD_OPCODE" value="41"> </opcode>
                             <opcode name="AppDomainUnload" message="$(string.RuntimePublisher.AppDomainUnloadOpcodeMessage)" symbol="CLR_APPDOMAINUNLOAD_OPCODE" value="42"> </opcode>
-                            <opcode name="TypeLoad" message="$(string.RuntimePublisher.TypeLoadOpcodeMessage)" symbol="CLR_TYPELOAD_OPCODE" value="46"> </opcode>
                         </opcodes>
                     </task>
 
@@ -404,7 +403,14 @@
                             <opcode name="KnownPathProbed" message="$(string.RuntimePublisher.KnownPathProbedOpcodeMessage)" symbol="CLR_BINDING_PATH_PROBED_OPCODE" value="15"/>
                         </opcodes>
                     </task>
-                <!--Next available ID is 33-->
+                    <task name="TypeLoad" symbol="CLR_TYPELOAD_TASK"
+                          value="33" eventGUID="{9DB1562B-512F-475D-8D4C-0C6D97C1E73C}"
+                          message="$(string.RuntimePublisher.TypeLoadTaskMessage)">
+                        <opcodes>
+                        </opcodes>
+                    </task>
+
+                <!--Next available ID is 34-->
                 </tasks>
                 <!--Maps-->
                 <maps>
@@ -3252,15 +3258,15 @@
 
                     <event value="73" version="0" level="win:Informational"  template="TypeLoadStart"
                            keywords="TypeDiagnosticKeyword"
-                           task="CLRLoader"
-                           opcode="TypeLoad"
+                           task="TypeLoad"
+                           opcode="win:Start"
                            symbol="TypeLoadStart"
                            message="$(string.RuntimePublisher.TypeLoadStartEventMessage)"/>
 
                     <event value="74" version="0" level="win:Informational"  template="TypeLoadStop"
                            keywords="TypeDiagnosticKeyword"
-                           task="CLRLoader"
-                           opcode="TypeLoad"
+                           task="TypeLoad"
+                           opcode="win:Stop"
                            symbol="TypeLoadStop"
                            message="$(string.RuntimePublisher.TypeLoadStopEventMessage)"/>
 
@@ -7214,6 +7220,7 @@
                 <string id="RuntimePublisher.CodeSymbolsTaskMessage" value="CodeSymbols" />
                 <string id="RuntimePublisher.TieredCompilationTaskMessage" value="TieredCompilation" />
                 <string id="RuntimePublisher.AssemblyLoaderTaskMessage" value="AssemblyLoader" />
+                <string id="RuntimePublisher.TypeLoadTaskMessage" value="TypeLoad" />
 
                 <string id="RundownPublisher.EEStartupTaskMessage" value="Runtime" />
                 <string id="RundownPublisher.MethodTaskMessage" value="Method" />
@@ -7606,7 +7613,6 @@
                 <string id="RuntimePublisher.FinalizeObjectOpcodeMessage" value="FinalizeObject" />
                 <string id="RuntimePublisher.BulkTypeOpcodeMessage" value="BulkType" />
                 <string id="RuntimePublisher.MethodDetailsOpcodeMessage" value="MethodDetails" />
-                <string id="RuntimePublisher.TypeLoadOpcodeMessage" value="TypeLoad" />
                 <string id="RuntimePublisher.MethodLoadOpcodeMessage" value="Load" />
                 <string id="RuntimePublisher.MethodUnloadOpcodeMessage" value="Unload" />
                 <string id="RuntimePublisher.MethodLoadVerboseOpcodeMessage" value="LoadVerbose" />

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -83,6 +83,8 @@
                              message="$(string.RuntimePublisher.CompilationDiagnosticKeywordMessage)" symbol="CLR_COMPILATIONDIAGNOSTIC_KEYWORD" />
                     <keyword name="MethodDiagnosticKeyword" mask="0x4000000000"
                              message="$(string.RuntimePublisher.MethodDiagnosticKeywordMessage)" symbol="CLR_METHODDIAGNOSTIC_KEYWORD" />
+                    <keyword name="TypeDiagnosticKeyword" mask="0x8000000000"
+                             message="$(string.RuntimePublisher.TypeDiagnosticKeywordMessage)" symbol="CLR_TYPEDIAGNOSTIC_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -245,6 +247,7 @@
                             <opcode name="AssemblyUnload" message="$(string.RuntimePublisher.AssemblyUnloadOpcodeMessage)" symbol="CLR_ASSEMBLYUNLOAD_OPCODE" value="38"> </opcode>
                             <opcode name="AppDomainLoad" message="$(string.RuntimePublisher.AppDomainLoadOpcodeMessage)" symbol="CLR_APPDOMAINLOAD_OPCODE" value="41"> </opcode>
                             <opcode name="AppDomainUnload" message="$(string.RuntimePublisher.AppDomainUnloadOpcodeMessage)" symbol="CLR_APPDOMAINUNLOAD_OPCODE" value="42"> </opcode>
+                            <opcode name="TypeLoad" message="$(string.RuntimePublisher.TypeLoadOpcodeMessage)" symbol="CLR_TYPELOAD_OPCODE" value="46"> </opcode>
                         </opcodes>
                     </task>
 
@@ -1895,6 +1898,34 @@
                         </UserData>
                     </template>
 
+                    <template tid="TypeLoadStart">
+                        <data name="TypeLoadStartID" inType="win:UInt32" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <TypeLoadStart xmlns="myNs">
+                                <TypeLoadStartID> %1 </TypeLoadStartID>
+                                <ClrInstanceID> %2 </ClrInstanceID>
+                            </TypeLoadStart>
+                        </UserData>
+                    </template>
+
+                    <template tid="TypeLoadStop">
+                        <data name="TypeLoadStartID" inType="win:UInt32" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <data name="LoadLevel" inType="win:UInt16" />
+                        <data name="TypeID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="TypeName" inType="win:UnicodeString" />
+                        <UserData>
+                            <TypeLoadStop xmlns="myNs">
+                                <TypeLoadStartID> %1 </TypeLoadStartID>
+                                <ClrInstanceID> %2 </ClrInstanceID>
+                                <LoadLevel> %3 </LoadLevel>
+                                <TypeID> %4 </TypeID>
+                                <TypeName> %5 </TypeName>
+                            </TypeLoadStop>
+                        </UserData>
+                    </template>
+
                     <template tid="MethodLoadUnload">
                         <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
                         <data name="ModuleID" inType="win:UInt64" outType="win:HexInt64" />
@@ -1977,6 +2008,17 @@
                                 <EntryPoint> %5 </EntryPoint>
                                 <ClrInstanceID> %6 </ClrInstanceID>
                             </R2RGetEntryPoint>
+                        </UserData>
+                    </template>
+
+                    <template tid="R2RGetEntryPointStarted">
+                        <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
+                        <data name="ClrInstanceID" inType="win:UInt16" />
+                        <UserData>
+                            <R2RGetEntryPointStarted xmlns="myNs">
+                                <MethodID> %1 </MethodID>
+                                <ClrInstanceID> %2 </ClrInstanceID>
+                            </R2RGetEntryPointStarted>
                         </UserData>
                     </template>
 
@@ -3200,12 +3242,27 @@
                            opcode="Running"
                            symbol="ThreadRunning"
                            message="$(string.RuntimePublisher.ThreadRunningEventMessage)"/>
+
                     <event value="72" version="0" level="win:Informational"  template="MethodDetails"
                            keywords="MethodDiagnosticKeyword"
                            task="CLRMethod"
                            opcode="MethodDetails"
                            symbol="MethodDetails"
                            message="$(string.RuntimePublisher.MethodDetailsEventMessage)"/>
+
+                    <event value="73" version="0" level="win:Informational"  template="TypeLoadStart"
+                           keywords="TypeDiagnosticKeyword"
+                           task="CLRLoader"
+                           opcode="TypeLoad"
+                           symbol="TypeLoadStart"
+                           message="$(string.RuntimePublisher.TypeLoadStartEventMessage)"/>
+
+                    <event value="74" version="0" level="win:Informational"  template="TypeLoadStop"
+                           keywords="TypeDiagnosticKeyword"
+                           task="CLRLoader"
+                           opcode="TypeLoad"
+                           symbol="TypeLoadStop"
+                           message="$(string.RuntimePublisher.TypeLoadStopEventMessage)"/>
 
                     <!-- CLR Exception events -->
                     <event value="80" version="0" level="win:Informational"
@@ -3364,10 +3421,15 @@
                            task="CLRMethod"
                            symbol="MethodLoad_V2" message="$(string.RuntimePublisher.MethodLoad_V2EventMessage)"/>
 
-                    <event value="159" version="0" level="win:Verbose" template="R2RGetEntryPoint"
+                    <event value="159" version="0" level="win:Informational" template="R2RGetEntryPoint"
                            keywords ="CompilationDiagnosticKeyword" opcode="MethodLoad"
                            task="CLRMethod"
                            symbol="R2RGetEntryPoint" message="$(string.RuntimePublisher.R2RGetEntryPointEventMessage)"/>
+
+                    <event value="160" version="0" level="win:Informational" template="R2RGetEntryPointStarted"
+                           keywords ="CompilationDiagnosticKeyword" opcode="MethodLoad"
+                           task="CLRMethod"
+                           symbol="R2RGetEntryPointStarted" message="$(string.RuntimePublisher.R2RGetEntryPointStartedEventMessage)"/>
 
                     <event value="142" version="0" level="win:Informational"  template="MethodLoadUnload"
                            keywords ="JitKeyword NGenKeyword" opcode="MethodUnload"
@@ -6899,6 +6961,8 @@
                 <string id="RuntimePublisher.ThreadCreatingEventMessage" value="ID=%1;%nClrInstanceID=%s" />
                 <string id="RuntimePublisher.ThreadRunningEventMessage" value="ID=%1;%nClrInstanceID=%s" />
                 <string id="RuntimePublisher.MethodDetailsEventMessage" value="MethodID=%1;%TypeID=%2;MethodToken=%3;TypeParameterCount=%4;LoaderModuleID=%5" />
+                <string id="RuntimePublisher.TypeLoadStartEventMessage" value="TypeLoadStartID=%1;ClrInstanceID=%2" />
+                <string id="RuntimePublisher.TypeLoadStopEventMessage" value="TypeLoadStartID=%1;ClrInstanceID=%2;LoadLevel=%3;TypeID=%4;TypeName=%5" />
                 <string id="RuntimePublisher.ExceptionExceptionThrownEventMessage" value="NONE" />
                 <string id="RuntimePublisher.ExceptionExceptionThrown_V1EventMessage" value="ExceptionType=%1;%nExceptionMessage=%2;%nExceptionEIP=%3;%nExceptionHRESULT=%4;%nExceptionFlags=%5;%nClrInstanceID=%6" />
                 <string id="RuntimePublisher.ExceptionExceptionHandlingEventMessage" value="EntryEIP=%1;%nMethodID=%2;%nMethodName=%3;%nClrInstanceID=%4" />
@@ -6917,6 +6981,7 @@
                 <string id="RuntimePublisher.MethodLoad_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
                 <string id="RuntimePublisher.MethodLoad_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7;%nReJITID=%8" />
                 <string id="RuntimePublisher.R2RGetEntryPointEventMessage" value="MethodID=%1;%nMethodName=%2;%nEntryPoint=%3;%nClrInstanceID=%4" />
+                <string id="RuntimePublisher.R2RGetEntryPointStartedEventMessage" value="MethodID=%1;%nClrInstanceID=%2" />
                 <string id="RuntimePublisher.MethodLoadVerboseEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9" />
                 <string id="RuntimePublisher.MethodLoadVerbose_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodLoadVerbose_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9;%nClrInstanceID=%10;%nReJITID=%11" />
@@ -7475,6 +7540,7 @@
                 <string id="RuntimePublisher.CompilationKeywordMessage" value="Compilation" />
                 <string id="RuntimePublisher.CompilationDiagnosticKeywordMessage" value="CompilationDiagnostic" />
                 <string id="RuntimePublisher.MethodDiagnosticKeywordMessage" value="MethodDiagnostic" />
+                <string id="RuntimePublisher.TypeDiagnosticKeywordMessage" value="TypeDiagnostic" />
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />
                 <string id="RundownPublisher.JitKeywordMessage" value="Jit" />
                 <string id="RundownPublisher.JittedMethodILToNativeMapRundownKeywordMessage" value="JittedMethodILToNativeMapRundown" />
@@ -7540,6 +7606,7 @@
                 <string id="RuntimePublisher.FinalizeObjectOpcodeMessage" value="FinalizeObject" />
                 <string id="RuntimePublisher.BulkTypeOpcodeMessage" value="BulkType" />
                 <string id="RuntimePublisher.MethodDetailsOpcodeMessage" value="MethodDetails" />
+                <string id="RuntimePublisher.TypeLoadOpcodeMessage" value="TypeLoad" />
                 <string id="RuntimePublisher.MethodLoadOpcodeMessage" value="Load" />
                 <string id="RuntimePublisher.MethodUnloadOpcodeMessage" value="Unload" />
                 <string id="RuntimePublisher.MethodLoadVerboseOpcodeMessage" value="LoadVerbose" />

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -2011,14 +2011,14 @@
                         </UserData>
                     </template>
 
-                    <template tid="R2RGetEntryPointStarted">
+                    <template tid="R2RGetEntryPointStart">
                         <data name="MethodID" inType="win:UInt64" outType="win:HexInt64" />
                         <data name="ClrInstanceID" inType="win:UInt16" />
                         <UserData>
-                            <R2RGetEntryPointStarted xmlns="myNs">
+                            <R2RGetEntryPointStart xmlns="myNs">
                                 <MethodID> %1 </MethodID>
                                 <ClrInstanceID> %2 </ClrInstanceID>
-                            </R2RGetEntryPointStarted>
+                            </R2RGetEntryPointStart>
                         </UserData>
                     </template>
 
@@ -3426,10 +3426,10 @@
                            task="CLRMethod"
                            symbol="R2RGetEntryPoint" message="$(string.RuntimePublisher.R2RGetEntryPointEventMessage)"/>
 
-                    <event value="160" version="0" level="win:Informational" template="R2RGetEntryPointStarted"
+                    <event value="160" version="0" level="win:Informational" template="R2RGetEntryPointStart"
                            keywords ="CompilationDiagnosticKeyword" opcode="MethodLoad"
                            task="CLRMethod"
-                           symbol="R2RGetEntryPointStarted" message="$(string.RuntimePublisher.R2RGetEntryPointStartedEventMessage)"/>
+                           symbol="R2RGetEntryPointStart" message="$(string.RuntimePublisher.R2RGetEntryPointStartEventMessage)"/>
 
                     <event value="142" version="0" level="win:Informational"  template="MethodLoadUnload"
                            keywords ="JitKeyword NGenKeyword" opcode="MethodUnload"
@@ -6981,7 +6981,7 @@
                 <string id="RuntimePublisher.MethodLoad_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7" />
                 <string id="RuntimePublisher.MethodLoad_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nClrInstanceID=%7;%nReJITID=%8" />
                 <string id="RuntimePublisher.R2RGetEntryPointEventMessage" value="MethodID=%1;%nMethodName=%2;%nEntryPoint=%3;%nClrInstanceID=%4" />
-                <string id="RuntimePublisher.R2RGetEntryPointStartedEventMessage" value="MethodID=%1;%nClrInstanceID=%2" />
+                <string id="RuntimePublisher.R2RGetEntryPointStartEventMessage" value="MethodID=%1;%nClrInstanceID=%2" />
                 <string id="RuntimePublisher.MethodLoadVerboseEventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9" />
                 <string id="RuntimePublisher.MethodLoadVerbose_V1EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9;%nClrInstanceID=%10" />
                 <string id="RuntimePublisher.MethodLoadVerbose_V2EventMessage" value="MethodID=%1;%nModuleID=%2;%nMethodStartAddress=%3;%nMethodSize=%4;%nMethodToken=%5;%nMethodFlags=%6;%nMethodNamespace=%7;%nMethodName=%8;%nMethodSignature=%9;%nClrInstanceID=%10;%nReJITID=%11" />

--- a/src/coreclr/src/vm/clsload.cpp
+++ b/src/coreclr/src/vm/clsload.cpp
@@ -3589,6 +3589,10 @@ TypeHandle ClassLoader::LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
     }
 #endif
 
+#if defined(FEATURE_EVENT_TRACE)
+    UINT32 typeLoad = ETW::TypeSystemLog::TypeLoadBegin();
+#endif
+
     // When using domain neutral assemblies (and not eagerly propagating dependency loads),
     // it's possible to get here without having injected the module into the current app domain.
     // GetDomainFile will accomplish that.
@@ -3610,6 +3614,10 @@ TypeHandle ClassLoader::LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
     _ASSERTE(typeHnd.GetLoadLevel() >= targetLevelUnderLock);
 
     PushFinalLevels(typeHnd, targetLevel, pInstContext);
+
+#if defined(FEATURE_EVENT_TRACE)
+    ETW::TypeSystemLog::TypeLoadEnd(typeLoad, typeHnd, (UINT16)targetLevel);
+#endif
 
     return typeHnd;
 }

--- a/src/coreclr/src/vm/clsload.cpp
+++ b/src/coreclr/src/vm/clsload.cpp
@@ -3616,7 +3616,10 @@ TypeHandle ClassLoader::LoadTypeHandleForTypeKey(TypeKey *pTypeKey,
     PushFinalLevels(typeHnd, targetLevel, pInstContext);
 
 #if defined(FEATURE_EVENT_TRACE)
-    ETW::TypeSystemLog::TypeLoadEnd(typeLoad, typeHnd, (UINT16)targetLevel);
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TypeLoadStop))
+    {
+        ETW::TypeSystemLog::TypeLoadEnd(typeLoad, typeHnd, (UINT16)targetLevel);
+    }
 #endif
 
     return typeHnd;

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -3156,7 +3156,7 @@ CrstBase * ETW::TypeSystemLog::GetHashCrst()
 // The number of type load operations
 // NOTE: This isn't the count of types loaded, as some types may have multiple type loads
 //       occur to them as they transition up type loader levels
-UINT32 s_TypeLoadOps = 0;
+LONG s_TypeLoadOps = 0;
 
 UINT32 ETW::TypeSystemLog::TypeLoadBegin()
 {
@@ -3165,7 +3165,7 @@ UINT32 ETW::TypeSystemLog::TypeLoadBegin()
         GC_TRIGGERS;
     } CONTRACTL_END;
 
-    UINT32 typeLoad = InterlockedIncrement(&s_TypeLoadOps);
+    UINT32 typeLoad = (UINT32)InterlockedIncrement(&s_TypeLoadOps);
 
     if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TypeLoadStart))
     {

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -3169,13 +3169,9 @@ UINT32 ETW::TypeSystemLog::TypeLoadBegin()
 
     if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, TypeLoadStart))
     {
-        EX_TRY
-        {
-            FireEtwTypeLoadStart(
-                typeLoad,
-                GetClrInstanceId());
-
-        } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+        FireEtwTypeLoadStart(
+            typeLoad,
+            GetClrInstanceId());
     }
 
     return typeLoad;
@@ -5369,22 +5365,18 @@ VOID ETW::MethodLog::GetR2RGetEntryPoint(MethodDesc *pMethodDesc, PCODE pEntryPo
     }
 }
 
-VOID ETW::MethodLog::GetR2RGetEntryPointStarted(MethodDesc *pMethodDesc)
+VOID ETW::MethodLog::GetR2RGetEntryPointStart(MethodDesc *pMethodDesc)
 {
     CONTRACTL{
         NOTHROW;
         GC_TRIGGERS;
     } CONTRACTL_END;
 
-    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, R2RGetEntryPointStarted))
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, R2RGetEntryPointStart))
     {
-        EX_TRY
-        {
-                FireEtwR2RGetEntryPointStarted(
-                    (UINT64)pMethodDesc,
-                    GetClrInstanceId());
-
-        } EX_CATCH{ } EX_END_CATCH(SwallowAllExceptions);
+        FireEtwR2RGetEntryPointStart(
+            (UINT64)pMethodDesc,
+            GetClrInstanceId());
     }
 }
 

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -934,7 +934,10 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     }
 
 done:
-    ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, R2RGetEntryPoint))
+    {
+        ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
+    }
     return pEntryPoint;
 }
 

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -830,6 +830,11 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     if (m_readyToRunCodeDisabled)
         goto done;
 
+    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, R2RGetEntryPointStarted))
+    {
+        ETW::MethodLog::GetR2RGetEntryPointStarted(pMD);
+    }
+
     uint offset;
     if (pMD->HasClassOrMethodInstantiation())
     {

--- a/src/coreclr/src/vm/readytoruninfo.cpp
+++ b/src/coreclr/src/vm/readytoruninfo.cpp
@@ -830,10 +830,7 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     if (m_readyToRunCodeDisabled)
         goto done;
 
-    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, R2RGetEntryPointStarted))
-    {
-        ETW::MethodLog::GetR2RGetEntryPointStarted(pMD);
-    }
+    ETW::MethodLog::GetR2RGetEntryPointStart(pMD);
 
     uint offset;
     if (pMD->HasClassOrMethodInstantiation())
@@ -937,10 +934,7 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     }
 
 done:
-    if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_DOTNET_Context, R2RGetEntryPoint))
-    {
-        ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
-    }
+    ETW::MethodLog::GetR2RGetEntryPoint(pMD, pEntryPoint);
     return pEntryPoint;
 }
 


### PR DESCRIPTION
Add events to track the time spent loading types, and making R2R code useable
- Allows for investigation of type loader performance
  - Uses a new keyword, as this event will generate many strings which is itself fairly slow
- Changes R2R events from Verbose events to Informational events
  - These events are already controlled by a separate keyword, and don't need to also be only emitted when Verbose eventing is on