### PR TITLE
Bump timeout in global-build.yml for debug runtime builds

### DIFF
--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -48,6 +48,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: Runtime_Debug
       buildArgs: -c release -runtimeConfiguration debug
+      timeoutInMinutes: 120
 
 #
 # Build with Debug config and Release runtimeConfiguration


### PR DESCRIPTION
A good build of the `runtime-live-build` pipeline takes between 45-55mins for the debug runtime configurations already so we sometimes run into the 60mins default Azure DevOps timeout if we happen to catch a slow machine.

Bumping the timeout to 120mins like we do in other pipelines to fix this.

Examples:
- https://dev.azure.com/dnceng/public/_build/results?buildId=756266&view=results
- https://dev.azure.com/dnceng/public/_build/results?buildId=756168&view=results
- https://dev.azure.com/dnceng/public/_build/results?buildId=756114&view=results