### PR TITLE
Assert that we don't get the value we don't want instead of attempting to check for a specific error code. Fixes #39955

### DIFF
--- a/src/libraries/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.cs
+++ b/src/libraries/System.IO.FileSystem/tests/Enumeration/ErrorHandlingTests.cs
@@ -73,8 +73,11 @@ namespace System.IO.Tests
             // Make sure we're returning the native error as expected (and not the PAL error on Unix)
             using (LastError le = new LastError(Path.GetRandomFileName()))
             {
-                // Conveniently ERROR_FILE_NOT_FOUND and ENOENT are both 0x2
-                Assert.Equal(2, le.Error);
+                // while ERROR_FILE_NOT_FOUND/ENOENT have predictable values on Windows, Linux and Mac,
+                //  we can't rely on ENOENT having the same value on other platforms. Instead, assert
+                //  that we didn't get the PAL error because we know its value.
+                const int PAL_Error_ENOENT = 0x1002D;
+                Assert.NotEqual(PAL_Error_ENOENT, le.Error);
             }
         }
 


### PR DESCRIPTION
errno values like ENOENT don't actually have reliable values cross-platform, and this test is actually making sure that PAL error codes don't show up where native error codes are meant to be, so just check for the PAL error code instead.