### PR TITLE
Fix CanCastTo behavior

### DIFF
--- a/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
+++ b/src/coreclr/src/tools/Common/TypeSystem/Common/CastingHelper.cs
@@ -166,6 +166,17 @@ namespace Internal.TypeSystem
                 case TypeFlags.SzArray:
                     return ((ArrayType)thisType).CanCastArrayTo(otherType, protect);
 
+                case TypeFlags.ByRef:
+                case TypeFlags.Pointer:
+                    if (otherType.Category == thisType.Category)
+                    {
+                        return ((ParameterizedType)thisType).CanCastParamTo(((ParameterizedType)otherType).ParameterType, protect);
+                    }
+                    return false;
+
+                case TypeFlags.FunctionPointer:
+                    return false;
+
                 default:
                     Debug.Assert(thisType.IsDefType);
                     return thisType.CanCastToClassOrInterface(otherType, protect);

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -923,12 +923,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Generics/Arrays/TypeParameters/MultiDim/**/*">
             <Issue>https://github.com/dotnet/runtime/issues/38260</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_r/*">
-            <Issue>https://github.com/dotnet/runtime/issues/32725</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Intrinsics/TypeIntrinsics_ro/*">
-            <Issue>https://github.com/dotnet/runtime/issues/32725</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
             <Issue>https://github.com/dotnet/runtime/issues/7597</Issue>
         </ExcludeList>
@@ -952,9 +946,6 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/SIMD/SimpleSIMDProgram/*">
             <Issue>https://github.com/dotnet/runtime/issues/35724</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Stress/ABI/**/*">
-            <Issue>https://github.com/dotnet/runtime/issues/32725</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
             <Issue>Not compatible with crossgen2</Issue>


### PR DESCRIPTION
In particular fix CanCastTo when used to implement the IsAssignableTo intrinsic

Fixes #32725 

(The issues noted in that bug around the JIT ABI stress tests are unrelated, but the failures don't repro either. I assume the issues were fixed earlier)