### PR TITLE
WASM: Enable GetAssemblyNameTest_ValidAssembly and add hook to include custom files into vfs

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -132,23 +132,12 @@
       <WasmFilesToIncludeInFileSystem Include="@(ContentWithTargetPath)" />
       <WasmFilesToIncludeInFileSystem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.BuildReference)' == 'true' and !$([System.String]::new('%(ReferenceCopyLocalPaths.Identity)').EndsWith('.resources.dll'))" />
       <WasmFilesToIncludeInFileSystem Include="@(WasmSatelliteAssemblies)" TargetPath="%(WasmSatelliteAssemblies.CultureName)\%(WasmSatelliteAssemblies.Filename)%(WasmSatelliteAssemblies.Extension)" />
+      <!-- Include files specified by test projects from publish dir -->
+      <WasmFilesToIncludeInFileSystem Include="@(WasmFilesToIncludeFromPublishDir -> '$(PublishDir)%(Identity)')" />
       <ExtraAssemblies Include="$(PublishDir)$(AssemblyName).dll" />
       <!-- We need these facades for some tests. -->
       <ExtraAssemblies Include="$(PublishDir)mscorlib.dll" />
       <ExtraAssemblies Include="$(PublishDir)System.Drawing.dll" />
-    </ItemGroup>
-    <!-- these tests load assemblies from the file system -->
-    <ItemGroup Condition="'$(AssemblyName)' == 'System.Reflection.MetadataLoadContext.Tests'">
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Private.CoreLib.dll" />
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.MetadataLoadContext.Tests.dll" />
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)mscorlib.dll" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(AssemblyName)' == 'System.Reflection.Metadata.Tests'">
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.Metadata.Tests.dll" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(AssemblyName)' == 'System.Reflection.Tests'">
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.Tests.dll" />
-      <WasmFilesToIncludeInFileSystem Include="$(PublishDir)System.Reflection.Tests.pdb" />
     </ItemGroup>
     <Error Condition="!Exists('$(MicrosoftNetCoreAppRuntimePackRidDir)')" Text="MicrosoftNetCoreAppRuntimePackRidDir=$(MicrosoftNetCoreAppRuntimePackRidDir) doesn't exist" />
     <WasmAppBuilder

--- a/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/libraries/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -139,4 +139,7 @@
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="$(SystemSecurityCryptographyAlgorithmsVersion)" />
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+    <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/System.Reflection.MetadataLoadContext.Tests.csproj
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/System.Reflection.MetadataLoadContext.Tests.csproj
@@ -74,4 +74,9 @@
   <ItemGroup>
     <ProjectReference Include="..\src\System.Reflection.MetadataLoadContext.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+    <WasmFilesToIncludeFromPublishDir Include="System.Private.CoreLib.dll" />
+    <WasmFilesToIncludeFromPublishDir Include="System.Reflection.MetadataLoadContext.Tests.dll" />
+    <WasmFilesToIncludeFromPublishDir Include="mscorlib.dll" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/libraries/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -64,4 +64,8 @@
     <ProjectReference Include="TestExe\System.Reflection.TestExe.csproj" />
     <ProjectReference Include="TestAssembly\TestAssembly.csproj" />
   </ItemGroup>
+    <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+    <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />
+    <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).pdb" />
+  </ItemGroup>
 </Project>

--- a/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
+++ b/src/libraries/System.Runtime.Loader/tests/AssemblyLoadContextTest.cs
@@ -18,7 +18,6 @@ namespace System.Runtime.Loader.Tests
         private const string TestAssemblyNotSupported = "System.Runtime.Loader.Test.AssemblyNotSupported";
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39379", TestPlatforms.Browser)]
         public static void GetAssemblyNameTest_ValidAssembly()
         {
             var expectedName = typeof(AssemblyLoadContextTest).Assembly.GetName();

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -30,4 +30,7 @@
     <ProjectReference Include="ReferencedClassLib\ReferencedClassLib.csproj" />
     <ProjectReference Include="ReferencedClassLibNeutralIsSatellite\ReferencedClassLibNeutralIsSatellite.csproj" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetOS)' == 'Browser'">
+    <WasmFilesToIncludeFromPublishDir Include="$(AssemblyName).dll" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/runtime/issues/39379