### PR TITLE
Fix __asm__ specifications for Clang

### DIFF
--- a/src/mono/configure.ac
+++ b/src/mono/configure.ac
@@ -4678,7 +4678,7 @@ case "$host" in
 		ACCESS_UNALIGNED="yes"
 		BTLS_SUPPORTED=yes
 		BTLS_PLATFORM=s390x
-		CFLAGS="$CFLAGS -mbackchain -D__USE_STRING_INLINES"
+		CFLAGS="$CFLAGS -mbackchain"
 		;;
 	riscv32-*)
 		TARGET=RISCV32

--- a/src/mono/mono/mini/mini-s390x.h
+++ b/src/mono/mono/mini/mini-s390x.h
@@ -158,7 +158,7 @@ struct SeqPointInfo {
 
 #define MONO_INIT_CONTEXT_FROM_FUNC(ctx,func) do {			\
 		MonoS390StackFrame *sframe;				\
-		__asm__ volatile("lgr   %0,15" : "=r" (sframe));	\
+		__asm__ volatile("lgr   %0,%%r15" : "=r" (sframe));	\
 		MONO_CONTEXT_SET_BP ((ctx), sframe->prev);		\
 		MONO_CONTEXT_SET_SP ((ctx), sframe->prev);		\
 		MONO_CONTEXT_SET_IP ((ctx), func);			\

--- a/src/mono/mono/utils/mono-context.h
+++ b/src/mono/mono/utils/mono-context.h
@@ -918,8 +918,8 @@ typedef struct ucontext MonoContext;
 		"std	%%f13,104(%1)\n"		\
 		"std	%%f14,112(%1)\n"		\
 		"std	%%f15,120(%1)\n"		\
-		: : "r" (&(ctx).uc_mcontext.gregs[0]),		\
-		    "r" (&(ctx).uc_mcontext.fpregs.fprs[0])	\
+		: : "a" (&(ctx).uc_mcontext.gregs[0]),		\
+		    "a" (&(ctx).uc_mcontext.fpregs.fprs[0])	\
 		: "memory"			\
 	)
 

--- a/src/mono/mono/utils/mono-hwcap-s390x.c
+++ b/src/mono/mono/utils/mono-hwcap-s390x.c
@@ -148,7 +148,7 @@ mono_hwcap_arch_init (void)
 	int lFacs = sizeof (facs) / 8;
 
 	__asm__ __volatile__ (
-		"lgfr\t0,%1\n\t"
+		"lgfr\t%%r0,%1\n\t"
 		".insn\ts,0xb2b00000,%0\n\t"
 		: "=m" (facs)
 		: "r" (lFacs)

--- a/src/mono/mono/utils/mono-tls.c
+++ b/src/mono/mono/utils/mono-tls.c
@@ -70,11 +70,11 @@
 #  endif
 # else
 #  define MONO_THREAD_VAR_OFFSET(var,offset) do { guint64 foo;  			\
-						__asm__ ("basr  %%r1,0\n\t"		\
+						__asm__ ("larl  %%r1,0f\n\t"		\
 							 "j     0f\n\t"			\
-							 ".quad " #var "@NTPOFF\n"	\
-							 "0:\n\t"			\
-							 "lg    %0,4(%%r1)\n\t"		\
+							 "0:.quad " #var "@NTPOFF\n"	\
+							 "1:\n\t"			\
+							 "lg    %0,0(%%r1)\n\t"		\
 							: "=r" (foo) : : "1");		\
 						offset = foo; } while (0)
 # endif

--- a/src/mono/mono/utils/valgrind.h
+++ b/src/mono/mono/utils/valgrind.h
@@ -831,15 +831,15 @@ typedef
  * (e.g. VEX/priv/guest_s390_decoder.c).
  */
 #define __SPECIAL_INSTRUCTION_PREAMBLE                           \
-                     "lr 15,15\n\t"                              \
-                     "lr 1,1\n\t"                                \
-                     "lr 2,2\n\t"                                \
-                     "lr 3,3\n\t"
+                     "lr %%r15,%%r15\n\t"                        \
+                     "lr %%r1,%%r1\n\t"                          \
+                     "lr %%r2,%%r2\n\t"                          \
+                     "lr %%r3,%%r3\n\t"
 
-#define __CLIENT_REQUEST_CODE "lr 2,2\n\t"
-#define __GET_NR_CONTEXT_CODE "lr 3,3\n\t"
-#define __CALL_NO_REDIR_CODE  "lr 4,4\n\t"
-#define __VEX_INJECT_IR_CODE  "lr 5,5\n\t"
+#define __CLIENT_REQUEST_CODE "lr %%r2,%%r2\n\t"
+#define __GET_NR_CONTEXT_CODE "lr %%r3,%%r3\n\t"
+#define __CALL_NO_REDIR_CODE  "lr %%r4,%%r4\n\t"
+#define __VEX_INJECT_IR_CODE  "lr %%r5,%%r5\n\t"
 
 #define VALGRIND_DO_CLIENT_REQUEST_EXPR(                         \
        _zzq_default, _zzq_request,                               \
@@ -854,15 +854,15 @@ typedef
    _zzq_args[4] = (unsigned long long int)(_zzq_arg4);           \
    _zzq_args[5] = (unsigned long long int)(_zzq_arg5);           \
    __asm__ volatile(/* r2 = args */                              \
-                    "lgr 2,%1\n\t"                               \
+                    "lgr %%r2,%1\n\t"                            \
                     /* r3 = default */                           \
-                    "lgr 3,%2\n\t"                               \
+                    "lgr %%r3,%2\n\t"                            \
                     __SPECIAL_INSTRUCTION_PREAMBLE               \
                     __CLIENT_REQUEST_CODE                        \
                     /* results = r3 */                           \
-                    "lgr %0, 3\n\t"                              \
+                    "lgr %0,%%r3\n\t"                            \
                     : "=d" (_zzq_result)                         \
-                    : "a" (&_zzq_args[0]), "0" (_zzq_default)    \
+                    : "a" (&_zzq_args[0]), "r" (_zzq_default)    \
                     : "cc", "2", "3", "memory"                   \
                    );                                            \
    _zzq_result;                                                  \
@@ -873,7 +873,7 @@ typedef
    volatile unsigned long long int __addr;                       \
    __asm__ volatile(__SPECIAL_INSTRUCTION_PREAMBLE               \
                     __GET_NR_CONTEXT_CODE                        \
-                    "lgr %0, 3\n\t"                              \
+                    "lgr %0,%%r3\n\t"                            \
                     : "=a" (__addr)                              \
                     :                                            \
                     : "cc", "3", "memory"                        \
@@ -4652,17 +4652,17 @@ typedef
       ,"d"(__builtin_dwarf_cfa())
 #  define VALGRIND_CFI_PROLOGUE                                   \
       ".cfi_remember_state\n\t"                                   \
-      "lgr 1,%1\n\t" /* copy the argvec pointer in r1 */          \
-      "lgr 7,11\n\t"                                              \
-      "lgr 11,%2\n\t"                                             \
+      "lgr %%r1,%1\n\t" /* copy the argvec pointer in r1 */       \
+      "lgr %%r7,%%r11\n\t"                                        \
+      "lgr %%r11,%2\n\t"                                          \
       ".cfi_def_cfa r11, 0\n\t"
 #  define VALGRIND_CFI_EPILOGUE                                   \
-      "lgr 11, 7\n\t"                                             \
+      "lgr %%r11,%%r7\n\t"                                        \
       ".cfi_restore_state\n\t"
 #else
 #  define __FRAME_POINTER
 #  define VALGRIND_CFI_PROLOGUE                                   \
-      "lgr 1,%1\n\t"
+      "lgr %%r1,%1\n\t"
 #  define VALGRIND_CFI_EPILOGUE
 #endif
 
@@ -4695,11 +4695,11 @@ typedef
       _argvec[0] = (unsigned long)_orig.nraddr;                  \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-160\n\t"                                      \
-         "lg 1, 0(1)\n\t"  /* target->r1 */                      \
+         "aghi %%r15,-160\n\t"                                   \
+         "lg   %%r1,0(%%r1)\n\t"  /* target->r1 */               \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,160\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,160\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "d" (&_argvec[0]) __FRAME_POINTER           \
@@ -4718,12 +4718,12 @@ typedef
       _argvec[1] = (unsigned long)arg1;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-160\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-160\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,160\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,160\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4742,13 +4742,13 @@ typedef
       _argvec[2] = (unsigned long)arg2;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-160\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-160\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,160\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,160\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4768,14 +4768,14 @@ typedef
       _argvec[3] = (unsigned long)arg3;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-160\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-160\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,160\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,160\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4796,15 +4796,15 @@ typedef
       _argvec[4] = (unsigned long)arg4;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-160\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-160\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,160\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,160\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4826,16 +4826,16 @@ typedef
       _argvec[5] = (unsigned long)arg5;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-160\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-160\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,160\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,160\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4859,17 +4859,17 @@ typedef
       _argvec[6] = (unsigned long)arg6;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-168\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-168\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,168\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,168\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4894,18 +4894,18 @@ typedef
       _argvec[7] = (unsigned long)arg7;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-176\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "mvc 168(8,15), 56(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-176\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "mvc  168(8,%%r15),56(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,176\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,176\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4931,19 +4931,19 @@ typedef
       _argvec[8] = (unsigned long)arg8;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-184\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "mvc 168(8,15), 56(1)\n\t"                              \
-         "mvc 176(8,15), 64(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-184\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "mvc  168(8,%%r15),56(%%r1)\n\t"                        \
+         "mvc  176(8,%%r15),64(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,184\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,184\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -4970,20 +4970,20 @@ typedef
       _argvec[9] = (unsigned long)arg9;                          \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-192\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "mvc 168(8,15), 56(1)\n\t"                              \
-         "mvc 176(8,15), 64(1)\n\t"                              \
-         "mvc 184(8,15), 72(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-192\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "mvc  168(8,%%r15),56(%%r1)\n\t"                        \
+         "mvc  176(8,%%r15),64(%%r1)\n\t"                        \
+         "mvc  184(8,%%r15),72(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,192\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,192\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -5011,21 +5011,21 @@ typedef
       _argvec[10] = (unsigned long)arg10;                        \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-200\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "mvc 168(8,15), 56(1)\n\t"                              \
-         "mvc 176(8,15), 64(1)\n\t"                              \
-         "mvc 184(8,15), 72(1)\n\t"                              \
-         "mvc 192(8,15), 80(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-200\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "mvc  168(8,%%r15),56(%%r1)\n\t"                        \
+         "mvc  176(8,%%r15),64(%%r1)\n\t"                        \
+         "mvc  184(8,%%r15),72(%%r1)\n\t"                        \
+         "mvc  192(8,%%r15),80(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,200\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,200\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -5054,22 +5054,22 @@ typedef
       _argvec[11] = (unsigned long)arg11;                        \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-208\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "mvc 168(8,15), 56(1)\n\t"                              \
-         "mvc 176(8,15), 64(1)\n\t"                              \
-         "mvc 184(8,15), 72(1)\n\t"                              \
-         "mvc 192(8,15), 80(1)\n\t"                              \
-         "mvc 200(8,15), 88(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-208\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "mvc  168(8,%%r15),56(%%r1)\n\t"                        \
+         "mvc  176(8,%%r15),64(%%r1)\n\t"                        \
+         "mvc  184(8,%%r15),72(%%r1)\n\t"                        \
+         "mvc  192(8,%%r15),80(%%r1)\n\t"                        \
+         "mvc  200(8,%%r15),88(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,208\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,208\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \
@@ -5099,23 +5099,23 @@ typedef
       _argvec[12] = (unsigned long)arg12;                        \
       __asm__ volatile(                                          \
          VALGRIND_CFI_PROLOGUE                                   \
-         "aghi 15,-216\n\t"                                      \
-         "lg 2, 8(1)\n\t"                                        \
-         "lg 3,16(1)\n\t"                                        \
-         "lg 4,24(1)\n\t"                                        \
-         "lg 5,32(1)\n\t"                                        \
-         "lg 6,40(1)\n\t"                                        \
-         "mvc 160(8,15), 48(1)\n\t"                              \
-         "mvc 168(8,15), 56(1)\n\t"                              \
-         "mvc 176(8,15), 64(1)\n\t"                              \
-         "mvc 184(8,15), 72(1)\n\t"                              \
-         "mvc 192(8,15), 80(1)\n\t"                              \
-         "mvc 200(8,15), 88(1)\n\t"                              \
-         "mvc 208(8,15), 96(1)\n\t"                              \
-         "lg 1, 0(1)\n\t"                                        \
+         "aghi %%r15,-216\n\t"                                   \
+         "lg   %%r2,8(%%r1)\n\t"                                 \
+         "lg   %%r3,16(%%r1)\n\t"                                \
+         "lg   %%r4,24(%%r1)\n\t"                                \
+         "lg   %%r5,32(%%r1)\n\t"                                \
+         "lg   %%r6,40(%%r1)\n\t"                                \
+         "mvc  160(8,%%r15),48(%%r1)\n\t"                        \
+         "mvc  168(8,%%r15),56(%%r1)\n\t"                        \
+         "mvc  176(8,%%r15),64(%%r1)\n\t"                        \
+         "mvc  184(8,%%r15),72(%%r1)\n\t"                        \
+         "mvc  192(8,%%r15),80(%%r1)\n\t"                        \
+         "mvc  200(8,%%r15),88(%%r1)\n\t"                        \
+         "mvc  208(8,%%r15),96(%%r1)\n\t"                        \
+         "lg   %%r1,0(%%r1)\n\t"                                 \
          VALGRIND_CALL_NOREDIR_R1                                \
-         "lgr %0, 2\n\t"                                         \
-         "aghi 15,216\n\t"                                       \
+         "lgr  %0,%%r2\n\t"                                      \
+         "aghi %%r15,216\n\t"                                    \
          VALGRIND_CFI_EPILOGUE                                   \
          : /*out*/   "=d" (_res)                                 \
          : /*in*/    "a" (&_argvec[0]) __FRAME_POINTER           \


### PR DESCRIPTION
!! This PR is a copy of mono/mono#20190,  please do not edit or review it in this repo !!<br/>Do not automatically approve this PR:<br/><br/>* Consider how the changes affect configurations in this repo,<br/>* Check effects on files that are not mirrored,<br/>* Identify test cases that may be needed in this repo.<br/><br/>!! Merge the PR only after the original PR is merged !!<br/><hr/><br/>This patch set will enable a clean build of mono for s390x using clang. The register specifications require the use of a prefix ('r' - general registers 'f' - floating point 'a' - access) rather than just a number. This has been fixed in the most recent level of clang. The current compilers (gcc and clang) are also better at optimizing string operations so the compiler option ```-D__USE_STRING_INLINES``` is also no longer required.