### PR TITLE
Generational aware analysis based on environment variable.

### DIFF
--- a/src/coreclr/src/gc/env/gcenv.ee.h
+++ b/src/coreclr/src/gc/env/gcenv.ee.h
@@ -86,7 +86,7 @@ public:
     static uint32_t GetTotalNumSizedRefHandles();
 
     static bool AnalyzeSurvivorsRequested(int condemnedGeneration);
-    static void AnalyzeSurvivorsFinished(int condemnedGeneration);
+    static void AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)());
 
     static void VerifySyncTableEntry();
     static void UpdateGCEventStatus(int publicLevel, int publicKeywords, int privateLevel, int privateKeywords);

--- a/src/coreclr/src/gc/env/gcenv.ee.h
+++ b/src/coreclr/src/gc/env/gcenv.ee.h
@@ -86,7 +86,7 @@ public:
     static uint32_t GetTotalNumSizedRefHandles();
 
     static bool AnalyzeSurvivorsRequested(int condemnedGeneration);
-    static void AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)());
+    static void AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)());
 
     static void VerifySyncTableEntry();
     static void UpdateGCEventStatus(int publicLevel, int publicKeywords, int privateLevel, int privateKeywords);

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -20909,26 +20909,19 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
     if (gc_t_join.joined())
 #endif //MULTIPLE_HEAPS
     {
-        uint64_t promoted_bytes = 0;
+        uint64_t total_promoted_bytes = 0;
 #ifdef HEAP_ANALYZE
         heap_analyze_enabled = FALSE;
 #ifdef MULTIPLE_HEAPS
         for (int i = 0; i < n_heaps; i++)
         {
-            promoted_bytes += g_promoted[i * 16];
+            promoted_bytes (i);
         }
 #else
-        promoted_bytes = g_promoted;
+        total_promoted_bytes = promoted_bytes (0);
 #endif //MULTIPLE_HEAPS
 
-        GCToEEInterface::AnalyzeSurvivorsFinished(condemned_gen_number, promoted_bytes, [](){
-            g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
-            {
-                uint64_t range = static_cast<uint64_t>(rangeEnd - rangeStart);
-                uint64_t rangeReserved = static_cast<uint64_t>(rangeEndReserved - rangeStart);
-                FIRE_EVENT(GCGenerationRange, generation, rangeStart, range, rangeReserved);
-            }, nullptr);
-        });
+        GCToEEInterface::AnalyzeSurvivorsFinished (condemned_gen_number, total_promoted_bytes, reportGenerationBounds);
 #endif // HEAP_ANALYZE
         GCToEEInterface::AfterGcScanRoots (condemned_gen_number, max_generation, &sc);
 

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -20909,9 +20909,26 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
     if (gc_t_join.joined())
 #endif //MULTIPLE_HEAPS
     {
+        uint64_t promoted_bytes = 0;
 #ifdef HEAP_ANALYZE
         heap_analyze_enabled = FALSE;
-        GCToEEInterface::AnalyzeSurvivorsFinished(condemned_gen_number);
+#ifdef MULTIPLE_HEAPS
+        for (int i = 0; i < n_heaps; i++)
+        {
+            promoted_bytes += g_promoted[i * 16];
+        }
+#else
+        promoted_bytes = g_promoted;
+#endif //MULTIPLE_HEAPS
+
+        GCToEEInterface::AnalyzeSurvivorsFinished(condemned_gen_number, promoted_bytes, [](){
+            g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
+            {
+                uint64_t range = static_cast<uint64_t>(rangeEnd - rangeStart);
+                uint64_t rangeReserved = static_cast<uint64_t>(rangeEndReserved - rangeStart);
+                FIRE_EVENT(GCGenerationRange, generation, rangeStart, range, rangeReserved);
+            }, nullptr);
+        });
 #endif // HEAP_ANALYZE
         GCToEEInterface::AfterGcScanRoots (condemned_gen_number, max_generation, &sc);
 

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -20921,7 +20921,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
         promoted_bytes_global = promoted_bytes (0);
 #endif //MULTIPLE_HEAPS
 
-        GCToEEInterface::AnalyzeSurvivorsFinished (condemned_gen_number, promoted_bytes_global, GCHeap::ReportGenerationBounds);
+        GCToEEInterface::AnalyzeSurvivorsFinished (settings.gc_index, condemned_gen_number, promoted_bytes_global, GCHeap::ReportGenerationBounds);
 #endif // HEAP_ANALYZE
         GCToEEInterface::AfterGcScanRoots (condemned_gen_number, max_generation, &sc);
 

--- a/src/coreclr/src/gc/gc.cpp
+++ b/src/coreclr/src/gc/gc.cpp
@@ -20909,19 +20909,19 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
     if (gc_t_join.joined())
 #endif //MULTIPLE_HEAPS
     {
-        uint64_t total_promoted_bytes = 0;
+        uint64_t promoted_bytes_global = 0;
 #ifdef HEAP_ANALYZE
         heap_analyze_enabled = FALSE;
 #ifdef MULTIPLE_HEAPS
         for (int i = 0; i < n_heaps; i++)
         {
-            promoted_bytes (i);
+            promoted_bytes_global += promoted_bytes (i);
         }
 #else
-        total_promoted_bytes = promoted_bytes (0);
+        promoted_bytes_global = promoted_bytes (0);
 #endif //MULTIPLE_HEAPS
 
-        GCToEEInterface::AnalyzeSurvivorsFinished (condemned_gen_number, total_promoted_bytes, reportGenerationBounds);
+        GCToEEInterface::AnalyzeSurvivorsFinished (condemned_gen_number, promoted_bytes_global, GCHeap::ReportGenerationBounds);
 #endif // HEAP_ANALYZE
         GCToEEInterface::AfterGcScanRoots (condemned_gen_number, max_generation, &sc);
 

--- a/src/coreclr/src/gc/gcconfig.h
+++ b/src/coreclr/src/gc/gcconfig.h
@@ -130,7 +130,7 @@ public:
     INT_CONFIG   (GCHeapHardLimitLOHPercent, "GCHeapHardLimitLOHPercent", "System.GC.HeapHardLimitLOHPercent", 0,        "Specifies the GC heap LOH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCHeapHardLimitPOHPercent, "GCHeapHardLimitPOHPercent", "System.GC.HeapHardLimitPOHPercent", 0,        "Specifies the GC heap POH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCEnabledInstructionSets,  "GCEnabledInstructionSets",  NULL,                                -1,       "Specifies whether GC can use AVX2 or AVX512F - 0 for neither, 1 for AVX2, 3 for AVX512F")\
-    INT_CONFIG   (GCGenAnalysisGen,       "GCGenAnalysisGen",       NULL,                             999,               "Specifies which generation to analysis")                                                 \
+    INT_CONFIG   (GCGenAnalysisGen,       "GCGenAnalysisGen",       NULL,                             -1,                "Specifies which generation to analysis")                                                 \
     INT_CONFIG   (GCGenAnalysisBytes,     "GCGenAnalysisBytes",     NULL,                             0,                 "Specifies how much promoted bytes to trigger generation analysis")                       \
 
 // This class is responsible for retreiving configuration information

--- a/src/coreclr/src/gc/gcconfig.h
+++ b/src/coreclr/src/gc/gcconfig.h
@@ -130,8 +130,6 @@ public:
     INT_CONFIG   (GCHeapHardLimitLOHPercent, "GCHeapHardLimitLOHPercent", "System.GC.HeapHardLimitLOHPercent", 0,        "Specifies the GC heap LOH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCHeapHardLimitPOHPercent, "GCHeapHardLimitPOHPercent", "System.GC.HeapHardLimitPOHPercent", 0,        "Specifies the GC heap POH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCEnabledInstructionSets,  "GCEnabledInstructionSets",  NULL,                                -1,       "Specifies whether GC can use AVX2 or AVX512F - 0 for neither, 1 for AVX2, 3 for AVX512F")\
-    INT_CONFIG   (GCGenAnalysisGen,       "GCGenAnalysisGen",       NULL,                             -1,                "Specifies which generation to analysis")                                                 \
-    INT_CONFIG   (GCGenAnalysisBytes,     "GCGenAnalysisBytes",     NULL,                             0,                 "Specifies how much promoted bytes to trigger generation analysis")                       \
 
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.

--- a/src/coreclr/src/gc/gcconfig.h
+++ b/src/coreclr/src/gc/gcconfig.h
@@ -130,6 +130,8 @@ public:
     INT_CONFIG   (GCHeapHardLimitLOHPercent, "GCHeapHardLimitLOHPercent", "System.GC.HeapHardLimitLOHPercent", 0,        "Specifies the GC heap LOH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCHeapHardLimitPOHPercent, "GCHeapHardLimitPOHPercent", "System.GC.HeapHardLimitPOHPercent", 0,        "Specifies the GC heap POH usage as a percentage of the total memory")                    \
     INT_CONFIG   (GCEnabledInstructionSets,  "GCEnabledInstructionSets",  NULL,                                -1,       "Specifies whether GC can use AVX2 or AVX512F - 0 for neither, 1 for AVX2, 3 for AVX512F")\
+    INT_CONFIG   (GCGenAnalysisGen,       "GCGenAnalysisGen",       NULL,                             999,               "Specifies which generation to analysis")                                                 \
+    INT_CONFIG   (GCGenAnalysisBytes,     "GCGenAnalysisBytes",     NULL,                             0,                 "Specifies how much promoted bytes to trigger generation analysis")                       \
 
 // This class is responsible for retreiving configuration information
 // for how the GC should operate.

--- a/src/coreclr/src/gc/gcee.cpp
+++ b/src/coreclr/src/gc/gcee.cpp
@@ -53,10 +53,10 @@ void GCHeap::UpdatePreGCCounters()
 #endif // BACKGROUND_GC
 
     FIRE_EVENT(GCStart_V2, count, depth, reason, static_cast<uint32_t>(type));
-    reportGenerationBounds();
+    ReportGenerationBounds();
 }
 
-void reportGenerationBounds()
+void GCHeap::ReportGenerationBounds()
 {
     g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
     {
@@ -153,7 +153,7 @@ void GCHeap::UpdatePostGCCounters()
 #endif //FEATURE_EVENT_TRACE
 
 #ifdef FEATURE_EVENT_TRACE
-    reportGenerationBounds();
+    ReportGenerationBounds();
 
     FIRE_EVENT(GCEnd_V1, static_cast<uint32_t>(pSettings->gc_index), condemned_gen);
 

--- a/src/coreclr/src/gc/gcee.cpp
+++ b/src/coreclr/src/gc/gcee.cpp
@@ -53,6 +53,11 @@ void GCHeap::UpdatePreGCCounters()
 #endif // BACKGROUND_GC
 
     FIRE_EVENT(GCStart_V2, count, depth, reason, static_cast<uint32_t>(type));
+    reportGenerationBounds();
+}
+
+void reportGenerationBounds()
+{
     g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
     {
         uint64_t range = static_cast<uint64_t>(rangeEnd - rangeStart);
@@ -148,12 +153,7 @@ void GCHeap::UpdatePostGCCounters()
 #endif //FEATURE_EVENT_TRACE
 
 #ifdef FEATURE_EVENT_TRACE
-    g_theGCHeap->DiagDescrGenerations([](void*, int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
-    {
-        uint64_t range = static_cast<uint64_t>(rangeEnd - rangeStart);
-        uint64_t rangeReserved = static_cast<uint64_t>(rangeEndReserved - rangeStart);
-        FIRE_EVENT(GCGenerationRange, generation, rangeStart, range, rangeReserved);
-    }, nullptr);
+    reportGenerationBounds();
 
     FIRE_EVENT(GCEnd_V1, static_cast<uint32_t>(pSettings->gc_index), condemned_gen);
 

--- a/src/coreclr/src/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/src/gc/gcenv.ee.standalone.inl
@@ -274,10 +274,10 @@ inline bool GCToEEInterface::AnalyzeSurvivorsRequested(int condemnedGeneration)
     return g_theGCToCLR->AnalyzeSurvivorsRequested(condemnedGeneration);
 }
 
-inline void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
+inline void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
 {
     assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->AnalyzeSurvivorsFinished(condemnedGeneration, promoted_bytes, reportGenerationBounds);
+    g_theGCToCLR->AnalyzeSurvivorsFinished(gcIndex, condemnedGeneration, promoted_bytes, reportGenerationBounds);
 }
 
 inline void GCToEEInterface::VerifySyncTableEntry()

--- a/src/coreclr/src/gc/gcenv.ee.standalone.inl
+++ b/src/coreclr/src/gc/gcenv.ee.standalone.inl
@@ -274,10 +274,10 @@ inline bool GCToEEInterface::AnalyzeSurvivorsRequested(int condemnedGeneration)
     return g_theGCToCLR->AnalyzeSurvivorsRequested(condemnedGeneration);
 }
 
-inline void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration)
+inline void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
 {
     assert(g_theGCToCLR != nullptr);
-    g_theGCToCLR->AnalyzeSurvivorsFinished(condemnedGeneration);
+    g_theGCToCLR->AnalyzeSurvivorsFinished(condemnedGeneration, promoted_bytes, reportGenerationBounds);
 }
 
 inline void GCToEEInterface::VerifySyncTableEntry()

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -315,8 +315,8 @@ public:
     size_t GetLastGCGenerationSize(int gen);
 
     virtual void Shutdown();
-};
 
-void reportGenerationBounds();
+    static void ReportGenerationBounds();
+};
 
 #endif  // GCIMPL_H_

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -317,4 +317,6 @@ public:
     virtual void Shutdown();
 };
 
+void reportGenerationBounds();
+
 #endif  // GCIMPL_H_

--- a/src/coreclr/src/gc/gcimpl.h
+++ b/src/coreclr/src/gc/gcimpl.h
@@ -31,7 +31,7 @@ inline void deleteGCShadow() {}
 inline void checkGCWriteBarrier() {}
 #endif
 
-void GCProfileWalkHeap();
+void GCProfileWalkHeap(bool etwOnly);
 
 class gc_heap;
 class CFinalize;
@@ -57,7 +57,7 @@ protected:
     friend void EnterAllocLock();
     friend void LeaveAllocLock();
     friend void ProfScanRootsHelper(Object** object, ScanContext *pSC, uint32_t dwFlags);
-    friend void GCProfileWalkHeap();
+    friend void GCProfileWalkHeap(bool etwOnly);
 
 public:
     //In order to keep gc.cpp cleaner, ugly EE specific code is relegated to methods.

--- a/src/coreclr/src/gc/gcinterface.ee.h
+++ b/src/coreclr/src/gc/gcinterface.ee.h
@@ -414,7 +414,7 @@ public:
     bool AnalyzeSurvivorsRequested(int condemnedGeneration) = 0;
 
     virtual
-    void AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)()) = 0;
+    void AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)()) = 0;
 
     virtual
     void VerifySyncTableEntry() = 0;

--- a/src/coreclr/src/gc/gcinterface.ee.h
+++ b/src/coreclr/src/gc/gcinterface.ee.h
@@ -414,7 +414,7 @@ public:
     bool AnalyzeSurvivorsRequested(int condemnedGeneration) = 0;
 
     virtual
-    void AnalyzeSurvivorsFinished(int condemnedGeneration) = 0;
+    void AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)()) = 0;
 
     virtual
     void VerifySyncTableEntry() = 0;

--- a/src/coreclr/src/gc/sample/gcenv.ee.cpp
+++ b/src/coreclr/src/gc/sample/gcenv.ee.cpp
@@ -339,7 +339,7 @@ inline bool GCToEEInterface::AnalyzeSurvivorsRequested(int condemnedGeneration)
     return false;
 }
 
-inline void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration)
+inline void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
 {
 
 }

--- a/src/coreclr/src/gc/sample/gcenv.ee.cpp
+++ b/src/coreclr/src/gc/sample/gcenv.ee.cpp
@@ -339,7 +339,7 @@ inline bool GCToEEInterface::AnalyzeSurvivorsRequested(int condemnedGeneration)
     return false;
 }
 
-inline void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
+inline void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
 {
 
 }

--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -712,8 +712,9 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"
 // 
 // Generational Aware Analysis
 // 
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisGen, W("GCGenAnalysisGen"), 0, "TBD")
-RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisBytes, W("GCGenAnalysisBytes"), 0, "TBD")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisGen, W("GCGenAnalysisGen"), 0, "The generation to trigger generational aware analysis")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisBytes, W("GCGenAnalysisBytes"), 0, "The number of bytes to trigger generational aware analysis")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisIndex, W("GCGenAnalysisIndex"), 0, "The gc index to trigger generational aware analysis")
 
 //
 // Diagnostics Ports

--- a/src/coreclr/src/inc/clrconfigvalues.h
+++ b/src/coreclr/src/inc/clrconfigvalues.h
@@ -709,6 +709,12 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeRundown, W("EventPipeRundown"), 1, "E
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeCircularMB, W("EventPipeCircularMB"), 1024, "The EventPipe circular buffer size in megabytes.")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"), 0, "Enable/disable capturing processor numbers in EventPipe event headers")
 
+// 
+// Generational Aware Analysis
+// 
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisGen, W("GCGenAnalysisGen"), 0, "TBD")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_GCGenAnalysisBytes, W("GCGenAnalysisBytes"), 0, "TBD")
+
 //
 // Diagnostics Ports
 //

--- a/src/coreclr/src/vm/CMakeLists.txt
+++ b/src/coreclr/src/vm/CMakeLists.txt
@@ -357,6 +357,7 @@ set(VM_SOURCES_WKS
     gcenv.ee.common.cpp
     gcenv.os.cpp
     gchelpers.cpp
+    genanalysis.cpp
     genmeth.cpp
     hosting.cpp
     ibclogger.cpp

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -85,8 +85,6 @@
                              message="$(string.RuntimePublisher.MethodDiagnosticKeywordMessage)" symbol="CLR_METHODDIAGNOSTIC_KEYWORD" />
                     <keyword name="TypeDiagnosticKeyword" mask="0x8000000000"
                              message="$(string.RuntimePublisher.TypeDiagnosticKeywordMessage)" symbol="CLR_TYPEDIAGNOSTIC_KEYWORD" />
-                    <keyword name="GenAwareKeyword" mask="0x10000000000"
-                             message="$(string.RuntimePublisher.GenAwareKeywordMessage)" symbol="CLR_GEN_AWARE_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -3798,11 +3796,11 @@
                            symbol="KnownPathProbed" message="$(string.RuntimePublisher.KnownPathProbedEventMessage)"/>
 
                     <event value="297" version="0" level="win:Informational"
-                           keywords ="GenAwareKeyword"
+                           keywords ="GCHeapDumpKeyword"
                            symbol="GenAwareBegin" message="$(string.RuntimePublisher.GenAwareBeginEventMessage)"/>
 
                     <event value="298" version="0" level="win:Informational"
-                           keywords ="GenAwareKeyword"
+                           keywords ="GCHeapDumpKeyword"
                            symbol="GenAwareEnd" message="$(string.RuntimePublisher.GenAwareEndEventMessage)"/>
                 </events>
             </provider>
@@ -7557,7 +7555,6 @@
                 <string id="RuntimePublisher.CompilationDiagnosticKeywordMessage" value="CompilationDiagnostic" />
                 <string id="RuntimePublisher.MethodDiagnosticKeywordMessage" value="MethodDiagnostic" />
                 <string id="RuntimePublisher.TypeDiagnosticKeywordMessage" value="TypeDiagnostic" />
-                <string id="RuntimePublisher.GenAwareKeywordMessage" value="GenAwareKeyword" />
                 <string id="RuntimePublisher.GenAwareBeginEventMessage" value="NONE" />
                 <string id="RuntimePublisher.GenAwareEndEventMessage" value="NONE" />
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />

--- a/src/coreclr/src/vm/ClrEtwAll.man
+++ b/src/coreclr/src/vm/ClrEtwAll.man
@@ -85,6 +85,8 @@
                              message="$(string.RuntimePublisher.MethodDiagnosticKeywordMessage)" symbol="CLR_METHODDIAGNOSTIC_KEYWORD" />
                     <keyword name="TypeDiagnosticKeyword" mask="0x8000000000"
                              message="$(string.RuntimePublisher.TypeDiagnosticKeywordMessage)" symbol="CLR_TYPEDIAGNOSTIC_KEYWORD" />
+                    <keyword name="GenAwareKeyword" mask="0x10000000000"
+                             message="$(string.RuntimePublisher.GenAwareKeywordMessage)" symbol="CLR_GEN_AWARE_KEYWORD" />
                 </keywords>
                 <!--Tasks-->
                 <tasks>
@@ -3795,6 +3797,13 @@
                            task="AssemblyLoader"
                            symbol="KnownPathProbed" message="$(string.RuntimePublisher.KnownPathProbedEventMessage)"/>
 
+                    <event value="297" version="0" level="win:Informational"
+                           keywords ="GenAwareKeyword"
+                           symbol="GenAwareBegin" message="$(string.RuntimePublisher.GenAwareBeginEventMessage)"/>
+
+                    <event value="298" version="0" level="win:Informational"
+                           keywords ="GenAwareKeyword"
+                           symbol="GenAwareEnd" message="$(string.RuntimePublisher.GenAwareEndEventMessage)"/>
                 </events>
             </provider>
 
@@ -7548,6 +7557,9 @@
                 <string id="RuntimePublisher.CompilationDiagnosticKeywordMessage" value="CompilationDiagnostic" />
                 <string id="RuntimePublisher.MethodDiagnosticKeywordMessage" value="MethodDiagnostic" />
                 <string id="RuntimePublisher.TypeDiagnosticKeywordMessage" value="TypeDiagnostic" />
+                <string id="RuntimePublisher.GenAwareKeywordMessage" value="GenAwareKeyword" />
+                <string id="RuntimePublisher.GenAwareBeginEventMessage" value="NONE" />
+                <string id="RuntimePublisher.GenAwareEndEventMessage" value="NONE" />
                 <string id="RundownPublisher.LoaderKeywordMessage" value="Loader" />
                 <string id="RundownPublisher.JitKeywordMessage" value="Jit" />
                 <string id="RundownPublisher.JittedMethodILToNativeMapRundownKeywordMessage" value="JittedMethodILToNativeMapRundown" />

--- a/src/coreclr/src/vm/ceemain.cpp
+++ b/src/coreclr/src/vm/ceemain.cpp
@@ -220,6 +220,8 @@
 #include "gdbjit.h"
 #endif // FEATURE_GDBJIT
 
+#include "genanalysis.h"
+
 #ifndef CROSSGEN_COMPILE
 static int GetThreadUICultureId(__out LocaleIDValue* pLocale);  // TODO: This shouldn't use the LCID.  We should rely on name instead
 
@@ -676,6 +678,7 @@ void EEStartupHelper()
         // Initialize the event pipe.
         EventPipe::Initialize();
 #endif // FEATURE_PERFTRACING
+        GenAnalysis::Initialize();
 
 #ifdef TARGET_UNIX
         PAL_SetShutdownCallback(EESocketCleanupHelper);

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -144,13 +144,6 @@ void EventPipe::FinishInitialize()
     }
 }
 
-GcGenAnalysisState gcGenAnalysisState = GcGenAnalysisState::Uninitialized;
-EventPipeSession* gcGenAnalysisEventPipeSession = nullptr;
-uint64_t gcGenAnalysisEventPipeSessionId = (uint64_t)-1;
-GcGenAnalysisState gcGenAnalysisConfigured = GcGenAnalysisState::Uninitialized;
-int64_t gcGenAnalysisGen = -1;
-int64_t gcGenAnalysisBytes = 0;
-
 //
 // If EventPipe environment variables are specified, parse them and start a session
 //
@@ -244,60 +237,6 @@ void EventPipe::EnableViaEnvironmentVariables()
             nullptr
         );
         EventPipe::StartStreaming(sessionID);
-    }
-#ifndef GEN_ANALYSIS_STRESS
-    if (gcGenAnalysisConfigured == GcGenAnalysisState::Uninitialized)
-    {
-        if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
-        {
-            gcGenAnalysisGen = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisGen);
-            if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisBytes")))
-            {
-                gcGenAnalysisBytes = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisBytes);
-                gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
-            }
-            else
-            {
-                gcGenAnalysisConfigured = GcGenAnalysisState::Disabled;
-            }
-        }
-    }
-    if ((gcGenAnalysisConfigured == GcGenAnalysisState::Enabled) && (gcGenAnalysisState == GcGenAnalysisState::Uninitialized))
-#endif
-    {
-        EnableGenerationalAwareSession();
-    }
-}
-
-void EventPipe::EnableGenerationalAwareSession()
-{
-    LPCWSTR outputPath = nullptr;
-    outputPath = GENAWARE_FILE_NAME;
-    NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
-    int providerCnt = 1;
-    pProviders = new EventPipeProviderConfiguration[providerCnt];
-    const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
-    const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
-    const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
-    const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
-    const uint64_t keyword                          = GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
-    pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
-    gcGenAnalysisEventPipeSessionId = EventPipe::Enable(
-        outputPath,
-        1024,
-        pProviders,
-        providerCnt,
-        EventPipeSessionType::File,
-        EventPipeSerializationFormat::NetTraceV4,
-        false,
-        nullptr
-    );
-    if (gcGenAnalysisEventPipeSessionId > 0)
-    {
-        gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
-        gcGenAnalysisEventPipeSession->Pause();
-        EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
-        gcGenAnalysisState = GcGenAnalysisState::Enabled;
     }
 }
 

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -262,7 +262,7 @@ void EventPipe::EnableViaEnvironmentVariables()
             }
         }
     }
-    if (gcGenAnalysisConfigured == 1 && gcGenAnalysisState == 0)
+    if ((gcGenAnalysisConfigured == GcGenAnalysisState::Enabled) && (gcGenAnalysisState == GcGenAnalysisState::Uninitialized))
 #endif
     {
         EnableGenerationalAwareSession();
@@ -272,16 +272,15 @@ void EventPipe::EnableViaEnvironmentVariables()
 void EventPipe::EnableGenerationalAwareSession()
 {
     LPCWSTR outputPath = nullptr;
-    outputPath = W("gcgenaware.nettrace");
+    outputPath = GENAWARE_FILE_NAME;
     NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
     int providerCnt = 1;
     pProviders = new EventPipeProviderConfiguration[providerCnt];
-    const uint64_t GenAwareKeyword                  = 0x10000000000; // This keyword is necessary for the start and stop events
     const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
     const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
     const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
     const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
-    const uint64_t keyword                          = GenAwareKeyword|GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
+    const uint64_t keyword                          = GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
     pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
     gcGenAnalysisEventPipeSessionId = EventPipe::Enable(
         outputPath,

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -164,7 +164,7 @@ void EventPipe::EnableViaEnvironmentVariables()
         {
             outputPath = configOutputPath;
         }
-        auto configuration = XplatEventLoggerConfiguration();
+        
         LPWSTR configToParse = eventpipeConfig;
         int providerCnt = 0;
 
@@ -183,6 +183,7 @@ void EventPipe::EnableViaEnvironmentVariables()
         }
         else
         {
+            auto configuration = XplatEventLoggerConfiguration();
             // Count how many providers there are to parse
             static WCHAR comma = W(',');
             while (*configToParse != '\0')

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -265,35 +265,40 @@ void EventPipe::EnableViaEnvironmentVariables()
     if (gcGenAnalysisConfigured == 1 && gcGenAnalysisState == 0)
 #endif
     {
-        LPCWSTR outputPath = nullptr;
-        outputPath = W("gcgenaware.nettrace");
-        NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
-        int providerCnt = 1;
-        pProviders = new EventPipeProviderConfiguration[providerCnt];
-        const uint64_t GenAwareKeyword                  = 0x10000000000; // This keyword is necessary for the start and stop events
-        const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
-        const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
-        const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
-        const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
-        const uint64_t keyword                          = GenAwareKeyword|GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
-        pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
-        gcGenAnalysisEventPipeSessionId = EventPipe::Enable(
-            outputPath,
-            1024,
-            pProviders,
-            providerCnt,
-            EventPipeSessionType::File,
-            EventPipeSerializationFormat::NetTraceV4,
-            false,
-            nullptr
-        );
-        if (gcGenAnalysisEventPipeSessionId > 0)
-        {
-            gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
-            gcGenAnalysisEventPipeSession->Pause();
-            EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
-            gcGenAnalysisState = GcGenAnalysisState::Enabled;
-        }
+        EnableGenerationalAwareSession();
+    }
+}
+
+void EventPipe::EnableGenerationalAwareSession()
+{
+    LPCWSTR outputPath = nullptr;
+    outputPath = W("gcgenaware.nettrace");
+    NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
+    int providerCnt = 1;
+    pProviders = new EventPipeProviderConfiguration[providerCnt];
+    const uint64_t GenAwareKeyword                  = 0x10000000000; // This keyword is necessary for the start and stop events
+    const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
+    const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
+    const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
+    const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
+    const uint64_t keyword                          = GenAwareKeyword|GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
+    pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
+    gcGenAnalysisEventPipeSessionId = EventPipe::Enable(
+        outputPath,
+        1024,
+        pProviders,
+        providerCnt,
+        EventPipeSessionType::File,
+        EventPipeSerializationFormat::NetTraceV4,
+        false,
+        nullptr
+    );
+    if (gcGenAnalysisEventPipeSessionId > 0)
+    {
+        gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
+        gcGenAnalysisEventPipeSession->Pause();
+        EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
+        gcGenAnalysisState = GcGenAnalysisState::Enabled;
     }
 }
 

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -244,6 +244,7 @@ void EventPipe::EnableViaEnvironmentVariables()
         );
         EventPipe::StartStreaming(sessionID);
     }
+#ifndef GEN_ANALYSIS_STRESS
     if (gcGenAnalysis == 0)
     {
         if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
@@ -261,6 +262,7 @@ void EventPipe::EnableViaEnvironmentVariables()
         }
     }
     if (gcGenAnalysis == 1 && gcGenAnalysisState == 0)
+#endif
     {
         LPCWSTR outputPath = nullptr;
         outputPath = W("gcgenaware.nettrace");

--- a/src/coreclr/src/vm/eventpipe.cpp
+++ b/src/coreclr/src/vm/eventpipe.cpp
@@ -246,10 +246,10 @@ void EventPipe::EnableViaEnvironmentVariables()
     }
     if (gcGenAnalysis == 0)
     {
-        if (CLRConfig::IsConfigOptionSpecified(L"GCGenAnalysisGen"))
+        if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
         {
             gcGenAnalysisGen = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisGen);
-            if (CLRConfig::IsConfigOptionSpecified(L"GCGenAnalysisBytes"))
+            if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisBytes")))
             {
                 gcGenAnalysisBytes = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisBytes);
                 gcGenAnalysis = 1;
@@ -262,7 +262,6 @@ void EventPipe::EnableViaEnvironmentVariables()
     }
     if (gcGenAnalysis == 1 && gcGenAnalysisState == 0)
     {
-        gcGenAnalysisState = 1;
         LPCWSTR outputPath = nullptr;
         outputPath = W("gcgenaware.nettrace");
         NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
@@ -285,9 +284,13 @@ void EventPipe::EnableViaEnvironmentVariables()
             false,
             nullptr
         );
-        gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
-        gcGenAnalysisEventPipeSession->Pause();
-        EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
+        if (gcGenAnalysisEventPipeSessionId > 0)
+        {
+            gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
+            gcGenAnalysisEventPipeSession->Pause();
+            EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
+            gcGenAnalysisState = 1;
+        }
     }
 }
 

--- a/src/coreclr/src/vm/eventpipe.h
+++ b/src/coreclr/src/vm/eventpipe.h
@@ -51,9 +51,6 @@ public:
     // Initialize environment variable based session
     static void EnableViaEnvironmentVariables();
 
-    // Initialize generation aware analysis sesssion
-    static void EnableGenerationalAwareSession();
-
     // Shutdown the event pipe.
     static void Shutdown();
 

--- a/src/coreclr/src/vm/eventpipe.h
+++ b/src/coreclr/src/vm/eventpipe.h
@@ -51,6 +51,9 @@ public:
     // Initialize environment variable based session
     static void EnableViaEnvironmentVariables();
 
+    // Initialize generation aware analysis sesssion
+    static void EnableGenerationalAwareSession();
+
     // Shutdown the event pipe.
     static void Shutdown();
 

--- a/src/coreclr/src/vm/eventpipesession.cpp
+++ b/src/coreclr/src/vm/eventpipesession.cpp
@@ -81,6 +81,7 @@ EventPipeSession::EventPipeSession(
 
     GetSystemTimeAsFileTime(&m_sessionStartTime);
     QueryPerformanceCounter(&m_sessionStartTimeStamp);
+    this->m_paused = false;
 }
 
 EventPipeSession::~EventPipeSession()
@@ -315,6 +316,16 @@ bool EventPipeSession::WriteAllBuffersToFile(bool *pEventsWritten)
     return !m_pFile->HasErrors();
 }
 
+void EventPipeSession::Pause()
+{
+    this->m_paused = true;
+}
+
+void EventPipeSession::Resume()
+{
+    this->m_paused = false;
+}
+
 bool EventPipeSession::WriteEvent(
     Thread *pThread,
     EventPipeEvent &event,
@@ -331,6 +342,11 @@ bool EventPipeSession::WriteEvent(
         MODE_ANY;
     }
     CONTRACTL_END;
+
+    if (this->m_paused)
+    {
+        return true;
+    }
 
     // Filter events specific to "this" session based on precomputed flag on provider/events.
     if (event.IsEnabled(GetMask()))

--- a/src/coreclr/src/vm/eventpipesession.h
+++ b/src/coreclr/src/vm/eventpipesession.h
@@ -96,6 +96,8 @@ private:
 
     void DisableIpcStreamingThread();
 
+    bool m_paused;
+
 public:
     EventPipeSession(
         uint32_t index,
@@ -110,6 +112,15 @@ public:
         EventPipeSessionSynchronousCallback callback = nullptr);
 
     ~EventPipeSession();
+
+    void Pause();
+
+    void Resume();
+
+    bool Paused()
+    {
+        return this->m_paused;
+    }
 
     uint64_t GetMask() const
     {

--- a/src/coreclr/src/vm/eventpipesession.h
+++ b/src/coreclr/src/vm/eventpipesession.h
@@ -104,6 +104,10 @@ private:
     // It is read in EventPipeSession::WriteEvent(). While it is possible for other preemptive threads to read
     // the field while GC is happening, it should not happen because the only gcGenAwareSession only subscribe
     // to GC events.
+    // 
+    // This functionality is a workaround because we couldn't safely Enable()/Disable() the session where we wanted to due to lock-leveling.
+    // we expect to remove it in the future once that limitation is resolved
+    // other scenarios are discouraged from using this given that we plan to make it go away
     bool m_paused;
 
 public:
@@ -121,10 +125,19 @@ public:
 
     ~EventPipeSession();
 
+    /**
+     * Please do not use this function, see EventPipeSession::m_paused for more information
+     */
     void Pause();
 
+    /**
+     * Please do not use this function, see EventPipeSession::m_paused for more information
+     */
     void Resume();
 
+    /**
+     * Please do not use this function, see EventPipeSession::m_paused for more information
+     */
     bool Paused()
     {
         return this->m_paused;

--- a/src/coreclr/src/vm/eventpipesession.h
+++ b/src/coreclr/src/vm/eventpipesession.h
@@ -96,6 +96,14 @@ private:
 
     void DisableIpcStreamingThread();
 
+    // Note - access to this field is NOT synchronized
+    //
+    // This field is currently modified in EventPipe::EnableViaEnvironmentVariables() during process startup
+    // and GCToEEInterface::AnalyzeSurvivorsFinished() while the GC has already synchronized all the threads.
+    // 
+    // It is read in EventPipeSession::WriteEvent(). While it is possible for other preemptive threads to read
+    // the field while GC is happening, it should not happen because the only gcGenAwareSession only subscribe
+    // to GC events.
     bool m_paused;
 
 public:

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -1095,9 +1095,14 @@ void BulkComLogger::WriteRcw(RCW *pRcw, Object *obj)
     _ASSERTE(m_currRcw < kMaxRcwCount);
 
 #ifdef FEATURE_COMINTEROP
+    TypeHandle typeHandle = obj->GetGCSafeTypeHandleIfPossible();
+    if (typeHandle == NULL)
+    {
+        return;
+    }
     EventRCWEntry &rcw = m_etwRcwData[m_currRcw];
     rcw.ObjectID = (ULONGLONG)obj;
-    rcw.TypeID = (ULONGLONG)obj->GetTypeHandle().AsTAddr();
+    rcw.TypeID = (ULONGLONG)typeHandle.AsTAddr();
     rcw.IUnk = (ULONGLONG)pRcw->GetIUnknown_NoAddRef();
     rcw.VTable = (ULONGLONG)pRcw->GetVTablePtr();
     rcw.RefCount = pRcw->GetRefCount();
@@ -1179,10 +1184,16 @@ void BulkComLogger::WriteCcw(ComCallWrapper *pCcw, Object **handle, Object *obj)
             flags |= EventCCWEntry::Strong;
     }
 
+    TypeHandle typeHandle = obj->GetGCSafeTypeHandleIfPossible();
+    if (typeHandle == NULL)
+    {
+        return;
+    }
+
     EventCCWEntry &ccw = m_etwCcwData[m_currCcw++];
     ccw.RootID = (ULONGLONG)handle;
     ccw.ObjectID = (ULONGLONG)obj;
-    ccw.TypeID = (ULONGLONG)obj->GetTypeHandle().AsTAddr();
+    ccw.TypeID = (ULONGLONG)typeHandle.AsTAddr();
     ccw.IUnk = (ULONGLONG)iUnk;
     ccw.RefCount = refCount;
     ccw.JupiterRefCount = 0;

--- a/src/coreclr/src/vm/eventtrace.cpp
+++ b/src/coreclr/src/vm/eventtrace.cpp
@@ -1463,7 +1463,12 @@ void BulkStaticsLogger::WriteEntry(AppDomain *domain, Object **address, Object *
         m_domain = domain;
     }
 
-    ULONGLONG th = (ULONGLONG)obj->GetTypeHandle().AsTAddr();
+    TypeHandle typeHandle = obj->GetGCSafeTypeHandleIfPossible();
+    if (typeHandle == NULL)
+    {
+        return;
+    }
+    ULONGLONG th = (ULONGLONG)typeHandle.AsTAddr();
     ETW::TypeSystemLog::LogTypeAndParametersIfNecessary(m_typeLogger, th, ETW::TypeSystemLog::kTypeLogBehaviorTakeLockAndLogIfFirstTime);
 
     // We should have at least 512 characters remaining in the buffer here.

--- a/src/coreclr/src/vm/fastserializer.cpp
+++ b/src/coreclr/src/vm/fastserializer.cpp
@@ -72,7 +72,6 @@ FileStreamWriter::FileStreamWriter(const SString &outputFilePath)
     m_pFileStream = new CFileStream();
     if (FAILED(m_pFileStream->OpenForWrite(outputFilePath)))
     {
-        _ASSERTE(!"Unable to open file for write.");
         delete m_pFileStream;
         m_pFileStream = NULL;
         return;

--- a/src/coreclr/src/vm/finalizerthread.cpp
+++ b/src/coreclr/src/vm/finalizerthread.cpp
@@ -9,6 +9,7 @@
 #include "jithost.h"
 #include "eventpipe.h"
 #include "eventpipesession.h"
+#include "genanalysis.h"
 
 #ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"
@@ -216,16 +217,7 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
     }
 }
 
-
-
 static BOOL s_FinalizerThreadOK = FALSE;
-
-extern int gcGenAnalysisState;
-extern EventPipeSession* gcGenAnalysisEventPipeSession;
-extern uint64_t gcGenAnalysisEventPipeSessionId;
-extern int gcGenAnalysis;
-extern int64_t gcGenAnalysisGen;
-extern int64_t gcGenAnalysisBytes;
 
 VOID FinalizerThread::FinalizerThreadWorker(void *args)
 {
@@ -276,7 +268,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
 #endif
         if (gcGenAnalysisState == 2)
         {
-            gcGenAnalysisState = 3;
+            gcGenAnalysisState = GcGenAnalysisState::Disabled;
             EventPipe::Disable(gcGenAnalysisEventPipeSessionId);
             // Writing an empty file to indicate completion
             fclose(fopen("trace.nettrace.completed","w+"));
@@ -313,7 +305,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
                     {
                         gcGenAnalysisEventPipeSession->Pause();
                         EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
-                        gcGenAnalysisState = 1;
+                        gcGenAnalysisState = GcGenAnalysisState::Enabled;
                     }
                 }
             }

--- a/src/coreclr/src/vm/finalizerthread.cpp
+++ b/src/coreclr/src/vm/finalizerthread.cpp
@@ -266,12 +266,12 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             g_TriggerHeapDump = FALSE;
         }
 #endif
-        if (gcGenAnalysisState == 2)
+        if (gcGenAnalysisState == GcGenAnalysisState::Done)
         {
             gcGenAnalysisState = GcGenAnalysisState::Disabled;
             EventPipe::Disable(gcGenAnalysisEventPipeSessionId);
             // Writing an empty file to indicate completion
-            fclose(fopen("trace.nettrace.completed","w+"));
+            fclose(fopen(GENAWARE_COMPLETION_FILE_NAME,"w+"));
 #ifdef GEN_ANALYSIS_STRESS
             {
                 EventPipe::EnableGenerationalAwareSession();

--- a/src/coreclr/src/vm/finalizerthread.cpp
+++ b/src/coreclr/src/vm/finalizerthread.cpp
@@ -274,7 +274,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             fclose(fopen(GENAWARE_COMPLETION_FILE_NAME,"w+"));
 #ifdef GEN_ANALYSIS_STRESS
             {
-                EventPipe::EnableGenerationalAwareSession();
+                GenAnalysis::EnableGenerationalAwareSession();
             }
 #endif
         }

--- a/src/coreclr/src/vm/finalizerthread.cpp
+++ b/src/coreclr/src/vm/finalizerthread.cpp
@@ -274,40 +274,7 @@ VOID FinalizerThread::FinalizerThreadWorker(void *args)
             fclose(fopen("trace.nettrace.completed","w+"));
 #ifdef GEN_ANALYSIS_STRESS
             {
-                LPCWSTR outputPath = nullptr;
-                outputPath = W("gcgenaware.nettrace");
-                NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
-                int providerCnt = 1;
-                pProviders = new EventPipeProviderConfiguration[providerCnt];
-                const uint64_t GenAwareKeyword                  = 0x10000000000; // This keyword is necessary for the start and stop events
-                const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
-                const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
-                const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
-                const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
-                const uint64_t keyword                          = GenAwareKeyword|GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
-                pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
-                gcGenAnalysisEventPipeSessionId = EventPipe::Enable(
-                    outputPath,
-                    1024,
-                    pProviders,
-                    providerCnt,
-                    EventPipeSessionType::File,
-                    EventPipeSerializationFormat::NetTraceV4,
-                    false,
-                    nullptr
-                );
-                if (gcGenAnalysisEventPipeSessionId > 0)
-                {
-                    gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
-                    // gcGenAnalysisEventPipeSession == nullptr is possible if EventPipe::Shutdown() is called
-                    // right after the Enable() call completes above and before EventPipe::GetSession() is called.
-                    if (gcGenAnalysisEventPipeSession != nullptr)
-                    {
-                        gcGenAnalysisEventPipeSession->Pause();
-                        EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
-                        gcGenAnalysisState = GcGenAnalysisState::Enabled;
-                    }
-                }
+                EventPipe::EnableGenerationalAwareSession();
             }
 #endif
         }

--- a/src/coreclr/src/vm/finalizerthread.cpp
+++ b/src/coreclr/src/vm/finalizerthread.cpp
@@ -8,6 +8,7 @@
 #include "threadsuspend.h"
 #include "jithost.h"
 #include "eventpipe.h"
+#include "eventpipesession.h"
 
 #ifdef FEATURE_COMINTEROP
 #include "runtimecallablewrapper.h"
@@ -220,7 +221,11 @@ void FinalizerThread::WaitForFinalizerEvent (CLREvent *event)
 static BOOL s_FinalizerThreadOK = FALSE;
 
 extern int gcGenAnalysisState;
+extern EventPipeSession* gcGenAnalysisEventPipeSession;
 extern uint64_t gcGenAnalysisEventPipeSessionId;
+extern int gcGenAnalysis;
+extern int64_t gcGenAnalysisGen;
+extern int64_t gcGenAnalysisBytes;
 
 VOID FinalizerThread::FinalizerThreadWorker(void *args)
 {

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -1599,7 +1599,9 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t
     
     if (gcGenAnalysisState == 1)
     {
+#ifndef GEN_ANALYSIS_STRESS
         if (condemnedGeneration == gcGenAnalysisGen && (promoted_bytes > (uint64_t)gcGenAnalysisBytes))
+#endif
         {
             gcGenAnalysisState = 2;
             gcGenAnalysisEventPipeSession->Resume();

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -1597,13 +1597,13 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t
         }
     }
     
-    if (gcGenAnalysisState == 1)
+    if (gcGenAnalysisState == GcGenAnalysisState::Enabled)
     {
 #ifndef GEN_ANALYSIS_STRESS
-        if (condemnedGeneration == gcGenAnalysisGen && (promoted_bytes > (uint64_t)gcGenAnalysisBytes))
+        if ((condemnedGeneration == gcGenAnalysisGen) && (promoted_bytes > (uint64_t)gcGenAnalysisBytes))
 #endif
         {
-            gcGenAnalysisState = 2;
+            gcGenAnalysisState = GcGenAnalysisState::Done;
             gcGenAnalysisEventPipeSession->Resume();
             FireEtwGenAwareBegin();
             s_forcedGCInProgress = true;

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -1603,7 +1603,6 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t
         if ((condemnedGeneration == gcGenAnalysisGen) && (promoted_bytes > (uint64_t)gcGenAnalysisBytes))
 #endif
         {
-            gcGenAnalysisState = GcGenAnalysisState::Done;
             gcGenAnalysisEventPipeSession->Resume();
             FireEtwGenAwareBegin();
             s_forcedGCInProgress = true;
@@ -1612,6 +1611,7 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t
             reportGenerationBounds();
             FireEtwGenAwareEnd();
             gcGenAnalysisEventPipeSession->Pause();
+            gcGenAnalysisState = GcGenAnalysisState::Done;
             EnableFinalization(true);
         }
     }

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -685,7 +685,7 @@ void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForE
 }
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
-void GCProfileWalkHeap()
+void GCProfileWalkHeap(bool etwOnly)
 {
     BOOL fWalkedHeapForProfiler = FALSE;
 
@@ -702,7 +702,7 @@ void GCProfileWalkHeap()
 
 #if defined (GC_PROFILING)
     {
-        BEGIN_PIN_PROFILER(CORProfilerTrackGC());
+        BEGIN_PIN_PROFILER(!etwOnly && CORProfilerTrackGC());
         GCProfileWalkHeapWorker(TRUE /* fProfilerPinned */, fShouldWalkHeapRootsForEtw, fShouldWalkHeapObjectsForEtw);
         fWalkedHeapForProfiler = TRUE;
         END_PIN_PROFILER();
@@ -764,7 +764,7 @@ void GCToEEInterface::DiagGCEnd(size_t index, int gen, int reason, bool fConcurr
     // we will do these for all GCs.
     if (!fConcurrent)
     {
-        GCProfileWalkHeap();
+        GCProfileWalkHeap(false);
     }
 
     if (CORProfilerTrackBasicGC() || (!fConcurrent && CORProfilerTrackGC()))
@@ -1607,7 +1607,7 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t
             gcGenAnalysisEventPipeSession->Resume();
             FireEtwGenAwareBegin();
             s_forcedGCInProgress = true;
-            GCProfileWalkHeap();
+            GCProfileWalkHeap(true);
             s_forcedGCInProgress = false;
             reportGenerationBounds();
             FireEtwGenAwareEnd();

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -1582,7 +1582,7 @@ bool GCToEEInterface::AnalyzeSurvivorsRequested(int condemnedGeneration)
     return false;
 }
 
-void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
+void GCToEEInterface::AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1600,7 +1600,7 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t
     if (gcGenAnalysisState == GcGenAnalysisState::Enabled)
     {
 #ifndef GEN_ANALYSIS_STRESS
-        if ((condemnedGeneration == gcGenAnalysisGen) && (promoted_bytes > (uint64_t)gcGenAnalysisBytes))
+        if ((condemnedGeneration == gcGenAnalysisGen) && (promoted_bytes > (uint64_t)gcGenAnalysisBytes) && (gcIndex > (uint64_t)gcGenAnalysisIndex))
 #endif
         {
             gcGenAnalysisEventPipeSession->Resume();

--- a/src/coreclr/src/vm/gcenv.ee.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.cpp
@@ -12,6 +12,13 @@
 
 #include "gcrefmap.h"
 
+int event_pipe_state = 0;
+EventPipeSession* pEventPipeSession = nullptr;
+uint64_t sessionId = (uint64_t)-1;
+bool gcGenAnalysis = false;
+int64_t gcGenAnalysisGen = 999;
+int64_t gcGenAnalysisBytes = 0;
+
 void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 {
     WRAPPER_NO_CONTRACT;
@@ -22,6 +29,43 @@ void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
     _ASSERTE(reason == SUSPEND_FOR_GC || reason == SUSPEND_FOR_GC_PREP);
 
     g_pDebugInterface->SuspendForGarbageCollectionStarted();
+    
+    if (GetIntConfigValue("GCGenAnalysisGen", nullptr, &gcGenAnalysisGen))
+    {
+        if (GetIntConfigValue("GCGenAnalysisBytes", nullptr, &gcGenAnalysisBytes))
+        {
+            gcGenAnalysis = true;
+        }
+    }
+    if (gcGenAnalysis && event_pipe_state == 0)
+    {
+        event_pipe_state = 1;
+        LPCWSTR outputPath = nullptr;
+        outputPath = W("trace.nettrace");        
+        NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
+        int providerCnt = 1;
+        pProviders = new EventPipeProviderConfiguration[providerCnt];
+        const uint64_t GenAwareKeyword                  = 0x10000000000; // This keyword is necessary for the start and stop events
+        const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
+        const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
+        const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
+        const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
+        const uint64_t keyword                          = GenAwareKeyword|GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
+        pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
+        sessionId = EventPipe::Enable(
+            outputPath,
+            1024,
+            pProviders,
+            providerCnt,
+            EventPipeSessionType::File,
+            EventPipeSerializationFormat::NetTraceV4,
+            false,
+            nullptr
+        );
+        pEventPipeSession= EventPipe::GetSession(sessionId);
+        pEventPipeSession->Pause();
+        EventPipe::StartStreaming(sessionId);
+    }
 
     ThreadSuspend::SuspendEE((ThreadSuspend::SUSPEND_REASON)reason);
 
@@ -31,10 +75,19 @@ void GCToEEInterface::SuspendEE(SUSPEND_REASON reason)
 void GCToEEInterface::RestartEE(bool bFinishedGC)
 {
     WRAPPER_NO_CONTRACT;
+    CONTRACT_VIOLATION(ThrowsViolation);
 
     g_pDebugInterface->ResumeForGarbageCollectionStarted();
 
     ThreadSuspend::RestartEE(bFinishedGC, TRUE);
+
+    if (event_pipe_state == 2)
+    {
+        event_pipe_state = 3;
+        EventPipe::Disable(sessionId);
+        // Writing an empty file to indicate completion
+        fclose(fopen("trace.nettrace.completed","w+"));
+    }
 }
 
 VOID GCToEEInterface::SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintptr_t lp2)
@@ -1582,7 +1635,7 @@ bool GCToEEInterface::AnalyzeSurvivorsRequested(int condemnedGeneration)
     return false;
 }
 
-void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration)
+void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)())
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1594,6 +1647,22 @@ void GCToEEInterface::AnalyzeSurvivorsFinished(int condemnedGeneration)
         if (gn.GetNotification(gea) != 0)
         {
             DACNotify::DoGCNotification(gea);
+        }
+    }
+    
+    if (event_pipe_state == 1)
+    {
+        if (condemnedGeneration == gcGenAnalysisGen && promoted_bytes > (uint64_t)gcGenAnalysisBytes)
+        {
+            event_pipe_state = 2;
+            pEventPipeSession->Resume();
+            FireEtwGenAwareBegin();
+            s_forcedGCInProgress = true;
+            GCProfileWalkHeap();
+            s_forcedGCInProgress = false;
+            reportGenerationBounds();
+            FireEtwGenAwareEnd();
+            pEventPipeSession->Pause();
         }
     }
 }

--- a/src/coreclr/src/vm/gcenv.ee.h
+++ b/src/coreclr/src/vm/gcenv.ee.h
@@ -77,7 +77,7 @@ public:
     uint32_t GetTotalNumSizedRefHandles();
 
     bool AnalyzeSurvivorsRequested(int condemnedGeneration);
-    void AnalyzeSurvivorsFinished(int condemnedGeneration);
+    void AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)());
 
     void VerifySyncTableEntry();
 

--- a/src/coreclr/src/vm/gcenv.ee.h
+++ b/src/coreclr/src/vm/gcenv.ee.h
@@ -77,7 +77,7 @@ public:
     uint32_t GetTotalNumSizedRefHandles();
 
     bool AnalyzeSurvivorsRequested(int condemnedGeneration);
-    void AnalyzeSurvivorsFinished(int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)());
+    void AnalyzeSurvivorsFinished(size_t gcIndex, int condemnedGeneration, uint64_t promoted_bytes, void (*reportGenerationBounds)());
 
     void VerifySyncTableEntry();
 

--- a/src/coreclr/src/vm/gcenv.ee.standalone.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.standalone.cpp
@@ -15,6 +15,9 @@
 
 #include "gctoclreventsink.h"
 #include "configuration.h"
+#include "eventpipe.h"
+#include "eventpipesession.h"
+extern bool s_forcedGCInProgress;
 
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;

--- a/src/coreclr/src/vm/gcenv.ee.standalone.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.standalone.cpp
@@ -17,13 +17,7 @@
 #include "configuration.h"
 #include "eventpipe.h"
 #include "eventpipesession.h"
-extern bool s_forcedGCInProgress;
-extern int gcGenAnalysisState;
-extern EventPipeSession* gcGenAnalysisEventPipeSession;
-extern uint64_t gcGenAnalysisEventPipeSessionId;
-extern int gcGenAnalysis;
-extern int64_t gcGenAnalysisGen;
-extern int64_t gcGenAnalysisBytes;
+#include "genanalysis.h"
 
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;

--- a/src/coreclr/src/vm/gcenv.ee.standalone.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.standalone.cpp
@@ -18,6 +18,12 @@
 #include "eventpipe.h"
 #include "eventpipesession.h"
 extern bool s_forcedGCInProgress;
+extern int gcGenAnalysisState;
+extern EventPipeSession* gcGenAnalysisEventPipeSession;
+extern uint64_t gcGenAnalysisEventPipeSessionId;
+extern int gcGenAnalysis;
+extern int64_t gcGenAnalysisGen;
+extern int64_t gcGenAnalysisBytes;
 
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;

--- a/src/coreclr/src/vm/gcenv.ee.static.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.static.cpp
@@ -15,6 +15,9 @@
 
 #include "gctoclreventsink.h"
 #include "configuration.h"
+#include "eventpipe.h"
+#include "eventpipesession.h"
+extern bool s_forcedGCInProgress;
 
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;

--- a/src/coreclr/src/vm/gcenv.ee.static.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.static.cpp
@@ -17,13 +17,7 @@
 #include "configuration.h"
 #include "eventpipe.h"
 #include "eventpipesession.h"
-extern bool s_forcedGCInProgress;
-extern int gcGenAnalysisState;
-extern EventPipeSession* gcGenAnalysisEventPipeSession;
-extern uint64_t gcGenAnalysisEventPipeSessionId;
-extern int gcGenAnalysis;
-extern int64_t gcGenAnalysisGen;
-extern int64_t gcGenAnalysisBytes;
+#include "genanalysis.h"
 
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;

--- a/src/coreclr/src/vm/gcenv.ee.static.cpp
+++ b/src/coreclr/src/vm/gcenv.ee.static.cpp
@@ -18,6 +18,12 @@
 #include "eventpipe.h"
 #include "eventpipesession.h"
 extern bool s_forcedGCInProgress;
+extern int gcGenAnalysisState;
+extern EventPipeSession* gcGenAnalysisEventPipeSession;
+extern uint64_t gcGenAnalysisEventPipeSessionId;
+extern int gcGenAnalysis;
+extern int64_t gcGenAnalysisGen;
+extern int64_t gcGenAnalysisBytes;
 
 // the method table for the WeakReference class
 extern MethodTable* pWeakReferenceMT;

--- a/src/coreclr/src/vm/genanalysis.cpp
+++ b/src/coreclr/src/vm/genanalysis.cpp
@@ -10,6 +10,7 @@ uint64_t gcGenAnalysisEventPipeSessionId = (uint64_t)-1;
 GcGenAnalysisState gcGenAnalysisConfigured = GcGenAnalysisState::Uninitialized;
 int64_t gcGenAnalysisGen = -1;
 int64_t gcGenAnalysisBytes = 0;
+int64_t gcGenAnalysisIndex = 0;
 
 /* static */ void GenAnalysis::Initialize()
 {
@@ -22,7 +23,15 @@ int64_t gcGenAnalysisBytes = 0;
             if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisBytes")))
             {
                 gcGenAnalysisBytes = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisBytes);
-                gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
+                if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisIndex")))
+                {
+                    gcGenAnalysisIndex = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisIndex);
+                    gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
+                }
+                else
+                {
+                    gcGenAnalysisConfigured = GcGenAnalysisState::Disabled;
+                }
             }
             else
             {

--- a/src/coreclr/src/vm/genanalysis.cpp
+++ b/src/coreclr/src/vm/genanalysis.cpp
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "common.h"
+#include "genanalysis.h"
+
+GcGenAnalysisState gcGenAnalysisState = GcGenAnalysisState::Uninitialized;
+EventPipeSession* gcGenAnalysisEventPipeSession = nullptr;
+uint64_t gcGenAnalysisEventPipeSessionId = (uint64_t)-1;
+GcGenAnalysisState gcGenAnalysisConfigured = GcGenAnalysisState::Uninitialized;
+int64_t gcGenAnalysisGen = -1;
+int64_t gcGenAnalysisBytes = 0;
+
+/* static */ void GenAnalysis::Initialize()
+{
+#ifndef GEN_ANALYSIS_STRESS
+    if (gcGenAnalysisConfigured == GcGenAnalysisState::Uninitialized)
+    {
+        if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisGen")))
+        {
+            gcGenAnalysisGen = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisGen);
+            if (CLRConfig::IsConfigOptionSpecified(W("GCGenAnalysisBytes")))
+            {
+                gcGenAnalysisBytes = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_GCGenAnalysisBytes);
+                gcGenAnalysisConfigured = GcGenAnalysisState::Enabled;
+            }
+            else
+            {
+                gcGenAnalysisConfigured = GcGenAnalysisState::Disabled;
+            }
+        }
+    }
+    if ((gcGenAnalysisConfigured == GcGenAnalysisState::Enabled) && (gcGenAnalysisState == GcGenAnalysisState::Uninitialized))
+#endif
+    {
+        EnableGenerationalAwareSession();
+    }    
+}
+
+/* static */ void GenAnalysis::EnableGenerationalAwareSession()
+{
+    LPCWSTR outputPath = nullptr;
+    outputPath = GENAWARE_FILE_NAME;
+    NewHolder<EventPipeProviderConfiguration> pProviders = nullptr;
+    int providerCnt = 1;
+    pProviders = new EventPipeProviderConfiguration[providerCnt];
+    const uint64_t GCHeapAndTypeNamesKeyword        = 0x00001000000; // This keyword is necessary for the type names
+    const uint64_t GCHeapSurvivalAndMovementKeyword = 0x00000400000; // This keyword is necessary for the generation range data.
+    const uint64_t GCHeapDumpKeyword                = 0x00000100000; // This keyword is necessary for enabling walking the heap
+    const uint64_t TypeKeyword                      = 0x00000080000; // This keyword is necessary for enabling BulkType events
+    const uint64_t keyword                          = GCHeapAndTypeNamesKeyword|GCHeapSurvivalAndMovementKeyword|GCHeapDumpKeyword|TypeKeyword;
+    pProviders[0] = EventPipeProviderConfiguration(W("Microsoft-Windows-DotNETRuntime"), keyword, 5, nullptr);
+    gcGenAnalysisEventPipeSessionId = EventPipe::Enable(
+        outputPath,
+        1024,
+        pProviders,
+        providerCnt,
+        EventPipeSessionType::File,
+        EventPipeSerializationFormat::NetTraceV4,
+        false,
+        nullptr
+    );
+    if (gcGenAnalysisEventPipeSessionId > 0)
+    {
+        gcGenAnalysisEventPipeSession= EventPipe::GetSession(gcGenAnalysisEventPipeSessionId);
+        gcGenAnalysisEventPipeSession->Pause();
+        EventPipe::StartStreaming(gcGenAnalysisEventPipeSessionId);
+        gcGenAnalysisState = GcGenAnalysisState::Enabled;
+    }
+}

--- a/src/coreclr/src/vm/genanalysis.h
+++ b/src/coreclr/src/vm/genanalysis.h
@@ -27,6 +27,7 @@ extern uint64_t gcGenAnalysisEventPipeSessionId;
 extern GcGenAnalysisState gcGenAnalysisConfigured;
 extern int64_t gcGenAnalysisGen;
 extern int64_t gcGenAnalysisBytes;
+extern int64_t gcGenAnalysisIndex;
 
 class GenAnalysis
 {

--- a/src/coreclr/src/vm/genanalysis.h
+++ b/src/coreclr/src/vm/genanalysis.h
@@ -11,6 +11,9 @@ enum GcGenAnalysisState
     Done = 3,
 };
 
+#define GENAWARE_FILE_NAME W("gcgenaware.nettrace")
+#define GENAWARE_COMPLETION_FILE_NAME "gcgenaware.nettrace.completed"
+
 extern bool s_forcedGCInProgress;
 extern GcGenAnalysisState gcGenAnalysisState;
 extern EventPipeSession* gcGenAnalysisEventPipeSession;

--- a/src/coreclr/src/vm/genanalysis.h
+++ b/src/coreclr/src/vm/genanalysis.h
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// #define GEN_ANALYSIS_STRESS
+
+enum GcGenAnalysisState
+{
+    Uninitialized = 0,
+    Enabled = 1,
+    Disabled = 2,
+    Done = 3,
+};
+
+extern bool s_forcedGCInProgress;
+extern GcGenAnalysisState gcGenAnalysisState;
+extern EventPipeSession* gcGenAnalysisEventPipeSession;
+extern uint64_t gcGenAnalysisEventPipeSessionId;
+extern GcGenAnalysisState gcGenAnalysisConfigured;
+extern int64_t gcGenAnalysisGen;
+extern int64_t gcGenAnalysisBytes;

--- a/src/coreclr/src/vm/genanalysis.h
+++ b/src/coreclr/src/vm/genanalysis.h
@@ -3,6 +3,12 @@
 
 // #define GEN_ANALYSIS_STRESS
 
+#ifndef __GENANALYSIS_H__
+#define __GENANALYSIS_H__
+
+#include "eventpipe.h"
+#include "eventpipesession.h"
+
 enum GcGenAnalysisState
 {
     Uninitialized = 0,
@@ -21,3 +27,12 @@ extern uint64_t gcGenAnalysisEventPipeSessionId;
 extern GcGenAnalysisState gcGenAnalysisConfigured;
 extern int64_t gcGenAnalysisGen;
 extern int64_t gcGenAnalysisBytes;
+
+class GenAnalysis
+{
+public:
+    static void Initialize();
+    static void EnableGenerationalAwareSession();
+};
+
+#endif 

--- a/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/src/vm/proftoeeinterfaceimpl.cpp
@@ -1091,7 +1091,7 @@ bool HeapWalkHelper(Object * pBO, void * pvContext)
     OBJECTREF *   arrObjRef      = NULL;
     size_t        cNumRefs       = 0;
     bool          bOnStack       = false;
-    MethodTable * pMT            = pBO->GetMethodTable();
+    MethodTable * pMT            = pBO->GetGCSafeMethodTable();
 
     ProfilerWalkHeapContext * pProfilerWalkHeapContext = (ProfilerWalkHeapContext *) pvContext;
 


### PR DESCRIPTION
# Generational aware analysis
This PR is intended to instrument the runtime so that it is possible to diagnose occasionally long ephemeral GC for .NET 5.0. This is meant to be a stop-gap before we have completed the long term TODOs and for advanced users who know exactly what they want only.

# What is the problem?
Long GCs are bad. Sometimes, these long GCs are ephemeral GCs (i.e. gen0 or gen1). This is often caused by accidental promotion (i.e. some gen0/gen1 objects are accidentally referenced by gen2 objects), causing us time to mark and promote them. That only happens once in a while. Once the objects are promoted, they are no longer gen0/gen1, so it won't cause long ephemeral GC anymore, but they become long-term debt. To diagnose issues like this, we would like to inspect the heap right at the spot when the ephemeral GC is long, and currently, there is no way to do that in .NET Core.

# How did we diagnose this?
Back in .NET framework days (dated back to at least 2010), we had an internal tool called [CrossGenerationLivenessCollector](https://github.com/cshung/perfview/blob/cross-generation-analysis/CrossHack.md) in PerfView. The tool served as a debugger and installed a conditional breakpoint in the runtime. When it hits, the tool captures a heap dump so that we can analyze the heap at that point in time.

# What is wrong with the approach above?
1. It requires embedding WinDBG binaries into PerfView.
2. It requires private symbols of `clr.dll`.
3. It does NOT work on .NET Core. 
> While it could be adapted so that it works on .NET Core for Windows, it certainly won't work on any platforms other than Windows.

# The proposed solution
Instead of having the tool to inspect the target process and capture a dump, we can have the runtime to evaluate the condition and have it emitting traces that allow PerfView to reconstruct the heap graph. This eliminates the need to have a debugger inspecting the runtime as well as the private symbols. By working within the runtime, we also have the advantage that the capability is automatically available across all platforms .NET Core supports. The reconstruction of the heap graph based on traces is currently available through PerfView and therefore is still Windows only.

> This proposal does not change what we will do for .NET framework. It is still going to be using CrossGenerationLivenessCollector. Requiring private symbols is just unfortunate and the analysis will be scoped for Microsoft internals only.

# How to use
If we happen to know once in a while we have a gen 1 GC that promoted more than 1,500,000 = (0x16E360) bytes. We can set these environment variables before starting up the process.
```cmd
set COMPLUS_GCGenAnalysisGen=1
set COMPLUS_GCGenAnalysisBytes=16E360
```
The runtime will start monitoring GC. A file named `trace.nettrace` will be created upon the 1st GC. When the application moves on, the GC that hit the condition will eventually happen, the runtime will emit traces into the file that allows PerfView to reconstruct the heap graph. When that GC completes, the file will be closed and available for inspection. To make it easier for people to know that happened, a separate empty file named `"trace.nettrace.completed"` will be generated to signal that the file is ready to be consumed.

# Testing
Right now, I have tested that the branch builds and works on Windows. With a hacked version of PerfView, I am available to reconstruct the heap graph and have the generational aware heap graph view working. I can also see the additional delimiting events in their raw form in the trace because they are not current

# Short term TODOs (Meant for .NET 5.0)
1. Naming (some of the stuff in the PR will be public (e.g. environment variable) and deserve better names)
2. More testing (cross-platform and server GC), and 
3. The PerfView side changes (Not constrained for .NET 5.0 timeframe).
4. Documentation (for example, a tutorial to use this feature)

# Long term TODOs (Meant for .NET 6 and beyond)
The PR is known to be incapable of:

- Enabling the analysis after the process starts.
- Canceling existing analysis.
- Having multiple pending analysis requests.
- Having some perf overhead of generating unused events.

The idea of this feature could be generalized so that the runtime waits for a general condition (instead of this specific condition) and do some general diagnostic work. We decided that this generalization is outside of the scope of the current release. A prototype is built to understand some of the complexities. It can be found [here](https://github.com/dotnet/runtime/pull/39093) (runtime part) and [here](https://github.com/dotnet/diagnostics/pull/1338) (diagnostics part). 

@dotnet/dotnet-diag 
@dotnet/gc 