### PR TITLE
[wasm] Use interp-only instead of interp-llvmonly as the default execution mode.

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -2006,10 +2006,6 @@ apply_root_domain_configuration_file_bindings (MonoDomain *domain, char *root_do
 static void
 mono_check_interp_supported (void)
 {
-#ifdef DISABLE_INTERPRETER
-	g_error ("Mono IL interpreter support is missing\n");
-#endif
-
 #ifdef MONO_CROSS_COMPILE
 	g_error ("--interpreter on cross-compile runtimes not supported\n");
 #endif
@@ -2999,7 +2995,7 @@ mono_runtime_set_execution_mode_full (int mode, gboolean override)
 		mono_llvm_only = TRUE;
 		break;
 
-	case MONO_EE_MODE_INTERP:
+	case MONO_AOT_MODE_INTERP_ONLY:
 		mono_check_interp_supported ();
 		mono_use_interpreter = TRUE;
 

--- a/src/mono/mono/mini/jit.h
+++ b/src/mono/mono/mini/jit.h
@@ -65,6 +65,8 @@ typedef enum {
 	MONO_AOT_MODE_INTERP_LLVMONLY,
 	/* Use only llvm compiled code, fall back to the interpeter */
 	MONO_AOT_MODE_LLVMONLY_INTERP,
+	/* Same as --interp */
+	MONO_AOT_MODE_INTERP_ONLY,
 	/* Sentinel value used internally by the runtime. We use a large number to avoid clashing with some internal values. */
 	MONO_AOT_MODE_LAST = 1000,
 } MonoAotMode;

--- a/src/mono/mono/mini/mini-runtime.h
+++ b/src/mono/mono/mini/mini-runtime.h
@@ -411,10 +411,8 @@ extern MonoEEFeatures mono_ee_features;
 
 //XXX this enum *MUST extend MonoAotMode as they are consumed together.
 typedef enum {
-	/* Always execute with interp, will use JIT to produce trampolines */
-	MONO_EE_MODE_INTERP = MONO_AOT_MODE_LAST,
+	MONO_EE_MODE_INTERP = MONO_AOT_MODE_INTERP_ONLY,
 } MonoEEMode;
-
 
 static inline MonoMethod*
 jinfo_get_method (MonoJitInfo *ji)


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20159,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>interp-llvmonly caused mono_llvm_only to be set, causing bad behavior like
stack walks not working.