### PR TITLE
Avoid using DateTime - Switch to DateTimeOffset

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Extensions.Logging.Console
                     var timestampFormat = FormatterOptions.TimestampFormat;
                     if (timestampFormat != null)
                     {
-                        var dateTime = FormatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
-                        timestamp = dateTime.ToString(timestampFormat);
+                        DateTimeOffset dateTimeOffset = FormatterOptions.UseUtcTimestamp ? DateTimeOffset.UtcNow : DateTimeOffset.Now;
+                        timestamp = dateTimeOffset.ToString(timestampFormat);
                     }
                     writer.WriteString("Timestamp", timestamp);
                     writer.WriteNumber(nameof(logEntry.EventId), eventId);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SimpleConsoleFormatter.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Extensions.Logging.Console
             string timestampFormat = FormatterOptions.TimestampFormat;
             if (timestampFormat != null)
             {
-                DateTime dateTime = GetCurrentDateTime();
-                timestamp = dateTime.ToString(timestampFormat);
+                DateTimeOffset dateTimeOffset = GetCurrentDateTime();
+                timestamp = dateTimeOffset.ToString(timestampFormat);
             }
             if (timestamp != null)
             {
@@ -126,9 +126,9 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        private DateTime GetCurrentDateTime()
+        private DateTimeOffset GetCurrentDateTime()
         {
-            return FormatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+            return FormatterOptions.UseUtcTimestamp ? DateTimeOffset.UtcNow : DateTimeOffset.Now;
         }
 
         private static string GetLogLevelString(LogLevel logLevel)

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/SystemdConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/SystemdConsoleFormatter.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Extensions.Logging.Console
             string timestampFormat = FormatterOptions.TimestampFormat;
             if (timestampFormat != null)
             {
-                DateTime dateTime = GetCurrentDateTime();
-                textWriter.Write(dateTime.ToString(timestampFormat));
+                DateTimeOffset dateTimeOffset = GetCurrentDateTime();
+                textWriter.Write(dateTimeOffset.ToString(timestampFormat));
             }
 
             // category and event id
@@ -96,9 +96,9 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        private DateTime GetCurrentDateTime()
+        private DateTimeOffset GetCurrentDateTime()
         {
-            return FormatterOptions.UseUtcTimestamp ? DateTime.UtcNow : DateTime.Now;
+            return FormatterOptions.UseUtcTimestamp ? DateTimeOffset.UtcNow : DateTimeOffset.Now;
         }
 
         private static string GetSyslogSeverityString(LogLevel logLevel)


### PR DESCRIPTION
It could behave incorrectly on netfx otherwise,

test Microsoft.Extensions.Logging.Console.Test.ConsoleLoggerTest.WriteCore_LogsCorrectTimestampInUtc exercises that code path. Eventhough CI does not fail for it, it does fails locally for net462.