### PR TITLE
[wasm] Enable stack tests that now work on browser-wasm

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameExtensionsTests.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackFrameExtensionsTests
     {
         public static IEnumerable<object[]> StackFrame_TestData()

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackFrameTests.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 namespace System.Diagnostics.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackFrameTests
     {
         [Fact]

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceSymbolsTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Diagnostics.SymbolStore.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/39650", TestPlatforms.Browser)]
     public class StackTraceSymbolsTests
     {
         [Fact]

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -29,7 +29,6 @@ namespace System.Diagnostics
 
 namespace System.Diagnostics.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
     public class StackTraceTests
     {
         [Fact]

--- a/src/libraries/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/TraceEventCacheClassTests.cs
@@ -48,7 +48,6 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         public void CallstackTest_NotEmpty()
         {
             var cache = new TraceEventCache();
@@ -56,7 +55,6 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         public void CallstackTest_ContainsExpectedFrames()
         {
             var cache = new TraceEventCache();

--- a/src/libraries/System.Diagnostics.TraceSource/tests/TraceListenerClassTests.cs
+++ b/src/libraries/System.Diagnostics.TraceSource/tests/TraceListenerClassTests.cs
@@ -313,7 +313,6 @@ namespace System.Diagnostics.TraceSourceTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void WriteFooterTest_Callstack()
         {

--- a/src/libraries/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
+++ b/src/libraries/System.Runtime.Extensions/tests/System/Environment.StackTrace.cs
@@ -68,7 +68,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39223", TestPlatforms.Browser)]
         public void StackTraceDoesNotStartWithInternalFrame()
         {
              string stackTrace = Environment.StackTrace;


### PR DESCRIPTION
reenables the tests tracked in https://github.com/dotnet/runtime/issues/39223