### PR TITLE
[browser] Remove ActiveIssue from BinaryPrimitives_StaticWithSpanArgument

### DIFF
--- a/src/libraries/System.Memory/tests/Span/Reflection.cs
+++ b/src/libraries/System.Memory/tests/Span/Reflection.cs
@@ -40,7 +40,6 @@ namespace System.SpanTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39311", TestPlatforms.Browser)]
         public static void BinaryPrimitives_StaticWithSpanArgument()
         {
             Type type = typeof(BinaryPrimitives);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/39311 is working now.