### PR TITLE
Fix CoreLib build when building libraries solutions

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -176,7 +176,8 @@
         <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
       </ProjectReference>
       <ProjectReference Condition="'%(Filename)' == 'System.Private.CoreLib'">
-        <UndefineProperties>$(UndefineProperties);TargetFramework</UndefineProperties>
+        <!-- Don't flow TargetFramework and Platform to use same inputs and outputs as the CoreLib's build as part of the runtime. -->
+        <UndefineProperties>$(UndefineProperties);TargetFramework;Platform</UndefineProperties>
         <SetConfiguration Condition="'$(RuntimeFlavor)' == 'CoreCLR' and
                                      '$(Configuration)' != '$(CoreCLRConfiguration)'">Configuration=$(CoreCLRConfiguration)</SetConfiguration>
         <SetConfiguration Condition="'$(RuntimeFlavor)' == 'Mono' and


### PR DESCRIPTION
If a project that is part of solution has a ProjectReference to CoreLib, the Platform property was set to AnyCPU and CoreLib was built with the wrong Platform/Platform_Target.

Fixes https://github.com/dotnet/runtime/issues/40073

cc @alnikola 