### PR TITLE
Disable GCStress for profiler tests

### DIFF
--- a/src/tests/profiler/eventpipe/eventpipe.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe.csproj
@@ -6,7 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/39932 -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/eventpipe/eventpipe.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- https://github.com/dotnet/runtime/issues/36028 -->
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
+++ b/src/tests/profiler/eventpipe/eventpipe_readevents.csproj
@@ -6,7 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
-    <!-- https://github.com/dotnet/runtime/issues/36028 -->
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/gc/gc.csproj
+++ b/src/tests/profiler/gc/gc.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/gc/gc.csproj
+++ b/src/tests/profiler/gc/gc.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/gc/gcbasic.csproj
+++ b/src/tests/profiler/gc/gcbasic.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/gc/gcbasic.csproj
+++ b/src/tests/profiler/gc/gcbasic.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/rejit/rejit.csproj
+++ b/src/tests/profiler/rejit/rejit.csproj
@@ -7,6 +7,7 @@
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/rejit/rejit.csproj
+++ b/src/tests/profiler/rejit/rejit.csproj
@@ -7,6 +7,7 @@
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
     <JitOptimizationSensitive>True</JitOptimizationSensitive>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
@@ -10,6 +10,7 @@
          Issue: https://github.com/dotnet/runtime/issues/37117
     -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
+++ b/src/tests/profiler/unittest/getappdomainstaticaddress.csproj
@@ -10,6 +10,7 @@
          Issue: https://github.com/dotnet/runtime/issues/37117
     -->
     <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/unittest/metadatagetdispenser.csproj
+++ b/src/tests/profiler/unittest/metadatagetdispenser.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/profiler/unittest/metadatagetdispenser.csproj
+++ b/src/tests/profiler/unittest/metadatagetdispenser.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestPriority>0</CLRTestPriority>
     <Optimize>true</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
+++ b/src/tests/tracing/eventpipe/eventsourceerror/eventsourceerror.csproj
@@ -4,7 +4,7 @@
     <OutputType>exe</OutputType>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/35884 -->
+    <!-- https://github.com/dotnet/runtime/issues/36028 -->
     <GCStressIncompatible>true</GCStressIncompatible>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>0</CLRTestPriority>

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -6,6 +6,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>0</CLRTestPriority>
+    <!-- This test provides no interesting scenarios for GCStress -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
+++ b/src/tests/tracing/eventpipe/gcdump/gcdump.csproj
@@ -6,7 +6,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <CLRTestPriority>0</CLRTestPriority>
-    <!-- Disable for GCStress due to test failure: https://github.com/dotnet/runtime/issues/39931 -->
     <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
There are a set of profiler tests either running in to an existing product bug exacerbated by GCStress, or they cause a lot of GCs and shouldn't be run under GCStress because they will take forever and are uninteresting test cases.

Fixes #39931
Fixes #39682
Fixes #35884