### PR TITLE
Negate find_object GetConservativeGC logic.

### DIFF
--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -18090,7 +18090,7 @@ uint8_t* gc_heap::find_object (uint8_t* interior)
         heap_segment* seg = find_segment (interior, FALSE);
         if (seg
 #ifdef FEATURE_CONSERVATIVE_GC
-            && (GCConfig::GetConservativeGC() || interior <= heap_segment_allocated(seg))
+            && (!GCConfig::GetConservativeGC() || interior <= heap_segment_allocated(seg))
 #endif
             )
         {

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -18093,8 +18093,6 @@ uint8_t* gc_heap::find_object (uint8_t* interior)
 #ifdef FEATURE_CONSERVATIVE_GC
             if (interior >= heap_segment_allocated(seg))
                 return 0;
-#else
-            assert (interior < heap_segment_allocated (seg));
 #endif
             // If interior falls within the first free object at the beginning of a generation,
             // we don't have brick entry for it, and we may incorrectly treat it as on large object heap.

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -18088,12 +18088,14 @@ uint8_t* gc_heap::find_object (uint8_t* interior)
     {
         // this is a pointer to a UOH object
         heap_segment* seg = find_segment (interior, FALSE);
-        if (seg
-#ifdef FEATURE_CONSERVATIVE_GC
-            && (!GCConfig::GetConservativeGC() || interior <= heap_segment_allocated(seg))
-#endif
-            )
+        if (seg)
         {
+#ifdef FEATURE_CONSERVATIVE_GC
+            if (interior >= heap_segment_allocated(seg))
+                return 0;
+#else
+            assert (interior < heap_segment_allocated (seg));
+#endif
             // If interior falls within the first free object at the beginning of a generation,
             // we don't have brick entry for it, and we may incorrectly treat it as on large object heap.
             int align_const = get_alignment_constant (heap_segment_read_only_p (seg)


### PR DESCRIPTION
This PR implements the suggested fix at https://github.com/dotnet/corert/issues/8205 that solves an assert that is hit when testing the Wasm backend of CoreRT and is required to fix the related issue https://github.com/dotnet/corert/issues/8210.

Fixes: https://github.com/dotnet/corert/issues/8210
Closes: https://github.com/dotnet/corert/issues/8205
