### PR TITLE
Add BinaryFormatter auditing EventSource

### DIFF
--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System.Runtime.Serialization.Formatters.csproj
@@ -61,6 +61,7 @@
     <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryFormatter.cs" />
     <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryFormatter.Core.cs" Condition="'$(TargetsBrowser)' != 'true'" />
     <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryFormatter.PlatformNotSupported.cs" Condition="'$(TargetsBrowser)' == 'true'" />
+    <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryFormatterEventSource.cs" />
     <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryFormatterWriter.cs" />
     <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryObjectInfo.cs" />
     <Compile Include="System\Runtime\Serialization\Formatters\Binary\BinaryObjectReader.cs" />

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.Core.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.Core.cs
@@ -39,7 +39,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             };
             try
             {
-                BinaryFormatterEventSource.Log.DeserializationStarted();
+                BinaryFormatterEventSource.Log.DeserializationStart();
                 var parser = new BinaryParser(serializationStream, reader);
                 return reader.Deserialize(parser);
             }
@@ -53,7 +53,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             }
             finally
             {
-                BinaryFormatterEventSource.Log.DeserializationEnded();
+                BinaryFormatterEventSource.Log.DeserializationStop();
             }
         }
 
@@ -80,7 +80,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
             try
             {
-                BinaryFormatterEventSource.Log.SerializationStarted();
+                BinaryFormatterEventSource.Log.SerializationStart();
                 var sow = new ObjectWriter(_surrogates, _context, formatterEnums, _binder);
                 BinaryFormatterWriter binaryWriter = new BinaryFormatterWriter(serializationStream, sow, _typeFormat);
                 sow.Serialize(graph, binaryWriter);
@@ -88,7 +88,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             }
             finally
             {
-                BinaryFormatterEventSource.Log.SerializationEnded();
+                BinaryFormatterEventSource.Log.SerializationStop();
             }
         }
     }

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.Core.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatter.Core.cs
@@ -39,6 +39,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             };
             try
             {
+                BinaryFormatterEventSource.Log.DeserializationStarted();
                 var parser = new BinaryParser(serializationStream, reader);
                 return reader.Deserialize(parser);
             }
@@ -49,6 +50,10 @@ namespace System.Runtime.Serialization.Formatters.Binary
             catch (Exception e)
             {
                 throw new SerializationException(SR.Serialization_CorruptedStream, e);
+            }
+            finally
+            {
+                BinaryFormatterEventSource.Log.DeserializationEnded();
             }
         }
 
@@ -73,10 +78,18 @@ namespace System.Runtime.Serialization.Formatters.Binary
                 _assemblyFormat = _assemblyFormat,
             };
 
-            var sow = new ObjectWriter(_surrogates, _context, formatterEnums, _binder);
-            BinaryFormatterWriter binaryWriter = new BinaryFormatterWriter(serializationStream, sow, _typeFormat);
-            sow.Serialize(graph, binaryWriter);
-            _crossAppDomainArray = sow._crossAppDomainArray;
+            try
+            {
+                BinaryFormatterEventSource.Log.SerializationStarted();
+                var sow = new ObjectWriter(_surrogates, _context, formatterEnums, _binder);
+                BinaryFormatterWriter binaryWriter = new BinaryFormatterWriter(serializationStream, sow, _typeFormat);
+                sow.Serialize(graph, binaryWriter);
+                _crossAppDomainArray = sow._crossAppDomainArray;
+            }
+            finally
+            {
+                BinaryFormatterEventSource.Log.SerializationEnded();
+            }
         }
     }
 }

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
@@ -12,11 +12,11 @@ namespace System.Runtime.Serialization.Formatters.Binary
         LocalizationResources = "FxResources.System.Runtime.Serialization.Formatters.SR")]
     internal sealed class BinaryFormatterEventSource : EventSource
     {
-        private const int EventId_SerializationStarted = 10;
-        private const int EventId_SerializationEnded = 11;
+        private const int EventId_SerializationStart = 10;
+        private const int EventId_SerializationStop = 11;
         private const int EventId_SerializingObject = 12;
-        private const int EventId_DeserializationStarted = 20;
-        private const int EventId_DeserializationEnded = 21;
+        private const int EventId_DeserializationStart = 20;
+        private const int EventId_DeserializationStop = 21;
         private const int EventId_DeserializingObject = 22;
 
         // Used to keep track of whether a write operation is in progress. It's
@@ -31,15 +31,15 @@ namespace System.Runtime.Serialization.Formatters.Binary
         {
         }
 
-        [Event(EventId_SerializationStarted, Opcode = EventOpcode.Start, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
-        public void SerializationStarted()
+        [Event(EventId_SerializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
+        public void SerializationStart()
         {
             if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
             {
                 try
                 {
                     _writeInProgress.Value = true;
-                    WriteEvent(EventId_SerializationStarted);
+                    WriteEvent(EventId_SerializationStart);
                 }
                 finally
                 {
@@ -48,15 +48,15 @@ namespace System.Runtime.Serialization.Formatters.Binary
             }
         }
 
-        [Event(EventId_SerializationEnded, Opcode = EventOpcode.Stop, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
-        public void SerializationEnded()
+        [Event(EventId_SerializationStop, Opcode = EventOpcode.Stop, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
+        public void SerializationStop()
         {
             if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
             {
                 try
                 {
                     _writeInProgress.Value = true;
-                    WriteEvent(EventId_SerializationEnded);
+                    WriteEvent(EventId_SerializationStop);
                 }
                 finally
                 {
@@ -90,15 +90,15 @@ namespace System.Runtime.Serialization.Formatters.Binary
             WriteEvent(EventId_SerializingObject, typeName);
         }
 
-        [Event(EventId_DeserializationStarted, Opcode = EventOpcode.Start, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
-        public void DeserializationStarted()
+        [Event(EventId_DeserializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
+        public void DeserializationStart()
         {
             if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
             {
                 try
                 {
                     _writeInProgress.Value = true;
-                    WriteEvent(EventId_DeserializationStarted);
+                    WriteEvent(EventId_DeserializationStart);
                 }
                 finally
                 {
@@ -107,15 +107,15 @@ namespace System.Runtime.Serialization.Formatters.Binary
             }
         }
 
-        [Event(EventId_DeserializationEnded, Opcode = EventOpcode.Stop, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
-        public void DeserializationEnded()
+        [Event(EventId_DeserializationStop, Opcode = EventOpcode.Stop, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
+        public void DeserializationStop()
         {
             if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
             {
                 try
                 {
                     _writeInProgress.Value = true;
-                    WriteEvent(EventId_DeserializationEnded);
+                    WriteEvent(EventId_DeserializationStop);
                 }
                 finally
                 {

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
@@ -1,0 +1,158 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading;
+
+namespace System.Runtime.Serialization.Formatters.Binary
+{
+    [EventSource(
+        Name = "System.Runtime.Serialization.Formatters.Binary.BinaryFormatterEventSource",
+        LocalizationResources = "FxResources.System.Runtime.Serialization.Formatters.SR")]
+    internal sealed class BinaryFormatterEventSource : EventSource
+    {
+        private const int EventId_SerializationStarted = 10;
+        private const int EventId_SerializationEnded = 11;
+        private const int EventId_SerializingObject = 12;
+        private const int EventId_DeserializationStarted = 20;
+        private const int EventId_DeserializationEnded = 21;
+        private const int EventId_DeserializingObject = 22;
+
+        // Used to keep track of whether a write operation is in progress. It's
+        // possible the listener itself uses BinaryFormatter to write to a log,
+        // and if this is the case we suppress our own logging events so that we
+        // enter an infinite recursion scenario.
+        private static readonly AsyncLocal<bool> _writeInProgress = new AsyncLocal<bool>();
+
+        public static readonly BinaryFormatterEventSource Log = new BinaryFormatterEventSource();
+
+        private BinaryFormatterEventSource()
+        {
+        }
+
+        [Event(EventId_SerializationStarted, Opcode = EventOpcode.Start, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
+        public void SerializationStarted()
+        {
+            if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
+            {
+                try
+                {
+                    _writeInProgress.Value = true;
+                    WriteEvent(EventId_SerializationStarted);
+                }
+                finally
+                {
+                    _writeInProgress.Value = false;
+                }
+            }
+        }
+
+        [Event(EventId_SerializationEnded, Opcode = EventOpcode.Stop, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
+        public void SerializationEnded()
+        {
+            if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
+            {
+                try
+                {
+                    _writeInProgress.Value = true;
+                    WriteEvent(EventId_SerializationEnded);
+                }
+                finally
+                {
+                    _writeInProgress.Value = false;
+                }
+            }
+        }
+
+        [NonEvent]
+        public void SerializingObject(Type type)
+        {
+            Debug.Assert(type != null);
+
+            if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
+            {
+                try
+                {
+                    _writeInProgress.Value = true;
+                    SerializingObject(type.AssemblyQualifiedName);
+                }
+                finally
+                {
+                    _writeInProgress.Value = false;
+                }
+            }
+        }
+
+        [Event(EventId_SerializingObject, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
+        private void SerializingObject(string? typeName)
+        {
+            WriteEvent(EventId_SerializingObject, typeName);
+        }
+
+        [Event(EventId_DeserializationStarted, Opcode = EventOpcode.Start, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
+        public void DeserializationStarted()
+        {
+            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
+            {
+                try
+                {
+                    _writeInProgress.Value = true;
+                    WriteEvent(EventId_DeserializationStarted);
+                }
+                finally
+                {
+                    _writeInProgress.Value = false;
+                }
+            }
+        }
+
+        [Event(EventId_DeserializationEnded, Opcode = EventOpcode.Stop, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
+        public void DeserializationEnded()
+        {
+            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
+            {
+                try
+                {
+                    _writeInProgress.Value = true;
+                    WriteEvent(EventId_DeserializationEnded);
+                }
+                finally
+                {
+                    _writeInProgress.Value = false;
+                }
+            }
+        }
+
+        [NonEvent]
+        public void DeserializingObject(Type type)
+        {
+            Debug.Assert(type != null);
+
+            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
+            {
+                try
+                {
+                    _writeInProgress.Value = true;
+                    DeserializingObject(type.AssemblyQualifiedName);
+                }
+                finally
+                {
+                    _writeInProgress.Value = false;
+                }
+            }
+        }
+
+        [Event(EventId_DeserializingObject, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
+        private void DeserializingObject(string? typeName)
+        {
+            WriteEvent(EventId_DeserializingObject, typeName);
+        }
+
+        public class Keywords
+        {
+            public const EventKeywords Serialization = (EventKeywords)1;
+            public const EventKeywords Deserialization = (EventKeywords)2;
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
@@ -8,8 +8,7 @@ using System.Threading;
 namespace System.Runtime.Serialization.Formatters.Binary
 {
     [EventSource(
-        Name = "System.Runtime.Serialization.Formatters.Binary.BinaryFormatterEventSource",
-        LocalizationResources = "FxResources.System.Runtime.Serialization.Formatters.SR")]
+        Name = "System.Runtime.Serialization.Formatters.Binary.BinaryFormatterEventSource")]
     internal sealed class BinaryFormatterEventSource : EventSource
     {
         private const int EventId_SerializationStart = 10;

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
@@ -23,7 +23,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
         {
         }
 
-        [Event(EventId_SerializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
+        [Event(EventId_SerializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Serialization, Level = EventLevel.Informational, ActivityOptions = EventActivityOptions.Recursive)]
         public void SerializationStart()
         {
             if (IsEnabled(EventLevel.Informational, Keywords.Serialization))
@@ -58,7 +58,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
             WriteEvent(EventId_SerializingObject, typeName);
         }
 
-        [Event(EventId_DeserializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
+        [Event(EventId_DeserializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Deserialization, Level = EventLevel.Informational, ActivityOptions = EventActivityOptions.Recursive)]
         public void DeserializationStart()
         {
             if (IsEnabled(EventLevel.Informational, Keywords.Deserialization))

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryFormatterEventSource.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Threading;
 
 namespace System.Runtime.Serialization.Formatters.Binary
 {
@@ -18,12 +17,6 @@ namespace System.Runtime.Serialization.Formatters.Binary
         private const int EventId_DeserializationStop = 21;
         private const int EventId_DeserializingObject = 22;
 
-        // Used to keep track of whether a write operation is in progress. It's
-        // possible the listener itself uses BinaryFormatter to write to a log,
-        // and if this is the case we suppress our own logging events so that we
-        // enter an infinite recursion scenario.
-        private static readonly AsyncLocal<bool> _writeInProgress = new AsyncLocal<bool>();
-
         public static readonly BinaryFormatterEventSource Log = new BinaryFormatterEventSource();
 
         private BinaryFormatterEventSource()
@@ -33,34 +26,18 @@ namespace System.Runtime.Serialization.Formatters.Binary
         [Event(EventId_SerializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
         public void SerializationStart()
         {
-            if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
+            if (IsEnabled(EventLevel.Informational, Keywords.Serialization))
             {
-                try
-                {
-                    _writeInProgress.Value = true;
-                    WriteEvent(EventId_SerializationStart);
-                }
-                finally
-                {
-                    _writeInProgress.Value = false;
-                }
+                WriteEvent(EventId_SerializationStart);
             }
         }
 
         [Event(EventId_SerializationStop, Opcode = EventOpcode.Stop, Keywords = Keywords.Serialization, Level = EventLevel.Informational)]
         public void SerializationStop()
         {
-            if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
+            if (IsEnabled(EventLevel.Informational, Keywords.Serialization))
             {
-                try
-                {
-                    _writeInProgress.Value = true;
-                    WriteEvent(EventId_SerializationStop);
-                }
-                finally
-                {
-                    _writeInProgress.Value = false;
-                }
+                WriteEvent(EventId_SerializationStop);
             }
         }
 
@@ -69,17 +46,9 @@ namespace System.Runtime.Serialization.Formatters.Binary
         {
             Debug.Assert(type != null);
 
-            if (IsEnabled(EventLevel.Informational, Keywords.Serialization) && !_writeInProgress.Value)
+            if (IsEnabled(EventLevel.Informational, Keywords.Serialization))
             {
-                try
-                {
-                    _writeInProgress.Value = true;
-                    SerializingObject(type.AssemblyQualifiedName);
-                }
-                finally
-                {
-                    _writeInProgress.Value = false;
-                }
+                SerializingObject(type.AssemblyQualifiedName);
             }
         }
 
@@ -92,34 +61,18 @@ namespace System.Runtime.Serialization.Formatters.Binary
         [Event(EventId_DeserializationStart, Opcode = EventOpcode.Start, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
         public void DeserializationStart()
         {
-            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
+            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization))
             {
-                try
-                {
-                    _writeInProgress.Value = true;
-                    WriteEvent(EventId_DeserializationStart);
-                }
-                finally
-                {
-                    _writeInProgress.Value = false;
-                }
+                WriteEvent(EventId_DeserializationStart);
             }
         }
 
         [Event(EventId_DeserializationStop, Opcode = EventOpcode.Stop, Keywords = Keywords.Deserialization, Level = EventLevel.Informational)]
         public void DeserializationStop()
         {
-            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
+            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization))
             {
-                try
-                {
-                    _writeInProgress.Value = true;
-                    WriteEvent(EventId_DeserializationStop);
-                }
-                finally
-                {
-                    _writeInProgress.Value = false;
-                }
+                WriteEvent(EventId_DeserializationStop);
             }
         }
 
@@ -128,17 +81,9 @@ namespace System.Runtime.Serialization.Formatters.Binary
         {
             Debug.Assert(type != null);
 
-            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization) && !_writeInProgress.Value)
+            if (IsEnabled(EventLevel.Informational, Keywords.Deserialization))
             {
-                try
-                {
-                    _writeInProgress.Value = true;
-                    DeserializingObject(type.AssemblyQualifiedName);
-                }
-                finally
-                {
-                    _writeInProgress.Value = false;
-                }
+                DeserializingObject(type.AssemblyQualifiedName);
             }
         }
 

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryObjectInfo.cs
@@ -268,8 +268,11 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         internal string GetAssemblyString() => _binderAssemblyString ?? _cache._assemblyString;
 
-        private void InvokeSerializationBinder(SerializationBinder? binder) =>
+        private void InvokeSerializationBinder(SerializationBinder? binder)
+        {
+            BinaryFormatterEventSource.Log.SerializingObject(_objectType!);
             binder?.BindToName(_objectType!, out _binderAssemblyString, out _binderTypeName);
+        }
 
         internal void GetMemberInfo(out string[]? outMemberNames, out Type[]? outMemberTypes, out object?[]? outMemberData)
         {
@@ -392,6 +395,8 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         private void InitReadConstructor(Type objectType, ISurrogateSelector? surrogateSelector, StreamingContext context)
         {
+            BinaryFormatterEventSource.Log.DeserializingObject(objectType);
+
             if (objectType.IsArray)
             {
                 InitNoMembers();

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterEventSourceTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterEventSourceTests.cs
@@ -103,56 +103,6 @@ namespace System.Runtime.Serialization.Formatters.Tests
             Assert.Equal(expected, listener.Log);
         }
 
-        [Fact]
-        public static void DoesNotRecordRecursiveSerializationPerformedByEventListener()
-        {
-            // First, serialization
-
-            LoggingEventListener listener = new LoggingEventListener();
-            listener.EventWritten += (source, args) => listener.Log.Add("Callback fired.");
-            listener.EventWritten += (source, args) => new BinaryFormatter().Serialize(Stream.Null, CreatePerson());
-
-            MemoryStream ms = new MemoryStream();
-            BinaryFormatter formatter = new BinaryFormatter();
-            formatter.Serialize(ms, CreatePerson());
-            ms.Position = 0;
-
-            string[] expected = new string[]
-            {
-                "SerializationStart [Start, 00000001]: <no payload>",
-                "Callback fired.",
-                "SerializingObject [Info, 00000001]: " + typeof(Person).AssemblyQualifiedName,
-                "Callback fired.",
-                "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
-                "Callback fired.",
-                "SerializationStop [Stop, 00000001]: <no payload>",
-                "Callback fired.",
-            };
-
-            Assert.Equal(expected, listener.Log);
-            listener.Log.Clear();
-
-            // Then, deserialization
-
-            ms.Position = 0;
-            formatter.Deserialize(ms);
-            listener.Dispose();
-
-            expected = new string[]
-            {
-                "DeserializationStart [Start, 00000002]: <no payload>",
-                "Callback fired.",
-                "DeserializingObject [Info, 00000002]: " + typeof(Person).AssemblyQualifiedName,
-                "Callback fired.",
-                "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
-                "Callback fired.",
-                "DeserializationStop [Stop, 00000002]: <no payload>",
-                "Callback fired.",
-            };
-
-            Assert.Equal(expected, listener.Log);
-        }
-
         private static Person CreatePerson()
         {
             return new Person()

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterEventSourceTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterEventSourceTests.cs
@@ -1,0 +1,254 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Threading;
+using Xunit;
+
+namespace System.Runtime.Serialization.Formatters.Tests
+{
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+    public static class BinaryFormatterEventSourceTests
+    {
+        private const string BinaryFormatterEventSourceName = "System.Runtime.Serialization.Formatters.Binary.BinaryFormatterEventSource";
+
+        [Fact]
+        public static void RecordsSerialization()
+        {
+            LoggingEventListener listener = new LoggingEventListener();
+
+            BinaryFormatter formatter = new BinaryFormatter();
+            formatter.Serialize(Stream.Null, CreatePerson());
+            listener.Dispose();
+
+            string[] expected = new string[]
+            {
+                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializingObject [Info, 00000001]: " + typeof(Person).AssemblyQualifiedName,
+                "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
+                "SerializationEnded [Stop, 00000001]: <no payload>",
+            };
+
+            Assert.Equal(expected, listener.Log);
+        }
+
+        [Fact]
+        public static void RecordsDeserialization()
+        {
+            MemoryStream ms = new MemoryStream();
+            BinaryFormatter formatter = new BinaryFormatter();
+            formatter.Serialize(ms, CreatePerson());
+            ms.Position = 0;
+
+            LoggingEventListener listener = new LoggingEventListener();
+            formatter.Deserialize(ms);
+            listener.Dispose();
+
+            string[] expected = new string[]
+            {
+                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializingObject [Info, 00000002]: " + typeof(Person).AssemblyQualifiedName,
+                "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
+                "DeserializationEnded [Stop, 00000002]: <no payload>",
+            };
+
+            Assert.Equal(expected, listener.Log);
+        }
+
+        [Fact]
+        public static void RecordsNestedSerializationCalls()
+        {
+            // First, serialization
+
+            LoggingEventListener listener = new LoggingEventListener();
+
+            MemoryStream ms = new MemoryStream();
+            BinaryFormatter formatter = new BinaryFormatter();
+            formatter.Serialize(ms, new ClassWithNestedDeserialization());
+            ms.Position = 0;
+
+            string[] expected = new string[]
+            {
+                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializingObject [Info, 00000001]: " + typeof(ClassWithNestedDeserialization).AssemblyQualifiedName,
+                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
+                "SerializationEnded [Stop, 00000001]: <no payload>",
+                "SerializationEnded [Stop, 00000001]: <no payload>",
+            };
+
+            Assert.Equal(expected, listener.Log);
+            listener.Log.Clear();
+
+            // Then, deserialization
+
+            ms.Position = 0;
+            formatter.Deserialize(ms);
+            listener.Dispose();
+
+            expected = new string[]
+            {
+                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializingObject [Info, 00000002]: " + typeof(ClassWithNestedDeserialization).AssemblyQualifiedName,
+                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
+                "DeserializationEnded [Stop, 00000002]: <no payload>",
+                "DeserializationEnded [Stop, 00000002]: <no payload>",
+            };
+
+            Assert.Equal(expected, listener.Log);
+        }
+
+        [Fact]
+        public static void DoesNotRecordRecursiveSerializationPerformedByEventListener()
+        {
+            // First, serialization
+
+            LoggingEventListener listener = new LoggingEventListener();
+            listener.EventWritten += (source, args) => listener.Log.Add("Callback fired.");
+            listener.EventWritten += (source, args) => new BinaryFormatter().Serialize(Stream.Null, CreatePerson());
+
+            MemoryStream ms = new MemoryStream();
+            BinaryFormatter formatter = new BinaryFormatter();
+            formatter.Serialize(ms, CreatePerson());
+            ms.Position = 0;
+
+            string[] expected = new string[]
+            {
+                "SerializationStarted [Start, 00000001]: <no payload>",
+                "Callback fired.",
+                "SerializingObject [Info, 00000001]: " + typeof(Person).AssemblyQualifiedName,
+                "Callback fired.",
+                "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
+                "Callback fired.",
+                "SerializationEnded [Stop, 00000001]: <no payload>",
+                "Callback fired.",
+            };
+
+            Assert.Equal(expected, listener.Log);
+            listener.Log.Clear();
+
+            // Then, deserialization
+
+            ms.Position = 0;
+            formatter.Deserialize(ms);
+            listener.Dispose();
+
+            expected = new string[]
+            {
+                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "Callback fired.",
+                "DeserializingObject [Info, 00000002]: " + typeof(Person).AssemblyQualifiedName,
+                "Callback fired.",
+                "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
+                "Callback fired.",
+                "DeserializationEnded [Stop, 00000002]: <no payload>",
+                "Callback fired.",
+            };
+
+            Assert.Equal(expected, listener.Log);
+        }
+
+        private static Person CreatePerson()
+        {
+            return new Person()
+            {
+                Name = "Some Chap",
+                HomeAddress = new Address()
+                {
+                    Street = "123 Anywhere Ln",
+                    City = "Anywhere ST 00000 United States"
+                }
+            };
+        }
+
+        private sealed class LoggingEventListener : EventListener
+        {
+            private readonly Thread _activeThread = Thread.CurrentThread;
+            internal readonly List<string> Log = new List<string>();
+
+            private void AddToLog(FormattableString message)
+            {
+                Log.Add(FormattableString.Invariant(message));
+            }
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name == BinaryFormatterEventSourceName)
+                {
+                    EnableEvents(eventSource, EventLevel.Verbose);
+                }
+
+                base.OnEventSourceCreated(eventSource);
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                // The test project is parallelized. We want to filter to only events that fired
+                // on the current thread, otherwise we could throw off the test results.
+
+                if (Thread.CurrentThread != _activeThread)
+                {
+                    return;
+                }
+
+                AddToLog($"{eventData.EventName} [{eventData.Opcode}, {(int)eventData.Keywords & int.MaxValue:X8}]: {ParsePayload(eventData.Payload)}");
+                base.OnEventWritten(eventData);
+            }
+
+            private static string ParsePayload(IReadOnlyCollection<object> collection)
+            {
+                if (collection?.Count > 0)
+                {
+                    return string.Join("; ", collection.Select(o => o?.ToString() ?? "<null>"));
+                }
+                else
+                {
+                    return "<no payload>";
+                }
+            }
+        }
+
+        [Serializable]
+        private class Person
+        {
+            public string Name { get; set; }
+            public Address HomeAddress { get; set; }
+        }
+
+        [Serializable]
+        private class Address
+        {
+            public string Street { get; set; }
+            public string City { get; set; }
+        }
+
+        [Serializable]
+        public class ClassWithNestedDeserialization : ISerializable
+        {
+            public ClassWithNestedDeserialization()
+            {
+            }
+
+            protected ClassWithNestedDeserialization(SerializationInfo info, StreamingContext context)
+            {
+                byte[] serializedData = (byte[])info.GetValue("SomeField", typeof(byte[]));
+                MemoryStream ms = new MemoryStream(serializedData);
+                BinaryFormatter formatter = new BinaryFormatter();
+                formatter.Deserialize(ms); // should deserialize an 'Address' instance
+            }
+
+            public void GetObjectData(SerializationInfo info, StreamingContext context)
+            {
+                MemoryStream ms = new MemoryStream();
+                BinaryFormatter formatter = new BinaryFormatter();
+                formatter.Serialize(ms, new Address());
+                info.AddValue("SomeField", ms.ToArray());
+            }
+        }
+    }
+}

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterEventSourceTests.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/BinaryFormatterEventSourceTests.cs
@@ -27,10 +27,10 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             string[] expected = new string[]
             {
-                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializationStart [Start, 00000001]: <no payload>",
                 "SerializingObject [Info, 00000001]: " + typeof(Person).AssemblyQualifiedName,
                 "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
-                "SerializationEnded [Stop, 00000001]: <no payload>",
+                "SerializationStop [Stop, 00000001]: <no payload>",
             };
 
             Assert.Equal(expected, listener.Log);
@@ -50,10 +50,10 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             string[] expected = new string[]
             {
-                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializationStart [Start, 00000002]: <no payload>",
                 "DeserializingObject [Info, 00000002]: " + typeof(Person).AssemblyQualifiedName,
                 "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
-                "DeserializationEnded [Stop, 00000002]: <no payload>",
+                "DeserializationStop [Stop, 00000002]: <no payload>",
             };
 
             Assert.Equal(expected, listener.Log);
@@ -73,12 +73,12 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             string[] expected = new string[]
             {
-                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializationStart [Start, 00000001]: <no payload>",
                 "SerializingObject [Info, 00000001]: " + typeof(ClassWithNestedDeserialization).AssemblyQualifiedName,
-                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializationStart [Start, 00000001]: <no payload>",
                 "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
-                "SerializationEnded [Stop, 00000001]: <no payload>",
-                "SerializationEnded [Stop, 00000001]: <no payload>",
+                "SerializationStop [Stop, 00000001]: <no payload>",
+                "SerializationStop [Stop, 00000001]: <no payload>",
             };
 
             Assert.Equal(expected, listener.Log);
@@ -92,12 +92,12 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             expected = new string[]
             {
-                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializationStart [Start, 00000002]: <no payload>",
                 "DeserializingObject [Info, 00000002]: " + typeof(ClassWithNestedDeserialization).AssemblyQualifiedName,
-                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializationStart [Start, 00000002]: <no payload>",
                 "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
-                "DeserializationEnded [Stop, 00000002]: <no payload>",
-                "DeserializationEnded [Stop, 00000002]: <no payload>",
+                "DeserializationStop [Stop, 00000002]: <no payload>",
+                "DeserializationStop [Stop, 00000002]: <no payload>",
             };
 
             Assert.Equal(expected, listener.Log);
@@ -119,13 +119,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             string[] expected = new string[]
             {
-                "SerializationStarted [Start, 00000001]: <no payload>",
+                "SerializationStart [Start, 00000001]: <no payload>",
                 "Callback fired.",
                 "SerializingObject [Info, 00000001]: " + typeof(Person).AssemblyQualifiedName,
                 "Callback fired.",
                 "SerializingObject [Info, 00000001]: " + typeof(Address).AssemblyQualifiedName,
                 "Callback fired.",
-                "SerializationEnded [Stop, 00000001]: <no payload>",
+                "SerializationStop [Stop, 00000001]: <no payload>",
                 "Callback fired.",
             };
 
@@ -140,13 +140,13 @@ namespace System.Runtime.Serialization.Formatters.Tests
 
             expected = new string[]
             {
-                "DeserializationStarted [Start, 00000002]: <no payload>",
+                "DeserializationStart [Start, 00000002]: <no payload>",
                 "Callback fired.",
                 "DeserializingObject [Info, 00000002]: " + typeof(Person).AssemblyQualifiedName,
                 "Callback fired.",
                 "DeserializingObject [Info, 00000002]: " + typeof(Address).AssemblyQualifiedName,
                 "Callback fired.",
-                "DeserializationEnded [Stop, 00000002]: <no payload>",
+                "DeserializationStop [Stop, 00000002]: <no payload>",
                 "Callback fired.",
             };
 

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-Solaris;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="BinaryFormatterEventSourceTests.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
     <Compile Include="BinaryFormatterTestData.cs" />
     <Compile Include="BinaryFormatterTests.cs" />
     <Compile Include="DisableBitTests.cs" />
@@ -17,7 +16,6 @@
     <Compile Include="FormatterTests.cs" />
     <Compile Include="PlatformExtensions.cs" />
     <Compile Include="SerializationBinderTests.cs" />
-    <Compile Include="SerializationGuardTests.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
     <Compile Include="SerializationInfoTests.cs" />
     <Compile Include="SerializationTypes.cs" />
     <Compile Include="SurrogateSelectorTests.cs" />
@@ -33,6 +31,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Compile Include="$(CommonPath)System\Collections\Generic\ReferenceEqualityComparer.cs"
              Link="Common\System\Collections\Generic\ReferenceEqualityComparer.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('$(NetCoreAppCurrent)'))">
+    <Compile Include="BinaryFormatterEventSourceTests.cs" />
+    <Compile Include="SerializationGuardTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersion)" />

--- a/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
+++ b/src/libraries/System.Runtime.Serialization.Formatters/tests/System.Runtime.Serialization.Formatters.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>$(NetCoreAppCurrent)-Windows_NT;$(NetCoreAppCurrent)-FreeBSD;$(NetCoreAppCurrent)-illumos;$(NetCoreAppCurrent)-Solaris;$(NetCoreAppCurrent)-Linux;$(NetCoreAppCurrent)-OSX;$(NetCoreAppCurrent)-iOS;$(NetCoreAppCurrent)-tvOS;net48</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="BinaryFormatterEventSourceTests.cs" Condition="'$(TargetFramework)' == '$(NetCoreAppCurrent)'" />
     <Compile Include="BinaryFormatterTestData.cs" />
     <Compile Include="BinaryFormatterTests.cs" />
     <Compile Include="DisableBitTests.cs" />


### PR DESCRIPTION
This is the last of the 5.0 runtime changes per [the `BinaryFormatter` obsoletion document](https://github.com/dotnet/designs/blob/master/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md). This introduces a new `EventSource` used by the serialization infrastructure to tell you when calls to `BinaryFormatter.Serialize` or `BinaryFormatter.Deserialize` take place. The are currently 6 events raised in total:

- Serialization started (no args)
- Serialization ended (no args)
- Serialization of a non-primitive object is occurring (`Type.AssemblyQualifiedName` is provided as an arg)
- Deserialization started (no args)
- Deserialization ended (no args)
- Deserialization of a non-primitive object is occurring (`Type.AssemblyQualifiedName` is provided as an arg)

This feature is _not_ a "global `SerializationBinder`" or a "global surrogate selector" and cannot be used to substitute types at runtime. Rather, as we begin to wind down `BinaryFormatter` within the runtime and libraries, it's meant to help app authors discover hidden `BinaryFormatter` dependencies within their own code or within any assemblies they pull into their apps.

There is an open question as to whether it would be useful to port this feature back to Full Framework as part of an overall defense-in-depth mechanism. I'm not considering that at the moment, but this code was designed such that it can be easily backported to Full Framework if needed. The code to hook up an `EventListener` would look the same both in Full Framework and in .NET 5.0+.