### PR TITLE
[release/5.0-preview8] Add JsonNumberHandling & support for (de)serializing numbers from/to string

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -244,6 +244,7 @@ namespace System.Text.Json
         public bool IgnoreReadOnlyFields { get { throw null; } set { } }
         public bool IncludeFields { get { throw null; } set { } }
         public int MaxDepth { get { throw null; } set { } }
+        public System.Text.Json.Serialization.JsonNumberHandling NumberHandling { get { throw null; } set { } }
         public bool PropertyNameCaseInsensitive { get { throw null; } set { } }
         public System.Text.Json.JsonNamingPolicy? PropertyNamingPolicy { get { throw null; } set { } }
         public System.Text.Json.JsonCommentHandling ReadCommentHandling { get { throw null; } set { } }
@@ -496,6 +497,14 @@ namespace System.Text.Json.Serialization
         WhenWritingDefault = 2,
         WhenWritingNull = 3,
     }
+    [System.FlagsAttribute]
+    public enum JsonNumberHandling
+    {
+        Strict = 0,
+        AllowReadingFromString = 1,
+        WriteAsString = 2,
+        AllowNamedFloatingPointLiterals = 4,
+    }
     public abstract partial class JsonAttribute : System.Attribute
     {
         protected JsonAttribute() { }
@@ -532,6 +541,12 @@ namespace System.Text.Json.Serialization
         [return: System.Diagnostics.CodeAnalysis.MaybeNullAttribute]
         public abstract T Read(ref System.Text.Json.Utf8JsonReader reader, System.Type typeToConvert, System.Text.Json.JsonSerializerOptions options);
         public abstract void Write(System.Text.Json.Utf8JsonWriter writer, T value, System.Text.Json.JsonSerializerOptions options);
+    }
+    [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Property | System.AttributeTargets.Field, AllowMultiple = false)]
+    public sealed partial class JsonNumberHandlingAttribute : System.Text.Json.Serialization.JsonAttribute
+    {
+        public JsonNumberHandlingAttribute(System.Text.Json.Serialization.JsonNumberHandling handling) { }
+        public System.Text.Json.Serialization.JsonNumberHandling Handling { get { throw null; } }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Constructor, AllowMultiple = false)]
     public sealed partial class JsonConstructorAttribute : System.Text.Json.Serialization.JsonAttribute

--- a/src/libraries/System.Text.Json/src/Resources/Strings.resx
+++ b/src/libraries/System.Text.Json/src/Resources/Strings.resx
@@ -536,4 +536,10 @@
   <data name="IgnoreConditionOnValueTypeInvalid" xml:space="preserve">
     <value>The ignore condition 'JsonIgnoreCondition.WhenWritingNull' is not valid on value-type member '{0}' on type '{1}'. Consider using 'JsonIgnoreCondition.WhenWritingDefault'.</value>
   </data>
+  <data name="NumberHandlingConverterMustBeBuiltIn" xml:space="preserve">
+    <value>'JsonNumberHandlingAttribute' cannot be placed on a property, field, or type that is handled by a custom converter. See usage(s) of converter '{0}' on type '{1}'.</value>
+  </data>
+  <data name="NumberHandlingOnPropertyTypeMustBeNumberOrCollection" xml:space="preserve">
+    <value>When 'JsonNumberHandlingAttribute' is placed on a property or field, the property or field must be a number or a collection. See member '{0}' on type '{1}'.</value>
+  </data>
 </root>

--- a/src/libraries/System.Text.Json/src/System.Text.Json.csproj
+++ b/src/libraries/System.Text.Json/src/System.Text.Json.csproj
@@ -60,6 +60,7 @@
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonExtensionDataAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIgnoreAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonIncludeAttribute.cs" />
+    <Compile Include="System\Text\Json\Serialization\Attributes\JsonNumberHandlingAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\Attributes\JsonPropertyNameAttribute.cs" />
     <Compile Include="System\Text\Json\Serialization\ClassType.cs" />
     <Compile Include="System\Text\Json\Serialization\ConverterList.cs" />
@@ -135,6 +136,7 @@
     <Compile Include="System\Text\Json\Serialization\JsonDefaultNamingPolicy.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonIgnoreCondition.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonNamingPolicy.cs" />
+    <Compile Include="System\Text\Json\Serialization\JsonNumberHandling.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonParameterInfo.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonParameterInfoOfT.cs" />
     <Compile Include="System\Text\Json\Serialization\JsonPropertyInfo.cs" />

--- a/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/JsonConstants.cs
@@ -37,6 +37,10 @@ namespace System.Text.Json
         public static ReadOnlySpan<byte> FalseValue => new byte[] { (byte)'f', (byte)'a', (byte)'l', (byte)'s', (byte)'e' };
         public static ReadOnlySpan<byte> NullValue => new byte[] { (byte)'n', (byte)'u', (byte)'l', (byte)'l' };
 
+        public static ReadOnlySpan<byte> NaNValue => new byte[] { (byte)'N', (byte)'a', (byte)'N' };
+        public static ReadOnlySpan<byte> PositiveInfinityValue => new byte[] { (byte)'I', (byte)'n', (byte)'f', (byte)'i', (byte)'n', (byte)'i', (byte)'t', (byte)'y' };
+        public static ReadOnlySpan<byte> NegativeInfinityValue => new byte[] { (byte)'-', (byte)'I', (byte)'n', (byte)'f', (byte)'i', (byte)'n', (byte)'i', (byte)'t', (byte)'y' };
+
         // Used to search for the end of a number
         public static ReadOnlySpan<byte> Delimiters => new byte[] { ListSeparator, CloseBrace, CloseBracket, Space, LineFeed, CarriageReturn, Tab, Slash };
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/JsonReaderHelper.cs
@@ -321,5 +321,82 @@ namespace System.Text.Json
             value = default;
             return false;
         }
+
+        public static char GetFloatingPointStandardParseFormat(ReadOnlySpan<byte> span)
+        {
+            // Assume that 'e/E' is closer to the end.
+            int startIndex = span.Length - 1;
+            for (int i = startIndex; i >= 0; i--)
+            {
+                byte token = span[i];
+                if (token == 'E' || token == 'e')
+                {
+                    return JsonConstants.ScientificNotationFormat;
+                }
+            }
+            return default;
+        }
+
+        public static bool TryGetFloatingPointConstant(ReadOnlySpan<byte> span, out float value)
+        {
+            if (span.Length == 3)
+            {
+                if (span.SequenceEqual(JsonConstants.NaNValue))
+                {
+                    value = float.NaN;
+                    return true;
+                }
+            }
+            else if (span.Length == 8)
+            {
+                if (span.SequenceEqual(JsonConstants.PositiveInfinityValue))
+                {
+                    value = float.PositiveInfinity;
+                    return true;
+                }
+            }
+            else if (span.Length == 9)
+            {
+                if (span.SequenceEqual(JsonConstants.NegativeInfinityValue))
+                {
+                    value = float.NegativeInfinity;
+                    return true;
+                }
+            }
+
+            value = 0;
+            return false;
+        }
+
+        public static bool TryGetFloatingPointConstant(ReadOnlySpan<byte> span, out double value)
+        {
+            if (span.Length == 3)
+            {
+                if (span.SequenceEqual(JsonConstants.NaNValue))
+                {
+                    value = double.NaN;
+                    return true;
+                }
+            }
+            else if (span.Length == 8)
+            {
+                if (span.SequenceEqual(JsonConstants.PositiveInfinityValue))
+                {
+                    value = double.PositiveInfinity;
+                    return true;
+                }
+            }
+            else if (span.Length == 9)
+            {
+                if (span.SequenceEqual(JsonConstants.NegativeInfinityValue))
+                {
+                    value = double.NegativeInfinity;
+                    return true;
+                }
+            }
+
+            value = 0;
+            return false;
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Reader/Utf8JsonReader.TryGet.cs
@@ -416,11 +416,38 @@ namespace System.Text.Json
         internal float GetSingleWithQuotes()
         {
             ReadOnlySpan<byte> span = GetUnescapedSpan();
-            if (!TryGetSingleCore(out float value, span))
+
+            if (JsonReaderHelper.TryGetFloatingPointConstant(span, out float value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Single);
+                return value;
             }
-            return value;
+
+            char numberFormat = JsonReaderHelper.GetFloatingPointStandardParseFormat(span);
+            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed, numberFormat)
+                && span.Length == bytesConsumed)
+            {
+                // NETCOREAPP implementation of the TryParse method above permits case-insenstive variants of the
+                // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
+                // The following logic reconciles the two implementations to enforce consistent behavior.
+                if (!float.IsNaN(value) && !float.IsPositiveInfinity(value) && !float.IsNegativeInfinity(value))
+                {
+                    return value;
+                }
+            }
+
+            throw ThrowHelper.GetFormatException(NumericType.Single);
+        }
+
+        internal float GetSingleFloatingPointConstant()
+        {
+            ReadOnlySpan<byte> span = GetUnescapedSpan();
+
+            if (JsonReaderHelper.TryGetFloatingPointConstant(span, out float value))
+            {
+                return value;
+            }
+
+            throw ThrowHelper.GetFormatException(NumericType.Single);
         }
 
         /// <summary>
@@ -449,11 +476,38 @@ namespace System.Text.Json
         internal double GetDoubleWithQuotes()
         {
             ReadOnlySpan<byte> span = GetUnescapedSpan();
-            if (!TryGetDoubleCore(out double value, span))
+
+            if (JsonReaderHelper.TryGetFloatingPointConstant(span, out double value))
             {
-                throw ThrowHelper.GetFormatException(NumericType.Double);
+                return value;
             }
-            return value;
+
+            char numberFormat = JsonReaderHelper.GetFloatingPointStandardParseFormat(span);
+            if (Utf8Parser.TryParse(span, out value, out int bytesConsumed, numberFormat)
+                && span.Length == bytesConsumed)
+            {
+                // NETCOREAPP implmentation of the TryParse method above permits case-insenstive variants of the
+                // float constants "NaN", "Infinity", "-Infinity". This differs from the NETFRAMEWORK implementation.
+                // The following logic reconciles the two implementations to enforce consistent behavior.
+                if (!double.IsNaN(value) && !double.IsPositiveInfinity(value) && !double.IsNegativeInfinity(value))
+                {
+                    return value;
+                }
+            }
+
+            throw ThrowHelper.GetFormatException(NumericType.Double);
+        }
+
+        internal double GetDoubleFloatingPointConstant()
+        {
+            ReadOnlySpan<byte> span = GetUnescapedSpan();
+
+            if (JsonReaderHelper.TryGetFloatingPointConstant(span, out double value))
+            {
+                return value;
+            }
+
+            throw ThrowHelper.GetFormatException(NumericType.Double);
         }
 
         /// <summary>
@@ -482,11 +536,15 @@ namespace System.Text.Json
         internal decimal GetDecimalWithQuotes()
         {
             ReadOnlySpan<byte> span = GetUnescapedSpan();
-            if (!TryGetDecimalCore(out decimal value, span))
+
+            char numberFormat = JsonReaderHelper.GetFloatingPointStandardParseFormat(span);
+            if (Utf8Parser.TryParse(span, out decimal value, out int bytesConsumed, numberFormat)
+                && span.Length == bytesConsumed)
             {
-                throw ThrowHelper.GetFormatException(NumericType.Decimal);
+                return value;
             }
-            return value;
+
+            throw ThrowHelper.GetFormatException(NumericType.Decimal);
         }
 
         /// <summary>
@@ -919,13 +977,8 @@ namespace System.Text.Json
                 throw ThrowHelper.GetInvalidOperationException_ExpectedNumber(TokenType);
             }
 
-            ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return TryGetSingleCore(out value, span);
-        }
+            ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;;
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetSingleCore(out float value, ReadOnlySpan<byte> span)
-        {
             if (Utf8Parser.TryParse(span, out float tmp, out int bytesConsumed, _numberFormat)
                 && span.Length == bytesConsumed)
             {
@@ -955,12 +1008,7 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return TryGetDoubleCore(out value, span);
-        }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetDoubleCore(out double value, ReadOnlySpan<byte> span)
-        {
             if (Utf8Parser.TryParse(span, out double tmp, out int bytesConsumed, _numberFormat)
                 && span.Length == bytesConsumed)
             {
@@ -990,12 +1038,7 @@ namespace System.Text.Json
             }
 
             ReadOnlySpan<byte> span = HasValueSequence ? ValueSequence.ToArray() : ValueSpan;
-            return TryGetDecimalCore(out value, span);
-        }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal bool TryGetDecimalCore(out decimal value, ReadOnlySpan<byte> span)
-        {
             if (Utf8Parser.TryParse(span, out decimal tmp, out int bytesConsumed, _numberFormat)
                 && span.Length == bytesConsumed)
             {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonNumberHandlingAttribute.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Attributes/JsonNumberHandlingAttribute.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// When placed on a type, property, or field, indicates what <see cref="JsonNumberHandling"/>
+    /// settings should be used when serializing or deserialing numbers.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+    public sealed class JsonNumberHandlingAttribute : JsonAttribute
+    {
+        /// <summary>
+        /// Indicates what settings should be used when serializing or deserialing numbers.
+        /// </summary>
+        public JsonNumberHandling Handling { get; }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="JsonNumberHandlingAttribute"/>.
+        /// </summary>
+        public JsonNumberHandlingAttribute(JsonNumberHandling handling)
+        {
+            if (!JsonSerializer.IsValidNumberHandlingValue(handling))
+            {
+                throw new ArgumentOutOfRangeException(nameof(handling));
+            }
+            Handling = handling;
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ArrayConverter.cs
@@ -38,7 +38,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
 
             JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
-            if (elementConverter.CanUseDirectReadOrWrite)
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < array.Length; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryDefaultConverter.cs
@@ -29,7 +29,9 @@ namespace System.Text.Json.Serialization.Converters
         /// </summary>
         protected virtual void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state) { }
 
-        internal override Type ElementType => typeof(TValue);
+        private static Type s_valueType = typeof(TValue);
+
+        internal override Type ElementType => s_valueType;
 
         protected Type KeyType = typeof(TKey);
         // For string keys we don't use a key converter
@@ -39,9 +41,9 @@ namespace System.Text.Json.Serialization.Converters
         protected JsonConverter<TKey>? _keyConverter;
         protected JsonConverter<TValue>? _valueConverter;
 
-        protected static JsonConverter<TValue> GetValueConverter(JsonClassInfo classInfo)
+        protected static JsonConverter<TValue> GetValueConverter(JsonClassInfo elementClassInfo)
         {
-            JsonConverter<TValue> converter = (JsonConverter<TValue>)classInfo.ElementClassInfo!.PropertyInfoForClassInfo.ConverterBase;
+            JsonConverter<TValue> converter = (JsonConverter<TValue>)elementClassInfo.PropertyInfoForClassInfo.ConverterBase;
             Debug.Assert(converter != null); // It should not be possible to have a null converter at this point.
 
             return converter;
@@ -57,6 +59,8 @@ namespace System.Text.Json.Serialization.Converters
             ref ReadStack state,
             [MaybeNullWhen(false)] out TCollection value)
         {
+            JsonClassInfo elementClassInfo = state.Current.JsonClassInfo.ElementClassInfo!;
+
             if (state.UseFastPath)
             {
                 // Fast path that avoids maintaining state variables and dealing with preserved references.
@@ -68,8 +72,8 @@ namespace System.Text.Json.Serialization.Converters
 
                 CreateCollection(ref reader, ref state);
 
-                JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
-                if (valueConverter.CanUseDirectReadOrWrite)
+                JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(elementClassInfo);
+                if (valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
                 {
                     // Process all elements.
                     while (true)
@@ -89,7 +93,7 @@ namespace System.Text.Json.Serialization.Converters
 
                         // Read the value and add.
                         reader.ReadWithVerify();
-                        TValue element = valueConverter.Read(ref reader, typeof(TValue), options);
+                        TValue element = valueConverter.Read(ref reader, s_valueType, options);
                         Add(key, element!, options, ref state);
                     }
                 }
@@ -114,7 +118,7 @@ namespace System.Text.Json.Serialization.Converters
                         reader.ReadWithVerify();
 
                         // Get the value from the converter and add it.
-                        valueConverter.TryRead(ref reader, typeof(TValue), options, ref state, out TValue element);
+                        valueConverter.TryRead(ref reader, s_valueType, options, ref state, out TValue element);
                         Add(key, element!, options, ref state);
                     }
                 }
@@ -172,7 +176,7 @@ namespace System.Text.Json.Serialization.Converters
                 }
 
                 // Process all elements.
-                JsonConverter<TValue> elementConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
+                JsonConverter<TValue> elementConverter = _valueConverter ??= GetValueConverter(elementClassInfo);
                 while (true)
                 {
                     if (state.Current.PropertyState == StackFramePropertyState.None)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/DictionaryOfTKeyTValueConverter.cs
@@ -49,16 +49,18 @@ namespace System.Text.Json.Serialization.Converters
                 enumerator = (Dictionary<TKey, TValue>.Enumerator)state.Current.CollectionEnumerator;
             }
 
+            JsonClassInfo elementClassInfo = state.Current.JsonClassInfo.ElementClassInfo!;
+
             JsonConverter<TKey> keyConverter = _keyConverter ??= GetKeyConverter(KeyType, options);
-            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
-            if (!state.SupportContinuation && valueConverter.CanUseDirectReadOrWrite)
+            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(elementClassInfo);
+
+            if (!state.SupportContinuation && valueConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 do
                 {
                     TKey key = enumerator.Current.Key;
                     keyConverter.WriteWithQuotes(writer, key, options, ref state);
-
                     valueConverter.Write(writer, enumerator.Current.Value, options);
                 } while (enumerator.MoveNext());
             }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryConverter.cs
@@ -71,7 +71,7 @@ namespace System.Text.Json.Serialization.Converters
                 enumerator = (IDictionaryEnumerator)state.Current.CollectionEnumerator;
             }
 
-            JsonConverter<object?> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
+            JsonConverter<object?> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo.ElementClassInfo!);
             do
             {
                 if (ShouldFlush(writer, ref state))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IDictionaryOfTKeyTValueConverter.cs
@@ -71,7 +71,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             JsonConverter<TKey> keyConverter = _keyConverter ??= GetKeyConverter(KeyType, options);
-            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
+            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo.ElementClassInfo!);
             do
             {
                 if (ShouldFlush(writer, ref state))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IEnumerableDefaultConverter.cs
@@ -16,9 +16,9 @@ namespace System.Text.Json.Serialization.Converters
         protected abstract void CreateCollection(ref Utf8JsonReader reader, ref ReadStack state, JsonSerializerOptions options);
         protected virtual void ConvertCollection(ref ReadStack state, JsonSerializerOptions options) { }
 
-        protected static JsonConverter<TElement> GetElementConverter(ref ReadStack state)
+        protected static JsonConverter<TElement> GetElementConverter(JsonClassInfo elementClassInfo)
         {
-            JsonConverter<TElement> converter = (JsonConverter<TElement>)state.Current.JsonClassInfo.ElementClassInfo!.PropertyInfoForClassInfo.ConverterBase;
+            JsonConverter<TElement> converter = (JsonConverter<TElement>)elementClassInfo.PropertyInfoForClassInfo.ConverterBase;
             Debug.Assert(converter != null); // It should not be possible to have a null converter at this point.
 
             return converter;
@@ -39,6 +39,8 @@ namespace System.Text.Json.Serialization.Converters
             ref ReadStack state,
             [MaybeNullWhen(false)] out TCollection value)
         {
+            JsonClassInfo elementClassInfo = state.Current.JsonClassInfo.ElementClassInfo!;
+
             if (state.UseFastPath)
             {
                 // Fast path that avoids maintaining state variables and dealing with preserved references.
@@ -50,8 +52,8 @@ namespace System.Text.Json.Serialization.Converters
 
                 CreateCollection(ref reader, ref state, options);
 
-                JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
-                if (elementConverter.CanUseDirectReadOrWrite)
+                JsonConverter<TElement> elementConverter = GetElementConverter(elementClassInfo);
+                if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
                 {
                     // Fast path that avoids validation and extra indirection.
                     while (true)
@@ -154,7 +156,7 @@ namespace System.Text.Json.Serialization.Converters
 
                 if (state.Current.ObjectState < StackFrameObjectState.ReadElements)
                 {
-                    JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
+                    JsonConverter<TElement> elementConverter = GetElementConverter(elementClassInfo);
 
                     // Process all elements.
                     while (true)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IListConverter.cs
@@ -49,36 +49,39 @@ namespace System.Text.Json.Serialization.Converters
 
         protected override bool OnWriteResume(Utf8JsonWriter writer, TCollection value, JsonSerializerOptions options, ref WriteStack state)
         {
-            IEnumerator enumerator;
-            if (state.Current.CollectionEnumerator == null)
+            IList list = value;
+
+            // Using an index is 2x faster than using an enumerator.
+            int index = state.Current.EnumeratorIndex;
+            JsonConverter<object?> elementConverter = GetElementConverter(ref state);
+
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
             {
-                enumerator = value.GetEnumerator();
-                if (!enumerator.MoveNext())
+                // Fast path that avoids validation and extra indirection.
+                for (; index < list.Count; index++)
                 {
-                    return true;
+                    elementConverter.Write(writer, list[index], options);
                 }
             }
             else
             {
-                enumerator = state.Current.CollectionEnumerator;
+                for (; index < list.Count; index++)
+                {
+                    object? element = list[index];
+                    if (!elementConverter.TryWrite(writer, element, options, ref state))
+                    {
+                        state.Current.EnumeratorIndex = index;
+                        return false;
+                    }
+
+                    if (ShouldFlush(writer, ref state))
+                    {
+                        state.Current.EnumeratorIndex = ++index;
+                        return false;
+                    }
+                }
             }
 
-            JsonConverter<object?> converter = GetElementConverter(ref state);
-            do
-            {
-                if (ShouldFlush(writer, ref state))
-                {
-                    state.Current.CollectionEnumerator = enumerator;
-                    return false;
-                }
-
-                object? element = enumerator.Current;
-                if (!converter.TryWrite(writer, element, options, ref state))
-                {
-                    state.Current.CollectionEnumerator = enumerator;
-                    return false;
-                }
-            } while (enumerator.MoveNext());
 
             return true;
         }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/IReadOnlyDictionaryOfTKeyTValueConverter.cs
@@ -42,7 +42,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             JsonConverter<TKey> keyConverter = _keyConverter ??= GetKeyConverter(KeyType, options);
-            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
+            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo.ElementClassInfo!);
             do
             {
                 if (ShouldFlush(writer, ref state))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ImmutableDictionaryOfTKeyTValueConverter.cs
@@ -53,7 +53,7 @@ namespace System.Text.Json.Serialization.Converters
             }
 
             JsonConverter<TKey> keyConverter = _keyConverter ??= GetKeyConverter(KeyType, options);
-            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo);
+            JsonConverter<TValue> valueConverter = _valueConverter ??= GetValueConverter(state.Current.JsonClassInfo.ElementClassInfo!);
             do
             {
                 if (ShouldFlush(writer, ref state))

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Collection/ListOfTConverter.cs
@@ -33,7 +33,7 @@ namespace System.Text.Json.Serialization.Converters
             int index = state.Current.EnumeratorIndex;
             JsonConverter<TElement> elementConverter = GetElementConverter(ref state);
 
-            if (elementConverter.CanUseDirectReadOrWrite)
+            if (elementConverter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
             {
                 // Fast path that avoids validation and extra indirection.
                 for (; index < list.Count; index++)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/KeyValuePairConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/KeyValuePairConverter.cs
@@ -86,6 +86,7 @@ namespace System.Text.Json.Serialization.Converters
             Debug.Assert(jsonParameterInfo != null);
             argState.ParameterIndex++;
             argState.JsonParameterInfo = jsonParameterInfo;
+            state.Current.NumberHandling = jsonParameterInfo.NumberHandling;
             return true;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectDefaultConverter.cs
@@ -265,6 +265,7 @@ namespace System.Text.Json.Serialization.Converters
 
                     // Remember the current property for JsonPath support if an exception is thrown.
                     state.Current.DeclaredJsonPropertyInfo = jsonPropertyInfo;
+                    state.Current.NumberHandling = jsonPropertyInfo.NumberHandling;
 
                     if (jsonPropertyInfo.ShouldSerialize)
                     {
@@ -321,6 +322,7 @@ namespace System.Text.Json.Serialization.Converters
                 {
                     JsonPropertyInfo jsonPropertyInfo = propertyCacheArray![state.Current.EnumeratorIndex];
                     state.Current.DeclaredJsonPropertyInfo = jsonPropertyInfo;
+                    state.Current.NumberHandling = jsonPropertyInfo.NumberHandling;
 
                     if (jsonPropertyInfo.ShouldSerialize)
                     {

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs
@@ -467,6 +467,9 @@ namespace System.Text.Json.Serialization.Converters
             state.Current.JsonPropertyName = utf8PropertyName;
 
             state.Current.CtorArgumentState.JsonParameterInfo = jsonParameterInfo;
+
+            state.Current.NumberHandling = jsonParameterInfo?.NumberHandling;
+
             return jsonParameterInfo != null;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/ByteConverter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class ByteConverter : JsonConverter<byte>
     {
+        public ByteConverter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override byte Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetByte();
@@ -23,6 +28,28 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, byte value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override byte ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String && (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetByteWithQuotes();
+            }
+
+            return reader.GetByte();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, byte value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DecimalConverter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class DecimalConverter : JsonConverter<decimal>
     {
+        public DecimalConverter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override decimal Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDecimal();
@@ -23,6 +28,29 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, decimal value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override decimal ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetDecimalWithQuotes();
+            }
+
+            return reader.GetDecimal();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, decimal value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/DoubleConverter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class DoubleConverter : JsonConverter<double>
     {
+        public DoubleConverter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override double Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetDouble();
@@ -23,6 +28,39 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, double value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override double ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                if ((JsonNumberHandling.AllowReadingFromString & handling) != 0)
+                {
+                    return reader.GetDoubleWithQuotes();
+                }
+                else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
+                {
+                    return reader.GetDoubleFloatingPointConstant();
+                }
+            }
+
+            return reader.GetDouble();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, double value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
+            {
+                writer.WriteFloatingPointConstant(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int16Converter.cs
@@ -1,12 +1,15 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class Int16Converter : JsonConverter<short>
     {
+        public Int16Converter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override short Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt16();
@@ -26,6 +29,30 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, short value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override short ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetInt16WithQuotes();
+            }
+
+            return reader.GetInt16();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, short value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                // For performance, lift up the writer implementation.
+                writer.WriteNumberValue((long)value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int32Converter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class Int32Converter : JsonConverter<int>
     {
+        public Int32Converter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt32();
@@ -24,6 +29,30 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, int value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override int ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetInt32WithQuotes();
+            }
+
+            return reader.GetInt32();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, int value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                // For performance, lift up the writer implementation.
+                writer.WriteNumberValue((long)value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/Int64Converter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class Int64Converter : JsonConverter<long>
     {
+        public Int64Converter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetInt64();
@@ -23,6 +28,29 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, long value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override long ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetInt64WithQuotes();
+            }
+
+            return reader.GetInt64();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, long value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/NullableConverter.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
+
 namespace System.Text.Json.Serialization.Converters
 {
     internal class NullableConverter<T> : JsonConverter<T?> where T : struct
@@ -12,6 +14,7 @@ namespace System.Text.Json.Serialization.Converters
         public NullableConverter(JsonConverter<T> converter)
         {
             _converter = converter;
+            IsInternalConverterForNumberType = converter.IsInternalConverterForNumberType;
         }
 
         public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -38,6 +41,33 @@ namespace System.Text.Json.Serialization.Converters
             else
             {
                 _converter.Write(writer, value.Value, options);
+            }
+        }
+
+        internal override T? ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling numberHandling)
+        {
+            // We do not check _converter.HandleNull, as the underlying struct cannot be null.
+            // A custom converter for some type T? can handle null.
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            T value = _converter.ReadNumberWithCustomHandling(ref reader, numberHandling);
+            return value;
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, T? value, JsonNumberHandling handling)
+        {
+            if (!value.HasValue)
+            {
+                // We do not check _converter.HandleNull, as the underlying struct cannot be null.
+                // A custom converter for some type T? can handle null.
+                writer.WriteNullValue();
+            }
+            else
+            {
+                _converter.WriteNumberWithCustomHandling(writer, value.Value, handling);
             }
         }
     }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SByteConverter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class SByteConverter : JsonConverter<sbyte>
     {
+        public SByteConverter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override sbyte Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetSByte();
@@ -23,6 +28,29 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, sbyte value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override sbyte ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetSByteWithQuotes();
+            }
+
+            return reader.GetSByte();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, sbyte value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/SingleConverter.cs
@@ -5,6 +5,12 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class SingleConverter : JsonConverter<float>
     {
+
+        public SingleConverter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override float Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetSingle();
@@ -23,6 +29,39 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, float value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override float ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                if ((JsonNumberHandling.AllowReadingFromString & handling) != 0)
+                {
+                    return reader.GetSingleWithQuotes();
+                }
+                else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
+                {
+                    return reader.GetSingleFloatingPointConstant();
+                }
+            }
+
+            return reader.GetSingle();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, float value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else if ((JsonNumberHandling.AllowNamedFloatingPointLiterals & handling) != 0)
+            {
+                writer.WriteFloatingPointConstant(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/StringConverter.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class StringConverter : JsonConverter<string>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt16Converter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class UInt16Converter : JsonConverter<ushort>
     {
+        public UInt16Converter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override ushort Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt16();
@@ -24,6 +29,30 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, ushort value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override ushort ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetUInt16WithQuotes();
+            }
+
+            return reader.GetUInt16();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, ushort value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                // For performance, lift up the writer implementation.
+                writer.WriteNumberValue((long)value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt32Converter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class UInt32Converter : JsonConverter<uint>
     {
+        public UInt32Converter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override uint Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt32();
@@ -24,6 +29,30 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, uint value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override uint ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetUInt32WithQuotes();
+            }
+
+            return reader.GetUInt32();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, uint value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                // For performance, lift up the writer implementation.
+                writer.WriteNumberValue((ulong)value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Value/UInt64Converter.cs
@@ -5,6 +5,11 @@ namespace System.Text.Json.Serialization.Converters
 {
     internal sealed class UInt64Converter : JsonConverter<ulong>
     {
+        public UInt64Converter()
+        {
+            IsInternalConverterForNumberType = true;
+        }
+
         public override ulong Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             return reader.GetUInt64();
@@ -23,6 +28,29 @@ namespace System.Text.Json.Serialization.Converters
         internal override void WriteWithQuotes(Utf8JsonWriter writer, ulong value, JsonSerializerOptions options, ref WriteStack state)
         {
             writer.WritePropertyName(value);
+        }
+
+        internal override ulong ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+        {
+            if (reader.TokenType == JsonTokenType.String &&
+                (JsonNumberHandling.AllowReadingFromString & handling) != 0)
+            {
+                return reader.GetUInt64WithQuotes();
+            }
+
+            return reader.GetUInt64();
+        }
+
+        internal override void WriteNumberWithCustomHandling(Utf8JsonWriter writer, ulong value, JsonNumberHandling handling)
+        {
+            if ((JsonNumberHandling.WriteAsString & handling) != 0)
+            {
+                writer.WriteNumberValueAsString(value);
+            }
+            else
+            {
+                writer.WriteNumberValue(value);
+            }
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -52,10 +52,14 @@ namespace System.Text.Json
         // Use an array (instead of List<T>) for highest performance.
         private volatile PropertyRef[]? _propertyRefsSorted;
 
-        public static JsonPropertyInfo AddProperty(MemberInfo memberInfo, Type memberType, Type parentClassType, JsonSerializerOptions options)
+        public static JsonPropertyInfo AddProperty(
+            MemberInfo memberInfo,
+            Type memberType,
+            Type parentClassType,
+            JsonNumberHandling? parentTypeNumberHandling,
+            JsonSerializerOptions options)
         {
             JsonIgnoreCondition? ignoreCondition = JsonPropertyInfo.GetAttribute<JsonIgnoreAttribute>(memberInfo)?.Condition;
-
             if (ignoreCondition == JsonIgnoreCondition.Always)
             {
                 return JsonPropertyInfo.CreateIgnoredPropertyPlaceholder(memberInfo, options);
@@ -75,6 +79,7 @@ namespace System.Text.Json
                 parentClassType,
                 converter,
                 options,
+                parentTypeNumberHandling,
                 ignoreCondition);
         }
 
@@ -85,6 +90,7 @@ namespace System.Text.Json
             Type parentClassType,
             JsonConverter converter,
             JsonSerializerOptions options,
+            JsonNumberHandling? parentTypeNumberHandling = null,
             JsonIgnoreCondition? ignoreCondition = null)
         {
             // Create the JsonPropertyInfo instance.
@@ -98,6 +104,7 @@ namespace System.Text.Json
                 memberInfo,
                 converter,
                 ignoreCondition,
+                parentTypeNumberHandling,
                 options);
 
             return jsonPropertyInfo;
@@ -113,13 +120,16 @@ namespace System.Text.Json
             JsonConverter converter,
             JsonSerializerOptions options)
         {
+            JsonNumberHandling? numberHandling = GetNumberHandlingForType(declaredPropertyType);
+
             JsonPropertyInfo jsonPropertyInfo = CreateProperty(
                 declaredPropertyType: declaredPropertyType,
                 runtimePropertyType: runtimePropertyType,
                 memberInfo: null, // Not a real property so this is null.
                 parentClassType: JsonClassInfo.ObjectType, // a dummy value (not used)
                 converter: converter,
-                options);
+                options,
+                parentTypeNumberHandling: numberHandling);
 
             Debug.Assert(jsonPropertyInfo.IsForClassInfo);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.cs
@@ -89,6 +89,8 @@ namespace System.Text.Json
                 Options);
 
             ClassType = converter.ClassType;
+            JsonNumberHandling? typeNumberHandling = GetNumberHandlingForType(Type);
+
             PropertyInfoForClassInfo = CreatePropertyInfoForClassInfo(Type, runtimeType, converter, Options);
 
             switch (ClassType)
@@ -124,7 +126,7 @@ namespace System.Text.Json
                                 if (propertyInfo.GetMethod?.IsPublic == true ||
                                     propertyInfo.SetMethod?.IsPublic == true)
                                 {
-                                    CacheMember(currentType, propertyInfo.PropertyType, propertyInfo, cache, ref ignoredMembers);
+                                    CacheMember(currentType, propertyInfo.PropertyType, propertyInfo, typeNumberHandling, cache, ref ignoredMembers);
                                 }
                                 else
                                 {
@@ -150,7 +152,7 @@ namespace System.Text.Json
                                 {
                                     if (hasJsonInclude || Options.IncludeFields)
                                     {
-                                        CacheMember(currentType, fieldInfo.FieldType, fieldInfo, cache, ref ignoredMembers);
+                                        CacheMember(currentType, fieldInfo.FieldType, fieldInfo, typeNumberHandling, cache, ref ignoredMembers);
                                     }
                                 }
                                 else
@@ -225,10 +227,11 @@ namespace System.Text.Json
             Type declaringType,
             Type memberType,
             MemberInfo memberInfo,
+            JsonNumberHandling? typeNumberHandling,
             Dictionary<string, JsonPropertyInfo> cache,
             ref Dictionary<string, MemberInfo>? ignoredMembers)
         {
-            JsonPropertyInfo jsonPropertyInfo = AddProperty(memberInfo, memberType, declaringType, Options);
+            JsonPropertyInfo jsonPropertyInfo = AddProperty(memberInfo, memberType, declaringType, typeNumberHandling, Options);
             Debug.Assert(jsonPropertyInfo.NameAsString != null);
 
             string memberName = memberInfo.Name;
@@ -569,6 +572,14 @@ namespace System.Text.Json
 
             return false;
 #endif
+        }
+
+        private static JsonNumberHandling? GetNumberHandlingForType(Type type)
+        {
+            var numberHandlingAttribute =
+                (JsonNumberHandlingAttribute?)JsonSerializerOptions.GetAttributeThatCanHaveMultiple(type, typeof(JsonNumberHandlingAttribute));
+
+            return numberHandlingAttribute?.Handling;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverter.cs
@@ -45,6 +45,16 @@ namespace System.Text.Json.Serialization
         internal bool IsValueType { get; set; }
 
         /// <summary>
+        /// Whether the converter is built-in.
+        /// </summary>
+        internal bool IsInternalConverter { get; set; }
+
+        /// <summary>
+        /// Whether the converter is built-in and handles a number type.
+        /// </summary>
+        internal bool IsInternalConverterForNumberType;
+
+        /// <summary>
         /// Loosely-typed ReadCore() that forwards to strongly-typed ReadCore().
         /// </summary>
         internal abstract object? ReadCoreAsObject(ref Utf8JsonReader reader, JsonSerializerOptions options, ref ReadStack state);
@@ -76,7 +86,7 @@ namespace System.Text.Json.Serialization
         internal abstract void WriteWithQuotesAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state);
 
         // Whether a type (ClassType.Object) is deserialized using a parameterized constructor.
-        internal virtual bool ConstructorIsParameterized => false;
+        internal virtual bool ConstructorIsParameterized { get; }
 
         internal ConstructorInfo? ConstructorInfo { get; set; }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
 
 namespace System.Text.Json.Serialization
 {
@@ -69,11 +68,6 @@ namespace System.Text.Json.Serialization
         /// </summary>
         internal bool CanBeNull { get; }
 
-        /// <summary>
-        /// Is the converter built-in.
-        /// </summary>
-        internal bool IsInternalConverter { get; set; }
-
         // This non-generic API is sealed as it just forwards to the generic version.
         internal sealed override bool TryWriteAsObject(Utf8JsonWriter writer, object? value, JsonSerializerOptions options, ref WriteStack state)
         {
@@ -131,7 +125,14 @@ namespace System.Text.Json.Serialization
                 // For performance, only perform validation on internal converters on debug builds.
                 if (IsInternalConverter)
                 {
-                    value = Read(ref reader, typeToConvert, options);
+                    if (IsInternalConverterForNumberType && state.Current.NumberHandling != null)
+                    {
+                        value = ReadNumberWithCustomHandling(ref reader, state.Current.NumberHandling.Value);
+                    }
+                    else
+                    {
+                        value = Read(ref reader, typeToConvert, options);
+                    }
                 }
                 else
 #endif
@@ -140,7 +141,15 @@ namespace System.Text.Json.Serialization
                     int originalPropertyDepth = reader.CurrentDepth;
                     long originalPropertyBytesConsumed = reader.BytesConsumed;
 
-                    value = Read(ref reader, typeToConvert, options);
+                    if (IsInternalConverterForNumberType && state.Current.NumberHandling != null)
+                    {
+                        value = ReadNumberWithCustomHandling(ref reader, state.Current.NumberHandling.Value);
+                    }
+                    else
+                    {
+                        value = Read(ref reader, typeToConvert, options);
+                    }
+
                     VerifyRead(
                         originalPropertyTokenType,
                         originalPropertyDepth,
@@ -309,7 +318,15 @@ namespace System.Text.Json.Serialization
 
                 int originalPropertyDepth = writer.CurrentDepth;
 
-                Write(writer, value, options);
+                if (IsInternalConverterForNumberType && state.Current.NumberHandling != null)
+                {
+                    WriteNumberWithCustomHandling(writer, value, state.Current.NumberHandling.Value);
+                }
+                else
+                {
+                    Write(writer, value, options);
+                }
+
                 VerifyWrite(originalPropertyDepth, writer);
                 return true;
             }
@@ -452,5 +469,11 @@ namespace System.Text.Json.Serialization
 
         internal sealed override void WriteWithQuotesAsObject(Utf8JsonWriter writer, object value, JsonSerializerOptions options, ref WriteStack state)
             => WriteWithQuotes(writer, (T)value, options, ref state);
+
+        internal virtual T ReadNumberWithCustomHandling(ref Utf8JsonReader reader, JsonNumberHandling handling)
+            => throw new InvalidOperationException();
+
+        internal virtual void WriteNumberWithCustomHandling(Utf8JsonWriter writer, T value, JsonNumberHandling handling)
+            => throw new InvalidOperationException();
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonNumberHandling.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonNumberHandling.cs
@@ -1,0 +1,32 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Text.Json.Serialization
+{
+    /// <summary>
+    /// Determines how <see cref="JsonSerializer"/> handles numbers when serializing and deserializing.
+    /// </summary>
+    [Flags]
+    public enum JsonNumberHandling
+    {
+        /// <summary>
+        /// Numbers will only be read from <see cref="JsonTokenType.Number"/> tokens and will only be written as JSON numbers (without quotes).
+        /// </summary>
+        Strict = 0x0,
+        /// <summary>
+        /// Numbers can be read from <see cref="JsonTokenType.String"/> tokens.
+        /// Does not prevent numbers from being read from <see cref="JsonTokenType.Number"/> token.
+        /// </summary>
+        AllowReadingFromString = 0x1,
+        /// <summary>
+        /// Numbers will be written as JSON strings (with quotes), not as JSON numbers.
+        /// </summary>
+        WriteAsString = 0x2,
+        /// <summary>
+        /// The "NaN", "Infinity", and "-Infinity" <see cref="JsonTokenType.String"/> tokens can be read as floating-point constants,
+        /// and the <see cref="float.NaN"/>, <see cref="double.PositiveInfinity"/>, and <see cref="float.NegativeInfinity"/>
+        /// values will be written as their corresponding JSON string representations.
+        /// </summary>
+        AllowNamedFloatingPointLiterals = 0x4
+    }
+}

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonParameterInfo.cs
@@ -27,6 +27,8 @@ namespace System.Text.Json
         // The name of the parameter as UTF-8 bytes.
         public byte[] NameAsUtf8Bytes { get; private set; } = null!;
 
+        public JsonNumberHandling? NumberHandling { get; private set; }
+
         // The zero-based position of the parameter in the formal parameter list.
         public int Position { get; private set; }
 
@@ -63,6 +65,7 @@ namespace System.Text.Json
             ShouldDeserialize = true;
             ConverterBase = matchingProperty.ConverterBase;
             IgnoreDefaultValuesOnRead = matchingProperty.IgnoreDefaultValuesOnRead;
+            NumberHandling = matchingProperty.NumberHandling;
         }
 
         // Create a parameter that is ignored at run-time. It uses the same type (typeof(sbyte)) to help

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfo.cs
@@ -50,6 +50,14 @@ namespace System.Text.Json
 
         public Type DeclaredPropertyType { get; private set; } = null!;
 
+        public virtual void GetPolicies(JsonIgnoreCondition? ignoreCondition, JsonNumberHandling? parentTypeNumberHandling, bool defaultValueIsNull)
+        {
+            DetermineSerializationCapabilities(ignoreCondition);
+            DeterminePropertyName();
+            DetermineIgnoreCondition(ignoreCondition, defaultValueIsNull);
+            DetermineNumberHandling(parentTypeNumberHandling);
+        }
+
         private void DeterminePropertyName()
         {
             if (MemberInfo == null)
@@ -174,6 +182,56 @@ namespace System.Text.Json
 #pragma warning restore CS0618 // IgnoreNullValues is obsolete
         }
 
+        private void DetermineNumberHandling(JsonNumberHandling? parentTypeNumberHandling)
+        {
+            if (IsForClassInfo)
+            {
+                if (parentTypeNumberHandling != null && !ConverterBase.IsInternalConverter)
+                {
+                    ThrowHelper.ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(this);
+                }
+
+                // Priority 1: Get handling from the type (parent type in this case is the type itself).
+                NumberHandling = parentTypeNumberHandling;
+
+                // Priority 2: Get handling from JsonSerializerOptions instance.
+                if (!NumberHandling.HasValue && Options.NumberHandling != JsonNumberHandling.Strict)
+                {
+                    NumberHandling = Options.NumberHandling;
+                }
+            }
+            else
+            {
+                JsonNumberHandling? handling = null;
+
+                // Priority 1: Get handling from attribute on property or field.
+                if (MemberInfo != null)
+                {
+                    JsonNumberHandlingAttribute? attribute = GetAttribute<JsonNumberHandlingAttribute>(MemberInfo);
+
+                    if (attribute != null &&
+                        !ConverterBase.IsInternalConverterForNumberType &&
+                        ((ClassType.Enumerable | ClassType.Dictionary) & ClassType) == 0)
+                    {
+                        ThrowHelper.ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(this);
+                    }
+
+                    handling = attribute?.Handling;
+                }
+
+                // Priority 2: Get handling from attribute on parent class type.
+                handling ??= parentTypeNumberHandling;
+
+                // Priority 3: Get handling from JsonSerializerOptions instance.
+                if (!handling.HasValue && Options.NumberHandling != JsonNumberHandling.Strict)
+                {
+                    handling = Options.NumberHandling;
+                }
+
+                NumberHandling = handling;
+            }
+        }
+
         public static TAttribute? GetAttribute<TAttribute>(MemberInfo memberInfo) where TAttribute : Attribute
         {
             return (TAttribute?)memberInfo.GetCustomAttribute(typeof(TAttribute), inherit: false);
@@ -181,13 +239,6 @@ namespace System.Text.Json
 
         public abstract bool GetMemberAndWriteJson(object obj, ref WriteStack state, Utf8JsonWriter writer);
         public abstract bool GetMemberAndWriteJsonExtensionData(object obj, ref WriteStack state, Utf8JsonWriter writer);
-
-        public virtual void GetPolicies(JsonIgnoreCondition? ignoreCondition, bool defaultValueIsNull)
-        {
-            DetermineSerializationCapabilities(ignoreCondition);
-            DeterminePropertyName();
-            DetermineIgnoreCondition(ignoreCondition, defaultValueIsNull);
-        }
 
         public abstract object? GetValueAsObject(object obj);
 
@@ -202,6 +253,7 @@ namespace System.Text.Json
             MemberInfo? memberInfo,
             JsonConverter converter,
             JsonIgnoreCondition? ignoreCondition,
+            JsonNumberHandling? parentTypeNumberHandling,
             JsonSerializerOptions options)
         {
             Debug.Assert(converter != null);
@@ -344,5 +396,7 @@ namespace System.Text.Json
         public bool ShouldSerialize { get; private set; }
         public bool ShouldDeserialize { get; private set; }
         public bool IsIgnored { get; private set; }
+
+        public JsonNumberHandling? NumberHandling { get; private set; }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonPropertyInfoOfT.cs
@@ -28,6 +28,7 @@ namespace System.Text.Json
             MemberInfo? memberInfo,
             JsonConverter converter,
             JsonIgnoreCondition? ignoreCondition,
+            JsonNumberHandling? parentTypeNumberHandling,
             JsonSerializerOptions options)
         {
             base.Initialize(
@@ -38,6 +39,7 @@ namespace System.Text.Json
                 memberInfo,
                 converter,
                 ignoreCondition,
+                parentTypeNumberHandling,
                 options);
 
             switch (memberInfo)
@@ -89,7 +91,7 @@ namespace System.Text.Json
                     }
             }
 
-            GetPolicies(ignoreCondition, defaultValueIsNull: Converter.CanBeNull);
+            GetPolicies(ignoreCondition, parentTypeNumberHandling, defaultValueIsNull: Converter.CanBeNull);
         }
 
         public override JsonConverter ConverterBase
@@ -209,13 +211,13 @@ namespace System.Text.Json
 
                 success = true;
             }
-            else if (Converter.CanUseDirectReadOrWrite)
+            else if (Converter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
             {
                 if (!isNullToken || !IgnoreDefaultValuesOnRead || !Converter.CanBeNull)
                 {
                     // Optimize for internal converters by avoiding the extra call to TryRead.
-                    T fastvalue = Converter.Read(ref reader, RuntimePropertyType!, Options);
-                    Set!(obj, fastvalue!);
+                    T fastValue = Converter.Read(ref reader, RuntimePropertyType!, Options);
+                    Set!(obj, fastValue!);
                 }
 
                 success = true;
@@ -253,7 +255,7 @@ namespace System.Text.Json
             else
             {
                 // Optimize for internal converters by avoiding the extra call to TryRead.
-                if (Converter.CanUseDirectReadOrWrite)
+                if (Converter.CanUseDirectReadOrWrite && state.Current.NumberHandling == null)
                 {
                     value = Converter.Read(ref reader, RuntimePropertyType!, Options);
                     success = true;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.HandlePropertyName.cs
@@ -55,6 +55,7 @@ namespace System.Text.Json
             }
 
             state.Current.JsonPropertyInfo = jsonPropertyInfo;
+            state.Current.NumberHandling = jsonPropertyInfo.NumberHandling;
             return jsonPropertyInfo;
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Helpers.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 
 namespace System.Text.Json
@@ -34,6 +35,12 @@ namespace System.Text.Json
             object? value = jsonConverter.ReadCoreAsObject(ref reader, options, ref state);
             Debug.Assert(value == null || value is TValue);
             return (TValue)value!;
+        }
+
+        internal static bool IsValidNumberHandlingValue(JsonNumberHandling handling)
+        {
+            int handlingValue = (int)handling;
+            return handlingValue >= 0 && handlingValue <= 7;
         }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.Converters.cs
@@ -325,7 +325,7 @@ namespace System.Text.Json
             return GetAttributeThatCanHaveMultiple(attributeType, classType, memberInfo, attributes);
         }
 
-        private static Attribute? GetAttributeThatCanHaveMultiple(Type classType, Type attributeType)
+        internal static Attribute? GetAttributeThatCanHaveMultiple(Type classType, Type attributeType)
         {
             object[] attributes = classType.GetCustomAttributes(attributeType, inherit: false);
             return GetAttributeThatCanHaveMultiple(attributeType, classType, null, attributes);

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializerOptions.cs
@@ -33,6 +33,7 @@ namespace System.Text.Json
         private ReferenceHandler? _referenceHandler;
         private JavaScriptEncoder? _encoder;
         private JsonIgnoreCondition _defaultIgnoreCondition;
+        private JsonNumberHandling _numberHandling;
 
         private int _defaultBufferSize = BufferSizeDefault;
         private int _maxDepth;
@@ -74,6 +75,7 @@ namespace System.Text.Json
             _referenceHandler = options._referenceHandler;
             _encoder = options._encoder;
             _defaultIgnoreCondition = options._defaultIgnoreCondition;
+            _numberHandling = options._numberHandling;
 
             _defaultBufferSize = options._defaultBufferSize;
             _maxDepth = options._maxDepth;
@@ -259,6 +261,27 @@ namespace System.Text.Json
                 }
 
                 _defaultIgnoreCondition = value;
+            }
+        }
+
+        /// <summary>
+        /// Specifies how number types should be handled when serializing or deserializing.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is set after serialization or deserialization has occurred.
+        /// </exception>
+        public JsonNumberHandling NumberHandling
+        {
+            get => _numberHandling;
+            set
+            {
+                VerifyMutable();
+
+                if (!JsonSerializer.IsValidNumberHandlingValue(value))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+                _numberHandling = value;
             }
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/ReadStackFrame.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text.Json.Serialization;
 
 namespace System.Text.Json
 {
@@ -46,6 +47,9 @@ namespace System.Text.Json
         public int CtorArgumentStateIndex;
         public ArgumentState? CtorArgumentState;
 
+        // Whether to use custom number handling.
+        public JsonNumberHandling? NumberHandling;
+
         public void EndConstructorParameter()
         {
             CtorArgumentState!.JsonParameterInfo = null;
@@ -62,6 +66,7 @@ namespace System.Text.Json
             MetadataId = null;
 
             // No need to clear these since they are overwritten each time:
+            //  NumberHandling
             //  UseExtensionProperty
         }
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStack.cs
@@ -68,12 +68,10 @@ namespace System.Text.Json
         public JsonConverter Initialize(Type type, JsonSerializerOptions options, bool supportContinuation)
         {
             JsonClassInfo jsonClassInfo = options.GetOrAddClassForRootType(type);
-            Current.JsonClassInfo = jsonClassInfo;
 
-            if ((jsonClassInfo.ClassType & (ClassType.Enumerable | ClassType.Dictionary)) == 0)
-            {
-                Current.DeclaredJsonPropertyInfo = jsonClassInfo.PropertyInfoForClassInfo;
-            }
+            Current.JsonClassInfo = jsonClassInfo;
+            Current.DeclaredJsonPropertyInfo = jsonClassInfo.PropertyInfoForClassInfo;
+            Current.NumberHandling = Current.DeclaredJsonPropertyInfo.NumberHandling;
 
             if (options.ReferenceHandler != null)
             {
@@ -97,12 +95,15 @@ namespace System.Text.Json
                 else
                 {
                     JsonClassInfo jsonClassInfo = Current.GetPolymorphicJsonPropertyInfo().RuntimeClassInfo;
+                    JsonNumberHandling? numberHandling = Current.NumberHandling;
 
                     AddCurrent();
                     Current.Reset();
 
                     Current.JsonClassInfo = jsonClassInfo;
                     Current.DeclaredJsonPropertyInfo = jsonClassInfo.PropertyInfoForClassInfo;
+                    // Allow number handling on property to win over handling on type.
+                    Current.NumberHandling = numberHandling ?? Current.DeclaredJsonPropertyInfo.NumberHandling;
                 }
             }
             else if (_continuationCount == 1)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/WriteStackFrame.cs
@@ -68,6 +68,9 @@ namespace System.Text.Json
         /// </remarks>
         public JsonPropertyInfo? PolymorphicJsonPropertyInfo;
 
+        // Whether to use custom number handling.
+        public JsonNumberHandling? NumberHandling;
+
         public void EndDictionaryElement()
         {
             PropertyState = StackFramePropertyState.None;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -226,6 +226,28 @@ namespace System.Text.Json
 
         [DoesNotReturn]
         [MethodImpl(MethodImplOptions.NoInlining)]
+        public static void ThrowInvalidOperationException_NumberHandlingOnPropertyInvalid(JsonPropertyInfo jsonPropertyInfo)
+        {
+            MemberInfo? memberInfo = jsonPropertyInfo.MemberInfo;
+
+            if (!jsonPropertyInfo.ConverterBase.IsInternalConverter)
+            {
+                throw new InvalidOperationException(SR.Format(
+                    SR.NumberHandlingConverterMustBeBuiltIn,
+                    jsonPropertyInfo.ConverterBase.GetType(),
+                    jsonPropertyInfo.IsForClassInfo ? jsonPropertyInfo.DeclaredPropertyType : memberInfo!.DeclaringType));
+            }
+
+            // This exception is only thrown for object properties.
+            Debug.Assert(!jsonPropertyInfo.IsForClassInfo && memberInfo != null);
+            throw new InvalidOperationException(SR.Format(
+                SR.NumberHandlingOnPropertyTypeMustBeNumberOrCollection,
+                memberInfo.Name,
+                memberInfo.DeclaringType));
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static void ThrowNotSupportedException_ObjectWithParameterizedCtorRefMetadataNotHonored(
             ReadOnlySpan<byte> propertyName,
             ref Utf8JsonReader reader,

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Decimal.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Decimal.cs
@@ -93,5 +93,13 @@ namespace System.Text.Json
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
+
+        internal void WriteNumberValueAsString(decimal value)
+        {
+            Span<byte> utf8Number = stackalloc byte[JsonConstants.MaximumFormatDecimalLength];
+            bool result = Utf8Formatter.TryFormat(value, utf8Number, out int bytesWritten);
+            Debug.Assert(result);
+            WriteNumberValueAsStringUnescaped(utf8Number.Slice(0, bytesWritten));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Double.cs
@@ -143,5 +143,33 @@ namespace System.Text.Json
             }
 #endif
         }
+
+        internal void WriteNumberValueAsString(double value)
+        {
+            Span<byte> utf8Number = stackalloc byte[JsonConstants.MaximumFormatDoubleLength];
+            bool result = TryFormatDouble(value, utf8Number, out int bytesWritten);
+            Debug.Assert(result);
+            WriteNumberValueAsStringUnescaped(utf8Number.Slice(0, bytesWritten));
+        }
+
+        internal void WriteFloatingPointConstant(double value)
+        {
+            if (double.IsNaN(value))
+            {
+                WriteNumberValueAsStringUnescaped(JsonConstants.NaNValue);
+            }
+            else if (double.IsPositiveInfinity(value))
+            {
+                WriteNumberValueAsStringUnescaped(JsonConstants.PositiveInfinityValue);
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                WriteNumberValueAsStringUnescaped(JsonConstants.NegativeInfinityValue);
+            }
+            else
+            {
+                WriteNumberValue(value);
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.Float.cs
@@ -143,5 +143,33 @@ namespace System.Text.Json
             }
 #endif
         }
+
+        internal void WriteNumberValueAsString(float value)
+        {
+            Span<byte> utf8Number = stackalloc byte[JsonConstants.MaximumFormatSingleLength];
+            bool result = TryFormatSingle(value, utf8Number, out int bytesWritten);
+            Debug.Assert(result);
+            WriteNumberValueAsStringUnescaped(utf8Number.Slice(0, bytesWritten));
+        }
+
+        internal void WriteFloatingPointConstant(float value)
+        {
+            if (float.IsNaN(value))
+            {
+                WriteNumberValueAsStringUnescaped(JsonConstants.NaNValue);
+            }
+            else if (float.IsPositiveInfinity(value))
+            {
+                WriteNumberValueAsStringUnescaped(JsonConstants.PositiveInfinityValue);
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                WriteNumberValueAsStringUnescaped(JsonConstants.NegativeInfinityValue);
+            }
+            else
+            {
+                WriteNumberValue(value);
+            }
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.SignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.SignedNumber.cs
@@ -106,5 +106,13 @@ namespace System.Text.Json
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
+
+        internal void WriteNumberValueAsString(long value)
+        {
+            Span<byte> utf8Number = stackalloc byte[JsonConstants.MaximumFormatInt64Length];
+            bool result = Utf8Formatter.TryFormat(value, utf8Number, out int bytesWritten);
+            Debug.Assert(result);
+            WriteNumberValueAsStringUnescaped(utf8Number.Slice(0, bytesWritten));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.String.cs
@@ -349,5 +349,19 @@ namespace System.Text.Json
                 ArrayPool<byte>.Shared.Return(valueArray);
             }
         }
+
+        /// <summary>
+        /// Writes a number as a JSON string. The string value is not escaped.
+        /// </summary>
+        /// <param name="utf8Value"></param>
+        internal void WriteNumberValueAsStringUnescaped(ReadOnlySpan<byte> utf8Value)
+        {
+            // The value has been validated prior to calling this method.
+
+            WriteStringByOptions(utf8Value);
+
+            SetFlagToAddListSeparatorBeforeNextItem();
+            _tokenType = JsonTokenType.String;
+        }
     }
 }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.UnsignedNumber.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.UnsignedNumber.cs
@@ -108,5 +108,13 @@ namespace System.Text.Json
             Debug.Assert(result);
             BytesPending += bytesWritten;
         }
+
+        internal void WriteNumberValueAsString(ulong value)
+        {
+            Span<byte> utf8Number = stackalloc byte[JsonConstants.MaximumFormatUInt64Length];
+            bool result = Utf8Formatter.TryFormat(value, utf8Number, out int bytesWritten);
+            Debug.Assert(result);
+            WriteNumberValueAsStringUnescaped(utf8Number.Slice(0, bytesWritten));
+        }
     }
 }

--- a/src/libraries/System.Text.Json/tests/JsonNumberTestData.cs
+++ b/src/libraries/System.Text.Json/tests/JsonNumberTestData.cs
@@ -3,8 +3,7 @@
 
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using Newtonsoft.Json;
+using System.Linq;
 
 namespace System.Text.Json.Tests
 {
@@ -21,6 +20,19 @@ namespace System.Text.Json.Tests
         public static List<float> Floats { get; set; }
         public static List<double> Doubles { get; set; }
         public static List<decimal> Decimals { get; set; }
+
+        public static List<byte?> NullableBytes { get; set; }
+        public static List<sbyte?> NullableSBytes { get; set; }
+        public static List<short?> NullableShorts { get; set; }
+        public static List<int?> NullableInts { get; set; }
+        public static List<long?> NullableLongs { get; set; }
+        public static List<ushort?> NullableUShorts { get; set; }
+        public static List<uint?> NullableUInts { get; set; }
+        public static List<ulong?> NullableULongs { get; set; }
+        public static List<float?> NullableFloats { get; set; }
+        public static List<double?> NullableDoubles { get; set; }
+        public static List<decimal?> NullableDecimals { get; set; }
+
         public static byte[] JsonData { get; set; }
 
         static JsonNumberTestData()
@@ -294,6 +306,19 @@ namespace System.Text.Json.Tests
 
             builder.Append("\"intEnd\": 0}");
             #endregion
+
+            // Make collections of nullable numbers.
+            NullableBytes = new List<byte?>(Bytes.Select(num => (byte?)num));
+            NullableSBytes = new List<sbyte?>(SBytes.Select(num => (sbyte?)num));
+            NullableShorts = new List<short?>(Shorts.Select(num => (short?)num));
+            NullableInts = new List<int?>(Ints.Select(num => (int?)num));
+            NullableLongs = new List<long?>(Longs.Select(num => (long?)num));
+            NullableUShorts = new List<ushort?>(UShorts.Select(num => (ushort?)num));
+            NullableUInts = new List<uint?>(UInts.Select(num => (uint?)num));
+            NullableULongs = new List<ulong?>(ULongs.Select(num => (ulong?)num));
+            NullableFloats = new List<float?>(Floats.Select(num => (float?)num));
+            NullableDoubles = new List<double?>(Doubles.Select(num => (double?)num));
+            NullableDecimals = new List<decimal?>(Decimals.Select(num => (decimal?)num));
 
             string jsonString = builder.ToString();
             JsonData = Encoding.UTF8.GetBytes(jsonString);

--- a/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/NumberHandlingTests.cs
@@ -1,0 +1,1414 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json.Tests;
+using Xunit;
+
+namespace System.Text.Json.Serialization.Tests
+{
+    public static partial class NumberHandlingTests
+    {
+        private static readonly JsonSerializerOptions s_optionReadFromStr = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.AllowReadingFromString
+        };
+
+        private static readonly JsonSerializerOptions s_optionWriteAsStr = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.WriteAsString
+        };
+
+        private static readonly JsonSerializerOptions s_optionReadAndWriteFromStr = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString
+        };
+
+        private static readonly JsonSerializerOptions s_optionsAllowFloatConstants = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.AllowNamedFloatingPointLiterals
+        };
+
+        private static readonly JsonSerializerOptions s_optionReadFromStrAllowFloatConstants = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.AllowNamedFloatingPointLiterals
+        };
+
+        private static readonly JsonSerializerOptions s_optionWriteAsStrAllowFloatConstants = new JsonSerializerOptions
+        {
+            NumberHandling = JsonNumberHandling.WriteAsString | JsonNumberHandling.AllowNamedFloatingPointLiterals
+        };
+
+        [Fact]
+        public static void Number_AsRootType_RoundTrip()
+        {
+            RunAsRootTypeTest(JsonNumberTestData.Bytes);
+            RunAsRootTypeTest(JsonNumberTestData.SBytes);
+            RunAsRootTypeTest(JsonNumberTestData.Shorts);
+            RunAsRootTypeTest(JsonNumberTestData.Ints);
+            RunAsRootTypeTest(JsonNumberTestData.Longs);
+            RunAsRootTypeTest(JsonNumberTestData.UShorts);
+            RunAsRootTypeTest(JsonNumberTestData.UInts);
+            RunAsRootTypeTest(JsonNumberTestData.ULongs);
+            RunAsRootTypeTest(JsonNumberTestData.Floats);
+            RunAsRootTypeTest(JsonNumberTestData.Doubles);
+            RunAsRootTypeTest(JsonNumberTestData.Decimals);
+            RunAsRootTypeTest(JsonNumberTestData.NullableBytes);
+            RunAsRootTypeTest(JsonNumberTestData.NullableSBytes);
+            RunAsRootTypeTest(JsonNumberTestData.NullableShorts);
+            RunAsRootTypeTest(JsonNumberTestData.NullableInts);
+            RunAsRootTypeTest(JsonNumberTestData.NullableLongs);
+            RunAsRootTypeTest(JsonNumberTestData.NullableUShorts);
+            RunAsRootTypeTest(JsonNumberTestData.NullableUInts);
+            RunAsRootTypeTest(JsonNumberTestData.NullableULongs);
+            RunAsRootTypeTest(JsonNumberTestData.NullableFloats);
+            RunAsRootTypeTest(JsonNumberTestData.NullableDoubles);
+            RunAsRootTypeTest(JsonNumberTestData.NullableDecimals);
+        }
+
+        private static void RunAsRootTypeTest<T>(List<T> numbers)
+        {
+            foreach (T number in numbers)
+            {
+                string numberAsString = GetNumberAsString(number);
+                string json = $"{numberAsString}";
+                string jsonWithNumberAsString = @$"""{numberAsString}""";
+                PerformAsRootTypeSerialization(number, json, jsonWithNumberAsString);
+            }
+        }
+
+        private static string GetNumberAsString<T>(T number)
+        {
+            return number switch
+            {
+                double @double => @double.ToString(JsonTestHelper.DoubleFormatString, CultureInfo.InvariantCulture),
+                float @float => @float.ToString(JsonTestHelper.SingleFormatString, CultureInfo.InvariantCulture),
+                decimal @decimal => @decimal.ToString(CultureInfo.InvariantCulture),
+                _ => number.ToString()
+            };
+        }
+
+        private static void PerformAsRootTypeSerialization<T>(T number, string jsonWithNumberAsNumber, string jsonWithNumberAsString)
+        {
+            // Option: read from string
+
+            // Deserialize
+            Assert.Equal(number, JsonSerializer.Deserialize<T>(jsonWithNumberAsNumber, s_optionReadFromStr));
+            Assert.Equal(number, JsonSerializer.Deserialize<T>(jsonWithNumberAsString, s_optionReadFromStr));
+
+            // Serialize
+            Assert.Equal(jsonWithNumberAsNumber, JsonSerializer.Serialize(number, s_optionReadFromStr));
+
+            // Option: write as string
+
+            // Deserialize
+            Assert.Equal(number, JsonSerializer.Deserialize<T>(jsonWithNumberAsNumber, s_optionWriteAsStr));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(jsonWithNumberAsString, s_optionWriteAsStr));
+
+            // Serialize
+            Assert.Equal(jsonWithNumberAsString, JsonSerializer.Serialize(number, s_optionWriteAsStr));
+
+            // Option: read and write from/to string
+
+            // Deserialize
+            Assert.Equal(number, JsonSerializer.Deserialize<T>(jsonWithNumberAsNumber, s_optionReadAndWriteFromStr));
+            Assert.Equal(number, JsonSerializer.Deserialize<T>(jsonWithNumberAsString, s_optionReadAndWriteFromStr));
+
+            // Serialize
+            Assert.Equal(jsonWithNumberAsString, JsonSerializer.Serialize(number, s_optionReadAndWriteFromStr));
+        }
+
+        [Fact]
+        public static void Number_AsBoxedRootType()
+        {
+            string numberAsString = @"""2""";
+
+            int @int = 2;
+            float @float = 2;
+            int? nullableInt = 2;
+            float? nullableFloat = 2;
+
+            Assert.Equal(numberAsString, JsonSerializer.Serialize((object)@int, s_optionReadAndWriteFromStr));
+            Assert.Equal(numberAsString, JsonSerializer.Serialize((object)@float, s_optionReadAndWriteFromStr));
+            Assert.Equal(numberAsString, JsonSerializer.Serialize((object)nullableInt, s_optionReadAndWriteFromStr));
+            Assert.Equal(numberAsString, JsonSerializer.Serialize((object)nullableFloat, s_optionReadAndWriteFromStr));
+
+            Assert.Equal(2, (int)JsonSerializer.Deserialize(numberAsString, typeof(int), s_optionReadAndWriteFromStr));
+            Assert.Equal(2, (float)JsonSerializer.Deserialize(numberAsString, typeof(float), s_optionReadAndWriteFromStr));
+            Assert.Equal(2, (int?)JsonSerializer.Deserialize(numberAsString, typeof(int?), s_optionReadAndWriteFromStr));
+            Assert.Equal(2, (float?)JsonSerializer.Deserialize(numberAsString, typeof(float?), s_optionReadAndWriteFromStr));
+        }
+
+        [Fact]
+        public static void Number_AsCollectionElement_RoundTrip()
+        {
+            RunAsCollectionElementTest(JsonNumberTestData.Bytes);
+            RunAsCollectionElementTest(JsonNumberTestData.SBytes);
+            RunAsCollectionElementTest(JsonNumberTestData.Shorts);
+            RunAsCollectionElementTest(JsonNumberTestData.Ints);
+            RunAsCollectionElementTest(JsonNumberTestData.Longs);
+            RunAsCollectionElementTest(JsonNumberTestData.UShorts);
+            RunAsCollectionElementTest(JsonNumberTestData.UInts);
+            RunAsCollectionElementTest(JsonNumberTestData.ULongs);
+            RunAsCollectionElementTest(JsonNumberTestData.Floats);
+            RunAsCollectionElementTest(JsonNumberTestData.Doubles);
+            RunAsCollectionElementTest(JsonNumberTestData.Decimals);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableBytes);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableSBytes);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableShorts);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableInts);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableLongs);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableUShorts);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableUInts);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableULongs);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableFloats);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableDoubles);
+            RunAsCollectionElementTest(JsonNumberTestData.NullableDecimals);
+        }
+
+        private static void RunAsCollectionElementTest<T>(List<T> numbers)
+        {
+            StringBuilder jsonBuilder_NumbersAsNumbers = new StringBuilder();
+            StringBuilder jsonBuilder_NumbersAsStrings = new StringBuilder();
+            StringBuilder jsonBuilder_NumbersAsNumbersAndStrings = new StringBuilder();
+            StringBuilder jsonBuilder_NumbersAsNumbersAndStrings_Alternate = new StringBuilder();
+            bool asNumber = false;
+
+            jsonBuilder_NumbersAsNumbers.Append("[");
+            jsonBuilder_NumbersAsStrings.Append("[");
+            jsonBuilder_NumbersAsNumbersAndStrings.Append("[");
+            jsonBuilder_NumbersAsNumbersAndStrings_Alternate.Append("[");
+
+            foreach (T number in numbers)
+            {
+                string numberAsString = GetNumberAsString(number);
+
+                string jsonWithNumberAsString = @$"""{numberAsString}""";
+
+                jsonBuilder_NumbersAsNumbers.Append($"{numberAsString},");
+                jsonBuilder_NumbersAsStrings.Append($"{jsonWithNumberAsString},");
+                jsonBuilder_NumbersAsNumbersAndStrings.Append(asNumber
+                    ? $"{numberAsString},"
+                    : $"{jsonWithNumberAsString},");
+                jsonBuilder_NumbersAsNumbersAndStrings_Alternate.Append(!asNumber
+                    ? $"{numberAsString},"
+                    : $"{jsonWithNumberAsString},");
+
+                asNumber = !asNumber;
+            }
+
+            jsonBuilder_NumbersAsNumbers.Remove(jsonBuilder_NumbersAsNumbers.Length - 1, 1);
+            jsonBuilder_NumbersAsStrings.Remove(jsonBuilder_NumbersAsStrings.Length - 1, 1);
+            jsonBuilder_NumbersAsNumbersAndStrings.Remove(jsonBuilder_NumbersAsNumbersAndStrings.Length - 1, 1);
+            jsonBuilder_NumbersAsNumbersAndStrings_Alternate.Remove(jsonBuilder_NumbersAsNumbersAndStrings_Alternate.Length - 1, 1);
+
+            jsonBuilder_NumbersAsNumbers.Append("]");
+            jsonBuilder_NumbersAsStrings.Append("]");
+            jsonBuilder_NumbersAsNumbersAndStrings.Append("]");
+            jsonBuilder_NumbersAsNumbersAndStrings_Alternate.Append("]");
+
+            string jsonNumbersAsStrings = jsonBuilder_NumbersAsStrings.ToString();
+
+            PerformAsCollectionElementSerialization(
+                numbers,
+                jsonBuilder_NumbersAsNumbers.ToString(),
+                jsonNumbersAsStrings,
+                jsonBuilder_NumbersAsNumbersAndStrings.ToString(),
+                jsonBuilder_NumbersAsNumbersAndStrings_Alternate.ToString());
+
+            // Reflection based tests for every collection type.
+            RunAllCollectionsRoundTripTest<T>(jsonNumbersAsStrings);
+        }
+
+        private static void PerformAsCollectionElementSerialization<T>(
+            List<T> numbers,
+            string json_NumbersAsNumbers,
+            string json_NumbersAsStrings,
+            string json_NumbersAsNumbersAndStrings,
+            string json_NumbersAsNumbersAndStrings_Alternate)
+        {
+            List<T> deserialized;
+
+            // Option: read from string
+
+            // Deserialize
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbers, s_optionReadFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsStrings, s_optionReadFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbersAndStrings, s_optionReadFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbersAndStrings_Alternate, s_optionReadFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            // Serialize
+            Assert.Equal(json_NumbersAsNumbers, JsonSerializer.Serialize(numbers, s_optionReadFromStr));
+
+            // Option: write as string
+
+            // Deserialize
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbers, s_optionWriteAsStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<List<T>>(json_NumbersAsStrings, s_optionWriteAsStr));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbersAndStrings, s_optionWriteAsStr));
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbersAndStrings_Alternate, s_optionWriteAsStr));
+
+            // Serialize
+            Assert.Equal(json_NumbersAsStrings, JsonSerializer.Serialize(numbers, s_optionWriteAsStr));
+
+            // Option: read and write from/to string
+
+            // Deserialize
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbers, s_optionReadAndWriteFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsStrings, s_optionReadAndWriteFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbersAndStrings, s_optionReadAndWriteFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            deserialized = JsonSerializer.Deserialize<List<T>>(json_NumbersAsNumbersAndStrings_Alternate, s_optionReadAndWriteFromStr);
+            AssertIEnumerableEqual(numbers, deserialized);
+
+            // Serialize
+            Assert.Equal(json_NumbersAsStrings, JsonSerializer.Serialize(numbers, s_optionReadAndWriteFromStr));
+        }
+
+        private static void AssertIEnumerableEqual<T>(IEnumerable<T> list1, IEnumerable<T> list2)
+        {
+            IEnumerator<T> enumerator1 = list1.GetEnumerator();
+            IEnumerator<T> enumerator2 = list2.GetEnumerator();
+
+            while (enumerator1.MoveNext())
+            {
+                enumerator2.MoveNext();
+                Assert.Equal(enumerator1.Current, enumerator2.Current);
+            }
+
+            Assert.False(enumerator2.MoveNext());
+        }
+
+        private static void RunAllCollectionsRoundTripTest<T>(string json)
+        {
+            foreach (Type type in CollectionTestTypes.DeserializableGenericEnumerableTypes<T>())
+            {
+                if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(HashSet<>))
+                {
+                    HashSet<T> obj1 = (HashSet<T>)JsonSerializer.Deserialize(json, type, s_optionReadAndWriteFromStr);
+                    string serialized = JsonSerializer.Serialize(obj1, s_optionReadAndWriteFromStr);
+
+                    HashSet<T> obj2 = (HashSet<T>)JsonSerializer.Deserialize(serialized, type, s_optionReadAndWriteFromStr);
+
+                    Assert.Equal(obj1.Count, obj2.Count);
+                    foreach (T element in obj1)
+                    {
+                        Assert.True(obj2.Contains(element));
+                    }
+                }
+                else if (type != typeof(byte[]))
+                {
+                    object obj = JsonSerializer.Deserialize(json, type, s_optionReadAndWriteFromStr);
+                    string serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+                    Assert.Equal(json, serialized);
+                }
+            }
+
+            foreach (Type type in CollectionTestTypes.DeserializableNonGenericEnumerableTypes())
+            {
+                // Deserialized as collection of JsonElements.
+                object obj = JsonSerializer.Deserialize(json, type, s_optionReadAndWriteFromStr);
+                // Serialized as strings with escaping.
+                string serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+
+                // Ensure escaped values were serialized accurately
+                List<T> list = JsonSerializer.Deserialize<List<T>>(serialized, s_optionReadAndWriteFromStr);
+                serialized = JsonSerializer.Serialize(list, s_optionReadAndWriteFromStr);
+                Assert.Equal(json, serialized);
+
+                // Serialize instance which is a collection of numbers (not JsonElements).
+                obj = Activator.CreateInstance(type, new[] { list });
+                serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+                Assert.Equal(json, serialized);
+            }
+        }
+
+        [Fact]
+        public static void Number_AsDictionaryElement_RoundTrip()
+        {
+            var dict = new Dictionary<int, float>();
+            for (int i = 0; i < 10; i++)
+            {
+                dict[JsonNumberTestData.Ints[i]] = JsonNumberTestData.Floats[i];
+            }
+
+            // Serialize
+            string serialized = JsonSerializer.Serialize(dict, s_optionReadAndWriteFromStr);
+            AssertDictionaryElements_StringValues(serialized);
+
+            // Deserialize
+            dict = JsonSerializer.Deserialize<Dictionary<int, float>>(serialized, s_optionReadAndWriteFromStr);
+
+            // Test roundtrip
+            JsonTestHelper.AssertJsonEqual(serialized, JsonSerializer.Serialize(dict, s_optionReadAndWriteFromStr));
+        }
+
+        private static void AssertDictionaryElements_StringValues(string serialized)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(serialized));
+            reader.Read();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+                else if (reader.TokenType == JsonTokenType.String)
+                {
+#if BUILDING_INBOX_LIBRARY
+                    Assert.False(reader.ValueSpan.Contains((byte)'\\'));
+#else
+                    foreach (byte val in reader.ValueSpan)
+                    {
+                        if (val == (byte)'\\')
+                        {
+                            Assert.True(false, "Unexpected escape token.");
+                        }
+                    }
+#endif
+                }
+                else
+                {
+                    Assert.Equal(JsonTokenType.PropertyName, reader.TokenType);
+                }
+            }
+        }
+
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39674", typeof(PlatformDetection), nameof(PlatformDetection.IsMonoInterpreter))]
+        public static void DictionariesRoundTrip()
+        {
+            RunAllDictionariessRoundTripTest(JsonNumberTestData.ULongs);
+            RunAllDictionariessRoundTripTest(JsonNumberTestData.Floats);
+            RunAllDictionariessRoundTripTest(JsonNumberTestData.Doubles);
+        }
+
+        private static void RunAllDictionariessRoundTripTest<T>(List<T> numbers)
+        {
+            StringBuilder jsonBuilder_NumbersAsStrings = new StringBuilder();
+
+            jsonBuilder_NumbersAsStrings.Append("{");
+
+            foreach (T number in numbers)
+            {
+                string numberAsString = GetNumberAsString(number);
+                string jsonWithNumberAsString = @$"""{numberAsString}""";
+
+                jsonBuilder_NumbersAsStrings.Append($"{jsonWithNumberAsString}:");
+                jsonBuilder_NumbersAsStrings.Append($"{jsonWithNumberAsString},");
+            }
+
+            jsonBuilder_NumbersAsStrings.Remove(jsonBuilder_NumbersAsStrings.Length - 1, 1);
+            jsonBuilder_NumbersAsStrings.Append("}");
+
+            string jsonNumbersAsStrings = jsonBuilder_NumbersAsStrings.ToString();
+
+            foreach (Type type in CollectionTestTypes.DeserializableDictionaryTypes<T>())
+            {
+                object obj = JsonSerializer.Deserialize(jsonNumbersAsStrings, type, s_optionReadAndWriteFromStr);
+                JsonTestHelper.AssertJsonEqual(jsonNumbersAsStrings, JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr));
+            }
+
+            foreach (Type type in CollectionTestTypes.DeserializableNonDictionaryTypes<T>())
+            {
+                Dictionary<T, T> dict = JsonSerializer.Deserialize<Dictionary<T, T>>(jsonNumbersAsStrings, s_optionReadAndWriteFromStr);
+
+                // Serialize instance which is a dictionary of numbers (not JsonElements).
+                object obj = Activator.CreateInstance(type, new[] { dict });
+                string serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+                JsonTestHelper.AssertJsonEqual(jsonNumbersAsStrings, serialized);
+            }
+        }
+
+        [Fact]
+        public static void Number_AsPropertyValue_RoundTrip()
+        {
+            var obj = new Class_With_NullableUInt64_And_Float()
+            {
+                NullableUInt64Number = JsonNumberTestData.NullableULongs.LastOrDefault(),
+                FloatNumbers = JsonNumberTestData.Floats
+            };
+
+            // Serialize
+            string serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+
+            // Deserialize
+            obj = JsonSerializer.Deserialize<Class_With_NullableUInt64_And_Float>(serialized, s_optionReadAndWriteFromStr);
+
+            // Test roundtrip
+            JsonTestHelper.AssertJsonEqual(serialized, JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr));
+        }
+
+        private class Class_With_NullableUInt64_And_Float
+        {
+            public ulong? NullableUInt64Number { get; set; }
+            [JsonInclude]
+            public List<float> FloatNumbers;
+        }
+
+        [Fact]
+        public static void Number_AsKeyValuePairValue_RoundTrip()
+        {
+            var obj = new KeyValuePair<ulong?, List<float>>(JsonNumberTestData.NullableULongs.LastOrDefault(), JsonNumberTestData.Floats);
+
+            // Serialize
+            string serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+
+            // Deserialize
+            obj = JsonSerializer.Deserialize<KeyValuePair<ulong?, List<float>>>(serialized, s_optionReadAndWriteFromStr);
+
+            // Test roundtrip
+            JsonTestHelper.AssertJsonEqual(serialized, JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr));
+        }
+
+        [Fact]
+        public static void Number_AsObjectWithParameterizedCtor_RoundTrip()
+        {
+            var obj = new MyClassWithNumbers(JsonNumberTestData.NullableULongs.LastOrDefault(), JsonNumberTestData.Floats);
+
+            // Serialize
+            string serialized = JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr);
+
+            // Deserialize
+            obj = JsonSerializer.Deserialize<MyClassWithNumbers>(serialized, s_optionReadAndWriteFromStr);
+
+            // Test roundtrip
+            JsonTestHelper.AssertJsonEqual(serialized, JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr));
+        }
+
+        private class MyClassWithNumbers
+        {
+            public ulong? Ulong { get; }
+            public List<float> ListOfFloats { get; }
+
+            public MyClassWithNumbers(ulong? @ulong, List<float> listOfFloats)
+            {
+                Ulong = @ulong;
+                ListOfFloats = listOfFloats;
+            }
+        }
+
+        [Fact]
+        public static void Number_AsObjectWithParameterizedCtor_PropHasAttribute()
+        {
+            string json = @"{""ListOfFloats"":[""1""]}";
+            // Strict handling on property overrides loose global policy.
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyClassWithNumbers_PropsHasAttribute>(json, s_optionReadFromStr));
+
+            // Serialize
+            json = @"{""ListOfFloats"":[1]}";
+            MyClassWithNumbers_PropsHasAttribute obj = JsonSerializer.Deserialize<MyClassWithNumbers_PropsHasAttribute>(json);
+
+            // Number serialized as JSON number due to strict handling on property which overrides loose global policy.
+            Assert.Equal(json, JsonSerializer.Serialize(obj, s_optionReadAndWriteFromStr));
+        }
+
+        private class MyClassWithNumbers_PropsHasAttribute
+        {
+            [JsonNumberHandling(JsonNumberHandling.Strict)]
+            public List<float> ListOfFloats { get; }
+
+            public MyClassWithNumbers_PropsHasAttribute(List<float> listOfFloats)
+            {
+                ListOfFloats = listOfFloats;
+            }
+        }
+
+        [Fact]
+        public static void FloatingPointConstants_Pass()
+        {
+            // Valid values
+            PerformFloatingPointSerialization("NaN");
+            PerformFloatingPointSerialization("Infinity");
+            PerformFloatingPointSerialization("-Infinity");
+
+            static void PerformFloatingPointSerialization(string testString)
+            {
+                string testStringAsJson = $@"""{testString}""";
+                string testJson = @$"{{""FloatNumber"":{testStringAsJson},""DoubleNumber"":{testStringAsJson}}}";
+
+                StructWithNumbers obj;
+                switch (testString)
+                {
+                    case "NaN":
+                        obj = JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionsAllowFloatConstants);
+                        Assert.Equal(float.NaN, obj.FloatNumber);
+                        Assert.Equal(double.NaN, obj.DoubleNumber);
+
+                        obj = JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionReadFromStr);
+                        Assert.Equal(float.NaN, obj.FloatNumber);
+                        Assert.Equal(double.NaN, obj.DoubleNumber);
+                        break;
+                    case "Infinity":
+                        obj = JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionsAllowFloatConstants);
+                        Assert.Equal(float.PositiveInfinity, obj.FloatNumber);
+                        Assert.Equal(double.PositiveInfinity, obj.DoubleNumber);
+
+                        obj = JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionReadFromStr);
+                        Assert.Equal(float.PositiveInfinity, obj.FloatNumber);
+                        Assert.Equal(double.PositiveInfinity, obj.DoubleNumber);
+                        break;
+                    case "-Infinity":
+                        obj = JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionsAllowFloatConstants);
+                        Assert.Equal(float.NegativeInfinity, obj.FloatNumber);
+                        Assert.Equal(double.NegativeInfinity, obj.DoubleNumber);
+
+                        obj = JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionReadFromStr);
+                        Assert.Equal(float.NegativeInfinity, obj.FloatNumber);
+                        Assert.Equal(double.NegativeInfinity, obj.DoubleNumber);
+                        break;
+                    default:
+                        Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionsAllowFloatConstants));
+                        return;
+                }
+
+                JsonTestHelper.AssertJsonEqual(testJson, JsonSerializer.Serialize(obj, s_optionsAllowFloatConstants));
+                JsonTestHelper.AssertJsonEqual(testJson, JsonSerializer.Serialize(obj, s_optionWriteAsStr));
+            }
+        }
+
+        [Theory]
+        [InlineData("naN")]
+        [InlineData("Nan")]
+        [InlineData("NAN")]
+        [InlineData("+Infinity")]
+        [InlineData("+infinity")]
+        [InlineData("infinity")]
+        [InlineData("infinitY")]
+        [InlineData("INFINITY")]
+        [InlineData("+INFINITY")]
+        [InlineData("-infinity")]
+        [InlineData("-infinitY")]
+        [InlineData("-INFINITY")]
+        [InlineData(" NaN")]
+        [InlineData(" Infinity")]
+        [InlineData(" -Infinity")]
+        [InlineData("NaN ")]
+        [InlineData("Infinity ")]
+        [InlineData("-Infinity ")]
+        [InlineData("a-Infinity")]
+        [InlineData("NaNa")]
+        [InlineData("Infinitya")]
+        [InlineData("-Infinitya")]
+        public static void FloatingPointConstants_Fail(string testString)
+        {
+            string testStringAsJson = $@"""{testString}""";
+            string testJson = @$"{{""FloatNumber"":{testStringAsJson},""DoubleNumber"":{testStringAsJson}}}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<StructWithNumbers>(testJson, s_optionReadFromStr));
+        }
+
+        [Fact]
+        public static void AllowFloatingPointConstants_WriteAsNumber_IfNotConstant()
+        {
+            float @float = 1;
+            // Not written as "1"
+            Assert.Equal("1", JsonSerializer.Serialize(@float, s_optionsAllowFloatConstants));
+
+            double @double = 1;
+            // Not written as "1"
+            Assert.Equal("1", JsonSerializer.Serialize(@double, s_optionsAllowFloatConstants));
+        }
+
+        [Theory]
+        [InlineData("NaN")]
+        [InlineData("Infinity")]
+        [InlineData("-Infinity")]
+        public static void Unquoted_FloatingPointConstants_Read_Fail(string testString)
+        {
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float>(testString, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double?>(testString, s_optionReadFromStr));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double>(testString, s_optionReadFromStrAllowFloatConstants));
+        }
+
+        private struct StructWithNumbers
+        {
+            public float FloatNumber { get; set; }
+            public double DoubleNumber { get; set; }
+        }
+
+        [Fact]
+        public static void ReadFromString_AllowFloatingPoint()
+        {
+            string json = @"{""IntNumber"":""1"",""FloatNumber"":""NaN""}";
+            ClassWithNumbers obj = JsonSerializer.Deserialize<ClassWithNumbers>(json, s_optionReadFromStrAllowFloatConstants);
+
+            Assert.Equal(1, obj.IntNumber);
+            Assert.Equal(float.NaN, obj.FloatNumber);
+
+            JsonTestHelper.AssertJsonEqual(@"{""IntNumber"":1,""FloatNumber"":""NaN""}", JsonSerializer.Serialize(obj, s_optionReadFromStrAllowFloatConstants));
+        }
+
+        [Fact]
+        public static void WriteAsString_AllowFloatingPoint()
+        {
+            string json = @"{""IntNumber"":""1"",""FloatNumber"":""NaN""}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithNumbers>(json, s_optionWriteAsStrAllowFloatConstants));
+
+            var obj = new ClassWithNumbers
+            {
+                IntNumber = 1,
+                FloatNumber = float.NaN
+            };
+
+            JsonTestHelper.AssertJsonEqual(json, JsonSerializer.Serialize(obj, s_optionWriteAsStrAllowFloatConstants));
+        }
+
+        public class ClassWithNumbers
+        {
+            public int IntNumber { get; set; }
+            public float FloatNumber { get; set; }
+        }
+
+        [Fact]
+        public static void FloatingPointConstants_IncompatibleNumber()
+        {
+            AssertFloatingPointIncompatible_Fails<byte>();
+            AssertFloatingPointIncompatible_Fails<sbyte>();
+            AssertFloatingPointIncompatible_Fails<short>();
+            AssertFloatingPointIncompatible_Fails<int>();
+            AssertFloatingPointIncompatible_Fails<long>();
+            AssertFloatingPointIncompatible_Fails<ushort>();
+            AssertFloatingPointIncompatible_Fails<uint>();
+            AssertFloatingPointIncompatible_Fails<ulong>();
+            AssertFloatingPointIncompatible_Fails<decimal>();
+            AssertFloatingPointIncompatible_Fails<byte?>();
+            AssertFloatingPointIncompatible_Fails<sbyte?>();
+            AssertFloatingPointIncompatible_Fails<short?>();
+            AssertFloatingPointIncompatible_Fails<int?>();
+            AssertFloatingPointIncompatible_Fails<long?>();
+            AssertFloatingPointIncompatible_Fails<ushort?>();
+            AssertFloatingPointIncompatible_Fails<uint?>();
+            AssertFloatingPointIncompatible_Fails<ulong?>();
+            AssertFloatingPointIncompatible_Fails<decimal?>();
+        }
+
+        private static void AssertFloatingPointIncompatible_Fails<T>()
+        {
+            string[] testCases = new[]
+            {
+                @"""NaN""",
+                @"""Infinity""",
+                @"""-Infinity""",
+            };
+
+            foreach (string test in testCases)
+            {
+                Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(test, s_optionReadFromStrAllowFloatConstants));
+            }
+        }
+
+        [Fact]
+        public static void UnsupportedFormats()
+        {
+            AssertUnsupportedFormatThrows<byte>();
+            AssertUnsupportedFormatThrows<sbyte>();
+            AssertUnsupportedFormatThrows<short>();
+            AssertUnsupportedFormatThrows<int>();
+            AssertUnsupportedFormatThrows<long>();
+            AssertUnsupportedFormatThrows<ushort>();
+            AssertUnsupportedFormatThrows<uint>();
+            AssertUnsupportedFormatThrows<ulong>();
+            AssertUnsupportedFormatThrows<float>();
+            AssertUnsupportedFormatThrows<decimal>();
+            AssertUnsupportedFormatThrows<byte?>();
+            AssertUnsupportedFormatThrows<sbyte?>();
+            AssertUnsupportedFormatThrows<short?>();
+            AssertUnsupportedFormatThrows<int?>();
+            AssertUnsupportedFormatThrows<long?>();
+            AssertUnsupportedFormatThrows<ushort?>();
+            AssertUnsupportedFormatThrows<uint?>();
+            AssertUnsupportedFormatThrows<ulong?>();
+            AssertUnsupportedFormatThrows<float?>();
+            AssertUnsupportedFormatThrows<decimal?>();
+        }
+
+        private static void AssertUnsupportedFormatThrows<T>()
+        {
+            string[] testCases = new[]
+            {
+                "$123.46", // Currency
+                "100.00 %", // Percent
+                 "1234,57", // Fixed point
+                 "00FF", // Hexadecimal
+            };
+
+            foreach (string test in testCases)
+            {
+                Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(test, s_optionReadFromStr));
+            }
+        }
+
+        [Fact]
+        public static void EscapingTest()
+        {
+            // Cause all characters to be escaped.
+            var encoderSettings = new TextEncoderSettings();
+            encoderSettings.ForbidCharacters('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '+', '-', 'e', 'E');
+
+            JavaScriptEncoder encoder = JavaScriptEncoder.Create(encoderSettings);
+            var options = new JsonSerializerOptions(s_optionReadAndWriteFromStr)
+            {
+                Encoder = encoder
+            };
+
+            PerformEscapingTest(JsonNumberTestData.Bytes, options);
+            PerformEscapingTest(JsonNumberTestData.SBytes, options);
+            PerformEscapingTest(JsonNumberTestData.Shorts, options);
+            PerformEscapingTest(JsonNumberTestData.Ints, options);
+            PerformEscapingTest(JsonNumberTestData.Longs, options);
+            PerformEscapingTest(JsonNumberTestData.UShorts, options);
+            PerformEscapingTest(JsonNumberTestData.UInts, options);
+            PerformEscapingTest(JsonNumberTestData.ULongs, options);
+            PerformEscapingTest(JsonNumberTestData.Floats, options);
+            PerformEscapingTest(JsonNumberTestData.Doubles, options);
+            PerformEscapingTest(JsonNumberTestData.Decimals, options);
+        }
+
+        private static void PerformEscapingTest<T>(List<T> numbers, JsonSerializerOptions options)
+        {
+            // All input characters are escaped
+            IEnumerable<string> numbersAsStrings = numbers.Select(num => GetNumberAsString(num));
+            string input = JsonSerializer.Serialize(numbersAsStrings, options);
+            AssertListNumbersEscaped(input);
+
+            // Unescaping works
+            List<T> deserialized = JsonSerializer.Deserialize<List<T>>(input, options);
+            Assert.Equal(numbers.Count, deserialized.Count);
+            for (int i = 0; i < numbers.Count; i++)
+            {
+                Assert.Equal(numbers[i], deserialized[i]);
+            }
+
+            // Every number is written as a string, and custom escaping is not honored.
+            string serialized = JsonSerializer.Serialize(deserialized, options);
+            AssertListNumbersUnescaped(serialized);
+        }
+
+        private static void AssertListNumbersEscaped(string json)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            reader.Read();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+                else
+                {
+                    Assert.Equal(JsonTokenType.String, reader.TokenType);
+#if BUILDING_INBOX_LIBRARY
+                    Assert.True(reader.ValueSpan.Contains((byte)'\\'));
+#else
+                    bool foundBackSlash = false;
+                    foreach (byte val in reader.ValueSpan)
+                    {
+                        if (val == (byte)'\\')
+                        {
+                            foundBackSlash = true;
+                            break;
+                        }
+                    }
+
+                    Assert.True(foundBackSlash, "Expected escape token.");
+#endif
+                }
+            }
+        }
+
+        private static void AssertListNumbersUnescaped(string json)
+        {
+            var reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(json));
+            reader.Read();
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    break;
+                }
+                else
+                {
+                    Assert.Equal(JsonTokenType.String, reader.TokenType);
+#if BUILDING_INBOX_LIBRARY
+                    Assert.False(reader.ValueSpan.Contains((byte)'\\'));
+#else
+                    foreach (byte val in reader.ValueSpan)
+                    {
+                        if (val == (byte)'\\')
+                        {
+                            Assert.True(false, "Unexpected escape token.");
+                        }
+                    }
+#endif
+                }
+            }
+        }
+
+        [Fact]
+        public static void Number_RoundtripNull()
+        {
+            Perform_Number_RoundTripNull_Test<byte>();
+            Perform_Number_RoundTripNull_Test<sbyte>();
+            Perform_Number_RoundTripNull_Test<short>();
+            Perform_Number_RoundTripNull_Test<int>();
+            Perform_Number_RoundTripNull_Test<long>();
+            Perform_Number_RoundTripNull_Test<ushort>();
+            Perform_Number_RoundTripNull_Test<uint>();
+            Perform_Number_RoundTripNull_Test<ulong>();
+            Perform_Number_RoundTripNull_Test<float>();
+            Perform_Number_RoundTripNull_Test<decimal>();
+        }
+
+        private static void Perform_Number_RoundTripNull_Test<T>()
+        {
+            string nullAsJson = "null";
+            string nullAsQuotedJson = $@"""{nullAsJson}""";
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(nullAsJson, s_optionReadAndWriteFromStr));
+            Assert.Equal("0", JsonSerializer.Serialize(default(T)));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(nullAsQuotedJson, s_optionReadAndWriteFromStr));
+        }
+
+        [Fact]
+        public static void NullableNumber_RoundtripNull()
+        {
+            Perform_NullableNumber_RoundTripNull_Test<byte?>();
+            Perform_NullableNumber_RoundTripNull_Test<sbyte?>();
+            Perform_NullableNumber_RoundTripNull_Test<short?>();
+            Perform_NullableNumber_RoundTripNull_Test<int?>();
+            Perform_NullableNumber_RoundTripNull_Test<long?>();
+            Perform_NullableNumber_RoundTripNull_Test<ushort?>();
+            Perform_NullableNumber_RoundTripNull_Test<uint?>();
+            Perform_NullableNumber_RoundTripNull_Test<ulong?>();
+            Perform_NullableNumber_RoundTripNull_Test<float?>();
+            Perform_NullableNumber_RoundTripNull_Test<decimal?>();
+        }
+
+        private static void Perform_NullableNumber_RoundTripNull_Test<T>()
+        {
+            string nullAsJson = "null";
+            string nullAsQuotedJson = $@"""{nullAsJson}""";
+
+            Assert.Null(JsonSerializer.Deserialize<T>(nullAsJson, s_optionReadAndWriteFromStr));
+            Assert.Equal(nullAsJson, JsonSerializer.Serialize(default(T)));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<T>(nullAsQuotedJson, s_optionReadAndWriteFromStr));
+        }
+
+        [Fact]
+        public static void Disallow_ArbritaryStrings_On_AllowFloatingPointConstants()
+        {
+            string json = @"""12345""";
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<byte?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<sbyte?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<short?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<int?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<long?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ushort?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<uint?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ulong?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<float?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<double?>(json, s_optionsAllowFloatConstants));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<decimal?>(json, s_optionsAllowFloatConstants));
+        }
+
+        [Fact]
+        public static void Attributes_OnMembers_Work()
+        {
+            // Bad JSON because Int should not be string.
+            string intIsString = @"{""Float"":""1234.5"",""Int"":""12345""}";
+
+            // Good JSON because Float can be string.
+            string floatIsString = @"{""Float"":""1234.5"",""Int"":12345}";
+
+            // Good JSON because Float can be number.
+            string floatIsNumber = @"{""Float"":1234.5,""Int"":12345}";
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWith_Attribute_OnNumber>(intIsString));
+
+            ClassWith_Attribute_OnNumber obj = JsonSerializer.Deserialize<ClassWith_Attribute_OnNumber>(floatIsString);
+            Assert.Equal(1234.5, obj.Float);
+            Assert.Equal(12345, obj.Int);
+
+            obj = JsonSerializer.Deserialize<ClassWith_Attribute_OnNumber>(floatIsNumber);
+            Assert.Equal(1234.5, obj.Float);
+            Assert.Equal(12345, obj.Int);
+
+            // Per options, float should be written as string.
+            JsonTestHelper.AssertJsonEqual(floatIsString, JsonSerializer.Serialize(obj));
+        }
+
+        private class ClassWith_Attribute_OnNumber
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            public float Float { get; set; }
+
+            public int Int { get; set; }
+        }
+
+        [Fact]
+        public static void Attribute_OnRootType_Works()
+        {
+            // Not allowed
+            string floatIsString = @"{""Float"":""1234"",""Int"":123}";
+
+            // Allowed
+            string floatIsNan = @"{""Float"":""NaN"",""Int"":123}";
+
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<Type_AllowFloatConstants>(floatIsString));
+
+            Type_AllowFloatConstants obj = JsonSerializer.Deserialize<Type_AllowFloatConstants>(floatIsNan);
+            Assert.Equal(float.NaN, obj.Float);
+            Assert.Equal(123, obj.Int);
+
+            JsonTestHelper.AssertJsonEqual(floatIsNan, JsonSerializer.Serialize(obj));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+        private class Type_AllowFloatConstants
+        {
+            public float Float { get; set; }
+
+            public int Int { get; set; }
+        }
+
+        [Fact]
+        public static void AttributeOnType_WinsOver_GlobalOption()
+        {
+            // Global options strict, type options loose
+            string json = @"{""Float"":""12345""}";
+            var obj1 = JsonSerializer.Deserialize<ClassWith_LooseAttribute>(json);
+
+            Assert.Equal(@"{""Float"":""12345""}", JsonSerializer.Serialize(obj1));
+
+            // Global options loose, type options strict
+            json = @"{""Float"":""12345""}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWith_StrictAttribute>(json, s_optionReadAndWriteFromStr));
+
+            var obj2 = new ClassWith_StrictAttribute() { Float = 12345 };
+            Assert.Equal(@"{""Float"":12345}", JsonSerializer.Serialize(obj2, s_optionReadAndWriteFromStr));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.Strict)]
+        public class ClassWith_StrictAttribute
+        {
+            public float Float { get; set; }
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+        private class ClassWith_LooseAttribute
+        {
+            public float Float { get; set; }
+        }
+
+        [Fact]
+        public static void AttributeOnMember_WinsOver_AttributeOnType()
+        {
+            string json = @"{""Double"":""NaN""}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWith_Attribute_On_TypeAndMember>(json));
+
+            var obj = new ClassWith_Attribute_On_TypeAndMember { Double = float.NaN };
+            Assert.Throws<ArgumentException>(() => JsonSerializer.Serialize(obj));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowNamedFloatingPointLiterals)]
+        private class ClassWith_Attribute_On_TypeAndMember
+        {
+            [JsonNumberHandling(JsonNumberHandling.Strict)]
+            public double Double { get; set; }
+        }
+
+        [Fact]
+        public static void Attribute_OnNestedType_Works()
+        {
+            string jsonWithShortProperty = @"{""Short"":""1""}";
+            ClassWith_ReadAsStringAttribute obj = JsonSerializer.Deserialize<ClassWith_ReadAsStringAttribute>(jsonWithShortProperty);
+            Assert.Equal(1, obj.Short);
+
+            string jsonWithMyObjectProperty = @"{""MyObject"":{""Float"":""1""}}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWith_ReadAsStringAttribute>(jsonWithMyObjectProperty));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public class ClassWith_ReadAsStringAttribute
+        {
+            public short Short { get; set; }
+
+            public ClassWith_StrictAttribute MyObject { get; set; }
+        }
+
+        [Fact]
+        public static void MemberAttributeAppliesToCollection_SimpleElements()
+        {
+            RunTest<int[]>();
+            RunTest<ConcurrentQueue<int>>();
+            RunTest<GenericICollectionWrapper<int>>();
+            RunTest<IEnumerable<int>>();
+            RunTest<Collection<int>>();
+            RunTest<ImmutableList<int>>();
+            RunTest<HashSet<int>>();
+            RunTest<List<int>>();
+            RunTest<IList<int>>();
+            RunTest<IList>();
+            RunTest<Queue<int>>();
+
+            static void RunTest<T>()
+            {
+                string json = @"{""MyList"":[""1"",""2""]}";
+                ClassWithSimpleCollectionProperty<T> obj = global::System.Text.Json.JsonSerializer.Deserialize<ClassWithSimpleCollectionProperty<T>>(json);
+                Assert.Equal(json, global::System.Text.Json.JsonSerializer.Serialize(obj));
+            }
+        }
+
+        public class ClassWithSimpleCollectionProperty<T>
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            public T MyList { get; set; }
+        }
+
+        [Fact]
+        public static void NestedCollectionElementTypeHandling_Overrides_ParentPropertyHandling()
+        {
+            // Strict policy on the collection element type overrides read-as-string on the collection property
+            string json = @"{""MyList"":[{""Float"":""1""}]}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithComplexListProperty>(json));
+
+            // Strict policy on the collection element type overrides write-as-string on the collection property
+            var obj = new ClassWithComplexListProperty
+            {
+                MyList = new List<ClassWith_StrictAttribute> { new ClassWith_StrictAttribute { Float = 1 } }
+            };
+            Assert.Equal(@"{""MyList"":[{""Float"":1}]}", JsonSerializer.Serialize(obj));
+        }
+
+        public class ClassWithComplexListProperty
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            public List<ClassWith_StrictAttribute> MyList { get; set; }
+        }
+
+        [Fact]
+        public static void MemberAttributeAppliesToDictionary_SimpleElements()
+        {
+            string json = @"{""First"":""1"",""Second"":""2""}";
+            ClassWithSimpleDictionaryProperty obj = JsonSerializer.Deserialize<ClassWithSimpleDictionaryProperty>(json);
+        }
+
+        public class ClassWithSimpleDictionaryProperty
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+            public Dictionary<string, int> MyDictionary { get; set; }
+        }
+
+        [Fact]
+        public static void NestedDictionaryElementTypeHandling_Overrides_ParentPropertyHandling()
+        {
+            // Strict policy on the dictionary element type overrides read-as-string on the collection property.
+            string json = @"{""MyDictionary"":{""Key"":{""Float"":""1""}}}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithComplexDictionaryProperty>(json));
+
+            // Strict policy on the collection element type overrides write-as-string on the collection property
+            var obj = new ClassWithComplexDictionaryProperty
+            {
+                MyDictionary = new Dictionary<string, ClassWith_StrictAttribute> { ["Key"] = new ClassWith_StrictAttribute { Float = 1 } }
+            };
+            Assert.Equal(@"{""MyDictionary"":{""Key"":{""Float"":1}}}", JsonSerializer.Serialize(obj));
+        }
+
+        public class ClassWithComplexDictionaryProperty
+        {
+            [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+            public Dictionary<string, ClassWith_StrictAttribute> MyDictionary { get; set; }
+        }
+
+        [Fact]
+        public static void TypeAttributeAppliesTo_CustomCollectionElements()
+        {
+            string json = @"[""1""]";
+            MyCustomList obj = JsonSerializer.Deserialize<MyCustomList>(json);
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+        public class MyCustomList : List<int> { }
+
+        [Fact]
+        public static void TypeAttributeAppliesTo_CustomCollectionElements_HonoredWhenProperty()
+        {
+            string json = @"{""List"":[""1""]}";
+            ClassWithCustomList obj = JsonSerializer.Deserialize<ClassWithCustomList>(json);
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+        }
+
+        public class ClassWithCustomList
+        {
+            public MyCustomList List { get; set; }
+        }
+
+        [Fact]
+        public static void TypeAttributeAppliesTo_CustomDictionaryElements()
+        {
+            string json = @"{""Key"":""1""}";
+            MyCustomDictionary obj = JsonSerializer.Deserialize<MyCustomDictionary>(json);
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+        public class MyCustomDictionary : Dictionary<string, int> { }
+
+        [Fact]
+        public static void TypeAttributeAppliesTo_CustomDictionaryElements_HonoredWhenProperty()
+        {
+            string json = @"{""Dictionary"":{""Key"":""1""}}";
+            ClassWithCustomDictionary obj = JsonSerializer.Deserialize<ClassWithCustomDictionary>(json);
+            Assert.Equal(json, JsonSerializer.Serialize(obj));
+        }
+
+        public class ClassWithCustomDictionary
+        {
+            public MyCustomDictionary Dictionary { get; set; }
+        }
+
+        [Fact]
+        public static void Attribute_OnType_NotRecursive()
+        {
+            // Recursive behavior would allow a string number.
+            // This is not supported.
+            string json = @"{""NestedClass"":{""MyInt"":""1""}}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<AttributeOnFirstLevel>(json));
+
+            var obj = new AttributeOnFirstLevel
+            {
+                NestedClass = new BadProperty { MyInt = 1 }
+            };
+            Assert.Equal(@"{""NestedClass"":{""MyInt"":1}}", JsonSerializer.Serialize(obj));
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString | JsonNumberHandling.WriteAsString)]
+        public class AttributeOnFirstLevel
+        {
+            public BadProperty NestedClass { get; set; }
+        }
+
+        public class BadProperty
+        {
+            public int MyInt { get; set; }
+        }
+
+        [Fact]
+        public static void HandlingOnMemberOverridesHandlingOnType_Enumerable()
+        {
+            string json = @"{""List"":[""1""]}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyCustomListWrapper>(json));
+
+            var obj = new MyCustomListWrapper
+            {
+                List = new MyCustomList { 1 }
+            };
+            Assert.Equal(@"{""List"":[1]}", JsonSerializer.Serialize(obj));
+        }
+
+        public class MyCustomListWrapper
+        {
+            [JsonNumberHandling(JsonNumberHandling.Strict)]
+            public MyCustomList List { get; set; }
+        }
+
+        [Fact]
+        public static void HandlingOnMemberOverridesHandlingOnType_Dictionary()
+        {
+            string json = @"{""Dictionary"":{""Key"":""1""}}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<MyCustomDictionaryWrapper>(json));
+
+            var obj1 = new MyCustomDictionaryWrapper
+            {
+                Dictionary = new MyCustomDictionary { ["Key"] = 1 }
+            };
+            Assert.Equal(@"{""Dictionary"":{""Key"":1}}", JsonSerializer.Serialize(obj1));
+        }
+
+        public class MyCustomDictionaryWrapper
+        {
+            [JsonNumberHandling(JsonNumberHandling.Strict)]
+            public MyCustomDictionary Dictionary { get; set; }
+        }
+
+        [Fact]
+        public static void Attribute_NotAllowed_On_NonNumber_NonCollection_Property()
+        {
+            string json = @"";
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_ObjectProperty>(json));
+            string exAsStr = ex.ToString();
+            Assert.Contains("MyProp", exAsStr);
+            Assert.Contains(typeof(ClassWith_NumberHandlingOn_ObjectProperty).ToString(), exAsStr);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWith_NumberHandlingOn_ObjectProperty()));
+            exAsStr = ex.ToString();
+            Assert.Contains("MyProp", exAsStr);
+            Assert.Contains(typeof(ClassWith_NumberHandlingOn_ObjectProperty).ToString(), exAsStr);
+        }
+
+        public class ClassWith_NumberHandlingOn_ObjectProperty
+        {
+            [JsonNumberHandling(JsonNumberHandling.Strict)]
+            public BadProperty MyProp { get; set; }
+        }
+
+        [Fact]
+        public static void Attribute_NotAllowed_On_Property_WithCustomConverter()
+        {
+            string json = @"";
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_Property_WithCustomConverter>(json));
+            string exAsStr = ex.ToString();
+            Assert.Contains(typeof(ConverterForInt32).ToString(), exAsStr);
+            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Property_WithCustomConverter).ToString(), exAsStr);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWith_NumberHandlingOn_Property_WithCustomConverter()));
+            exAsStr = ex.ToString();
+            Assert.Contains(typeof(ConverterForInt32).ToString(), exAsStr);
+            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Property_WithCustomConverter).ToString(), exAsStr);
+        }
+
+        public class ClassWith_NumberHandlingOn_Property_WithCustomConverter
+        {
+            [JsonNumberHandling(JsonNumberHandling.Strict)]
+            [JsonConverter(typeof(ConverterForInt32))]
+            public int MyProp { get; set; }
+        }
+
+        [Fact]
+        public static void Attribute_NotAllowed_On_Type_WithCustomConverter()
+        {
+            string json = @"";
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Deserialize<ClassWith_NumberHandlingOn_Type_WithCustomConverter>(json));
+            string exAsStr = ex.ToString();
+            Assert.Contains(typeof(ConverterForMyType).ToString(), exAsStr);
+            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Type_WithCustomConverter).ToString(), exAsStr);
+
+            ex = Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(new ClassWith_NumberHandlingOn_Type_WithCustomConverter()));
+            exAsStr = ex.ToString();
+            Assert.Contains(typeof(ConverterForMyType).ToString(), exAsStr);
+            Assert.Contains(typeof(ClassWith_NumberHandlingOn_Type_WithCustomConverter).ToString(), exAsStr);
+        }
+
+        [JsonNumberHandling(JsonNumberHandling.Strict)]
+        [JsonConverter(typeof(ConverterForMyType))]
+        public class ClassWith_NumberHandlingOn_Type_WithCustomConverter
+        {
+        }
+
+        private class ConverterForMyType : JsonConverter<ClassWith_NumberHandlingOn_Type_WithCustomConverter>
+        {
+            public override ClassWith_NumberHandlingOn_Type_WithCustomConverter Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(Utf8JsonWriter writer, ClassWith_NumberHandlingOn_Type_WithCustomConverter value, JsonSerializerOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Fact]
+        public static void CustomConverterOverridesBuiltInLogic()
+        {
+            var options = new JsonSerializerOptions(s_optionReadAndWriteFromStr)
+            {
+                Converters = { new ConverterForInt32(), new ConverterForFloat() }
+            };
+
+            string json = @"""32""";
+
+            // Converter returns 25 regardless of input.
+            Assert.Equal(25, JsonSerializer.Deserialize<int>(json, options));
+
+            // Converter throws this exception regardless of input.
+            Assert.Throws<NotImplementedException>(() => JsonSerializer.Serialize(4, options));
+
+            json = @"""NaN""";
+
+            // Converter returns 25 if NaN.
+            Assert.Equal(25, JsonSerializer.Deserialize<float?>(json, options));
+
+            // Converter writes 25 if NaN.
+            Assert.Equal("25", JsonSerializer.Serialize((float?)float.NaN, options));
+        }
+
+        public class ConverterForFloat : JsonConverter<float?>
+        {
+            public override float? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                if (reader.TokenType == JsonTokenType.String && reader.GetString() == "NaN")
+                {
+                    return 25;
+                }
+
+                throw new NotSupportedException();
+            }
+
+            public override void Write(Utf8JsonWriter writer, float? value, JsonSerializerOptions options)
+            {
+                if (float.IsNaN(value.Value))
+                {
+                    writer.WriteNumberValue(25);
+                    return;
+                }
+
+                throw new NotSupportedException();
+            }
+        }
+
+        [Fact]
+        public static void JsonNumberHandling_ArgOutOfRangeFail()
+        {
+            // Global options
+            ArgumentOutOfRangeException ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new JsonSerializerOptions { NumberHandling = (JsonNumberHandling)(-1) });
+            Assert.Contains("value", ex.ToString());
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new JsonSerializerOptions { NumberHandling = (JsonNumberHandling)(8) });
+
+            ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => new JsonNumberHandlingAttribute((JsonNumberHandling)(-1)));
+            Assert.Contains("handling", ex.ToString());
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new JsonNumberHandlingAttribute((JsonNumberHandling)(8)));
+        }
+    }
+}

--- a/src/libraries/System.Text.Json/tests/Serialization/Object.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Object.ReadTests.cs
@@ -278,7 +278,7 @@ namespace System.Text.Json.Serialization.Tests
 
             internal CollectionWithoutPublicParameterlessCtor()
             {
-                Debug.Fail("The JsonSerializer should not be callin non-public ctors, by default.");
+                Debug.Fail("The JsonSerializer should not be calling non-public ctors, by default.");
             }
 
             public CollectionWithoutPublicParameterlessCtor(List<object> list)
@@ -286,7 +286,7 @@ namespace System.Text.Json.Serialization.Tests
                 _list = list;
             }
 
-            public object this[int index] { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public object this[int index] { get => _list[index]; set => _list[index] = value; }
 
             public bool IsFixedSize => throw new NotImplementedException();
 

--- a/src/libraries/System.Text.Json/tests/Serialization/OptionsTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/OptionsTests.cs
@@ -589,6 +589,7 @@ namespace System.Text.Json.Serialization.Tests
                 {
                     options.ReadCommentHandling = JsonCommentHandling.Disallow;
                     options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault;
+                    options.NumberHandling = JsonNumberHandling.AllowReadingFromString;
                 }
                 else
                 {
@@ -635,6 +636,10 @@ namespace System.Text.Json.Serialization.Tests
                     else if (property.Name == "DefaultIgnoreCondition")
                     {
                         Assert.Equal(options.DefaultIgnoreCondition, newOptions.DefaultIgnoreCondition);
+                    }
+                    else if (property.Name == "NumberHandling")
+                    {
+                        Assert.Equal(options.NumberHandling, newOptions.NumberHandling);
                     }
                     else
                     {

--- a/src/libraries/System.Text.Json/tests/Serialization/Stream.Collections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Stream.Collections.cs
@@ -98,7 +98,7 @@ namespace System.Text.Json.Serialization.Tests
 
                 // TODO: https://github.com/dotnet/runtime/issues/35611.
                 // Can't control order of dictionary elements when serializing, so reference metadata might not match up.
-                if(!(DictionaryTypes<TElement>().Contains(type) && options.ReferenceHandler == ReferenceHandler.Preserve))
+                if(!(CollectionTestTypes.DictionaryTypes<TElement>().Contains(type) && options.ReferenceHandler == ReferenceHandler.Preserve))
                 {
                     JsonTestHelper.AssertJsonEqual(expectedJson, serialized);
                 }
@@ -287,7 +287,7 @@ namespace System.Text.Json.Serialization.Tests
 
         private static IEnumerable<Type> CollectionTypes<TElement>()
         {
-            foreach (Type type in EnumerableTypes<TElement>())
+            foreach (Type type in CollectionTestTypes.EnumerableTypes<TElement>())
             {
                 yield return type;
             }
@@ -301,41 +301,15 @@ namespace System.Text.Json.Serialization.Tests
                 yield return type;
             }
             // Dictionary types
-            foreach (Type type in DictionaryTypes<TElement>())
+            foreach (Type type in CollectionTestTypes.DictionaryTypes<TElement>())
             {
                 yield return type;
             }
         }
 
-        private static IEnumerable<Type> EnumerableTypes<TElement>()
-        {
-            yield return typeof(TElement[]); // ArrayConverter
-            yield return typeof(ConcurrentQueue<TElement>); // ConcurrentQueueOfTConverter
-            yield return typeof(GenericICollectionWrapper<TElement>); // ICollectionOfTConverter
-            yield return typeof(WrapperForIEnumerable); // IEnumerableConverter
-            yield return typeof(WrapperForIReadOnlyCollectionOfT<TElement>); // IEnumerableOfTConverter
-            yield return typeof(Queue); // IEnumerableWithAddMethodConverter
-            yield return typeof(WrapperForIList); // IListConverter
-            yield return typeof(Collection<TElement>); // IListOfTConverter
-            yield return typeof(ImmutableList<TElement>); // ImmutableEnumerableOfTConverter
-            yield return typeof(HashSet<TElement>); // ISetOfTConverter
-            yield return typeof(List<TElement>); // ListOfTConverter
-            yield return typeof(Queue<TElement>); // QueueOfTConverter
-        }
-
         private static IEnumerable<Type> ObjectNotationTypes<TElement>()
         {
             yield return typeof(KeyValuePair<TElement, TElement>); // KeyValuePairConverter
-        }
-
-        private static IEnumerable<Type> DictionaryTypes<TElement>()
-        {
-            yield return typeof(Dictionary<string, TElement>); // DictionaryOfStringTValueConverter
-            yield return typeof(Hashtable); // IDictionaryConverter
-            yield return typeof(ConcurrentDictionary<string, TElement>); // IDictionaryOfStringTValueConverter
-            yield return typeof(GenericIDictionaryWrapper<string, TElement>); // IDictionaryOfStringTValueConverter
-            yield return typeof(ImmutableDictionary<string, TElement>); // ImmutableDictionaryOfStringTValueConverter
-            yield return typeof(GenericIReadOnlyDictionaryWrapper<string, TElement>); // IReadOnlyDictionaryOfStringTValueConverter
         }
 
         private static HashSet<Type> StackTypes<TElement>() => new HashSet<Type>
@@ -389,7 +363,7 @@ namespace System.Text.Json.Serialization.Tests
         [InlineData("]")]
         public static void DeserializeDictionaryStartsWithInvalidJson(string json)
         {
-            foreach (Type type in DictionaryTypes<string>())
+            foreach (Type type in CollectionTestTypes.DictionaryTypes<string>())
             {
                 Assert.ThrowsAsync<JsonException>(async () =>
                 {
@@ -404,7 +378,7 @@ namespace System.Text.Json.Serialization.Tests
         [Fact]
         public static void SerializeEmptyCollection()
         {
-            foreach (Type type in EnumerableTypes<int>())
+            foreach (Type type in CollectionTestTypes.EnumerableTypes<int>())
             {
                 Assert.Equal("[]", JsonSerializer.Serialize(GetEmptyCollection<int>(type)));
             }
@@ -414,7 +388,7 @@ namespace System.Text.Json.Serialization.Tests
                 Assert.Equal("[]", JsonSerializer.Serialize(GetEmptyCollection<int>(type)));
             }
 
-            foreach (Type type in DictionaryTypes<int>())
+            foreach (Type type in CollectionTestTypes.DictionaryTypes<int>())
             {
                 Assert.Equal("{}", JsonSerializer.Serialize(GetEmptyCollection<int>(type)));
             }

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.NonGenericCollections.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.NonGenericCollections.cs
@@ -218,6 +218,16 @@ namespace System.Text.Json.Serialization.Tests
             _list = new List<object>(items);
         }
 
+        public WrapperForIList(IEnumerable items)
+        {
+            _list = new List<object>();
+
+            foreach (object item in items)
+            {
+                _list.Add(item);
+            }
+        }
+
         public object this[int index] { get => ((IList)_list)[index]; set => ((IList)_list)[index] = value; }
 
         public bool IsFixedSize => ((IList)_list).IsFixedSize;

--- a/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/TestClasses/TestClasses.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
 using Xunit;
 
@@ -1887,6 +1889,70 @@ namespace System.Text.Json.Serialization.Tests
         public override string ConvertName(string name)
         {
             return string.Concat(name.Select((x, i) => i > 0 && char.IsUpper(x) ? "_" + x.ToString() : x.ToString())).ToLower();
+        }
+    }
+
+    public static class CollectionTestTypes
+    {
+        public static IEnumerable<Type> EnumerableTypes<TElement>()
+        {
+            yield return typeof(TElement[]); // ArrayConverter
+            yield return typeof(ConcurrentQueue<TElement>); // ConcurrentQueueOfTConverter
+            yield return typeof(GenericICollectionWrapper<TElement>); // ICollectionOfTConverter
+            yield return typeof(WrapperForIEnumerable); // IEnumerableConverter
+            yield return typeof(WrapperForIReadOnlyCollectionOfT<TElement>); // IEnumerableOfTConverter
+            yield return typeof(Queue); // IEnumerableWithAddMethodConverter
+            yield return typeof(WrapperForIList); // IListConverter
+            yield return typeof(Collection<TElement>); // IListOfTConverter
+            yield return typeof(ImmutableList<TElement>); // ImmutableEnumerableOfTConverter
+            yield return typeof(HashSet<TElement>); // ISetOfTConverter
+            yield return typeof(List<TElement>); // ListOfTConverter
+            yield return typeof(Queue<TElement>); // QueueOfTConverter
+        }
+
+        public static IEnumerable<Type> DeserializableGenericEnumerableTypes<TElement>()
+        {
+            yield return typeof(TElement[]); // ArrayConverter
+            yield return typeof(ConcurrentQueue<TElement>); // ConcurrentQueueOfTConverter
+            yield return typeof(GenericICollectionWrapper<TElement>); // ICollectionOfTConverter
+            yield return typeof(IEnumerable<TElement>); // IEnumerableConverter
+            yield return typeof(Collection<TElement>); // IListOfTConverter
+            yield return typeof(ImmutableList<TElement>); // ImmutableEnumerableOfTConverter
+            yield return typeof(HashSet<TElement>); // ISetOfTConverter
+            yield return typeof(List<TElement>); // ListOfTConverter
+            yield return typeof(Queue<TElement>); // QueueOfTConverter
+        }
+
+        public static IEnumerable<Type> DeserializableNonGenericEnumerableTypes()
+        {
+            yield return typeof(Queue); // IEnumerableWithAddMethodConverter
+            yield return typeof(WrapperForIList); // IListConverter
+        }
+
+        public static IEnumerable<Type> DictionaryTypes<TElement>()
+        {
+            yield return typeof(Dictionary<string, TElement>); // DictionaryOfStringTValueConverter
+            yield return typeof(Hashtable); // IDictionaryConverter
+            yield return typeof(ConcurrentDictionary<string, TElement>); // IDictionaryOfStringTValueConverter
+            yield return typeof(GenericIDictionaryWrapper<string, TElement>); // IDictionaryOfStringTValueConverter
+            yield return typeof(ImmutableDictionary<string, TElement>); // ImmutableDictionaryOfStringTValueConverter
+            yield return typeof(GenericIReadOnlyDictionaryWrapper<string, TElement>); // IReadOnlyDictionaryOfStringTValueConverter
+        }
+
+        public static IEnumerable<Type> DeserializableDictionaryTypes<TElement>()
+        {
+            yield return typeof(Dictionary<string, TElement>); // DictionaryOfStringTValueConverter
+            yield return typeof(Hashtable); // IDictionaryConverter
+            yield return typeof(ConcurrentDictionary<string, TElement>); // IDictionaryOfStringTValueConverter
+            yield return typeof(GenericIDictionaryWrapper<string, TElement>); // IDictionaryOfStringTValueConverter
+            yield return typeof(ImmutableDictionary<string, TElement>); // ImmutableDictionaryOfStringTValueConverter
+            yield return typeof(IReadOnlyDictionary<string, TElement>); // IReadOnlyDictionaryOfStringTValueConverter
+        }
+
+        public static IEnumerable<Type> DeserializableNonDictionaryTypes<TElement>()
+        {
+            yield return typeof(Hashtable); // IDictionaryConverter
+            yield return typeof(SortedList); // IDictionaryConverter
         }
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -93,6 +93,7 @@
     <Compile Include="Serialization\Null.ReadTests.cs" />
     <Compile Include="Serialization\Null.WriteTests.cs" />
     <Compile Include="Serialization\NullableTests.cs" />
+    <Compile Include="Serialization\NumberHandlingTests.cs" />
     <Compile Include="Serialization\Object.ReadTests.cs" />
     <Compile Include="Serialization\Object.WriteTests.cs" />
     <Compile Include="Serialization\OptionsTests.cs" />


### PR DESCRIPTION
Port of https://github.com/dotnet/runtime/pull/39363 into the `release/5.0-preview8` branch.

#### Description
Fixes https://github.com/dotnet/runtime/issues/30255 in preview 8.

This adds the APIs and implementation for a `JsonSerializer` feature that enables reading and writing numbers from/to JSON strings, including the floating-point constant representations "NaN", "Infinity", and "-Infinity".

#### Customer Impact
This is a highly requested feature and will enable better interop between the users of the serializer and various API endpoints across the web.