### PR TITLE
turn pauseonstart test off for Windows

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -304,6 +304,13 @@
         </ExcludeList>
     </ItemGroup>
 
+    <!-- Windows all architecture excludes -->
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/pauseonstart/**">
+            <Issue>https://github.com/dotnet/runtime/issues/38847</Issue>
+        </ExcludeList>
+    </ItemGroup>
+
     <!-- Windows x64 specific excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetArchitecture)' == 'x64' and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/JitBlue/GitHub_18056/Bool_And_Op_cs_do/*">


### PR DESCRIPTION
There is an intermittent timeout only on Windows for the PauseOnStart tests.  Work towards a solution is being tracked in #38847.  This turns the test off for Windows CI legs.

CC @tommcdon 