### PR TITLE
Fix validation of arguments in the Slice

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ArraySegment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ArraySegment.cs
@@ -140,7 +140,7 @@ namespace System
         {
             ThrowInvalidOperationIfDefault();
 
-            if ((uint)index > (uint)_count || (uint)count > (uint)(_count - index))
+            if ((uint)index >= (uint)_count | (uint)count > (uint)(_count - index))
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexException();
             }


### PR DESCRIPTION
The previous validation did not cover the case where the index = _count.
In this case, the segment offset is equal to the offset of the next segment.
This behavior breaks tests for the ArraySegmentPool.
Specifically, the ArraySegmentPool considers it to be a ArraySegment that belongs to a different array region, so try to free the wrong region of the pool.
Demonstration in the link: https://github.com/wizardars/ArraySegmentPool