### PR TITLE
[mono] Disable cfgdir config on Windows netcore builds

### DIFF
--- a/src/mono/winconfig.h
+++ b/src/mono/winconfig.h
@@ -67,6 +67,9 @@
 #ifndef DISABLE_DLLMAP
 #define DISABLE_DLLMAP 1
 #endif
+#ifndef DISABLE_CFGDIR_CONFIG
+#define DISABLE_CFGDIR_CONFIG 1
+#endif
 #endif
 
 /* Disable runtime state dumping */


### PR DESCRIPTION
This was already disabled with autotools, but I forgot to update winconfig.h as well.