### PR TITLE
Fix FCall implementation collision on ARM64

### DIFF
--- a/src/coreclr/src/vm/comdependenthandle.cpp
+++ b/src/coreclr/src/vm/comdependenthandle.cpp
@@ -86,6 +86,9 @@ FCIMPL2(VOID, DependentHandle::nSetPrimary, OBJECTHANDLE handle, Object *_primar
 
     _ASSERTE(handle != NULL);
 
+    // Avoid collision with MarshalNative::GCHandleInternalSet
+    FCUnique(0x12);
+
     IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
     mgr->StoreObjectInHandle(handle, _primary);
 }


### PR DESCRIPTION
Fixes #39701.  Two FCalls, `DependentHandle::nSetPrimary` and `MarshalNative::GCHandleInternalSet`, had identical implementations, which led to a failure in `ECall::GetFCallImpl` ("Duplicate pImplementation entries found in reverse fcall table").  Add `FCUnique()` to make them different.