### PR TITLE
Use lib prefix for native library names for consistency

### DIFF
--- a/src/coreclr/src/vm/reflectioninvocation.cpp
+++ b/src/coreclr/src/vm/reflectioninvocation.cpp
@@ -2391,7 +2391,6 @@ FCIMPL1(INT32, ReflectionEnum::InternalGetCorElementType, Object *pRefThis) {
     return pMT->GetClass_NoLogging()->GetInternalCorElementType();
 }
 FCIMPLEND
-#include <optdefault.h>
 
 //*******************************************************************************
 struct TempEnumValue

--- a/src/libraries/Common/src/Interop/FreeBSD/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/FreeBSD/Interop.Libraries.cs
@@ -6,6 +6,6 @@ internal static partial class Interop
     internal static partial class Libraries
     {
         internal const string Odbc32 = "libodbc.so.2";
-        internal const string MsQuic = "msquic";
+        internal const string MsQuic = "libmsquic.so";
     }
 }

--- a/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/Linux/Interop.Libraries.cs
@@ -7,6 +7,6 @@ internal static partial class Interop
     {
         internal const string Odbc32 = "libodbc.so.2";
         internal const string OpenLdap = "libldap-2.4.so.2";
-        internal const string MsQuic = "msquic";
+        internal const string MsQuic = "libmsquic.so";
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         internal const string Odbc32 = "libodbc.2.dylib";
         internal const string OpenLdap = "libldap";
         internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
-        internal const string AppleCryptoNative = "System.Security.Cryptography.Native.Apple";
-        internal const string MsQuic = "msquic";
+        internal const string AppleCryptoNative = "libSystem.Security.Cryptography.Native.Apple";
+        internal const string MsQuic = "libmsquic";
     }
 }

--- a/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -5,16 +5,16 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        internal const string CoreFoundationLibrary = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation.dylib";
-        internal const string CoreServicesLibrary = "/System/Library/Frameworks/CoreServices.framework/CoreServices.dylib";
-        internal const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork.dylib";
+        internal const string CoreFoundationLibrary = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+        internal const string CoreServicesLibrary = "/System/Library/Frameworks/CoreServices.framework/CoreServices";
+        internal const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork";
         internal const string libobjc = "/usr/lib/libobjc.dylib";
         internal const string libproc = "/usr/lib/libproc.dylib";
         internal const string LibSystemCommonCrypto = "/usr/lib/system/libcommonCrypto.dylib";
         internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel.dylib";
         internal const string Odbc32 = "libodbc.2.dylib";
         internal const string OpenLdap = "libldap.dylib";
-        internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration.dylib";
+        internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
         internal const string AppleCryptoNative = "libSystem.Security.Cryptography.Native.Apple.dylib";
         internal const string MsQuic = "libmsquic.dylib";
     }

--- a/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/libraries/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -5,17 +5,17 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        internal const string CoreFoundationLibrary = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
-        internal const string CoreServicesLibrary = "/System/Library/Frameworks/CoreServices.framework/CoreServices";
-        internal const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork";
+        internal const string CoreFoundationLibrary = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation.dylib";
+        internal const string CoreServicesLibrary = "/System/Library/Frameworks/CoreServices.framework/CoreServices.dylib";
+        internal const string CFNetworkLibrary = "/System/Library/Frameworks/CFNetwork.framework/CFNetwork.dylib";
         internal const string libobjc = "/usr/lib/libobjc.dylib";
         internal const string libproc = "/usr/lib/libproc.dylib";
-        internal const string LibSystemCommonCrypto = "/usr/lib/system/libcommonCrypto";
-        internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel";
+        internal const string LibSystemCommonCrypto = "/usr/lib/system/libcommonCrypto.dylib";
+        internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel.dylib";
         internal const string Odbc32 = "libodbc.2.dylib";
-        internal const string OpenLdap = "libldap";
-        internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
-        internal const string AppleCryptoNative = "libSystem.Security.Cryptography.Native.Apple";
-        internal const string MsQuic = "libmsquic";
+        internal const string OpenLdap = "libldap.dylib";
+        internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration.dylib";
+        internal const string AppleCryptoNative = "libSystem.Security.Cryptography.Native.Apple.dylib";
+        internal const string MsQuic = "libmsquic.dylib";
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/Interop/Interop.Libraries.cs
+++ b/src/libraries/Common/tests/TestUtilities/Interop/Interop.Libraries.cs
@@ -6,7 +6,7 @@ internal static partial class Interop
     internal static partial class Libraries
     {
         // Shims
-        public const string CryptoNative = "System.Security.Cryptography.Native.OpenSsl";
-        public const string SystemNative = "System.Native";
+        public const string CryptoNative = "libSystem.Security.Cryptography.Native.OpenSsl";
+        public const string SystemNative = "libSystem.Native";
     }
 }


### PR DESCRIPTION
#33236 added lib prefix to the native libraries, but it was missed in number of places.