### PR TITLE
Only check inexact match when no exact match is found.

### DIFF
--- a/src/libraries/Common/src/System/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/libraries/Common/src/System/Data/ProviderBase/DbMetaDataFactory.cs
@@ -278,7 +278,7 @@ namespace System.Data.ProviderBase
                             exactCollectionName = candidateCollectionName;
                             haveExactMatch = true;
                         }
-                        else
+                        else if (haveExactMatch == false)
                         {
                             // have an inexact match - ok only if it is the only one
                             if (exactCollectionName != null)

--- a/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbMetaDataFactory.cs
+++ b/src/libraries/System.Data.OleDb/src/System/Data/ProviderBase/DbMetaDataFactory.cs
@@ -303,7 +303,7 @@ namespace System.Data.ProviderBase
                             exactCollectionName = candidateCollectionName;
                             haveExactMatch = true;
                         }
-                        else
+                        else if (haveExactMatch == false)
                         {
                             // have an inexact match - ok only if it is the only one
                             if (exactCollectionName != null)


### PR DESCRIPTION
Fix #39620

Avoid the exact match result be overwrite by later inexact ones.
This may not happen due to limited callsites, just make the code more clear.