### PR TITLE
[browser][io] Workaround for issue MoveDirectory

### DIFF
--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -382,6 +382,8 @@ namespace System.IO
             }
 
 #if TARGET_BROWSER
+            // renaming a file doesn't return correct error code on emscripten if one of the parent paths does not exist,
+            // manually workaround it for now (https://github.com/dotnet/runtime/issues/40305)
             if (!Directory.Exists(Path.GetDirectoryName(sourceFullPath)))
             {
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));

--- a/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs
@@ -381,6 +381,17 @@ namespace System.IO
                 throw new IOException(SR.Format(SR.IO_AlreadyExists_Name, destFullPath));
             }
 
+#if TARGET_BROWSER
+            if (!Directory.Exists(Path.GetDirectoryName(sourceFullPath)))
+            {
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+            }
+            if (!Directory.Exists(Path.GetDirectoryName(destFullPath)))
+            {
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destFullPath));
+            }
+#endif
+
             if (Interop.Sys.Rename(sourceFullPath, destFullPath) < 0)
             {
                 Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();


### PR DESCRIPTION
- Issue workaround while waiting for emscripten fix.  https://github.com/dotnet/runtime/issues/40305
- The following code checks for the existence of the source and destination directories which replaces the same code in the emscripten code.

emscripten tracking issue:  https://github.com/emscripten-core/emscripten/issues/11804

This will allow the issue to be resolved in the tests without waiting for emscripten release.