### PR TITLE
Address slowdowns in type loader performance

### DIFF
--- a/src/coreclr/src/debug/daccess/nidump.cpp
+++ b/src/coreclr/src/debug/daccess/nidump.cpp
@@ -7996,7 +7996,7 @@ void NativeImageDumper::DumpMethodDesc( PTR_MethodDesc md, PTR_Module module )
                               InstantiatedMethodDesc, METHODDESCS );
 
 #ifdef FEATURE_COMINTEROP
-        if (imd->IMD_HasComPlusCallInfo())
+        if (imd->IsGenericComPlusCall())
         {
             PTR_ComPlusCallInfo compluscall = imd->IMD_GetComPlusCallInfo();
             DumpComPlusCallInfo( compluscall, METHODDESCS );

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1184,10 +1184,17 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
         return;
 
     // Step 1: Validate compatibility of return types on overriding methods
-    if (pMT->GetClass()->HasCovariantOverride())
+    if (pMT->GetClass()->HasCovariantOverride() && !pModule->GetReadyToRunInfo()->SkipTypeValidation())
     {
         for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
         {
+            if (pMT->GetRestoredSlot(i) == pParentMT->GetRestoredSlot(i))
+            {
+                // The real check is that the MethodDesc's must not match, but a simple VTable check will
+                // work most of the time, and is far faster than the GetMethodDescForSlot method.
+                _ASSERTE(pMT->GetMethodDescForSlot(i) == pParentMT->GetMethodDescForSlot(i));
+                continue;
+            }
             MethodDesc* pMD = pMT->GetMethodDescForSlot(i);
             MethodDesc* pParentMD = pParentMT->GetMethodDescForSlot(i);
 
@@ -1245,6 +1252,14 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
 
         for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
         {
+            if (pMT->GetRestoredSlot(i) == pParentMT->GetRestoredSlot(i))
+            {
+                // The real check is that the MethodDesc's must not match, but a simple VTable check will
+                // work most of the time, and is far faster than the GetMethodDescForSlot method.
+                _ASSERTE(pMT->GetMethodDescForSlot(i) == pParentMT->GetMethodDescForSlot(i));
+                continue;
+            }
+
             MethodDesc* pMD = pMT->GetMethodDescForSlot(i);
             MethodDesc* pParentMD = pParentMT->GetMethodDescForSlot(i);
             if (pMD == pParentMD)

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1184,7 +1184,7 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
         return;
 
     // Step 1: Validate compatibility of return types on overriding methods
-    if (pMT->GetClass()->HasCovariantOverride() && !pMT->GetModule()->GetReadyToRunInfo()->SkipTypeValidation())
+    if (pMT->GetClass()->HasCovariantOverride() && (!pMT->GetModule()->IsReadyToRun() || !pMT->GetModule()->GetReadyToRunInfo()->SkipTypeValidation()))
     {
         for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
         {

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1184,7 +1184,7 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
         return;
 
     // Step 1: Validate compatibility of return types on overriding methods
-    if (pMT->GetClass()->HasCovariantOverride() && !pModule->GetReadyToRunInfo()->SkipTypeValidation())
+    if (pMT->GetClass()->HasCovariantOverride() && !pMT->GetModule()->GetReadyToRunInfo()->SkipTypeValidation())
     {
         for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
         {

--- a/src/coreclr/src/vm/class.cpp
+++ b/src/coreclr/src/vm/class.cpp
@@ -1184,107 +1184,112 @@ void ClassLoader::ValidateMethodsWithCovariantReturnTypes(MethodTable* pMT)
         return;
 
     // Step 1: Validate compatibility of return types on overriding methods
-
-    for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
+    if (pMT->GetClass()->HasCovariantOverride())
     {
-        MethodDesc* pMD = pMT->GetMethodDescForSlot(i);
-        MethodDesc* pParentMD = pParentMT->GetMethodDescForSlot(i);
-
-        if (pMD == pParentMD)
-            continue;
-
-        if (!pMD->RequiresCovariantReturnTypeChecking() && !pParentMD->RequiresCovariantReturnTypeChecking())
-            continue;
-
-        // If the bit is not set on this method, but we reach here because it's been set on the method at the same slot on
-        // the base type, set the bit for the current method to ensure any future overriding method down the chain gets checked.
-        if (!pMD->RequiresCovariantReturnTypeChecking())
-            pMD->SetRequiresCovariantReturnTypeChecking();
-
-        // The context used to load the return type of the parent method has to use the generic method arguments
-        // of the overriding method, otherwise the type comparison below will not work correctly
-        SigTypeContext context1(pParentMD->GetClassInstantiation(), pMD->GetMethodInstantiation());
-        MetaSig methodSig1(pParentMD);
-        TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
-
-        SigTypeContext context2(pMD);
-        MetaSig methodSig2(pMD);
-        TypeHandle hType2 = methodSig2.GetReturnProps().GetTypeHandleThrowing(pMD->GetModule(), &context2, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
-
-        if (!IsCompatibleWith(hType1, hType2))
+        for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
         {
-            SString strAssemblyName;
-            pMD->GetAssembly()->GetDisplayName(strAssemblyName);
+            MethodDesc* pMD = pMT->GetMethodDescForSlot(i);
+            MethodDesc* pParentMD = pParentMT->GetMethodDescForSlot(i);
 
-            SString strInvalidTypeName;
-            TypeString::AppendType(strInvalidTypeName, TypeHandle(pMD->GetMethodTable()));
+            if (pMD == pParentMD)
+                continue;
 
-            SString strInvalidMethodName;
-            TypeString::AppendMethod(strInvalidMethodName, pMD, pMD->GetMethodInstantiation());
+            if (!pMD->RequiresCovariantReturnTypeChecking() && !pParentMD->RequiresCovariantReturnTypeChecking())
+                continue;
 
-            SString strParentMethodName;
-            TypeString::AppendMethod(strParentMethodName, pParentMD, pParentMD->GetMethodInstantiation());
+            // If the bit is not set on this method, but we reach here because it's been set on the method at the same slot on
+            // the base type, set the bit for the current method to ensure any future overriding method down the chain gets checked.
+            if (!pMD->RequiresCovariantReturnTypeChecking())
+                pMD->SetRequiresCovariantReturnTypeChecking();
 
-            COMPlusThrow(
-                kTypeLoadException,
-                IDS_CLASSLOAD_MI_BADRETURNTYPE,
-                strInvalidMethodName,
-                strInvalidTypeName,
-                strAssemblyName,
-                strParentMethodName);
+            // The context used to load the return type of the parent method has to use the generic method arguments
+            // of the overriding method, otherwise the type comparison below will not work correctly
+            SigTypeContext context1(pParentMD->GetClassInstantiation(), pMD->GetMethodInstantiation());
+            MetaSig methodSig1(pParentMD);
+            TypeHandle hType1 = methodSig1.GetReturnProps().GetTypeHandleThrowing(pParentMD->GetModule(), &context1, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
+
+            SigTypeContext context2(pMD);
+            MetaSig methodSig2(pMD);
+            TypeHandle hType2 = methodSig2.GetReturnProps().GetTypeHandleThrowing(pMD->GetModule(), &context2, ClassLoader::LoadTypesFlag::LoadTypes, CLASS_LOAD_EXACTPARENTS);
+
+            if (!IsCompatibleWith(hType1, hType2))
+            {
+                SString strAssemblyName;
+                pMD->GetAssembly()->GetDisplayName(strAssemblyName);
+
+                SString strInvalidTypeName;
+                TypeString::AppendType(strInvalidTypeName, TypeHandle(pMD->GetMethodTable()));
+
+                SString strInvalidMethodName;
+                TypeString::AppendMethod(strInvalidMethodName, pMD, pMD->GetMethodInstantiation());
+
+                SString strParentMethodName;
+                TypeString::AppendMethod(strParentMethodName, pParentMD, pParentMD->GetMethodInstantiation());
+
+                COMPlusThrow(
+                    kTypeLoadException,
+                    IDS_CLASSLOAD_MI_BADRETURNTYPE,
+                    strInvalidMethodName,
+                    strInvalidTypeName,
+                    strAssemblyName,
+                    strParentMethodName);
+            }
         }
     }
 
     // Step 2: propate overriding MethodImpls to applicable vtable slots if the declaring method has the attribute
 
-    MethodTable::MethodDataWrapper hMTData(MethodTable::GetMethodData(pMT, FALSE));
-
-    for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
+    if (pMT->GetClass()->HasVTableMethodImpl())
     {
-        MethodDesc* pMD = pMT->GetMethodDescForSlot(i);
-        MethodDesc* pParentMD = pParentMT->GetMethodDescForSlot(i);
-        if (pMD == pParentMD)
-            continue;
+        MethodTable::MethodDataWrapper hMTData(MethodTable::GetMethodData(pMT, FALSE));
 
-        // The attribute is only applicable to MethodImpls. For anything else, it will be treated as a no-op
-        if (!pMD->IsMethodImpl())
-            continue;
-
-        // Search if the attribute has been applied on this vtable slot, either by the current MethodImpl, or by a previous
-        // MethodImpl somewhere in the base type hierarchy.
-        bool foundAttribute = false;
-        MethodTable* pCurrentMT = pMT;
-        while (!foundAttribute && pCurrentMT != NULL && i < pCurrentMT->GetNumVirtuals())
+        for (WORD i = 0; i < pParentMT->GetNumVirtuals(); i++)
         {
-            MethodDesc* pCurrentMD = pCurrentMT->GetMethodDescForSlot(i);
+            MethodDesc* pMD = pMT->GetMethodDescForSlot(i);
+            MethodDesc* pParentMD = pParentMT->GetMethodDescForSlot(i);
+            if (pMD == pParentMD)
+                continue;
 
             // The attribute is only applicable to MethodImpls. For anything else, it will be treated as a no-op
-            if (pCurrentMD->IsMethodImpl())
+            if (!pMD->IsMethodImpl())
+                continue;
+
+            // Search if the attribute has been applied on this vtable slot, either by the current MethodImpl, or by a previous
+            // MethodImpl somewhere in the base type hierarchy.
+            bool foundAttribute = false;
+            MethodTable* pCurrentMT = pMT;
+            while (!foundAttribute && pCurrentMT != NULL && i < pCurrentMT->GetNumVirtuals())
             {
-                BYTE* pVal = NULL;
-                ULONG cbVal = 0;
-                if (pCurrentMD->GetCustomAttribute(WellKnownAttribute::PreserveBaseOverridesAttribute, (const void**)&pVal, &cbVal) == S_OK)
-                    foundAttribute = true;
+                MethodDesc* pCurrentMD = pCurrentMT->GetMethodDescForSlot(i);
+
+                // The attribute is only applicable to MethodImpls. For anything else, it will be treated as a no-op
+                if (pCurrentMD->IsMethodImpl())
+                {
+                    BYTE* pVal = NULL;
+                    ULONG cbVal = 0;
+                    if (pCurrentMD->GetCustomAttribute(WellKnownAttribute::PreserveBaseOverridesAttribute, (const void**)&pVal, &cbVal) == S_OK)
+                        foundAttribute = true;
+                }
+
+                pCurrentMT = pCurrentMT->GetParentMethodTable();
             }
 
-            pCurrentMT = pCurrentMT->GetParentMethodTable();
-        }
+            if (!foundAttribute)
+                continue;
 
-        if (!foundAttribute)
-            continue;
-
-        // Search for any vtable slot still pointing at the parent method, and update it with the current overriding method
-        for (WORD j = i; j < pParentMT->GetNumVirtuals(); j++)
-        {
-            MethodDesc* pCurrentMD = pMT->GetMethodDescForSlot(j);
-            if (pCurrentMD == pParentMD)
+            // Search for any vtable slot still pointing at the parent method, and update it with the current overriding method
+            for (WORD j = i; j < pParentMT->GetNumVirtuals(); j++)
             {
-                // This is a vtable slot that needs to be updated to the new overriding method because of the
-                // presence of the attribute.
-                pMT->SetSlot(j, pMT->GetSlot(i));
-                _ASSERT(pMT->GetMethodDescForSlot(j) == pMD);
+                MethodDesc* pCurrentMD = pMT->GetMethodDescForSlot(j);
+                if (pCurrentMD == pParentMD)
+                {
+                    // This is a vtable slot that needs to be updated to the new overriding method because of the
+                    // presence of the attribute.
+                    pMT->SetSlot(j, pMT->GetSlot(i));
+                    _ASSERT(pMT->GetMethodDescForSlot(j) == pMD);
 
-                hMTData->UpdateImplMethodDesc(pMD, j);
+                    hMTData->UpdateImplMethodDesc(pMD, j);
+                }
             }
         }
     }

--- a/src/coreclr/src/vm/class.h
+++ b/src/coreclr/src/vm/class.h
@@ -1158,6 +1158,30 @@ public:
     }
 #endif // FEATURE_COMINTEROP
 
+    inline void SetHasVTableMethodImpl()
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_VMFlags |= VMFLAG_VTABLEMETHODIMPL;
+    }
+
+    inline BOOL HasVTableMethodImpl()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (m_VMFlags & VMFLAG_VTABLEMETHODIMPL);
+    }
+
+    inline void SetHasCovariantOverride()
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_VMFlags |= VMFLAG_COVARIANTOVERRIDE;
+    }
+
+    inline BOOL HasCovariantOverride()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (m_VMFlags & VMFLAG_COVARIANTOVERRIDE);
+    }
+
 #ifdef _DEBUG
     inline DWORD IsDestroyed()
     {
@@ -1691,8 +1715,8 @@ public:
         VMFLAG_HASCOCLASSATTRIB                = 0x01000000,
         VMFLAG_COMEVENTITFMASK                 = 0x02000000, // class is a special COM event interface
 #endif // FEATURE_COMINTEROP
-        // unused                              = 0x04000000,
-        // unused                              = 0x08000000,
+        VMFLAG_VTABLEMETHODIMPL                = 0x04000000, // class uses MethodImpl to override virtual function defined on class
+        VMFLAG_COVARIANTOVERRIDE               = 0x08000000, // class has a covariant override
 
         // This one indicates that the fields of the valuetype are
         // not tightly packed and is used to check whether we can

--- a/src/coreclr/src/vm/method.inl
+++ b/src/coreclr/src/vm/method.inl
@@ -133,11 +133,14 @@ inline BOOL MethodDesc::IsQCall()
 FORCEINLINE DWORD MethodDesc::IsGenericComPlusCall()
 {
     LIMITED_METHOD_CONTRACT;
-    return (mcInstantiated == GetClassification() && AsInstantiatedMethodDesc()->IMD_HasComPlusCallInfo());
+    return m_wFlags & mdcHasComPlusCallInfo;
 }
+
 inline void MethodDesc::SetupGenericComPlusCall()
 {
     LIMITED_METHOD_CONTRACT;
+    m_wFlags |= mdcHasComPlusCallInfo;
+
     AsInstantiatedMethodDesc()->IMD_SetupGenericComPlusCall();
 }
 #endif // FEATURE_COMINTEROP

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -2410,6 +2410,7 @@ MethodTableBuilder::EnumerateMethodImpls()
 
                         compatibleSignatures = TRUE;
                         bmtMetaData->rgMethodImplTokens[i].fRequiresCovariantReturnTypeChecking = true;
+                        bmtMetaData->fHasCovariantOverride = true;
                     }
                 }
 
@@ -5680,6 +5681,17 @@ MethodTableBuilder::ProcessMethodImpls()
                         }
 
                         Substitution *pDeclSubst = &bmtMetaData->pMethodDeclSubsts[m];
+                        if (bmtMetaData->fHasCovariantOverride)
+                            GetHalfBakedClass()->SetHasCovariantOverride();
+                        if (GetParentMethodTable() != NULL)
+                        {
+                            auto parentClass = GetParentMethodTable()->GetClass();
+                            if (parentClass->HasCovariantOverride())
+                                GetHalfBakedClass()->SetHasCovariantOverride();
+                            if (parentClass->HasVTableMethodImpl())
+                                GetHalfBakedClass()->SetHasVTableMethodImpl();
+                        }
+                        
                         MethodTable * pDeclMT = NULL;
                         MethodSignature declSig(GetModule(), szName, pSig, cbSig, NULL);
 
@@ -5784,6 +5796,7 @@ MethodTableBuilder::ProcessMethodImpls()
                             }
                             else
                             {
+                                GetHalfBakedClass()->SetHasVTableMethodImpl();
                                 declMethod = FindDeclMethodOnClassInHierarchy(it, pDeclMT, declSig);
                             }
 

--- a/src/coreclr/src/vm/methodtablebuilder.cpp
+++ b/src/coreclr/src/vm/methodtablebuilder.cpp
@@ -5590,6 +5590,19 @@ MethodTableBuilder::ProcessMethodImpls()
 {
     STANDARD_VM_CONTRACT;
 
+    if (bmtMetaData->fHasCovariantOverride)
+    {
+        GetHalfBakedClass()->SetHasCovariantOverride();
+    }
+    if (GetParentMethodTable() != NULL)
+    {
+        EEClass* parentClass = GetParentMethodTable()->GetClass();
+        if (parentClass->HasCovariantOverride())
+            GetHalfBakedClass()->SetHasCovariantOverride();
+        if (parentClass->HasVTableMethodImpl())
+            GetHalfBakedClass()->SetHasVTableMethodImpl();
+    }
+
     if (bmtMethod->dwNumberMethodImpls == 0)
         return;
 
@@ -5681,16 +5694,6 @@ MethodTableBuilder::ProcessMethodImpls()
                         }
 
                         Substitution *pDeclSubst = &bmtMetaData->pMethodDeclSubsts[m];
-                        if (bmtMetaData->fHasCovariantOverride)
-                            GetHalfBakedClass()->SetHasCovariantOverride();
-                        if (GetParentMethodTable() != NULL)
-                        {
-                            auto parentClass = GetParentMethodTable()->GetClass();
-                            if (parentClass->HasCovariantOverride())
-                                GetHalfBakedClass()->SetHasCovariantOverride();
-                            if (parentClass->HasVTableMethodImpl())
-                                GetHalfBakedClass()->SetHasVTableMethodImpl();
-                        }
                         
                         MethodTable * pDeclMT = NULL;
                         MethodSignature declSig(GetModule(), szName, pSig, cbSig, NULL);

--- a/src/coreclr/src/vm/methodtablebuilder.h
+++ b/src/coreclr/src/vm/methodtablebuilder.h
@@ -2284,11 +2284,11 @@ private:
     class DeclaredMethodIterator
     {
       private:
-        int                 m_numDeclaredMethods;
-        bmtMDMethod       **m_declaredMethods;
-        int                 m_idx; // not SLOT_INDEX?
+        const int            m_numDeclaredMethods;
+        bmtMDMethod ** const m_declaredMethods;
+        int                  m_idx; // not SLOT_INDEX?
 #ifdef _DEBUG
-        bmtMDMethod *       m_debug_pMethod;
+        bmtMDMethod *        m_debug_pMethod;
 #endif
 
       public:

--- a/src/coreclr/src/vm/methodtablebuilder.h
+++ b/src/coreclr/src/vm/methodtablebuilder.h
@@ -2006,6 +2006,8 @@ private:
         MethodImplTokenPair *rgMethodImplTokens;
         Substitution *pMethodDeclSubsts;    // Used to interpret generic variables in the interface of the declaring type
 
+        bool fHasCovariantOverride;
+
         //-----------------------------------------------------------------------------------------
         inline bmtMetaDataInfo() { LIMITED_METHOD_CONTRACT; memset((void *)this, NULL, sizeof(*this)); }
     };  // struct bmtMetaDataInfo
@@ -2282,7 +2284,8 @@ private:
     class DeclaredMethodIterator
     {
       private:
-        MethodTableBuilder &m_mtb;
+        int                 m_numDeclaredMethods;
+        bmtMDMethod       **m_declaredMethods;
         int                 m_idx; // not SLOT_INDEX?
 #ifdef _DEBUG
         bmtMDMethod *       m_debug_pMethod;

--- a/src/coreclr/src/vm/methodtablebuilder.inl
+++ b/src/coreclr/src/vm/methodtablebuilder.inl
@@ -15,7 +15,10 @@
 
 //***************************************************************************************
 inline MethodTableBuilder::DeclaredMethodIterator::DeclaredMethodIterator(
-            MethodTableBuilder &mtb) : m_mtb(mtb), m_idx(-1)
+            MethodTableBuilder &mtb) : 
+                m_numDeclaredMethods((int)mtb.NumDeclaredMethods()),
+                m_declaredMethods(mtb.bmtMethod->m_rgDeclaredMethods),
+                m_idx(-1)
 {
     LIMITED_METHOD_CONTRACT;
 }
@@ -24,7 +27,7 @@ inline MethodTableBuilder::DeclaredMethodIterator::DeclaredMethodIterator(
 inline int MethodTableBuilder::DeclaredMethodIterator::CurrentIndex()
 {
     LIMITED_METHOD_CONTRACT;
-    CONSISTENCY_CHECK_MSG(0 <= m_idx && m_idx < (int)m_mtb.NumDeclaredMethods(),
+    CONSISTENCY_CHECK_MSG(0 <= m_idx && m_idx < m_numDeclaredMethods,
                           "Invalid iterator state.");
     return m_idx;
 }
@@ -33,7 +36,7 @@ inline int MethodTableBuilder::DeclaredMethodIterator::CurrentIndex()
 inline BOOL MethodTableBuilder::DeclaredMethodIterator::Next()
 {
     LIMITED_METHOD_CONTRACT;
-    if (m_idx + 1 >= (int)m_mtb.NumDeclaredMethods())
+    if (m_idx + 1 >= m_numDeclaredMethods)
         return FALSE;
     m_idx++;
     INDEBUG(m_debug_pMethod = GetMDMethod();)
@@ -55,7 +58,7 @@ inline BOOL MethodTableBuilder::DeclaredMethodIterator::Prev()
 inline void MethodTableBuilder::DeclaredMethodIterator::ResetToEnd()
 {
     LIMITED_METHOD_CONTRACT;
-    m_idx = (int)m_mtb.NumDeclaredMethods();
+    m_idx = m_numDeclaredMethods;
 }
 
 //***************************************************************************************
@@ -130,7 +133,7 @@ MethodTableBuilder::DeclaredMethodIterator::GetMDMethod() const
 {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(FitsIn<SLOT_INDEX>(m_idx)); // Review: m_idx should probably _be_ a SLOT_INDEX, but that asserts.
-    return (*m_mtb.bmtMethod)[static_cast<SLOT_INDEX>(m_idx)];
+    return m_declaredMethods[m_idx];
 }
 
 //*******************************************************************************

--- a/src/coreclr/src/vm/siginfo.cpp
+++ b/src/coreclr/src/vm/siginfo.cpp
@@ -1288,7 +1288,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                 pGenericTypeModule = pModule;
             }
 
-            TypeHandle genericType = psig.GetGenericInstType(pModule, fLoadTypes, level, pZapSigContext);
+            TypeHandle genericType = psig.GetGenericInstType(pModule, fLoadTypes, CLASS_LOAD_APPROXPARENTS, pZapSigContext);
 
             if (genericType.IsNull())
             {

--- a/src/coreclr/src/vm/siginfo.cpp
+++ b/src/coreclr/src/vm/siginfo.cpp
@@ -1288,7 +1288,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                 pGenericTypeModule = pModule;
             }
 
-            TypeHandle genericType = psig.GetGenericInstType(pModule, fLoadTypes, CLASS_LOAD_APPROXPARENTS, pZapSigContext);
+            TypeHandle genericType = psig.GetGenericInstType(pModule, fLoadTypes, level < CLASS_LOAD_APPROXPARENTS ? level : CLASS_LOAD_APPROXPARENTS, pZapSigContext);
 
             if (genericType.IsNull())
             {


### PR DESCRIPTION
- Add flags to `MethodTable` allow the runtime to avoid all of the work in the `ValidateMethodsWithCovariantReturnTypes` function
  - This is by far the most significant performance improvement here
- Reduce the load level required when parsing a generic instance signature when finding the open type definition
  - This reduces type load events by a small margin
- Tweak the handling of ComPlusCallInfo and HasNativeCodeSlot flags so that MethodDesc::SizeOf can be more efficient
  - Iterating through `MethodDesc` structures via both the Declared and Introduced method iterators shows that the codegen is better in this path
  - Performance improvement is small though, as most of the cost is due to memory access cost.
- Reduce indirections required in iterating through the `DeclaredMethodIterator` by pulling the necessary details into the iterator at constructor time

Partially addresses issue #13339 