### PR TITLE
[wasm] Re-enable some tests in the System.Net.WebSockets.Tests namespace

### DIFF
--- a/src/libraries/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
+++ b/src/libraries/Common/tests/System/Net/WebSockets/WebSocketCreateTest.cs
@@ -101,6 +101,7 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Theory]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Net.Sockets is not supported on this platform.
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         [InlineData(0b_1000_0001, 0b_0_000_0001, false)] // fin + text, no mask + length == 1
         [InlineData(0b_1100_0001, 0b_0_000_0001, true)] // fin + rsv1 + text, no mask + length == 1
@@ -147,6 +148,7 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(~TestPlatforms.Browser)] // System.Net.Sockets is not supported on this platform.
         [ActiveIssue("https://github.com/dotnet/runtime/issues/34690", TestPlatforms.Windows, TargetFrameworkMonikers.Netcoreapp, TestRuntimes.Mono)]
         public async Task ReceiveAsync_ServerSplitHeader_ValidDataReceived()
         {

--- a/src/libraries/System.Net.WebSockets.WebSocketProtocol/tests/WebSocketProtocolTests.cs
+++ b/src/libraries/System.Net.WebSockets.WebSocketProtocol/tests/WebSocketProtocolTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Net.WebSockets.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/38807", TestPlatforms.Browser)]
     public sealed class WebSocketProtocolCreateTests : WebSocketCreateTest
     {
         protected override WebSocket CreateFromStream(Stream stream, bool isServer, string subProtocol, TimeSpan keepAliveInterval) =>

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Net.WebSockets.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/38807", TestPlatforms.Browser)]
     public sealed class WebSocketTests : WebSocketCreateTest
     {
         protected override WebSocket CreateFromStream(Stream stream, bool isServer, string subProtocol, TimeSpan keepAliveInterval) =>


### PR DESCRIPTION
There is no repro for https://github.com/dotnet/runtime/issues/38807 at the moment so the related tests have been enabled.
Two tests have been disabled due to PNSE (see https://github.com/dotnet/runtime/pull/39346).

Fixes: https://github.com/dotnet/runtime/issues/38807 

The test run result: `Tests run: 177, Errors: 0, Failures: 0, Skipped: 0.`