### PR TITLE
Enable dumping GC tables in release builds

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -8814,8 +8814,7 @@ public:
         bool doLateDisasm; // Run the late disassembler
 #endif                     // LATE_DISASM
 
-#if DUMP_GC_TABLES && !defined(DEBUG) && defined(JIT32_GCENCODER)
-// Only the JIT32_GCENCODER implements GC dumping in non-DEBUG code.
+#if DUMP_GC_TABLES && !defined(DEBUG)
 #pragma message("NOTE: this non-debug build has GC ptr table dumping always enabled!")
         static const bool dspGCtbls = true;
 #endif

--- a/src/coreclr/src/jit/gcencode.cpp
+++ b/src/coreclr/src/jit/gcencode.cpp
@@ -3633,7 +3633,15 @@ void GCInfo::gcFindPtrsInFrame(const void* infoBlock, const void* codeBlock, uns
 template class JitHashTable<RegSlotIdKey, RegSlotIdKey, GcSlotId>;
 template class JitHashTable<StackSlotIdKey, StackSlotIdKey, GcSlotId>;
 
-#ifdef DEBUG
+#if defined(DEBUG) || DUMP_GC_TABLES
+
+// This is a copy of GcStackSlotBaseNames from gcinfotypes.h so we can compile in to non-DEBUG builds.
+const char* const JitGcStackSlotBaseNames[] =
+{
+    "caller.sp",
+    "sp",
+    "frame",
+};
 
 static const char* const GcSlotFlagsNames[] = {"",
                                                "(byref) ",
@@ -3652,7 +3660,7 @@ class GcInfoEncoderWithLogging
 
 public:
     GcInfoEncoderWithLogging(GcInfoEncoder* gcInfoEncoder, bool verbose)
-        : m_gcInfoEncoder(gcInfoEncoder), m_doLogging(verbose || JitConfig.JitGCInfoLogging() != 0)
+        : m_gcInfoEncoder(gcInfoEncoder), m_doLogging(verbose INDEBUG( || JitConfig.JitGCInfoLogging() != 0 ))
     {
     }
 
@@ -3662,7 +3670,7 @@ public:
         if (m_doLogging)
         {
             printf("Stack slot id for offset %d (0x%x) (%s) %s= %d.\n", spOffset, spOffset,
-                   GcStackSlotBaseNames[spBase], GcSlotFlagsNames[flags & 7], newSlotId);
+                   JitGcStackSlotBaseNames[spBase], GcSlotFlagsNames[flags & 7], newSlotId);
         }
         return newSlotId;
     }
@@ -3827,14 +3835,14 @@ public:
 };
 
 #define GCENCODER_WITH_LOGGING(withLog, realEncoder)                                                                   \
-    GcInfoEncoderWithLogging  withLog##Var(realEncoder, compiler->verbose || compiler->opts.dspGCtbls);                \
+    GcInfoEncoderWithLogging  withLog##Var(realEncoder, INDEBUG(compiler->verbose ||) compiler->opts.dspGCtbls);       \
     GcInfoEncoderWithLogging* withLog = &withLog##Var;
 
-#else // DEBUG
+#else // !(defined(DEBUG) || DUMP_GC_TABLES)
 
 #define GCENCODER_WITH_LOGGING(withLog, realEncoder) GcInfoEncoder* withLog = realEncoder;
 
-#endif // DEBUG
+#endif // !(defined(DEBUG) || DUMP_GC_TABLES) 
 
 void GCInfo::gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSize, unsigned prologSize)
 {
@@ -4006,7 +4014,7 @@ void GCInfo::gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSiz
 #endif // DISPLAY_SIZES
 }
 
-#ifdef DEBUG
+#if defined(DEBUG) || DUMP_GC_TABLES
 #define Encoder GcInfoEncoderWithLogging
 #else
 #define Encoder GcInfoEncoder

--- a/src/coreclr/src/jit/gcencode.cpp
+++ b/src/coreclr/src/jit/gcencode.cpp
@@ -3636,12 +3636,7 @@ template class JitHashTable<StackSlotIdKey, StackSlotIdKey, GcSlotId>;
 #if defined(DEBUG) || DUMP_GC_TABLES
 
 // This is a copy of GcStackSlotBaseNames from gcinfotypes.h so we can compile in to non-DEBUG builds.
-const char* const JitGcStackSlotBaseNames[] =
-{
-    "caller.sp",
-    "sp",
-    "frame",
-};
+const char* const JitGcStackSlotBaseNames[] = {"caller.sp", "sp", "frame"};
 
 static const char* const GcSlotFlagsNames[] = {"",
                                                "(byref) ",
@@ -3660,7 +3655,7 @@ class GcInfoEncoderWithLogging
 
 public:
     GcInfoEncoderWithLogging(GcInfoEncoder* gcInfoEncoder, bool verbose)
-        : m_gcInfoEncoder(gcInfoEncoder), m_doLogging(verbose INDEBUG( || JitConfig.JitGCInfoLogging() != 0 ))
+        : m_gcInfoEncoder(gcInfoEncoder), m_doLogging(verbose INDEBUG(|| JitConfig.JitGCInfoLogging() != 0))
     {
     }
 
@@ -3842,7 +3837,7 @@ public:
 
 #define GCENCODER_WITH_LOGGING(withLog, realEncoder) GcInfoEncoder* withLog = realEncoder;
 
-#endif // !(defined(DEBUG) || DUMP_GC_TABLES) 
+#endif // !(defined(DEBUG) || DUMP_GC_TABLES)
 
 void GCInfo::gcInfoBlockHdrSave(GcInfoEncoder* gcInfoEncoder, unsigned methodSize, unsigned prologSize)
 {

--- a/src/coreclr/src/jit/jit.h
+++ b/src/coreclr/src/jit/jit.h
@@ -422,7 +422,7 @@ typedef ptrdiff_t ssize_t;
 
 /*****************************************************************************/
 
-#define DUMP_GC_TABLES 1
+#define DUMP_GC_TABLES DEBUG
 #define VERIFY_GC_TABLES 0
 #define REARRANGE_ADDS 1
 

--- a/src/coreclr/src/jit/jit.h
+++ b/src/coreclr/src/jit/jit.h
@@ -422,7 +422,7 @@ typedef ptrdiff_t ssize_t;
 
 /*****************************************************************************/
 
-#define DUMP_GC_TABLES DEBUG
+#define DUMP_GC_TABLES 1
 #define VERIFY_GC_TABLES 0
 #define REARRANGE_ADDS 1
 

--- a/src/coreclr/src/jit/target.h
+++ b/src/coreclr/src/jit/target.h
@@ -1619,11 +1619,11 @@ public:
     static const enum ArgOrder g_tgtArgOrder;
 };
 
-#if defined(DEBUG) || defined(LATE_DISASM)
+#if defined(DEBUG) || defined(LATE_DISASM) || DUMP_GC_TABLES
 const char* getRegName(unsigned reg, bool isFloat = false); // this is for gcencode.cpp and disasm.cpp that don't use
                                                             // the regNumber type
 const char* getRegName(regNumber reg, bool isFloat = false);
-#endif // defined(DEBUG) || defined(LATE_DISASM)
+#endif // defined(DEBUG) || defined(LATE_DISASM) || DUMP_GC_TABLES
 
 #ifdef DEBUG
 const char* getRegNameFloat(regNumber reg, var_types type);

--- a/src/coreclr/src/jit/utils.cpp
+++ b/src/coreclr/src/jit/utils.cpp
@@ -128,7 +128,7 @@ const char* varTypeName(var_types vt)
     return varTypeNames[vt];
 }
 
-#if defined(DEBUG) || defined(LATE_DISASM)
+#if defined(DEBUG) || defined(LATE_DISASM) || DUMP_GC_TABLES
 /*****************************************************************************
  *
  *  Return the name of the given register.
@@ -164,7 +164,7 @@ const char* getRegName(unsigned reg,
 {
     return getRegName((regNumber)reg, isFloat);
 }
-#endif // defined(DEBUG) || defined(LATE_DISASM)
+#endif // defined(DEBUG) || defined(LATE_DISASM) || DUMP_GC_TABLES
 
 #if defined(DEBUG)
 


### PR DESCRIPTION
To enable this, change jit.h from:
```
#define DUMP_GC_TABLES DEBUG
```
to:
```
#define DUMP_GC_TABLES 1
```

and build a Release JIT.
