### PR TITLE
fix missing command case

### DIFF
--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -199,6 +199,8 @@ void ProcessDiagnosticsProtocolHelper::HandleIpcMessage(DiagnosticsIpc::IpcMessa
     case ProcessCommandId::GetProcessInfo:
         ProcessDiagnosticsProtocolHelper::GetProcessInfo(message, pStream);
         break;
+    case ProcessCommandId::ResumeRuntime:
+        ProcessDiagnosticsProtocolHelper::ResumeRuntimeStartup(message, pStream);
 
     default:
         STRESS_LOG1(LF_DIAGNOSTICS_PORT, LL_WARNING, "Received unknown request type (%d)\n", message.GetHeader().CommandSet);

--- a/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
+++ b/src/coreclr/src/vm/processdiagnosticsprotocolhelper.cpp
@@ -201,6 +201,7 @@ void ProcessDiagnosticsProtocolHelper::HandleIpcMessage(DiagnosticsIpc::IpcMessa
         break;
     case ProcessCommandId::ResumeRuntime:
         ProcessDiagnosticsProtocolHelper::ResumeRuntimeStartup(message, pStream);
+        break;
 
     default:
         STRESS_LOG1(LF_DIAGNOSTICS_PORT, LL_WARNING, "Received unknown request type (%d)\n", message.GetHeader().CommandSet);


### PR DESCRIPTION
resolves #39683

Since the test was off when it was merged, it didn't catch the missing switch case statement.