### PR TITLE
Reenable ExceptionDispatchInfo.SetCurrentStackTrace test on WASM

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Runtime/ExceptionServices/ExceptionDispatchInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Runtime/ExceptionServices/ExceptionDispatchInfoTests.cs
@@ -49,7 +49,6 @@ namespace System.Runtime.ExceptionServices.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/39341", TestPlatforms.Browser)]
         public static void SetCurrentStackTrace_IncludedInExceptionStackTrace()
         {
             Exception e;


### PR DESCRIPTION
It was fixed by https://github.com/dotnet/runtime/pull/40031.