### PR TITLE
Unregister callback when setting a provider for deferred delete

### DIFF
--- a/src/coreclr/src/vm/eventpipeprovider.cpp
+++ b/src/coreclr/src/vm/eventpipeprovider.cpp
@@ -306,6 +306,9 @@ void EventPipeProvider::SetDeleteDeferred()
 {
     LIMITED_METHOD_CONTRACT;
     m_deleteDeferred = true;
+    // EventSources will be collected once they ungregister themselves,
+    // so we can't call back in to them.
+    m_pCallbackFunction = NULL;
 }
 
 void EventPipeProvider::RefreshAllEvents()


### PR DESCRIPTION
If an EventSource gets garbage collected before the session dies it will be put in a deferred delete state, and then when the session dies it will attempt to call back in to the EventSource to update it about the session dying. If the reverse PInvoke has been collected it will cause an AV and a runtime crash. See more thorough investigation at #36028. We already to the right thing and ignore the callback if it's null during session deletion.

Fixes #36028

The only test I have that has a reliable repro rate relies on GCStress being set, so I don't have a test for this to check in, but I have tested it manually that it solves the issue.