### PR TITLE
Disable crossgen2smoke test for GCStress

### DIFF
--- a/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
+++ b/src/tests/readytorun/crossgen2/crossgen2smoke.csproj
@@ -5,6 +5,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
 
+    <!-- Disable for GCStress due to timeout test failures: https://github.com/dotnet/runtime/issues/33949 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+
     <!-- ilasm round-trip testing doesn't make sense for this test -->
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     


### PR DESCRIPTION
It times out in some modes, especially HeapVerify modes.

Issue: https://github.com/dotnet/runtime/issues/33949