### PR TITLE
[wasm] Address TODO in pal_runtimeinformation.c

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ProcessorArchitecture.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.ProcessorArchitecture.cs
@@ -13,7 +13,8 @@ internal static partial class Interop
             x86,
             x64,
             ARM,
-            ARM64
+            ARM64,
+            WASM
         }
     }
 }

--- a/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.c
+++ b/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.c
@@ -41,7 +41,8 @@ int32_t SystemNative_GetUnixVersion(char* version, int* capacity)
  0 - x86
  1 - x64
  2 - ARM
- 3 - ARM64 */
+ 3 - ARM64
+ 4 - WASM */
 int32_t SystemNative_GetOSArchitecture()
 {
 #if defined(TARGET_ARM)
@@ -50,8 +51,10 @@ int32_t SystemNative_GetOSArchitecture()
     return ARCH_ARM64;
 #elif defined(TARGET_AMD64)
     return ARCH_X64;
-#elif defined(TARGET_X86) || defined(TARGET_WASM) // TODO: add arch for WASM
+#elif defined(TARGET_X86)
     return ARCH_X86;
+#elif defined(TARGET_WASM)
+    return ARCH_WASM;
 #else
 #error Unidentified Architecture
 #endif
@@ -61,7 +64,8 @@ int32_t SystemNative_GetOSArchitecture()
 0 - x86
 1 - x64
 2 - ARM
-3 - ARM64 */
+3 - ARM64
+4 - WASM */
 int32_t SystemNative_GetProcessArchitecture()
 {
 #if defined(TARGET_ARM)
@@ -70,8 +74,10 @@ int32_t SystemNative_GetProcessArchitecture()
     return ARCH_ARM64;
 #elif defined(TARGET_AMD64)
     return ARCH_X64;
-#elif defined(TARGET_X86) || defined(TARGET_WASM) // TODO: add arch for WASM
+#elif defined(TARGET_X86)
     return ARCH_X86;
+#elif defined(TARGET_WASM)
+    return ARCH_WASM;
 #else
 #error Unidentified Architecture
 #endif

--- a/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.h
+++ b/src/libraries/Native/Unix/System.Native/pal_runtimeinformation.h
@@ -21,5 +21,6 @@ enum
     ARCH_X86,
     ARCH_X64,
     ARCH_ARM,
-    ARCH_ARM64
+    ARCH_ARM64,
+    ARCH_WASM
 };

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.Unix.cs
@@ -34,6 +34,8 @@ namespace System.Runtime.InteropServices
                     return Architecture.X64;
                 case Interop.Sys.ProcessorArchitecture.ARM64:
                     return Architecture.Arm64;
+                case Interop.Sys.ProcessorArchitecture.WASM:
+                    return Architecture.Wasm;
                 case Interop.Sys.ProcessorArchitecture.x86:
                 default:
                     Debug.Assert(arch == Interop.Sys.ProcessorArchitecture.x86, "Unidentified Architecture");

--- a/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
+++ b/src/libraries/System.Runtime.InteropServices.RuntimeInformation/tests/CheckArchitectureTests.cs
@@ -44,5 +44,13 @@ namespace System.Runtime.InteropServices.RuntimeInformationTests
             Assert.Equal(osArch, RuntimeInformation.OSArchitecture);
             Assert.Equal(processArch, RuntimeInformation.ProcessArchitecture);
         }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Browser)]
+        public void VerifyBrowserArchitecture()
+        {
+            Assert.Equal(Architecture.Wasm, RuntimeInformation.OSArchitecture);
+            Assert.Equal(Architecture.Wasm, RuntimeInformation.ProcessArchitecture);
+        }
     }
 }


### PR DESCRIPTION
The WASM architecture wasn't added there since we already hardcode the architecture to wasm in the managed layer.
For consistency we should still define it in the PAL though and address the TODO comment.

Also added a test that verifies we indeed get the correct wasm architecture on the Browser platform.