### PR TITLE
[runtime] Initialize the class if needed in type_is_blittable ().

### DIFF
--- a/src/libraries/Common/src/Interop/Interop.Calendar.cs
+++ b/src/libraries/Common/src/Interop/Interop.Calendar.cs
@@ -15,20 +15,8 @@ internal static partial class Interop
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
         internal static extern unsafe ResultCode GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, char* result, int resultCapacity);
 
-#if MONO
-        // Temp workaround for pinvoke callbacks for Mono
-        // https://github.com/dotnet/runtime/issues/39100
-
-        internal unsafe delegate void EnumCalendarInfoCallback(
-           char* calendarString,
-           IntPtr context);
-
-        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
-        internal static extern bool EnumCalendarInfo(IntPtr callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
-#else
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
         internal static extern unsafe bool EnumCalendarInfo(delegate* <char*, IntPtr, void> callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
-#endif
 
         [DllImport(Libraries.GlobalizationNative, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]
         internal static extern int GetLatestJapaneseEra();

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs
@@ -423,26 +423,12 @@ namespace System.Globalization
             return result;
         }
 
-#if MONO
-        private static unsafe bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, ref IcuEnumCalendarsData callbackContext)
-        {
-            // Temp workaround for pinvoke callbacks for Mono
-            // https://github.com/dotnet/runtime/issues/39100
-            var calendarInfoCallback = new Interop.Globalization.EnumCalendarInfoCallback(EnumCalendarInfoCallback);
-            return Interop.Globalization.EnumCalendarInfo(
-                System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate(calendarInfoCallback),
-                localeName, calendarId, dataType, (IntPtr)Unsafe.AsPointer(ref callbackContext));
-        }
-
-        [Mono.MonoPInvokeCallback(typeof(Interop.Globalization.EnumCalendarInfoCallback))]
-#else
         private static unsafe bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, ref IcuEnumCalendarsData callbackContext)
         {
             return Interop.Globalization.EnumCalendarInfo(&EnumCalendarInfoCallback, localeName, calendarId, dataType, (IntPtr)Unsafe.AsPointer(ref callbackContext));
         }
 
         [UnmanagedCallersOnly]
-#endif
         private static unsafe void EnumCalendarInfoCallback(char* calendarStringPtr, IntPtr context)
         {
             try

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -3979,9 +3979,13 @@ type_is_blittable (MonoType *type)
 	case MONO_TYPE_U:
 	case MONO_TYPE_PTR:
 	case MONO_TYPE_FNPTR:
+	case MONO_TYPE_VOID:
 		return TRUE;
-	default:
-		return m_class_is_blittable (mono_class_from_mono_type_internal (type));
+	default: {
+		MonoClass *klass = mono_class_from_mono_type_internal (type);
+		mono_class_init_sizes (klass);
+		return m_class_is_blittable (klass);
+	}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39100.