### PR TITLE
Remove potential NULLCHECK creation after LIR on arm32.

### DIFF
--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -9294,7 +9294,7 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 //    basicBlock - basic block of the node.
 //
 // Notes:
-//    the function should not be called after lowering for platforms that does not support
+//    the function should not be called after lowering for platforms that do not support
 //    emitting NULLCHECK nodes, like arm32. Use `Lowering::TransformUnusedIndirection`
 //    that handles it and calls this function when appropriate.
 //

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -9302,7 +9302,7 @@ void Compiler::gtChangeOperToNullCheck(GenTree* tree, BasicBlock* block)
 {
     assert(tree->OperIs(GT_FIELD, GT_IND, GT_OBJ, GT_BLK, GT_DYN_BLK));
     tree->ChangeOper(GT_NULLCHECK);
-    tree->ChangeType(TYP_BYTE);
+    tree->ChangeType(TYP_INT);
     block->bbFlags |= BBF_HAS_NULLCHECK;
     optMethodFlags |= OMF_HAS_NULLCHECK;
 }

--- a/src/coreclr/src/jit/compiler.cpp
+++ b/src/coreclr/src/jit/compiler.cpp
@@ -9293,6 +9293,11 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 //    tree       - the node to change;
 //    basicBlock - basic block of the node.
 //
+// Notes:
+//    the function should not be called after lowering for platforms that does not support
+//    emitting NULLCHECK nodes, like arm32. Use `Lowering::TransformUnusedIndirection`
+//    that handles it and calls this function when appropriate.
+//
 void Compiler::gtChangeOperToNullCheck(GenTree* tree, BasicBlock* block)
 {
     assert(tree->OperIs(GT_FIELD, GT_IND, GT_OBJ, GT_BLK, GT_DYN_BLK));

--- a/src/coreclr/src/jit/liveness.cpp
+++ b/src/coreclr/src/jit/liveness.cpp
@@ -2127,8 +2127,8 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
                 if (!removed && node->IsUnusedValue())
                 {
                     // IR doesn't expect dummy uses of `GT_OBJ/BLK/DYN_BLK`.
-                    JITDUMP("Replace an unused OBJ/BLK node [%06d] with a NULLCHECK\n", dspTreeID(node));
-                    gtChangeOperToNullCheck(node, block);
+                    JITDUMP("Transform an unused OBJ/BLK node [%06d]\n", dspTreeID(node));
+                    Lowering::TransformUnusedIndirection(node->AsIndir(), this, block);
                 }
             }
             break;

--- a/src/coreclr/src/jit/lower.cpp
+++ b/src/coreclr/src/jit/lower.cpp
@@ -6488,7 +6488,7 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
     // - On XARCH, use GT_IND if we have a contained address, and GT_NULLCHECK otherwise.
     // In all cases, change the type to TYP_INT.
     //
-    assert(ind->OperIs(GT_NULLCHECK, GT_IND));
+    assert(ind->OperIs(GT_NULLCHECK, GT_IND, GT_BLK, GT_OBJ));
 
     ind->gtType = TYP_INT;
 #ifdef TARGET_ARM64
@@ -6499,12 +6499,12 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
     bool useNullCheck = !ind->Addr()->isContained();
 #endif // !TARGET_XARCH
 
-    if (useNullCheck && ind->OperIs(GT_IND))
+    if (useNullCheck && !ind->OperIs(GT_NULLCHECK))
     {
         comp->gtChangeOperToNullCheck(ind, block);
         ind->ClearUnusedValue();
     }
-    else if (!useNullCheck && ind->OperIs(GT_NULLCHECK))
+    else if (!useNullCheck && !ind->OperIs(GT_IND))
     {
         ind->ChangeOper(GT_IND);
         ind->SetUnusedValue();


### PR DESCRIPTION
@erozenfeld noticed that changes from https://github.com/dotnet/runtime/pull/39824 could work wrong on arm32 because we could create a NullCheck node after Lower phase. If it reaches codegen it will fail there. I don't have a repro test, this path is probably unreachable for arm32 currently, but it is better to use a newly added function from #40226 to handle it.

Also, use `TYP_INT` for the new `NULLCHECK` nodes, before in some places we were using `TYP_BYTE`. The actual type doesn't matter, codegen ignores it.

No libs diffs.