### PR TITLE
Modify build-test scripts to use response files for Crossgen compilation

### DIFF
--- a/src/coreclr/build-test.cmd
+++ b/src/coreclr/build-test.cmd
@@ -653,17 +653,14 @@ if defined __CompositeBuildMode (
 )
 
 for %%F in ("%CORE_ROOT%\System.*.dll";"%CORE_ROOT%\Microsoft.*.dll";%CORE_ROOT%\netstandard.dll;%CORE_ROOT%\mscorlib.dll) do (
-    if not "%%~nxF"=="Microsoft.CodeAnalysis.VisualBasic.dll" (
-    if not "%%~nxF"=="Microsoft.CodeAnalysis.CSharp.dll" (
-    if not "%%~nxF"=="Microsoft.CodeAnalysis.dll" (
     if not "%%~nxF"=="System.Runtime.WindowsRuntime.dll" (
         if defined __CompositeBuildMode (
             echo %%F>>!__CompositeResponseFile!
         ) else (
-            call :PrecompileAssembly "%%F" %%~nxF __TotalPrecompiled __FailedToPrecompile __FailedAssemblies
+            call :PrecompileAssembly %%F %%~nxF __TotalPrecompiled __FailedToPrecompile __FailedAssemblies
             echo Processed: !__TotalPrecompiled!, failed !__FailedToPrecompile!
         )
-    )))))
+    ))
 )
 
 if defined __CompositeBuildMode (
@@ -695,18 +692,32 @@ set AssemblyName=%2
 
 REM Intentionally avoid using the .dll extension to prevent
 REM subsequent compilations from picking it up as a reference
-set __CrossgenOutputFile="%CORE_ROOT%\temp.ni._dll"
+set __CrossgenOutputFile=%CORE_ROOT%\temp.ni._dll
+set __CrossgenResponseFile="%CORE_ROOT%\%AssemblyName%.rsp
 set __CrossgenCmd=
 
+del /Q %__CrossgenResponseFile%
+
 if defined __DoCrossgen (
-    set __CrossgenCmd=!__CrossgenExe! /Platform_Assemblies_Paths "!CORE_ROOT!" /in !AssemblyPath! /out !__CrossgenOutputFile!
-    echo !__CrossgenCmd!
-    !__CrossgenCmd!
+    set __CrossgenCmd=!__CrossgenExe! @!__CrossgenResponseFile!
+    echo /Platform_Assemblies_Paths "!CORE_ROOT!">>!__CrossgenResponseFile!
+    echo /in !AssemblyPath!>>!__CrossgenResponseFile!
+    echo /out !__CrossgenOutputFile!>>!__CrossgenResponseFile!
 ) else (
-    set __CrossgenCmd=!__Crossgen2Dll! -r:"!CORE_ROOT!\System.*.dll" -r:"!CORE_ROOT!\Microsoft.*.dll" -r:"!CORE_ROOT!\mscorlib.dll" -r:"!CORE_ROOT!\netstandard.dll" -O --inputbubble --out:!__CrossgenOutputFile! !AssemblyPath! --targetarch %__BuildArch%
-    echo !__CrossgenCmd!
-    call !__CrossgenCmd!
+    set __CrossgenCmd=!__Crossgen2Dll! @!__CrossgenResponseFile!
+    echo -r:!CORE_ROOT!\System.*.dll>>!__CrossgenResponseFile!
+    echo -r:!CORE_ROOT!\Microsoft.*.dll>>!__CrossgenResponseFile!
+    echo -r:!CORE_ROOT!\mscorlib.dll>>!__CrossgenResponseFile!
+    echo -r:!CORE_ROOT!\netstandard.dll>>!__CrossgenResponseFile!
+    echo -O>>!__CrossgenResponseFile!
+    echo --inputbubble>>!__CrossgenResponseFile!
+    echo --out:!__CrossgenOutputFile!>>!__CrossgenResponseFile!
+    echo !AssemblyPath!>>!__CrossgenResponseFile!
+    echo --targetarch:!__BuildArch!>>!__CrossgenResponseFile!
 )
+
+echo !__CrossgenCmd!
+call !__CrossgenCmd!
 
 set /a __exitCode = !errorlevel!
 

--- a/src/coreclr/build-test.sh
+++ b/src/coreclr/build-test.sh
@@ -168,35 +168,30 @@ precompile_coreroot_fx()
     local outputDir="$overlayDir"/out
 
     # Delete previously crossgened assemblies
-    rm "$overlayDir"/*.ni.dll
-
-    # Collect reference assemblies for Crossgen2
-    local crossgen2References=""
+    rm "$overlayDir"/*.ni.dll 2>/dev/null
 
     if [[ "$__DoCrossgen2" != 0 ]]; then
         compilerName=Crossgen2
 
         mkdir "$outputDir"
-
-        skipCrossGenFiles+=('Microsoft.CodeAnalysis.CSharp.dll')
-        skipCrossGenFiles+=('Microsoft.CodeAnalysis.dll')
-        skipCrossGenFiles+=('Microsoft.CodeAnalysis.VisualBasic.dll')
-
-        for reference in "$overlayDir"/*.dll; do
-            crossgen2References+=" -r:${reference}"
-        done
     fi
 
     echo "${__MsgPrefix}Running ${compilerName} on framework assemblies in CORE_ROOT: '${CORE_ROOT}'"
 
     local totalPrecompiled=0
     local failedToPrecompile=0
-    local compositeCommandLine="${__DotNetCli}"
-    compositeCommandLine+=" $__Crossgen2Dll"
-    compositeCommandLine+=" --composite"
-    compositeCommandLine+=" -O"
-    compositeCommandLine+=" --out:$outputDir/framework-r2r.dll"
-    compositeCommandLine+=" --targetarch ${__BuildArch}"
+    local compositeOutputFile=$outputDir/framework-r2r.dll
+    local compositeResponseFile=$compositeOutputFile.rsp
+    local compositeCommandLine="${__DotNetCli} $__Crossgen2Dll @$compositeResponseFile"
+
+    if [[ "$__CompositeBuildMode" != 0 ]]; then
+        rm $compositeResponseFile 2>/dev/null
+        echo --composite>>$compositeResponseFile
+        echo -O>>$compositeResponseFile
+        echo --out:$compositeOutputFile>>$compositeResponseFile
+        echo --targetarch:${__BuildArch}>>$compositeResponseFile
+    fi
+
     declare -a failedAssemblies
 
     filesToPrecompile=$(find -L "$overlayDir" -maxdepth 1 -iname Microsoft.\*.dll -o -iname System.\*.dll -o -iname netstandard.dll -o -iname mscorlib.dll -type f)
@@ -207,18 +202,32 @@ precompile_coreroot_fx()
         fi
 
         if [[ "$__CompositeBuildMode" != 0 ]]; then
-            compositeCommandLine+=" $filename"
+            echo $filename>>$compositeResponseFile
             continue
         fi
 
         local commandLine=""
+        local responseFile="$overlayDir/$(basename $filename).rsp"
+
+        rm $responseFile 2>/dev/null
 
         if [[ "$__DoCrossgen" != 0 ]]; then
-            commandLine="$__CrossgenExe /Platform_Assemblies_Paths $overlayDir $filename"
+            commandLine="$__CrossgenExe @$responseFile"
+            echo /Platform_Assemblies_Paths>>$responseFile
+            echo $overlayDir>>$responseFile
+            echo $filename>>$responseFile
         fi
 
         if [[ "$__DoCrossgen2" != 0 ]]; then
-            commandLine="${__DotNetCli} $__Crossgen2Dll $crossgen2References -O --inputbubble --out $outputDir/$(basename $filename) $filename --targetarch ${__BuildArch}"
+            commandLine="${__DotNetCli} $__Crossgen2Dll @$responseFile"
+            echo -O>>$responseFile
+            echo --inputbubble>>$responseFile
+            echo --out:$outputDir/$(basename $filename)>>$responseFile
+            echo --targetarch:${__BuildArch}>>$responseFile
+            echo $filename>>$responseFile
+            for reference in $overlayDir/*.dll; do
+                echo -r:$reference>>$responseFile
+            done
         fi
 
         echo Precompiling "$filename"
@@ -245,6 +254,8 @@ precompile_coreroot_fx()
 
     if [[ "$__CompositeBuildMode" != 0 ]]; then
         # Compile the entire framework in composite build mode
+        echo "Response file: $compositeResponseFile"
+        cat $compositeResponseFile
         echo "Compiling composite R2R framework: $compositeCommandLine"
         $compositeCommandLine
         local exitCode="$?"


### PR DESCRIPTION
Also, delete the no longer used Crossgen2 framework exceptions.
The response file makes it much easier to rerun the compiler for
a particular framework assembly.

Thanks

Tomas

/cc: @dotnet/crossgen-contrib