### PR TITLE
Extensions.Logging: JsonConsoleFormatter serializes scope and state properties using native json type

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -18,6 +19,7 @@ namespace Microsoft.Extensions.Logging.Console
     internal class JsonConsoleFormatter : ConsoleFormatter, IDisposable
     {
         private IDisposable _optionsReloadToken;
+        private char[] _singleCharArray = new char[1];
 
         public JsonConsoleFormatter(IOptionsMonitor<JsonConsoleFormatterOptions> options)
             : base (ConsoleFormatterNames.Json)
@@ -143,29 +145,64 @@ namespace Microsoft.Extensions.Logging.Console
             }
         }
 
-        private static void WriteItem(Utf8JsonWriter writer, KeyValuePair<string, object> item)
+        private void WriteItem(Utf8JsonWriter writer, KeyValuePair<string, object> item)
         {
-            writer.WritePropertyName(item.Key);
-            switch (item.Value)
+            if (item.Value is bool boolValue)
             {
-                case bool _:
-                case byte _:
-                case sbyte _:
-                case char _:
-                case decimal _:
-                case double _:
-                case float _:
-                case int _:
-                case uint _:
-                case long _:
-                case ulong _:
-                case short _:
-                case ushort _:
-                    JsonSerializer.Serialize(writer, item.Value);
-                    break;
-                default:
-                    writer.WriteStringValue(ToInvariantString(item.Value));
-                    break;
+                writer.WriteBoolean(item.Key, boolValue);
+            }
+            else if (item.Value is byte byteValue)
+            {
+                writer.WriteNumber(item.Key, byteValue);
+            }
+            else if (item.Value is sbyte sbyteValue)
+            {
+                writer.WriteNumber(item.Key, sbyteValue);
+            }
+            else if (item.Value is char charValue)
+            {
+                _singleCharArray[0] = charValue;
+                writer.WriteString(item.Key, _singleCharArray.AsSpan());
+            }
+            else if (item.Value is decimal decimalValue)
+            {
+                writer.WriteNumber(item.Key, decimalValue);
+            }
+            else if (item.Value is double doubleValue)
+            {
+                writer.WriteNumber(item.Key, doubleValue);
+            }
+            else if (item.Value is float floatValue)
+            {
+                writer.WriteNumber(item.Key, floatValue);
+            }
+            else if (item.Value is int intValue)
+            {
+                writer.WriteNumber(item.Key, intValue);
+            }
+            else if (item.Value is uint uintValue)
+            {
+                writer.WriteNumber(item.Key, uintValue);
+            }
+            else if (item.Value is long longValue)
+            {
+                writer.WriteNumber(item.Key, longValue);
+            }
+            else if (item.Value is ulong ulongValue)
+            {
+                writer.WriteNumber(item.Key, ulongValue);
+            }
+            else if (item.Value is short shortValue)
+            {
+                writer.WriteNumber(item.Key, shortValue);
+            }
+            else if (item.Value is ushort ushortValue)
+            {
+                writer.WriteNumber(item.Key, ushortValue);
+            }
+            else
+            {
+                writer.WriteString(item.Key, ToInvariantString(item.Value));
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -8,6 +8,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -19,7 +20,6 @@ namespace Microsoft.Extensions.Logging.Console
     internal class JsonConsoleFormatter : ConsoleFormatter, IDisposable
     {
         private IDisposable _optionsReloadToken;
-        private char[] _singleCharArray = new char[1];
 
         public JsonConsoleFormatter(IOptionsMonitor<JsonConsoleFormatterOptions> options)
             : base (ConsoleFormatterNames.Json)
@@ -160,8 +160,11 @@ namespace Microsoft.Extensions.Logging.Console
                     writer.WriteNumber(key, sbyteValue);
                     break;
                 case char charValue:
-                    _singleCharArray[0] = charValue;
-                    writer.WriteString(key, _singleCharArray.AsSpan());
+#if NETCOREAPP
+                    writer.WriteString(key, MemoryMarshal.CreateSpan(ref charValue, 1));
+#else
+                    writer.WriteString(key, charValue.ToString());
+#endif
                     break;
                 case decimal decimalValue:
                     writer.WriteNumber(key, decimalValue);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -193,6 +193,9 @@ namespace Microsoft.Extensions.Logging.Console
                 case ushort ushortValue:
                     writer.WriteNumber(key, ushortValue);
                     break;
+                case null:
+                    writer.WriteNull(key);
+                    break;
                 default:
                     writer.WriteString(key, ToInvariantString(item.Value));
                     break;

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -147,62 +147,52 @@ namespace Microsoft.Extensions.Logging.Console
 
         private void WriteItem(Utf8JsonWriter writer, KeyValuePair<string, object> item)
         {
-            if (item.Value is bool boolValue)
+            var key = item.Key;
+            switch (item.Value)
             {
-                writer.WriteBoolean(item.Key, boolValue);
-            }
-            else if (item.Value is byte byteValue)
-            {
-                writer.WriteNumber(item.Key, byteValue);
-            }
-            else if (item.Value is sbyte sbyteValue)
-            {
-                writer.WriteNumber(item.Key, sbyteValue);
-            }
-            else if (item.Value is char charValue)
-            {
-                _singleCharArray[0] = charValue;
-                writer.WriteString(item.Key, _singleCharArray.AsSpan());
-            }
-            else if (item.Value is decimal decimalValue)
-            {
-                writer.WriteNumber(item.Key, decimalValue);
-            }
-            else if (item.Value is double doubleValue)
-            {
-                writer.WriteNumber(item.Key, doubleValue);
-            }
-            else if (item.Value is float floatValue)
-            {
-                writer.WriteNumber(item.Key, floatValue);
-            }
-            else if (item.Value is int intValue)
-            {
-                writer.WriteNumber(item.Key, intValue);
-            }
-            else if (item.Value is uint uintValue)
-            {
-                writer.WriteNumber(item.Key, uintValue);
-            }
-            else if (item.Value is long longValue)
-            {
-                writer.WriteNumber(item.Key, longValue);
-            }
-            else if (item.Value is ulong ulongValue)
-            {
-                writer.WriteNumber(item.Key, ulongValue);
-            }
-            else if (item.Value is short shortValue)
-            {
-                writer.WriteNumber(item.Key, shortValue);
-            }
-            else if (item.Value is ushort ushortValue)
-            {
-                writer.WriteNumber(item.Key, ushortValue);
-            }
-            else
-            {
-                writer.WriteString(item.Key, ToInvariantString(item.Value));
+                case bool boolValue:
+                    writer.WriteBoolean(key, boolValue);
+                    break;
+                case byte byteValue:
+                    writer.WriteNumber(key, byteValue);
+                    break;
+                case sbyte sbyteValue:
+                    writer.WriteNumber(key, sbyteValue);
+                    break;
+                case char charValue:
+                    _singleCharArray[0] = charValue;
+                    writer.WriteString(key, _singleCharArray.AsSpan());
+                    break;
+                case decimal decimalValue:
+                    writer.WriteNumber(key, decimalValue);
+                    break;
+                case double doubleValue:
+                    writer.WriteNumber(key, doubleValue);
+                    break;
+                case float floatValue:
+                    writer.WriteNumber(key, floatValue);
+                    break;
+                case int intValue:
+                    writer.WriteNumber(key, intValue);
+                    break;
+                case uint uintValue:
+                    writer.WriteNumber(key, uintValue);
+                    break;
+                case long longValue:
+                    writer.WriteNumber(key, longValue);
+                    break;
+                case ulong ulongValue:
+                    writer.WriteNumber(key, ulongValue);
+                    break;
+                case short shortValue:
+                    writer.WriteNumber(key, shortValue);
+                    break;
+                case ushort ushortValue:
+                    writer.WriteNumber(key, ushortValue);
+                    break;
+                default:
+                    writer.WriteString(key, ToInvariantString(item.Value));
+                    break;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -6,8 +6,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
@@ -83,7 +85,7 @@ namespace Microsoft.Extensions.Logging.Console
                         {
                             foreach (KeyValuePair<string, object> item in stateProperties)
                             {
-                                writer.WriteString(item.Key, ToInvariantString(item.Value));
+                                WriteItem(writer, item);
                             }
                         }
                         writer.WriteEndObject();
@@ -128,7 +130,7 @@ namespace Microsoft.Extensions.Logging.Console
                         state.WriteString("Message", scope.ToString());
                         foreach (KeyValuePair<string, object> item in scopes)
                         {
-                            state.WriteString(item.Key, ToInvariantString(item.Value));
+                            WriteItem(state, item);
                         }
                         state.WriteEndObject();
                     }
@@ -138,6 +140,32 @@ namespace Microsoft.Extensions.Logging.Console
                     }
                 }, writer);
                 writer.WriteEndArray();
+            }
+        }
+
+        private static void WriteItem(Utf8JsonWriter writer, KeyValuePair<string, object> item)
+        {
+            writer.WritePropertyName(item.Key);
+            switch (item.Value)
+            {
+                case bool _:
+                case byte _:
+                case sbyte _:
+                case char _:
+                case decimal _:
+                case double _:
+                case float _:
+                case int _:
+                case uint _:
+                case long _:
+                case ulong _:
+                case short _:
+                case ushort _:
+                    JsonSerializer.Serialize(writer, item.Value);
+                    break;
+                default:
+                    writer.WriteStringValue(ToInvariantString(item.Value));
+                    break;
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        public void Log_StateAndScopeContainsDyanmicObject_SerializesAsString()
+        public void Log_StateAndScopeContainsDynamicObject_SerializesAsString()
         {
             // Arrange
             var t = SetUp(
@@ -373,6 +373,35 @@ namespace Microsoft.Extensions.Logging.Console.Test
             string message = sink.Writes[0].Message;
             Assert.Contains("\"Object\":\"{ a = 1, b = 2 }\"", message);
             Assert.Contains("\"LogEntryObject\":\"{ c = 1, d = 2 }\"", message);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void Log_StateAndScopeContainsNull_SerializesAsNullString()
+        {
+            // Arrange
+            var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    IncludeScopes = true
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            using (logger.BeginScope("{Null}", (object)null))
+            {
+                logger.LogInformation("{LogEntryNull}", (object)null);
+            }
+
+            // Assert
+            string message = sink.Writes[0].Message;
+            Assert.Contains("\"Null\":\"(null)\"", message);
+            Assert.Contains("\"LogEntryNull\":\"(null)\"", message);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -3,8 +3,7 @@
 
 using System;
 using System.Text.Json;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Logging.Console;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging.Test.Console;
 using Xunit;
 
@@ -20,9 +19,10 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
                 new SimpleConsoleFormatterOptions { IncludeScopes = true },
                 new ConsoleFormatterOptions { IncludeScopes = true },
-                new JsonConsoleFormatterOptions {
+                new JsonConsoleFormatterOptions
+                {
                     IncludeScopes = true,
-                    JsonWriterOptions = new JsonWriterOptions() { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping } 
+                    JsonWriterOptions = new JsonWriterOptions() { Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping }
                 });
             var logger = t.Logger;
             var sink = t.Sink;
@@ -99,12 +99,12 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Critical\",\"Category\":\"test\",\"Message\":\"[null]\""
                 + ",\"State\":{\"Message\":\"[null]\",\"{OriginalFormat}\":\"[null]\"}}"
-                +  Environment.NewLine,
+                + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Critical\",\"Category\":\"test\",\"Message\":\"[null]\""
                 + ",\"State\":{\"Message\":\"[null]\",\"{OriginalFormat}\":\"[null]\"}}"
-                +  Environment.NewLine,
+                + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(1 * t.WritesPerMsg, t.WritesPerMsg)));
 
             Assert.Equal(
@@ -112,7 +112,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 + ",\"Message\":\"[null]\""
                 + ",\"Exception\":{\"Message\":\"Invalid value\",\"Type\":\"System.InvalidOperationException\",\"StackTrace\":[],\"HResult\":-2146233079}"
                 + ",\"State\":{\"Message\":\"[null]\",\"{OriginalFormat}\":\"[null]\"}}"
-                +  Environment.NewLine,
+                + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(2 * t.WritesPerMsg, t.WritesPerMsg)));
         }
 
@@ -137,7 +137,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             // Act
             logger.LogInformation(exception, "exception message with {0}", "stacktrace");
             logger.Log(LogLevel.Information, 0, state: "exception message", exception: exception, formatter: (a, b) => a);
-            
+
             using (logger.BeginScope("scope1 {name1}", 123))
             using (logger.BeginScope("scope2 {name1} {name2}", 456, 789))
                 logger.Log(LogLevel.Information, 0, state: "exception message", exception: exception, formatter: (a, b) => a);
@@ -150,7 +150,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 + ",\"Exception\":{\"Message\":\"Invalid value\",\"Type\":\"System.InvalidOperationException\",\"StackTrace\":[],\"HResult\":-2146233079}"
                 + ",\"State\":{\"Message\":\"exception message with stacktrace\",\"0\":\"stacktrace\",\"{OriginalFormat}\":\"exception message with {0}\"}"
                 + ",\"Scopes\":[]"
-                +"}" +  Environment.NewLine,
+                + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
@@ -158,15 +158,15 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 + ",\"Exception\":{\"Message\":\"Invalid value\",\"Type\":\"System.InvalidOperationException\",\"StackTrace\":[],\"HResult\":-2146233079}"
                 + ",\"State\":{\"Message\":\"exception message\"}"
                 + ",\"Scopes\":[]"
-                +"}" +  Environment.NewLine,
+                + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(1 * t.WritesPerMsg, t.WritesPerMsg)));
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"exception message\""
                 + ",\"Exception\":{\"Message\":\"Invalid value\",\"Type\":\"System.InvalidOperationException\",\"StackTrace\":[],\"HResult\":-2146233079}"
                 + ",\"State\":{\"Message\":\"exception message\"}"
-                + ",\"Scopes\":[{\"Message\":\"scope1 123\",\"name1\":\"123\",\"{OriginalFormat}\":\"scope1 {name1}\"},{\"Message\":\"scope2 456 789\",\"name1\":\"456\",\"name2\":\"789\",\"{OriginalFormat}\":\"scope2 {name1} {name2}\"}]"
-                +"}" +  Environment.NewLine,
+                + ",\"Scopes\":[{\"Message\":\"scope1 123\",\"name1\":123,\"{OriginalFormat}\":\"scope1 {name1}\"},{\"Message\":\"scope2 456 789\",\"name1\":456,\"name2\":789,\"{OriginalFormat}\":\"scope2 {name1} {name2}\"}]"
+                + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(2 * t.WritesPerMsg, t.WritesPerMsg)));
         }
 
@@ -198,8 +198,8 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"exception message\""
                 + ",\"State\":{\"Message\":\"exception message\"}"
-                + ",\"Scopes\":[{\"Message\":\"scope1 123\",\"name1\":\"123\",\"{OriginalFormat}\":\"scope1 {name1}\"},{\"Message\":\"scope2 456 789\",\"name1\":\"456\",\"name2\":\"789\",\"{OriginalFormat}\":\"scope2 {name1} {name2}\"}]"
-                +"}" +  Environment.NewLine,
+                + ",\"Scopes\":[{\"Message\":\"scope1 123\",\"name1\":123,\"{OriginalFormat}\":\"scope1 {name1}\"},{\"Message\":\"scope2 456 789\",\"name1\":456,\"name2\":789,\"{OriginalFormat}\":\"scope2 {name1} {name2}\"}]"
+                + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
         }
 
@@ -232,10 +232,147 @@ namespace Microsoft.Extensions.Logging.Console.Test
             Assert.Equal(
                 "{\"EventId\":0,\"LogLevel\":\"Information\",\"Category\":\"test\""
                 + ",\"Message\":\"1\""
-                + ",\"State\":{\"Message\":\"1\",\"LogEntryNumber\":\"1\",\"{OriginalFormat}\":\"{LogEntryNumber}\"}"
-                + ",\"Scopes\":[{\"Message\":\"2\",\"Number\":\"2\",\"{OriginalFormat}\":\"{Number}\"},{\"Message\":\"3\",\"AnotherNumber\":\"3\",\"{OriginalFormat}\":\"{AnotherNumber}\"}]"
-                +"}" +  Environment.NewLine,
+                + ",\"State\":{\"Message\":\"1\",\"LogEntryNumber\":1,\"{OriginalFormat}\":\"{LogEntryNumber}\"}"
+                + ",\"Scopes\":[{\"Message\":\"2\",\"Number\":2,\"{OriginalFormat}\":\"{Number}\"},{\"Message\":\"3\",\"AnotherNumber\":3,\"{OriginalFormat}\":\"{AnotherNumber}\"}]"
+                + "}" + Environment.NewLine,
                 GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg)));
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(true, "true")]
+        [InlineData((byte)1, "1")]
+        [InlineData((sbyte)1, "1")]
+        [InlineData('a', "\"a\"")]
+        [InlineData(1, "1")]
+        [InlineData((uint)1, "1")]
+        [InlineData((long)1, "1")]
+        [InlineData((ulong)1, "1")]
+        [InlineData((short)1, "1")]
+        [InlineData((ushort)1, "1")]
+        public void Log_StateAndScopeContainsBuiltInValueType_SerializesValue(object value, string expectedJsonValue)
+        {
+            // Arrange
+            var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    IncludeScopes = true
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            using (logger.BeginScope("{Value}", value))
+            {
+                logger.LogInformation("{LogEntryValue}", value);
+            }
+
+            // Assert
+            string message = sink.Writes[0].Message;
+            Assert.Contains("\"Value\":" + expectedJsonValue + ",", message);
+            Assert.Contains("\"LogEntryValue\":" + expectedJsonValue + ",", message);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(1.2d)]
+        [InlineData(1.2f)]
+        public void Log_StateAndScopeContainsFloatingPointType_SerializesValue(object value)
+        {
+            // Arrange
+            var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    IncludeScopes = true
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            using (logger.BeginScope("{Value}", value))
+            {
+                logger.LogInformation("{LogEntryValue}", value);
+            }
+
+            // Assert
+            string message = sink.Writes[0].Message;
+            AssertMessageValue(message, "Value");
+            AssertMessageValue(message, "LogEntryValue");
+
+            static void AssertMessageValue(string message, string propertyName)
+            {
+                var serializedValueMatch = Regex.Match(message, "\"" + propertyName + "\":(.*?),");
+                Assert.Equal(2, serializedValueMatch.Groups.Count);
+                string jsonValue = serializedValueMatch.Groups[1].Value;
+                Assert.True(double.TryParse(jsonValue, out var floatingPointValue), "The json doesn not contain a floating point value: " + jsonValue);
+                Assert.Equal(1.2, floatingPointValue, 2);
+            }
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void Log_StateAndScopeContainsDecimal_SerializesValue()
+        {
+            // Arrange
+            var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    IncludeScopes = true
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            using (logger.BeginScope("{Value}", 1.2m))
+            {
+                logger.LogInformation("{LogEntryValue}", 1.2m);
+            }
+
+            // Assert
+            string message = sink.Writes[0].Message;
+            Assert.Contains("\"Value\":1.2,", message);
+            Assert.Contains("\"LogEntryValue\":1.2,", message);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        public void Log_StateAndScopeContainsDyanmicObject_SerializesAsString()
+        {
+            // Arrange
+            var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    IncludeScopes = true
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            using (logger.BeginScope("{Object}", new { a = 1, b = 2 }))
+            {
+                logger.LogInformation("{LogEntryObject}", new { c = 1, d = 2 });
+            }
+
+            // Assert
+            string message = sink.Writes[0].Message;
+            Assert.Contains("\"Object\":\"{ a = 1, b = 2 }\"", message);
+            Assert.Contains("\"LogEntryObject\":\"{ c = 1, d = 2 }\"", message);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Globalization;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging.Test.Console;
@@ -302,7 +303,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
                 var serializedValueMatch = Regex.Match(message, "\"" + propertyName + "\":(.*?),");
                 Assert.Equal(2, serializedValueMatch.Groups.Count);
                 string jsonValue = serializedValueMatch.Groups[1].Value;
-                Assert.True(double.TryParse(jsonValue, out var floatingPointValue), "The json doesn not contain a floating point value: " + jsonValue);
+                Assert.True(double.TryParse(jsonValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var floatingPointValue), "The json doesn not contain a floating point value: " + jsonValue);
                 Assert.Equal(1.2, floatingPointValue, 2);
             }
         }


### PR DESCRIPTION
This PR changes the `JsonConsoleFormatter` to convert the values of the k/v in state and scope to json native types when it is a built-in value type.

I haven't found a way to remove converters easily from the JsonSerializer.
I used the JsonSerializer as I didn't want to reimplement the logic.

Should I reimplement the serialization logic to avoid the cost of the JsonSerializer? Is there already something available I can reuse?
Should I add support for NullableTypes?

Fixes #39870

/cc @maryamariyan
