### PR TITLE
[browser] Normalize array magic numbers and remove switch

### DIFF
--- a/src/mono/wasm/runtime/binding_support.js
+++ b/src/mono/wasm/runtime/binding_support.js
@@ -226,7 +226,7 @@ var BindingSupportLib = {
 
 				return enumValue;
 
-
+			case 10: // arrays
 			case 11: 
 			case 12: 
 			case 13: 
@@ -361,26 +361,7 @@ var BindingSupportLib = {
 			// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Typed_arrays
 			if (!!(js_obj.buffer instanceof ArrayBuffer && js_obj.BYTES_PER_ELEMENT)) 
 			{
-				var arrayType = 0;
-				if (js_obj instanceof Int8Array)
-					arrayType = 11;
-				if (js_obj instanceof Uint8Array)
-					arrayType = 12;
-				if (js_obj instanceof Uint8ClampedArray)
-					arrayType = 12;
-				if (js_obj instanceof Int16Array)
-					arrayType = 13;
-				if (js_obj instanceof Uint16Array)
-					arrayType = 14;
-				if (js_obj instanceof Int32Array)
-					arrayType = 15;
-				if (js_obj instanceof Uint32Array)
-					arrayType = 16;
-				if (js_obj instanceof Float32Array)
-					arrayType = 17;
-				if (js_obj instanceof Float64Array)
-					arrayType = 18;
-
+				var arrayType = js_obj[Symbol.for("wasm type")];
 				var heapBytes = this.js_typedarray_to_heap(js_obj);
 				var bufferArray = this.mono_typed_array_new(heapBytes.byteOffset, js_obj.length, js_obj.BYTES_PER_ELEMENT, arrayType);
 				Module._free(heapBytes.byteOffset);
@@ -516,7 +497,7 @@ var BindingSupportLib = {
 
 			this.typedarray_copy_from(newTypedArray, pinned_array, begin, end, bytes_per_element);
 			return newTypedArray;
-		},		
+		},
 		js_to_mono_enum: function (method, parmIdx, js_obj) {
 			this.bindings_lazy_init ();
     

--- a/src/mono/wasm/runtime/corebindings.c
+++ b/src/mono/wasm/runtime/corebindings.c
@@ -98,8 +98,9 @@ void core_initialize_internals ()
 // Float32Array		| float		| float
 // Float64Array		| double	| double
 // typed array marshalling
-#define MARSHAL_ARRAY_BYTE 11
-#define MARSHAL_ARRAY_UBYTE 12
+#define MARSHAL_ARRAY_BYTE 10
+#define MARSHAL_ARRAY_UBYTE 11
+#define MARSHAL_ARRAY_UBYTE_C 12 // alias of MARSHAL_ARRAY_UBYTE
 #define MARSHAL_ARRAY_SHORT 13
 #define MARSHAL_ARRAY_USHORT 14
 #define MARSHAL_ARRAY_INT 15

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -568,8 +568,9 @@ MonoClass* mono_get_uri_class(MonoException** exc)
 #define MARSHAL_TYPE_SAFEHANDLE 23
 
 // typed array marshalling
-#define MARSHAL_ARRAY_BYTE 11
-#define MARSHAL_ARRAY_UBYTE 12
+#define MARSHAL_ARRAY_BYTE 10
+#define MARSHAL_ARRAY_UBYTE 11
+#define MARSHAL_ARRAY_UBYTE_C 12
 #define MARSHAL_ARRAY_SHORT 13
 #define MARSHAL_ARRAY_USHORT 14
 #define MARSHAL_ARRAY_INT 15


### PR DESCRIPTION
This pr standardizes on one set of magic numbers for marshaling to remove extra type inference logic.   We were already storing some nearly identical integer type information in the "wasm type" symbol.  This adds the missing value from that data and uses and uses the symbol data instead of switching on type.