### PR TITLE
[runtime] Fix GC problems in create_cattr_named()/typed()

### DIFF
--- a/src/mono/mono/metadata/handle.h
+++ b/src/mono/mono/metadata/handle.h
@@ -516,6 +516,9 @@ TYPED_HANDLE_DECL (MonoObject);
 TYPED_HANDLE_DECL (MonoException);
 TYPED_HANDLE_DECL (MonoAppContext);
 
+/* Simpler version of MONO_HANDLE_NEW if the handle is not used */
+#define MONO_HANDLE_PIN(object) MONO_HANDLE_NEW (MonoObject, (object))
+
 // Structs cannot be cast to structs.
 // As well, a function is needed because an anonymous struct cannot be initialized in C.
 static inline MonoObjectHandle


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/39774 and https://github.com/dotnet/runtime/pull/39856 to the `release/5.0-preview8` branch.

Fixes https://github.com/dotnet/runtime/issues/39473 (Tests failed on WASM with NRE in CustomAttributeTypedArgument.CanonicalizeValue)

**Description**

Fixes an issue where the Mono runtime/GC wasn't correctly tracking newly created objects when creating a custom attribute type. This resulted in rare and random `NullReferenceException`'s during the dotnet/runtime libraries tests. We also got one report from Blazor that looks like the same thing.

**Customer Impact**

Random `NullReferenceException` when creating custom attribute instances.

**Risk**

Low, we ran several libraries tests in a loop for multiple hours to confirm the issue was fixed.