### PR TITLE
Disable processinfo test for ilasm round-trip testing

### DIFF
--- a/src/tests/tracing/eventpipe/processinfo/processinfo.csproj
+++ b/src/tests/tracing/eventpipe/processinfo/processinfo.csproj
@@ -7,6 +7,10 @@
     <CLRTestPriority>0</CLRTestPriority>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- ilasm round-trip testing doesn't work, as test expects unchanged assembly name.
+         Issue: https://github.com/dotnet/runtime/issues/39935
+    -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/39935