### PR TITLE
Replaced string.Compare with Buffer.EndsWith to fix #39140

### DIFF
--- a/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/src/StringSegment.cs
@@ -310,15 +310,14 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
             }
 
-            bool result = false;
-            int textLength = text.Length;
-
-            if (HasValue && Length >= textLength)
+            if (HasValue)
             {
-                result = string.Compare(Buffer, Offset, text, 0, textLength, comparisonType) == 0;
+                return this.AsSpan().StartsWith(text.AsSpan(), comparisonType);
             }
-
-            return result;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>
@@ -338,16 +337,14 @@ namespace Microsoft.Extensions.Primitives
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.text);
             }
 
-            bool result = false;
-            int textLength = text.Length;
-            int comparisonLength = Offset + Length - textLength;
-
-            if (HasValue && comparisonLength > 0)
+            if (HasValue)
             {
-                result = string.Compare(Buffer, comparisonLength, text, 0, textLength, comparisonType) == 0;
+                return this.AsSpan().EndsWith(text.AsSpan(), comparisonType);
             }
-
-            return result;
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
+++ b/src/libraries/Microsoft.Extensions.Primitives/tests/StringSegmentTest.cs
@@ -259,6 +259,19 @@ namespace Microsoft.Extensions.Primitives
         }
 
         [Fact]
+        public void StringSegment_EndsWith_Slash()
+        {
+            // Arrange
+            var segment = new StringSegment("/");
+
+            // Act
+            var result = segment.EndsWith("/", StringComparison.Ordinal);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
         public void StringSegment_EndsWith_Invalid()
         {
             // Arrange
@@ -584,6 +597,32 @@ namespace Microsoft.Extensions.Primitives
 
             // Assert
             Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public void StringSegment_Equals_InvariantCultureIgnoreCase()
+        {
+            // Arrange
+            var segment = new StringSegment("xaex", 1, 2);
+
+            // Act
+            var result = segment.Equals("\u00C6", StringComparison.InvariantCultureIgnoreCase);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void StringSegment_Equals_InvariantCultureIgnoreCase_StringSegment()
+        {
+            // Arrange
+            var segment = new StringSegment("xaex", 1, 2);
+
+            // Act
+            var result = segment.Equals(new StringSegment("\u00C6"), StringComparison.InvariantCultureIgnoreCase);
+
+            // Assert
+            Assert.True(result);
         }
 
         [Fact]


### PR DESCRIPTION
Replaced string.Compare with Buffer.EndsWith/StartsWith in both
StringSegment.EndsWith and StringSegment.StartsWith.
string.Compare caused issues in StringSegment.EndsWith when the Buffer
is only one character long.
Replaced string.Compare in StringSegment.StartsWith as well to make
both StartsWith and EndsWith function similarly.

EDIT: As @GrabYourPitchforks already said in that issue, both of those shouldn't be using string.Compare.

Fix #39140