### PR TITLE
Fix code coverage for .NET Framework when using /t:test

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -17,6 +17,7 @@
 
     <RunScriptHost Condition="'$(TargetOS)' == 'Windows_NT'">$(RunScriptHostDir)dotnet.exe</RunScriptHost>
     <RunScriptHost Condition="'$(TargetOS)' != 'Windows_NT'">$(RunScriptHostDir)dotnet</RunScriptHost>
+    <RunScriptHost Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">xunit.console.exe</RunScriptHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/eng/testing/xunit/xunit.console.targets
+++ b/eng/testing/xunit/xunit.console.targets
@@ -7,7 +7,7 @@
   <PropertyGroup Condition="'$(TargetsMobile)' != 'true'">
     <_depsFileArgument Condition="'$(GenerateDependencyFile)' == 'true'">--depsfile $(AssemblyName).deps.json</_depsFileArgument>
     <RunScriptCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">"$(RunScriptHost)" exec --runtimeconfig $(AssemblyName).runtimeconfig.json $(_depsFileArgument) xunit.console.dll</RunScriptCommand>
-    <RunScriptCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">xunit.console.exe</RunScriptCommand>
+    <RunScriptCommand Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">$(RunScriptHost)</RunScriptCommand>
 
     <RunScriptCommand>$(RunScriptCommand) $(TargetFileName)</RunScriptCommand>
     <RunScriptCommand>$(RunScriptCommand) -xml $(TestResultsName)</RunScriptCommand>


### PR DESCRIPTION
After: https://github.com/dotnet/runtime/commit/809a06f45161ae686a06b9e9ccc2f45097b91657 code coverage when using /t:test is no longer working for .NET Framework and now that tests run for all tfms by default people would get an error like:

```
  pushd C:\CodeHub\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Release\
  "dotnet.exe" tool run coverlet "Microsoft.Extensions.Logging.Console.Tests.dll" --target "\dotnet.exe" --targetargs "xunit.console.exe Microsoft.Extensions.Logging.Console.Tests.dll -xml testResults.xml -nologo -notrait category=OuterLoop -notrait category=failing" --format "opencover" --output "coverage.opencover.xml" --verbosity "normal" --use-source-link --exclude-by-file "C:\CodeHub\runtime\src\libraries\Common\src\System\SR.*" --exclude-by-file "C:\CodeHub\runtime\src\libraries\Common\src\System\NotImplemented.cs" --include-directory "\shared\Microsoft.NETCore.App\5.0.0" --include "[Microsoft.Extensions.Logging.Console]*" --include "[System.Private.CoreLib]*"
  "dotnet.exe" tool run reportgenerator "-reports:coverage.opencover.xml" "-targetdir:C:\CodeHub\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Release\report" "-reporttypes:Html" "-verbosity:Info"
  popd
  ===========================================================================================================
  BadImageFormatException during MetadataReaderProvider.FromPortablePdbStream in InstrumentationHelper.PortablePdbHasLocalSource, unable to check if module has got local source.
  Start process '\dotnet.exe' failed with 'The system cannot find the file specified'
  2020-07-24T13:56:36: The report file 'coverage.opencover.xml' is invalid. File does not exist (Full path: 'C:\CodeHub\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Release\coverage.opencover.xml').
  2020-07-24T13:56:36: No report files specified.
  ----- end Fri 07/24/2020 13:56:36.82 ----- exit code 1 ----------------------------------------------------------
C:\CodeHub\runtime\eng\testing\tests.targets(117,5): error : One or more tests failed while running tests from 'Microsoft.Extensions.Logging.Console.Tests'. Please check C:\CodeHub\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Release\testResults.xml for details! [C:\CodeHub\runtime\src\libraries\Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests.csproj]
Build FAILED.
C:\CodeHub\runtime\eng\testing\tests.targets(117,5): error : One or more tests failed while running tests from 'Microsoft.Extensions.Logging.Console.Tests'. Please check C:\CodeHub\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Release\testResults.xml for details! [C:\CodeHub\runtime\src\libraries\Microsoft.Extensions.Logging.Console\tests\Microsoft.Extensions.Logging.Console.Tests.csproj]
    0 Warning(s)
    1 Error(s)
Time Elapsed 00:00:17.71
```

after this fix, code coverage for netfx is collected correctly.

```
  Calculating coverage result...
    Generating report 'C:\repos\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Debug\coverage.opencover.xml'
  +--------------------------------------+--------+--------+--------+
  | Module                               | Line   | Branch | Method |
  +--------------------------------------+--------+--------+--------+
  | Microsoft.Extensions.Logging.Console | 70.12% | 81.74% | 70.74% |
  +--------------------------------------+--------+--------+--------+

  +---------+--------+--------+--------+
  |         | Line   | Branch | Method |
  +---------+--------+--------+--------+
  | Total   | 70.12% | 81.74% | 70.74% |
  +---------+--------+--------+--------+
  | Average | 70.12% | 81.73% | 70.73% |
  +---------+--------+--------+--------+

  2020-07-24T15:22:08: Writing report file 'C:\repos\runtime\artifacts\bin\Microsoft.Extensions.Logging.Console.Tests\net461-Debug\report\index.htm'
  2020-07-24T15:22:08: Report generation took 0.3 seconds
  ----- end Fri 07/24/2020 15:22:08.50 ----- exit code 0 ----------------------------------------------------------
```

We were trying to use the host from the testhost and since we no longer have a testhost for .NET Framework, coverlet was failing to find the file, we should use the same host as for running tests which is `xunit.console.exe`.

Thanks @maryamariyan for reporting