### PR TITLE
Adding sequential read as the file option in ReadAllBytes

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/File.cs
@@ -328,7 +328,7 @@ namespace System.IO
         public static byte[] ReadAllBytes(string path)
         {
             // bufferSize == 1 used to avoid unnecessary buffer in FileStream
-            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1))
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 1, FileOptions.SequentialScan))
             {
                 long fileLength = fs.Length;
                 if (fileLength > int.MaxValue)


### PR DESCRIPTION
Fixing #40001, adding Sequential Read file option for ReadAllBytes in File.cs.