### PR TITLE
Tolerate pathological growth of optCSEHash

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6365,6 +6365,7 @@ protected:
 
     static const size_t s_optCSEhashSize;
     static const size_t s_optCSEhashGrowthFactor;
+    static const size_t s_optCSEhashBucketSize;
     size_t              optCSEhashSize;     // Size of hashtable
     size_t              optCSEhashCount;    // Number of entries in hashtable
     size_t              optCSEhashMaxCountBeforeResize; // Number of entries before resize

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6364,6 +6364,10 @@ protected:
     };
 
     static const size_t s_optCSEhashSize;
+    static const size_t s_optCSEhashGrowthFactor;
+    size_t              optCSEhashSize;     // Size of hashtable
+    size_t              optCSEhashCount;    // Number of entries in hashtable
+    size_t              optCSEhashMaxCountBeforeResize; // Number of entries before resize
     CSEdsc**            optCSEhash;
     CSEdsc**            optCSEtab;
 

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6363,10 +6363,10 @@ protected:
                                    // not used for shared const CSE's
     };
 
-    static const size_t s_optCSEhashSize;
+    static const size_t s_optCSEhashSizeInitial;
     static const size_t s_optCSEhashGrowthFactor;
     static const size_t s_optCSEhashBucketSize;
-    size_t              optCSEhashSize;                 // Size of hashtable
+    size_t              optCSEhashSize;                 // The current size of hashtable
     size_t              optCSEhashCount;                // Number of entries in hashtable
     size_t              optCSEhashMaxCountBeforeResize; // Number of entries before resize
     CSEdsc**            optCSEhash;

--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -6366,8 +6366,8 @@ protected:
     static const size_t s_optCSEhashSize;
     static const size_t s_optCSEhashGrowthFactor;
     static const size_t s_optCSEhashBucketSize;
-    size_t              optCSEhashSize;     // Size of hashtable
-    size_t              optCSEhashCount;    // Number of entries in hashtable
+    size_t              optCSEhashSize;                 // Size of hashtable
+    size_t              optCSEhashCount;                // Number of entries in hashtable
     size_t              optCSEhashMaxCountBeforeResize; // Number of entries before resize
     CSEdsc**            optCSEhash;
     CSEdsc**            optCSEtab;

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -38,7 +38,7 @@ void Compiler::optCSEstop()
 
     CSEdsc*  dsc;
     CSEdsc** ptr;
-    unsigned cnt;
+    size_t   cnt;
 
     optCSEtab = new (this, CMK_CSE) CSEdsc*[optCSECandidateCount]();
 
@@ -641,13 +641,13 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         {
             if (optCSEhashCount == optCSEhashMaxCountBeforeResize)
             {
-                size_t newOptCSEhashSize      = optCSEhashSize * s_optCSEhashGrowthFactor;
-                CSEdsc** newOptCSEhash = new (this, CMK_CSE) CSEdsc*[newOptCSEhashSize]();
+                size_t newOptCSEhashSize = optCSEhashSize * s_optCSEhashGrowthFactor;
+                CSEdsc** newOptCSEhash   = new (this, CMK_CSE) CSEdsc*[newOptCSEhashSize]();
 
                 // Iterate through each existing entry, moving to the new table
                 CSEdsc** ptr;
-                CSEdsc* dsc;
-                size_t cnt;
+                CSEdsc*  dsc;
+                size_t   cnt;
                 for (cnt = optCSEhashSize, ptr = optCSEhash; cnt; cnt--, ptr++)
                 {
                     for (dsc = *ptr; dsc;)
@@ -657,15 +657,15 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
                         size_t newHval = optCSEKeyToHashIndex(dsc->csdHashKey, newOptCSEhashSize);
 
                         // Move CSEdsc to bucket in enlarged table
-                        dsc->csdNextInBucket = newOptCSEhash[newHval];
+                        dsc->csdNextInBucket   = newOptCSEhash[newHval];
                         newOptCSEhash[newHval] = dsc;
 
                         dsc = nextDsc;
                     }
                 }
 
-                optCSEhash = newOptCSEhash;
-                optCSEhashSize = newOptCSEhashSize;
+                optCSEhash                     = newOptCSEhash;
+                optCSEhashSize                 = newOptCSEhashSize;
                 optCSEhashMaxCountBeforeResize = optCSEhashMaxCountBeforeResize * s_optCSEhashGrowthFactor;
             }
 

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -22,6 +22,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 /* static */
 const size_t Compiler::s_optCSEhashSize         = EXPSET_SZ * 2;
 const size_t Compiler::s_optCSEhashGrowthFactor = 2;
+const size_t Compiler::s_optCSEhashBucketSize   = 4;
 
 /*****************************************************************************
  *
@@ -377,8 +378,8 @@ void Compiler::optValnumCSE_Init()
     optCSEhash = new (this, CMK_CSE) CSEdsc*[s_optCSEhashSize]();
 
     optCSEhashSize                 = s_optCSEhashSize;
-    optCSEhashMaxCountBeforeResize = optCSEhashSize * s_optCSEhashGrowthFactor;
-    optCSEhashCount                = 0
+    optCSEhashMaxCountBeforeResize = optCSEhashSize * s_optCSEhashBucketSize;
+    optCSEhashCount                = 0;
 
     optCSECandidateCount = 0;
     optDoCSE             = false; // Stays false until we find duplicate CSE tree
@@ -641,7 +642,7 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
             if (optCSEhashCount == optCSEhashMaxCountBeforeResize)
             {
                 size_t newOptCSEhashSize      = optCSEhashSize * s_optCSEhashGrowthFactor;
-                CSEdsc** newOptCSEhash = new (this, CMK_CSE) CSEdsc*[new_optCSEhashSize]();
+                CSEdsc** newOptCSEhash = new (this, CMK_CSE) CSEdsc*[newOptCSEhashSize]();
 
                 // Iterate through each existing entry, moving to the new table
                 CSEdsc** ptr;

--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -20,7 +20,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 /*****************************************************************************/
 
 /* static */
-const size_t Compiler::s_optCSEhashSize         = EXPSET_SZ * 2;
+const size_t Compiler::s_optCSEhashSizeInitial  = EXPSET_SZ * 2;
 const size_t Compiler::s_optCSEhashGrowthFactor = 2;
 const size_t Compiler::s_optCSEhashBucketSize   = 4;
 
@@ -375,9 +375,9 @@ void Compiler::optValnumCSE_Init()
     cseMaskTraits = nullptr;
 
     // Allocate and clear the hash bucket table
-    optCSEhash = new (this, CMK_CSE) CSEdsc*[s_optCSEhashSize]();
+    optCSEhash = new (this, CMK_CSE) CSEdsc*[s_optCSEhashSizeInitial]();
 
-    optCSEhashSize                 = s_optCSEhashSize;
+    optCSEhashSize                 = s_optCSEhashSizeInitial;
     optCSEhashMaxCountBeforeResize = optCSEhashSize * s_optCSEhashBucketSize;
     optCSEhashCount                = 0;
 
@@ -641,8 +641,8 @@ unsigned Compiler::optValnumCSE_Index(GenTree* tree, Statement* stmt)
         {
             if (optCSEhashCount == optCSEhashMaxCountBeforeResize)
             {
-                size_t newOptCSEhashSize = optCSEhashSize * s_optCSEhashGrowthFactor;
-                CSEdsc** newOptCSEhash   = new (this, CMK_CSE) CSEdsc*[newOptCSEhashSize]();
+                size_t   newOptCSEhashSize = optCSEhashSize * s_optCSEhashGrowthFactor;
+                CSEdsc** newOptCSEhash     = new (this, CMK_CSE) CSEdsc*[newOptCSEhashSize]();
 
                 // Iterate through each existing entry, moving to the new table
                 CSEdsc** ptr;


### PR DESCRIPTION
The `optCSEhash` can grow an unbounded amount if the function has numerous trees which are put into the `optCSEhash` as possible CSE candidates, but fewer than `MAX_CSE_CNT` are found, then the compiler will spend excessive amounts of time looking up entries in the `optCSEhash`.

This fix addresses the issue by making the `optCSEhash` able to grow its count of buckets.

This fixes #32733, but I'm not certain its the right approach. Potentially avoiding the pathological growth of the hash table would be a better approach.
