### PR TITLE
Disable copy ctor test on Mono

### DIFF
--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -964,6 +964,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Miscellaneous/CopyCtor/**">
+            <Issue>Handling for Copy constructors isn't present in mono interop</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/StringMarshalling/AnsiBSTR/AnsiBStrTest/**">
             <Issue>Crashes during LLVM AOT compilation.</Issue>
         </ExcludeList>


### PR DESCRIPTION
The underlying feature here was designed only for IJW, which isn't supported by mono