### PR TITLE
Port "Stop using transport packages for CoreCLR assets (#40002)" to preview 8

### DIFF
--- a/src/coreclr/src/.nuget/Directory.Build.props
+++ b/src/coreclr/src/.nuget/Directory.Build.props
@@ -9,8 +9,10 @@
     <!-- defined in Packaging.targets, but we need this before targets are imported -->
     <PackagePlatform>AnyCPU</PackagePlatform>
 
-    <!-- build the transport package which includes product and symbols in addition to standard packages -->
-    <CreatePackedPackage Condition="'$(CreatePackedPackage)' == ''">true</CreatePackedPackage>
+    <!-- build the transport package which includes product and symbols in addition to standard packages
+    This is a legacy setting as we tend to use symbol packages for symbol indexing and we don't use
+    transport packages to flow dependencies anymore -->
+    <CreatePackedPackage Condition="'$(CreatePackedPackage)' == ''">false</CreatePackedPackage>
 
     <!-- indicates that lib prefix is not added to library names for Unix-like operating systems -->
     <SkipLibraryPrefixFromUnix>true</SkipLibraryPrefixFromUnix>


### PR DESCRIPTION
## Summary

This ports #40002 from master to prevent publishing these to NuGet

```xml
  <Package Id="transport.dotnet-ilverify" />
  <Package Id="transport.Microsoft.ILVerification" />
  <Package Id="transport.Microsoft.NET.Sdk.IL" />
  <Package Id="transport.Microsoft.NETCore.ILAsm" />
  <Package Id="transport.Microsoft.NETCore.ILDAsm" />
  <Package Id="transport.Microsoft.NETCore.TestHost" />
  <Package Id="transport.runtime.win-x64.Microsoft.NETCore.ILAsm" />
  <Package Id="transport.runtime.win-x64.Microsoft.NETCore.ILDAsm" />
  <Package Id="transport.runtime.win-x64.Microsoft.NETCore.TestHost" />
```

## Customer Impact

We'll start seeing packages that get published but not consumed. We also don't intend to support these packages. See #38924

## Regression

Only 5.0 previews versions of this package have been made available on NuGet, so no.

## Risk 

Very low. These packages were old transport mechanisms pre-consolidation days. There were no internal consumers in any search.