### PR TITLE
Crossgen2 composite GC stress pipeline

### DIFF
--- a/eng/pipelines/coreclr/crossgen2-gcstress.yml
+++ b/eng/pipelines/coreclr/crossgen2-gcstress.yml
@@ -1,0 +1,60 @@
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 6 * * 0,1"
+  displayName: Sat and Sun at 10:00 PM (UTC-8:00)
+  branches:
+    include:
+    - master
+  always: true
+
+jobs:
+#
+# Checkout repository
+#
+- template: /eng/pipelines/common/checkout-job.yml
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/build-coreclr-and-libraries-job.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Linux_arm64
+    - OSX_x64
+    - Windows_NT_x64
+    - Windows_NT_arm64
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: gcstress-extra
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/build-test-job.yml
+    buildConfig: checked
+    platforms:
+    - CoreClrTestBuildHost # Either OSX_x64 or Linux_x64
+    jobParameters:
+      testGroup: gcstress-extra
+      liveLibrariesBuildConfig: Release
+
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+    helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+    buildConfig: checked
+    platforms:
+    - Linux_x64
+    - Linux_arm64
+    - OSX_x64
+    - Windows_NT_x64
+    - Windows_NT_arm64
+    jobParameters:
+      testGroup: gcstress-extra
+      readyToRun: true
+      crossgen2: true
+      compositeBuildMode: true
+      displayNameArgs: Composite
+      liveLibrariesBuildConfig: Release

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -84,6 +84,10 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       __ResponseFile="$__OutputFile.rsp"
       rm $__ResponseFile
 
+      // Suppress the GC stress COMPlus for the duration of Crossgen2 execution
+      local gcStressModeToRestore = $COMPlus_GCStress;
+      export COMPlus_GCStress=
+
       __Command=$_DebuggerFullPath
       # Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
       if [ ! -z ${__TestDotNetCmd+x} ] %3B then
@@ -109,6 +113,8 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       echo "Running CrossGen2: $__Command"
       $__Command
       __cg2ExitCode=$?
+
+      export COMPlus_GCStress=$gcStressModeToRestore
   }
 
     if [ ! -z ${CompositeBuildMode+x} ]%3B then
@@ -212,6 +218,10 @@ if defined RunCrossGen2 (
     set __ResponseFile=!__OutputFile!.rsp
     del /Q !__ResponseFile!
 
+    REM Suppress GC stress mode for the duration of Crossgen2 execution
+    set __gcStressModeToRestore=!COMPlus_GCStress!
+    set COMPlus_GCStress=
+
     set __Command=!_DebuggerFullPath!
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
     if defined __TestDotNetCmd (
@@ -237,6 +247,8 @@ if defined RunCrossGen2 (
     echo "!__Command!"
     call !__Command!
     set CrossGen2Status=!ERRORLEVEL!
+    set COMPlus_GCStress=!__gcStressModeToRestore!
+
     Exit /b 0
 
 :DoneCrossgen2Operations

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -86,7 +86,11 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
 
       // Suppress the GC stress COMPlus for the duration of Crossgen2 execution
       local gcStressModeToRestore = $COMPlus_GCStress;
+      local heapVerifyModeToRestore = $COMPlus_HeapVerify;
+      local readyToRunModeToRestore = $COMPlus_ReadyToRun;
       export COMPlus_GCStress=
+      export COMPlus_HeapVerify=
+      export COMPlus_ReadyToRun=
 
       __Command=$_DebuggerFullPath
       # Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
@@ -115,6 +119,8 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       __cg2ExitCode=$?
 
       export COMPlus_GCStress=$gcStressModeToRestore
+      export COMPlus_HeapVerify=$heapVerifyModeToRestore
+      export COMPlus_ReadyToRun=$readyToRunModeToRestore
   }
 
     if [ ! -z ${CompositeBuildMode+x} ]%3B then
@@ -221,6 +227,10 @@ if defined RunCrossGen2 (
     REM Suppress GC stress mode for the duration of Crossgen2 execution
     set __gcStressModeToRestore=!COMPlus_GCStress!
     set COMPlus_GCStress=
+    set __heapVerifyModeToRestore=!COMPlus_HeapVerify!
+    set COMPlus_HeapVerify=
+    set __readyToRunModeToRestore=!COMPlus_ReadyToRun!
+    set COMPlus_ReadyToRun=
 
     set __Command=!_DebuggerFullPath!
     REM Tests run locally need __TestDotNetCmd (set by runtest.py) or a compatible 5.0 dotnet runtime in the path
@@ -248,6 +258,8 @@ if defined RunCrossGen2 (
     call !__Command!
     set CrossGen2Status=!ERRORLEVEL!
     set COMPlus_GCStress=!__gcStressModeToRestore!
+    set COMPlus_HeapVerify=!__heapVerifyModeToRestore!
+    set COMPlus_ReadyToRun=!__readyToRunModeToRestore!
 
     Exit /b 0
 


### PR DESCRIPTION
/cc @dotnet/crossgen-contrib 

I have a first reasonable run at

https://dev.azure.com/dnceng/public/_build/results?buildId=746207&view=results

after I fixed the CLRTest.Crossgen2.targets script to suppress the GC stress mode for the duration of Crossgen2 compilation, otherwise it seems to me that the "dotnet" command used to run Crossgen2 silently picks up the COMPlus variable and runs Crossgen2 itself in GC stress mode, causing impractical compilation times and work item timeouts left and right. The script modification hopefully also

Fixes: https://github.com/dotnet/runtime/issues/39933

Thanks

Tomas