### PR TITLE
Fix build on some libs projects when metadata isn't available

### DIFF
--- a/eng/references.targets
+++ b/eng/references.targets
@@ -49,7 +49,7 @@
     <ItemGroup>
       <ProjectReferenceWithConfiguration PrivateAssets="all"
                                          Private="false"
-                                         Condition="$(NetCoreAppLibrary.Contains('$([System.IO.Path]::GetFileNameWithoutExtension('%(MSBuildSourceProjectFile)'));'))" />
+                                         Condition="$(NetCoreAppLibrary.Contains('$([System.IO.Path]::GetFileNameWithoutExtension('%(ProjectReferenceWithConfiguration.MSBuildSourceProjectFile)'));'))" />
     </ItemGroup>
   </Target>
 

--- a/eng/references.targets
+++ b/eng/references.targets
@@ -49,7 +49,7 @@
     <ItemGroup>
       <ProjectReferenceWithConfiguration PrivateAssets="all"
                                          Private="false"
-                                         Condition="$(NetCoreAppLibrary.Contains('$([System.IO.Path]::GetFileNameWithoutExtension('%(ProjectReferenceWithConfiguration.MSBuildSourceProjectFile)'));'))" />
+                                         Condition="$(NetCoreAppLibrary.Contains('%(Filename);'))" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
The `MSBuildSourceProjectFile` metadata isn't always set (ie when building an sln). While reviewing I noticed that we can just use the item's identity instead.