### PR TITLE
WASM: Fix System.Net.Primitives and tests

### DIFF
--- a/src/libraries/Common/src/System/Net/NetworkInformation/HostInformationPal.Browser.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/HostInformationPal.Browser.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.NetworkInformation
+{
+    internal static class HostInformationPal
+    {
+        public static string GetHostName()
+        {
+            return Environment.MachineName;
+        }
+
+        public static string GetDomainName()
+        {
+            return Environment.UserDomainName;
+        }
+    }
+}

--- a/src/libraries/Common/src/System/Net/NetworkInformation/InterfaceInfoPal.Browser.cs
+++ b/src/libraries/Common/src/System/Net/NetworkInformation/InterfaceInfoPal.Browser.cs
@@ -1,0 +1,14 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.Net.NetworkInformation
+{
+    internal static class InterfaceInfoPal
+    {
+        public static uint InterfaceNameToIndex(string interfaceName)
+        {
+            // zero means "unknown"
+            return 0;
+        }
+    }
+}

--- a/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/libraries/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -117,14 +117,22 @@
     <Compile Include="System\Net\SocketException.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs"
              Link="Common\System\Net\SocketAddressPal.Unix.cs" />
-    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs"
-             Link="Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs"
              Link="Common\System\Net\Sockets\SocketErrorPal.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs"
              Link="Common\Interop\Unix\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
              Link="Common\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.IPAddress.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs"
+             Link="Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs" />
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs"
+             Link="Common\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainName.cs"
              Link="Common\Interop\Unix\System.Native\Interop.GetDomainName.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetHostName.cs"
@@ -133,14 +141,14 @@
              Link="Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs"
              Link="Common\Interop\Unix\System.Native\Interop.HostEntry.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs"
-             Link="Common\Interop\Unix\System.Native\Interop.IPAddress.cs" />
-    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs"
-             Link="Common\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs"
              Link="Common\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs"
-             Link="Common\Interop\Unix\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Browser.cs"
+             Link="Common\System\Net\NetworkInformation\HostInformationPal.Browser.cs" />
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Browser.cs"
+             Link="Common\System\Net\NetworkInformation\InterfaceInfoPal.Browser.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Win32.Primitives" />

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/CookieTest/CookiePortTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/CookieTest/CookiePortTest.cs
@@ -13,65 +13,65 @@ namespace System.Net.Primitives.Functional.Tests
         public CookiePortTest()
         {
             _cc = new CookieContainer();
-            _cookie = new Cookie("name", "value1", "/path", "localhost");
+            _cookie = new Cookie("name", "value1", "/path", "example.com");
             // use both space and comma as delimiter
             _cookie.Port = "\"80 110,1050, 1090 ,1100\"";
-            _cc.Add(new Uri("http://localhost/path"), _cookie);
+            _cc.Add(new Uri("http://example.com/path"), _cookie);
         }
 
         [Fact]
         public void Port_SetMultiplePorts_Port1Set()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:80/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:80/path"));
             Assert.Equal(1, cookies.Count);
         }
 
         [Fact]
         public void Port_SpaceDelimiter_PortSet()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:110/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:110/path"));
             Assert.Equal(1, cookies.Count);
         }
 
         [Fact]
         public void Port_CommaDelimiter_PortSet()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:1050/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:1050/path"));
             Assert.Equal(1, cookies.Count);
         }
 
         [Fact]
         public void Port_CommaSpaceDelimiter_PortSet()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:1090/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:1090/path"));
             Assert.Equal(1, cookies.Count);
         }
 
         [Fact]
         public void Port_SpaceCommaDelimiter_PortSet()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:1100/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:1100/path"));
             Assert.Equal(1, cookies.Count);
         }
 
         [Fact]
         public void Port_SetMultiplePorts_NoPortMatch()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:1000/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:1000/path"));
             Assert.Equal(0, cookies.Count);
         }
 
         [Fact]
         public void Port_SetMultiplePorts_NoPathMatch()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost:1050"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com:1050"));
             Assert.Equal(0, cookies.Count);
         }
 
         [Fact]
         public void Port_NoPortSpecified_ReturnsCookies()
         {
-            CookieCollection cookies = _cc.GetCookies(new Uri("http://localhost/path"));
+            CookieCollection cookies = _cc.GetCookies(new Uri("http://example.com/path"));
             Assert.Equal(1, cookies.Count);
         }
     }

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/SocketAddressTest.cs
@@ -98,7 +98,7 @@ namespace System.Net.Primitives.Functional.Tests
         [Theory]
         [InlineData(AddressFamily.Packet)]
         [InlineData(AddressFamily.ControllerAreaNetwork)]
-        [PlatformSpecific(~TestPlatforms.Linux)]
+        [PlatformSpecific(~(TestPlatforms.Linux | TestPlatforms.Browser))]
         public static void ToString_UnsupportedFamily_Throws(AddressFamily family)
         {
             Assert.Throws<PlatformNotSupportedException>(() => new SocketAddress(family));

--- a/src/libraries/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
+++ b/src/libraries/System.Net.Primitives/tests/PalTests/System.Net.Primitives.Pal.Tests.csproj
@@ -85,8 +85,6 @@
   <ItemGroup Condition="'$(TargetsUnix)' == 'true' or '$(TargetsBrowser)' == 'true'">
     <Compile Include="..\..\src\System\Net\SocketException.Unix.cs"
              Link="ProductionCode\System\Net\SocketException.Unix.cs" />
-    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs"
-             Link="Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\SocketAddressPal.Unix.cs"
              Link="Common\System\Net\SocketAddressPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs"
@@ -97,21 +95,31 @@
              Link="ProductionCode\Interop\Unix\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
              Link="ProductionCode\Common\Interop\Unix\Interop.Libraries.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainName.cs"
-             Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.GetDomainName.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetHostName.cs"
-             Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.GetHostName.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNameInfo.cs"
-             Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs" />
-    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs"
-             Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.HostEntry.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.IPAddress.cs"
              Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.IPAddress.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.SocketAddress.cs"
              Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.SocketAddress.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Unix.cs"
+             Link="Common\System\Net\NetworkInformation\HostInformationPal.Unix.cs" />
     <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs"
-             Link="ProductionCode\Common\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs" />
+             Link="Common\System\Net\NetworkInformation\InterfaceInfoPal.Unix.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetDomainName.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.GetDomainName.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetHostName.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.GetHostName.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.GetNameInfo.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.GetNameInfo.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.HostEntry.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.HostEntry.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs"
-             Link="ProductionCode\Common\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs" />
+             Link="Common\Interop\Unix\System.Native\Interop.InterfaceNameToIndex.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsBrowser)' == 'true'">
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\HostInformationPal.Browser.cs"
+             Link="Common\System\Net\NetworkInformation\HostInformationPal.Browser.cs" />
+    <Compile Include="$(CommonPath)System\Net\NetworkInformation\InterfaceInfoPal.Browser.cs"
+             Link="ProductionCode\Common\System\Net\NetworkInformation\InterfaceInfoPal.Browser.cs" />
   </ItemGroup>
 </Project>

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -33,8 +33,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Parallel\tests\System.Linq.Parallel.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\PalTests\System.Net.Primitives.Pal.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ObjectModel\tests\System.ObjectModel.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Uri\tests\FunctionalTests\System.Private.Uri.Functional.Tests.csproj" />


### PR DESCRIPTION
Add HostInformationPal and InterfaceInfoPal implementations for Browser.

In CookiePortTest.cs use example.com instead of localhost for the tests since Browser uses `localhost` as the `Environment.MachineName` and that changes the test values.

Allows the tests to run on WebAssembly:
```
System.Net.Primitives.Pal.Tests: Tests run: 60, Errors: 0, Failures: 0, Skipped: 0. Time: 0.15872s
System.Net.Primitives.Functional.Tests: Tests run: 2620, Errors: 0, Failures: 0, Skipped: 1. Time: 3.145804s
```