### PR TITLE
Disable eventpipe test under GCStress due to test failure

### DIFF
--- a/src/tests/profiler/eventpipe/eventpipe.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/39932 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />


### PR DESCRIPTION
Issue: https://github.com/dotnet/runtime/issues/39932