### PR TITLE
Cleanup P2P in JavaScript InteropServices tests lib

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -17,8 +17,4 @@
     <Compile Include="System\Runtime\InteropServices\JavaScript\HelperMarshal.cs" />
     <Compile Include="System\Runtime\InteropServices\JavaScript\Http\HttpRequestMessageTest.cs" />    
   </ItemGroup>
-  <ItemGroup>
-    <!-- Part of the shared framework but not exposed. -->
-    <ProjectReference Include="..\src\System.Runtime.InteropServices.JavaScript.csproj" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
The P2P isn't need anymore as the library is now part of the targeting pack.