### PR TITLE
fix regression in ChannelBinding/NTLM auth

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -446,28 +446,50 @@ namespace System.Net.Security
                     if (inSecBuffers.Count > 2)
                     {
                         inUnmanagedBuffer[2].BufferType = inSecBuffers._item2.Type;
-                        inUnmanagedBuffer[2].cbBuffer = inSecBuffers._item2.Token.Length;
-                        inUnmanagedBuffer[2].pvBuffer = inSecBuffers._item2.UnmanagedToken != null ?
-                            (IntPtr)inSecBuffers._item2.UnmanagedToken.DangerousGetHandle() :
-                            (IntPtr)pinnedToken2;
+                        if (inSecBuffers._item2.UnmanagedToken != null)
+                        {
+                            Debug.Assert(inSecBuffers._item2.Type == SecurityBufferType.SECBUFFER_CHANNEL_BINDINGS);
+                            inUnmanagedBuffer[2].pvBuffer = (IntPtr)inSecBuffers._item2.UnmanagedToken.DangerousGetHandle();
+                            inUnmanagedBuffer[2].cbBuffer = ((ChannelBinding)inSecBuffers._item2.UnmanagedToken).Size;
+                        }
+                        else
+                        {
+                            inUnmanagedBuffer[2].cbBuffer = inSecBuffers._item2.Token.Length;
+                            inUnmanagedBuffer[2].pvBuffer = (IntPtr)pinnedToken2;
+                        }
+
                     }
 
                     if (inSecBuffers.Count > 1)
                     {
                         inUnmanagedBuffer[1].BufferType = inSecBuffers._item1.Type;
-                        inUnmanagedBuffer[1].cbBuffer = inSecBuffers._item1.Token.Length;
-                        inUnmanagedBuffer[1].pvBuffer = inSecBuffers._item1.UnmanagedToken != null ?
-                            (IntPtr)inSecBuffers._item1.UnmanagedToken.DangerousGetHandle() :
-                            (IntPtr)pinnedToken1;
+                        if (inSecBuffers._item1.UnmanagedToken != null)
+                        {
+                            Debug.Assert(inSecBuffers._item1.Type == SecurityBufferType.SECBUFFER_CHANNEL_BINDINGS);
+                            inUnmanagedBuffer[1].pvBuffer = (IntPtr)inSecBuffers._item1.UnmanagedToken.DangerousGetHandle();
+                            inUnmanagedBuffer[1].cbBuffer = ((ChannelBinding)inSecBuffers._item1.UnmanagedToken).Size;
+                        }
+                        else
+                        {
+                            inUnmanagedBuffer[1].cbBuffer = inSecBuffers._item1.Token.Length;
+                            inUnmanagedBuffer[1].pvBuffer = (IntPtr)pinnedToken1;
+                        }
                     }
 
                     if (inSecBuffers.Count > 0)
                     {
                         inUnmanagedBuffer[0].BufferType = inSecBuffers._item0.Type;
-                        inUnmanagedBuffer[0].cbBuffer = inSecBuffers._item0.Token.Length;
-                        inUnmanagedBuffer[0].pvBuffer = inSecBuffers._item0.UnmanagedToken != null ?
-                            (IntPtr)inSecBuffers._item0.UnmanagedToken.DangerousGetHandle() :
-                            (IntPtr)pinnedToken0;
+                        if (inSecBuffers._item0.UnmanagedToken != null)
+                        {
+                            Debug.Assert(inSecBuffers._item0.Type == SecurityBufferType.SECBUFFER_CHANNEL_BINDINGS);
+                            inUnmanagedBuffer[0].pvBuffer = (IntPtr)inSecBuffers._item0.UnmanagedToken.DangerousGetHandle();
+                            inUnmanagedBuffer[0].cbBuffer = ((ChannelBinding)inSecBuffers._item0.UnmanagedToken).Size;
+                        }
+                        else
+                        {
+                            inUnmanagedBuffer[0].cbBuffer = inSecBuffers._item0.Token.Length;
+                            inUnmanagedBuffer[0].pvBuffer = (IntPtr)pinnedToken0;
+                        }
                     }
 
                     fixed (byte* pinnedOutBytes = outSecBuffer.token)
@@ -687,28 +709,50 @@ namespace System.Net.Security
                     if (inSecBuffers.Count > 2)
                     {
                         inUnmanagedBuffer[2].BufferType = inSecBuffers._item2.Type;
-                        inUnmanagedBuffer[2].cbBuffer = inSecBuffers._item2.Token.Length;
-                        inUnmanagedBuffer[2].pvBuffer = inSecBuffers._item2.UnmanagedToken != null ?
-                            (IntPtr)inSecBuffers._item2.UnmanagedToken.DangerousGetHandle() :
-                            (IntPtr)pinnedToken2;
+                        if (inSecBuffers._item2.UnmanagedToken != null)
+                        {
+                            Debug.Assert(inSecBuffers._item2.Type == SecurityBufferType.SECBUFFER_CHANNEL_BINDINGS);
+                            inUnmanagedBuffer[2].pvBuffer = (IntPtr)inSecBuffers._item2.UnmanagedToken.DangerousGetHandle();
+                            inUnmanagedBuffer[2].cbBuffer = ((ChannelBinding)inSecBuffers._item2.UnmanagedToken).Size;
+                        }
+                        else
+                        {
+                            inUnmanagedBuffer[2].cbBuffer = inSecBuffers._item2.Token.Length;
+                            inUnmanagedBuffer[2].pvBuffer = (IntPtr)pinnedToken2;
+                        }
+
                     }
 
                     if (inSecBuffers.Count > 1)
                     {
                         inUnmanagedBuffer[1].BufferType = inSecBuffers._item1.Type;
-                        inUnmanagedBuffer[1].cbBuffer = inSecBuffers._item1.Token.Length;
-                        inUnmanagedBuffer[1].pvBuffer = inSecBuffers._item1.UnmanagedToken != null ?
-                            (IntPtr)inSecBuffers._item1.UnmanagedToken.DangerousGetHandle() :
-                            (IntPtr)pinnedToken1;
+                        if (inSecBuffers._item1.UnmanagedToken != null)
+                        {
+                            Debug.Assert(inSecBuffers._item1.Type == SecurityBufferType.SECBUFFER_CHANNEL_BINDINGS);
+                            inUnmanagedBuffer[1].pvBuffer = (IntPtr)inSecBuffers._item1.UnmanagedToken.DangerousGetHandle();
+                            inUnmanagedBuffer[1].cbBuffer = ((ChannelBinding)inSecBuffers._item1.UnmanagedToken).Size;
+                        }
+                        else
+                        {
+                            inUnmanagedBuffer[1].cbBuffer = inSecBuffers._item0.Token.Length;
+                            inUnmanagedBuffer[1].pvBuffer = (IntPtr)pinnedToken0;
+                        }
                     }
 
                     if (inSecBuffers.Count > 0)
                     {
                         inUnmanagedBuffer[0].BufferType = inSecBuffers._item0.Type;
-                        inUnmanagedBuffer[0].cbBuffer = inSecBuffers._item0.Token.Length;
-                        inUnmanagedBuffer[0].pvBuffer = inSecBuffers._item0.UnmanagedToken != null ?
-                            (IntPtr)inSecBuffers._item0.UnmanagedToken.DangerousGetHandle() :
-                            (IntPtr)pinnedToken0;
+                        if (inSecBuffers._item0.UnmanagedToken != null)
+                        {
+                            Debug.Assert(inSecBuffers._item0.Type == SecurityBufferType.SECBUFFER_CHANNEL_BINDINGS);
+                            inUnmanagedBuffer[0].pvBuffer = (IntPtr)inSecBuffers._item0.UnmanagedToken.DangerousGetHandle();
+                            inUnmanagedBuffer[0].cbBuffer = ((ChannelBinding)inSecBuffers._item0.UnmanagedToken).Size;
+                        }
+                        else
+                        {
+                            inUnmanagedBuffer[0].cbBuffer = inSecBuffers._item0.Token.Length;
+                            inUnmanagedBuffer[0].pvBuffer = (IntPtr)pinnedToken0;
+                        }
                     }
 
                     fixed (byte* pinnedOutBytes = outSecBuffer.token)

--- a/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
+++ b/src/libraries/Common/src/Interop/Windows/SspiCli/SecuritySafeHandles.cs
@@ -734,8 +734,8 @@ namespace System.Net.Security
                         }
                         else
                         {
-                            inUnmanagedBuffer[1].cbBuffer = inSecBuffers._item0.Token.Length;
-                            inUnmanagedBuffer[1].pvBuffer = (IntPtr)pinnedToken0;
+                            inUnmanagedBuffer[1].cbBuffer = inSecBuffers._item1.Token.Length;
+                            inUnmanagedBuffer[1].pvBuffer = (IntPtr)pinnedToken1;
                         }
                     }
 


### PR DESCRIPTION
This regression caused by #32008. The old security buffer had dedicated size property. With the PR, we switched to using Span and Span.Length. However that is not correct for TokenBinding. For that the span is empty e.g. `cbBuffer` becomes 0 and OS will reject ChannelBinding buffer. 
Alternatively we can convert the UnmanagedToken to Span as well. But since currently doing not have any good test infrastructure for this, I would prefer to limit the changes.

This effectively solves #39011 but I will leave it open until we have tests to prevent regression like this. 

contributes to #39011.