### PR TITLE
[wasm] Enable several library test suites 

### DIFF
--- a/src/libraries/System.Security.Permissions/tests/EvidenceBaseTests.cs
+++ b/src/libraries/System.Security.Permissions/tests/EvidenceBaseTests.cs
@@ -39,6 +39,7 @@ namespace System.Security.Permissions.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Security.Cryptography.Algorithms is not supported on this platform.
         public static void HashCallMethods()
         {
             Hash hash = new Hash(Reflection.Assembly.Load(new Reflection.AssemblyName("System.Reflection")));

--- a/src/libraries/System.Security.Permissions/tests/MembershipConditionTests.cs
+++ b/src/libraries/System.Security.Permissions/tests/MembershipConditionTests.cs
@@ -61,6 +61,7 @@ namespace System.Security.Permissions.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Security.Cryptography.Algorithms is not supported on this platform.
         public static void HashMembershipConditionCallMethods()
         {
             HashMembershipCondition hmc = new HashMembershipCondition(Cryptography.SHA1.Create(), new byte[1]);
@@ -78,6 +79,7 @@ namespace System.Security.Permissions.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Security.Cryptography.X509Certificates is not supported on this platform.
         public static void PublisherMembershipConditionCallMethods()
         {
             PublisherMembershipCondition pmc = new PublisherMembershipCondition(new System.Security.Cryptography.X509Certificates.X509Certificate());

--- a/src/libraries/System.Security.Permissions/tests/PermissionTests.cs
+++ b/src/libraries/System.Security.Permissions/tests/PermissionTests.cs
@@ -210,6 +210,7 @@ namespace System.Security.Permissions.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Security.Cryptography.X509Certificates is not supported on this platform.
         public static void PublisherIdentityPermissionCallMethods()
         {
             PublisherIdentityPermission pip = new PublisherIdentityPermission(new System.Security.Cryptography.X509Certificates.X509Certificate());

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -38,9 +38,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ObjectModel\tests\System.ObjectModel.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Uri\tests\FunctionalTests\System.Private.Uri.Functional.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSerializer\ReflectionOnly\System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSerializer\System.Xml.XmlSerializer.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Security.Permissions\tests\System.Security.Permissions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ValueTuple\tests\System.ValueTuple.Tests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

- System.Xml.XmlSerializer.ReflectionOnly.Tests (`Tests run: 229, Errors: 0, Failures: 0, Skipped: 0.`)
- System.Xml.XmlSerializer.Tests (`Tests run: 231, Errors: 0, Failures: 0, Skipped: 0.`)
- System.Security.Permissions.Tests test suites (`Tests run: 136, Errors: 0, Failures: 0, Skipped: 0.`)