### PR TITLE
Default activity name to caller member name if not provided

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/ref/System.Diagnostics.DiagnosticSourceActivity.cs
@@ -134,7 +134,8 @@ namespace System.Diagnostics
         public string Name { get { throw null; } }
         public string? Version { get { throw null; } }
         public bool HasListeners() { throw null; }
-        public System.Diagnostics.Activity? StartActivity(string name, System.Diagnostics.ActivityKind kind = ActivityKind.Internal)  { throw null; }
+        public System.Diagnostics.Activity? StartActivity(ActivityKind kind, string name = "") { throw null; }
+        public System.Diagnostics.Activity? StartActivity(string name = "", System.Diagnostics.ActivityKind kind = ActivityKind.Internal)  { throw null; }
         public System.Diagnostics.Activity? StartActivity(string name, System.Diagnostics.ActivityKind kind, System.Diagnostics.ActivityContext parentContext, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags = null, System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityLink>? links = null, System.DateTimeOffset startTime = default) { throw null; }
         public System.Diagnostics.Activity? StartActivity(string name, System.Diagnostics.ActivityKind kind, string parentId, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, object?>>? tags = null, System.Collections.Generic.IEnumerable<System.Diagnostics.ActivityLink>? links = null, System.DateTimeOffset startTime = default) { throw null; }
         public static void AddActivityListener(System.Diagnostics.ActivityListener listener) { throw null; }

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivitySource.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace System.Diagnostics
 {
@@ -71,10 +72,19 @@ namespace System.Diagnostics
         /// <summary>
         /// Creates a new <see cref="Activity"/> object if there is any listener to the Activity, returns null otherwise.
         /// </summary>
+        /// <param name="kind">The <see cref="ActivityKind"/></param>
+        /// <param name="name">The operation name of the Activity</param>
+        /// <returns>The created <see cref="Activity"/> object or null if there is no any event listener.</returns>
+        public Activity? StartActivity(ActivityKind kind, [CallerMemberName] string name = "")
+            => StartActivity(name, kind, default, null, null, null, default);
+
+        /// <summary>
+        /// Creates a new <see cref="Activity"/> object if there is any listener to the Activity, returns null otherwise.
+        /// </summary>
         /// <param name="name">The operation name of the Activity</param>
         /// <param name="kind">The <see cref="ActivityKind"/></param>
         /// <returns>The created <see cref="Activity"/> object or null if there is no any event listener.</returns>
-        public Activity? StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
+        public Activity? StartActivity([CallerMemberName] string name = "", ActivityKind kind = ActivityKind.Internal)
             => StartActivity(name, kind, default, null, null, null, default);
 
         /// <summary>


### PR DESCRIPTION
To simplify even more the usage pattern for `ActivitySource.StartActivity`, 
offering a default value that matches the caller name makes sense and 
makes for a good default that could be handy, when not providing the 
other explicit parameters.

Providing the inverted parameters overloads makes sense too so that 
passing the `ActivityKind` (which looks like the most obvious customization 
point when starting activities) can also default the name to the caller.