### PR TITLE
When invoking class constructor ensure class is initialized

### DIFF
--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/INVOCATION_FLAGS.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/INVOCATION_FLAGS.cs
@@ -14,7 +14,8 @@ namespace System.Reflection
         INVOCATION_FLAGS_INITIALIZED = 0x00000001,
         // it's used for both method and field to signify that no access is allowed
         INVOCATION_FLAGS_NO_INVOKE = 0x00000002,
-        /* unused 0x00000004 */
+        // Set for static ctors, to ensure that the static ctor is run as a static ctor before it is explicitly executed via reflection
+        INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR = 0x00000004,
         // Set for static ctors and ctors on abstract types, which
         // can be invoked only if the "this" object is provided (even if it's null).
         INVOCATION_FLAGS_NO_CTOR_INVOKE = 0x00000008,

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -290,8 +290,14 @@ namespace System.Reflection
             {
                 // Run the class constructor through the class constructor mechanism instead of the Invoke path.
                 // This avoids allowing mutation of readonly static fields, and initializes the type correctly.
-                RuntimeHelpers.RunClassConstructor(DeclaringType!.TypeHandle);
-                return;
+
+                var declaringType = DeclaringType;
+
+                // Handle module ctors, by not running them. They are always executed automatically
+                if (declaringType != null)
+                    RuntimeHelpers.RunClassConstructor(declaringType.TypeHandle);
+
+                return null;
             }
 
             Signature sig = Signature;

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Runtime.CompilerServices;
 using System.Text;
 using RuntimeTypeCache = System.RuntimeType.RuntimeTypeCache;
 
@@ -47,7 +48,12 @@ namespace System.Reflection
                         // We don't need other flags if this method cannot be invoked
                         invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE;
                     }
-                    else if (IsStatic || declaringType != null && declaringType.IsAbstract)
+                    else if (IsStatic)
+                    {
+                        invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR |
+                                           INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
+                    }
+                    else if (declaringType != null && declaringType.IsAbstract)
                     {
                         invocationFlags |= INVOCATION_FLAGS.INVOCATION_FLAGS_NO_CTOR_INVOKE;
                     }
@@ -276,6 +282,9 @@ namespace System.Reflection
 
             if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE) != 0)
                 ThrowNoInvokeException();
+
+            if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR) != 0)
+                RuntimeHelpers.RunClassConstructor(DeclaringType!.TypeHandle);
 
             // check basic method consistency. This call will throw if there are problems in the target/method relationship
             CheckConsistency(obj);

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -283,11 +283,16 @@ namespace System.Reflection
             if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NO_INVOKE) != 0)
                 ThrowNoInvokeException();
 
-            if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR) != 0)
-                RuntimeHelpers.RunClassConstructor(DeclaringType!.TypeHandle);
-
             // check basic method consistency. This call will throw if there are problems in the target/method relationship
             CheckConsistency(obj);
+
+            if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_RUN_CLASS_CONSTRUCTOR) != 0)
+            {
+                // Run the class constructor through the class constructor mechanism instead of the Invoke path.
+                // This avoids allowing mutation of readonly static fields, and initializes the type correctly.
+                RuntimeHelpers.RunClassConstructor(DeclaringType!.TypeHandle);
+                return;
+            }
 
             Signature sig = Signature;
 

--- a/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
+++ b/src/coreclr/src/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.cs
@@ -293,9 +293,10 @@ namespace System.Reflection
 
                 var declaringType = DeclaringType;
 
-                // Handle module ctors, by not running them. They are always executed automatically
                 if (declaringType != null)
                     RuntimeHelpers.RunClassConstructor(declaringType.TypeHandle);
+                else
+                    RuntimeHelpers.RunModuleConstructor(Module.ModuleHandle);
 
                 return null;
             }

--- a/src/libraries/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/ConstructorInfoTests.cs
@@ -69,6 +69,7 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/40351", TestRuntimes.Mono)]
         public void Invoke_StaticConstructorMultipleTimes()
         {
             ConstructorInfo[] constructors = GetConstructors(typeof(ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection));

--- a/src/libraries/System.Reflection/tests/ConstructorInfoTests.cs
+++ b/src/libraries/System.Reflection/tests/ConstructorInfoTests.cs
@@ -79,12 +79,13 @@ namespace System.Reflection.Tests
             Assert.Equal(0, ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection.VisibleStatics.s_cctorCallCount);
             object obj = constructors[0].Invoke(null, new object[] { });
             Assert.Null(obj);
-            Assert.Equal(2, ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection.VisibleStatics.s_cctorCallCount);
+            Assert.Equal(1, ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection.VisibleStatics.s_cctorCallCount);
 
-            // Subsequent invocations of the static cctor should run the cctor only once
+            // Subsequent invocations of the static cctor should not run the cctor at all, as it has already executed
+            // and running multiple times opens up the possibility of modifying read only static data
             obj = constructors[0].Invoke(null, new object[] { });
             Assert.Null(obj);
-            Assert.Equal(3, ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection.VisibleStatics.s_cctorCallCount);
+            Assert.Equal(1, ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection.VisibleStatics.s_cctorCallCount);
         }
 
         [Fact]


### PR DESCRIPTION
When invoking the class constructor method via reflection invoke, ensure that the class constructor is run via the standard run class constructor pathway before manually invoking the class constructor

This ensure that all of the various data structures associated with the class constructor are initialized such as valuetype statics.

Fixes #1748