### PR TITLE
[mono] Fix warnings on OSX netcore

### DIFF
--- a/src/mono/mono/eventpipe/ep-event-source.c
+++ b/src/mono/mono/eventpipe/ep-event-source.c
@@ -210,7 +210,7 @@ ep_event_source_send_process_info (
 	os_info_utf16 = ep_rt_utf8_to_utf16_string (_ep_os_info, -1);
 	arch_info_utf16 = ep_rt_utf8_to_utf16_string (_ep_arch_info, -1);
 
-	EventData data [3] = { 0 };
+	EventData data [3] = { { 0 } };
 	if (command_line_utf16)
 		ep_event_data_init (&data[0], (uint64_t)command_line_utf16, (uint32_t)((ep_rt_utf16_string_len (command_line_utf16) + 1) * sizeof (ep_char16_t)), 0);
 	if (os_info_utf16)

--- a/src/mono/mono/metadata/mono-config.c
+++ b/src/mono/mono/metadata/mono-config.c
@@ -666,8 +666,7 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 	MONO_REQ_GC_UNSAFE_MODE;
 
 	MonoConfigParseState state = {NULL};
-	int i;
-	char *aname, *cfg, *cfg_name;
+	char *cfg_name;
 	const char *bundled_config;
 	
 	state.assembly = assembly;
@@ -684,6 +683,7 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 
 #ifndef DISABLE_CFGDIR_CONFIG
 	int got_it = 0;
+	char *aname, *cfg;
 	cfg_name = g_strdup_printf ("%s.config", mono_image_get_name (assembly));
 	const char *cfg_dir = mono_get_config_dir ();
 	if (!cfg_dir) {
@@ -691,7 +691,7 @@ mono_config_for_assembly_internal (MonoImage *assembly)
 		return;
 	}
 
-	for (i = 0; (aname = get_assembly_filename (assembly, i)) != NULL; ++i) {
+	for (int i = 0; (aname = get_assembly_filename (assembly, i)) != NULL; ++i) {
 		cfg = g_build_filename (cfg_dir, "mono", "assemblies", aname, cfg_name, (const char*)NULL);
 		got_it += mono_config_parse_file_with_context (&state, cfg);
 		g_free (cfg);

--- a/src/mono/mono/mini/debugger-agent.c
+++ b/src/mono/mono/mini/debugger-agent.c
@@ -3598,9 +3598,9 @@ dbg_path_get_basename (const char *filename)
 	return g_strdup (&r[1]);
 }
 
-GENERATE_TRY_GET_CLASS_WITH_CACHE(hidden_klass, "System.Diagnostics", "DebuggerHiddenAttribute")
-GENERATE_TRY_GET_CLASS_WITH_CACHE(step_through_klass, "System.Diagnostics", "DebuggerStepThroughAttribute")
-GENERATE_TRY_GET_CLASS_WITH_CACHE(non_user_klass, "System.Diagnostics", "DebuggerNonUserCodeAttribute")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE(hidden_klass, "System.Diagnostics", "DebuggerHiddenAttribute")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE(step_through_klass, "System.Diagnostics", "DebuggerStepThroughAttribute")
+static GENERATE_TRY_GET_CLASS_WITH_CACHE(non_user_klass, "System.Diagnostics", "DebuggerNonUserCodeAttribute")
 
 static void
 init_jit_info_dbg_attrs (MonoJitInfo *ji)


### PR DESCRIPTION
This commit brings us back to zero warnings for the default build configuration.