### PR TITLE
Fix libraries outerloop builds

### DIFF
--- a/eng/pipelines/libraries/base-job.yml
+++ b/eng/pipelines/libraries/base-job.yml
@@ -20,6 +20,7 @@ parameters:
   testDisplayName: ''
   testScope: ''
   pool: ''
+  runTests: false
 
 jobs:
   - template: /eng/common/templates/job/job.yml
@@ -91,6 +92,9 @@ jobs:
         - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
           - _runtimeDownloadPath: '$(Build.SourcesDirectory)/artifacts/transport/${{ parameters.runtimeFlavor }}'
           - _runtimeConfigurationArg: -rc ${{ parameters.liveRuntimeBuildConfig }}
+          - ${{ if eq(parameters.runTests, true) }}:
+            - _runtimeArtifactName: '$(runtimeFlavorName)Product_${{ parameters.runtimeVariant}}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveRuntimeBuildConfig }}'
+            - _runtimeArtifactsPathArg: ' /p:RuntimeArtifactsPath=$(_runtimeDownloadPath)'
           - ${{ if eq(parameters.testDisplayName, '') }}:
             - _testRunNamePrefixSuffix: $(runtimeFlavorName)_${{ parameters.liveRuntimeBuildConfig }}
           - ${{ if ne(parameters.testDisplayName, '') }}:
@@ -121,4 +125,13 @@ jobs:
 
       steps:
       - template: /eng/pipelines/common/clone-checkout-bundle-step.yml
+
+      - ${{ if and(ne(parameters.liveRuntimeBuildConfig, ''), eq(parameters.runTests, true)) }}:
+        - template: /eng/pipelines/common/download-artifact-step.yml
+          parameters:
+            unpackFolder: $(_runtimeDownloadPath)
+            artifactFileName: '$(_runtimeArtifactName)$(archiveExtension)'
+            artifactName: '$(_runtimeArtifactName)'
+            displayName: '$(runtimeFlavorName) build drop'
+
       - ${{ parameters.steps }}

--- a/eng/pipelines/libraries/build-job.yml
+++ b/eng/pipelines/libraries/build-job.yml
@@ -41,6 +41,7 @@ jobs:
       isOfficialAllConfigurations: ${{ parameters.isOfficialAllConfigurations }}
       liveRuntimeBuildConfig: ${{ parameters.liveRuntimeBuildConfig }}
       runtimeFlavor: ${{ parameters.runtimeFlavor }}
+      runTests: ${{ parameters.runTests }}
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
       preBuildSteps: ${{ parameters.preBuildSteps }}
       container: ${{ parameters.container }}
@@ -50,6 +51,11 @@ jobs:
       testScope: ${{ parameters.testScope }}
       name: build
       displayName: 'Build'
+
+      ${{ if and(ne(parameters.liveRuntimeBuildConfig, ''), eq(parameters.runTests, true)) }}:
+        dependsOn:
+        # Use full product dependency for test runs
+        - ${{ format('{0}_{1}_product_build_{2}{3}_{4}_{5}', parameters.runtimeFlavor, parameters.runtimeVariant, parameters.osGroup, parameters.osSubgroup, parameters.archType, parameters.liveRuntimeBuildConfig) }}
 
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.archType, parameters.buildConfig) }}

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -40,6 +40,7 @@ jobs:
       condition: ${{ parameters.condition }}
       pool: ${{ parameters.pool }}
       testScope: ${{ parameters.testScope }}
+      runTests: true
       ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
         displayName: ${{ format('Test Run {0} {1}', parameters.liveRuntimeBuildConfig, parameters.runtimeDisplayName) }}
         name: ${{ format('test_run_{0}_{1}', parameters.liveRuntimeBuildConfig, parameters.runtimeDisplayName) }}
@@ -61,10 +62,6 @@ jobs:
       variables:
         - librariesTestsArtifactName: ${{ format('libraries_test_assets_{0}_{1}_{2}', parameters.osGroup, parameters.dependsOnTestArchitecture, parameters.dependsOnTestBuildConfiguration) }}
         - _archiveTestsParameter: /p:ArchiveTests=true
-        
-        - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
-          - _runtimeArtifactName: '$(runtimeFlavorName)Product_${{ parameters.runtimeVariant}}_${{ parameters.osGroup }}${{ parameters.osSubgroup }}_${{ parameters.archType }}_${{ parameters.liveRuntimeBuildConfig }}'
-          - _runtimeArtifactsPathArg: ' /p:RuntimeArtifactsPath=$(_runtimeDownloadPath)'
 
         - ${{ parameters.variables }}
 
@@ -84,14 +81,6 @@ jobs:
             artifactName: $(librariesTestsArtifactName)
             artifactFileName: $(librariesTestsArtifactName)$(archiveExtension)
             unpackFolder: $(Build.SourcesDirectory)/artifacts
-        
-        - ${{ if ne(parameters.liveRuntimeBuildConfig, '') }}:
-          - template: /eng/pipelines/common/download-artifact-step.yml
-            parameters:
-              unpackFolder: $(_runtimeDownloadPath)
-              artifactFileName: '$(_runtimeArtifactName)$(archiveExtension)'
-              artifactName: '$(_runtimeArtifactName)'
-              displayName: '$(runtimeFlavorName) build drop'
 
         - ${{ if in(parameters.coreclrTestGroup, 'gcstress0x3-gcstress0xc', 'gcstress-extra') }}:
           # We need to find and download the GC stress dependencies (namely, coredistools). Put them

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -595,7 +595,6 @@ jobs:
       isFullMatrix: ${{ variables.isFullMatrix }}
       framework: allConfigurations
       runTests: true
-      liveRuntimeBuildConfig: release
       condition: >-
         or(
           eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),


### PR DESCRIPTION
If `runTests: true` and `liveRuntimeBuildConfig != ''` we need to depend on a runtime job and download it's assets before running the tests.
 
cc: @bartonjs @antonfirsov 