### PR TITLE
Handle success case for overlapped IO in Windows Diagnostics IPC PAL

### DIFF
--- a/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -283,8 +283,6 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
             // SERVER
             _ASSERTE(rgIpcPollHandles[i].pIpc->mode == DiagnosticsIpc::ConnectionMode::SERVER);
             pHandles[i] = rgIpcPollHandles[i].pIpc->_oOverlap.hEvent;
-            if (callback != nullptr)
-                callback("Added SERVER handle to pHandles", (uint32_t)pHandles[i]);
         }
         else
         {
@@ -310,8 +308,6 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
                     {
                         case ERROR_IO_PENDING:
                             pHandles[i] = rgIpcPollHandles[i].pStream->_oOverlap.hEvent;
-                            if (callback != nullptr)
-                                callback("Added CLIENT handle to pHandles", (uint32_t)pHandles[i]);
                             break;
                         case ERROR_PIPE_NOT_CONNECTED:
                             // hangup
@@ -329,15 +325,11 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
                 {
                     // there's already data to be read
                     pHandles[i] = rgIpcPollHandles[i].pStream->_oOverlap.hEvent;
-                    if (callback != nullptr)
-                        callback("Added CLIENT handle to pHandles", (uint32_t)pHandles[i]);
                 }
             }
             else
             {
                 pHandles[i] = rgIpcPollHandles[i].pStream->_oOverlap.hEvent;
-                if (callback != nullptr)
-                    callback("Added CLIENT handle to pHandles", (uint32_t)pHandles[i]);
             }
         }
     }

--- a/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
+++ b/src/coreclr/src/debug/debug-pal/win/diagnosticsipc.cpp
@@ -302,6 +302,12 @@ int32_t IpcStream::DiagnosticsIpc::Poll(IpcPollHandle *rgIpcPollHandles, uint32_
                             return -1;
                     }
                 }
+                else
+                {
+                    // there's already data to be read
+                    pHandles[i] = rgIpcPollHandles[i].pStream->_oOverlap.hEvent;
+                }
+                
             }
             else
             {

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -306,9 +306,6 @@
 
     <!-- Windows all architecture excludes -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsWindows)' == 'true' and '$(RuntimeFlavor)' == 'coreclr'">
-        <ExcludeList Include="$(XunitTestBinBase)/tracing/eventpipe/pauseonstart/pauseonstart/**">
-            <Issue>https://github.com/dotnet/runtime/issues/38847</Issue>
-        </ExcludeList>
     </ItemGroup>
 
     <!-- Windows x64 specific excludes -->


### PR DESCRIPTION
fixes #38847 (see the issue for more details on my investigation)

There is a missing `else` condition on the error checking for a call to `Read` with OverlappedIO.  In this case, the value in `pHandles[0]` is unset.  `pHandles[0]` could be:
1. complete junk -> `WaitForMultipleObjects` will fail and everything corrects on the second call to `Poll`
2. _any_ other waitable handle -> `WaitForMultipleObjects` is now waiting on the forward server connection which won't signal and _some other_ handle which presumably also won't signal.

In the second case, we will hang and timeout the test.  The runtime is effectively single threaded in this state, because the only other thread is waiting in `ceemain.cpp` on the Pause On Start event.

CC @tommcdon @BruceForstall @dotnet/dotnet-diag 