### PR TITLE
Fix the trimming tests to link non-app assemblies correctly.

### DIFF
--- a/eng/testing/linker/SupportFiles/Directory.Build.targets
+++ b/eng/testing/linker/SupportFiles/Directory.Build.targets
@@ -20,11 +20,14 @@
   </Target>
 
   <Target Name="EnsureAllAssembliesAreLinked"
-          AfterTargets="PrepareForILLink"> 
+          BeforeTargets="PrepareForILLink"> 
     <ItemGroup>
       <ManagedAssemblyToLink>
         <TrimMode>link</TrimMode>
       </ManagedAssemblyToLink>
+
+      <!-- Pass the app assembly as a root -->
+      <TrimmerRootAssembly Include="@(IntermediateAssembly)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
The PrepareForILLink target will pass any ManagedAssemblyToLink that isn't marked as IsTrimmable=true to a TrimmerRootAssembly. This will cause the assembly to be passed to the linker with `-a`, which means the asesmbly won't be fully trimmed. So any assembly outside of the runtimepack will be passed with -a (for example Microsoft.Extensions.*).

Fix this by moving to BeforeTargets=PrepareForILLink and marking the single application assembly as a root.

Thanks to @davidfowl for finding this issue.

Here's an example diff of the linker command:

![image](https://user-images.githubusercontent.com/8291187/89131829-40e39280-d4d5-11ea-88fd-3b98aa985f78.png)

Note that the 2 Microsoft.Extensions.DependencyInjection assemblies are no longer passed with `-a`.