### PR TITLE
Fix a condition that decides if initReg should be zero-initialized

### DIFF
--- a/src/coreclr/src/jit/codegenarm.cpp
+++ b/src/coreclr/src/jit/codegenarm.cpp
@@ -45,7 +45,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //                          if caller knows for certain the constant will fit.
 //
 // Return Value:
-//    returns true if the immediate was too large and tmpReg was used and modified.
+//    returns true if the immediate was small enough to be encoded inside instruction. If not,
+//    returns false meaning the immediate was too large and tmpReg was used and modified.
 //
 bool CodeGen::genInstrWithConstant(
     instruction ins, emitAttr attr, regNumber reg1, regNumber reg2, ssize_t imm, insFlags flags, regNumber tmpReg)
@@ -100,7 +101,8 @@ bool CodeGen::genInstrWithConstant(
 //    tmpReg                  - an available temporary register
 //
 // Return Value:
-//    true if `tmpReg` was used.
+//    returns true if the immediate was small enough to be encoded inside instruction. If not,
+//    returns false meaning the immediate was too large and tmpReg was used and modified.
 //
 bool CodeGen::genStackPointerAdjustment(ssize_t spDelta, regNumber tmpReg)
 {

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -4816,7 +4816,7 @@ void CodeGen::genStoreLclTypeSIMD12(GenTree* treeNode)
 // Arguments:
 //     initReg          - register to use as scratch register
 //     pInitRegModified - OUT parameter. *pInitRegModified set to 'true' if 'initReg' is
-//                        not zero after this call.
+//                        set to a non-zero value.
 //
 // Return Value:
 //     None

--- a/src/coreclr/src/jit/codegenarm64.cpp
+++ b/src/coreclr/src/jit/codegenarm64.cpp
@@ -54,7 +54,8 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 //                          Default: false.
 //
 // Return Value:
-//    returns true if the immediate was too large and tmpReg was used and modified.
+//    returns true if the immediate was small enough to be encoded inside instruction. If not,
+//    returns false meaning the immediate was too large and tmpReg was used and modified.
 //
 bool CodeGen::genInstrWithConstant(instruction ins,
                                    emitAttr    attr,
@@ -156,7 +157,10 @@ void CodeGen::genStackPointerAdjustment(ssize_t spDelta, regNumber tmpReg, bool*
     // Even though INS_add is specified here, the encoder will choose either
     // an INS_add or an INS_sub and encode the immediate as a positive value
     //
-    if (genInstrWithConstant(INS_add, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, spDelta, tmpReg, true))
+    bool wasTempRegisterUsedForImm =
+        !genInstrWithConstant(INS_add, EA_PTRSIZE, REG_SPBASE, REG_SPBASE, spDelta, tmpReg, true);
+
+    if (wasTempRegisterUsedForImm)
     {
         if (pTmpRegIsZero != nullptr)
         {

--- a/src/coreclr/src/jit/codegenarmarch.cpp
+++ b/src/coreclr/src/jit/codegenarmarch.cpp
@@ -562,7 +562,7 @@ void CodeGen::genSetRegToIcon(regNumber reg, ssize_t val, var_types type, insFla
 //
 // Arguments:
 //     initReg          - register to use as a scratch register
-//     pInitRegModified - OUT parameter. *pInitRegModified is set to 'true' if and only if
+//     pInitRegModified - OUT parameter. *pInitRegModified is set to 'true' since
 //                        this call sets 'initReg' to a non-zero value.
 //
 // Return Value:

--- a/src/coreclr/src/jit/codegencommon.cpp
+++ b/src/coreclr/src/jit/codegencommon.cpp
@@ -6124,6 +6124,7 @@ regNumber CodeGen::genGetZeroReg(regNumber initReg, bool* pInitRegModified)
 //                                                       start zero initializing memory.
 //    initReg          - A scratch register (that gets set to zero on some platforms).
 //    pInitRegModified - Sets a flag that tells the callee whether or not the initReg register got zeroed.
+//                       'true' if this method sets initReg to non-zero value. Else 'false'.
 //
 void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, bool* pInitRegModified)
 {
@@ -7672,9 +7673,10 @@ void CodeGen::genFnProlog()
 
     /* Choose the register to use for zero initialization */
 
-    regNumber initReg         = REG_SCRATCH; // Unless we find a better register below
-    bool      initRegModified = true;
-    regMaskTP excludeMask     = intRegState.rsCalleeRegArgMaskLiveIn;
+    regNumber initReg    = REG_SCRATCH; // Unless we find a better register below
+    bool initRegModified = true; // Track if initReg holds non-zero value. If 'false' i.e. it holds zero value, then we
+                                 // skip zero initializing it again.
+    regMaskTP excludeMask = intRegState.rsCalleeRegArgMaskLiveIn;
     regMaskTP tempMask;
 
     // We should not use the special PINVOKE registers as the initReg


### PR DESCRIPTION
In #36321, we renamed variable `pInitRegZeroed` to `pInitRegModified` which exposed a problem where the semantics of `genInstrWithConstant` was misintepreted in `genStackPointerAdjustment()` which was further used in `genFnProlog()` to decide whether to skip zero-initialization of `initReg` or not. 
I went through all the relevant methods to double check if this problem doesn't exist. I also updated comments of methods that takes `pInitRegModified` to reflect what value it holds.

I did pmi after my change and I don't see any difference which makes sense because this bug was hit in JITstressregs mode.

Fixes: #39247