### PR TITLE
Added the Parse() method as a constructor

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -30,6 +30,11 @@ namespace System.Numerics
         private static readonly BigInteger s_bnZeroInt = new BigInteger(0);
         private static readonly BigInteger s_bnMinusOneInt = new BigInteger(-1);
 
+        public BigInteger(string value)
+        {
+            return Parse(value, NumberStyles.Integer);
+        }
+        
         public BigInteger(int value)
         {
             if (value == int.MinValue)


### PR DESCRIPTION
If `Parse()` is the main method of BigInt and the only thing that will accomplish the intended purpose of BigInteger, being *Able to store arbitrarily large numbers* as said in the documentation and numbers with infinite limits, why use inefficient constructors that will try to convert the `new()` overload to different datatypes which 1) is inefficient and could be faster and 2) **HAS A MAXIMUM VALUE** which is **not** what was intended for BigInteger