### PR TITLE
Remove GetIPCEventSendBufferContinuation

### DIFF
--- a/src/coreclr/src/debug/ee/debugger.h
+++ b/src/coreclr/src/debug/ee/debugger.h
@@ -738,12 +738,12 @@ public:
         CONTRACTL_END;
 
         DebuggerIPCEvent *dipce = (DebuggerIPCEvent *) new (nothrow) BYTE [CorDBIPC_BUFFER_SIZE];
-        dipce->next = NULL;
 
         LOG((LF_CORDB,LL_INFO1000000, "About to GIPCESBC 0x%x\n",dipce));
 
         if (dipce != NULL)
         {
+            dipce->next = NULL;
             eventCur->next = dipce;
         }
 #ifdef _DEBUG

--- a/src/coreclr/src/debug/ee/debugger.h
+++ b/src/coreclr/src/debug/ee/debugger.h
@@ -725,37 +725,6 @@ public:
         return GetRCThreadSendBuffer();
     }
 
-    DebuggerIPCEvent *GetIPCEventSendBufferContinuation(
-        DebuggerIPCEvent *eventCur)
-    {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-            PRECONDITION(eventCur != NULL);
-            PRECONDITION(eventCur->next == NULL);
-        }
-        CONTRACTL_END;
-
-        DebuggerIPCEvent *dipce = (DebuggerIPCEvent *) new (nothrow) BYTE [CorDBIPC_BUFFER_SIZE];
-
-        LOG((LF_CORDB,LL_INFO1000000, "About to GIPCESBC 0x%x\n",dipce));
-
-        if (dipce != NULL)
-        {
-            dipce->next = NULL;
-            eventCur->next = dipce;
-        }
-#ifdef _DEBUG
-        else
-        {
-            _ASSERTE( !"GetIPCEventSendBufferContinuation failed to allocate mem!" );
-        }
-#endif //_DEBUG
-
-        return dipce;
-    }
-
     // Send an IPCEvent once we're ready for sending. This should be done inbetween
     // SENDIPCEVENT_BEGIN & SENDIPCEVENT_END. See definition of SENDIPCEVENT_BEGIN
     // for usage pattern


### PR DESCRIPTION
This fixes #38792, however I can't find any calling function in other releases or framework code. It feels like dead code, but I can't say for sure. @noahfalk or @mikem8361 do you remember where `GetIPCEventSendBufferContinuation` was used?