### PR TITLE
Annotate DependencyInjection to make it linker friendly

### DIFF
--- a/eng/testing/linker/project.csproj.template
+++ b/eng/testing/linker/project.csproj.template
@@ -9,6 +9,10 @@
     <_ExtraTrimmerArgs>{ExtraTrimmerArgs} $(_ExtraTrimmerArgs)</_ExtraTrimmerArgs>
   </PropertyGroup>
 
+  <ItemGroup>
+    {AdditionalProjectReferences}
+  </ItemGroup>
+
   <!-- Logic to override the default IlLink tasks that come from the SDK and use the one
   we use in dotnet/runtime repo -->
 

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -57,7 +57,7 @@
       <_projectSourceFile>%(TestConsoleApps.ProjectCompileItems)</_projectSourceFile>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="'$(AdditionalProjectReferences)' != ''">
       <_additionalProjectReferenceTemp Include="$(AdditionalProjectReferences)" />
       <_additionalProjectReference Include="&lt;ProjectReference Include=&quot;$(LibrariesProjectRoot)%(_additionalProjectReferenceTemp.Identity)\src\%(_additionalProjectReferenceTemp.Identity).csproj&quot; SkipUseReferenceAssembly=&quot;true&quot; /&gt;" />
     </ItemGroup>

--- a/eng/testing/linker/trimmingTests.targets
+++ b/eng/testing/linker/trimmingTests.targets
@@ -58,6 +58,15 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <_additionalProjectReferenceTemp Include="$(AdditionalProjectReferences)" />
+      <_additionalProjectReference Include="&lt;ProjectReference Include=&quot;$(LibrariesProjectRoot)%(_additionalProjectReferenceTemp.Identity)\src\%(_additionalProjectReferenceTemp.Identity).csproj&quot; SkipUseReferenceAssembly=&quot;true&quot; /&gt;" />
+    </ItemGroup>
+    
+    <PropertyGroup>
+      <_additionalProjectReferencesString>@(_additionalProjectReference, '%0a')</_additionalProjectReferencesString>
+    </PropertyGroup>
+
+    <ItemGroup>
       <_additionalProjectSourceFiles Include="%(TestConsoleApps.AdditionalSourceFiles)" />
     </ItemGroup>
 
@@ -69,7 +78,8 @@
                                                  .Replace('{TargetingPackDir}','$(MicrosoftNetCoreAppRefPackDir)')
                                                  .Replace('{RuntimeIdentifier}','%(TestConsoleApps.TestRuntimeIdentifier)')
                                                  .Replace('{MicrosoftNETILLinkTasksVersion}', '$(MicrosoftNETILLinkTasksVersion)')
-                                                 .Replace('{ExtraTrimmerArgs}', '%(TestConsoleApps.ExtraTrimmerArgs)'))"
+                                                 .Replace('{ExtraTrimmerArgs}', '%(TestConsoleApps.ExtraTrimmerArgs)')
+                                                 .Replace('{AdditionalProjectReferences}', '$(_additionalProjectReferencesString)'))"
                       Overwrite="true" />
     <Copy SourceFiles="$(_projectSourceFile)"
           DestinationFolder="$(_projectDir)" />

--- a/src/libraries/Common/src/Extensions/ActivatorUtilities/ActivatorUtilities.cs
+++ b/src/libraries/Common/src/Extensions/ActivatorUtilities/ActivatorUtilities.cs
@@ -40,7 +40,10 @@ namespace Microsoft.Extensions.Internal
         /// <param name="instanceType">The type to activate</param>
         /// <param name="parameters">Constructor arguments not provided by the <paramref name="provider"/>.</param>
         /// <returns>An activated object of type instanceType</returns>
-        public static object CreateInstance(IServiceProvider provider, Type instanceType, params object[] parameters)
+        public static object CreateInstance(
+            IServiceProvider provider,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type instanceType,
+            params object[] parameters)
         {
             int bestLength = -1;
             bool seenPreferred = false;
@@ -49,11 +52,9 @@ namespace Microsoft.Extensions.Internal
 
             if (!instanceType.GetTypeInfo().IsAbstract)
             {
-                foreach (ConstructorInfo? constructor in instanceType
-                    .GetTypeInfo()
-                    .DeclaredConstructors)
+                foreach (ConstructorInfo? constructor in instanceType.GetConstructors())
                 {
-                    if (!constructor.IsStatic && constructor.IsPublic)
+                    if (!constructor.IsStatic)
                     {
                         var matcher = new ConstructorMatcher(constructor);
                         bool isPreferred = constructor.IsDefined(typeof(ActivatorUtilitiesConstructorAttribute), false);
@@ -104,7 +105,9 @@ namespace Microsoft.Extensions.Internal
         /// A factory that will instantiate instanceType using an <see cref="IServiceProvider"/>
         /// and an argument array containing objects matching the types defined in argumentTypes
         /// </returns>
-        public static ObjectFactory CreateFactory(Type instanceType, Type[] argumentTypes)
+        public static ObjectFactory CreateFactory(
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type instanceType,
+            Type[] argumentTypes)
         {
             FindApplicableConstructor(instanceType, argumentTypes, out ConstructorInfo? constructor, out int?[]? parameterMap);
 
@@ -126,11 +129,10 @@ namespace Microsoft.Extensions.Internal
         /// <param name="provider">The service provider used to resolve dependencies</param>
         /// <param name="parameters">Constructor arguments not provided by the <paramref name="provider"/>.</param>
         /// <returns>An activated object of type T</returns>
-        public static T CreateInstance<T>(IServiceProvider provider, params object[] parameters)
+        public static T CreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IServiceProvider provider, params object[] parameters)
         {
             return (T)CreateInstance(provider, typeof(T), parameters);
         }
-
 
         /// <summary>
         /// Retrieve an instance of the given type from the service provider. If one is not found then instantiate it directly.
@@ -138,7 +140,7 @@ namespace Microsoft.Extensions.Internal
         /// <typeparam name="T">The type of the service</typeparam>
         /// <param name="provider">The service provider used to resolve dependencies</param>
         /// <returns>The resolved service or created instance</returns>
-        public static T GetServiceOrCreateInstance<T>(IServiceProvider provider)
+        public static T GetServiceOrCreateInstance<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(IServiceProvider provider)
         {
             return (T)GetServiceOrCreateInstance(provider, typeof(T));
         }
@@ -149,7 +151,9 @@ namespace Microsoft.Extensions.Internal
         /// <param name="provider">The service provider</param>
         /// <param name="type">The type of the service</param>
         /// <returns>The resolved service or created instance</returns>
-        public static object GetServiceOrCreateInstance(IServiceProvider provider, Type type)
+        public static object GetServiceOrCreateInstance(
+            IServiceProvider provider,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type type)
         {
             return provider.GetService(type) ?? CreateInstance(provider, type);
         }
@@ -214,7 +218,7 @@ namespace Microsoft.Extensions.Internal
         }
 
         private static void FindApplicableConstructor(
-            Type instanceType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type instanceType,
             Type[] argumentTypes,
             out ConstructorInfo matchingConstructor,
             out int?[] matchingParameterMap)
@@ -235,14 +239,14 @@ namespace Microsoft.Extensions.Internal
 
         // Tries to find constructor based on provided argument types
         private static bool TryFindMatchingConstructor(
-            Type instanceType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type instanceType,
             Type[] argumentTypes,
             [NotNullWhen(true)] ref ConstructorInfo? matchingConstructor,
             [NotNullWhen(true)] ref int?[]? parameterMap)
         {
-            foreach (ConstructorInfo? constructor in instanceType.GetTypeInfo().DeclaredConstructors)
+            foreach (ConstructorInfo? constructor in instanceType.GetConstructors())
             {
-                if (constructor.IsStatic || !constructor.IsPublic)
+                if (constructor.IsStatic)
                 {
                     continue;
                 }
@@ -270,15 +274,15 @@ namespace Microsoft.Extensions.Internal
 
         // Tries to find constructor marked with ActivatorUtilitiesConstructorAttribute
         private static bool TryFindPreferredConstructor(
-            Type instanceType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type instanceType,
             Type[] argumentTypes,
             [NotNullWhen(true)] ref ConstructorInfo? matchingConstructor,
             [NotNullWhen(true)] ref int?[]? parameterMap)
         {
             bool seenPreferred = false;
-            foreach (ConstructorInfo? constructor in instanceType.GetTypeInfo().DeclaredConstructors)
+            foreach (ConstructorInfo? constructor in instanceType.GetConstructors())
             {
-                if (constructor.IsStatic || !constructor.IsPublic)
+                if (constructor.IsStatic)
                 {
                     continue;
                 }

--- a/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
+++ b/src/libraries/Common/src/Extensions/ParameterDefaultValue/ParameterDefaultValue.cs
@@ -4,6 +4,7 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Microsoft.Extensions.Internal
@@ -41,8 +42,12 @@ namespace Microsoft.Extensions.Internal
                 // Workaround for https://github.com/dotnet/corefx/issues/11797
                 if (defaultValue == null && parameter.ParameterType.IsValueType)
                 {
-                    defaultValue = Activator.CreateInstance(parameter.ParameterType);
+                    defaultValue = CreateValueType(parameter.ParameterType);
                 }
+
+                [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2006:UnrecognizedReflectionPattern",
+                    Justification = "CreateInstance is only called on a ValueType, which will always have a default constructor.")]
+                object? CreateValueType(Type t) => Activator.CreateInstance(t);
 
                 // Handle nullable enums
                 if (defaultValue != null &&

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Extensions/ServiceCollectionDescriptorExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection.Extensions
@@ -124,7 +125,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// <param name="service">The type of the service to register.</param>
         public static void TryAddTransient(
             this IServiceCollection collection,
-            Type service)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type service)
         {
             if (collection == null)
             {
@@ -151,7 +152,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         public static void TryAddTransient(
             this IServiceCollection collection,
             Type service,
-            Type implementationType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (collection == null)
             {
@@ -210,7 +211,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// </summary>
         /// <typeparam name="TService">The type of the service to add.</typeparam>
         /// <param name="collection">The <see cref="IServiceCollection"/>.</param>
-        public static void TryAddTransient<TService>(this IServiceCollection collection)
+        public static void TryAddTransient<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection collection)
             where TService : class
         {
             if (collection == null)
@@ -229,7 +230,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// <typeparam name="TService">The type of the service to add.</typeparam>
         /// <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
         /// <param name="collection">The <see cref="IServiceCollection"/>.</param>
-        public static void TryAddTransient<TService, TImplementation>(this IServiceCollection collection)
+        public static void TryAddTransient<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection collection)
             where TService : class
             where TImplementation : class, TService
         {
@@ -265,7 +266,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// <param name="service">The type of the service to register.</param>
         public static void TryAddScoped(
             this IServiceCollection collection,
-            Type service)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type service)
         {
             if (collection == null)
             {
@@ -292,7 +293,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         public static void TryAddScoped(
             this IServiceCollection collection,
             Type service,
-            Type implementationType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (collection == null)
             {
@@ -351,7 +352,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// </summary>
         /// <typeparam name="TService">The type of the service to add.</typeparam>
         /// <param name="collection">The <see cref="IServiceCollection"/>.</param>
-        public static void TryAddScoped<TService>(this IServiceCollection collection)
+        public static void TryAddScoped<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection collection)
             where TService : class
         {
             if (collection == null)
@@ -370,7 +371,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// <typeparam name="TService">The type of the service to add.</typeparam>
         /// <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
         /// <param name="collection">The <see cref="IServiceCollection"/>.</param>
-        public static void TryAddScoped<TService, TImplementation>(this IServiceCollection collection)
+        public static void TryAddScoped<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection collection)
             where TService : class
             where TImplementation : class, TService
         {
@@ -406,7 +407,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// <param name="service">The type of the service to register.</param>
         public static void TryAddSingleton(
             this IServiceCollection collection,
-            Type service)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type service)
         {
             if (collection == null)
             {
@@ -433,7 +434,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         public static void TryAddSingleton(
             this IServiceCollection collection,
             Type service,
-            Type implementationType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (collection == null)
             {
@@ -492,7 +493,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// </summary>
         /// <typeparam name="TService">The type of the service to add.</typeparam>
         /// <param name="collection">The <see cref="IServiceCollection"/>.</param>
-        public static void TryAddSingleton<TService>(this IServiceCollection collection)
+        public static void TryAddSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection collection)
             where TService : class
         {
             if (collection == null)
@@ -511,7 +512,7 @@ namespace Microsoft.Extensions.DependencyInjection.Extensions
         /// <typeparam name="TService">The type of the service to add.</typeparam>
         /// <typeparam name="TImplementation">The type of the implementation to use.</typeparam>
         /// <param name="collection">The <see cref="IServiceCollection"/>.</param>
-        public static void TryAddSingleton<TService, TImplementation>(this IServiceCollection collection)
+        public static void TryAddSingleton<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection collection)
             where TService : class
             where TImplementation : class, TService
         {

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/Microsoft.Extensions.DependencyInjection.Abstractions.csproj
@@ -16,6 +16,9 @@
              Link="Common\src\Extensions\ActivatorUtilities\ActivatorUtilitiesConstructorAttribute.cs" />
     <Compile Include="$(CommonPath)Extensions\ActivatorUtilities\ObjectFactory.cs"
              Link="Common\src\Extensions\ActivatorUtilities\ObjectFactory.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceCollectionServiceExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -23,7 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddTransient(
             this IServiceCollection services,
             Type serviceType,
-            Type implementationType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (services == null)
             {
@@ -86,7 +87,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <seealso cref="ServiceLifetime.Transient"/>
-        public static IServiceCollection AddTransient<TService, TImplementation>(this IServiceCollection services)
+        public static IServiceCollection AddTransient<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection services)
             where TService : class
             where TImplementation : class, TService
         {
@@ -108,7 +109,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <seealso cref="ServiceLifetime.Transient"/>
         public static IServiceCollection AddTransient(
             this IServiceCollection services,
-            Type serviceType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type serviceType)
         {
             if (services == null)
             {
@@ -131,7 +132,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <seealso cref="ServiceLifetime.Transient"/>
-        public static IServiceCollection AddTransient<TService>(this IServiceCollection services)
+        public static IServiceCollection AddTransient<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection services)
             where TService : class
         {
             if (services == null)
@@ -201,8 +202,6 @@ namespace Microsoft.Extensions.DependencyInjection
             return services.AddTransient(typeof(TService), implementationFactory);
         }
 
-
-
         /// <summary>
         /// Adds a scoped service of the type specified in <paramref name="serviceType"/> with an
         /// implementation of the type specified in <paramref name="implementationType"/> to the
@@ -216,7 +215,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddScoped(
             this IServiceCollection services,
             Type serviceType,
-            Type implementationType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (services == null)
             {
@@ -279,7 +278,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <seealso cref="ServiceLifetime.Scoped"/>
-        public static IServiceCollection AddScoped<TService, TImplementation>(this IServiceCollection services)
+        public static IServiceCollection AddScoped<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection services)
             where TService : class
             where TImplementation : class, TService
         {
@@ -301,7 +300,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <seealso cref="ServiceLifetime.Scoped"/>
         public static IServiceCollection AddScoped(
             this IServiceCollection services,
-            Type serviceType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type serviceType)
         {
             if (services == null)
             {
@@ -324,7 +323,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <seealso cref="ServiceLifetime.Scoped"/>
-        public static IServiceCollection AddScoped<TService>(this IServiceCollection services)
+        public static IServiceCollection AddScoped<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection services)
             where TService : class
         {
             if (services == null)
@@ -408,7 +407,7 @@ namespace Microsoft.Extensions.DependencyInjection
         public static IServiceCollection AddSingleton(
             this IServiceCollection services,
             Type serviceType,
-            Type implementationType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (services == null)
             {
@@ -471,7 +470,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <seealso cref="ServiceLifetime.Singleton"/>
-        public static IServiceCollection AddSingleton<TService, TImplementation>(this IServiceCollection services)
+        public static IServiceCollection AddSingleton<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(this IServiceCollection services)
             where TService : class
             where TImplementation : class, TService
         {
@@ -493,7 +492,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <seealso cref="ServiceLifetime.Singleton"/>
         public static IServiceCollection AddSingleton(
             this IServiceCollection services,
-            Type serviceType)
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type serviceType)
         {
             if (services == null)
             {
@@ -516,7 +515,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="services">The <see cref="IServiceCollection"/> to add the service to.</param>
         /// <returns>A reference to this instance after the operation has completed.</returns>
         /// <seealso cref="ServiceLifetime.Singleton"/>
-        public static IServiceCollection AddSingleton<TService>(this IServiceCollection services)
+        public static IServiceCollection AddSingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TService>(this IServiceCollection services)
             where TService : class
         {
             if (services == null)
@@ -651,7 +650,7 @@ namespace Microsoft.Extensions.DependencyInjection
         private static IServiceCollection Add(
             IServiceCollection collection,
             Type serviceType,
-            Type implementationType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
             ServiceLifetime lifetime)
         {
             var descriptor = new ServiceDescriptor(serviceType, implementationType, lifetime);

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceDescriptor.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -20,7 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="lifetime">The <see cref="ServiceLifetime"/> of the service.</param>
         public ServiceDescriptor(
             Type serviceType,
-            Type implementationType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
             ServiceLifetime lifetime)
             : this(serviceType, lifetime)
         {
@@ -96,6 +97,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public Type ServiceType { get; }
 
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
         public Type? ImplementationType { get; }
 
         public object? ImplementationInstance { get; }
@@ -151,7 +153,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TService">The type of the service.</typeparam>
         /// <typeparam name="TImplementation">The type of the implementation.</typeparam>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Transient<TService, TImplementation>()
+        public static ServiceDescriptor Transient<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
             where TService : class
             where TImplementation : class, TService
         {
@@ -166,7 +168,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="service">The type of the service.</param>
         /// <param name="implementationType">The type of the implementation.</param>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Transient(Type service, Type implementationType)
+        public static ServiceDescriptor Transient(
+            Type service,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (service == null)
             {
@@ -254,7 +258,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TService">The type of the service.</typeparam>
         /// <typeparam name="TImplementation">The type of the implementation.</typeparam>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Scoped<TService, TImplementation>()
+        public static ServiceDescriptor Scoped<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
             where TService : class
             where TImplementation : class, TService
         {
@@ -269,7 +273,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="service">The type of the service.</param>
         /// <param name="implementationType">The type of the implementation.</param>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Scoped(Type service, Type implementationType)
+        public static ServiceDescriptor Scoped(
+            Type service,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             return Describe(service, implementationType, ServiceLifetime.Scoped);
         }
@@ -347,7 +353,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <typeparam name="TService">The type of the service.</typeparam>
         /// <typeparam name="TImplementation">The type of the implementation.</typeparam>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Singleton<TService, TImplementation>()
+        public static ServiceDescriptor Singleton<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>()
             where TService : class
             where TImplementation : class, TService
         {
@@ -362,7 +368,9 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="service">The type of the service.</param>
         /// <param name="implementationType">The type of the implementation.</param>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Singleton(Type service, Type implementationType)
+        public static ServiceDescriptor Singleton(
+            Type service,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType)
         {
             if (service == null)
             {
@@ -488,7 +496,7 @@ namespace Microsoft.Extensions.DependencyInjection
             return new ServiceDescriptor(serviceType, implementationInstance);
         }
 
-        private static ServiceDescriptor Describe<TService, TImplementation>(ServiceLifetime lifetime)
+        private static ServiceDescriptor Describe<TService, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TImplementation>(ServiceLifetime lifetime)
             where TService : class
             where TImplementation : class, TService
         {
@@ -507,7 +515,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="implementationType">The type of the implementation.</param>
         /// <param name="lifetime">The lifetime of the service.</param>
         /// <returns>A new instance of <see cref="ServiceDescriptor"/>.</returns>
-        public static ServiceDescriptor Describe(Type serviceType, Type implementationType, ServiceLifetime lifetime)
+        public static ServiceDescriptor Describe(
+            Type serviceType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
+            ServiceLifetime lifetime)
         {
             return new ServiceDescriptor(serviceType, implementationType, lifetime);
         }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/Microsoft.Extensions.DependencyInjection.csproj
@@ -25,6 +25,12 @@
              Link="Common\src\Extensions\TypeNameHelper\TypeNameHelper.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMembersAttribute.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\DynamicallyAccessedMemberTypes.cs" />
+    <Compile Include="$(CoreLibSharedDir)System\Diagnostics\CodeAnalysis\UnconditionalSuppressMessageAttribute.cs" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection.Abstractions\src\Microsoft.Extensions.DependencyInjection.Abstractions.csproj" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/CallSiteFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.Internal;
@@ -244,16 +245,16 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
             return null;
         }
 
-        private ServiceCallSite CreateConstructorCallSite(ResultCache lifetime, Type serviceType, Type implementationType,
+        private ServiceCallSite CreateConstructorCallSite(
+            ResultCache lifetime,
+            Type serviceType,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] Type implementationType,
             CallSiteChain callSiteChain)
         {
             try
             {
                 callSiteChain.Add(serviceType, implementationType);
-                ConstructorInfo[] constructors = implementationType.GetTypeInfo()
-                    .DeclaredConstructors
-                    .Where(constructor => constructor.IsPublic)
-                    .ToArray();
+                ConstructorInfo[] constructors = implementationType.GetConstructors();
 
                 ServiceCallSite[] parameterCallSites = null;
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ActivatorUtilitiesTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ActivatorUtilitiesTests.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        ServiceProvider provider = new ServiceCollection().BuildServiceProvider();
+
+        // ActivatorUtilities.CreateFactory fails due to https://github.com/mono/linker/issues/1398
+        //ObjectFactory factory = ActivatorUtilities.CreateFactory(typeof(ServiceA), Array.Empty<Type>());
+        //ServiceA serviceA = factory(provider, null) as ServiceA;
+        ServiceB serviceB = ActivatorUtilities.CreateInstance(provider, typeof(ServiceB)) as ServiceB;
+        ServiceC serviceC = ActivatorUtilities.CreateInstance<ServiceC>(provider);
+        ServiceD serviceD = ActivatorUtilities.GetServiceOrCreateInstance(provider, typeof(ServiceD)) as ServiceD;
+        ServiceE serviceE = ActivatorUtilities.GetServiceOrCreateInstance<ServiceE>(provider);
+
+        if (//serviceA is null ||
+            serviceB is null ||
+            serviceC is null ||
+            serviceD is null ||
+            serviceE is null)
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+
+    private class ServiceA { }
+    private class ServiceB { }
+    private class ServiceC { }
+    private class ServiceD { }
+    private class ServiceE { }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/Microsoft.Extensions.DependencyInjection.TrimmingTests.proj
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/Microsoft.Extensions.DependencyInjection.TrimmingTests.proj
@@ -1,0 +1,14 @@
+<Project DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props))" />
+
+  <PropertyGroup>
+    <AdditionalProjectReferences>Microsoft.Extensions.DependencyInjection</AdditionalProjectReferences>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <TestConsoleAppSourceFiles Include="ActivatorUtilitiesTests.cs" />
+    <TestConsoleAppSourceFiles Include="ServiceCollectionExtensionsTests.cs" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets))" />
+</Project>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ServiceCollectionExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.DependencyInjection;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        IServiceCollection descriptors = new ServiceCollection();
+        descriptors.AddTransient<ServiceA>();
+        descriptors.AddScoped(typeof(ServiceB));
+        descriptors.AddSingleton(typeof(IServiceC), typeof(ServiceC));
+
+        ServiceProvider provider = descriptors.BuildServiceProvider();
+
+        if (provider.GetService<ServiceA>() is null ||
+            provider.GetService<ServiceB>() is null ||
+            provider.GetService<IServiceC>() is null)
+        {
+            return -1;
+        }
+
+        return 100;
+    }
+
+    private class ServiceA { }
+    private class ServiceB { }
+    private interface IServiceC { }
+    private class ServiceC : IServiceC { }
+}

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ServiceCollectionExtensionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/tests/TrimmingTests/ServiceCollectionExtensionsTests.cs
@@ -12,11 +12,38 @@ class Program
         descriptors.AddScoped(typeof(ServiceB));
         descriptors.AddSingleton(typeof(IServiceC), typeof(ServiceC));
 
+        descriptors.AddTransient<IServiceD, ServiceD>();
+        descriptors.AddTransient<IServiceE, ServiceE>();
+        descriptors.AddTransient(typeof(IServiceF), typeof(ServiceF));
+
+        descriptors.AddTransient<IServiceG, ServiceG>();
+        descriptors.AddTransient(typeof(Logger<>));
+
+        descriptors.AddTransient<IServiceH, ServiceH1>();
+        descriptors.AddTransient<IServiceH, ServiceH2>();
+
         ServiceProvider provider = descriptors.BuildServiceProvider();
 
         if (provider.GetService<ServiceA>() is null ||
             provider.GetService<ServiceB>() is null ||
-            provider.GetService<IServiceC>() is null)
+            provider.GetService<IServiceC>() is null ||
+            provider.GetService<IServiceF>()?.ServiceE?.ServiceD is null ||
+            provider.GetService<Logger<IServiceG>>() is null)
+        {
+            return -1;
+        }
+
+        int hServices = 0;
+        foreach (IServiceH h in provider.GetServices<IServiceH>())
+        {
+            hServices++;
+            if (h == null)
+            {
+                return -1;
+            }
+        }
+
+        if (hServices != 2)
         {
             return -1;
         }
@@ -28,4 +55,29 @@ class Program
     private class ServiceB { }
     private interface IServiceC { }
     private class ServiceC : IServiceC { }
+
+    public interface IServiceD { }
+    public interface IServiceE { IServiceD ServiceD { get; } }
+    public interface IServiceF { IServiceE ServiceE { get; } }
+    public class ServiceD : IServiceD
+    {
+    }
+    public class ServiceE : IServiceE
+    {
+        public IServiceD ServiceD { get; }
+        public ServiceE(IServiceD d) { ServiceD = d; }
+    }
+    public class ServiceF : IServiceF
+    {
+        public IServiceE ServiceE { get; }
+        public ServiceF(IServiceE e) { ServiceE = e; }
+    }
+
+    public class Logger<T> { }
+    public interface IServiceG { }
+    public class ServiceG : IServiceG { }
+
+    public interface IServiceH { }
+    public class ServiceH1 : IServiceH { }
+    public class ServiceH2 : IServiceH { }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/UnconditionalSuppressMessageAttribute.cs
@@ -13,7 +13,12 @@ namespace System.Diagnostics.CodeAnalysis
     /// <see cref="ConditionalAttribute"/>. So it is always preserved in the compiled assembly.
     /// </remarks>
     [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
-    public sealed class UnconditionalSuppressMessageAttribute : Attribute
+#if SYSTEM_PRIVATE_CORELIB
+    public
+#else
+    internal
+#endif
+    sealed class UnconditionalSuppressMessageAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnconditionalSuppressMessageAttribute"/>


### PR DESCRIPTION
Fix #39745

With this change, the remaining (current) ILLinker warnings for the 2 DependencyInjection libraries are:

```
F:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection\src\ServiceLookup\Expressions\ExpressionResolverBuilder.cs(135,17): Trim analysis warning IL2006: Microsoft.Extensions.DependencyInjection.ServiceLookup.ExpressionResolverBuilder.VisitIEnumerable(IEnumerableCallSite,Object): Call to 'System.Reflection.MethodInfo.MakeGenericMethod' is not recognized.
F:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection\src\ServiceLookup\ILEmit\ILEmitResolverBuilder.cs(216,17): Trim analysis warning IL2006: Microsoft.Extensions.DependencyInjection.ServiceLookup.ILEmitResolverBuilder.VisitIEnumerable(IEnumerableCallSite,ILEmitResolverBuilderContext): Call to 'System.Reflection.MethodInfo.MakeGenericMethod' is not recognized.
F:\git\runtime2\src\libraries\Microsoft.Extensions.DependencyInjection\src\ServiceLookup\CallSiteFactory.cs(241,17): Trim analysis warning IL2006: Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteFactory.TryCreateOpenGeneric(ServiceDescriptor,Type,CallSiteChain,Int32): Calling to 'System.Type.MakeGenericType' on unrecognized value.
```