### PR TITLE
[wasm] Fix Environment.StackTrace on WASM

### DIFF
--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -1830,6 +1830,7 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 
 	g_assert (skip >= 0);
 
+#ifndef TARGET_WASM
 	if (mono_llvm_only) {
 		GSList *l, *ips;
 		MonoDomain *frame_domain;
@@ -1859,7 +1860,9 @@ ves_icall_get_frame_info (gint32 skip, MonoBoolean need_file_info,
 		/* No way to resolve generic instances */
 		actual_method = jmethod;
 		*native_offset = frame_ip - (guint8*)ji->code_start;
-	} else {
+	} else
+#endif
+	{
 		mono_arch_flush_register_windows ();
 		MONO_INIT_CONTEXT_FROM_FUNC (&ctx, ves_icall_get_frame_info);
 


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20156,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>Don't try to use get_unwind_backtrace because _Unwind_Backtrace is not available on wasm.

Fixes https://github.com/dotnet/runtime/issues/39223
Fixes https://github.com/dotnet/runtime/issues/39341

