### PR TITLE
Correct a few mistakes in the ComInterop code

### DIFF
--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComHresults.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComHresults.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
         internal const int E_NOINTERFACE = unchecked((int)0x80004002);
         internal const int E_FAIL = unchecked((int)0x80004005);
-        internal const int E_NOTIMPL = unchecked((int)0x80000001);
+        internal const int E_NOTIMPL = unchecked((int)0x80004001);
 
         internal const int TYPE_E_LIBNOTREGISTERED = unchecked((int)0x8002801D);
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComHresults.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/ComHresults.cs
@@ -24,7 +24,6 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
         internal const int E_NOINTERFACE = unchecked((int)0x80004002);
         internal const int E_FAIL = unchecked((int)0x80004005);
-        internal const int E_NOTIMPL = unchecked((int)0x80004001);
 
         internal const int TYPE_E_LIBNOTREGISTERED = unchecked((int)0x8002801D);
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/VarEnumSelector.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/VarEnumSelector.cs
@@ -97,8 +97,8 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
                 { VarEnum.VT_UI2,       typeof(ushort) },
                 { VarEnum.VT_UI4,       typeof(uint) },
                 { VarEnum.VT_UI8,       typeof(ulong) },
-                { VarEnum.VT_INT,       typeof(IntPtr) },
-                { VarEnum.VT_UINT,      typeof(UIntPtr) },
+                { VarEnum.VT_INT,       typeof(int) },
+                { VarEnum.VT_UINT,      typeof(uint) },
                 { VarEnum.VT_BOOL,      typeof(bool) },
                 { VarEnum.VT_R4,        typeof(float) },
                 { VarEnum.VT_R8,        typeof(double) },
@@ -256,13 +256,13 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             if (argumentType == typeof(IntPtr))
             {
-                primitiveVarEnum = VarEnum.VT_INT;
+                primitiveVarEnum = VarEnum.VT_PTR;
                 return true;
             }
 
             if (argumentType == typeof(UIntPtr))
             {
-                primitiveVarEnum = VarEnum.VT_UINT;
+                primitiveVarEnum = VarEnum.VT_PTR;
                 return true;
             }
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/VarEnumSelector.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/VarEnumSelector.cs
@@ -256,13 +256,13 @@ namespace Microsoft.CSharp.RuntimeBinder.ComInterop
 
             if (argumentType == typeof(IntPtr))
             {
-                primitiveVarEnum = VarEnum.VT_PTR;
+                primitiveVarEnum = VarEnum.VT_INT;
                 return true;
             }
 
             if (argumentType == typeof(UIntPtr))
             {
-                primitiveVarEnum = VarEnum.VT_PTR;
+                primitiveVarEnum = VarEnum.VT_UINT;
                 return true;
             }
 

--- a/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/Variant.Extended.cs
+++ b/src/libraries/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/ComInterop/Variant.Extended.cs
@@ -69,14 +69,14 @@ namespace System.Runtime.InteropServices
 
         // VT_INT
 
-        public void SetAsByrefInt(ref IntPtr value)
+        public void SetAsByrefInt(ref int value)
         {
             SetAsByref(ref value, VarEnum.VT_INT);
         }
 
         // VT_UINT
 
-        public void SetAsByrefUint(ref UIntPtr value)
+        public void SetAsByrefUint(ref uint value)
         {
             SetAsByref(ref value, VarEnum.VT_UINT);
         }


### PR DESCRIPTION
1. Remove `ComHresults.E_NOTIMPL` as it's not used.
    - "_Not implemented_" is `0x80004001`. See the [references here](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/705fb797-2175-4a90-b5a3-3918024b10b8).

2. Correct the mapping `VT_INT/VT_UINT` to `int/uint` in `CreateComToManagedPrimitiveTypes`
    - `VT_INT` indicates an integer and `VT_UINT` indicates an unsigned integer. See [VARENUM Constants here](https://docs.microsoft.com/en-us/windows/win32/api/wtypes/ne-wtypes-varenum#constants).

3. Update `SetAsByRefInt/SetAsByrefUint` to take `int/uint` instead of `IntPtr/UIntPtr`

All are as suggested in https://github.com/dotnet/runtime/pull/40234#discussion_r469579244

/cc @AaronRobinsonMSFT and @elinor-fung