### PR TITLE
Don't remove dead indirections that may throw.

### DIFF
--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6450,41 +6450,7 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
 
         if (ind->OperIs(GT_NULLCHECK) || ind->IsUnusedValue())
         {
-            // A nullcheck is essentially the same as an indirection with no use.
-            // The difference lies in whether a target register must be allocated.
-            // On XARCH we can generate a compare with no target register as long as the addresss
-            // is not contained.
-            // On ARM64 we can generate a load to REG_ZR in all cases.
-            // However, on ARM we must always generate a load to a register.
-            // In the case where we require a target register, it is better to use GT_IND, since
-            // GT_NULLCHECK is a non-value node and would therefore require an internal register
-            // to use as the target. That is non-optimal because it will be modeled as conflicting
-            // with the source register(s).
-            // So, to summarize:
-            // - On ARM64, always use GT_NULLCHECK for a dead indirection.
-            // - On ARM, always use GT_IND.
-            // - On XARCH, use GT_IND if we have a contained address, and GT_NULLCHECK otherwise.
-            // In all cases, change the type to TYP_INT.
-            //
-            ind->gtType = TYP_INT;
-#ifdef TARGET_ARM64
-            bool useNullCheck = true;
-#elif TARGET_ARM
-            bool useNullCheck = false;
-#else  // TARGET_XARCH
-            bool useNullCheck = !ind->Addr()->isContained();
-#endif // !TARGET_XARCH
-
-            if (useNullCheck && ind->OperIs(GT_IND))
-            {
-                ind->ChangeOper(GT_NULLCHECK);
-                ind->ClearUnusedValue();
-            }
-            else if (!useNullCheck && ind->OperIs(GT_NULLCHECK))
-            {
-                ind->ChangeOper(GT_IND);
-                ind->SetUnusedValue();
-            }
+            TransformUnusedIndirection(ind, comp, m_block);
         }
     }
     else
@@ -6493,6 +6459,55 @@ void Lowering::LowerIndir(GenTreeIndir* ind)
         // is a complex one it could benefit from an `LEA` that is not contained.
         const bool isContainable = false;
         TryCreateAddrMode(ind->Addr(), isContainable);
+    }
+}
+
+//------------------------------------------------------------------------
+// TransformUnusedIndirection: change the opcode and the type of the unused indirection.
+//
+// Arguments:
+//    ind   - Indirection to transform.
+//    comp  - Compiler instance.
+//    block - Basic block of the indirection.
+//
+void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, BasicBlock* block)
+{
+    // A nullcheck is essentially the same as an indirection with no use.
+    // The difference lies in whether a target register must be allocated.
+    // On XARCH we can generate a compare with no target register as long as the addresss
+    // is not contained.
+    // On ARM64 we can generate a load to REG_ZR in all cases.
+    // However, on ARM we must always generate a load to a register.
+    // In the case where we require a target register, it is better to use GT_IND, since
+    // GT_NULLCHECK is a non-value node and would therefore require an internal register
+    // to use as the target. That is non-optimal because it will be modeled as conflicting
+    // with the source register(s).
+    // So, to summarize:
+    // - On ARM64, always use GT_NULLCHECK for a dead indirection.
+    // - On ARM, always use GT_IND.
+    // - On XARCH, use GT_IND if we have a contained address, and GT_NULLCHECK otherwise.
+    // In all cases, change the type to TYP_INT.
+    //
+    assert(ind->OperIs(GT_NULLCHECK, GT_IND));
+
+    ind->gtType = TYP_INT;
+#ifdef TARGET_ARM64
+    bool useNullCheck = true;
+#elif TARGET_ARM
+    bool useNullCheck = false;
+#else  // TARGET_XARCH
+    bool useNullCheck = !ind->Addr()->isContained();
+#endif // !TARGET_XARCH
+
+    if (useNullCheck && ind->OperIs(GT_IND))
+    {
+        comp->gtChangeOperToNullCheck(ind, block);
+        ind->ClearUnusedValue();
+    }
+    else if (!useNullCheck && ind->OperIs(GT_NULLCHECK))
+    {
+        ind->ChangeOper(GT_IND);
+        ind->SetUnusedValue();
     }
 }
 

--- a/src/coreclr/src/jit/lower.h
+++ b/src/coreclr/src/jit/lower.h
@@ -8,6 +8,7 @@ XX                               Lower                                       XX
 XX                                                                           XX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 */
 
 #ifndef _LOWER_H_
@@ -531,6 +532,8 @@ public:
     // Return true if 'node' is a containable HWIntrinsic op.
     bool IsContainableHWIntrinsicOp(GenTreeHWIntrinsic* containingNode, GenTree* node, bool* supportsRegOptional);
 #endif // FEATURE_HW_INTRINSICS
+
+    static void TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, BasicBlock* block);
 
 private:
     static bool NodesAreEquivalentLeaves(GenTree* candidate, GenTree* storeInd);

--- a/src/tests/JIT/Regression/JitBlue/GitHub_39823/GitHub_39823.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_39823/GitHub_39823.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Diagnostics;
+
+class Runtime_39823
+{
+    struct IntsWrapped
+    {
+        public int i1;
+        public int i2;
+        public int i3;
+        public int i4;
+    };
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static unsafe int TestUnusedObjCopy(IntsWrapped* ps)
+    {
+        IntsWrapped s = *ps;
+        return 100;
+    }
+
+
+    public static unsafe int Main()
+    {
+        try
+        {
+            TestUnusedObjCopy((IntsWrapped*)0);
+            Debug.Assert(false, "unreachable");
+        }
+        catch
+        {
+            return 100;
+        }
+        return -1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/GitHub_39823/GitHub_39823.csproj
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_39823/GitHub_39823.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Liveness incorrectly removed indirection rhs's of dead assignments.
This change fixes that.

Fixes #39823.