### PR TITLE
Enable CBOR property tests in CI runs

### DIFF
--- a/src/libraries/System.Formats.Cbor/tests/PropertyTests/CborPropertyTests.cs
+++ b/src/libraries/System.Formats.Cbor/tests/PropertyTests/CborPropertyTests.cs
@@ -12,7 +12,7 @@ namespace System.Formats.Cbor.Tests
     public static class CborPropertyTests
     {
         private const string? ReplaySeed = "(42,42)"; // set a seed for deterministic runs, null for randomized runs
-        private const int MaxTests = 10_000;
+        private const int MaxTests = 100; // FsCheck default is 100
 
         [Property(Replay = ReplaySeed, MaxTest = MaxTests, Arbitrary = new[] { typeof(CborRandomGenerators) })]
         public static void Roundtrip_Int64(CborConformanceMode mode, long input)
@@ -178,7 +178,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Property(Replay = ReplaySeed, MaxTest = MaxTests, Arbitrary = new[] { typeof(CborRandomGenerators) })]
-        public static void PropertyTest_Roundtrip(CborPropertyTestContext input)
+        public static void CborDocument_Roundtrip(CborPropertyTestContext input)
         {
             byte[] encoding = CborDocumentSerializer.encode(input);
 
@@ -188,7 +188,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Property(Replay = ReplaySeed, MaxTest = MaxTests, Arbitrary = new[] { typeof(CborRandomGenerators) })]
-        public static void PropertyTest_SkipValue(CborPropertyTestContext input)
+        public static void CborDocument_SkipValue(CborPropertyTestContext input)
         {
             int length = input.RootDocuments.Length;
             input.RootDocuments = new[] { CborDocument.NewArray(_isDefiniteLength: true, input.RootDocuments) };
@@ -205,7 +205,7 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Property(Replay = ReplaySeed, MaxTest = MaxTests, Arbitrary = new[] { typeof(CborRandomGenerators) })]
-        public static void PropertyTest_SkipToParent(CborPropertyTestContext input)
+        public static void CborDocument_SkipToParent(CborPropertyTestContext input)
         {
             input.RootDocuments = new[] { CborDocument.NewArray(_isDefiniteLength: true, input.RootDocuments) };
             byte[] encoding = CborDocumentSerializer.encode(input);

--- a/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
+++ b/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
@@ -1,20 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)</TargetFrameworks>
     <nullable>enable</nullable>
-    <CborPropertyTests>false</CborPropertyTests>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(CborPropertyTests)' == 'True'">
-    <DefineConstants>$(DefineConstants),CBOR_PROPERTY_TESTS</DefineConstants>
     <!-- Referenced assembly 'FsCheck' does not have a strong name.-->
     <NoWarn>CS8002</NoWarn>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>
+    <Compile Include="PropertyTests\CborPropertyTests.cs" />
+    <Compile Include="PropertyTests\CborRandomGenerators.cs" />
     <Compile Include="Reader\CborReaderTests.cs" />
     <Compile Include="Reader\CborReaderTests.ByteString.cs" />
     <Compile Include="Reader\CborReaderTests.TextString.cs" />
@@ -36,18 +33,13 @@
     <Compile Include="Writer\CborWriterTests.TextString.cs" />
     <Compile Include="CoseKeyHelpers.cs" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(CborPropertyTests)' == 'True'">
-    <Compile Include="PropertyTests\CborPropertyTests.cs" />
-    <Compile Include="PropertyTests\CborRandomGenerators.cs" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Formats.Cbor.csproj" />
+    <ProjectReference Include="CborDocument\System.Formats.Cbor.Tests.DataModel.fsproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\System.Formats.Cbor.csproj" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(CborPropertyTests)' == 'True'">
-    <ProjectReference Include="CborDocument\System.Formats.Cbor.Tests.DataModel.fsproj" />
     <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
   </ItemGroup>
 </Project>

--- a/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
+++ b/src/libraries/System.Formats.Cbor/tests/System.Formats.Cbor.Tests.csproj
@@ -5,7 +5,6 @@
     <!-- Referenced assembly 'FsCheck' does not have a strong name.-->
     <NoWarn>CS8002</NoWarn>
   </PropertyGroup>
-  
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
@@ -37,9 +36,7 @@
   <ItemGroup>
     <ProjectReference Include="..\src\System.Formats.Cbor.csproj" />
     <ProjectReference Include="CborDocument\System.Formats.Cbor.Tests.DataModel.fsproj" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <PackageReference Include="FsCheck" Version="$(FsCheckVersion)" />
     <PackageReference Include="FsCheck.Xunit" Version="$(FsCheckVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
@ViktorHofer as discussed I've reduced the default number of test runs and enabled the property tests to run by default. The tests use a fixed seed, so they should run deterministically.