### PR TITLE
Proposal: FormUrlEncodedContent - make key non Nullable

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/FormUrlEncodedContent.cs
@@ -12,13 +12,13 @@ namespace System.Net.Http
 {
     public class FormUrlEncodedContent : ByteArrayContent
     {
-        public FormUrlEncodedContent(IEnumerable<KeyValuePair<string?, string?>> nameValueCollection)
+        public FormUrlEncodedContent(IEnumerable<KeyValuePair<string, string?>> nameValueCollection)
             : base(GetContentByteArray(nameValueCollection))
         {
             Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
         }
 
-        private static byte[] GetContentByteArray(IEnumerable<KeyValuePair<string?, string?>> nameValueCollection)
+        private static byte[] GetContentByteArray(IEnumerable<KeyValuePair<string, string?>> nameValueCollection)
         {
             if (nameValueCollection == null)
             {
@@ -27,7 +27,7 @@ namespace System.Net.Http
 
             // Encode and concatenate data
             StringBuilder builder = new StringBuilder();
-            foreach (KeyValuePair<string?, string?> pair in nameValueCollection)
+            foreach (KeyValuePair<string, string?> pair in nameValueCollection)
             {
                 if (builder.Length > 0)
                 {


### PR DESCRIPTION
As described in #38494, it is not easy to use Dictionary to create FormUrlEncodedContent instance. 

I revisited the code and it seems to me we shouldn't support nullable keys. Instead of null key we should use empty string.