### PR TITLE
Re-enabled signing validation

### DIFF
--- a/eng/pipelines/official/stages/publish.yml
+++ b/eng/pipelines/official/stages/publish.yml
@@ -27,8 +27,7 @@ stages:
     - PrepareForPublish
     # The following checks are run after the build in the validation and release pipelines
     # And thus are not enabled here. They can be enabled for dev builds for spot testing if desired
-    enableSymbolValidation: false
-    enableSigningValidation: false
+    enableSymbolValidation: false    
     enableNugetValidation: false
     enableSourceLinkValidation: false
     SDLValidationParameters:


### PR DESCRIPTION
https://github.com/dotnet/core-eng/issues/9933
re-enabled signing validation after the fix in arcade https://github.com/dotnet/arcade/pull/5840

@mmitche you previously disabled it and there were more changes in validation, please could you check it?
