### PR TITLE
Disable MSB3270 warning when referencing CoreLib

### DIFF
--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -185,6 +185,10 @@
         <Private>false</Private>
       </ProjectReference>
     </ItemGroup>
+    <!-- Disable TargetArchitectureMismatch warning when we reference CoreLib which is platform specific. -->
+    <PropertyGroup Condition="@(ProjectReference->AnyHaveMetadataValue('Identity', '$(CoreLibProject)'))">
+      <ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>None</ResolveAssemblyWarnOrErrorOnTargetArchitectureMismatch>
+    </PropertyGroup>
   </Target>
 
   <!-- Used for packaging -->


### PR DESCRIPTION
We intentionally reference CoreLib (platform specific) from our platform neutral (=AnyCPU) assemblies, ie System.Runtime. Disabling the warning that is shown in VS.