### PR TITLE
Extend Linker test job timeout to 2 hours

### DIFF
--- a/eng/pipelines/runtime-linker-tests.yml
+++ b/eng/pipelines/runtime-linker-tests.yml
@@ -64,6 +64,7 @@ jobs:
     - Linux_x64
     jobParameters:
       testGroup: innerloop
+      timeoutInMinutes: 120
       nameSuffix: Runtime_Release
       buildArgs: -s clr+libs -c $(_BuildConfig)
       extraStepsTemplate: /eng/pipelines/libraries/execute-trimming-tests-steps.yml


### PR DESCRIPTION
@safern 

Ideally, we will want to also make the trimming tests run in parallel but for now, we are at least extending the timeout given that we have a few builds where building is a bit slower and the job is timing out.