### PR TITLE
Make macOS targets in global build job template default to 120 minutes timeout

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -25,10 +25,16 @@ jobs:
     dependsOn: checkout
     pool: ${{ parameters.pool }}
     container: ${{ parameters.container }}
-    timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
     condition: and(succeeded(), ${{ parameters.condition }})
     workspace:
       clean: all
+
+    # macOS hosted pool machines are slower so we need to give a greater timeout for global-build
+    # which builds multiple subsets.
+    ${{ if and(contains(parameters.pool.vmImage, 'macOS'), eq(parameters.timeoutInMinutes, '')) }}:
+      timeoutInMinutes: 120
+    ${{ if or(not(contains(parameters.pool.vmImage, 'macOS')), ne(parameters.timeoutInMinutes, '')) }}:
+      timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
 
     variables:
       - name: _osParameter

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -48,7 +48,6 @@ jobs:
       testGroup: innerloop
       nameSuffix: Runtime_Debug
       buildArgs: -c release -runtimeConfiguration debug
-      timeoutInMinutes: 120
 
 #
 # Build with Debug config and Release runtimeConfiguration


### PR DESCRIPTION
macOS hosted pools are migrating however the new machines have less cores and our global builds take longer so we're seeing timeouts.

tested in: https://dev.azure.com/dnceng/public/_build/results?buildId=756902&view=results
the expanded yml looks like this:

```yml
  - job: build_tvOS_arm64_Release_AllSubsets_Mono
    condition: >-
      and(succeeded(), or(
        eq(dependencies.checkout.outputs['SetPathVars_libraries.containsChange'], true),
        eq(dependencies.checkout.outputs['SetPathVars_mono.containsChange'], true),
        eq(dependencies.checkout.outputs['SetPathVars_installer.containsChange'], true),
        eq(variables['isFullMatrix'], true)))
    continueOnError: false
    dependsOn:
    - checkout
    displayName: Build tvOS arm64 Release AllSubsets_Mono
    pool:
      vmImage: macOS-10.14
    timeoutInMinutes: 120
```

I didn't put it in `xplat-setup.yml` for all jobs as it seems like the long poles are the global-build jobs which build multiple subsets as part of the same job. However if we start seeing other individual legs that don't use global-build jobs, I can adjust and move it to `xplat-setup.yml`.

