### PR TITLE
Add linker annotation to LazyDebugView to avoid warnings

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Lazy.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Lazy.cs
@@ -508,7 +508,7 @@ namespace System
 
     /// <summary>A debugger view of the Lazy&lt;T&gt; to surface additional debugging properties and
     /// to ensure that the Lazy&lt;T&gt; does not become initialized if it was not already.</summary>
-    internal sealed class LazyDebugView<T>
+    internal sealed class LazyDebugView<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>
     {
         // The Lazy object being viewed.
         private readonly Lazy<T> _lazy;


### PR DESCRIPTION
In reality this is only to get rid of the warnings, the class is never instatiated by the managed code, so the annotation has no effect on including more code.
When in debugger the class is instatiated with the same T of an existing Lazy<T> which has the same annotation, so the T will always fulfill the annotation's requirements.