### PR TITLE
Fix releasing of file handle in binder tracing

### DIFF
--- a/src/coreclr/src/binder/bindertracing.cpp
+++ b/src/coreclr/src/binder/bindertracing.cpp
@@ -216,14 +216,14 @@ namespace BinderTracing
 
     AssemblyBindOperation::~AssemblyBindOperation()
     {
-        if (!BinderTracing::IsEnabled() || ShouldIgnoreBind())
-            return;
+        if (BinderTracing::IsEnabled() && !ShouldIgnoreBind())
+        {
+            // Make sure the bind request is populated. Tracing may have been enabled mid-bind.
+            if (!m_populatedBindRequest)
+                PopulateBindRequest(m_bindRequest);
 
-        // Make sure the bind request is populated. Tracing may have been enabled mid-bind.
-        if (!m_populatedBindRequest)
-            PopulateBindRequest(m_bindRequest);
-
-        FireAssemblyLoadStop(m_bindRequest, m_resultAssembly, m_cached);
+            FireAssemblyLoadStop(m_bindRequest, m_resultAssembly, m_cached);
+        }
 
         if (m_resultAssembly != nullptr)
             m_resultAssembly->Release();

--- a/src/libraries/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs
@@ -106,20 +106,6 @@ namespace System.Runtime.Loader.Tests
 
         class CollectibleWithOneAssemblyLoadedTest : TestBase
         {
-            string _assemblyPath;
-
-            [MethodImpl(MethodImplOptions.NoInlining)]
-            public void Execute()
-            {
-                _assemblyPath = _testClassTypes[0].Assembly.Location;
-            }
-
-            public void DeleteAssemblyFile()
-            {
-                // ResourceAssemblyLoadContext outputs each loaded assembly to TEMP, so we
-                // can delete an unloaded assembly file without affecting other loads
-                File.Delete(_assemblyPath);
-            }
         }
 
         [Fact]
@@ -131,11 +117,9 @@ namespace System.Runtime.Loader.Tests
 
             var test = new CollectibleWithOneAssemblyLoadedTest();
             test.CreateContextAndLoadAssembly();
-            test.Execute();
             test.UnloadAndClearContext();
 
             test.CheckContextUnloaded();
-            test.DeleteAssemblyFile();
         }
 
         class CollectibleWithOneAssemblyLoadedWithStaticTest : TestBase

--- a/src/libraries/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/CollectibleAssemblyLoadContextTest.cs
@@ -106,6 +106,20 @@ namespace System.Runtime.Loader.Tests
 
         class CollectibleWithOneAssemblyLoadedTest : TestBase
         {
+            string _assemblyPath;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public void Execute()
+            {
+                _assemblyPath = _testClassTypes[0].Assembly.Location;
+            }
+
+            public void DeleteAssemblyFile()
+            {
+                // ResourceAssemblyLoadContext outputs each loaded assembly to TEMP, so we
+                // can delete an unloaded assembly file without affecting other loads
+                File.Delete(_assemblyPath);
+            }
         }
 
         [Fact]
@@ -117,9 +131,11 @@ namespace System.Runtime.Loader.Tests
 
             var test = new CollectibleWithOneAssemblyLoadedTest();
             test.CreateContextAndLoadAssembly();
+            test.Execute();
             test.UnloadAndClearContext();
 
             test.CheckContextUnloaded();
+            test.DeleteAssemblyFile();
         }
 
         class CollectibleWithOneAssemblyLoadedWithStaticTest : TestBase


### PR DESCRIPTION
`AssemblyBindOperation` was only releasing the file handle if binder tracing was on...

Fix #39609 

cc @vitek-karas @janvorli 

Not sure if there's a good / reliable way to add a test for this.