### PR TITLE
Check more patterns for retBuffer.

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -860,7 +860,8 @@ class SuperPMIReplay:
             altjit_string = "*" if self.coreclr_args.altjit else ""
             altjit_flags = [
                 "-jitoption", "force", "AltJit=" + altjit_string,
-                "-jitoption", "force", "AltJitNgen=" + altjit_string
+                "-jitoption", "force", "AltJitNgen=" + altjit_string,
+                "-jitoption", "force", "EnableExtraSuperPmiQueries=0"
             ]
             flags += altjit_flags
 
@@ -1032,8 +1033,10 @@ class SuperPMIReplayAsmDiffs:
                 altjit_flags = [
                     "-jitoption", "force", "AltJit=" + altjit_string,
                     "-jitoption", "force", "AltJitNgen=" + altjit_string,
+                    "-jitoption", "force", "EnableExtraSuperPmiQueries=0",
                     "-jit2option", "force", "AltJit=" + altjit_string,
-                    "-jit2option", "force", "AltJitNgen=" + altjit_string
+                    "-jit2option", "force", "AltJitNgen=" + altjit_string,
+                    "-jit2option", "force", "EnableExtraSuperPmiQueries=0"
                 ]
                 flags += altjit_flags
 
@@ -1208,7 +1211,8 @@ class SuperPMIReplayAsmDiffs:
                 altjit_string = "*" if self.coreclr_args.altjit else ""
                 altjit_flags = [
                     "-jitoption", "force", "AltJit=" + altjit_string,
-                    "-jitoption", "force", "AltJitNgen=" + altjit_string
+                    "-jitoption", "force", "AltJitNgen=" + altjit_string,
+                    "-jitoption", "force", "EnableExtraSuperPmiQueries=0"
                 ]
 
                 async def create_asm(print_prefix, item, self, text_differences, base_asm_location, diff_asm_location):

--- a/src/coreclr/src/jit/morph.cpp
+++ b/src/coreclr/src/jit/morph.cpp
@@ -8946,7 +8946,7 @@ GenTree* Compiler::fgMorphCall(GenTreeCall* call)
 
         GenTree* dest = call->gtCallArgs->GetNode();
         assert(dest->OperGet() != GT_ARGPLACE); // If it was, we'd be in a remorph, which we've already excluded above.
-        if (dest->gtType == TYP_BYREF && !(dest->OperGet() == GT_ADDR && dest->AsOp()->gtOp1->OperGet() == GT_LCL_VAR))
+        if (dest->TypeIs(TYP_BYREF) && !dest->IsLocalAddrExpr())
         {
             // We'll exempt helper calls from this, assuming that the helper implementation
             // follows the old convention, and does whatever barrier is required.


### PR DESCRIPTION
We force return buffers containing GC pointers to be on the stack and before we make a copy we check if the return buffer is already on the stack. Fix the check by adding `LCL_VAR_ADDR`, `ADD(LCL_VAR_ADDR, CNST)` patterns.

Fixes https://github.com/dotnet/runtime/issues/39947, however, the issue happens because of the several factors:
1. `EnableExtraSuperPmiQueries` is a debug only variable that is set during collection;
2. debug only `makeExtraStructQueries` is called in checked and it could find a SIMD type when SIMD intrinsics are not used, it would call  `setUsesSIMDTypes(true) {_usesSIMDTypes = true; }` in compiler;
3. based on the value of `_usesSIMDTypes` struct promotion could make different decisions, for example, promote `struct A {simd16 a; }`;
4. lclmorph doesn't replace `ADDR(LCL_VAR)` as `LCL_VAR_ADDR` if the lclVar is promoted;
5. `LCL_VAR_ADDR` was not recognized by the function changed in this PR and it led to additional VM questions that were failing during release replay.

This PR fixes only the 5th. We could fix the first by:
1. disable `EnableExtraSuperPmiQueries` until we need it again;
2. don't record `EnableExtraSuperPmiQueries` value during collection (hack `void MethodContext::recGetIntConfigValue(const WCHAR* name, int defaultValue, int result)`);
3. pass `-jitoption force EnableExtraSuperPmiQueries=0 -jit2option force EnableExtraSuperPmiQueries=0` during SPMI replay;
4. do less in `makeExtraStructQueries`.


The rest SPMI chk/rel diffs are covered by https://github.com/dotnet/runtime/issues/39908