### PR TITLE
Remove outdated comment in System.CM.Composition.Tests

### DIFF
--- a/src/libraries/System.ComponentModel.Composition/tests/System.ComponentModel.Composition.Tests.csproj
+++ b/src/libraries/System.ComponentModel.Composition/tests/System.ComponentModel.Composition.Tests.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <!-- TODO: Add net472 configuration after OOB package bug is fixed: https://github.com/dotnet/runtime/issues/23497 -->
   <PropertyGroup>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>


### PR DESCRIPTION
We don't plan to add a .NETFramework test configuration for this library anymore.