### PR TITLE
Add support for reporting byrefs to RVA static fields of collectible assemblies

### DIFF
--- a/src/coreclr/src/vm/assembly.cpp
+++ b/src/coreclr/src/vm/assembly.cpp
@@ -190,6 +190,19 @@ void Assembly::Init(AllocMemTracker *pamTracker, LoaderAllocator *pLoaderAllocat
     //  loading it entirely.
     //CacheFriendAssemblyInfo();
 
+#ifndef CROSSGEN_COMPILE
+    if (IsCollectible())
+    {
+        COUNT_T size;
+        BYTE *start = (BYTE*)m_pManifest->GetFile()->GetLoadedImageContents(&size);
+        if (start != NULL)
+        {
+            GCX_COOP();
+            LoaderAllocator::AssociateMemoryWithLoaderAllocator(start, start + size, m_pLoaderAllocator);
+        }
+    }
+#endif
+
     {
         CANNOTTHROWCOMPLUSEXCEPTION();
         FAULT_FORBID();

--- a/src/coreclr/src/vm/commodule.cpp
+++ b/src/coreclr/src/vm/commodule.cpp
@@ -643,6 +643,12 @@ void QCALLTYPE COMModule::SetFieldRVAContent(QCall::ModuleHandle pModule, INT32 
     if (pContent != NULL)
         memcpy(pvBlob, pContent, length);
 
+    if (pReflectionModule->IsCollectible())
+    {
+        GCX_COOP();
+        LoaderAllocator::AssociateMemoryWithLoaderAllocator((BYTE*)pvBlob, ((BYTE*)pvBlob) + length, pReflectionModule->GetLoaderAllocator());
+    }
+
     // set FieldRVA into metadata. Note that this is not final RVA in the image if save to disk. We will do another round of fix up upon save.
     IfFailThrow( pRCW->GetEmitter()->SetFieldRVA(tkField, dwRVA) );
 

--- a/src/coreclr/src/vm/loaderallocator.cpp
+++ b/src/coreclr/src/vm/loaderallocator.cpp
@@ -662,6 +662,11 @@ BOOL QCALLTYPE LoaderAllocator::Destroy(QCall::LoaderAllocatorHandle pLoaderAllo
         STRESS_LOG1(LF_CLASSLOADER, LL_INFO100, "Begin LoaderAllocator::Destroy for loader allocator %p\n", reinterpret_cast<void *>(static_cast<PTR_LoaderAllocator>(pLoaderAllocator)));
         LoaderAllocatorID *pID = pLoaderAllocator->Id();
 
+        {
+            GCX_COOP();
+            LoaderAllocator::RemoveMemoryToLoaderAllocatorAssociation(pLoaderAllocator);
+        }
+
         // This will probably change for shared code unloading
         _ASSERTE(pID->GetType() == LAT_Assembly);
 
@@ -1982,6 +1987,44 @@ UMEntryThunkCache *LoaderAllocator::GetUMEntryThunkCache()
     }
     _ASSERTE(m_pUMEntryThunkCache);
     return m_pUMEntryThunkCache;
+}
+
+/* static */
+void LoaderAllocator::RemoveMemoryToLoaderAllocatorAssociation(LoaderAllocator* pLoaderAllocator)
+{
+    CONTRACTL {
+        THROWS;
+        MODE_COOPERATIVE;
+    } CONTRACTL_END;
+
+    GlobalLoaderAllocator* pGlobalAllocator = (GlobalLoaderAllocator*)SystemDomain::GetGlobalLoaderAllocator();
+    pGlobalAllocator->m_memoryAssociations.RemoveRanges(pLoaderAllocator);
+}
+
+/* static */
+void LoaderAllocator::AssociateMemoryWithLoaderAllocator(BYTE *start, const BYTE *end, LoaderAllocator* pLoaderAllocator)
+{
+    CONTRACTL {
+        THROWS;
+        MODE_COOPERATIVE;
+    } CONTRACTL_END;
+
+    GlobalLoaderAllocator* pGlobalAllocator = (GlobalLoaderAllocator*)SystemDomain::GetGlobalLoaderAllocator();
+    pGlobalAllocator->m_memoryAssociations.AddRange(start, end, pLoaderAllocator);
+}
+
+/* static */
+PTR_LoaderAllocator LoaderAllocator::GetAssociatedLoaderAllocator_Unsafe(TADDR ptr)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    GlobalLoaderAllocator* pGlobalAllocator = (GlobalLoaderAllocator*)SystemDomain::GetGlobalLoaderAllocator();
+    LoaderAllocator* pLoaderAllocator;
+    if (pGlobalAllocator->m_memoryAssociations.IsInRangeWorker_Unlocked(ptr, reinterpret_cast<TADDR *>(&pLoaderAllocator)))
+    {
+        return pLoaderAllocator;
+    }
+    return NULL;
 }
 
 #endif // !CROSSGEN_COMPILE

--- a/src/coreclr/src/vm/lockedrangelist.h
+++ b/src/coreclr/src/vm/lockedrangelist.h
@@ -1,0 +1,49 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// -------------------------------------------------------
+// This just wraps the RangeList methods in a read or
+// write lock depending on the operation.
+// -------------------------------------------------------
+
+class LockedRangeList : public RangeList
+{
+  public:
+    VPTR_VTABLE_CLASS(LockedRangeList, RangeList)
+
+    LockedRangeList() : RangeList(), m_RangeListRWLock(COOPERATIVE_OR_PREEMPTIVE, LOCK_TYPE_DEFAULT)
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
+
+    ~LockedRangeList()
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
+
+  protected:
+
+    virtual BOOL AddRangeWorker(const BYTE *start, const BYTE *end, void *id)
+    {
+        WRAPPER_NO_CONTRACT;
+        SimpleWriteLockHolder lh(&m_RangeListRWLock);
+        return RangeList::AddRangeWorker(start,end,id);
+    }
+
+    virtual void RemoveRangesWorker(void *id, const BYTE *start = NULL, const BYTE *end = NULL)
+    {
+        WRAPPER_NO_CONTRACT;
+        SimpleWriteLockHolder lh(&m_RangeListRWLock);
+        RangeList::RemoveRangesWorker(id,start,end);
+    }
+
+    virtual BOOL IsInRangeWorker(TADDR address, TADDR *pID = NULL)
+    {
+        WRAPPER_NO_CONTRACT;
+        SUPPORTS_DAC;
+        SimpleReadLockHolder lh(&m_RangeListRWLock);
+        return RangeList::IsInRangeWorker(address, pID);
+    }
+
+    SimpleRWLock m_RangeListRWLock;
+};

--- a/src/coreclr/src/vm/lockedrangelist.h
+++ b/src/coreclr/src/vm/lockedrangelist.h
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#ifndef __LockedRangeList_h__
+#define __LockedRangeList_h__
+
 // -------------------------------------------------------
 // This just wraps the RangeList methods in a read or
 // write lock depending on the operation.
@@ -19,6 +22,13 @@ class LockedRangeList : public RangeList
     ~LockedRangeList()
     {
         LIMITED_METHOD_CONTRACT;
+    }
+
+    BOOL IsInRangeWorker_Unlocked(TADDR address, TADDR *pID = NULL)
+    {
+        WRAPPER_NO_CONTRACT;
+        SUPPORTS_DAC;
+        return RangeList::IsInRangeWorker(address, pID);
     }
 
   protected:
@@ -47,3 +57,5 @@ class LockedRangeList : public RangeList
 
     SimpleRWLock m_RangeListRWLock;
 };
+
+#endif // __LockedRangeList_h__

--- a/src/coreclr/src/vm/siginfo.cpp
+++ b/src/coreclr/src/vm/siginfo.cpp
@@ -4900,6 +4900,16 @@ void PromoteCarefully(promote_func   fn,
         return;
     }
 
+#ifndef CROSSGEN_COMPILE
+    if (sc->promotion)
+    {
+        LoaderAllocator*pLoaderAllocator = LoaderAllocator::GetAssociatedLoaderAllocator_Unsafe(PTR_TO_TADDR(*ppObj));
+        if (pLoaderAllocator != NULL)
+        {
+            GcReportLoaderAllocator(fn, sc, pLoaderAllocator);
+        }
+    }
+#endif // CROSSGEN_COMPILE
 #endif // !defined(DACCESS_COMPILE)
 
     (*fn) (ppObj, sc, flags);

--- a/src/coreclr/tests/issues.targets
+++ b/src/coreclr/tests/issues.targets
@@ -961,6 +961,9 @@
 
     <!-- Known failures for mono runtime on *all* architectures/operating systems -->
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'mono'" >
+        <ExcludeList Include="$(XunitTestBinBase)/Loader/CollectibleAssemblies/ByRefLocals/**">
+            <Issue>https://github.com/dotnet/runtime/issues/40394</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)/Interop/PInvoke/Miscellaneous/CopyCtor/**">
             <Issue>Handling for Copy constructors isn't present in mono interop</Issue>
         </ExcludeList>

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/ByRefLocals.cs
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/ByRefLocals.cs
@@ -1,0 +1,107 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+
+class Program
+{
+    static int Main(string[] args)
+    {
+        var holdResult = HoldAssembliesAliveThroughByRefFields(out GCHandle gch1, out GCHandle gch2);
+        if (holdResult != 100)
+            return holdResult;
+
+        // At this point, nothing should keep the collectible assembly alive
+        // Loop for a bit forcing the GC to run, and then it should be freed
+        for (int i = 0; i < 20; i++)
+        {
+            GC.Collect(2);
+            GC.WaitForPendingFinalizers();
+        }
+
+        if (gch1.Target != null)
+        {
+            return 3;
+        }
+        if (gch2.Target != null)
+        {
+            return 4;
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int HoldAssembliesAliveThroughByRefFields(out GCHandle gch1, out GCHandle gch2)
+    {
+        var span1 = LoadAssembly(out gch1);
+        var span2 = CreateAssemblyDynamically(out gch2);
+        for (int i = 0; i < 20; i++)
+        {
+            Console.WriteLine(span1[0]);
+            Console.WriteLine(span2[0]);
+            GC.Collect(2);
+            GC.WaitForPendingFinalizers();
+            if (gch1.Target == null)
+            {
+                return 1;
+            }
+            if (gch2.Target == null)
+            {
+                return 2;
+            }
+        }
+
+        return 100;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ReadOnlySpan<byte> LoadAssembly(out GCHandle gchToAssembly)
+    {
+        var alc = new AssemblyLoadContext("test", isCollectible: true);
+        var a = alc.LoadFromAssemblyPath(Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Unloaded.dll"));
+        gchToAssembly = GCHandle.Alloc(a, GCHandleType.WeakTrackResurrection);
+
+        var spanAccessor = (IReturnSpan)Activator.CreateInstance(a.GetType("SpanAccessor"));
+
+        alc.Unload();
+
+        return spanAccessor.GetSpan();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static ReadOnlySpan<byte> CreateAssemblyDynamically(out GCHandle gchToAssembly)
+    {
+        AssemblyBuilder ab =
+            AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("tempAssembly"),
+            AssemblyBuilderAccess.RunAndCollect);
+        ModuleBuilder modb = ab.DefineDynamicModule("tempAssembly.dll");
+
+        var byRefAccessField = modb.DefineInitializedData("RawBytes", new byte[] {1,2,3,4,5}, FieldAttributes.Public | FieldAttributes.Static);
+        modb.CreateGlobalFunctions();
+
+        TypeBuilder tb = modb.DefineType("GetSpanType", TypeAttributes.Class, typeof(object), new Type[]{typeof(IReturnSpan)});
+        var mb = tb.DefineMethod("GetSpan", MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.Virtual, typeof(ReadOnlySpan<byte>), new Type[]{});
+        ILGenerator myMethodIL = mb.GetILGenerator();
+        myMethodIL.Emit(OpCodes.Ldsflda, byRefAccessField);
+        myMethodIL.Emit(OpCodes.Ldc_I4_4);
+        myMethodIL.Emit(OpCodes.Newobj, typeof(ReadOnlySpan<byte>).GetConstructor(new Type[]{typeof(void*), typeof(int)}));
+        myMethodIL.Emit(OpCodes.Ret);
+
+        var getSpanType = tb.CreateType();
+
+        gchToAssembly = GCHandle.Alloc(getSpanType, GCHandleType.WeakTrackResurrection);
+
+        var spanAccessor = (IReturnSpan)Activator.CreateInstance(getSpanType);
+
+        return spanAccessor.GetSpan();
+    }
+
+}

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/ByRefLocals.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/ByRefLocals.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Exe</OutputType>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="Unloaded.csproj" />
+    <ProjectReference Include="SpanAccessor.csproj" />
+    <Compile Include="ByRefLocals.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/SpanAccessor.cs
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/SpanAccessor.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public interface IReturnSpan
+{
+    ReadOnlySpan<byte> GetSpan();
+}

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/SpanAccessor.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/SpanAccessor.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="SpanAccessor.cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.cs
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.cs
@@ -2,12 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.CompilerServices;
 
 public class SpanAccessor : IReturnSpan
 {
     public static ReadOnlySpan<byte> RawData => new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+
     public ReadOnlySpan<byte> GetSpan()
     {
         return RawData;
+    }
+}
+
+public class ThreadStaticSpanAccessor : IReturnSpan
+{
+    [ThreadStatic]
+    public static byte ThreadStaticByte = 7;
+
+    public unsafe ReadOnlySpan<byte> GetSpan()
+    {
+        return new ReadOnlySpan<byte>(Unsafe.AsPointer(ref ThreadStaticByte), 1);
     }
 }

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.cs
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+public class SpanAccessor : IReturnSpan
+{
+    public static ReadOnlySpan<byte> RawData => new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    public ReadOnlySpan<byte> GetSpan()
+    {
+        return RawData;
+    }
+}

--- a/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.csproj
+++ b/src/tests/Loader/CollectibleAssemblies/ByRefLocals/Unloaded.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <CLRTestPriority>0</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="SpanAccessor.csproj" />
+    <Compile Include="Unloaded.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add support for reporting byrefs to RVA static fields of collectible assemblies

- Keep track of all RVA static field locations
  - For assemblies loaded from PE files, use a range that is the entire PE range
  - For assemblies dynamically created, use piecemeal ranges for each individual RVA static field
- Report byref references via the GcReportLoaderAllocator mechanism in PromoteCarefully

- Add a test to cover this scenario

fixes #13348