### PR TITLE
[wasm] Enable System.Linq.Expressions.Tests test suite

### DIFF
--- a/src/libraries/System.Linq.Expressions/tests/Call/CallTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Call/CallTests.cs
@@ -290,6 +290,7 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [PerCompilationType(nameof(Call_NoParameters_TestData))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39771", TestPlatforms.Browser)]
         public static void Call_NoParameters(Expression instance, MethodInfo method, object expected, bool useInterpreter)
         {
             Expression call = Expression.Call(instance, method);

--- a/src/libraries/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/IndexExpression/IndexExpressionTests.cs
@@ -654,6 +654,7 @@ namespace System.Linq.Expressions.Tests
 
 
         [Theory, ClassData(typeof(CompilationTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39771", TestPlatforms.Browser)]
         public static void ConstrainedVirtualCall(bool useInterpreter)
         {
             // Virtual call via base declaration to valuetype.

--- a/src/libraries/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/libraries/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -52,6 +52,7 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39771", TestPlatforms.Browser)]
         public void ReadAndWriteVars(bool useInterpreter)
         {
             ParameterExpression x = Expression.Variable(typeof(int));
@@ -82,6 +83,7 @@ namespace System.Linq.Expressions.Tests
 
         [Theory]
         [ClassData(typeof(CompilationTypes))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/39771", TestPlatforms.Browser)]
         public void AliasingAllowed(bool useInterpreter)
         {
             ParameterExpression x = Expression.Variable(typeof(int));

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -30,7 +30,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Globalization.Calendars\tests\CalendarTestWithConfigSwitch\System.Globalization.CalendarsWithConfigSwitch.Tests.csproj" />
 
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.FileSystem\tests\System.IO.FileSystem.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Parallel\tests\System.Linq.Parallel.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Primitives\tests\FunctionalTests\System.Net.Primitives.Functional.Tests.csproj" />


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422.

Several tests are disabled with the active issue https://github.com/dotnet/runtime/issues/39771 (BadImageFormatException : Method has no body)

The test run result: `Tests run: 30833, Errors: 0, Failures: 0, Skipped: 0`