### PR TITLE
Add 10 when digit is [a-fA-F] in ConfigMethodRange::InitRanges

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -1764,6 +1764,10 @@ void Compiler::compInit(ArenaAllocator*       pAlloc,
     info.compPerfScore = 0.0;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
+#if defined(DEBUG) || defined(INLINE_DATA)
+    info.compMethodHashPrivate = 0;
+#endif // defined(DEBUG) || defined(INLINE_DATA)
+
 #ifdef DEBUG
     // Opt-in to jit stress based on method hash ranges.
     //
@@ -5286,10 +5290,6 @@ int Compiler::compCompile(CORINFO_MODULE_HANDLE classPtr,
     // set this early so we can use it without relying on random memory values
     verbose = compIsForInlining() ? impInlineInfo->InlinerCompiler->verbose : false;
 #endif
-
-#if defined(DEBUG) || defined(INLINE_DATA)
-    info.compMethodHashPrivate = 0;
-#endif // defined(DEBUG) || defined(INLINE_DATA)
 
 #if FUNC_INFO_LOGGING
     LPCWSTR tmpJitFuncInfoFilename = JitConfig.JitFuncInfoFile();

--- a/src/coreclr/src/jit/utils.cpp
+++ b/src/coreclr/src/jit/utils.cpp
@@ -767,11 +767,11 @@ void ConfigMethodRange::InitRanges(const WCHAR* rangeStr, unsigned capacity)
             }
             else if ((L'A' <= *p) && (*p <= L'F'))
             {
-                n = (*p++) - L'A';
+                n = (*p++) - L'A' + 10;
             }
             else if ((L'a' <= *p) && (*p <= L'f'))
             {
-                n = (*p++) - L'a';
+                n = (*p++) - L'a' + 10;
             }
 
             int j = 16 * i + n;


### PR DESCRIPTION
Fix small issue that broke `JitStressRange` after 6dd6b6cc9a60768cf96235a5990bec4894e9106c 