### PR TITLE
Fix a deadlock in EventSource and CounterGroup

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -210,9 +210,10 @@ namespace System.Diagnostics.Tracing
                     elapsed = now - _timeStampSinceCollectionStarted;
                 }
 
-                // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload callback can be re-entrant
-                // i.e. it's possible it calls back into EnableTimer() above, since WritePayload callback
-                // can contain user code with EventSource constructor.
+                // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload
+                // callback can be re-entrant to CounterGroup (i.e. it's possible it calls back into EnableTimer()
+                // above, since WritePayload callback can contain user code that can invoke EventSource constructor
+                // and lead to a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
                 foreach (DiagnosticCounter counter in _counters)
                 {
                     counter.WritePayload((float)elapsed.TotalSeconds, _pollingIntervalInMilliseconds);


### PR DESCRIPTION
Fix #40190 

A deadlock can occur when the callback encountered in counter.WritePayload() contains a path that contains a EventSource constructor. EventSource constructor tries to take EventSource.EventListenerLock which may already be held by another thread. Simultaneously, the thread that holds to the EventListenerLock can be blocked on s_CounterGroupLock if it calls enable on an EventSource with EventCounter enabled, resulting in a deadlock.

Essentially the only change in this PR is taking out the call to counter.WritePayload(); to out of the scope of s_counterGroupLock. The fields in CounterGroup (both static and non-static) are still read/written inside s_counterGroupLock.

Note: We may need to backport this fix to 3.1. 
