### PR TITLE
Support dotnet pack on libs src project

### DIFF
--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -29,7 +29,7 @@
 
   <PropertyGroup>
     <PkgProjPath>$(MSBuildProjectDirectory)\..\pkg\$(MSBuildProjectName).pkgproj</PkgProjPath>
-    <!-- Point to our cusotm pack target which builds the pkgproj instead. -->
+    <!-- Point to our custom pack target which builds the pkgproj instead. -->
     <PackDependsOn Condition="'$(IsSourceProject)' == 'true' and
                               Exists('$(PkgProjPath)')">_BuildPkgProj</PackDependsOn>
   </PropertyGroup>

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -26,4 +26,16 @@
                       '$(_excludeCompile)' == 'true' and
                       '%(Dependency.Identity)' != '_._'" />
   </Target>
+
+  <PropertyGroup>
+    <PkgProjPath>$(MSBuildProjectDirectory)\..\pkg\$(MSBuildProjectName).pkgproj</PkgProjPath>
+    <!-- Point to our cusotm pack target which builds the pkgproj instead. -->
+    <PackDependsOn Condition="'$(IsSourceProject)' == 'true' and
+                              Exists('$(PkgProjPath)')">_BuildPkgProj</PackDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_BuildPkgProj">
+    <MSBuild Projects="$(PkgProjPath)"
+             Targets="Build" />
+  </Target>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/37960

Not adding the redirection to the ref project to make the src project the single entrypoint for `dotnet pack`. This probably needs some documentation updates as well.