### PR TITLE
[release/5.0-Preview8] Workaround duplicate package icon in packages

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -1,4 +1,9 @@
 <Project>
+  <ItemGroup>
+    <!-- workaround duplicate icon.  If PackageIconFile is set, don't include PackageIconFullPath in package
+         can be removed when we have an arcade build with https://github.com/dotnet/arcade/pull/5818 -->
+    <None Condition="'$(PackageIconFile)' != ''" Update="$(PackageIconFullPath)" Pack="false" />
+  </ItemGroup>
   <!--     There are some packages where we require only one ref for a specific framework to be present. In order to avoid problems with this package when targetting 
            dektop with RAR we will make sure there are no exclude=compile references in the package.
     For more info, please check issues:


### PR DESCRIPTION
Real fix is https://github.com/dotnet/arcade/pull/5818 but that will
take a while to make it into the preview8 branches (if at all).