### PR TITLE
Make ObjectStackAllocationTests work correctly under crossgen2

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -923,9 +923,6 @@
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Methodical/tailcall_v4/hijacking/*">
             <Issue>https://github.com/dotnet/runtime/issues/7597</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests/*">
-            <Issue>Not compatible with crossgen2</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/JIT/Regression/clr-x64-JIT/v4.0/devdiv374539/DevDiv_374539/*">
             <Issue>https://github.com/dotnet/runtime/issues/32732</Issue>
         </ExcludeList>

--- a/src/coreclr/tests/src/CLRTest.CrossGen.targets
+++ b/src/coreclr/tests/src/CLRTest.CrossGen.targets
@@ -72,6 +72,8 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
       fi
     fi
 
+    ExtraCrossGen2Args+=" $(CrossGen2TestExtraArguments)"
+
     if [ ! -z ${LargeVersionBubble+x} ]%3B then
         ExtraCrossGen2Args+=" --inputbubble"
     fi
@@ -174,6 +176,8 @@ if defined RunCrossGen (
 )
 REM CrossGen2 Script
 if defined RunCrossGen2 (
+    set ExtraCrossGen2Args=!ExtraCrossGen2Args! $(CrossGen2TestExtraArguments)
+
     if defined LargeVersionBubble ( set ExtraCrossGen2Args=!ExtraCrossGen2Args! --inputbubble)
     call :TakeLock
     set CrossGen2Status=0

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.cs
@@ -110,7 +110,7 @@ namespace ObjectStackAllocation
                 Console.WriteLine("GCStress is enabled");
                 expectedAllocationKind = AllocationKind.Undefined;
             }
-            else if (!SPCOptimizationsEnabled()) {
+            else if (!SPCOptimizationsEnabled() && !Crossgen2Test()) {
                 Console.WriteLine("System.Private.CoreLib.dll optimizations are disabled");
                 expectedAllocationKind = AllocationKind.Heap;
             }
@@ -179,6 +179,12 @@ namespace ObjectStackAllocation
         static bool GCStressEnabled()
         {
             return Environment.GetEnvironmentVariable("COMPlus_GCStress") != null;
+        }
+
+        static bool Crossgen2Test()
+        {
+            // CrossGen2 doesn't respect the debuggable attribute
+            return Environment.GetEnvironmentVariable("RunCrossGen2") != null;
         }
 
         static void CallTestAndVerifyAllocation(Test test, int expectedResult, AllocationKind expectedAllocationsKind)

--- a/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/ObjectStackAllocationTests.csproj
@@ -10,6 +10,7 @@
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
   <PropertyGroup>
+    <CrossGen2TestExtraArguments>--codegenopt JitObjectStackAllocation=1</CrossGen2TestExtraArguments>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)
 set COMPlus_TieredCompilation=0


### PR DESCRIPTION
- Add a mechanism for passing arbitrary arguments to the crossgen2 process while running crossgen2 tests
- Pass the `--codegenopt JitObjectStackAllocation=1` when compiling this test with Crossgen2. This will result in enabling the object stack allocation feature during compilation
- As Crossgen2 currently disregards the debuggable attribute when deciding codegen mode, detect the presence running crossgen2 and expect allocation to occur on the stack even if S.P.C is debuggable

Fixes #32729