### PR TITLE
Disable getappdomainstaticaddress for JIT stress modes

### DIFF
--- a/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
@@ -6,6 +6,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- This test currently fails for TailcallStress. Disable for JIT stress modes until this is fixed.
+         Issue: https://github.com/dotnet/runtime/issues/37117
+    -->
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/37117