### PR TITLE
Revert "Fix FCall implementation collision on ARM64"

### DIFF
--- a/src/coreclr/src/vm/comdependenthandle.cpp
+++ b/src/coreclr/src/vm/comdependenthandle.cpp
@@ -86,9 +86,6 @@ FCIMPL2(VOID, DependentHandle::nSetPrimary, OBJECTHANDLE handle, Object *_primar
 
     _ASSERTE(handle != NULL);
 
-    // Avoid collision with MarshalNative::GCHandleInternalSet
-    FCUnique(0x12);
-
     IGCHandleManager *mgr = GCHandleUtilities::GetGCHandleManager();
     mgr->StoreObjectInHandle(handle, _primary);
 }


### PR DESCRIPTION
Reverts dotnet/runtime#39810

Trying to find out why OSX clients are failing