### PR TITLE
Fix typo in comment in StringBuilderCache.cs

### DIFF
--- a/src/libraries/Common/src/System/Text/StringBuilderCache.cs
+++ b/src/libraries/Common/src/System/Text/StringBuilderCache.cs
@@ -8,7 +8,7 @@ namespace System.Text
     internal static class StringBuilderCache
     {
         // The value 360 was chosen in discussion with performance experts as a compromise between using
-        // as litle memory per thread as possible and still covering a large part of short-lived
+        // as little memory per thread as possible and still covering a large part of short-lived
         // StringBuilder creations on the startup path of VS designers.
         internal const int MaxBuilderSize = 360;
         private const int DefaultCapacity = 16; // == StringBuilder.DefaultCapacity


### PR DESCRIPTION
Fixes 'litle' => 'little'