### PR TITLE
Fix CA1836 rule violations excluding Memory/Span

### DIFF
--- a/src/libraries/Common/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
+++ b/src/libraries/Common/src/System/Data/ProviderBase/DbConnectionPoolGroup.cs
@@ -105,7 +105,7 @@ namespace System.Data.ProviderBase
             ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool> oldPoolCollection = null;
             lock (this)
             {
-                if (_poolCollection.Count > 0)
+                if (!_poolCollection.IsEmpty)
                 {
                     oldPoolCollection = _poolCollection;
                     _poolCollection = new ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>();
@@ -232,7 +232,7 @@ namespace System.Data.ProviderBase
             //     to avoid conflict with DbConnectionFactory.CreateConnectionPoolGroup replacing pool entry
             lock (this)
             {
-                if (_poolCollection.Count > 0)
+                if (!_poolCollection.IsEmpty)
                 {
                     var newPoolCollection = new ConcurrentDictionary<DbConnectionPoolIdentity, DbConnectionPool>();
 
@@ -267,7 +267,7 @@ namespace System.Data.ProviderBase
 
                 // must be pruning thread to change state and no connections
                 // otherwise pruning thread risks making entry disabled soon after user calls ClearPool
-                if (0 == _poolCollection.Count)
+                if (_poolCollection.IsEmpty)
                 {
                     if (PoolGroupStateActive == _state)
                     {

--- a/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Extensions.Http
             }
 
             // We didn't totally empty the cleanup queue, try again later.
-            if (_expiredHandlers.Count > 0)
+            if (!_expiredHandlers.IsEmpty)
             {
                 StartCleanupTimer();
             }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -156,7 +156,7 @@ namespace System.Collections.Immutable
         public bool IsEmpty
         {
             [NonVersionable]
-            get { return this.Length == 0; }
+            get { return this.array!.Length == 0; }
         }
 
         /// <summary>

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Minimal.cs
@@ -265,7 +265,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T>.Builder ToBuilder()
         {
             var self = this;
-            if (self.Length == 0)
+            if (self.IsEmpty)
             {
                 return new Builder(); // allow the builder to create itself with a reasonable default capacity
             }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.cs
@@ -194,7 +194,7 @@ namespace System.Collections.Immutable
         public int LastIndexOf(T item)
         {
             var self = this;
-            if (self.Length == 0)
+            if (self.IsEmpty)
             {
                 return -1;
             }
@@ -211,7 +211,7 @@ namespace System.Collections.Immutable
         public int LastIndexOf(T item, int startIndex)
         {
             var self = this;
-            if (self.Length == 0 && startIndex == 0)
+            if (self.IsEmpty && startIndex == 0)
             {
                 return -1;
             }
@@ -293,7 +293,7 @@ namespace System.Collections.Immutable
             self.ThrowNullRefIfNotInitialized();
             Requires.Range(index >= 0 && index <= self.Length, nameof(index));
 
-            if (self.Length == 0)
+            if (self.IsEmpty)
             {
                 return ImmutableArray.Create(item);
             }
@@ -326,7 +326,7 @@ namespace System.Collections.Immutable
             Requires.Range(index >= 0 && index <= self.Length, nameof(index));
             Requires.NotNull(items, nameof(items));
 
-            if (self.Length == 0)
+            if (self.IsEmpty)
             {
                 return ImmutableArray.CreateRange(items);
             }
@@ -412,7 +412,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> Add(T item)
         {
             var self = this;
-            if (self.Length == 0)
+            if (self.IsEmpty)
             {
                 return ImmutableArray.Create(item);
             }

--- a/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -70,7 +70,7 @@ namespace System.Linq
             // immutable array object that would be allocated when it's passed as an IEnumerable<T>,
             // and for the EnumeratorObject that would be allocated when enumerating the boxed array.
 
-            return immutableArray.Length == 0 ?
+            return immutableArray.IsEmpty ?
                 Enumerable.Empty<TResult>() :
                 SelectManyIterator(immutableArray, collectionSelector, resultSelector);
         }
@@ -96,7 +96,7 @@ namespace System.Linq
         /// <param name="immutableArray"></param>
         public static bool Any<T>(this ImmutableArray<T> immutableArray)
         {
-            return immutableArray.Length > 0;
+            return !immutableArray.IsEmpty;
         }
 
         /// <summary>
@@ -258,7 +258,7 @@ namespace System.Linq
         {
             Requires.NotNull(func, nameof(func));
 
-            if (immutableArray.Length == 0)
+            if (immutableArray.IsEmpty)
             {
                 return default(T)!;
             }
@@ -357,7 +357,7 @@ namespace System.Linq
 
             // In the event of an empty array, generate the same exception
             // that the linq extension method would.
-            return immutableArray.Length > 0
+            return !immutableArray.IsEmpty
                 ? immutableArray[0]
                 : Enumerable.First(immutableArray.array!);
         }
@@ -402,7 +402,7 @@ namespace System.Linq
         {
             // In the event of an empty array, generate the same exception
             // that the linq extension method would.
-            return immutableArray.Length > 0
+            return !immutableArray.IsEmpty
                 ? immutableArray[immutableArray.Length - 1]
                 : Enumerable.Last(immutableArray.array!);
         }

--- a/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
+++ b/src/libraries/System.Memory/src/System/Buffers/SequenceReader.Search.cs
@@ -75,7 +75,7 @@ namespace System.Buffers
                 return false;
             }
 
-            Debug.Assert(sequence.Length > 0);
+            Debug.Assert(!sequence.IsEmpty);
             span = sequence.IsSingleSegment ? sequence.First.Span : sequence.ToArray();
             return true;
         }
@@ -436,7 +436,7 @@ namespace System.Buffers
                 return false;
             }
 
-            Debug.Assert(sequence.Length > 0);
+            Debug.Assert(!sequence.IsEmpty);
             span = sequence.IsSingleSegment ? sequence.First.Span : sequence.ToArray();
             return true;
         }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslSessionsCache.cs
@@ -115,7 +115,7 @@ namespace System.Net.Security
         //
         internal static SafeFreeCredentials? TryCachedCredential(byte[]? thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
-            if (s_cachedCreds.Count == 0)
+            if (s_cachedCreds.IsEmpty)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info(null, $"Not found, Current Cache Count = {s_cachedCreds.Count}");
                 return null;

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlQueryType.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XmlQueryType.cs
@@ -148,7 +148,7 @@ namespace System.Xml.Xsl
                 return false;
 
             // None is subtype of every other type
-            if (Count == 0)
+            if (IsEmpty)
                 return false;
 
             // Check item types

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/DebugDirectory/DebugDirectoryBuilder.cs
@@ -185,7 +185,7 @@ namespace System.Reflection.PortableExecutable
                 Throw.ArgumentNull(nameof(checksum));
             }
 
-            if (checksum.Length == 0)
+            if (checksum.IsEmpty)
             {
                 Throw.ArgumentEmptyArray(nameof(checksum));
             }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Properties/Ecma/EcmaProperty.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Properties/Ecma/EcmaProperty.cs
@@ -81,7 +81,7 @@ namespace System.Reflection.TypeLoading.Ecma
             sb.Append(sig.ReturnType);
             sb.Append(' ');
             sb.Append(Name);
-            if (sig.ParameterTypes.Length != 0)
+            if (!sig.ParameterTypes.IsEmpty)
             {
                 sb.Append('[');
                 for (int i = 0; i < sig.ParameterTypes.Length; i++)

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.cs
@@ -318,7 +318,7 @@ namespace System.Threading.Tasks
                     }
 
                     // If we have encountered any exceptions, then throw.
-                    if ((exceptionQ != null) && (exceptionQ.Count > 0))
+                    if ((exceptionQ != null) && (!exceptionQ.IsEmpty))
                     {
                         ThrowSingleCancellationExceptionOrOtherException(exceptionQ, parallelOptions.CancellationToken,
                                                                          new AggregateException(exceptionQ));


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/roslyn-analyzers/pull/3876
I ran the rule again now that it no longer reports for types `Memory`, `Span`, `ReadOnlyMemory` & `ReadOnlySpan`.