### PR TITLE
Reduced code size and optimized name key creation for JSON properties and parameters

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -456,7 +456,7 @@ namespace System.Text.Json
             if (length > 7)
             {
                 key = Unsafe.ReadUnaligned<ulong>(ref reference) & 0x00ffffffffffffffL;
-                length = Math.Min(length, 0xff);
+                key |= (ulong)Math.Min(length, 0xff) << 56;
             }
             else
             {
@@ -464,15 +464,14 @@ namespace System.Text.Json
                     length > 5 ? Unsafe.ReadUnaligned<uint>(ref reference) | (ulong)Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref reference, 4)) << 32 :
                     length > 3 ? Unsafe.ReadUnaligned<uint>(ref reference) :
                     length > 1 ? Unsafe.ReadUnaligned<ushort>(ref reference) : 0UL;
+                key |= (ulong)length << 56;
 
-                if ((length & 1) == 1)
+                if ((length & 1) != 0)
                 {
-                    int offset = length - 1;
+                    var offset = length - 1;
                     key |= (ulong)Unsafe.Add(ref reference, offset) << (offset * 8);
                 }
             }
-
-            key |= (ulong)length << 56;
 
             // Verify key contains the embedded bytes as expected.
             const int BitsInByte = 8;

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonClassInfo.Cache.cs
@@ -446,84 +446,48 @@ namespace System.Text.Json
         /// </summary>
         // AggressiveInlining used since this method is only called from two locations and is on a hot path.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static ulong GetKey(ReadOnlySpan<byte> propertyName)
+        public static ulong GetKey(ReadOnlySpan<byte> name)
         {
-            const int BitsInByte = 8;
             ulong key;
-            int length = propertyName.Length;
+
+            ref byte reference = ref MemoryMarshal.GetReference(name);
+            int length = name.Length;
 
             if (length > 7)
             {
-                key = MemoryMarshal.Read<ulong>(propertyName)
-                    & 0x00FFFFFFFFFFFFFF
-                    // Include the length with a max of 0xFF.
-                    | ((ulong)Math.Min(length, 0xFF)) << (7 * BitsInByte);
-            }
-            else if (length > 3)
-            {
-                key = MemoryMarshal.Read<uint>(propertyName);
-
-                if (length == 7)
-                {
-                    key |= (ulong)propertyName[6] << (6 * BitsInByte)
-                        | (ulong)propertyName[5] << (5 * BitsInByte)
-                        | (ulong)propertyName[4] << (4 * BitsInByte)
-                        | (ulong)7 << (7 * BitsInByte);
-                }
-                else if (length == 6)
-                {
-                    key |= (ulong)propertyName[5] << (5 * BitsInByte)
-                        | (ulong)propertyName[4] << (4 * BitsInByte)
-                        | (ulong)6 << (7 * BitsInByte);
-                }
-                else if (length == 5)
-                {
-                    key |= (ulong)propertyName[4] << (4 * BitsInByte)
-                        | (ulong)5 << (7 * BitsInByte);
-                }
-                else
-                {
-                    key |= (ulong)4 << (7 * BitsInByte);
-                }
-            }
-            else if (length > 1)
-            {
-                key = MemoryMarshal.Read<ushort>(propertyName);
-
-                if (length == 3)
-                {
-                    key |= (ulong)propertyName[2] << (2 * BitsInByte)
-                        | (ulong)3 << (7 * BitsInByte);
-                }
-                else
-                {
-                    key |= (ulong)2 << (7 * BitsInByte);
-                }
-            }
-            else if (length == 1)
-            {
-                key = propertyName[0]
-                    | (ulong)1 << (7 * BitsInByte);
+                key = Unsafe.ReadUnaligned<ulong>(ref reference) & 0x00ffffffffffffffL;
+                length = Math.Min(length, 0xff);
             }
             else
             {
-                // An empty name is valid.
-                key = 0;
+                key =
+                    length > 5 ? Unsafe.ReadUnaligned<uint>(ref reference) | (ulong)Unsafe.ReadUnaligned<ushort>(ref Unsafe.Add(ref reference, 4)) << 32 :
+                    length > 3 ? Unsafe.ReadUnaligned<uint>(ref reference) :
+                    length > 1 ? Unsafe.ReadUnaligned<ushort>(ref reference) : 0UL;
+
+                if ((length & 1) == 1)
+                {
+                    int offset = length - 1;
+                    key |= (ulong)Unsafe.Add(ref reference, offset) << (offset * 8);
+                }
             }
 
+            key |= (ulong)length << 56;
+
             // Verify key contains the embedded bytes as expected.
+            const int BitsInByte = 8;
             Debug.Assert(
                 // Verify embedded property name.
-                (length < 1 || propertyName[0] == ((key & ((ulong)0xFF << BitsInByte * 0)) >> BitsInByte * 0)) &&
-                (length < 2 || propertyName[1] == ((key & ((ulong)0xFF << BitsInByte * 1)) >> BitsInByte * 1)) &&
-                (length < 3 || propertyName[2] == ((key & ((ulong)0xFF << BitsInByte * 2)) >> BitsInByte * 2)) &&
-                (length < 4 || propertyName[3] == ((key & ((ulong)0xFF << BitsInByte * 3)) >> BitsInByte * 3)) &&
-                (length < 5 || propertyName[4] == ((key & ((ulong)0xFF << BitsInByte * 4)) >> BitsInByte * 4)) &&
-                (length < 6 || propertyName[5] == ((key & ((ulong)0xFF << BitsInByte * 5)) >> BitsInByte * 5)) &&
-                (length < 7 || propertyName[6] == ((key & ((ulong)0xFF << BitsInByte * 6)) >> BitsInByte * 6)) &&
+                (name.Length < 1 || name[0] == ((key & ((ulong)0xFF << BitsInByte * 0)) >> BitsInByte * 0)) &&
+                (name.Length < 2 || name[1] == ((key & ((ulong)0xFF << BitsInByte * 1)) >> BitsInByte * 1)) &&
+                (name.Length < 3 || name[2] == ((key & ((ulong)0xFF << BitsInByte * 2)) >> BitsInByte * 2)) &&
+                (name.Length < 4 || name[3] == ((key & ((ulong)0xFF << BitsInByte * 3)) >> BitsInByte * 3)) &&
+                (name.Length < 5 || name[4] == ((key & ((ulong)0xFF << BitsInByte * 4)) >> BitsInByte * 4)) &&
+                (name.Length < 6 || name[5] == ((key & ((ulong)0xFF << BitsInByte * 5)) >> BitsInByte * 5)) &&
+                (name.Length < 7 || name[6] == ((key & ((ulong)0xFF << BitsInByte * 6)) >> BitsInByte * 6)) &&
                 // Verify embedded length.
-                (length >= 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == (ulong)length) &&
-                (length < 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == 0xFF));
+                (name.Length >= 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == (ulong)name.Length) &&
+                (name.Length < 0xFF || (key & ((ulong)0xFF << BitsInByte * 7)) >> BitsInByte * 7 == 0xFF));
 
             return key;
         }


### PR DESCRIPTION
The proposed implementation tries to read multi byte values if possible and has no length checks generated during accessing the span.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20175
Intel Xeon CPU E5-2687W 0 3.10GHz, 2 CPU, 32 logical and 16 physical cores
.NET Core SDK=5.0.100-preview.7.20366.15
  [Host]     : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT
  DefaultJob : .NET Core 5.0.0 (CoreCLR 5.0.20.36411, CoreFX 5.0.20.36411), X64 RyuJIT


```
|          Method |   value |     Mean |     Error |    StdDev |   Median | Code Size |
|---------------- |-------- |---------:|----------:|----------:|---------:|----------:|
| **GetKeyOptimized** | **Byte[0]** | **5.563 ns** | **0.0038 ns** | **0.0031 ns** | **5.563 ns** |     **205 B** |
|   GetKeyRuntime | Byte[0] | 5.557 ns | 0.0046 ns | 0.0041 ns | 5.555 ns |     422 B |
| **GetKeyOptimized** | **Byte[1]** | **4.310 ns** | **0.0778 ns** | **0.0728 ns** | **4.336 ns** |     **205 B** |
|   GetKeyRuntime | Byte[1] | 5.286 ns | 0.0126 ns | 0.0098 ns | 5.285 ns |     422 B |
| **GetKeyOptimized** | **Byte[2]** | **5.586 ns** | **0.1395 ns** | **0.1305 ns** | **5.516 ns** |     **205 B** |
|   GetKeyRuntime | Byte[2] | 5.012 ns | 0.0094 ns | 0.0078 ns | 5.009 ns |     422 B |
| **GetKeyOptimized** | **Byte[3]** | **4.697 ns** | **0.1277 ns** | **0.1195 ns** | **4.718 ns** |     **205 B** |
|   GetKeyRuntime | Byte[3] | 4.840 ns | 0.1338 ns | 0.1875 ns | 4.770 ns |     422 B |
| **GetKeyOptimized** | **Byte[4]** | **5.837 ns** | **0.0033 ns** | **0.0030 ns** | **5.838 ns** |     **205 B** |
|   GetKeyRuntime | Byte[4] | 5.573 ns | 0.0188 ns | 0.0176 ns | 5.564 ns |     422 B |
| **GetKeyOptimized** | **Byte[5]** | **4.380 ns** | **0.1292 ns** | **0.2263 ns** | **4.278 ns** |     **205 B** |
|   GetKeyRuntime | Byte[5] | 4.995 ns | 0.0026 ns | 0.0020 ns | 4.995 ns |     422 B |
| **GetKeyOptimized** | **Byte[6]** | **5.307 ns** | **0.1436 ns** | **0.1763 ns** | **5.275 ns** |     **205 B** |
|   GetKeyRuntime | Byte[6] | 4.652 ns | 0.0052 ns | 0.0044 ns | 4.653 ns |     422 B |
| **GetKeyOptimized** | **Byte[7]** | **4.163 ns** | **0.0017 ns** | **0.0014 ns** | **4.163 ns** |     **205 B** |
|   GetKeyRuntime | Byte[7] | 4.798 ns | 0.0023 ns | 0.0019 ns | 4.798 ns |     422 B |
| **GetKeyOptimized** | **Byte[8]** | **3.713 ns** | **0.0614 ns** | **0.0479 ns** | **3.694 ns** |     **205 B** |
|   GetKeyRuntime | Byte[8] | 4.290 ns | 0.0825 ns | 0.0731 ns | 4.284 ns |     422 B |
| **GetKeyOptimized** | **Byte[9]** | **3.667 ns** | **0.0120 ns** | **0.0112 ns** | **3.665 ns** |     **205 B** |
|   GetKeyRuntime | Byte[9] | 4.244 ns | 0.0096 ns | 0.0080 ns | 4.238 ns |     422 B |

```csharp
[Benchmark]
[ArgumentsSource(nameof(GetArguments))]
public static ulong GetKeyOptimized(byte[] value)
{
    return GetKey(value);
    static ulong GetKey(ReadOnlySpan<byte> name) => /* new implementation */;
}

[Benchmark]
[ArgumentsSource(nameof(GetArguments))]
public ulong GetKeyRuntime(byte[] value)
{
    return GetKey(value);
    static ulong GetKey(ReadOnlySpan<byte> name) => /* original implementation */;
}

public IEnumerable<object> GetArguments()
{
    for (var length = 0; length < 10; length++)
    {
        var array = new byte[length];
        for (var index = 0; index < length; index++)
            array[index] = (byte)('a' + index);
        yield return array;
    }
}
```