### PR TITLE
Fix parsing of embedded .clsidmap in comhost

### DIFF
--- a/src/installer/corehost/cli/comhost/clsidmap.cpp
+++ b/src/installer/corehost/cli/comhost/clsidmap.cpp
@@ -43,16 +43,8 @@ namespace
         return S_OK;
     }
 
-    clsid_map parse_stream(_Inout_ pal::istream_t &json_map_raw)
+    clsid_map get_map_from_json(_In_ const json_parser_t &json)
     {
-        json_parser_t json;
-
-        if (!json.parse_stream(json_map_raw, _X("<embedded .clsidmap>")))
-        {
-            trace::error(_X("Embedded .clsidmap format is invalid"));
-            throw HResultException{ StatusCode::InvalidConfigFile };
-        }
-
         // Process JSON and construct a map
         HRESULT hr;
         clsid_map mapping;
@@ -86,16 +78,6 @@ namespace
         return mapping;
     }
 
-    class memory_buffer : public std::basic_streambuf<pal::istream_t::char_type>
-    {
-    public:
-        memory_buffer(_In_ DWORD dataInBytes, _In_reads_bytes_(dataInBytes) void *data)
-        {
-            auto raw_begin = reinterpret_cast<pal::istream_t::char_type*>(data);
-            setg(raw_begin, raw_begin, raw_begin + (dataInBytes / sizeof(pal::istream_t::char_type)));
-        }
-    };
-
     clsid_map get_json_map_from_resource(bool &found_resource)
     {
         found_resource = false;
@@ -117,9 +99,14 @@ namespace
         if (data == nullptr)
             throw HResultException{ E_UNEXPECTED }; // This should never happen in Windows 7+
 
-        memory_buffer resourceBuffer{ size, data };
-        pal::istream_t stream{ &resourceBuffer };
-        return parse_stream(stream);
+        json_parser_t json;
+        if (!json.parse_raw_data(reinterpret_cast<char*>(data), size, _X("<embedded .clsidmap>")))
+        {
+            trace::error(_X("Embedded .clsidmap format is invalid"));
+            throw HResultException{ StatusCode::InvalidConfigFile };
+        }
+
+        return get_map_from_json(json);
     }
 
     bool is_binary_unsigned(const pal::string_t &path)
@@ -190,8 +177,14 @@ namespace
         if (!pal::file_exists(map_file_name))
             return {};
 
-        pal::ifstream_t file{ map_file_name };
-        return parse_stream(file);
+        json_parser_t json;
+        if (!json.parse_file(map_file_name))
+        {
+            trace::error(_X("File .clsidmap format is invalid"));
+            throw HResultException{ StatusCode::InvalidConfigFile };
+        }
+
+        return get_map_from_json(json);
     }
 }
 

--- a/src/installer/corehost/cli/json_parser.cpp
+++ b/src/installer/corehost/cli/json_parser.cpp
@@ -76,6 +76,8 @@ void json_parser_t::realloc_buffer(size_t size)
 
 bool json_parser_t::parse_raw_data(char* data, int64_t size, const pal::string_t& context)
 {
+    assert(data != nullptr);
+
     constexpr auto flags = rapidjson::ParseFlag::kParseStopWhenDoneFlag | rapidjson::ParseFlag::kParseCommentsFlag;
 #ifdef _WIN32
     // Can't use in-situ parsing on Windows, as JSON data is encoded in
@@ -133,7 +135,7 @@ bool json_parser_t::parse_file(const pal::string_t& path)
     pal::ifstream_t file{ path };
     if (!file.good())
     {
-        trace::error(_X("Cannot use file for resource [%s]: %s"), path.c_str(), pal::strerror(errno));
+        trace::error(_X("Cannot use file stream for [%s]: %s"), path.c_str(), pal::strerror(errno));
         return false;
     }
 
@@ -142,7 +144,7 @@ bool json_parser_t::parse_file(const pal::string_t& path)
     auto stream_size = file.tellg();
     if (stream_size == -1)
     {
-        trace::error(_X("Failed to get size of resource [%s]"), path.c_str());
+        trace::error(_X("Failed to get size of file [%s]"), path.c_str());
         return false;
     }
 

--- a/src/installer/corehost/cli/json_parser.cpp
+++ b/src/installer/corehost/cli/json_parser.cpp
@@ -74,7 +74,7 @@ void json_parser_t::realloc_buffer(size_t size)
     m_json[size] = '\0';
 }
 
-bool json_parser_t::parse_json(char* data, int64_t size, const pal::string_t& context)
+bool json_parser_t::parse_raw_data(char* data, int64_t size, const pal::string_t& context)
 {
     constexpr auto flags = rapidjson::ParseFlag::kParseStopWhenDoneFlag | rapidjson::ParseFlag::kParseCommentsFlag;
 #ifdef _WIN32
@@ -109,26 +109,6 @@ bool json_parser_t::parse_json(char* data, int64_t size, const pal::string_t& co
     return true;
 }
 
-bool json_parser_t::parse_stream(pal::istream_t& stream,
-                                 const pal::string_t& context)
-{
-    if (!stream.good())
-    {
-        trace::error(_X("Cannot use stream for resource [%s]: %s"), context.c_str(), pal::strerror(errno));
-        return false;
-    }
-
-    auto current_pos = ::get_utf8_bom_length(stream);
-    stream.seekg(0, stream.end);
-    auto stream_size = stream.tellg();
-    stream.seekg(current_pos, stream.beg);
-
-    realloc_buffer(stream_size - current_pos);
-    stream.read(m_json.data(), stream_size - current_pos);
-
-    return parse_json(m_json.data(), m_json.size(), context);
-}
-
 bool json_parser_t::parse_file(const pal::string_t& path)
 {
     // This code assumes that the caller has checked that the file `path` exists
@@ -145,13 +125,33 @@ bool json_parser_t::parse_file(const pal::string_t& path)
 
         if (m_bundle_data != nullptr)
         {
-            bool result = parse_json(m_bundle_data, m_bundle_location->size, path);
+            bool result = parse_raw_data(m_bundle_data, m_bundle_location->size, path);
             return result;
         }
     }
 
     pal::ifstream_t file{ path };
-    return parse_stream(file, path);
+    if (!file.good())
+    {
+        trace::error(_X("Cannot use file for resource [%s]: %s"), path.c_str(), pal::strerror(errno));
+        return false;
+    }
+
+    auto current_pos = ::get_utf8_bom_length(file);
+    file.seekg(0, file.end);
+    auto stream_size = file.tellg();
+    if (stream_size == -1)
+    {
+        trace::error(_X("Failed to get size of resource [%s]"), path.c_str());
+        return false;
+    }
+
+    file.seekg(current_pos, file.beg);
+
+    realloc_buffer(stream_size - current_pos);
+    file.read(m_json.data(), stream_size - current_pos);
+
+    return parse_raw_data(m_json.data(), m_json.size(), path);
 }
 
 json_parser_t::~json_parser_t()

--- a/src/installer/corehost/cli/json_parser.h
+++ b/src/installer/corehost/cli/json_parser.h
@@ -30,7 +30,7 @@ class json_parser_t {
 
         const document_t& document() const { return m_document; }
 
-        bool parse_stream(pal::istream_t& stream, const pal::string_t& context);
+        bool parse_raw_data(char* data, int64_t size, const pal::string_t& context);
         bool parse_file(const pal::string_t& path);
 
         json_parser_t()
@@ -52,7 +52,6 @@ class json_parser_t {
         const bundle::location_t* m_bundle_location; // Location of this json file within the bundle.
 
         void realloc_buffer(size_t size);
-        bool parse_json(char* data, int64_t size, const pal::string_t& context);
 };
 
 #endif // __JSON_PARSER_H__

--- a/src/installer/tests/Assets/TestProjects/ComLibrary/ComLibrary.csproj
+++ b/src/installer/tests/Assets/TestProjects/ComLibrary/ComLibrary.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <RuntimeFrameworkVersion>$(MNAVersion)</RuntimeFrameworkVersion>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
`comhost` is crashing during registration. `json_parser_t::parse_stream` is using `seekg`/`tellg` to find the size of the stream. For the embedded .clsidmap, the stream buffer did not override / implement everything, so those functions would error out. We didn't check for error, so we would just use the invalid size and AV.

- Switch to operating on raw data and size for embedded .clsidmap instead of creating a stream
- Fold `json_parser_t::parse_stream` into `json_parser_t::parse_file` and check for error when getting the size of the stream
- Make tests use HostModel to create a comhost with an embedded .clsidmap instead of using a loose file

Fixes #39954

cc @AaronRobinsonMSFT @jkoritzinsky @vitek-karas 