### PR TITLE
Fix duplicate icon correctly in Preview8

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -59,7 +59,7 @@
     <MicrosoftDotNetGenFacadesVersion>5.0.0-beta.20364.3</MicrosoftDotNetGenFacadesVersion>
     <MicrosoftDotNetXUnitExtensionsVersion>5.0.0-beta.20364.3</MicrosoftDotNetXUnitExtensionsVersion>
     <MicrosoftDotNetXUnitConsoleRunnerVersion>2.5.1-beta.20364.3</MicrosoftDotNetXUnitConsoleRunnerVersion>
-    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20364.3</MicrosoftDotNetBuildTasksPackagingVersion>
+    <MicrosoftDotNetBuildTasksPackagingVersion>5.0.0-beta.20374.3</MicrosoftDotNetBuildTasksPackagingVersion>
     <MicrosoftDotNetRemoteExecutorVersion>5.0.0-beta.20364.3</MicrosoftDotNetRemoteExecutorVersion>
     <MicrosoftDotNetVersionToolsTasksVersion>5.0.0-beta.20364.3</MicrosoftDotNetVersionToolsTasksVersion>
     <!-- Installer dependencies -->

--- a/eng/packaging.targets
+++ b/eng/packaging.targets
@@ -1,9 +1,4 @@
 <Project>
-  <ItemGroup>
-    <!-- workaround duplicate icon.  If PackageIconFile is set, don't include PackageIconFullPath in package
-         can be removed when we have an arcade build with https://github.com/dotnet/arcade/pull/5818 -->
-    <None Condition="'$(PackageIconFile)' != ''" Update="$(PackageIconFullPath)" Pack="false" />
-  </ItemGroup>
   <!--     There are some packages where we require only one ref for a specific framework to be present. In order to avoid problems with this package when targetting 
            dektop with RAR we will make sure there are no exclude=compile references in the package.
     For more info, please check issues:

--- a/src/coreclr/src/.nuget/Directory.Build.props
+++ b/src/coreclr/src/.nuget/Directory.Build.props
@@ -3,6 +3,9 @@
 
   <!-- Packaging projects (.pkgproj) are non-SDK-style, so they need to directly import Directory.Build.props -->
   <Import Project="../Directory.Build.props" />
+  
+  <Import Project="$(NuGetPackageRoot)\microsoft.dotnet.build.tasks.packaging\$(MicrosoftDotNetBuildTasksPackagingVersion)\build\Microsoft.DotNet.Build.Tasks.Packaging.props" />
+
   <Import Project="packaging.props" />
 
   <PropertyGroup>

--- a/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
+++ b/src/installer/pkg/projects/netcoreapp/pkg/Microsoft.NETCore.App.Crossgen2.pkgproj
@@ -38,7 +38,7 @@
           DependsOnTargets="ConvertItems"
           BeforeTargets="GetPackageFiles">
     <ItemGroup>
-      <RuntimeFile Include="@(File->HasMetadata('TargetPath'))" />
+      <RuntimeFile Include="@(File->HasMetadata('TargetPath'))" Exclude="$(PackageIconFullPath)" />
       <File Remove="@(RuntimeFile)" />
     </ItemGroup>
 


### PR DESCRIPTION
I had previously made a workaround to fix the duplicate icon issue in preview8.  This workaround fixed the issue for libraries, but not coreclr or installer.  I was making the workaround to avoid having to flow arcade into preview8.

This turned out to be problematic since the bug surfaced elsewhere in preview8, so its safer to just fix the right way in preview 8 by updating the packaging tool with the right fix.

This undoes my workaround and cherry-picks the fixes from master.