### PR TITLE
Stop using transport packages for CoreCLR assets

### DIFF
--- a/src/coreclr/src/.nuget/Directory.Build.props
+++ b/src/coreclr/src/.nuget/Directory.Build.props
@@ -3,7 +3,7 @@
 
   <!-- Packaging projects (.pkgproj) are non-SDK-style, so they need to directly import Directory.Build.props -->
   <Import Project="../Directory.Build.props" />
-  
+
   <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.props" />
 
   <Import Project="packaging.props" />
@@ -12,8 +12,10 @@
     <!-- defined in Packaging.targets, but we need this before targets are imported -->
     <PackagePlatform>AnyCPU</PackagePlatform>
 
-    <!-- build the transport package which includes product and symbols in addition to standard packages -->
-    <CreatePackedPackage Condition="'$(CreatePackedPackage)' == ''">true</CreatePackedPackage>
+    <!-- build the transport package which includes product and symbols in addition to standard packages
+    This is a legacy setting as we tend to use symbol packages for symbol indexing and we don't use
+    transport packages to flow dependencies anymore -->
+    <CreatePackedPackage Condition="'$(CreatePackedPackage)' == ''">false</CreatePackedPackage>
 
     <!-- indicates that lib prefix is not added to library names for Unix-like operating systems -->
     <SkipLibraryPrefixFromUnix>true</SkipLibraryPrefixFromUnix>


### PR DESCRIPTION
All the uses of transport packages are fulfilled in some other way now: flow to upstream repositories is either done with other packages or gone with the runtime merge, and all symbols are indexed with symbol packages. 

Fixes #38924