### PR TITLE
Don't suspend for debugger while holding the slot backpatching lock

### DIFF
--- a/src/coreclr/src/debug/ee/debugger.cpp
+++ b/src/coreclr/src/debug/ee/debugger.cpp
@@ -15242,15 +15242,6 @@ HRESULT Debugger::FuncEvalSetup(DebuggerIPCE_FuncEvalInfo *pEvalInfo,
         return CORDBG_E_FUNC_EVAL_BAD_START_POINT;
     }
 
-    if (MethodDescBackpatchInfoTracker::IsLockOwnedByAnyThread())
-    {
-        // A thread may have suspended for the debugger while holding the slot backpatching lock while trying to enter
-        // cooperative GC mode. If the FuncEval calls a method that is eligible for slot backpatching (virtual or interface
-        // methods that are eligible for tiering), the FuncEval may deadlock on trying to acquire the same lock. Fail the
-        // FuncEval to avoid the issue.
-        return CORDBG_E_FUNC_EVAL_BAD_START_POINT;
-    }
-
     // Create a DebuggerEval to hold info about this eval while its in progress. Constructor copies the thread's
     // CONTEXT.
     DebuggerEval *pDE = new (interopsafe, nothrow) DebuggerEval(filterContext, pEvalInfo, fInException);

--- a/src/coreclr/src/vm/callcounting.cpp
+++ b/src/coreclr/src/vm/callcounting.cpp
@@ -815,8 +815,7 @@ void CallCountingManager::CompleteCallCounting()
     {
         CodeVersionManager *codeVersionManager = appDomain->GetCodeVersionManager();
 
-        MethodDescBackpatchInfoTracker::PollForDebuggerSuspension();
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
+        MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder;
 
         // Backpatching entry point slots requires cooperative GC mode, see
         // MethodDescBackpatchInfoTracker::Backpatch_Locked(). The code version manager's table lock is an unsafe lock that
@@ -947,8 +946,7 @@ void CallCountingManager::StopAndDeleteAllCallCountingStubs()
     TieredCompilationManager *tieredCompilationManager = GetAppDomain()->GetTieredCompilationManager();
     bool scheduleTieringBackgroundWork = false;
     {
-        MethodDescBackpatchInfoTracker::PollForDebuggerSuspension();
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
+        MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder;
 
         ThreadSuspend::SuspendEE(ThreadSuspend::SUSPEND_OTHER);
         struct AutoRestartEE

--- a/src/coreclr/src/vm/codeversion.cpp
+++ b/src/coreclr/src/vm/codeversion.cpp
@@ -1759,7 +1759,8 @@ PCODE CodeVersionManager::PublishVersionableCodeIfNecessary(
         do
         {
             bool mayHaveEntryPointSlotsToBackpatch = doPublish && pMethodDesc->MayHaveEntryPointSlotsToBackpatch();
-            MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder(mayHaveEntryPointSlotsToBackpatch);
+            MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder(
+                mayHaveEntryPointSlotsToBackpatch);
 
             // Try a faster check to see if we can avoid checking the currently active code version
             // - For the default code version, if a profiler is attached it may be notified of JIT events and may request rejit

--- a/src/coreclr/src/vm/crst.h
+++ b/src/coreclr/src/vm/crst.h
@@ -362,13 +362,14 @@ private:
     {
         m_dwFlags = 0;
     }
+
     // ------------------------------- Holders ------------------------------
- public:
-     //
-     // CrstHolder is optimized for the common use that takes the lock in constructor
-     // and releases it in destructor. Users that require all Holder features
-     // can use CrstHolderWithState.
-     //
+public:
+    //
+    // CrstHolder is optimized for the common use that takes the lock in constructor
+    // and releases it in destructor. Users that require all Holder features
+    // can use CrstHolderWithState.
+    //
     class CrstHolder
     {
         CrstBase * m_pCrst;
@@ -397,11 +398,22 @@ private:
     // Generally, it's better to use a regular CrstHolder, and then use the Release() / Acquire() methods on it.
     // This just exists to convert legacy OS Critical Section patterns over to holders.
     typedef DacHolder<CrstBase *, CrstBase::ReleaseLock, CrstBase::AcquireLock, 0, CompareDefault> UnsafeCrstInverseHolder;
+
+    class CrstAndForbidSuspendForDebuggerHolder
+    {
+    private:
+        CrstBase *m_pCrst;
+        Thread *m_pThreadForExitingForbidRegion;
+
+    public:
+        CrstAndForbidSuspendForDebuggerHolder(CrstBase *pCrst);
+        ~CrstAndForbidSuspendForDebuggerHolder();
+    };
 };
 
 typedef CrstBase::CrstHolder CrstHolder;
 typedef CrstBase::CrstHolderWithState CrstHolderWithState;
-
+typedef CrstBase::CrstAndForbidSuspendForDebuggerHolder CrstAndForbidSuspendForDebuggerHolder;
 
 // The CRST.
 class Crst : public CrstBase

--- a/src/coreclr/src/vm/fptrstubs.cpp
+++ b/src/coreclr/src/vm/fptrstubs.cpp
@@ -151,10 +151,12 @@ PCODE FuncPtrStubs::GetFuncPtrStub(MethodDesc * pMD, PrecodeType type)
 
     if (setTargetAfterAddingToHashTable)
     {
+        GCX_PREEMP();
+
         _ASSERTE(pMD->IsVersionableWithVtableSlotBackpatch());
 
         PCODE temporaryEntryPoint = pMD->GetTemporaryEntryPoint();
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
+        MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCPreemp slotBackpatchLockHolder;
 
         // Set the funcptr stub's entry point to the current entry point inside the lock and after the funcptr stub is exposed,
         // to synchronize with backpatching in MethodDesc::BackpatchEntryPointSlots()

--- a/src/coreclr/src/vm/method.cpp
+++ b/src/coreclr/src/vm/method.cpp
@@ -4882,8 +4882,10 @@ void MethodDesc::RecordAndBackpatchEntryPointSlot(
 {
     WRAPPER_NO_CONTRACT;
 
+    GCX_PREEMP();
+
     LoaderAllocator *mdLoaderAllocator = GetLoaderAllocator();
-    MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
+    MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder;
 
     RecordAndBackpatchEntryPointSlot_Locked(
         mdLoaderAllocator,

--- a/src/coreclr/src/vm/methoddescbackpatchinfo.cpp
+++ b/src/coreclr/src/vm/methoddescbackpatchinfo.cpp
@@ -65,7 +65,6 @@ void EntryPointSlots::Backpatch_Locked(TADDR slot, SlotType slotType, PCODE entr
 // MethodDescBackpatchInfoTracker
 
 CrstStatic MethodDescBackpatchInfoTracker::s_lock;
-bool MethodDescBackpatchInfoTracker::s_isLocked = false;
 
 #ifndef DACCESS_COMPILE
 
@@ -122,31 +121,5 @@ bool MethodDescBackpatchInfoTracker::IsLockOwnedByCurrentThread()
 #endif
 }
 #endif // _DEBUG
-
-#ifndef DACCESS_COMPILE
-void MethodDescBackpatchInfoTracker::PollForDebuggerSuspension()
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_TRIGGERS;
-        MODE_PREEMPTIVE;
-    }
-    CONTRACTL_END;
-
-    _ASSERTE(!IsLockOwnedByCurrentThread());
-
-    // If suspension is pending for the debugger, pulse the GC mode to suspend the thread here. Following this call, typically
-    // the lock is acquired and the GC mode is changed, and suspending there would cause FuncEvals to fail (see
-    // Debugger::FuncEvalSetup() at the reference to IsLockOwnedByAnyThread()). Since this thread is in preemptive mode, the
-    // debugger may think it's already suspended and it would be unfortunate to suspend the thread with the lock held.
-    Thread *thread = GetThread();
-    _ASSERTE(thread != nullptr);
-    if (thread->HasThreadState(Thread::TS_DebugSuspendPending))
-    {
-        GCX_COOP();
-    }
-}
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/coreclr/src/vm/prestub.cpp
+++ b/src/coreclr/src/vm/prestub.cpp
@@ -95,7 +95,8 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, BO
 
     // Only take the lock if the method is versionable with vtable slot backpatch, for recording slots and synchronizing with
     // backpatching slots
-    MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder(isVersionableWithVtableSlotBackpatch);
+    MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder(
+        isVersionableWithVtableSlotBackpatch);
 
     // Get the method entry point inside the lock above to synchronize with backpatching in
     // MethodDesc::BackpatchEntryPointSlots()

--- a/src/coreclr/src/vm/rejit.cpp
+++ b/src/coreclr/src/vm/rejit.cpp
@@ -643,7 +643,7 @@ HRESULT ReJitManager::UpdateActiveILVersions(
     SHash<CodeActivationBatchTraits>::Iterator endIter = mgrToCodeActivationBatch.End();
 
     {
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
+        MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder;
 
         for (SHash<CodeActivationBatchTraits>::Iterator iter = beginIter; iter != endIter; iter++)
         {

--- a/src/coreclr/src/vm/threads.cpp
+++ b/src/coreclr/src/vm/threads.cpp
@@ -1598,6 +1598,7 @@ Thread::Thread()
     m_DeserializationTracker = NULL;
 
     m_currentPrepareCodeConfig = nullptr;
+    m_isInForbidSuspendForDebuggerRegion = false;
 
 #ifdef _DEBUG
     memset(dangerousObjRefs, 0, sizeof(dangerousObjRefs));

--- a/src/coreclr/src/vm/threads.h
+++ b/src/coreclr/src/vm/threads.h
@@ -4750,6 +4750,21 @@ public:
 
 private:
     PrepareCodeConfig *m_currentPrepareCodeConfig;
+
+#ifndef DACCESS_COMPILE
+public:
+    bool IsInForbidSuspendForDebuggerRegion() const
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_isInForbidSuspendForDebuggerRegion;
+    }
+
+    void EnterForbidSuspendForDebuggerRegion();
+    void ExitForbidSuspendForDebuggerRegion();
+#endif
+
+private:
+    bool m_isInForbidSuspendForDebuggerRegion;
 };
 
 // End of class Thread

--- a/src/coreclr/src/vm/threads.inl
+++ b/src/coreclr/src/vm/threads.inl
@@ -195,6 +195,24 @@ inline Thread::CurrentPrepareCodeConfigHolder::~CurrentPrepareCodeConfigHolder()
     config->SetNextInSameThread(nullptr);
 }
 
+inline void Thread::EnterForbidSuspendForDebuggerRegion()
+{
+    WRAPPER_NO_CONTRACT;
+    _ASSERTE(this == GetThread());
+
+    _ASSERTE(!m_isInForbidSuspendForDebuggerRegion);
+    m_isInForbidSuspendForDebuggerRegion = true;
+}
+
+inline void Thread::ExitForbidSuspendForDebuggerRegion()
+{
+    WRAPPER_NO_CONTRACT;
+    _ASSERTE(this == GetThread());
+
+    _ASSERTE(m_isInForbidSuspendForDebuggerRegion);
+    m_isInForbidSuspendForDebuggerRegion = false;
+}
+
 #ifdef HOST_WINDOWS
 inline size_t Thread::GetOffsetOfThreadStatic(void* pThreadStatic)
 {

--- a/src/coreclr/src/vm/tieredcompilation.cpp
+++ b/src/coreclr/src/vm/tieredcompilation.cpp
@@ -448,8 +448,7 @@ void TieredCompilationManager::DeactivateTieringDelay()
         COUNT_T methodCount = methodsPendingCounting->GetCount();
         CodeVersionManager *codeVersionManager = GetAppDomain()->GetCodeVersionManager();
 
-        MethodDescBackpatchInfoTracker::PollForDebuggerSuspension();
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
+        MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder;
 
         // Backpatching entry point slots requires cooperative GC mode, see
         // MethodDescBackpatchInfoTracker::Backpatch_Locked(). The code version manager's table lock is an unsafe lock that
@@ -819,11 +818,8 @@ void TieredCompilationManager::ActivateCodeVersion(NativeCodeVersion nativeCodeV
     HRESULT hr = S_OK;
     {
         bool mayHaveEntryPointSlotsToBackpatch = pMethod->MayHaveEntryPointSlotsToBackpatch();
-        if (mayHaveEntryPointSlotsToBackpatch)
-        {
-            MethodDescBackpatchInfoTracker::PollForDebuggerSuspension();
-        }
-        MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder(mayHaveEntryPointSlotsToBackpatch);
+        MethodDescBackpatchInfoTracker::ConditionalLockHolderForGCCoop slotBackpatchLockHolder(
+            mayHaveEntryPointSlotsToBackpatch);
 
         // Backpatching entry point slots requires cooperative GC mode, see
         // MethodDescBackpatchInfoTracker::Backpatch_Locked(). The code version manager's table lock is an unsafe lock that

--- a/src/coreclr/src/vm/virtualcallstub.cpp
+++ b/src/coreclr/src/vm/virtualcallstub.cpp
@@ -2765,7 +2765,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStub(PCODE            ad
         TADDR slot = holder->stub()->implTargetSlot(&slotType);
         pMD->RecordAndBackpatchEntryPointSlot(m_loaderAllocator, slot, slotType);
 
-        // RecordAndBackpatchEntryPointSlot() takes a lock that would exit and reenter cooperative GC mode
+        // RecordAndBackpatchEntryPointSlot() may exit and reenter cooperative GC mode
         *pMayHaveReenteredCooperativeGCMode = true;
     }
 #endif
@@ -2827,7 +2827,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStubLong(PCODE          
         TADDR slot = holder->stub()->implTargetSlot(&slotType);
         pMD->RecordAndBackpatchEntryPointSlot(m_loaderAllocator, slot, slotType);
 
-        // RecordAndBackpatchEntryPointSlot() takes a lock that would exit and reenter cooperative GC mode
+        // RecordAndBackpatchEntryPointSlot() may exit and reenter cooperative GC mode
         *pMayHaveReenteredCooperativeGCMode = true;
     }
 #endif
@@ -3020,7 +3020,7 @@ ResolveCacheElem *VirtualCallStubManager::GenerateResolveCacheElem(void *addrOfC
             (TADDR)&e->target,
             EntryPointSlots::SlotType_Normal);
 
-        // RecordAndBackpatchEntryPointSlot() takes a lock that would exit and reenter cooperative GC mode
+        // RecordAndBackpatchEntryPointSlot() may exit and reenter cooperative GC mode
         *pMayHaveReenteredCooperativeGCMode = true;
     }
 #endif


### PR DESCRIPTION
- Mostly reverted the previous workaround for the issue (commit fc06054a774e28a5a47bbe862adcf03251abb43c)
- Added a forbid-suspend-for-debugger region in preemptive GC mode
- Added a crst holder type that acquires a lock and enters the forbid region
- Where the slot backpatching lock would be taken where cooperative GC mode may be entered inside that lock, the new crst holder is used
- When a suspend for debugger is requested, a thread in preemptive GC mode that is in the forbid region is considered not yet suspended and is synched later similarly to threads in cooperative GC mode

Fixes https://github.com/dotnet/runtime/issues/37278