### PR TITLE
Allow execution of R2R code in singlefile app on windows.

### DIFF
--- a/src/coreclr/src/utilcode/pedecoder.cpp
+++ b/src/coreclr/src/utilcode/pedecoder.cpp
@@ -1781,9 +1781,7 @@ void PEDecoder::LayoutILOnly(void *base, BOOL allowFullPE) const
         DWORD newProtection = PAGE_READONLY;
 #else
         DWORD newProtection = section->Characteristics & IMAGE_SCN_MEM_EXECUTE ?
-            section->Characteristics & IMAGE_SCN_MEM_WRITE ?
-                PAGE_EXECUTE_READWRITE :
-                PAGE_EXECUTE_READ :
+            PAGE_EXECUTE_READ :
             section->Characteristics & IMAGE_SCN_MEM_WRITE ?
                 PAGE_READWRITE :
                 PAGE_READONLY;

--- a/src/coreclr/src/utilcode/pedecoder.cpp
+++ b/src/coreclr/src/utilcode/pedecoder.cpp
@@ -1770,20 +1770,31 @@ void PEDecoder::LayoutILOnly(void *base, BOOL allowFullPE) const
                            PAGE_READONLY, &oldProtection))
         ThrowLastError();
 
-    // Finally, apply proper protection to copied sections
-    section = sectionStart;
-    while (section < sectionEnd)
+    // Finally, apply proper protection to copied sections    
+    for (section = sectionStart; section < sectionEnd; section++)
     {
         // Add appropriate page protection.
-        if ((section->Characteristics & VAL32(IMAGE_SCN_MEM_WRITE)) == 0)
-        {
-            if (!ClrVirtualProtect((void *) ((BYTE *)base + VAL32(section->VirtualAddress)),
-                                   VAL32(section->Misc.VirtualSize),
-                                   PAGE_READONLY, &oldProtection))
-                ThrowLastError();
-        }
+#if defined(CROSSGEN_COMPILE) || defined(TARGET_UNIX)
+        if (section->Characteristics & IMAGE_SCN_MEM_WRITE)
+            continue;
 
-        section++;
+        DWORD newProtection = PAGE_READONLY;
+#else
+        DWORD newProtection = section->Characteristics & IMAGE_SCN_MEM_EXECUTE ?
+            section->Characteristics & IMAGE_SCN_MEM_WRITE ?
+                PAGE_EXECUTE_READWRITE :
+                PAGE_EXECUTE_READ :
+            section->Characteristics & IMAGE_SCN_MEM_WRITE ?
+                PAGE_READWRITE :
+                PAGE_READONLY;
+#endif
+
+        if (!ClrVirtualProtect((void*)((BYTE*)base + VAL32(section->VirtualAddress)),
+            VAL32(section->Misc.VirtualSize),
+            newProtection, &oldProtection))
+        {
+            ThrowLastError();
+        }
     }
 
     RETURN;

--- a/src/coreclr/src/vm/peimagelayout.cpp
+++ b/src/coreclr/src/vm/peimagelayout.cpp
@@ -445,6 +445,19 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source)
             ThrowHR(COR_E_BADIMAGEFORMAT);
 
         ApplyBaseRelocations();
+
+        // Check if there is a static function table.
+        COUNT_T cbSize = 0;
+        PT_RUNTIME_FUNCTION   pExceptionDir = (PT_RUNTIME_FUNCTION)GetDirectoryEntryData(IMAGE_DIRECTORY_ENTRY_EXCEPTION, &cbSize);
+        DWORD tableSize = cbSize / sizeof(T_RUNTIME_FUNCTION);
+
+        if (pExceptionDir != NULL)
+        {
+            if (!RtlAddFunctionTable(pExceptionDir, tableSize, (DWORD64)this->GetBase()))
+                ThrowLastError();
+
+                //TODO: WIP remember tbl to undo the above when releasing img
+        }
     }
 #endif
 }

--- a/src/coreclr/src/vm/peimagelayout.cpp
+++ b/src/coreclr/src/vm/peimagelayout.cpp
@@ -446,7 +446,8 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source)
 
         ApplyBaseRelocations();
 
-        // Check if there is a static function table.
+        // Check if there is a static function table and install it. (except x86)
+#if !defined(TARGET_X86)
         COUNT_T cbSize = 0;
         PT_RUNTIME_FUNCTION   pExceptionDir = (PT_RUNTIME_FUNCTION)GetDirectoryEntryData(IMAGE_DIRECTORY_ENTRY_EXCEPTION, &cbSize);
         DWORD tableSize = cbSize / sizeof(T_RUNTIME_FUNCTION);
@@ -458,6 +459,7 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source)
 
                 //TODO: WIP remember tbl to undo the above when releasing img
         }
+#endif //TARGET_X86
     }
 #endif
 }

--- a/src/coreclr/src/vm/peimagelayout.cpp
+++ b/src/coreclr/src/vm/peimagelayout.cpp
@@ -402,18 +402,29 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source)
         EEFileLoadException::Throw(GetPath(), COR_E_BADIMAGEFORMAT);
     LOG((LF_LOADER, LL_INFO100, "PEImage: Opening manually mapped stream\n"));
 
-
+#if !defined(CROSSGEN_COMPILE) && !defined(TARGET_UNIX)
+    // on Windows we may want to enable execution if the image contains R2R sections
+    // so must ensure the mapping is compatible with that
     m_FileMap.Assign(WszCreateFileMapping(INVALID_HANDLE_VALUE, NULL,
-                                          PAGE_READWRITE, 0,
-                                          source->GetVirtualSize(), NULL));
+        PAGE_EXECUTE_READWRITE, 0,
+        source->GetVirtualSize(), NULL));
+
+    DWORD allAccess = FILE_MAP_EXECUTE | FILE_MAP_WRITE;
+#else
+    m_FileMap.Assign(WszCreateFileMapping(INVALID_HANDLE_VALUE, NULL,
+        PAGE_READWRITE, 0,
+        source->GetVirtualSize(), NULL));
+
+    DWORD allAccess = FILE_MAP_ALL_ACCESS;
+#endif
+
     if (m_FileMap == NULL)
         ThrowLastError();
 
-
-    m_FileView.Assign(CLRMapViewOfFile(m_FileMap, FILE_MAP_ALL_ACCESS, 0, 0, 0,
+    m_FileView.Assign(CLRMapViewOfFile(m_FileMap, allAccess, 0, 0, 0,
                                 (void *) source->GetPreferredBase()));
     if (m_FileView == NULL)
-        m_FileView.Assign(CLRMapViewOfFile(m_FileMap, FILE_MAP_ALL_ACCESS, 0, 0, 0));
+        m_FileView.Assign(CLRMapViewOfFile(m_FileMap, allAccess, 0, 0, 0));
 
     if (m_FileView == NULL)
         ThrowLastError();
@@ -421,9 +432,20 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source)
     source->LayoutILOnly(m_FileView, TRUE); //@TODO should be false for streams
     IfFailThrow(Init(m_FileView));
 
-#ifdef CROSSGEN_COMPILE
+#if defined(CROSSGEN_COMPILE)
     if (HasNativeHeader())
+    {
         ApplyBaseRelocations();
+    }
+#elif !defined(TARGET_UNIX)
+    if ((HasNativeHeader() || HasReadyToRunHeader()) && g_fAllowNativeImages)
+    {
+        //Do base relocation for PE, if necessary.
+        if (!IsNativeMachineFormat())
+            ThrowHR(COR_E_BADIMAGEFORMAT);
+
+        ApplyBaseRelocations();
+    }
 #endif
 }
 

--- a/src/coreclr/src/vm/peimagelayout.cpp
+++ b/src/coreclr/src/vm/peimagelayout.cpp
@@ -438,7 +438,7 @@ ConvertedImageLayout::ConvertedImageLayout(PEImageLayout* source)
         ApplyBaseRelocations();
     }
 #elif !defined(TARGET_UNIX)
-    if ((HasNativeHeader() || HasReadyToRunHeader()) && g_fAllowNativeImages)
+    if (HasCorHeader() && (HasNativeHeader() || HasReadyToRunHeader()) && g_fAllowNativeImages)
     {
         //Do base relocation for PE, if necessary.
         if (!IsNativeMachineFormat())

--- a/src/coreclr/src/vm/peimagelayout.h
+++ b/src/coreclr/src/vm/peimagelayout.h
@@ -110,7 +110,10 @@ protected:
 public:
 #ifndef DACCESS_COMPILE
     ConvertedImageLayout(PEImageLayout* source);
+    virtual ~ConvertedImageLayout();
 #endif
+private:
+    PT_RUNTIME_FUNCTION m_pExceptionDir;
 };
 
 class MappedImageLayout: public PEImageLayout

--- a/src/coreclr/src/vm/peimagelayout.h
+++ b/src/coreclr/src/vm/peimagelayout.h
@@ -53,7 +53,7 @@ public:
     static PEImageLayout* LoadFromFlat(PEImageLayout* pflatimage);
     static PEImageLayout* Load(PEImage* pOwner, BOOL bNTSafeLoad, BOOL bThrowOnError = TRUE);
     static PEImageLayout* LoadFlat(PEImage* pOwner);
-    static PEImageLayout* LoadConverted(PEImage* pOwner);
+    static PEImageLayout* LoadConverted(PEImage* pOwner, BOOL isInBundle = FALSE);
     static PEImageLayout* LoadNative(LPCWSTR fullPath);
     static PEImageLayout* Map(PEImage* pOwner);
 #endif
@@ -109,10 +109,11 @@ protected:
     CLRMapViewHolder m_FileView;
 public:
 #ifndef DACCESS_COMPILE
-    ConvertedImageLayout(PEImageLayout* source);
+    ConvertedImageLayout(PEImageLayout* source, BOOL isInBundle = FALSE);
     virtual ~ConvertedImageLayout();
 #endif
 private:
+    bool m_isInBundle;
     PT_RUNTIME_FUNCTION m_pExceptionDir;
 };
 


### PR DESCRIPTION
The following changes were made:

- [x] Copy executable PE sections in LayoutILOnly, if there are any, into executable memory.
- [x] Apply relocs if R2R code is present.
- [x] Exception stuff (`RtlAddFunctionTable` / `RtlDeleteFunctionTable` for non-x86 unwind).

Fixes:https://github.com/dotnet/runtime/issues/39409 