### PR TITLE
Disable gcdump test under GCStress due to test failure

### DIFF
--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/39931 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/39931