### PR TITLE
Fix double-writes in test projects

### DIFF
--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -37,6 +37,7 @@
                       Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
     <PackageReference Include="xunit.runner.console"
                       Version="$(XUnitVersion)"
+                      GeneratePathProperty="true"
                       Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" />
   </ItemGroup>
 
@@ -62,7 +63,9 @@
     <ItemGroup>
       <!-- Copy test runner to output directory -->
       <None Include="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\*"
-            Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe"
+            Exclude="$([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.*exe.config;
+                     $([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.console.x86.exe;
+                     $([System.IO.Path]::GetDirectoryName('$(XunitConsole472Path)'))\xunit.abstractions.dll"
             Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' and '$(XunitConsole472Path)' != ''"
             CopyToOutputDirectory="PreserveNewest"
             Visible="false" />

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -77,5 +77,13 @@
             CopyToOutputDirectory="PreserveNewest"
             Visible="false" />
     </ItemGroup>
+
+    <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
+    <ItemGroup Condition="'$(ArchiveTests)' != 'true'">
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.utility.net452.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.reporters.net452.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.utility.netcoreapp10.dll" />
+      <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.reporters.netcoreapp10.dll" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/eng/testing/xunit/xunit.props
+++ b/eng/testing/xunit/xunit.props
@@ -31,18 +31,4 @@
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
   </ItemGroup>
-
-  <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
-  <Choose>
-    <When Condition="'$(ArchiveTests)' != 'true'">
-      <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-        <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.utility.net452.dll" />
-        <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.reporters.net452.dll" />
-      </ItemGroup>
-      <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-        <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.utility.netcoreapp10.dll" />
-        <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.reporters.netcoreapp10.dll" />
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>

--- a/eng/testing/xunit/xunit.props
+++ b/eng/testing/xunit/xunit.props
@@ -16,7 +16,7 @@
   <ItemGroup Condition="'$(ArchiveTests)' != 'true'">
     <!-- Microsoft.Net.Test.Sdk brings a lot of assemblies with it. To reduce helix payload submission size we disable it on CI. -->
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" GeneratePathProperty="true" />
     <!--
       Microsoft.Net.Test.Sdk has a dependency on Newtonsoft.Json v9.0.1. We upgrade the dependency version
       with the one used in libraries to have a consistent set of dependency versions. Additionally this works
@@ -31,4 +31,18 @@
           CopyToOutputDirectory="PreserveNewest"
           Visible="false" />
   </ItemGroup>
+
+  <!-- Workaround for https://github.com/xunit/xunit/issues/1651 -->
+  <Choose>
+    <When Condition="'$(ArchiveTests)' != 'true'">
+      <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+        <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.utility.net452.dll" />
+        <None Remove="$(Pkgxunit_runner_visualstudio)\build\net452\xunit.runner.reporters.net452.dll" />
+      </ItemGroup>
+      <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+        <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.utility.netcoreapp10.dll" />
+        <None Remove="$(Pkgxunit_runner_visualstudio)\build\netcoreapp2.1\xunit.runner.reporters.netcoreapp10.dll" />
+      </ItemGroup>
+    </When>
+  </Choose>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/28683

We can delete all this when switching to `dotnet test`. This should speed up test project builds as it prevents up-to-date checks to be broken. Roslyn is applying the same workaround: https://github.com/dotnet/roslyn-tools/commit/bbabf119bfba57ce1efe5ba7a9ad641b10e9c1f8.