### PR TITLE
Fix ILLink warnings for removed attributes when Debugger.IsSupported is false

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.LinkAttributes.Shared.xml
@@ -29,13 +29,5 @@
     <type fullname="System.Diagnostics.DebuggerVisualizerAttribute">
       <attribute internal="RemoveAttributeInstances" />
     </type>
-
-    <!-- Attributes used during pretty stack trace printing -->
-    <type fullname="System.Diagnostics.StackTraceHiddenAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
-    <type fullname="System.Runtime.CompilerServices.CompilerGeneratedAttribute">
-      <attribute internal="RemoveAttributeInstances" />
-    </type>
   </assembly>
 </linker>


### PR DESCRIPTION
When `Debugger.IsSupported` feature switch is false, we trim unnecessary attributes in the code - specifically attributes like `CompilerGeneratedAttribute` and `StackTraceHiddenAttribute`. However, we still have code accessing these attributes, which causes the ILLinker to warn that it is removing the attributes, but code still uses them.

To fix this, remove these attributes from being trimmed when Debugger.IsSupported is false. Instead these attributes will be preserved always so things like "is anonymous type" checks and stack trace tostring will behave correctly.

Fix #39707