### PR TITLE
[runtime] If the initial pinvoke lookup fails, emit some code inside the managed-to-native wrapper to retry to lookup on every call until it succeeds. 

### DIFF
--- a/src/mono/mono/cil/cil-opcodes.xml
+++ b/src/mono/mono/cil/cil-opcodes.xml
@@ -325,4 +325,6 @@
 <opcode name="mono_ld_delegate_method_ptr" input="Pop1" output="PushI" args="InlineNone" o1="0xF0" o2="0x1E" flow="next" />
 <opcode name="mono_rethrow" input="PopRef" output="Push0" args="InlineNone" o1="0xF0" o2="0x1F" flow="throw" type="Objmodel" />
 <opcode name="mono_get_sp" input="Pop0" output="PushI" args="InlineNone" o1="0xF0" o2="0x20" flow="next" />
+<opcode name="mono_methodconst" input="Pop0" output="PushI" args="InlineI" o1="0xF0" o2="0x21" flow="next" />
+<opcode name="mono_pinvoke_addr_cache" input="Pop0" output="PushI" args="InlineI" o1="0xF0" o2="0x22" flow="next" />
 </opdesc>

--- a/src/mono/mono/cil/opcode.def
+++ b/src/mono/mono/cil/opcode.def
@@ -325,6 +325,8 @@ OPDEF(CEE_MONO_LDPTR_PROFILER_ALLOCATION_COUNT, "mono_ldptr_profiler_allocation_
 OPDEF(CEE_MONO_LD_DELEGATE_METHOD_PTR, "mono_ld_delegate_method_ptr", Pop1, PushI, InlineNone, 0, 2, 0xF0, 0x1E, NEXT)
 OPDEF(CEE_MONO_RETHROW, "mono_rethrow", PopRef, Push0, InlineNone, 0, 2, 0xF0, 0x1F, ERROR)
 OPDEF(CEE_MONO_GET_SP, "mono_get_sp", Pop0, PushI, InlineNone, 0, 2, 0xF0, 0x20, NEXT)
+OPDEF(CEE_MONO_METHODCONST, "mono_methodconst", Pop0, PushI, InlineI, 0, 2, 0xF0, 0x21, NEXT)
+OPDEF(CEE_MONO_PINVOKE_ADDR_CACHE, "mono_pinvoke_addr_cache", Pop0, PushI, InlineI, 0, 2, 0xF0, 0x22, NEXT)
 #ifndef OPALIAS
 #define _MONO_CIL_OPALIAS_DEFINED_
 #define OPALIAS(a,s,r)

--- a/src/mono/mono/metadata/jit-icall-reg.h
+++ b/src/mono/mono/metadata/jit-icall-reg.h
@@ -340,6 +340,7 @@ MONO_JIT_ICALL (ves_icall_runtime_class_init) \
 MONO_JIT_ICALL (ves_icall_string_alloc) \
 MONO_JIT_ICALL (ves_icall_string_new_wrapper) \
 MONO_JIT_ICALL (ves_icall_thread_finish_async_abort) \
+MONO_JIT_ICALL (mono_marshal_lookup_pinvoke) \
 	\
 MONO_JIT_ICALL (count) \
 

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -2055,7 +2055,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	if (need_gc_safe)
 		gc_safe_transition_builder_add_locals (&gc_safe_transition_builder);
 
-	if (!func && !aot) {
+	if (!func && !aot && !func_param && !MONO_CLASS_IS_IMPORT (mb->method->klass)) {
 		/*
 		 * On netcore, its possible to register pinvoke resolvers at runtime, so
 		 * a pinvoke lookup can fail, and then succeed later. So if the

--- a/src/mono/mono/metadata/marshal-ilgen.c
+++ b/src/mono/mono/metadata/marshal-ilgen.c
@@ -2007,6 +2007,7 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 	MonoClass *klass;
 	int i, argnum, *tmp_locals;
 	int type, param_shift = 0;
+	int func_addr_local = -1;
 	gboolean need_gc_safe = FALSE;
 	GCSafeTransitionBuilder gc_safe_transition_builder;
 
@@ -2051,8 +2052,40 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		mono_mb_add_local (mb, sig->ret);
 	}
 
-	if (need_gc_safe) {
-	        gc_safe_transition_builder_add_locals (&gc_safe_transition_builder);
+	if (need_gc_safe)
+		gc_safe_transition_builder_add_locals (&gc_safe_transition_builder);
+
+	if (!func && !aot) {
+		/*
+		 * On netcore, its possible to register pinvoke resolvers at runtime, so
+		 * a pinvoke lookup can fail, and then succeed later. So if the
+		 * original lookup failed, do a lookup every time until it
+		 * succeeds.
+		 * This adds some overhead, but only when the pinvoke lookup
+		 * was not initially successful.
+		 * FIXME: AOT case
+		 */
+		func_addr_local = mono_mb_add_local (mb, int_type);
+
+		int cache_local = mono_mb_add_local (mb, int_type);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_PINVOKE_ADDR_CACHE, &piinfo->method);
+		mono_mb_emit_stloc (mb, cache_local);
+
+		mono_mb_emit_ldloc (mb, cache_local);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		int pos = mono_mb_emit_branch (mb, CEE_BRTRUE);
+
+		mono_mb_emit_ldloc (mb, cache_local);
+		mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+		mono_mb_emit_op (mb, CEE_MONO_METHODCONST, &piinfo->method);
+		mono_mb_emit_icall (mb, mono_marshal_lookup_pinvoke);
+		mono_mb_emit_byte (mb, CEE_STIND_I);
+
+		mono_mb_patch_branch (mb, pos);
+		mono_mb_emit_ldloc (mb, cache_local);
+		mono_mb_emit_byte (mb, CEE_LDIND_I);
+		mono_mb_emit_stloc (mb, func_addr_local);
 	}
 
 	/*
@@ -2123,22 +2156,23 @@ emit_native_wrapper_ilgen (MonoImage *image, MonoMethodBuilder *mb, MonoMethodSi
 		g_assert_not_reached ();
 #endif
 	} else {
-		if (aot) {
-			/* Reuse the ICALL_ADDR opcode for pinvokes too */
-			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-			mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
-			if (piinfo->piflags & PINVOKE_ATTRIBUTE_SUPPORTS_LAST_ERROR) {
-				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-				mono_mb_emit_byte (mb, CEE_MONO_SAVE_LAST_ERROR);
-			}
-			mono_mb_emit_calli (mb, csig);
+		if (func_addr_local != -1) {
+			mono_mb_emit_ldloc (mb, func_addr_local);
 		} else {
-			if (piinfo->piflags & PINVOKE_ATTRIBUTE_SUPPORTS_LAST_ERROR) {
+			if (aot) {
+				/* Reuse the ICALL_ADDR opcode for pinvokes too */
 				mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
-				mono_mb_emit_byte (mb, CEE_MONO_SAVE_LAST_ERROR);
+				mono_mb_emit_op (mb, CEE_MONO_ICALL_ADDR, &piinfo->method);
 			}
-			mono_mb_emit_native_call (mb, csig, func);
 		}
+		if (piinfo->piflags & PINVOKE_ATTRIBUTE_SUPPORTS_LAST_ERROR) {
+			mono_mb_emit_byte (mb, MONO_CUSTOM_PREFIX);
+			mono_mb_emit_byte (mb, CEE_MONO_SAVE_LAST_ERROR);
+		}
+		if (func_addr_local != -1 || aot)
+			mono_mb_emit_calli (mb, csig);
+		else
+			mono_mb_emit_native_call (mb, csig, func);
 	}
 
 	if (MONO_TYPE_ISSTRUCT (sig->ret)) {

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -6760,7 +6760,6 @@ mono_marshal_lookup_pinvoke (MonoMethod *method)
 
 	g_assert (method);
 	addr = mono_lookup_pinvoke_call_internal (method, error);
-	printf ("%p\n", addr);
 	if (!addr)
 		g_assert (!is_ok (error));
 	mono_error_set_pending_exception (error);

--- a/src/mono/mono/metadata/marshal.c
+++ b/src/mono/mono/metadata/marshal.c
@@ -255,6 +255,7 @@ mono_marshal_init (void)
 		register_icall (mono_threads_attach_coop, mono_icall_sig_ptr_ptr_ptr, TRUE);
 		register_icall (mono_threads_detach_coop, mono_icall_sig_void_ptr_ptr, TRUE);
 		register_icall (mono_marshal_get_type_object, mono_icall_sig_object_ptr, TRUE);
+		register_icall (mono_marshal_lookup_pinvoke, mono_icall_sig_ptr_ptr, FALSE);
 
 		mono_cominterop_init ();
 		mono_remoting_init ();
@@ -3683,7 +3684,7 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 	 * In AOT mode and embedding scenarios, it is possible that the icall is not
 	 * registered in the runtime doing the AOT compilation.
 	 */
-	if (!piinfo->addr && !aot) {
+	if (!pinvoke && !piinfo->addr && !aot) {
 		/* if there's no code but the error isn't set, just use a fairly generic exception. */
 		if (is_ok (emitted_error))
 			mono_error_set_generic_error (emitted_error, "System", "MissingMethodException", "");
@@ -3701,8 +3702,6 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 
 		return res;
 	}
-
-	g_assert (is_ok (emitted_error));
 
 	/* internal calls: we simply push all arguments and call the method (no conversions) */
 	if (method->iflags & (METHOD_IMPL_ATTRIBUTE_INTERNAL_CALL | METHOD_IMPL_ATTRIBUTE_RUNTIME)) {
@@ -3732,8 +3731,6 @@ mono_marshal_get_native_wrapper (MonoMethod *method, gboolean check_exceptions, 
 	}
 
 	g_assert (pinvoke);
-	if (!aot)
-		g_assert (piinfo->addr);
 
 	csig = mono_metadata_signature_dup_full (get_method_image (method), sig);
 	mono_marshal_set_callconv_from_modopt (method, csig, FALSE);
@@ -6753,6 +6750,21 @@ mono_marshal_get_type_object (MonoClass *klass)
 	MonoObject *result = (MonoObject*)mono_type_get_object_checked (mono_domain_get (), type, error);
 	mono_error_set_pending_exception (error);
 	return result;
+}
+
+gpointer
+mono_marshal_lookup_pinvoke (MonoMethod *method)
+{
+	ERROR_DECL (error);
+	gpointer addr;
+
+	g_assert (method);
+	addr = mono_lookup_pinvoke_call_internal (method, error);
+	printf ("%p\n", addr);
+	if (!addr)
+		g_assert (!is_ok (error));
+	mono_error_set_pending_exception (error);
+	return addr;
 }
 
 void

--- a/src/mono/mono/metadata/marshal.h
+++ b/src/mono/mono/metadata/marshal.h
@@ -605,6 +605,10 @@ mono_marshal_need_free (MonoType *t, MonoMethodPInvoke *piinfo, MonoMarshalSpec 
 ICALL_EXTERN_C
 MonoObject* mono_marshal_get_type_object (MonoClass *klass);
 
+ICALL_EXTERN_C
+gpointer
+mono_marshal_lookup_pinvoke (MonoMethod *method);
+
 ICALL_EXPORT
 guint32 
 ves_icall_System_Runtime_InteropServices_Marshal_GetLastWin32Error (void);

--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -6605,6 +6605,7 @@ encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info, guint8 *buf, guint
 	case MONO_PATCH_INFO_ICALL_ADDR_CALL:
 	case MONO_PATCH_INFO_METHOD_RGCTX:
 	case MONO_PATCH_INFO_METHOD_CODE_SLOT:
+	case MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE:
 		encode_method_ref (acfg, patch_info->data.method, p, &p);
 		break;
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
@@ -8484,7 +8485,8 @@ can_encode_patch (MonoAotCompile *acfg, MonoJumpInfo *patch_info)
 	case MONO_PATCH_INFO_METHOD:
 	case MONO_PATCH_INFO_METHOD_FTNDESC:
 	case MONO_PATCH_INFO_METHODCONST:
-	case MONO_PATCH_INFO_METHOD_CODE_SLOT: {
+	case MONO_PATCH_INFO_METHOD_CODE_SLOT:
+	case MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE: {
 		MonoMethod *method = patch_info->data.method;
 
 		return can_encode_method (acfg, method);

--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -3854,7 +3854,8 @@ decode_patch (MonoAotModule *aot_module, MonoMemPool *mp, MonoJumpInfo *ji, guin
 	case MONO_PATCH_INFO_ICALL_ADDR:
 	case MONO_PATCH_INFO_ICALL_ADDR_CALL:
 	case MONO_PATCH_INFO_METHOD_RGCTX:
-	case MONO_PATCH_INFO_METHOD_CODE_SLOT: {
+	case MONO_PATCH_INFO_METHOD_CODE_SLOT:
+	case MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE: {
 		MethodRef ref;
 		gboolean res;
 

--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -6111,12 +6111,24 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 			}
 			case CEE_MONO_LDPTR:
 			case CEE_MONO_CLASSCONST:
+			case CEE_MONO_METHODCONST:
 				token = read32 (td->ip + 1);
 				td->ip += 5;
 				interp_add_ins (td, MINT_MONO_LDPTR);
 				td->last_ins->data [0] = get_data_item_index (td, mono_method_get_wrapper_data (method, token));
 				PUSH_SIMPLE_TYPE (td, STACK_TYPE_I);
 				break;
+			case CEE_MONO_PINVOKE_ADDR_CACHE: {
+				token = read32 (td->ip + 1);
+				td->ip += 5;
+				interp_add_ins (td, MINT_MONO_LDPTR);
+				g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
+				/* This is a memory slot used by the wrapper */
+				gpointer addr = mono_domain_alloc0 (td->rtm->domain, sizeof (gpointer));
+				td->last_ins->data [0] = get_data_item_index (td, addr);
+				PUSH_SIMPLE_TYPE (td, STACK_TYPE_I);
+				break;
+			}
 			case CEE_MONO_OBJADDR:
 				CHECK_STACK (td, 1);
 				++td->ip;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10759,11 +10759,14 @@ mono_ldptr:
 			break;
 		case MONO_CEE_MONO_PINVOKE_ADDR_CACHE: {
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
-			// FIXME: AOT
-			g_assert (!cfg->compile_aot);
+			MonoMethod *pinvoke_method = mono_method_get_wrapper_data (method, token);
 			/* This is a memory slot used by the wrapper */
-			gpointer addr = mono_domain_alloc0 (cfg->domain, sizeof (gpointer));
-			EMIT_NEW_PCONST (cfg, ins, addr);
+			if (cfg->compile_aot) {
+				EMIT_NEW_AOTCONST (cfg, ins, MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE, pinvoke_method);
+			} else {
+				gpointer addr = mono_domain_alloc0 (cfg->domain, sizeof (gpointer));
+				EMIT_NEW_PCONST (cfg, ins, addr);
+			}
 			*sp++ = ins;
 			break;
 		}

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10752,6 +10752,21 @@ mono_ldptr:
 			*sp++ = ins;
 			inline_costs += CALL_COST * MIN(10, num_calls++);
 			break;
+		case MONO_CEE_MONO_METHODCONST:
+			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
+			EMIT_NEW_METHODCONST (cfg, ins, mono_method_get_wrapper_data (method, token));
+			*sp++ = ins;
+			break;
+		case MONO_CEE_MONO_PINVOKE_ADDR_CACHE: {
+			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
+			// FIXME: AOT
+			g_assert (!cfg->compile_aot);
+			/* This is a memory slot used by the wrapper */
+			gpointer addr = mono_domain_alloc0 (cfg->domain, sizeof (gpointer));
+			EMIT_NEW_PCONST (cfg, ins, addr);
+			*sp++ = ins;
+			break;
+		}
 		case MONO_CEE_MONO_NOT_TAKEN:
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
 			cfg->cbb->out_of_line = TRUE;

--- a/src/mono/mono/mini/method-to-ir.c
+++ b/src/mono/mono/mini/method-to-ir.c
@@ -10759,7 +10759,7 @@ mono_ldptr:
 			break;
 		case MONO_CEE_MONO_PINVOKE_ADDR_CACHE: {
 			g_assert (method->wrapper_type != MONO_WRAPPER_NONE);
-			MonoMethod *pinvoke_method = mono_method_get_wrapper_data (method, token);
+			MonoMethod *pinvoke_method = (MonoMethod*)mono_method_get_wrapper_data (method, token);
 			/* This is a memory slot used by the wrapper */
 			if (cfg->compile_aot) {
 				EMIT_NEW_AOTCONST (cfg, ins, MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE, pinvoke_method);

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -1239,6 +1239,7 @@ mono_patch_info_hash (gconstpointer data)
 	case MONO_PATCH_INFO_SIGNATURE:
 	case MONO_PATCH_INFO_METHOD_CODE_SLOT:
 	case MONO_PATCH_INFO_AOT_JIT_INFO:
+	case MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE:
 		return hash | (gssize)ji->data.target;
 	case MONO_PATCH_INFO_GSHAREDVT_CALL:
 		return hash | (gssize)ji->data.gsharedvt->method;
@@ -1442,6 +1443,10 @@ mono_resolve_patch_target (MonoMethod *method, MonoDomain *domain, guint8 *code,
 		}
 		mono_domain_unlock (domain);
 		target = code_slot;
+		break;
+	}
+	case MONO_PATCH_INFO_METHOD_PINVOKE_ADDR_CACHE: {
+		target = mono_domain_alloc0 (domain, sizeof (gpointer));
 		break;
 	}
 	case MONO_PATCH_INFO_GC_SAFE_POINT_FLAG:

--- a/src/mono/mono/mini/patch-info.h
+++ b/src/mono/mono/mini/patch-info.h
@@ -82,3 +82,6 @@ PATCH_INFO(SPECIFIC_TRAMPOLINES_GOT_SLOTS_BASE, "specific_trampolines_got_slots_
  */
 PATCH_INFO(R8_GOT, "r8_got")
 PATCH_INFO(R4_GOT, "r4_got")
+
+/* MonoMethod* -> the address of a memory slot which is used to cache the pinvoke address */
+PATCH_INFO(METHOD_PINVOKE_ADDR_CACHE, "pinvoke_addr_cache")


### PR DESCRIPTION
Fixes #35219