### PR TITLE
Fix creating RegionInfo object using names with different casing.

### DIFF
--- a/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
+++ b/src/libraries/System.Globalization/tests/System/Globalization/RegionInfoTests.cs
@@ -79,6 +79,24 @@ namespace System.Globalization.Tests
             }).Dispose();
         }
 
+
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        // We are testing with "no" as it match a neutral culture name. We want ensure this not conflict with region name.
+        [InlineData("no")]
+        [InlineData("No")]
+        [InlineData("NO")]
+        public void ValidateUsingCasedRegionName(string regionName)
+        {
+            RemoteExecutor.Invoke(name =>
+            {
+                // It is important to do this test in the following order because we have internal cache for regions.
+                // creating the region with the original input name should be the first to do to ensure not cached before.
+                string resultedName = new RegionInfo(name).Name;
+                string expectedName = new RegionInfo(name.ToUpperInvariant()).Name;
+                Assert.Equal(expectedName, resultedName);
+            }, regionName).Dispose();
+        }
+
         [Theory]
         [InlineData("en-US", "United States")]
         [OuterLoop("May fail on machines with multiple language packs installed")] // see https://github.com/dotnet/runtime/issues/30132

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -152,7 +152,7 @@ namespace System.Globalization
         /// </remarks>
         private static Dictionary<string, string> RegionNames =>
             s_regionNames ??=
-            new Dictionary<string, string>(257 /* prime */)
+            new Dictionary<string, string>(257 /* prime */, StringComparer.OrdinalIgnoreCase)
             {
                 { "001", "en-001" },
                 { "029", "en-029" },


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39991