### PR TITLE
Improve codegen for `Marshal.ThrowExceptionForHr`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Security;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -611,6 +612,7 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        [StackTraceHidden]
         private static void InternalThrowExceptionForHr(int errorCode, IntPtr errorInfo)
         {
             throw GetExceptionForHR(errorCode, errorInfo)!;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -599,7 +599,7 @@ namespace System.Runtime.InteropServices
         {
             if (errorCode < 0)
             {
-                throw GetExceptionForHR(errorCode, IntPtr.Zero)!;
+                InternalThrowExceptionForHr(errorCode, IntPtr.Zero);
             }
         }
 
@@ -607,8 +607,13 @@ namespace System.Runtime.InteropServices
         {
             if (errorCode < 0)
             {
-                throw GetExceptionForHR(errorCode, errorInfo)!;
+                InternalThrowExceptionForHr(errorCode, errorInfo);
             }
+        }
+
+        private static void InternalThrowExceptionForHr(int errorCode, IntPtr errorInfo)
+        {
+            throw GetExceptionForHR(errorCode, errorInfo)!;
         }
 
         public static IntPtr SecureStringToBSTR(SecureString s)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -600,7 +600,7 @@ namespace System.Runtime.InteropServices
         {
             if (errorCode < 0)
             {
-                InternalThrowExceptionForHr(errorCode, IntPtr.Zero);
+                throw GetExceptionForHR(errorCode)!;
             }
         }
 
@@ -608,14 +608,8 @@ namespace System.Runtime.InteropServices
         {
             if (errorCode < 0)
             {
-                InternalThrowExceptionForHr(errorCode, errorInfo);
+                throw GetExceptionForHR(errorCode, errorInfo)!;
             }
-        }
-
-        [StackTraceHidden]
-        private static void InternalThrowExceptionForHr(int errorCode, IntPtr errorInfo)
-        {
-            throw GetExceptionForHR(errorCode, errorInfo)!;
         }
 
         public static IntPtr SecureStringToBSTR(SecureString s)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Security;
 using System.Reflection;
 using System.Runtime.CompilerServices;


### PR DESCRIPTION
Moves the actual `throw` path to a separate method to improve inlining candidacy of the validation methods and only hit the slow non-inlined pathway when the error code is a fail.

Example code that wasn't being inlined:

```cs
internal ComPtr<ID3D12Resource> CreateCommittedResource(InternalAllocDesc* desc)
{
    ....

    using ComPtr<ID3D12Resource> resource = default;

    // this wasn't being inlined :(
    Marshal.ThrowExceptionForHr(DevicePointer->CreateCommittedResource(
            &heapProperties,
            D3D12_HEAP_FLAGS.D3D12_HEAP_FLAG_NONE,
            &desc->Desc,
            desc->InitialState,
            desc->ClearValue is null ? null : &clearVal,
            resource.Iid,
            (void**)&resource
    ));

    return resource.Move();
}
```