### PR TITLE
[wasm] Enable System.ComponentModel.TypeConverter test suite

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/tests/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTypeConverterTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/Security/Authentication/ExtendedProtection/ExtendedProtectionPolicyTypeConverterTests.cs
@@ -30,12 +30,14 @@ namespace System.Security.Authentication.ExtendedProtection.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Net.Security is not supported on this platform.
         public void ConvertTo_NullTypeTests()
         {
             Assert.Throws<ArgumentNullException>(() => converter.ConvertTo(null, CultureInfo.InvariantCulture, new ExtendedProtectionPolicy(PolicyEnforcement.Never), null));
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Net.Security is not supported on this platform.
         public void ConvertTo_PositiveTests()
         {
             ExtendedProtectionPolicy policy = new ExtendedProtectionPolicy(PolicyEnforcement.Never);
@@ -55,6 +57,7 @@ namespace System.Security.Authentication.ExtendedProtection.Tests
         }
 
         [Theory]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Net.Security is not supported on this platform.
         [InlineData(typeof(int))]
         [InlineData(typeof(ExtendedProtectionPolicy))]
         [InlineData(typeof(bool))]

--- a/src/libraries/System.ComponentModel.TypeConverter/tests/XTypeDescriptionProviderTests.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/tests/XTypeDescriptionProviderTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace System.Xml.Linq.Tests
 {
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/39709", TestPlatforms.Browser)]
     public class XTypeDescriptionProviderTests
     {
         [Fact]

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -22,7 +22,6 @@
 
   <ItemGroup Condition="'$(TargetOS)' == 'Browser' and '$(RunDisabledWasmTests)' != 'true'">
     <!-- Builds currently do not pass -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ComponentModel.TypeConverter\tests\System.ComponentModel.TypeConverter.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Data.Common\tests\System.Data.Common.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\TestWithConfigSwitches\System.Diagnostics.DiagnosticSource.Switches.Tests.csproj" />
 


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422

- Several tests are skipped due to PlatformNotSupportedException.
- XTypeDescriptionProviderTests tests are marked with active issue https://github.com/dotnet/runtime/issues/39709

The test run result: `Tests run: 7771, Errors: 0, Failures: 0, Skipped: 4.`


