### PR TITLE
Add missing space padding before exception message in log (#39534)

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -86,10 +86,6 @@ namespace Microsoft.Extensions.Logging.Console
 
             // scope information
             WriteScopeInformation(textWriter, scopeProvider, singleLine);
-            if (singleLine)
-            {
-                textWriter.Write(' ');
-            }
             WriteMessage(textWriter, message, singleLine);
 
             // Example:
@@ -112,6 +108,7 @@ namespace Microsoft.Extensions.Logging.Console
             {
                 if (singleLine)
                 {
+                    textWriter.Write(' ');
                     WriteReplacing(textWriter, Environment.NewLine, " ", message);
                 }
                 else

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/SimpleConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/SimpleConsoleFormatterTests.cs
@@ -89,8 +89,35 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 GetMessage(sink.Writes.GetRange(1 * t.WritesPerMsg, t.WritesPerMsg)));
 
             Assert.Equal(
-                "crit: test[0]" + " " + "[null]" + "System.InvalidOperationException: Invalid value" + Environment.NewLine,
+                "crit: test[0]" + " " + "[null]" + " " + "System.InvalidOperationException: Invalid value" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(2 * t.WritesPerMsg, t.WritesPerMsg)));
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void Log_SingleLine_LogsWhenBothMessageAndExceptionProvided()
+        {
+            // Arrange
+            var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Simple },
+                new SimpleConsoleFormatterOptions { SingleLine = true }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+            var exception = new InvalidOperationException("Invalid value");
+
+            // Act
+            logger.LogCritical(eventId: 0, message: "exception happened");
+            logger.LogCritical(eventId: 0, message: "exception happened", exception: exception);
+
+            // Assert
+            Assert.Equal(4, sink.Writes.Count);
+            Assert.Equal(
+                "crit: test[0]" + " " + "exception happened" + Environment.NewLine,
+                GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
+
+            Assert.Equal(
+                "crit: test[0]" + " " + "exception happened" + " " + "System.InvalidOperationException: Invalid value" + Environment.NewLine,
+                GetMessage(sink.Writes.GetRange(1 * t.WritesPerMsg, t.WritesPerMsg)));
         }
     }
 }


### PR DESCRIPTION
Cherry picks PR https://github.com/dotnet/runtime/pull/39534 to master branch