### PR TITLE
Fix ActivitySource.StartActivity when start time is provided

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -986,7 +986,7 @@ namespace System.Diagnostics
                 }
             }
 
-            activity.StartTimeUtc = startTime == default ? DateTime.UtcNow : startTime.DateTime;
+            activity.StartTimeUtc = startTime == default ? DateTime.UtcNow : startTime.UtcDateTime;
 
             activity.IsAllDataRequested = request == ActivityDataRequest.AllData || request == ActivityDataRequest.AllDataAndRecorded;
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/ActivitySourceTests.cs
@@ -323,12 +323,15 @@ namespace System.Diagnostics.Tests
                 attributes.Add(new KeyValuePair<string, object>("tag2", "tagValue2"));
                 attributes.Add(new KeyValuePair<string, object>("tag3", "tagValue3"));
 
-                using (Activity activity = source.StartActivity("a1", ActivityKind.Client, ctx, attributes, links))
+                DateTimeOffset startTime = DateTimeOffset.UtcNow;
+
+                using (Activity activity = source.StartActivity("a1", ActivityKind.Client, ctx, attributes, links, startTime))
                 {
                     Assert.NotNull(activity);
                     Assert.Equal("a1", activity.OperationName);
                     Assert.Equal("a1", activity.DisplayName);
                     Assert.Equal(ActivityKind.Client, activity.Kind);
+                    Assert.Equal(startTime, activity.StartTimeUtc);
 
                     Assert.Equal(ctx.TraceId, activity.TraceId);
                     Assert.Equal(ctx.SpanId, activity.ParentSpanId);


### PR DESCRIPTION
Fixes #39879 

Calling `ActivitySource.StartActivity` and providing a `startTime` was not using `startTime.UtcDateTime`.

@tarekgh