### PR TITLE
Jit: fix some sources of x64 chk/rel diffs

### DIFF
--- a/src/coreclr/src/jit/codegenlinear.cpp
+++ b/src/coreclr/src/jit/codegenlinear.cpp
@@ -344,7 +344,6 @@ void CodeGen::genCodeForBBlist()
             needLabel = true;
         }
 
-#if defined(DEBUG) || defined(LATE_DISASM)
         // We also want to start a new Instruction group by calling emitAddLabel below,
         // when we need accurate bbWeights for this block in the emitter.  We force this
         // whenever our previous block was a BBJ_COND and it has a different weight than us.
@@ -356,7 +355,6 @@ void CodeGen::genCodeForBBlist()
         {
             needLabel = true;
         }
-#endif // DEBUG || LATE_DISASM
 
         if (needLabel)
         {

--- a/src/coreclr/src/jit/emitxarch.cpp
+++ b/src/coreclr/src/jit/emitxarch.cpp
@@ -163,8 +163,10 @@ bool emitter::IsDstSrcSrcAVXInstruction(instruction ins)
 
 bool emitter::AreUpper32BitsZero(regNumber reg)
 {
-    // Don't look back across IG boundaries (possible control flow)
-    if (emitCurIGinsCnt == 0)
+    // If there are no instructions in this IG, we can look back at
+    // the previous IG's instructions if this IG is an extension.
+    //
+    if ((emitCurIGinsCnt == 0) && ((emitCurIG->igFlags & IGF_EXTEND) == 0))
     {
         return false;
     }


### PR DESCRIPTION
Break IGs for perfscores the same way in chk and rel. Also, fix the xarch
peephole to work across extended IGs.

Closes #39845.