### PR TITLE
Fix `fgUpdateChangedFlowGraph`.

### DIFF
--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -1875,8 +1875,7 @@ void Compiler::fgUpdateChangedFlowGraph()
 
     fgComputePreds();
     fgComputeEnterBlocksSet();
-    fgComputeReachabilitySets();
-    fgComputeDoms();
+    fgComputeReachability();
 }
 
 /*****************************************************************************


### PR DESCRIPTION
`fgComputeDoms` has an assumption that the flow graph
has no unreachable blocks. It's checked with this assert:

https://github.com/dotnet/runtime/blob/ad325b014124b1adb9306abf95fdac85e3f7f2f4/src/coreclr/src/jit/flowgraph.cpp#L2342

This assert fired when testing #39474 (`Convert Math{F}.CoreCLR methods from FCall to QCall`)
when we are updating the flow graph after inserting GC polls.

This change switches `fgUpdateChangedFlowGraph` to call `fgComputeReachability`,
which both removes unreachable blocks and calls `fgComputeDoms`.

pin-icount reported a 0.0043% throughput improvement, which is within noise level.