### PR TITLE
Add nullability annotations for *XPath* files in Xml/Dom and Xml/Xsl

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXPathNavigator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXPathNavigator.cs
@@ -2198,7 +2198,7 @@ namespace System.Xml
             do
             {
                 end = current;
-                current = NextSibling(node);
+                current = NextSibling(current);
             }
             while (current != null
                    && current.IsText);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXPathNavigator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXPathNavigator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,6 +9,7 @@ using System.Text;
 using System.Xml.Schema;
 using System.Xml.XPath;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml
 {
@@ -16,7 +18,7 @@ namespace System.Xml
         private readonly XmlDocument _document; // owner document
         private XmlNode _source; // navigator position
         private int _attributeIndex; // index in attribute collection for attribute
-        private XmlElement _namespaceParent; // parent for namespace
+        private XmlElement? _namespaceParent; // parent for namespace
 
         public DocumentXPathNavigator(XmlDocument document, XmlNode node)
         {
@@ -70,7 +72,7 @@ namespace System.Xml
                         {
                             throw new InvalidOperationException(SR.Xdom_Node_Modify_ReadOnly);
                         }
-                        DeleteToFollowingSibling(node.NextSibling, end);
+                        DeleteToFollowingSibling(node.NextSibling!, end);
                     }
                     goto case XmlNodeType.Element;
                 case XmlNodeType.Element:
@@ -113,7 +115,7 @@ namespace System.Xml
         {
             get
             {
-                XmlAttribute attribute = _source as XmlAttribute;
+                XmlAttribute? attribute = _source as XmlAttribute;
                 if (attribute != null
                     && attribute.IsNamespace)
                 {
@@ -153,7 +155,7 @@ namespace System.Xml
         {
             get
             {
-                XmlAttribute attribute = _source as XmlAttribute;
+                XmlAttribute? attribute = _source as XmlAttribute;
                 if (attribute != null
                     && attribute.IsNamespace)
                 {
@@ -180,6 +182,8 @@ namespace System.Xml
                     case XmlNodeType.SignificantWhitespace:
                         return ValueText;
                     default:
+                        Debug.Assert(_source.Value != null);
+                        // TODO: It could be better to switch this to nullable even if that implies switching it in the base type.
                         return _source.Value;
                 }
             }
@@ -189,7 +193,7 @@ namespace System.Xml
         {
             get
             {
-                XmlElement element = _document.DocumentElement;
+                XmlElement? element = _document.DocumentElement;
                 if (element != null)
                 {
                     return element.InnerText;
@@ -204,8 +208,8 @@ namespace System.Xml
             {
                 CalibrateText();
 
-                string value = _source.Value;
-                XmlNode nextSibling = NextSibling(_source);
+                string? value = _source.Value;
+                XmlNode? nextSibling = NextSibling(_source);
                 if (nextSibling != null
                     && nextSibling.IsText)
                 {
@@ -219,6 +223,8 @@ namespace System.Xml
                            && nextSibling.IsText);
                     value = builder.ToString();
                 }
+                // TODO: Not sure if this is right, maybe we should change to return string.Empty in case of null.
+                Debug.Assert(value != null);
                 return value;
             }
         }
@@ -235,7 +241,7 @@ namespace System.Xml
         {
             get
             {
-                XmlElement element = _source as XmlElement;
+                XmlElement? element = _source as XmlElement;
                 if (element != null)
                 {
                     return element.IsEmpty;
@@ -266,7 +272,7 @@ namespace System.Xml
         {
             get
             {
-                XmlElement element = _source as XmlElement;
+                XmlElement? element = _source as XmlElement;
                 if (element != null
                     && element.HasAttributes)
                 {
@@ -291,7 +297,7 @@ namespace System.Xml
 
         public override bool MoveToAttribute(string localName, string namespaceURI)
         {
-            XmlElement element = _source as XmlElement;
+            XmlElement? element = _source as XmlElement;
             if (element != null
                 && element.HasAttributes)
             {
@@ -320,7 +326,7 @@ namespace System.Xml
 
         public override bool MoveToFirstAttribute()
         {
-            XmlElement element = _source as XmlElement;
+            XmlElement? element = _source as XmlElement;
             if (element != null
                 && element.HasAttributes)
             {
@@ -341,13 +347,13 @@ namespace System.Xml
 
         public override bool MoveToNextAttribute()
         {
-            XmlAttribute attribute = _source as XmlAttribute;
+            XmlAttribute? attribute = _source as XmlAttribute;
             if (attribute == null
                 || attribute.IsNamespace)
             {
                 return false;
             }
-            XmlAttributeCollection attributes;
+            XmlAttributeCollection? attributes;
             if (!CheckAttributePosition(attribute, out attributes, _attributeIndex)
                 && !ResetAttributePosition(attribute, attributes, out _attributeIndex))
             {
@@ -368,11 +374,11 @@ namespace System.Xml
 
         public override string GetNamespace(string name)
         {
-            XmlNode node = _source;
+            XmlNode? node = _source;
             while (node != null
                    && node.NodeType != XmlNodeType.Element)
             {
-                XmlAttribute attribute = node as XmlAttribute;
+                XmlAttribute? attribute = node as XmlAttribute;
                 if (attribute != null)
                 {
                     node = attribute.OwnerElement;
@@ -383,7 +389,7 @@ namespace System.Xml
                 }
             }
 
-            XmlElement element = node as XmlElement;
+            XmlElement? element = node as XmlElement;
             if (element != null)
             {
                 string localName;
@@ -400,7 +406,7 @@ namespace System.Xml
 
                 do
                 {
-                    XmlAttribute attribute = element.GetAttributeNode(localName, namespaceUri);
+                    XmlAttribute? attribute = element.GetAttributeNode(localName, namespaceUri);
                     if (attribute != null)
                     {
                         return attribute.Value;
@@ -427,7 +433,7 @@ namespace System.Xml
             {
                 return false;
             }
-            XmlElement element = _source as XmlElement;
+            XmlElement? element = _source as XmlElement;
             if (element != null)
             {
                 string localName;
@@ -444,7 +450,7 @@ namespace System.Xml
 
                 do
                 {
-                    XmlAttribute attribute = element.GetAttributeNode(localName, namespaceUri);
+                    XmlAttribute? attribute = element.GetAttributeNode(localName, namespaceUri);
                     if (attribute != null)
                     {
                         _namespaceParent = (XmlElement)_source;
@@ -467,7 +473,7 @@ namespace System.Xml
 
         public override bool MoveToFirstNamespace(XPathNamespaceScope scope)
         {
-            XmlElement element = _source as XmlElement;
+            XmlElement? element = _source as XmlElement;
             if (element == null)
             {
                 return false;
@@ -553,7 +559,7 @@ namespace System.Xml
             }
 
             Debug.Assert(attributes != null && attributes.parent != null);
-            XmlElement element = attributes.parent.ParentNode as XmlElement;
+            XmlElement? element = attributes.parent.ParentNode as XmlElement;
             while (element != null)
             {
                 if (element.HasAttributes)
@@ -571,13 +577,13 @@ namespace System.Xml
 
         public override bool MoveToNextNamespace(XPathNamespaceScope scope)
         {
-            XmlAttribute attribute = _source as XmlAttribute;
+            XmlAttribute? attribute = _source as XmlAttribute;
             if (attribute == null
                 || !attribute.IsNamespace)
             {
                 return false;
             }
-            XmlAttributeCollection attributes;
+            XmlAttributeCollection? attributes;
             int index = _attributeIndex;
             if (!CheckAttributePosition(attribute, out attributes, index)
                 && !ResetAttributePosition(attribute, attributes, out index))
@@ -668,7 +674,7 @@ namespace System.Xml
             }
 
             Debug.Assert(attributes != null && attributes.parent != null);
-            XmlElement element = attributes.parent.ParentNode as XmlElement;
+            XmlElement? element = attributes.parent.ParentNode as XmlElement;
             while (element != null)
             {
                 if (element.HasAttributes)
@@ -684,25 +690,26 @@ namespace System.Xml
             return false;
         }
 
-        private bool PathHasDuplicateNamespace(XmlElement top, XmlElement bottom, string localName)
+        private bool PathHasDuplicateNamespace(XmlElement? top, XmlElement bottom, string localName)
         {
+            XmlElement? current = bottom;
             string namespaceUri = _document.strReservedXmlns;
-            while (bottom != null
-                   && bottom != top)
+            while (current != null
+                   && current != top)
             {
-                XmlAttribute attribute = bottom.GetAttributeNode(localName, namespaceUri);
+                XmlAttribute? attribute = current.GetAttributeNode(localName, namespaceUri);
                 if (attribute != null)
                 {
                     return true;
                 }
-                bottom = bottom.ParentNode as XmlElement;
+                current = current.ParentNode as XmlElement;
             }
             return false;
         }
 
-        public override string LookupNamespace(string prefix)
+        public override string? LookupNamespace(string prefix)
         {
-            string ns = base.LookupNamespace(prefix);
+            string? ns = base.LookupNamespace(prefix);
             if (ns != null)
             {
                 ns = this.NameTable.Add(ns);
@@ -712,7 +719,7 @@ namespace System.Xml
 
         public override bool MoveToNext()
         {
-            XmlNode sibling = NextSibling(_source);
+            XmlNode? sibling = NextSibling(_source);
             if (sibling == null)
             {
                 return false;
@@ -728,7 +735,7 @@ namespace System.Xml
                     }
                 }
             }
-            XmlNode parent = ParentNode(sibling);
+            XmlNode? parent = ParentNode(sibling);
             Debug.Assert(parent != null);
             while (!IsValidChild(parent, sibling))
             {
@@ -744,7 +751,7 @@ namespace System.Xml
 
         public override bool MoveToPrevious()
         {
-            XmlNode sibling = PreviousSibling(_source);
+            XmlNode? sibling = PreviousSibling(_source);
             if (sibling == null)
             {
                 return false;
@@ -764,7 +771,7 @@ namespace System.Xml
                     sibling = TextStart(sibling);
                 }
             }
-            XmlNode parent = ParentNode(sibling);
+            XmlNode? parent = ParentNode(sibling);
             Debug.Assert(parent != null);
             while (!IsValidChild(parent, sibling))
             {
@@ -787,12 +794,12 @@ namespace System.Xml
             {
                 return false;
             }
-            XmlNode parent = ParentNode(_source);
+            XmlNode? parent = ParentNode(_source);
             if (parent == null)
             {
                 return false;
             }
-            XmlNode sibling = FirstChild(parent);
+            XmlNode? sibling = FirstChild(parent);
             Debug.Assert(sibling != null);
             while (!IsValidChild(parent, sibling))
             {
@@ -808,7 +815,7 @@ namespace System.Xml
 
         public override bool MoveToFirstChild()
         {
-            XmlNode child;
+            XmlNode? child;
             switch (_source.NodeType)
             {
                 case XmlNodeType.Element:
@@ -843,13 +850,13 @@ namespace System.Xml
 
         public override bool MoveToParent()
         {
-            XmlNode parent = ParentNode(_source);
+            XmlNode? parent = ParentNode(_source);
             if (parent != null)
             {
                 _source = parent;
                 return true;
             }
-            XmlAttribute attribute = _source as XmlAttribute;
+            XmlAttribute? attribute = _source as XmlAttribute;
             if (attribute != null)
             {
                 parent = attribute.IsNamespace ? _namespaceParent : attribute.OwnerElement;
@@ -867,10 +874,10 @@ namespace System.Xml
         {
             while (true)
             {
-                XmlNode parent = _source.ParentNode;
+                XmlNode? parent = _source.ParentNode;
                 if (parent == null)
                 {
-                    XmlAttribute attribute = _source as XmlAttribute;
+                    XmlAttribute? attribute = _source as XmlAttribute;
                     if (attribute == null)
                     {
                         break;
@@ -888,7 +895,7 @@ namespace System.Xml
 
         public override bool MoveTo(XPathNavigator other)
         {
-            DocumentXPathNavigator that = other as DocumentXPathNavigator;
+            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
             if (that != null
                 && _document == that._document)
             {
@@ -902,7 +909,7 @@ namespace System.Xml
 
         public override bool MoveToId(string id)
         {
-            XmlElement element = _document.GetElementById(id);
+            XmlElement? element = _document.GetElementById(id);
             if (element != null)
             {
                 _source = element;
@@ -919,7 +926,7 @@ namespace System.Xml
                 return false;
             }
 
-            XmlNode child = FirstChild(_source);
+            XmlNode? child = FirstChild(_source);
             if (child != null)
             {
                 do
@@ -945,7 +952,7 @@ namespace System.Xml
                 return false;
             }
 
-            XmlNode child = FirstChild(_source);
+            XmlNode? child = FirstChild(_source);
             if (child != null)
             {
                 int mask = GetContentKindMask(type);
@@ -967,10 +974,10 @@ namespace System.Xml
             return false;
         }
 
-        public override bool MoveToFollowing(string localName, string namespaceUri, XPathNavigator end)
+        public override bool MoveToFollowing(string localName, string namespaceUri, XPathNavigator? end)
         {
-            XmlNode pastFollowing = null;
-            DocumentXPathNavigator that = end as DocumentXPathNavigator;
+            XmlNode? pastFollowing = null;
+            DocumentXPathNavigator? that = end as DocumentXPathNavigator;
             if (that != null)
             {
                 if (_document != that._document)
@@ -990,7 +997,7 @@ namespace System.Xml
                 pastFollowing = that._source;
             }
 
-            XmlNode following = _source;
+            XmlNode? following = _source;
             if (following.NodeType == XmlNodeType.Attribute)
             {
                 following = ((XmlAttribute)following).OwnerElement;
@@ -1001,7 +1008,7 @@ namespace System.Xml
             }
             do
             {
-                XmlNode firstChild = following.FirstChild;
+                XmlNode? firstChild = following.FirstChild;
                 if (firstChild != null)
                 {
                     following = firstChild;
@@ -1010,7 +1017,7 @@ namespace System.Xml
                 {
                     while (true)
                     {
-                        XmlNode nextSibling = following.NextSibling;
+                        XmlNode? nextSibling = following.NextSibling;
                         if (nextSibling != null)
                         {
                             following = nextSibling;
@@ -1018,7 +1025,7 @@ namespace System.Xml
                         }
                         else
                         {
-                            XmlNode parent = following.ParentNode;
+                            XmlNode? parent = following.ParentNode;
                             if (parent != null)
                             {
                                 following = parent;
@@ -1043,10 +1050,10 @@ namespace System.Xml
             return true;
         }
 
-        public override bool MoveToFollowing(XPathNodeType type, XPathNavigator end)
+        public override bool MoveToFollowing(XPathNodeType type, XPathNavigator? end)
         {
-            XmlNode pastFollowing = null;
-            DocumentXPathNavigator that = end as DocumentXPathNavigator;
+            XmlNode? pastFollowing = null;
+            DocumentXPathNavigator? that = end as DocumentXPathNavigator;
             if (that != null)
             {
                 if (_document != that._document)
@@ -1071,7 +1078,7 @@ namespace System.Xml
             {
                 return false;
             }
-            XmlNode following = _source;
+            XmlNode? following = _source;
             switch (following.NodeType)
             {
                 case XmlNodeType.Attribute:
@@ -1090,7 +1097,7 @@ namespace System.Xml
             }
             do
             {
-                XmlNode firstChild = following.FirstChild;
+                XmlNode? firstChild = following.FirstChild;
                 if (firstChild != null)
                 {
                     following = firstChild;
@@ -1099,7 +1106,7 @@ namespace System.Xml
                 {
                     while (true)
                     {
-                        XmlNode nextSibling = following.NextSibling;
+                        XmlNode? nextSibling = following.NextSibling;
                         if (nextSibling != null)
                         {
                             following = nextSibling;
@@ -1107,7 +1114,7 @@ namespace System.Xml
                         }
                         else
                         {
-                            XmlNode parent = following.ParentNode;
+                            XmlNode? parent = following.ParentNode;
                             if (parent != null)
                             {
                                 following = parent;
@@ -1132,7 +1139,7 @@ namespace System.Xml
 
         public override bool MoveToNext(string localName, string namespaceUri)
         {
-            XmlNode sibling = NextSibling(_source);
+            XmlNode? sibling = NextSibling(_source);
             if (sibling == null)
             {
                 return false;
@@ -1154,7 +1161,7 @@ namespace System.Xml
 
         public override bool MoveToNext(XPathNodeType type)
         {
-            XmlNode sibling = NextSibling(_source);
+            XmlNode? sibling = NextSibling(_source);
             if (sibling == null)
             {
                 return false;
@@ -1191,7 +1198,7 @@ namespace System.Xml
         {
             get
             {
-                XmlNode child;
+                XmlNode? child;
                 switch (_source.NodeType)
                 {
                     case XmlNodeType.Element:
@@ -1225,7 +1232,7 @@ namespace System.Xml
 
         public override bool IsSamePosition(XPathNavigator other)
         {
-            DocumentXPathNavigator that = other as DocumentXPathNavigator;
+            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
             if (that != null)
             {
                 this.CalibrateText();
@@ -1237,9 +1244,9 @@ namespace System.Xml
             return false;
         }
 
-        public override bool IsDescendant(XPathNavigator other)
+        public override bool IsDescendant(XPathNavigator? other)
         {
-            DocumentXPathNavigator that = other as DocumentXPathNavigator;
+            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
             if (that != null)
             {
                 return IsDescendant(_source, that._source);
@@ -1257,7 +1264,7 @@ namespace System.Xml
 
         public override bool CheckValidity(XmlSchemaSet schemas, ValidationEventHandler validationEventHandler)
         {
-            XmlDocument ownerDocument;
+            XmlDocument? ownerDocument;
 
             if (_source.NodeType == XmlNodeType.Document)
             {
@@ -1282,19 +1289,22 @@ namespace System.Xml
                 throw new InvalidOperationException(SR.XmlDocument_NoSchemaInfo);
             }
 
+            // TODO: should we guard against null in above condition instead?
+            // DocumentSchemaValidator assumes that ownedDocument can never be null.
+            Debug.Assert(ownerDocument != null);
             DocumentSchemaValidator validator = new DocumentSchemaValidator(ownerDocument, schemas, validationEventHandler);
             validator.PsviAugmentation = false;
             return validator.Validate(_source);
         }
 
-        private static XmlNode OwnerNode(XmlNode node)
+        private static XmlNode? OwnerNode(XmlNode node)
         {
-            XmlNode parent = node.ParentNode;
+            XmlNode? parent = node.ParentNode;
             if (parent != null)
             {
                 return parent;
             }
-            XmlAttribute attribute = node as XmlAttribute;
+            XmlAttribute? attribute = node as XmlAttribute;
             if (attribute != null)
             {
                 return attribute.OwnerElement;
@@ -1305,7 +1315,7 @@ namespace System.Xml
         private static int GetDepth(XmlNode node)
         {
             int depth = 0;
-            XmlNode owner = OwnerNode(node);
+            XmlNode? owner = OwnerNode(node);
             while (owner != null)
             {
                 depth++;
@@ -1327,7 +1337,9 @@ namespace System.Xml
             {
                 if (node2.XPNodeType == XPathNodeType.Attribute)
                 {
-                    XmlElement element = ((XmlAttribute)node1).OwnerElement;
+                    XmlElement? element = ((XmlAttribute)node1).OwnerElement;
+                    Debug.Assert(element != null);
+                    // TODO: Should this also check for null instead?
                     if (element.HasAttributes)
                     {
                         XmlAttributeCollection attributes = element.Attributes;
@@ -1357,7 +1369,7 @@ namespace System.Xml
             }
 
             //neither of the node is Namespace node or Attribute node
-            XmlNode nextNode = node1.NextSibling;
+            XmlNode? nextNode = node1.NextSibling;
             while (nextNode != null && nextNode != node2)
                 nextNode = nextNode.NextSibling;
             if (nextNode == null)
@@ -1368,9 +1380,9 @@ namespace System.Xml
                 return XmlNodeOrder.Before;
         }
 
-        public override XmlNodeOrder ComparePosition(XPathNavigator other)
+        public override XmlNodeOrder ComparePosition(XPathNavigator? other)
         {
-            DocumentXPathNavigator that = other as DocumentXPathNavigator;
+            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
             if (that == null)
             {
                 return XmlNodeOrder.Unknown;
@@ -1391,11 +1403,11 @@ namespace System.Xml
                 return base.ComparePosition(other);
             }
 
-            XmlNode node1 = _source;
-            XmlNode node2 = that._source;
+            XmlNode? node1 = _source;
+            XmlNode? node2 = that._source;
 
-            XmlNode parent1 = OwnerNode(node1);
-            XmlNode parent2 = OwnerNode(node2);
+            XmlNode? parent1 = OwnerNode(node1);
+            XmlNode? parent2 = OwnerNode(node2);
             if (parent1 == parent2)
             {
                 if (parent1 == null)
@@ -1423,6 +1435,8 @@ namespace System.Xml
                 {
                     return XmlNodeOrder.Before;
                 }
+                Debug.Assert(node2 != null);
+                // TODO: What ensures that node2 is not null.
                 parent2 = OwnerNode(node2);
             }
             else if (depth1 > depth2)
@@ -1437,6 +1451,8 @@ namespace System.Xml
                 {
                     return XmlNodeOrder.After;
                 }
+                Debug.Assert(node1 != null);
+                // TODO: What ensures that node1 is not null.
                 parent1 = OwnerNode(node1);
             }
 
@@ -1461,13 +1477,13 @@ namespace System.Xml
 
         public override XPathNodeIterator SelectDescendants(string localName, string namespaceURI, bool matchSelf)
         {
-            string nsAtom = _document.NameTable.Get(namespaceURI);
+            string? nsAtom = _document.NameTable.Get(namespaceURI);
             if (nsAtom == null || _source.NodeType == XmlNodeType.Attribute)
                 return new DocumentXPathNodeIterator_Empty(this);
 
             Debug.Assert(this.NodeType != XPathNodeType.Attribute && this.NodeType != XPathNodeType.Namespace && this.NodeType != XPathNodeType.All);
 
-            string localNameAtom = _document.NameTable.Get(localName);
+            string? localNameAtom = _document.NameTable.Get(localName);
             if (localNameAtom == null)
                 return new DocumentXPathNodeIterator_Empty(this);
 
@@ -1606,7 +1622,7 @@ namespace System.Xml
 
         public override XmlWriter ReplaceRange(XPathNavigator lastSiblingToReplace)
         {
-            DocumentXPathNavigator that = lastSiblingToReplace as DocumentXPathNavigator;
+            DocumentXPathNavigator? that = lastSiblingToReplace as DocumentXPathNavigator;
             if (that == null)
             {
                 if (lastSiblingToReplace == null)
@@ -1664,7 +1680,7 @@ namespace System.Xml
 
         public override void DeleteRange(XPathNavigator lastSiblingToDelete)
         {
-            DocumentXPathNavigator that = lastSiblingToDelete as DocumentXPathNavigator;
+            DocumentXPathNavigator? that = lastSiblingToDelete as DocumentXPathNavigator;
             if (that == null)
             {
                 if (lastSiblingToDelete == null)
@@ -1693,7 +1709,7 @@ namespace System.Xml
                         {
                             goto default;
                         }
-                        XmlNode parent = OwnerNode(attribute);
+                        XmlNode? parent = OwnerNode(attribute);
                         DeleteAttribute(attribute, _attributeIndex);
                         if (parent != null)
                         {
@@ -1730,7 +1746,7 @@ namespace System.Xml
                 {
                     throw new InvalidOperationException(SR.Xpn_BadPosition);
                 }
-                XmlNode parent = OwnerNode(node);
+                XmlNode? parent = OwnerNode(node);
                 DeleteToFollowingSibling(node, end);
                 if (parent != null)
                 {
@@ -1752,7 +1768,7 @@ namespace System.Xml
                     {
                         goto default;
                     }
-                    XmlNode parent = OwnerNode(attribute);
+                    XmlNode? parent = OwnerNode(attribute);
                     DeleteAttribute(attribute, _attributeIndex);
                     if (parent != null)
                     {
@@ -1785,7 +1801,7 @@ namespace System.Xml
 
         private static void DeleteAttribute(XmlAttribute attribute, int index)
         {
-            XmlAttributeCollection attributes;
+            XmlAttributeCollection? attributes;
 
             if (!CheckAttributePosition(attribute, out attributes, index)
                 && !ResetAttributePosition(attribute, attributes, out index))
@@ -1801,7 +1817,7 @@ namespace System.Xml
 
         internal static void DeleteToFollowingSibling(XmlNode node, XmlNode end)
         {
-            XmlNode parent = node.ParentNode;
+            XmlNode? parent = node.ParentNode;
 
             if (parent == null)
             {
@@ -1814,21 +1830,22 @@ namespace System.Xml
             }
             while (node != end)
             {
+                Debug.Assert(node != null, "This method needs to be called with the beforehand check of NextSibling being not null from node to end");
                 XmlNode temp = node;
-                node = node.NextSibling;
+                node = node.NextSibling!;
                 parent.RemoveChild(temp);
             }
             parent.RemoveChild(node);
         }
 
-        private static XmlNamespaceManager GetNamespaceManager(XmlNode node, XmlDocument document)
+        private static XmlNamespaceManager GetNamespaceManager(XmlNode? node, XmlDocument document)
         {
             XmlNamespaceManager namespaceManager = new XmlNamespaceManager(document.NameTable);
             List<XmlElement> elements = new List<XmlElement>();
 
             while (node != null)
             {
-                XmlElement element = node as XmlElement;
+                XmlElement? element = node as XmlElement;
                 if (element != null
                     && element.HasAttributes)
                 {
@@ -1853,15 +1870,16 @@ namespace System.Xml
             return namespaceManager;
         }
 
+        [MemberNotNull(nameof(_source))]
         internal void ResetPosition(XmlNode node)
         {
             Debug.Assert(node != null, "Undefined navigator position");
             Debug.Assert(node == _document || node.OwnerDocument == _document, "Navigator switched documents");
             _source = node;
-            XmlAttribute attribute = node as XmlAttribute;
+            XmlAttribute? attribute = node as XmlAttribute;
             if (attribute != null)
             {
-                XmlElement element = attribute.OwnerElement;
+                XmlElement? element = attribute.OwnerElement;
                 if (element != null)
                 {
                     ResetAttributePosition(attribute, element.Attributes, out _attributeIndex);
@@ -1873,7 +1891,7 @@ namespace System.Xml
             }
         }
 
-        private static bool ResetAttributePosition(XmlAttribute attribute, XmlAttributeCollection attributes, out int index)
+        private static bool ResetAttributePosition(XmlAttribute attribute, [NotNullWhen(true)] XmlAttributeCollection? attributes, out int index)
         {
             if (attributes != null)
             {
@@ -1890,9 +1908,9 @@ namespace System.Xml
             return false;
         }
 
-        private static bool CheckAttributePosition(XmlAttribute attribute, out XmlAttributeCollection attributes, int index)
+        private static bool CheckAttributePosition(XmlAttribute attribute, [NotNullWhen(true)] out XmlAttributeCollection? attributes, int index)
         {
-            XmlElement element = attribute.OwnerElement;
+            XmlElement? element = attribute.OwnerElement;
             if (element != null)
             {
                 attributes = element.Attributes;
@@ -1912,7 +1930,7 @@ namespace System.Xml
 
         private void CalibrateText()
         {
-            XmlNode text = PreviousText(_source);
+            XmlNode? text = PreviousText(_source);
             while (text != null)
             {
                 ResetPosition(text);
@@ -1920,9 +1938,9 @@ namespace System.Xml
             }
         }
 
-        private XmlNode ParentNode(XmlNode node)
+        private XmlNode? ParentNode(XmlNode node)
         {
-            XmlNode parent = node.ParentNode;
+            XmlNode? parent = node.ParentNode;
 
             if (!_document.HasEntityReferences)
             {
@@ -1931,7 +1949,7 @@ namespace System.Xml
             return ParentNodeTail(parent);
         }
 
-        private XmlNode ParentNodeTail(XmlNode parent)
+        private XmlNode? ParentNodeTail(XmlNode? parent)
         {
             while (parent != null
                    && parent.NodeType == XmlNodeType.EntityReference)
@@ -1941,9 +1959,9 @@ namespace System.Xml
             return parent;
         }
 
-        private XmlNode FirstChild(XmlNode node)
+        private XmlNode? FirstChild(XmlNode node)
         {
-            XmlNode child = node.FirstChild;
+            XmlNode? child = node.FirstChild;
 
             if (!_document.HasEntityReferences)
             {
@@ -1952,7 +1970,7 @@ namespace System.Xml
             return FirstChildTail(child);
         }
 
-        private XmlNode FirstChildTail(XmlNode child)
+        private XmlNode? FirstChildTail(XmlNode? child)
         {
             while (child != null
                    && child.NodeType == XmlNodeType.EntityReference)
@@ -1962,9 +1980,9 @@ namespace System.Xml
             return child;
         }
 
-        private XmlNode NextSibling(XmlNode node)
+        private XmlNode? NextSibling(XmlNode node)
         {
-            XmlNode sibling = node.NextSibling;
+            XmlNode? sibling = node.NextSibling;
 
             if (!_document.HasEntityReferences)
             {
@@ -1973,17 +1991,18 @@ namespace System.Xml
             return NextSiblingTail(node, sibling);
         }
 
-        private XmlNode NextSiblingTail(XmlNode node, XmlNode sibling)
+        private XmlNode? NextSiblingTail(XmlNode node, XmlNode? sibling)
         {
+            XmlNode? current = node;
             while (sibling == null)
             {
-                node = node.ParentNode;
-                if (node == null
-                    || node.NodeType != XmlNodeType.EntityReference)
+                current = current.ParentNode;
+                if (current == null
+                    || current.NodeType != XmlNodeType.EntityReference)
                 {
                     return null;
                 }
-                sibling = node.NextSibling;
+                sibling = current.NextSibling;
             }
             while (sibling != null
                    && sibling.NodeType == XmlNodeType.EntityReference)
@@ -1993,9 +2012,9 @@ namespace System.Xml
             return sibling;
         }
 
-        private XmlNode PreviousSibling(XmlNode node)
+        private XmlNode? PreviousSibling(XmlNode node)
         {
-            XmlNode sibling = node.PreviousSibling;
+            XmlNode? sibling = node.PreviousSibling;
 
             if (!_document.HasEntityReferences)
             {
@@ -2004,17 +2023,18 @@ namespace System.Xml
             return PreviousSiblingTail(node, sibling);
         }
 
-        private XmlNode PreviousSiblingTail(XmlNode node, XmlNode sibling)
+        private XmlNode? PreviousSiblingTail(XmlNode node, XmlNode? sibling)
         {
+            XmlNode? current = node;
             while (sibling == null)
             {
-                node = node.ParentNode;
-                if (node == null
-                    || node.NodeType != XmlNodeType.EntityReference)
+                current = current.ParentNode;
+                if (current == null
+                    || current.NodeType != XmlNodeType.EntityReference)
                 {
                     return null;
                 }
-                sibling = node.PreviousSibling;
+                sibling = current.PreviousSibling;
             }
             while (sibling != null
                    && sibling.NodeType == XmlNodeType.EntityReference)
@@ -2024,9 +2044,9 @@ namespace System.Xml
             return sibling;
         }
 
-        private XmlNode PreviousText(XmlNode node)
+        private XmlNode? PreviousText(XmlNode node)
         {
-            XmlNode text = node.PreviousText;
+            XmlNode? text = node.PreviousText;
 
             if (!_document.HasEntityReferences)
             {
@@ -2035,7 +2055,7 @@ namespace System.Xml
             return PreviousTextTail(node, text);
         }
 
-        private XmlNode PreviousTextTail(XmlNode node, XmlNode text)
+        private XmlNode? PreviousTextTail(XmlNode node, XmlNode? text)
         {
             if (text != null)
             {
@@ -2045,16 +2065,17 @@ namespace System.Xml
             {
                 return null;
             }
-            XmlNode sibling = node.PreviousSibling;
+            XmlNode? sibling = node.PreviousSibling;
+            XmlNode? current = node;
             while (sibling == null)
             {
-                node = node.ParentNode;
-                if (node == null
-                    || node.NodeType != XmlNodeType.EntityReference)
+                current = current.ParentNode;
+                if (current == null
+                    || current.NodeType != XmlNodeType.EntityReference)
                 {
                     return null;
                 }
-                sibling = node.PreviousSibling;
+                sibling = current.PreviousSibling;
             }
             while (sibling != null)
             {
@@ -2075,16 +2096,17 @@ namespace System.Xml
             return null;
         }
 
-        internal static bool IsFollowingSibling(XmlNode left, XmlNode right)
+        internal static bool IsFollowingSibling(XmlNode left, [NotNullWhen(true)] XmlNode? right)
         {
+            XmlNode? currentLeft = left;
             while (true)
             {
-                left = left.NextSibling;
-                if (left == null)
+                currentLeft = currentLeft.NextSibling;
+                if (currentLeft == null)
                 {
                     break;
                 }
-                if (left == right)
+                if (currentLeft == right)
                 {
                     return true;
                 }
@@ -2096,10 +2118,10 @@ namespace System.Xml
         {
             while (true)
             {
-                XmlNode parent = bottom.ParentNode;
+                XmlNode? parent = bottom.ParentNode;
                 if (parent == null)
                 {
-                    XmlAttribute attribute = bottom as XmlAttribute;
+                    XmlAttribute? attribute = bottom as XmlAttribute;
                     if (attribute == null)
                     {
                         break;
@@ -2156,28 +2178,30 @@ namespace System.Xml
         private XmlNode TextStart(XmlNode node)
         {
             XmlNode start;
+            XmlNode? current = node;
 
             do
             {
-                start = node;
-                node = PreviousSibling(node);
+                start = current;
+                current = PreviousSibling(current);
             }
-            while (node != null
-                   && node.IsText);
+            while (current != null
+                   && current.IsText);
             return start;
         }
 
         private XmlNode TextEnd(XmlNode node)
         {
             XmlNode end;
+            XmlNode? current = node;
 
             do
             {
-                end = node;
-                node = NextSibling(node);
+                end = current;
+                current = NextSibling(node);
             }
-            while (node != null
-                   && node.IsText);
+            while (current != null
+                   && current.IsText);
             return end;
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXPathNavigator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXPathNavigator.cs
@@ -115,8 +115,7 @@ namespace System.Xml
         {
             get
             {
-                XmlAttribute? attribute = _source as XmlAttribute;
-                if (attribute != null
+                if (_source is XmlAttribute attribute
                     && attribute.IsNamespace)
                 {
                     return string.Empty;
@@ -155,8 +154,7 @@ namespace System.Xml
         {
             get
             {
-                XmlAttribute? attribute = _source as XmlAttribute;
-                if (attribute != null
+                if (_source is XmlAttribute attribute
                     && attribute.IsNamespace)
                 {
                     return string.Empty;
@@ -183,7 +181,10 @@ namespace System.Xml
                         return ValueText;
                     default:
                         Debug.Assert(_source.Value != null);
-                        // TODO: It could be better to switch this to nullable even if that implies switching it in the base type.
+                        // TODO-NULLABLE: Consider switching this.Value to nullable even if that implies switching it in the base type.
+                        // Also consider the following:
+                        //   * this.SetValue() does not accept null.
+                        //   * _source.Value is nullable.
                         return _source.Value;
                 }
             }
@@ -223,7 +224,8 @@ namespace System.Xml
                            && nextSibling.IsText);
                     value = builder.ToString();
                 }
-                // TODO: Not sure if this is right, maybe we should change to return string.Empty in case of null.
+                // TODO-NULLABLE: Consider making this nullable given that _source.Value is nullable,
+                // OR we could change this getter to return string.Empty if _source.Value == null.
                 Debug.Assert(value != null);
                 return value;
             }
@@ -241,8 +243,7 @@ namespace System.Xml
         {
             get
             {
-                XmlElement? element = _source as XmlElement;
-                if (element != null)
+                if (_source is XmlElement element)
                 {
                     return element.IsEmpty;
                 }
@@ -272,8 +273,7 @@ namespace System.Xml
         {
             get
             {
-                XmlElement? element = _source as XmlElement;
-                if (element != null
+                if (_source is XmlElement element
                     && element.HasAttributes)
                 {
                     XmlAttributeCollection attributes = element.Attributes;
@@ -297,8 +297,7 @@ namespace System.Xml
 
         public override bool MoveToAttribute(string localName, string namespaceURI)
         {
-            XmlElement? element = _source as XmlElement;
-            if (element != null
+            if (_source is XmlElement element
                 && element.HasAttributes)
             {
                 XmlAttributeCollection attributes = element.Attributes;
@@ -326,8 +325,7 @@ namespace System.Xml
 
         public override bool MoveToFirstAttribute()
         {
-            XmlElement? element = _source as XmlElement;
-            if (element != null
+            if (_source is XmlElement element
                 && element.HasAttributes)
             {
                 XmlAttributeCollection attributes = element.Attributes;
@@ -347,8 +345,7 @@ namespace System.Xml
 
         public override bool MoveToNextAttribute()
         {
-            XmlAttribute? attribute = _source as XmlAttribute;
-            if (attribute == null
+            if (!(_source is XmlAttribute attribute)
                 || attribute.IsNamespace)
             {
                 return false;
@@ -378,8 +375,7 @@ namespace System.Xml
             while (node != null
                    && node.NodeType != XmlNodeType.Element)
             {
-                XmlAttribute? attribute = node as XmlAttribute;
-                if (attribute != null)
+                if (node is XmlAttribute attribute)
                 {
                     node = attribute.OwnerElement;
                 }
@@ -473,8 +469,7 @@ namespace System.Xml
 
         public override bool MoveToFirstNamespace(XPathNamespaceScope scope)
         {
-            XmlElement? element = _source as XmlElement;
-            if (element == null)
+            if (!(_source is XmlElement element))
             {
                 return false;
             }
@@ -577,8 +572,7 @@ namespace System.Xml
 
         public override bool MoveToNextNamespace(XPathNamespaceScope scope)
         {
-            XmlAttribute? attribute = _source as XmlAttribute;
-            if (attribute == null
+            if (!(_source is XmlAttribute attribute)
                 || !attribute.IsNamespace)
             {
                 return false;
@@ -856,8 +850,7 @@ namespace System.Xml
                 _source = parent;
                 return true;
             }
-            XmlAttribute? attribute = _source as XmlAttribute;
-            if (attribute != null)
+            if (_source is XmlAttribute attribute)
             {
                 parent = attribute.IsNamespace ? _namespaceParent : attribute.OwnerElement;
                 if (parent != null)
@@ -877,8 +870,7 @@ namespace System.Xml
                 XmlNode? parent = _source.ParentNode;
                 if (parent == null)
                 {
-                    XmlAttribute? attribute = _source as XmlAttribute;
-                    if (attribute == null)
+                    if (!(_source is XmlAttribute attribute))
                     {
                         break;
                     }
@@ -895,8 +887,7 @@ namespace System.Xml
 
         public override bool MoveTo(XPathNavigator other)
         {
-            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
-            if (that != null
+            if (other is DocumentXPathNavigator that
                 && _document == that._document)
             {
                 _source = that._source;
@@ -977,8 +968,7 @@ namespace System.Xml
         public override bool MoveToFollowing(string localName, string namespaceUri, XPathNavigator? end)
         {
             XmlNode? pastFollowing = null;
-            DocumentXPathNavigator? that = end as DocumentXPathNavigator;
-            if (that != null)
+            if (end is DocumentXPathNavigator that)
             {
                 if (_document != that._document)
                 {
@@ -1053,8 +1043,7 @@ namespace System.Xml
         public override bool MoveToFollowing(XPathNodeType type, XPathNavigator? end)
         {
             XmlNode? pastFollowing = null;
-            DocumentXPathNavigator? that = end as DocumentXPathNavigator;
-            if (that != null)
+            if (end is DocumentXPathNavigator that)
             {
                 if (_document != that._document)
                 {
@@ -1232,8 +1221,7 @@ namespace System.Xml
 
         public override bool IsSamePosition(XPathNavigator other)
         {
-            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
-            if (that != null)
+            if (other is DocumentXPathNavigator that)
             {
                 this.CalibrateText();
                 that.CalibrateText();
@@ -1246,8 +1234,7 @@ namespace System.Xml
 
         public override bool IsDescendant(XPathNavigator? other)
         {
-            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
-            if (that != null)
+            if (other is DocumentXPathNavigator that)
             {
                 return IsDescendant(_source, that._source);
             }
@@ -1289,7 +1276,6 @@ namespace System.Xml
                 throw new InvalidOperationException(SR.XmlDocument_NoSchemaInfo);
             }
 
-            // TODO: should we guard against null in above condition instead?
             // DocumentSchemaValidator assumes that ownedDocument can never be null.
             Debug.Assert(ownerDocument != null);
             DocumentSchemaValidator validator = new DocumentSchemaValidator(ownerDocument, schemas, validationEventHandler);
@@ -1304,8 +1290,7 @@ namespace System.Xml
             {
                 return parent;
             }
-            XmlAttribute? attribute = node as XmlAttribute;
-            if (attribute != null)
+            if (node is XmlAttribute attribute)
             {
                 return attribute.OwnerElement;
             }
@@ -1339,7 +1324,6 @@ namespace System.Xml
                 {
                     XmlElement? element = ((XmlAttribute)node1).OwnerElement;
                     Debug.Assert(element != null);
-                    // TODO: Should this also check for null instead?
                     if (element.HasAttributes)
                     {
                         XmlAttributeCollection attributes = element.Attributes;
@@ -1382,8 +1366,7 @@ namespace System.Xml
 
         public override XmlNodeOrder ComparePosition(XPathNavigator? other)
         {
-            DocumentXPathNavigator? that = other as DocumentXPathNavigator;
-            if (that == null)
+            if (!(other is DocumentXPathNavigator that))
             {
                 return XmlNodeOrder.Unknown;
             }
@@ -1436,7 +1419,6 @@ namespace System.Xml
                     return XmlNodeOrder.Before;
                 }
                 Debug.Assert(node2 != null);
-                // TODO: What ensures that node2 is not null.
                 parent2 = OwnerNode(node2);
             }
             else if (depth1 > depth2)
@@ -1452,7 +1434,6 @@ namespace System.Xml
                     return XmlNodeOrder.After;
                 }
                 Debug.Assert(node1 != null);
-                // TODO: What ensures that node1 is not null.
                 parent1 = OwnerNode(node1);
             }
 
@@ -1622,8 +1603,7 @@ namespace System.Xml
 
         public override XmlWriter ReplaceRange(XPathNavigator lastSiblingToReplace)
         {
-            DocumentXPathNavigator? that = lastSiblingToReplace as DocumentXPathNavigator;
-            if (that == null)
+            if (!(lastSiblingToReplace is DocumentXPathNavigator that))
             {
                 if (lastSiblingToReplace == null)
                 {
@@ -1680,8 +1660,7 @@ namespace System.Xml
 
         public override void DeleteRange(XPathNavigator lastSiblingToDelete)
         {
-            DocumentXPathNavigator? that = lastSiblingToDelete as DocumentXPathNavigator;
-            if (that == null)
+            if (!(lastSiblingToDelete is DocumentXPathNavigator that))
             {
                 if (lastSiblingToDelete == null)
                 {
@@ -1845,8 +1824,7 @@ namespace System.Xml
 
             while (node != null)
             {
-                XmlElement? element = node as XmlElement;
-                if (element != null
+                if (node is XmlElement element
                     && element.HasAttributes)
                 {
                     elements.Add(element);
@@ -1876,8 +1854,7 @@ namespace System.Xml
             Debug.Assert(node != null, "Undefined navigator position");
             Debug.Assert(node == _document || node.OwnerDocument == _document, "Navigator switched documents");
             _source = node;
-            XmlAttribute? attribute = node as XmlAttribute;
-            if (attribute != null)
+            if (node is XmlAttribute attribute)
             {
                 XmlElement? element = attribute.OwnerElement;
                 if (element != null)
@@ -2121,8 +2098,7 @@ namespace System.Xml
                 XmlNode? parent = bottom.ParentNode;
                 if (parent == null)
                 {
-                    XmlAttribute? attribute = bottom as XmlAttribute;
-                    if (attribute == null)
+                    if (!(bottom is XmlAttribute attribute))
                     {
                         break;
                     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXmlWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/DocumentXmlWriter.cs
@@ -472,7 +472,7 @@ namespace System.Xml
                     throw new InvalidOperationException(SR.Xdom_Node_Modify_ReadOnly);
                 }
 
-                DocumentXPathNavigator.DeleteToFollowingSibling(_start.NextSibling, _end);
+                DocumentXPathNavigator.DeleteToFollowingSibling(_start.NextSibling!, _end);
             }
 
             XmlNode fragment0 = _fragment[0];

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElement.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlElement.cs
@@ -634,10 +634,10 @@ namespace System.Xml
 
         internal override string XPLocalName { get { return LocalName; } }
 
-        internal override string? GetXPAttribute(string localName, string ns)
+        internal override string GetXPAttribute(string localName, string ns)
         {
             if (ns == OwnerDocument.strReservedXmlns)
-                return null;
+                return string.Empty;
 
             XmlAttribute? attr = GetAttributeNode(localName, ns);
             if (attr != null)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Dom/XmlNode.cs
@@ -1408,7 +1408,7 @@ namespace System.Xml
             }
         }
 
-        internal virtual string? GetXPAttribute(string localName, string namespaceURI)
+        internal virtual string GetXPAttribute(string localName, string namespaceURI)
         {
             return string.Empty;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXPathEnvironment.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXPathEnvironment.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Xml.Xsl.Qil;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
@@ -23,7 +23,7 @@ namespace System.Xml.Xsl.XPath
 
         Node Number(double value);
 
-        Node Operator(XPathOperator op, Node left, Node right);
+        Node Operator(XPathOperator op, [AllowNull] Node left, [AllowNull] Node right);
 
         Node Axis(XPathAxis xpathAxis, XPathNodeType nodeType, string? prefix, string? name);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
@@ -1,8 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Xml.XPath;
 
 namespace System.Xml.Xsl.XPath
@@ -13,7 +15,9 @@ namespace System.Xml.Xsl.XPath
         void StartBuild();
 
         // Should be called after build for result tree post-processing
-        Node EndBuild(Node result);
+        [return: MaybeNull]
+        [return: NotNullIfNotNull("result")]
+        Node EndBuild([AllowNull] Node result);
 
         Node String(string value);
 
@@ -21,7 +25,7 @@ namespace System.Xml.Xsl.XPath
 
         Node Operator(XPathOperator op, Node left, Node right);
 
-        Node Axis(XPathAxis xpathAxis, XPathNodeType nodeType, string prefix, string name);
+        Node Axis(XPathAxis xpathAxis, XPathNodeType nodeType, string? prefix, string? name);
 
         Node JoinStep(Node left, Node right);
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/IXpathBuilder.cs
@@ -9,6 +9,7 @@ using System.Xml.XPath;
 
 namespace System.Xml.Xsl.XPath
 {
+    // TODO-NULLABLE: Replace [MaybeNull] with ? once https://github.com/dotnet/runtime/pull/40197 is in.
     internal interface IXPathBuilder<Node>
     {
         // Should be called once per build

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathAxis.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathAxis.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 namespace System.Xml.Xsl.XPath
 {
     // Order is important - we use them as an index in QilAxis & AxisMask arrays

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
@@ -113,17 +113,21 @@ namespace System.Xml.Xsl.XPath
             return _f.Double(value);
         }
 
-        public virtual QilNode Operator(XPathOperator op, QilNode left, QilNode right)
+        public virtual QilNode Operator(XPathOperator op, [AllowNull] QilNode left, [AllowNull] QilNode right)
         {
             Debug.Assert(op != XPathOperator.Unknown);
-            switch (s_operatorGroup[(int)op])
+            XPathOperatorGroup opGroup = s_operatorGroup[(int)op];
+
+            Debug.Assert((opGroup != XPathOperatorGroup.Negate && right != null) || (opGroup == XPathOperatorGroup.Negate && right == null));
+
+            switch (opGroup)
             {
-                case XPathOperatorGroup.Logical: return LogicalOperator(op, left, right);
-                case XPathOperatorGroup.Equality: return EqualityOperator(op, left, right);
-                case XPathOperatorGroup.Relational: return RelationalOperator(op, left, right);
-                case XPathOperatorGroup.Arithmetic: return ArithmeticOperator(op, left, right);
-                case XPathOperatorGroup.Negate: return NegateOperator(op, left, right);
-                case XPathOperatorGroup.Union: return UnionOperator(op, left, right);
+                case XPathOperatorGroup.Logical: return LogicalOperator(op, left!, right!);
+                case XPathOperatorGroup.Equality: return EqualityOperator(op, left!, right!);
+                case XPathOperatorGroup.Relational: return RelationalOperator(op, left!, right!);
+                case XPathOperatorGroup.Arithmetic: return ArithmeticOperator(op, left!, right!);
+                case XPathOperatorGroup.Negate: return NegateOperator(op, left!);
+                case XPathOperatorGroup.Union: return UnionOperator(op, left, right!);
                 default:
                     Debug.Fail(op + " is not a valid XPathOperator");
                     return null;
@@ -272,10 +276,9 @@ namespace System.Xml.Xsl.XPath
             }
         }
 
-        private QilNode NegateOperator(XPathOperator op, QilNode left, QilNode right)
+        private QilNode NegateOperator(XPathOperator op, QilNode left)
         {
             Debug.Assert(op == XPathOperator.UnaryMinus);
-            Debug.Assert(right == null);
             return _f.Negate(_f.ConvertToNumber(left));
         }
 
@@ -296,7 +299,7 @@ namespace System.Xml.Xsl.XPath
             }
         }
 
-        private QilNode UnionOperator(XPathOperator op, QilNode left, QilNode right)
+        private QilNode UnionOperator(XPathOperator op, QilNode? left, QilNode right)
         {
             Debug.Assert(op == XPathOperator.Union);
             if (left == null)
@@ -1043,10 +1046,10 @@ namespace System.Xml.Xsl.XPath
                 }
                 else
                 {
-                    Debug.Assert(argTypes != null);
+                    Debug.Assert(args.Count == 0 || argTypes != null);
                     for (int i = 0; i < args.Count; i++)
                     {
-                        if (argTypes[i] == XmlTypeCode.Node && f.CannotBeNodeSet(args[i]))
+                        if (argTypes![i] == XmlTypeCode.Node && f.CannotBeNodeSet(args[i]))
                         {
                             throw new XPathCompileException(SR.XPath_NodeSetArgumentExpected, name, (i + 1).ToString(CultureInfo.InvariantCulture));
                         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathBuilder.cs
@@ -71,9 +71,8 @@ namespace System.Xml.Xsl.XPath
             numFixupCurrent = numFixupPosition = numFixupLast = 0;
         }
 
-        [return: MaybeNull]
         [return: NotNullIfNotNull("result")]
-        public virtual QilNode EndBuild([AllowNull] QilNode result)
+        public virtual QilNode? EndBuild(QilNode? result)
         {
             if (result == null)
             { // special door to clean builder state in exception handlers
@@ -113,7 +112,7 @@ namespace System.Xml.Xsl.XPath
             return _f.Double(value);
         }
 
-        public virtual QilNode Operator(XPathOperator op, [AllowNull] QilNode left, [AllowNull] QilNode right)
+        public virtual QilNode Operator(XPathOperator op, QilNode? left, QilNode? right)
         {
             Debug.Assert(op != XPathOperator.Unknown);
             XPathOperatorGroup opGroup = s_operatorGroup[(int)op];

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathCompileException.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathCompileException.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -9,7 +10,7 @@ namespace System.Xml.Xsl.XPath
     [Serializable]
     internal class XPathCompileException : XslLoadException
     {
-        public string queryString;
+        public string? queryString;
         public int startChar;
         public int endChar;
 
@@ -28,9 +29,9 @@ namespace System.Xml.Xsl.XPath
         internal XPathCompileException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            queryString = (string)info.GetValue("QueryString", typeof(string));
-            startChar = (int)info.GetValue("StartChar", typeof(int));
-            endChar = (int)info.GetValue("EndChar", typeof(int));
+            queryString = (string)info.GetValue("QueryString", typeof(string))!;
+            startChar = (int)info.GetValue("StartChar", typeof(int))!;
+            endChar = (int)info.GetValue("EndChar", typeof(int))!;
         }
 
         public override void GetObjectData(SerializationInfo info, StreamingContext context)
@@ -79,7 +80,7 @@ namespace System.Xml.Xsl.XPath
             }
         }
 
-        internal string MarkOutError()
+        internal string? MarkOutError()
         {
             if (queryString == null || queryString.Trim(' ').Length == 0)
             {
@@ -105,7 +106,7 @@ namespace System.Xml.Xsl.XPath
         internal override string FormatDetailedMessage()
         {
             string message = Message;
-            string error = MarkOutError();
+            string? error = MarkOutError();
 
             if (error != null && error.Length > 0)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathContext.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathContext.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 #if DontUse
 // XPathContext is not used any more but comments in it and Replacer visitor may be used to
 // optimize code XSLT generates on last().

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathOperator.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathOperator.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 namespace System.Xml.Xsl.XPath
 {
     // order is importent. We are using them as an index in OperatorGroup & QilOperator & XPathOperatorToQilNodeType arrays

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathParser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathParser.cs
@@ -57,11 +57,7 @@ namespace System.Xml.Xsl.XPath
 #endif
             }
             Debug.Assert(_posInfo.Count == 0, "PushPosInfo() and PopPosInfo() calls have been unbalanced");
-            // Many callers assume that the return value is not null.
-            // TODO: Should we instead make this method nullable?
-            // When is it possible to fall into the catch block?
-            Debug.Assert(result != null);
-            return result;
+            return result!;
         }
 
         #region Location paths and node tests

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathParser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathParser.cs
@@ -367,9 +367,7 @@ namespace System.Xml.Xsl.XPath
                 op = XPathOperator.UnaryMinus;
                 int opPrec = s_XPathOperatorPrecedence[(int)op];
                 _scanner.NextLex();
-                Node right = default;
-                Debug.Assert(right != null);
-                opnd = _builder!.Operator(op, ParseSubExpr(opPrec), right);
+                opnd = _builder!.Operator(op, ParseSubExpr(opPrec), default(Node));
             }
             else
             {
@@ -424,9 +422,7 @@ namespace System.Xml.Xsl.XPath
             if (_scanner.Kind == LexKind.Union)
             {
                 PushPosInfo(startChar, _scanner.PrevLexEnd);
-                Node left = default;
-                Debug.Assert(left != null);
-                opnd1 = _builder!.Operator(XPathOperator.Union, left, opnd1);
+                opnd1 = _builder!.Operator(XPathOperator.Union, default(Node), opnd1);
                 PopPosInfo();
 
                 while (_scanner.Kind == LexKind.Union)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathQilFactory.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathQilFactory.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System.Diagnostics;
 using System.Xml.Schema;
 using System.Xml.Xsl.Qil;
@@ -289,7 +290,7 @@ namespace System.Xml.Xsl.XPath
         }
 
         // Returns null if the given expression is never a node-set
-        public QilNode TryEnsureNodeSet(QilNode n)
+        public QilNode? TryEnsureNodeSet(QilNode n)
         {
             if (n.XmlType.IsNode && n.XmlType.IsNotRtf)
             {
@@ -307,7 +308,7 @@ namespace System.Xml.Xsl.XPath
         // Throws an exception if the given expression is never a node-set
         public QilNode EnsureNodeSet(QilNode n)
         {
-            QilNode result = TryEnsureNodeSet(n);
+            QilNode? result = TryEnsureNodeSet(n);
             if (result == null)
             {
                 throw new XPathCompileException(SR.XPath_NodeSetExpected);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathScanner.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPath/XPathScanner.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 // <spec>http://www.w3.org/TR/xpath#exprlex</spec>
 //------------------------------------------------------------------------------
 
@@ -62,9 +63,9 @@ namespace System.Xml.Xsl.XPath
         private int _curIndex;
         private char _curChar;
         private LexKind _kind;
-        private string _name;
-        private string _prefix;
-        private string _stringValue;
+        private string? _name;
+        private string? _prefix;
+        private string? _stringValue;
         private bool _canBeFunction;
         private int _lexStart;
         private int _prevLexEnd;
@@ -423,6 +424,8 @@ namespace System.Xml.Xsl.XPath
             }
             else
             {
+                Debug.Assert(_prefix != null);
+                Debug.Assert(_name != null);
                 if (_prefix.Length != 0 || _name.Length > 3)
                     return false;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/XPathConvert.cs
@@ -8,7 +8,9 @@
 *
 */
 
+#nullable enable
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace System.Xml.Xsl
@@ -2016,8 +2018,9 @@ namespace System.Xml.Xsl
                 AssertValid();
             }
 
-            public int CompareTo(object obj)
+            public int CompareTo(object? obj)
             {
+                Debug.Assert(obj != null);
                 BigInteger bi = (BigInteger)obj;
                 AssertValid();
                 bi.AssertValid();

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
@@ -63,9 +63,8 @@ namespace System.Xml.Xsl.Xslt
             filter.Variable.Binding = newBinding;
         }
 
-        [return: MaybeNull]
         [return: NotNullIfNotNull("result")]
-        public virtual QilNode EndBuild([AllowNull] QilNode result)
+        public virtual QilNode? EndBuild(QilNode? result)
         {
             Debug.Assert(_inTheBuild, "StartBuild() wasn't called");
             if (result == null)
@@ -82,7 +81,7 @@ namespace System.Xml.Xsl.Xslt
             return result;
         }
 
-        public QilNode Operator(XPathOperator op, [AllowNull] QilNode left, [AllowNull] QilNode right)
+        public QilNode Operator(XPathOperator op, QilNode? left, QilNode? right)
         {
             Debug.Assert(op == XPathOperator.Union);
             Debug.Assert(left != null);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -9,6 +10,7 @@ using System.Xml.XPath;
 using System.Xml.Schema;
 using System.Xml.Xsl.Qil;
 using System.Xml.Xsl.XPath;
+using System.Diagnostics.CodeAnalysis;
 
 namespace System.Xml.Xsl.Xslt
 {
@@ -61,7 +63,9 @@ namespace System.Xml.Xsl.Xslt
             filter.Variable.Binding = newBinding;
         }
 
-        public virtual QilNode EndBuild(QilNode result)
+        [return: MaybeNull]
+        [return: NotNullIfNotNull("result")]
+        public virtual QilNode EndBuild([AllowNull] QilNode result)
         {
             Debug.Assert(_inTheBuild, "StartBuild() wasn't called");
             if (result == null)
@@ -97,7 +101,7 @@ namespace System.Xml.Xsl.Xslt
             }
         }
 
-        private static QilLoop BuildAxisFilter(QilPatternFactory f, QilIterator itr, XPathAxis xpathAxis, XPathNodeType nodeType, string name, string nsUri)
+        private static QilLoop BuildAxisFilter(QilPatternFactory f, QilIterator itr, XPathAxis xpathAxis, XPathNodeType nodeType, string? name, string? nsUri)
         {
             QilNode nameTest = (
                 name != null && nsUri != null ? f.Eq(f.NameOf(itr), f.QName(name, nsUri)) : // ns:bar || bar
@@ -120,7 +124,7 @@ namespace System.Xml.Xsl.Xslt
             return filter;
         }
 
-        public QilNode Axis(XPathAxis xpathAxis, XPathNodeType nodeType, string prefix, string name)
+        public QilNode Axis(XPathAxis xpathAxis, XPathNodeType nodeType, string? prefix, string? name)
         {
             Debug.Assert(
                 xpathAxis == XPathAxis.Child ||
@@ -141,7 +145,7 @@ namespace System.Xml.Xsl.Xslt
                     priority = 0.5;
                     break;
                 default:
-                    string nsUri = prefix == null ? null : _environment.ResolvePrefix(prefix);
+                    string? nsUri = prefix == null ? null : _environment.ResolvePrefix(prefix);
                     result = BuildAxisFilter(_f, _f.For(_fixupNode), xpathAxis, nodeType, name, nsUri);
                     switch (nodeType)
                     {
@@ -214,7 +218,9 @@ namespace System.Xml.Xsl.Xslt
                 }
             }
             Debug.Assert(right.NodeType == QilNodeType.Filter);
-            QilLoop lastParent = GetLastParent(right);
+            QilLoop? lastParent = GetLastParent(right);
+            Debug.Assert(lastParent != null);
+
             FixupFilterBinding(parentFilter, ancestor ? _f.Ancestor(lastParent.Variable) : _f.Parent(lastParent.Variable));
             lastParent.Body = _f.And(lastParent.Body, _f.Not(_f.IsEmpty(parentFilter)));
             SetPriority(right, 0.5);
@@ -336,7 +342,7 @@ namespace System.Xml.Xsl.Xslt
         private class Annotation
         {
             public double Priority;
-            public QilLoop Parent;
+            public QilLoop? Parent;
         }
 
         public static void SetPriority(QilNode node, double priority)
@@ -359,7 +365,7 @@ namespace System.Xml.Xsl.Xslt
             node.Annotation = ann;
         }
 
-        private static QilLoop GetLastParent(QilNode node)
+        private static QilLoop? GetLastParent(QilNode node)
         {
             return ((Annotation)node.Annotation).Parent;
         }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternBuilder.cs
@@ -82,7 +82,7 @@ namespace System.Xml.Xsl.Xslt
             return result;
         }
 
-        public QilNode Operator(XPathOperator op, QilNode left, QilNode right)
+        public QilNode Operator(XPathOperator op, [AllowNull] QilNode left, [AllowNull] QilNode right)
         {
             Debug.Assert(op == XPathOperator.Union);
             Debug.Assert(left != null);

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternParser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternParser.cs
@@ -24,7 +24,7 @@ namespace System.Xml.Xsl.Xslt
         private IPatternBuilder? _ptrnBuilder;
         private readonly XPathParser _predicateParser = new XPathParser();
 
-        public QilNode? Parse(XPathScanner scanner, IPatternBuilder ptrnBuilder)
+        public QilNode Parse(XPathScanner scanner, IPatternBuilder ptrnBuilder)
         {
             Debug.Assert(_scanner == null && _ptrnBuilder == null);
             Debug.Assert(scanner != null && ptrnBuilder != null);
@@ -45,7 +45,7 @@ namespace System.Xml.Xsl.Xslt
                 _scanner = null;
 #endif
             }
-            return result;
+            return result!;
         }
 
         /*

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternParser.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/Xslt/XPathPatternParser.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#nullable enable
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml;
@@ -19,15 +20,15 @@ namespace System.Xml.Xsl.Xslt
             IXPathBuilder<QilNode> GetPredicateBuilder(QilNode context);
         }
 
-        private XPathScanner _scanner;
-        private IPatternBuilder _ptrnBuilder;
+        private XPathScanner? _scanner;
+        private IPatternBuilder? _ptrnBuilder;
         private readonly XPathParser _predicateParser = new XPathParser();
 
-        public QilNode Parse(XPathScanner scanner, IPatternBuilder ptrnBuilder)
+        public QilNode? Parse(XPathScanner scanner, IPatternBuilder ptrnBuilder)
         {
             Debug.Assert(_scanner == null && _ptrnBuilder == null);
             Debug.Assert(scanner != null && ptrnBuilder != null);
-            QilNode result = null;
+            QilNode? result = null;
             ptrnBuilder.StartBuild();
             try
             {
@@ -54,10 +55,10 @@ namespace System.Xml.Xsl.Xslt
         {
             QilNode opnd = ParseLocationPathPattern();
 
-            while (_scanner.Kind == LexKind.Union)
+            while (_scanner!.Kind == LexKind.Union)
             {
                 _scanner.NextLex();
-                opnd = _ptrnBuilder.Operator(XPathOperator.Union, opnd, ParseLocationPathPattern());
+                opnd = _ptrnBuilder!.Operator(XPathOperator.Union, opnd, ParseLocationPathPattern());
             }
             return opnd;
         }
@@ -69,11 +70,11 @@ namespace System.Xml.Xsl.Xslt
         {
             QilNode opnd;
 
-            switch (_scanner.Kind)
+            switch (_scanner!.Kind)
             {
                 case LexKind.Slash:
                     _scanner.NextLex();
-                    opnd = _ptrnBuilder.Axis(XPathAxis.Root, XPathNodeType.All, null, null);
+                    opnd = _ptrnBuilder!.Axis(XPathAxis.Root, XPathNodeType.All, null, null);
 
                     if (XPathParser.IsStep(_scanner.Kind))
                     {
@@ -82,7 +83,7 @@ namespace System.Xml.Xsl.Xslt
                     return opnd;
                 case LexKind.SlashSlash:
                     _scanner.NextLex();
-                    return _ptrnBuilder.JoinStep(
+                    return _ptrnBuilder!.JoinStep(
                         _ptrnBuilder.Axis(XPathAxis.Root, XPathNodeType.All, null, null),
                         _ptrnBuilder.JoinStep(
                             _ptrnBuilder.Axis(XPathAxis.DescendantOrSelf, XPathNodeType.All, null, null),
@@ -97,11 +98,11 @@ namespace System.Xml.Xsl.Xslt
                         {
                             case LexKind.Slash:
                                 _scanner.NextLex();
-                                opnd = _ptrnBuilder.JoinStep(opnd, ParseRelativePathPattern());
+                                opnd = _ptrnBuilder!.JoinStep(opnd, ParseRelativePathPattern());
                                 break;
                             case LexKind.SlashSlash:
                                 _scanner.NextLex();
-                                opnd = _ptrnBuilder.JoinStep(opnd,
+                                opnd = _ptrnBuilder!.JoinStep(opnd,
                                     _ptrnBuilder.JoinStep(
                                         _ptrnBuilder.Axis(XPathAxis.DescendantOrSelf, XPathNodeType.All, null, null),
                                         ParseRelativePathPattern()
@@ -122,7 +123,7 @@ namespace System.Xml.Xsl.Xslt
         */
         private QilNode ParseIdKeyPattern()
         {
-            Debug.Assert(_scanner.CanBeFunction);
+            Debug.Assert(_scanner!.CanBeFunction);
             Debug.Assert(_scanner.Prefix.Length == 0);
             Debug.Assert(_scanner.Name == "id" || _scanner.Name == "key");
             List<QilNode> args = new List<QilNode>(2);
@@ -132,7 +133,7 @@ namespace System.Xml.Xsl.Xslt
                 _scanner.NextLex();
                 _scanner.PassToken(LexKind.LParens);
                 _scanner.CheckToken(LexKind.String);
-                args.Add(_ptrnBuilder.String(_scanner.StringValue));
+                args.Add(_ptrnBuilder!.String(_scanner.StringValue));
                 _scanner.NextLex();
                 _scanner.PassToken(LexKind.RParens);
                 return _ptrnBuilder.Function("", "id", args);
@@ -142,7 +143,7 @@ namespace System.Xml.Xsl.Xslt
                 _scanner.NextLex();
                 _scanner.PassToken(LexKind.LParens);
                 _scanner.CheckToken(LexKind.String);
-                args.Add(_ptrnBuilder.String(_scanner.StringValue));
+                args.Add(_ptrnBuilder!.String(_scanner.StringValue));
                 _scanner.NextLex();
                 _scanner.PassToken(LexKind.Comma);
                 _scanner.CheckToken(LexKind.String);
@@ -165,19 +166,19 @@ namespace System.Xml.Xsl.Xslt
             {
                 if (LocalAppContextSwitches.LimitXPathComplexity)
                 {
-                    throw _scanner.CreateException(SR.Xslt_InputTooComplex);
+                    throw _scanner!.CreateException(SR.Xslt_InputTooComplex);
                 }
             }
             QilNode opnd = ParseStepPattern();
-            if (_scanner.Kind == LexKind.Slash)
+            if (_scanner!.Kind == LexKind.Slash)
             {
                 _scanner.NextLex();
-                opnd = _ptrnBuilder.JoinStep(opnd, ParseRelativePathPattern());
+                opnd = _ptrnBuilder!.JoinStep(opnd, ParseRelativePathPattern());
             }
             else if (_scanner.Kind == LexKind.SlashSlash)
             {
                 _scanner.NextLex();
-                opnd = _ptrnBuilder.JoinStep(opnd,
+                opnd = _ptrnBuilder!.JoinStep(opnd,
                     _ptrnBuilder.JoinStep(
                         _ptrnBuilder.Axis(XPathAxis.DescendantOrSelf, XPathNodeType.All, null, null),
                         ParseRelativePathPattern()
@@ -197,7 +198,7 @@ namespace System.Xml.Xsl.Xslt
             QilNode opnd;
             XPathAxis axis;
 
-            switch (_scanner.Kind)
+            switch (_scanner!.Kind)
             {
                 case LexKind.Dot:
                 case LexKind.DotDot:
@@ -225,11 +226,11 @@ namespace System.Xml.Xsl.Xslt
             }
 
             XPathNodeType nodeType;
-            string nodePrefix, nodeName;
+            string? nodePrefix, nodeName;
             XPathParser.InternalParseNodeTest(_scanner, axis, out nodeType, out nodePrefix, out nodeName);
-            opnd = _ptrnBuilder.Axis(axis, nodeType, nodePrefix, nodeName);
+            opnd = _ptrnBuilder!.Axis(axis, nodeType, nodePrefix, nodeName);
 
-            XPathPatternBuilder xpathPatternBuilder = _ptrnBuilder as XPathPatternBuilder;
+            XPathPatternBuilder? xpathPatternBuilder = _ptrnBuilder as XPathPatternBuilder;
             if (xpathPatternBuilder != null)
             {
                 //for XPathPatternBuilder, get all predicates and then build them
@@ -256,9 +257,9 @@ namespace System.Xml.Xsl.Xslt
         */
         private QilNode ParsePredicate(QilNode context)
         {
-            Debug.Assert(_scanner.Kind == LexKind.LBracket);
+            Debug.Assert(_scanner!.Kind == LexKind.LBracket);
             _scanner.NextLex();
-            QilNode result = _predicateParser.Parse(_scanner, _ptrnBuilder.GetPredicateBuilder(context), LexKind.RBracket);
+            QilNode result = _predicateParser.Parse(_scanner, _ptrnBuilder!.GetPredicateBuilder(context), LexKind.RBracket);
             Debug.Assert(_scanner.Kind == LexKind.RBracket);
             _scanner.NextLex();
             return result;


### PR DESCRIPTION
*Please pay attention to the TODOs inlined.*

This finishes nullability annotations of `*XPath*.cs` files.
There is still XPath-related code within files that doesn't include XPath in their name, those will be eventually annotated in subsequent PRs.