### PR TITLE
Make dotnet-Microsoft.XmlSerializer.Generator run on latest framework

### DIFF
--- a/src/libraries/Microsoft.XmlSerializer.Generator/pkg/build/dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/pkg/build/dotnet-Microsoft.XmlSerializer.Generator.runtimeconfig.json
@@ -5,6 +5,6 @@
       "name": "Microsoft.NETCore.App",
       "version": "2.0.0"
     },
-    "rollForward": "Major"
+    "rollForward": "LatestMajor"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/39227
Fixes https://github.com/dotnet/runtime/issues/1390