### PR TITLE
[Infra] Add ABORT based dumps back for macOS

### DIFF
--- a/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/src/tests/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -60,6 +60,15 @@ namespace CoreclrTestLib
         public static extern bool Process32NextW(IntPtr snapshot, ref ProcessEntry32W entry);
     }
 
+    static class libSystem
+    {
+        [DllImport(nameof(libSystem))]
+        public static extern int kill(int pid, int signal);
+
+        public const int SIGABRT = 0x6;
+    }
+
+
     static class libproc
     {
         [DllImport(nameof(libproc))]
@@ -205,6 +214,33 @@ namespace CoreclrTestLib
 
         static bool CollectCrashDump(Process process, string path)
         {
+            // special case for macOS to collect a dump that contains native information.
+            // createdump (as of this commit) does not collect native information in the
+            // dumps it collects and therefore can't be debugged using lldb.  It collects
+            // elf dumps that contain all the managed information needed to light up
+            // `dotnet-dump analyze`, but that prevents mac LLDB from being able to debug
+            // them.  Conversely, dotnet-dump and lldb cannot get managed information from
+            // a mach based dump (what the ABORT produces).  Due to this, we collect both in
+            // case someone needs native or managed.
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                int pid = process.Id;
+                Console.WriteLine($"Aborting process {pid} to generate dump");
+                int status = libSystem.kill(pid, libSystem.SIGABRT);
+
+                string defaultCoreDumpPath = $"/cores/core.{pid}";
+
+                if (status == 0 && File.Exists(defaultCoreDumpPath))
+                {
+                    Console.WriteLine($"Moving dump for {pid} to {path}.");
+                    File.Move(defaultCoreDumpPath, path + ".native", true);
+                }
+                else
+                {
+                    Console.WriteLine($"Unable to find OS-generated dump for {pid} at default path: {defaultCoreDumpPath}");
+                }
+            }
+
             ProcessStartInfo createdumpInfo = null;
             string coreRoot = Environment.GetEnvironmentVariable("CORE_ROOT");
             string createdumpPath = Path.Combine(coreRoot, "createdump");

--- a/src/tests/tracing/eventpipe/FAKETEST/FAKETEST.cs
+++ b/src/tests/tracing/eventpipe/FAKETEST/FAKETEST.cs
@@ -1,0 +1,83 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Diagnostics.Tools.RuntimeClient;
+using Tracing.Tests.Common;
+using System.Text;
+using System.Threading;
+using System.IO;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.Tests.ReverseValidation
+{
+    public class ReverseValidation
+    {
+        public static async Task<bool> TEST_RuntimeIsResilientToServerClosing()
+        {
+            bool fSuccess = true;
+            string serverName = ReverseServer.MakeServerAddress();
+            Logger.logger.Log($"Server name is '{serverName}'");
+            Task<bool> subprocessTask = Utils.RunSubprocess(
+                currentAssembly: Assembly.GetExecutingAssembly(),
+                environment: new Dictionary<string,string> 
+                {
+                    { Utils.DiagnosticsMonitorAddressEnvKey, serverName },
+                    { Utils.DiagnosticsMonitorPauseOnStartEnvKey, "0" }
+                },
+                duringExecution: async (_) =>
+                {
+                    // Just wait longer than the 10 minute timeout
+                    await Task.Delay(TimeSpan.FromMinutes(20));
+                }
+            );
+
+            // Test should purposefully timeout here
+            fSuccess &= await subprocessTask;
+
+            return fSuccess;
+        }
+
+        public static async Task<int> Main(string[] args)
+        {
+            if (args.Length >= 1)
+            {
+                Console.Out.WriteLine("Subprocess started!  Waiting for input...");
+                var input = Console.In.ReadLine(); // will block until data is sent across stdin
+                Console.Out.WriteLine($"Received '{input}'.  Exiting...");
+                return 0;
+            }
+
+            bool fSuccess = true;
+            if (!IpcTraceTest.EnsureCleanEnvironment())
+                return -1;
+            IEnumerable<MethodInfo> tests = typeof(ReverseValidation).GetMethods().Where(mi => mi.Name.StartsWith("TEST_"));
+            foreach (var test in tests)
+            {
+                Logger.logger.Log($"PID: {System.Diagnostics.Process.GetCurrentProcess().Id}");
+                Logger.logger.Log($"::== Running test: {test.Name}");
+                bool result = true;
+                try
+                {
+                    result = await (Task<bool>)test.Invoke(null, new object[] {});
+                }
+                catch (Exception e)
+                {
+                    result = false;
+                    Logger.logger.Log(e.ToString());
+                }
+                fSuccess &= result;
+                Logger.logger.Log($"Test passed: {result}");
+                Logger.logger.Log($"");
+
+            }
+            return fSuccess ? 100 : -1;
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/FAKETEST/FAKETEST.csproj
+++ b/src/tests/tracing/eventpipe/FAKETEST/FAKETEST.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CLRTestPriority>0</CLRTestPriority>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/38524 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Recently discovered that the dumps generated `createdump` on mac are _only_ debuggable in `dotnet-dump analyze` and _only_ contain the necessary information to inspect managed code.  This is due to `createdump` generating an ELF dump on a macOS system which typically would have a MACH format dump.  This means that the `createdump` dump can't be debugged under LLDB to inspect native information.  The previous version of the dumping logic invoked a `SIGABRT` causing the system to generate the core dump in the MACH format.  This dump could be inspected under LLDB for native information, but could not be used to inspect managed information since SOS doesn't know how to unwind a MACH coredump.

To combat this, I'm adding back in the `SIGABRT` mechanism for macOS _in addition to_ the `createdump` mechanism.  This unfortunately results in 2x the dumps on macOS, but also allows us to be able to triage managed code or native code.

I'm open to switching entirely to one or the other with a small preference for _just_ the `SIGABRT` mechanism due to native code usually being the thing needing triaging for `coreclr` tests.  Once `createdump`/`SOS` have a MACH format dumper and reader, we could rely solely on `createdump` on macOS.

CC @tommcdon  