### PR TITLE
Switch Windows arm64 testing to use Windows.10.Arm64v8.Open queue.

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -124,7 +124,7 @@ jobs:
     # Windows_NT arm64
     - ${{ if eq(parameters.platform, 'Windows_NT_arm64') }}:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.jobParameters.helixQueueGroup, 'pr', 'ci', 'libraries')) }}:
-        - Windows.10.Arm64.Open
+        - Windows.10.Arm64v8.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - Windows.10.Arm64
 


### PR DESCRIPTION
Windows arm testing has been scaled back in #39655 so now we can start
using better machines for Windows arm64 testing. These machines were
previously used for Windows arm testing.
