### PR TITLE
Fix Failing Casing Tests with Invariant Culture

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/TextInfoTests.cs
@@ -171,7 +171,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        private static readonly string [] s_cultureNames = new string[] { "", "en-US", "fr", "fr-FR" };
+        private static readonly string [] s_cultureNames = new string[] { "en-US", "fr", "fr-FR" };
 
         // ToLower_TestData_netcore has the data which is specific to netcore framework
         public static IEnumerable<object[]> ToLower_TestData_netcore()
@@ -180,6 +180,11 @@ namespace System.Globalization.Tests
             {
                 // DESERT CAPITAL LETTER LONG I has a lower case variant (but not on Windows 7).
                 yield return new object[] { cultureName, "\U00010400", PlatformDetection.IsWindows7 ? "\U00010400" : "\U00010428" };
+            }
+
+            if (!PlatformDetection.IsNlsGlobalization)
+            {
+                yield return new object[] { "", "\U00010400", PlatformDetection.IsWindows7 ? "\U00010400" : "\U00010428" };
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Nls.cs
@@ -18,6 +18,8 @@ namespace System.Globalization
             Debug.Assert(pSourceLen <= pResultLen);
 
             // Check for Invariant to avoid A/V in LCMapStringEx
+            // We don't specify LCMAP_LINGUISTIC_CASING for Invariant because it will enable Turkish-I behavior too which is not
+            // right for Invariant.
             uint linguisticCasing = IsInvariantLocale(_textInfoName) ? 0 : LCMAP_LINGUISTIC_CASING;
 
             int ret = Interop.Kernel32.LCMapStringEx(_sortHandle != IntPtr.Zero ? null : _textInfoName,

--- a/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
@@ -50,8 +50,6 @@ namespace System.Text.Tests
         [InlineData('\u0130', '\u0130', '\u0130')] // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
         [InlineData('\u0131', '\u0131', '\u0131')] // U+0131 LATIN SMALL LETTER DOTLESS I
         [InlineData('\u1E9E', '\u1E9E', '\u1E9E')] // U+1E9E LATIN CAPITAL LETTER SHARP S
-        [InlineData(0x10400, 0x10400, 0x10428)] // U+10400 DESERET CAPITAL LETTER LONG I
-        [InlineData(0x10428, 0x10400, 0x10428)] // U+10428 DESERET SMALL LETTER LONG I
         public static void Casing_Invariant(int original, int upper, int lower)
         {
             var rune = new Rune(original);

--- a/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/RuneTests.cs
@@ -57,6 +57,26 @@ namespace System.Text.Tests
             Assert.Equal(new Rune(lower), Rune.ToLowerInvariant(rune));
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsIcuGlobalization))]
+        [InlineData('0', '0', '0')]
+        [InlineData('a', 'A', 'a')]
+        [InlineData('i', 'I', 'i')]
+        [InlineData('z', 'Z', 'z')]
+        [InlineData('A', 'A', 'a')]
+        [InlineData('I', 'I', 'i')]
+        [InlineData('Z', 'Z', 'z')]
+        [InlineData('\u00DF', '\u00DF', '\u00DF')] // U+00DF LATIN SMALL LETTER SHARP S
+        [InlineData('\u0130', '\u0130', '\u0130')] // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
+        [InlineData('\u0131', '\u0131', '\u0131')] // U+0131 LATIN SMALL LETTER DOTLESS I
+        [InlineData(0x10400, 0x10400, 0x10428)] // U+10400 DESERET CAPITAL LETTER LONG I
+        [InlineData(0x10428, 0x10400, 0x10428)] // U+10428 DESERET SMALL LETTER LONG I
+        public static void ICU_Casing_Invariant(int original, int upper, int lower)
+        {
+            var rune = new Rune(original);
+            Assert.Equal(new Rune(upper), Rune.ToUpperInvariant(rune));
+            Assert.Equal(new Rune(lower), Rune.ToLowerInvariant(rune));
+        }
+
         [Theory]
         [MemberData(nameof(GeneralTestData_BmpCodePoints_NoSurrogates))]
         public static void Ctor_Cast_Char_Valid(GeneralTestData testData)


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39522
The test was failing because of a regression on Windows side.