### PR TITLE
Ensure CoreCLR pkgproj include packaging props

### DIFF
--- a/src/coreclr/src/.nuget/Directory.Build.props
+++ b/src/coreclr/src/.nuget/Directory.Build.props
@@ -3,6 +3,9 @@
 
   <!-- Packaging projects (.pkgproj) are non-SDK-style, so they need to directly import Directory.Build.props -->
   <Import Project="../Directory.Build.props" />
+  
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.props" />
+
   <Import Project="packaging.props" />
 
   <PropertyGroup>


### PR DESCRIPTION
Since these projects don't directly consume the nupkg they didn't
automatically get props when we added it.