### PR TITLE
[wasm] Remove System.ValueTuple.Tests test suite from the exclusion list

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -32,7 +32,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Parallel\tests\System.Linq.Parallel.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.ValueTuple\tests\System.ValueTuple.Tests.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Part of https://github.com/dotnet/runtime/issues/38422

The test run result: `Tests run: 97, Errors: 0, Failures: 0, Skipped: 0.`