### PR TITLE
Mark the multifolder GC2 test as GC stress incompatible until fixed

### DIFF
--- a/src/tests/readytorun/multifolder/multifolder.csproj
+++ b/src/tests/readytorun/multifolder/multifolder.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
+    <GCStressIncompatible>true</GCStressIncompatible> <!-- https://github.com/dotnet/runtime/issues/39933 -->
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
 


### PR DESCRIPTION
/cc @dotnet/crossgen-contrib 