### PR TITLE
Add brew update before brew bundle

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -11,6 +11,7 @@ if [ "$1" = "Linux" ]; then
     fi
 elif [ "$1" = "OSX" ] || [ "$1" = "tvOS" ] || [ "$1" = "iOS" ]; then
     engdir=$(dirname "${BASH_SOURCE[0]}")
+    brew update --preinstall
     brew bundle --no-lock --file "${engdir}/Brewfile"
     if [ "$?" != "0" ]; then
         exit 1;


### PR DESCRIPTION
Every OSX lane appears to be failing because of an issue with brew bundle expecting the latest homebrew but not automatically updating: https://github.com/Homebrew/homebrew-bundle/issues/751

So forcibly update, which is apparently good practice anyway: https://github.com/Homebrew/homebrew-bundle/issues/751#issuecomment-664958735

If this is fixed promptly on homebrew's end, then maybe we don't need to take this? But this should at least get things green again.