### PR TITLE
Re-work fix for flow graph update.

### DIFF
--- a/src/coreclr/src/jit/compiler.h
+++ b/src/coreclr/src/jit/compiler.h
@@ -4964,7 +4964,7 @@ protected:
 
     // When the flow graph changes, we need to update the block numbers, predecessor lists, reachability sets, and
     // dominators.
-    void fgUpdateChangedFlowGraph();
+    void fgUpdateChangedFlowGraph(bool computeDoms = true);
 
 public:
     // Compute the predecessors of the blocks in the control flow graph.

--- a/src/coreclr/src/jit/flowgraph.cpp
+++ b/src/coreclr/src/jit/flowgraph.cpp
@@ -1865,7 +1865,7 @@ bool Compiler::fgReachable(BasicBlock* b1, BasicBlock* b2)
  *  it again.
  */
 
-void Compiler::fgUpdateChangedFlowGraph()
+void Compiler::fgUpdateChangedFlowGraph(bool computeDoms)
 {
     // We need to clear this so we don't hit an assert calling fgRenumberBlocks().
     fgDomsComputed = false;
@@ -1875,7 +1875,11 @@ void Compiler::fgUpdateChangedFlowGraph()
 
     fgComputePreds();
     fgComputeEnterBlocksSet();
-    fgComputeReachability();
+    fgComputeReachabilitySets();
+    if (computeDoms)
+    {
+        fgComputeDoms();
+    }
 }
 
 /*****************************************************************************
@@ -3722,7 +3726,8 @@ PhaseStatus Compiler::fgInsertGCPolls()
     {
         noway_assert(opts.OptimizationEnabled());
         fgReorderBlocks();
-        fgUpdateChangedFlowGraph();
+        constexpr bool computeDoms = false;
+        fgUpdateChangedFlowGraph(computeDoms);
     }
 #ifdef DEBUG
     if (verbose)


### PR DESCRIPTION
In #39878 I switched fgUpdateChangedFlowGraph to call fgComputeReachability,
which both removes unreachable blocks and calls fgComputeDoms. As mentioned
in that PR, in addition to removing unreachable blocks fgRemoveUnreachableBlocks
updates `BBF_LOOP_HEAD` flags even if no unreachable blocks were found. That resulted
in some diffs, both positive and negative, from downstream effects: e.g., in some cases
we now recognize more loops, which changes weights, etc.

Some of the negative diffs affected benchmarks we are tracking, e.g., in #40094
`System.Text.RegularExpressions.Tests.Perf_Regex_Common` had a 10% regression
because of codegen diffs in the large dynamic method created when compiling regular expressions.

Because of these regressions, I decided to go with a more surgical fix for the original issue (assert when
computing dominators after inlining GC polls). The downstream phases don't really need the dominator
info so I changed fgUpdateChangedFlowGraph to not re-compute dominators after GC poll inlining.

This reverses all diffs from #39878 and fixes #40094.