### PR TITLE
[mono][interp] Intrinsify BitOperations.Log2

### DIFF
--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -5358,6 +5358,7 @@ call_newobj:
 			ip++;
 			MINT_IN_BREAK;
 		}
+#if !defined(_MSC_VER)
 		MINT_IN_CASE(MINT_INTRINS_BITOPS_LOG2_32) {
 			sp [-1].data.i = 31 ^ (gint32)__builtin_clz ((guint32)sp [-1].data.i | 1);
 			++ip;
@@ -5368,6 +5369,7 @@ call_newobj:
 			++ip;
 			MINT_IN_BREAK;
 		}
+#endif
 		MINT_IN_CASE(MINT_INTRINS_UNSAFE_BYTE_OFFSET) {
 			sp -= 2;
 			sp [0].data.nati = (guint8*)sp [1].data.p - (guint8*)sp [0].data.p;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -5358,6 +5358,16 @@ call_newobj:
 			ip++;
 			MINT_IN_BREAK;
 		}
+		MINT_IN_CASE(MINT_INTRINS_BITOPS_LOG2_32) {
+			sp [-1].data.i = 31 ^ (gint32)__builtin_clz ((guint32)sp [-1].data.i | 1);
+			++ip;
+			MINT_IN_BREAK;
+		}
+		MINT_IN_CASE(MINT_INTRINS_BITOPS_LOG2_64) {
+			sp [-1].data.i = 63 ^ (gint32)__builtin_clz ((guint64)sp [-1].data.l | 1);
+			++ip;
+			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_INTRINS_UNSAFE_BYTE_OFFSET) {
 			sp -= 2;
 			sp [0].data.nati = (guint8*)sp [1].data.p - (guint8*)sp [0].data.p;

--- a/src/mono/mono/mini/interp/interp.c
+++ b/src/mono/mono/mini/interp/interp.c
@@ -5359,6 +5359,17 @@ call_newobj:
 			MINT_IN_BREAK;
 		}
 #if !defined(_MSC_VER)
+		MINT_IN_CASE(MINT_INTRINS_BITOPS_TZC_32) {
+			sp [-1].data.i = (gint32)__builtin_ctz ((guint32)sp [-1].data.i);
+			++ip;
+			MINT_IN_BREAK;
+		}
+		MINT_IN_CASE(MINT_INTRINS_BITOPS_TZC_64) {
+			guint64 value = (guint64)sp [-1].data.l;
+			sp [-1].data.i = value == 0 ? 64 : (gint32)__builtin_ctz (value);
+			++ip;
+			MINT_IN_BREAK;
+		}
 		MINT_IN_CASE(MINT_INTRINS_BITOPS_LOG2_32) {
 			sp [-1].data.i = 31 ^ (gint32)__builtin_clz ((guint32)sp [-1].data.i | 1);
 			++ip;

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -800,3 +800,5 @@ OPDEF(MINT_INTRINS_ORDINAL_IGNORE_CASE_ASCII, "intrins_ordinal_ignore_case_ascii
 OPDEF(MINT_INTRINS_64ORDINAL_IGNORE_CASE_ASCII, "intrins_64ordinal_ignore_case_ascii", 1, Pop2, Push1, MintOpNoArgs)
 OPDEF(MINT_INTRINS_U32_TO_DECSTR, "intrins_u32_to_decstr", 3, Pop1, Push1, MintOpNoArgs)
 OPDEF(MINT_INTRINS_WIDEN_ASCII_TO_UTF16, "intrins_widen_ascii_to_utf16", 1, Pop3, Push1, MintOpNoArgs)
+OPDEF(MINT_INTRINS_BITOPS_LOG2_32, "intrins_bitops_log2_32", 1, Pop1, Push1, MintOpNoArgs)
+OPDEF(MINT_INTRINS_BITOPS_LOG2_64, "intrins_bitops_log2_64", 1, Pop1, Push1, MintOpNoArgs)

--- a/src/mono/mono/mini/interp/mintops.def
+++ b/src/mono/mono/mini/interp/mintops.def
@@ -802,3 +802,5 @@ OPDEF(MINT_INTRINS_U32_TO_DECSTR, "intrins_u32_to_decstr", 3, Pop1, Push1, MintO
 OPDEF(MINT_INTRINS_WIDEN_ASCII_TO_UTF16, "intrins_widen_ascii_to_utf16", 1, Pop3, Push1, MintOpNoArgs)
 OPDEF(MINT_INTRINS_BITOPS_LOG2_32, "intrins_bitops_log2_32", 1, Pop1, Push1, MintOpNoArgs)
 OPDEF(MINT_INTRINS_BITOPS_LOG2_64, "intrins_bitops_log2_64", 1, Pop1, Push1, MintOpNoArgs)
+OPDEF(MINT_INTRINS_BITOPS_TZC_32, "intrins_bitops_tzc_32", 1, Pop1, Push1, MintOpNoArgs)
+OPDEF(MINT_INTRINS_BITOPS_TZC_64, "intrins_bitops_tzc_64", 1, Pop1, Push1, MintOpNoArgs)

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1522,8 +1522,11 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 #if !defined(_MSC_VER)
 	else if (in_corlib && !strcmp (klass_name_space, "System.Numerics") && !strcmp (klass_name, "BitOperations")) {
 		if (!strcmp (tm, "Log2")) {
-			gboolean is_long = csignature->params [0]->type == MONO_TYPE_U8;
+			gboolean is_long = csignature->params [0]->type == MONO_TYPE_U8 || csignature->params [0]->type == MONO_TYPE_I8;
 			*op = is_long ? MINT_INTRINS_BITOPS_LOG2_64 : MINT_INTRINS_BITOPS_LOG2_32;
+		} else if (!strcmp (tm, "TrailingZeroCount")) {
+			gboolean is_long = csignature->params [0]->type == MONO_TYPE_U8 || csignature->params [0]->type == MONO_TYPE_I8;
+			*op = is_long ? MINT_INTRINS_BITOPS_TZC_64 : MINT_INTRINS_BITOPS_TZC_32;
 		}
 	} 
 #endif

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1518,6 +1518,11 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 	} else if (in_corlib && !strcmp (klass_name_space, "System.Text") && !strcmp (klass_name, "ASCIIUtility")) {
 		if (!strcmp (tm, "WidenAsciiToUtf16"))
 			*op = MINT_INTRINS_WIDEN_ASCII_TO_UTF16;
+	} else if (in_corlib && !strcmp (klass_name_space, "System.Numerics") && !strcmp (klass_name, "BitOperations")) {
+		if (!strcmp (tm, "Log2")) {
+			gboolean is_long = csignature->params [0]->type == MONO_TYPE_U8;
+			*op = is_long ? MINT_INTRINS_BITOPS_LOG2_64 : MINT_INTRINS_BITOPS_LOG2_32;
+		}
 	} else if (in_corlib && !strcmp (klass_name_space, "System") && !strcmp (klass_name, "Number")) {
 		if (!strcmp (tm, "UInt32ToDecStr") && csignature->param_count == 1) {
 			ERROR_DECL(error);

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -1518,12 +1518,16 @@ interp_handle_intrinsics (TransformData *td, MonoMethod *target_method, MonoClas
 	} else if (in_corlib && !strcmp (klass_name_space, "System.Text") && !strcmp (klass_name, "ASCIIUtility")) {
 		if (!strcmp (tm, "WidenAsciiToUtf16"))
 			*op = MINT_INTRINS_WIDEN_ASCII_TO_UTF16;
-	} else if (in_corlib && !strcmp (klass_name_space, "System.Numerics") && !strcmp (klass_name, "BitOperations")) {
+	}
+#if !defined(_MSC_VER)
+	else if (in_corlib && !strcmp (klass_name_space, "System.Numerics") && !strcmp (klass_name, "BitOperations")) {
 		if (!strcmp (tm, "Log2")) {
 			gboolean is_long = csignature->params [0]->type == MONO_TYPE_U8;
 			*op = is_long ? MINT_INTRINS_BITOPS_LOG2_64 : MINT_INTRINS_BITOPS_LOG2_32;
 		}
-	} else if (in_corlib && !strcmp (klass_name_space, "System") && !strcmp (klass_name, "Number")) {
+	} 
+#endif
+	else if (in_corlib && !strcmp (klass_name_space, "System") && !strcmp (klass_name, "Number")) {
 		if (!strcmp (tm, "UInt32ToDecStr") && csignature->param_count == 1) {
 			ERROR_DECL(error);
 			MonoVTable *vtable = mono_class_vtable_checked (td->rtm->domain, target_method->klass, error);


### PR DESCRIPTION
It's used in NumberFormatter, Array.Sort and SpanHelpers.

e.g. the following code uses it under the hood:
`235235235325.ToString("X")`

^ For Mono-Wasm:
before: 18.4 ms (in a loop)
after: 15.2 ms