### PR TITLE
Remove BundleDir/PublishDir at the end of ArchiveTests to save disk space

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -50,8 +50,8 @@
     <ZipDirectory SourceDirectory="$(_ZipSourceDirectory)"
                   DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
                   Overwrite="true" />
-    <!-- delete the OutDir in CI builds to save disk space on build agents since it's no longer needed -->
-    <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true'" Directories="$(OutDir)" />
+    <!-- delete the BundleDir and PublishDir in CI builds to save disk space on build agents since they're no longer needed -->
+    <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true'" Directories="$(BundleDir);$(PublishDir)" />
   </Target>
 
   <UsingTask TaskName="GenerateRunScript" AssemblyFile="$(InstallerTasksAssemblyPath)"/>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -41,7 +41,6 @@
     <Error Condition="'$(TestArchiveTestsDir)' == ''" Text="TestArchiveTestsDir property to archive the test folder must be set." />
 
     <PropertyGroup>
-      <BundleDir>$([MSBuild]::NormalizeDirectory('$(OutDir)', 'AppBundle'))</BundleDir>
       <_ZipSourceDirectory>$(OutDir)</_ZipSourceDirectory>
       <_ZipSourceDirectory Condition="'$(TargetOS)' == 'Browser'">$(BundleDir)</_ZipSourceDirectory>
     </PropertyGroup>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -50,6 +50,8 @@
     <ZipDirectory SourceDirectory="$(_ZipSourceDirectory)"
                   DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
                   Overwrite="true" />
+    <!-- delete the OutDir in CI builds to save disk space on build agents since it's no longer needed -->
+    <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true'" Directories="$(OutDir)" />
   </Target>
 
   <UsingTask TaskName="GenerateRunScript" AssemblyFile="$(InstallerTasksAssemblyPath)"/>

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -14,6 +14,13 @@
     <Compile Include="XsltSettings.cs" />
     <Compile Include="XunitAssemblyAttribute.cs" />
     <Compile Include="XslCompiledTransform.cs" />
+    <Compile Include="..\XslTransformApi\CThread.cs" />
+    <Compile Include="..\XslTransformApi\CThreads.cs" />
+    <Compile Include="..\XslTransformApi\DataHelper.cs" />
+    <Compile Include="..\XslTransformApi\ExceptionVerifier.cs" />
+    <Compile Include="..\XslTransformApi\MyNavigator.cs" />
+    <Compile Include="..\XslTransformApi\ReaderType.cs" />
+    <Compile Include="..\XslTransformApi\ThreadFunc.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\TestFiles\**\*"
@@ -25,6 +32,5 @@
     <ProjectReference Include="$(CommonTestPath)System\Xml\ModuleCore\ModuleCore.csproj" />
     <ProjectReference Include="$(CommonTestPath)System\Xml\XmlCoreTest\XmlCoreTest.csproj" />
     <ProjectReference Include="$(CommonTestPath)System\Xml\XmlDiff\XmlDiff.csproj" />
-    <ProjectReference Include="..\XslTransformApi\System.Xml.Xsl.XslTransformApi.Tests.csproj" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslCompiledTransformApi/System.Xml.Xsl.XslCompiledTransformApi.Tests.csproj
@@ -14,7 +14,7 @@
     <Compile Include="XsltSettings.cs" />
     <Compile Include="XunitAssemblyAttribute.cs" />
     <Compile Include="XslCompiledTransform.cs" />
-    <Compile Include="..\XslTransformApi\CThread.cs" />
+    <Compile Include="..\XslTransformApi\cthread.cs" />
     <Compile Include="..\XslTransformApi\CThreads.cs" />
     <Compile Include="..\XslTransformApi\DataHelper.cs" />
     <Compile Include="..\XslTransformApi\ExceptionVerifier.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/ReaderType.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/ReaderType.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Xml.Tests
+{
+    public enum ReaderType
+    {
+        XmlTextReader, XmlNodeReader, XmlValidatingReader, XsltReader, Unknown
+    }
+}

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/System.Xml.Xsl.XslTransformApi.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="DataHelper.cs" />
     <Compile Include="ExceptionVerifier.cs" />
     <Compile Include="MyNavigator.cs" />
+    <Compile Include="ReaderType.cs" />
     <Compile Include="ThreadFunc.cs" />
     <Compile Include="XSLTransform.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />

--- a/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
+++ b/src/libraries/System.Private.Xml/tests/Xslt/XslTransformApi/XSLTransform.cs
@@ -27,11 +27,6 @@ namespace System.Xml.Tests
         XmlDocument, XPathDocument, Unknown
     }
 
-    public enum ReaderType
-    {
-        XmlTextReader, XmlNodeReader, XmlValidatingReader, XsltReader, Unknown
-    }
-
     ////////////////////////////////////////////////////////////////
     // Module declaration for LTM usage
     //


### PR DESCRIPTION
Hosted build agents have not a lot of free disk space and since we don't need these dirs anymore after we created the test archive we can delete it.