### PR TITLE
[Arm64] Treat Math/MathF.FusedMultiplyAdd as intrinsics

### DIFF
--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -326,12 +326,12 @@ private:
     void LowerHWIntrinsicCmpOp(GenTreeHWIntrinsic* node, genTreeOps cmpOp);
     void LowerHWIntrinsicCreate(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicDot(GenTreeHWIntrinsic* node);
-    void LowerFusedMultiplyAdd(GenTreeHWIntrinsic* node);
-
 #if defined(TARGET_XARCH)
+    void LowerFusedMultiplyAdd(GenTreeHWIntrinsic* node);
     void LowerHWIntrinsicToScalar(GenTreeHWIntrinsic* node);
 #elif defined(TARGET_ARM64)
     bool IsValidConstForMovImm(GenTreeHWIntrinsic* node);
+    void LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);
 #endif // !TARGET_XARCH && !TARGET_ARM64
 
     union VectorConstant {

--- a/src/coreclr/src/jit/lowerarmarch.cpp
+++ b/src/coreclr/src/jit/lowerarmarch.cpp
@@ -517,6 +517,76 @@ void Lowering::LowerSIMD(GenTreeSIMD* simdNode)
 #endif // FEATURE_SIMD
 
 #ifdef FEATURE_HW_INTRINSICS
+
+//----------------------------------------------------------------------------------------------
+// LowerHWIntrinsicFusedMultiplyAddScalar: Lowers AdvSimd_FusedMultiplyAddScalar intrinsics
+//   when some of the operands are negated by "containing" such negation.
+//
+//  Arguments:
+//     node - The original hardware intrinsic node
+//
+// |  op1 | op2 | op3 |
+// |  +   |  +  |  +  | AdvSimd_FusedMultiplyAddScalar
+// |  +   |  +  |  -  | AdvSimd_FusedMultiplySubtractScalar
+// |  +   |  -  |  +  | AdvSimd_FusedMultiplySubtractScalar
+// |  +   |  -  |  -  | AdvSimd_FusedMultiplyAddScalar
+// |  -   |  +  |  +  | AdvSimd_FusedMultiplySubtractNegatedScalar
+// |  -   |  +  |  -  | AdvSimd_FusedMultiplyAddNegatedScalar
+// |  -   |  -  |  +  | AdvSimd_FusedMultiplyAddNegatedScalar
+// |  -   |  -  |  -  | AdvSimd_FusedMultiplySubtractNegatedScalar
+//
+void Lowering::LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node)
+{
+    assert(node->gtHWIntrinsicId == NI_AdvSimd_FusedMultiplyAddScalar);
+
+    const HWIntrinsic intrin(node);
+
+    GenTree* op1 = intrin.op1;
+    GenTree* op2 = intrin.op2;
+    GenTree* op3 = intrin.op3;
+
+    auto lowerOperand = [this](GenTree* op) {
+        bool wasNegated = false;
+
+        if (op->OperIsHWIntrinsic() &&
+            ((op->AsHWIntrinsic()->gtHWIntrinsicId == NI_AdvSimd_Arm64_DuplicateToVector64) ||
+             (op->AsHWIntrinsic()->gtHWIntrinsicId == NI_Vector64_CreateScalarUnsafe)))
+        {
+            GenTreeHWIntrinsic* createVector64 = op->AsHWIntrinsic();
+            GenTree*            valueOp        = createVector64->gtGetOp1();
+
+            if (valueOp->OperIs(GT_NEG))
+            {
+                createVector64->gtOp1 = valueOp->gtGetOp1();
+                BlockRange().Remove(valueOp);
+                wasNegated = true;
+            }
+        }
+
+        return wasNegated;
+    };
+
+    const bool op1WasNegated = lowerOperand(op1);
+    const bool op2WasNegated = lowerOperand(op2);
+    const bool op3WasNegated = lowerOperand(op3);
+
+    if (op1WasNegated)
+    {
+        if (op2WasNegated != op3WasNegated)
+        {
+            node->gtHWIntrinsicId = NI_AdvSimd_FusedMultiplyAddNegatedScalar;
+        }
+        else
+        {
+            node->gtHWIntrinsicId = NI_AdvSimd_FusedMultiplySubtractNegatedScalar;
+        }
+    }
+    else if (op2WasNegated != op3WasNegated)
+    {
+        node->gtHWIntrinsicId = NI_AdvSimd_FusedMultiplySubtractScalar;
+    }
+}
+
 //----------------------------------------------------------------------------------------------
 // Lowering::LowerHWIntrinsic: Perform containment analysis for a hardware intrinsic node.
 //
@@ -572,6 +642,10 @@ void Lowering::LowerHWIntrinsic(GenTreeHWIntrinsic* node)
             LowerHWIntrinsicCmpOp(node, GT_NE);
             return;
         }
+
+        case NI_AdvSimd_FusedMultiplyAddScalar:
+            LowerHWIntrinsicFusedMultiplyAddScalar(node);
+            break;
 
         default:
             break;


### PR DESCRIPTION
This PR consists of three parts:

1) Changes importer in a way that treats `Math.FusedMultiplyAdd` and `MathF.FusedMultiplyAdd` as JIT intrinsics by transforming a call to `MathF.FusedMultiplyAdd` into
```c#
return AdvSimd.FusedMultiplyAddScalar(
    Vector64.CreateScalarUnsafe(z),
    Vector64.CreateScalarUnsafe(y),
    Vector64.CreateScalarUnsafe(x)
    ).ToScalar();
```

and transforming a call to `Math.FusedMultiplyAdd` into
```c#
return AdvSimd.FusedMultiplyAddScalar(
    Vector64.Create(z),
    Vector64.Create(y),
    Vector64.Create(x)
    ).ToScalar();
```

2) Adds some sort of containment analysis to Lower that can "contain" negation of the intrinsic operands and by utilizing an appropriate fused intrinsics from the following list:
- AdvSimd_FusedMultiplyAddScalar
- AdvSimd_FusedMultiplyAddNegatedScalar
- AdvSimd_FusedMultiplySubtractScalar
- AdvSimd_FusedMultiplySubtractNegatedScalar

The second change is **not required** to resolve #40078 but would be nice to have and basically is arm64 implementation of work that @EgorBo did in https://github.com/dotnet/coreclr/pull/27060

I attached JitDisasm for methods in MathFusedMultiplyAdd_ro before and after the changes.
[MathFusedMultiplyAdd_ro-After.txt](https://github.com/dotnet/runtime/files/5024095/MathFusedMultiplyAdd_ro-After.txt)
[MathFusedMultiplyAdd_ro-Before.txt](https://github.com/dotnet/runtime/files/5024096/MathFusedMultiplyAdd_ro-Before.txt)

As an example, the following are two assembly listings for `Check5(double,double,double)` that corresponds to `Math.FusedMultiplyAdd(op1, -op2,  op3)`

**Before:**
```asm
; Assembly listing for method MathFusedMultiplyAddTest.Program:Check5(double,double,double)
; Emitting BLENDED_CODE for generic ARM64 CPU - Windows
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  4,  4   )  double  ->  [fp+0x20]  
;  V01 arg1         [V01,T01] (  4,  4   )  double  ->  [fp+0x18]  
;  V02 arg2         [V02,T02] (  4,  4   )  double  ->  [fp+0x10]  
;# V03 OutArgs      [V03    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]   "OutgoingArgSpace"
;  V04 tmp1         [V04,T03] (  2,  4   )  double  ->   d8         "non-inline candidate call"
;  V05 tmp2         [V05,T04] (  2,  4   )  double  ->   d0         "argument with side effect"
;
; Lcl frame size = 24

G_M65527_IG01:
        A9BD7BFD          stp     fp, lr, [sp,#-48]!
        FD0017E8          str     d8, [sp,#40]
        910003FD          mov     fp, sp
						;; bbWeight=1    PerfScore 2.50
G_M65527_IG02:
        FD000FA1          str     d1, [fp,#24]
        1E614021          fneg    d1, d1
        FD0013A0          str     d0, [fp,#32]
        FD000BA2          str     d2, [fp,#16]
        97FFC317          bl      MathFusedMultiplyAddTest.Program:ReferenceMultiplyAdd(double,double,double):double
        1E604008          fmov    d8, d0
        FD400FA1          ldr     d1, [fp,#24]	// [V01 arg1]
        1E614021          fneg    d1, d1
        FD4013A0          ldr     d0, [fp,#32]	// [V00 arg0]
        FD400BA2          ldr     d2, [fp,#16]	// [V02 arg2]
        97FF26EF          bl      System.Math:FusedMultiplyAdd(double,double,double):double
        1E604001          fmov    d1, d0
        1E604100          fmov    d0, d8
        97FFC314          bl      MathFusedMultiplyAddTest.Program:CompareDoubles(double,double)
						;; bbWeight=1    PerfScore 17.50
G_M65527_IG03:
        FD4017E8          ldr     d8, [sp,#40]
        A8C37BFD          ldp     fp, lr, [sp],#48
        D65F03C0          ret     lr
						;; bbWeight=1    PerfScore 4.00

; Total bytes of code 80, prolog size 12, PerfScore 32.00, (MethodHash=95450008) for method MathFusedMultiplyAddTest.Program:Check5(double,double,double)
; ============================================================
```

**After:**
```asm
; Assembly listing for method MathFusedMultiplyAddTest.Program:Check5(double,double,double)
; Emitting BLENDED_CODE for generic ARM64 CPU - Windows
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  4,  4   )  double  ->  [fp+0x28]  
;  V01 arg1         [V01,T01] (  4,  4   )  double  ->  [fp+0x20]  
;  V02 arg2         [V02,T02] (  4,  4   )  double  ->  [fp+0x18]  
;# V03 OutArgs      [V03    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]   "OutgoingArgSpace"
;  V04 tmp1         [V04,T03] (  2,  4   )  double  ->   d0         "argument with side effect"
;
; Lcl frame size = 32

G_M65527_IG01:
        A9BD7BFD          stp     fp, lr, [sp,#-48]!
        910003FD          mov     fp, sp
						;; bbWeight=1    PerfScore 1.50
G_M65527_IG02:
        FD0013A1          str     d1, [fp,#32]
        1E614021          fneg    d1, d1
        FD0017A0          str     d0, [fp,#40]
        FD000FA2          str     d2, [fp,#24]
        97FFC36C          bl      MathFusedMultiplyAddTest.Program:ReferenceMultiplyAdd(double,double,double):double
        FD400FA2          ldr     d2, [fp,#24]	// [V02 arg2]
        1E604041          fmov    d1, d2
        FD4013B0          ldr     d16, [fp,#32]	// [V01 arg1]
        FD4017B1          ldr     d17, [fp,#40]	// [V00 arg0]
        1F518601          fmsub   d1, d16, d17, d1
        97FFC36C          bl      MathFusedMultiplyAddTest.Program:CompareDoubles(double,double)
						;; bbWeight=1    PerfScore 16.50
G_M65527_IG03:
        A8C37BFD          ldp     fp, lr, [sp],#48
        D65F03C0          ret     lr
						;; bbWeight=1    PerfScore 2.00

; Total bytes of code 60, prolog size 8, PerfScore 26.00, (MethodHash=95450008) for method MathFusedMultiplyAddTest.Program:Check5(double,double,double)
; ============================================================
```

3. Makes LSRA to prefer `op1Reg` for `targetReg` of intrinsics that have *"simd-to-simd move"* semantics. For example, both `Vector64.CreateScalarUnsafe(float)` and `AdvSimd.Arm64.DuplicateToVector64(double)` (this is what `Vector64.Create(double)` gets lowered to) have this semantics. With that change the code for `Check5` have one less instruction:
```asm
; Assembly listing for method MathFusedMultiplyAddTest.Program:Check5(double,double,double)
; Emitting BLENDED_CODE for generic ARM64 CPU - Windows
; optimized code
; fp based frame
; partially interruptible
; Final local variable assignments
;
;  V00 arg0         [V00,T00] (  4,  4   )  double  ->  [fp+0x28]  
;  V01 arg1         [V01,T01] (  4,  4   )  double  ->  [fp+0x20]  
;  V02 arg2         [V02,T02] (  4,  4   )  double  ->  [fp+0x18]  
;# V03 OutArgs      [V03    ] (  1,  1   )  lclBlk ( 0) [sp+0x00]   "OutgoingArgSpace"
;  V04 tmp1         [V04,T03] (  2,  4   )  double  ->   d0         "argument with side effect"
;
; Lcl frame size = 32

G_M65527_IG01:
        A9BD7BFD          stp     fp, lr, [sp,#-48]!
        910003FD          mov     fp, sp
						;; bbWeight=1    PerfScore 1.50
G_M65527_IG02:
        FD0013A1          str     d1, [fp,#32]
        1E614021          fneg    d1, d1
        FD0017A0          str     d0, [fp,#40]
        FD000FA2          str     d2, [fp,#24]
        97FFC37E          bl      MathFusedMultiplyAddTest.Program:ReferenceMultiplyAdd(double,double,double):double
        FD400FA2          ldr     d2, [fp,#24]	// [V02 arg2]
        FD4013A1          ldr     d1, [fp,#32]	// [V01 arg1]
        FD4017B0          ldr     d16, [fp,#40]	// [V00 arg0]
        1F508821          fmsub   d1, d1, d16, d2
        97FFC37F          bl      MathFusedMultiplyAddTest.Program:CompareDoubles(double,double)
						;; bbWeight=1    PerfScore 16.00
G_M65527_IG03:
        A8C37BFD          ldp     fp, lr, [sp],#48
        D65F03C0          ret     lr
						;; bbWeight=1    PerfScore 2.00

; Total bytes of code 56, prolog size 8, PerfScore 25.10, (MethodHash=95450008) for method MathFusedMultiplyAddTest.Program:Check5(double,double,double)
; ============================================================
```
Thanks @CarolEidt for proposing the solution to the issue with redundant `fmov` instruction.


The following are JitDisasm for methods in MathFusedMultiplyAdd_ro after all the changes (including the ones to LSRA).
[MathFusedMultiplyAdd_ro-After2.txt](https://github.com/dotnet/runtime/files/5031763/MathFusedMultiplyAdd_ro-After2.txt)