### PR TITLE
Fix for unsafe CSE of Structs

### DIFF
--- a/src/coreclr/src/jit/optcse.cpp
+++ b/src/coreclr/src/jit/optcse.cpp
@@ -2526,8 +2526,9 @@ public:
 #ifdef DEBUG
                     if (m_pCompiler->verbose)
                     {
-                        printf("Moderate CSE Promotion (CSE is live across a call) (%u >= %u)\n", cseRefCnt,
-                               moderateRefCnt);
+                        printf("Moderate CSE Promotion (%s) (%u >= %u)\n",
+                               candidate->LiveAcrossCall() ? "CSE is live across a call" : "not enregisterable",
+                               cseRefCnt, moderateRefCnt);
                     }
 #endif
                     cse_def_cost = 2;
@@ -2558,8 +2559,9 @@ public:
 #ifdef DEBUG
                     if (m_pCompiler->verbose)
                     {
-                        printf("Conservative CSE Promotion (CSE never live at call) (%u < %u)\n", cseRefCnt,
-                               moderateRefCnt);
+                        printf("Conservative CSE Promotion (%s) (%u < %u)\n",
+                               candidate->LiveAcrossCall() ? "CSE is live across a call" : "not enregisterable",
+                               cseRefCnt, moderateRefCnt);
                     }
 #endif
                     cse_def_cost = 2;

--- a/src/coreclr/src/jit/valuenum.cpp
+++ b/src/coreclr/src/jit/valuenum.cpp
@@ -4137,14 +4137,23 @@ ValueNum Compiler::fgValueNumberArrIndexVal(GenTree*             tree,
 
 ValueNum Compiler::fgValueNumberByrefExposedLoad(var_types type, ValueNum pointerVN)
 {
-    ValueNum memoryVN = fgCurMemoryVN[ByrefExposed];
-    // The memoization for VNFunc applications does not factor in the result type, so
-    // VNF_ByrefExposedLoad takes the loaded type as an explicit parameter.
-    ValueNum typeVN = vnStore->VNForIntCon(type);
-    ValueNum loadVN =
-        vnStore->VNForFunc(type, VNF_ByrefExposedLoad, typeVN, vnStore->VNNormalValue(pointerVN), memoryVN);
-
-    return loadVN;
+    if (type == TYP_STRUCT)
+    {
+        // We can't assign a value number for a read of a struct as we can't determine
+        // how many bytes will be read by this load, so return a new unique value number
+        //
+        return vnStore->VNForExpr(compCurBB, TYP_STRUCT);
+    }
+    else
+    {
+        ValueNum memoryVN = fgCurMemoryVN[ByrefExposed];
+        // The memoization for VNFunc applications does not factor in the result type, so
+        // VNF_ByrefExposedLoad takes the loaded type as an explicit parameter.
+        ValueNum typeVN = vnStore->VNForIntCon(type);
+        ValueNum loadVN =
+            vnStore->VNForFunc(type, VNF_ByrefExposedLoad, typeVN, vnStore->VNNormalValue(pointerVN), memoryVN);
+        return loadVN;
+    }
 }
 
 var_types ValueNumStore::TypeOfVN(ValueNum vn)

--- a/src/tests/JIT/Regression/JitBlue/Runtime_38920/Runtime_38920.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_38920/Runtime_38920.cs
@@ -1,0 +1,121 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+class TestStructs
+{
+    static int exitStatus = 100;
+
+    struct StructA
+    {
+        public int a;
+    }
+
+    // Make both structs with >4 fields to prevent struct promoting and force byref passing.
+    struct CastFromStruct20
+    {
+        int z;
+        public StructA structField;
+        public int b;
+        public int c;
+        int q;
+    }
+
+    struct CastToStruct8
+    {
+        bool a;
+        bool b;
+        bool c;
+        bool d;
+        public int e; // Overlaps with b in CastFromStruct
+    }
+
+    struct CastToStruct12
+    {
+        bool a;
+        bool b;
+        bool c;
+        bool d;
+        public int e; // Overlaps with b in CastFromStruct
+        public int f; // Overlaps with c in CastFromStruct
+    }
+
+
+    // our src local var has to be an implicit byref, otherwise we won't try to recover struct handle from it.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void UnsafeCastFromAPrimitiveStructFieldToStruct(CastFromStruct20 impByRefStruct20, int b, int c)
+    {
+        CastToStruct8  to8  = new CastToStruct8();
+        CastToStruct12 to12 = new CastToStruct12();
+
+	// possible incorrect CSE def of impByRefStruct20.structField
+	//
+        to8 = Unsafe.As<StructA, CastToStruct8>(ref impByRefStruct20.structField);
+
+        for (int i =0; i<10; i++)
+        {
+            // possible incorrect CSE use of impByRefStruct20.structField
+            //
+            to12 = Unsafe.As<StructA, CastToStruct12>(ref impByRefStruct20.structField);
+        }
+
+        // Check that we modified to8.e correctly
+        if (to8.e != b)
+        {
+            Console.WriteLine("to8.e has the wrong value: " + to8.e + " expected " + b);
+            exitStatus = -1;
+        }
+
+        // Check that we modified to12.e correctly
+        if (to12.e != b)
+        {
+            Console.WriteLine("to12.e has the wrong value: " + to12.e + " expected " + b);
+            exitStatus = -1;
+        }
+
+        // Check that we modified to12.f correctly
+        if (to12.f != c)
+        {
+            Console.WriteLine("to12.f has the wrong value: " + to12.f + " expected " + c);
+            exitStatus = -1;
+        }
+    }
+
+    public static int Main()
+    {
+        int b = 1;
+        int c = 2;
+
+        CastFromStruct20 s = new CastFromStruct20();
+
+        s.b = b;
+        s.c = c;
+        UnsafeCastFromAPrimitiveStructFieldToStruct(s, b, c);
+
+        s.b = ++b;  // 2
+        s.c = ++c;  // 3
+        UnsafeCastFromAPrimitiveStructFieldToStruct(s, b, c);
+
+        b = b * b;
+        c = c * c;
+        s.b = b;    // 4
+        s.c = c;    // 9
+        UnsafeCastFromAPrimitiveStructFieldToStruct(s, b, c);
+
+	if (exitStatus == 100)
+        {
+            Console.WriteLine("Test Passed");
+        }
+        else
+        {
+            Console.WriteLine("FAILED");
+        }
+
+        return exitStatus;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_38920/Runtime_38920.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_38920/Runtime_38920.cs
@@ -53,8 +53,8 @@ class TestStructs
         CastToStruct8  to8  = new CastToStruct8();
         CastToStruct12 to12 = new CastToStruct12();
 
-	// possible incorrect CSE def of impByRefStruct20.structField
-	//
+        // possible incorrect CSE def of impByRefStruct20.structField
+        //
         to8 = Unsafe.As<StructA, CastToStruct8>(ref impByRefStruct20.structField);
 
         for (int i =0; i<10; i++)
@@ -107,7 +107,7 @@ class TestStructs
         s.c = c;    // 9
         UnsafeCastFromAPrimitiveStructFieldToStruct(s, b, c);
 
-	if (exitStatus == 100)
+        if (exitStatus == 100)
         {
             Console.WriteLine("Test Passed");
         }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_38920/Runtime_38920.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_38920/Runtime_38920.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
- Assign a unique value number when reading a struct field as we don't know the size of the read
- Modify the Jit Dump for CSE
- No Asm diffs in the Frameworks
- Added new test Runtime_38920.cs