### PR TITLE
improve exception message when HTTP2 connection establishment fails

### DIFF
--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -435,6 +435,9 @@
   <data name="net_http_http2_stream_error" xml:space="preserve">
     <value>The HTTP/2 server reset the stream. HTTP/2 error code '{0}' (0x{1}).</value>
   </data>
+  <data name="net_http_http2_connection_not_established" xml:space="preserve">
+    <value>An HTTP/2 connection could not be established because the server did not complete the HTTP/2 handshake.</value>
+  </data>
   <data name="net_MethodNotImplementedException" xml:space="preserve">
     <value>This method is not implemented by this class.</value>
   </data>


### PR DESCRIPTION
Fixes #40219 

Two related changes here:
(1) When processing the initial SETTINGS frame from the server fails, generate a better error message
(2) Change the logic around the "missing frame" exception so that it applies in all cases where ReadFrameAsync is called, not just the main loop