### PR TITLE
Mono: Ensure tasklets are removed in netcore build

### DIFF
--- a/src/mono/mono/metadata/object-offsets.h
+++ b/src/mono/mono/metadata/object-offsets.h
@@ -167,11 +167,13 @@ DECL_OFFSET(MonoJitTlsData, stack_restore_ctx)
 DECL_OFFSET(MonoGSharedVtMethodRuntimeInfo, locals_size)
 DECL_OFFSET(MonoGSharedVtMethodRuntimeInfo, entries) //XXX more to fix here
 
+#if !defined(ENABLE_NETCORE)
 DECL_OFFSET(MonoContinuation, stack_used_size)
 DECL_OFFSET(MonoContinuation, saved_stack)
 DECL_OFFSET(MonoContinuation, return_sp)
 DECL_OFFSET(MonoContinuation, lmf)
 DECL_OFFSET(MonoContinuation, return_ip)
+#endif
 
 DECL_OFFSET(MonoDelegateTrampInfo, method)
 DECL_OFFSET(MonoDelegateTrampInfo, invoke_impl)

--- a/src/mono/mono/mini/exceptions-amd64.c
+++ b/src/mono/mono/mini/exceptions-amd64.c
@@ -1905,7 +1905,7 @@ void mono_arch_code_chunk_destroy (void *chunk)
 }
 #endif /* MONO_ARCH_HAVE_UNWIND_TABLE */
 
-#if MONO_SUPPORT_TASKLETS && !defined(DISABLE_JIT)
+#if MONO_SUPPORT_TASKLETS && !defined(DISABLE_JIT) && !defined(ENABLE_NETCORE)
 MonoContinuationRestore
 mono_tasklets_arch_restore (void)
 {
@@ -1956,7 +1956,7 @@ mono_tasklets_arch_restore (void)
 	saved = start;
 	return (MonoContinuationRestore)saved;
 }
-#endif /* MONO_SUPPORT_TASKLETS && !defined(DISABLE_JIT) */
+#endif /* MONO_SUPPORT_TASKLETS && !defined(DISABLE_JIT) && !defined(ENABLE_NETCORE) */
 
 /*
  * mono_arch_setup_resume_sighandler_ctx:
@@ -1975,14 +1975,14 @@ mono_arch_setup_resume_sighandler_ctx (MonoContext *ctx, gpointer func)
 	MONO_CONTEXT_SET_IP (ctx, func);
 }
 
-#if !MONO_SUPPORT_TASKLETS || defined(DISABLE_JIT)
+#if (!MONO_SUPPORT_TASKLETS || defined(DISABLE_JIT)) && !defined(ENABLE_NETCORE)
 MonoContinuationRestore
 mono_tasklets_arch_restore (void)
 {
 	g_assert_not_reached ();
 	return NULL;
 }
-#endif /* !MONO_SUPPORT_TASKLETS || defined(DISABLE_JIT) */
+#endif /* (!MONO_SUPPORT_TASKLETS || defined(DISABLE_JIT)) && !defined(ENABLE_NETCORE) */
 
 void
 mono_arch_undo_ip_adjustment (MonoContext *ctx)

--- a/src/mono/mono/mini/exceptions-x86.c
+++ b/src/mono/mono/mini/exceptions-x86.c
@@ -1175,7 +1175,7 @@ mono_arch_handle_altstack_exception (void *sigctx, MONO_SIG_HANDLER_INFO_TYPE *s
 #endif
 }
 
-#if MONO_SUPPORT_TASKLETS
+#if MONO_SUPPORT_TASKLETS && !defined(ENABLE_NETCORE)
 MonoContinuationRestore
 mono_tasklets_arch_restore (void)
 {

--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -4596,7 +4596,9 @@ mini_init (const char *filename, const char *runtime_version)
 	mono_simd_intrinsics_init ();
 #endif
 
+#ifndef ENABLE_NETCORE
 	mono_tasklets_init ();
+#endif
 
 	register_trampolines (domain);
 

--- a/src/mono/mono/mini/tasklets.c
+++ b/src/mono/mono/mini/tasklets.c
@@ -12,6 +12,7 @@
 #include "mono/metadata/loader-internals.h"
 #include "mono/utils/mono-tls-inline.h"
 
+#if !defined(ENABLE_NETCORE)
 #if defined(MONO_SUPPORT_TASKLETS)
 
 #include "mono/metadata/loader-internals.h"
@@ -213,5 +214,7 @@ mono_tasklets_init(void)
 	mono_add_internal_call_internal ("Mono.Tasklets.Continuation::restore", continuation_restore);
 
 }
-#endif
+#endif /* MONO_SUPPORT_TASKLETS */
+
+#endif /* ENABLE_NETCORE */
 

--- a/src/mono/mono/mini/tasklets.h
+++ b/src/mono/mono/mini/tasklets.h
@@ -7,6 +7,7 @@
 
 #include "mini.h"
 
+#if !defined(ENABLE_NETCORE)
 typedef struct {
 	MonoLMF *lmf;
 	gpointer top_sp;
@@ -30,6 +31,8 @@ void  mono_tasklets_init    (void);
 void  mono_tasklets_cleanup (void);
 
 MonoContinuationRestore mono_tasklets_arch_restore (void);
+
+#endif /* ENABLE_NETCORE */
 
 #endif /* __MONO_TASKLETS_H__ */
 


### PR DESCRIPTION
Tasklets were an old mono-specific extension for continuations that is no longer relevant.