### PR TITLE
Build Globalization native shim as C++ and don't define __typeof

### DIFF
--- a/src/libraries/Native/Unix/Common/pal_compiler.h
+++ b/src/libraries/Native/Unix/Common/pal_compiler.h
@@ -33,3 +33,11 @@
 #define EXTERN_C extern
 #endif // __cplusplus
 #endif // EXTERN_C
+
+#ifndef TYPEOF
+#ifdef __cplusplus
+#define TYPEOF decltype
+#else
+#define TYPEOF __typeof
+#endif // __cplusplus
+#endif // TYPEOF

--- a/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
+++ b/src/libraries/Native/Unix/System.Globalization.Native/CMakeLists.txt
@@ -59,6 +59,10 @@ set(NATIVEGLOBALIZATION_SOURCES
     entrypoints.c
 )
 
+if (MSVC)
+    set_source_files_properties(${NATIVEGLOBALIZATION_SOURCES} PROPERTIES LANGUAGE CXX)
+endif()
+
 include_directories("../Common")
 
 if (GEN_SHARED_LIB)

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.c
@@ -19,7 +19,7 @@
 #include "pal_icushim.h"
 
 // Define pointers to all the used ICU functions
-#define PER_FUNCTION_BLOCK(fn, lib) __typeof(fn)* fn##_ptr;
+#define PER_FUNCTION_BLOCK(fn, lib) TYPEOF(fn)* fn##_ptr;
 FOR_ALL_ICU_FUNCTIONS
 #undef PER_FUNCTION_BLOCK
 
@@ -43,7 +43,7 @@ static void* libicui18n = NULL;
 #define PER_FUNCTION_BLOCK(fn, lib) \
     c_static_assert_msg((sizeof(#fn) + MaxICUVersionStringWithSuffixLength + 1) <= sizeof(symbolName), "The symbolName is too small for symbol " #fn); \
     sprintf(symbolName, #fn "%s", symbolVersion); \
-    fn##_ptr = (__typeof(fn)*)dlsym(lib, symbolName); \
+    fn##_ptr = (TYPEOF(fn)*)dlsym(lib, symbolName); \
     if (fn##_ptr == NULL) { fprintf(stderr, "Cannot get symbol %s from " #lib "\nError: %s\n", symbolName, dlerror()); abort(); }
 
 static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbolName, char* symbolVersion, char* suffix)
@@ -90,7 +90,7 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
 
 #define PER_FUNCTION_BLOCK(fn, lib) \
     sprintf_s(symbolName, SYMBOL_NAME_SIZE, #fn "%s", symbolVersion); \
-    fn##_ptr = (__typeof(fn)*)GetProcAddress((HMODULE)lib, symbolName); \
+    fn##_ptr = (TYPEOF(fn)*)GetProcAddress((HMODULE)lib, symbolName); \
     if (fn##_ptr == NULL) { fprintf(stderr, "Cannot get symbol %s from " #lib "\nError: %u\n", symbolName, GetLastError()); abort(); }
 
 static int FindICULibs()

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -46,16 +46,20 @@
 
 #include "icu.h"
 
-#ifndef __typeof
-#define __typeof decltype
-#endif
-
 #define HAVE_SET_MAX_VARIABLE 1
 #define UDAT_STANDALONE_SHORTER_WEEKDAYS 1
 
 #endif
 
 #include "pal_compiler.h"
+
+#ifndef TYPEOF
+#ifdef __cplusplus
+#define TYPEOF decltype
+#else
+#define TYPEOF __typeof
+#endif // __cplusplus
+#endif // TYPEOF
 
 #if !defined(STATIC_ICU)
 // List of all functions from the ICU libraries that are used in the System.Globalization.Native.so
@@ -180,7 +184,7 @@
     FOR_ALL_OS_CONDITIONAL_ICU_FUNCTIONS
 
 // Declare pointers to all the used ICU functions
-#define PER_FUNCTION_BLOCK(fn, lib) EXTERN_C __typeof(fn)* fn##_ptr;
+#define PER_FUNCTION_BLOCK(fn, lib) EXTERN_C TYPEOF(fn)* fn##_ptr;
 FOR_ALL_ICU_FUNCTIONS
 #undef PER_FUNCTION_BLOCK
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim_internal.h
@@ -53,14 +53,6 @@
 
 #include "pal_compiler.h"
 
-#ifndef TYPEOF
-#ifdef __cplusplus
-#define TYPEOF decltype
-#else
-#define TYPEOF __typeof
-#endif // __cplusplus
-#endif // TYPEOF
-
 #if !defined(STATIC_ICU)
 // List of all functions from the ICU libraries that are used in the System.Globalization.Native.so
 #define FOR_ALL_UNCONDITIONAL_ICU_FUNCTIONS \

--- a/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
+++ b/src/libraries/Native/Unix/System.Native/pal_networkstatistics.c
@@ -193,8 +193,8 @@ int32_t SystemNative_GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
         return -1;
     }
 
-    __typeof(systemStats.icps_inhist[0])* inHist = systemStats.icps_inhist;
-    __typeof(systemStats.icps_outhist[0])* outHist = systemStats.icps_outhist;
+    TYPEOF(systemStats.icps_inhist[0])* inHist = systemStats.icps_inhist;
+    TYPEOF(systemStats.icps_outhist[0])* outHist = systemStats.icps_outhist;
 
     retStats->AddressMaskRepliesReceived = inHist[ICMP_MASKREPLY];
     retStats->AddressMaskRepliesSent = outHist[ICMP_MASKREPLY];

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.c
@@ -11,12 +11,12 @@
 #include "opensslshim.h"
 
 // Define pointers to all the used OpenSSL functions
-#define REQUIRED_FUNCTION(fn) __typeof(fn) fn##_ptr;
-#define NEW_REQUIRED_FUNCTION(fn) __typeof(fn) fn##_ptr;
-#define LIGHTUP_FUNCTION(fn) __typeof(fn) fn##_ptr;
-#define FALLBACK_FUNCTION(fn) __typeof(fn) fn##_ptr;
-#define RENAMED_FUNCTION(fn,oldfn) __typeof(fn) fn##_ptr;
-#define LEGACY_FUNCTION(fn) __typeof(fn) fn##_ptr;
+#define REQUIRED_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define NEW_REQUIRED_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define LIGHTUP_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define FALLBACK_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
+#define RENAMED_FUNCTION(fn,oldfn) TYPEOF(fn) fn##_ptr;
+#define LEGACY_FUNCTION(fn) TYPEOF(fn) fn##_ptr;
 FOR_ALL_OPENSSL_FUNCTIONS
 #undef LEGACY_FUNCTION
 #undef RENAMED_FUNCTION
@@ -131,23 +131,23 @@ static void InitializeOpenSSLShim()
 
     // Get pointers to all the functions that are needed
 #define REQUIRED_FUNCTION(fn) \
-    if (!(fn##_ptr = (__typeof(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
+    if (!(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
 
 #define NEW_REQUIRED_FUNCTION(fn) \
-    if (!v1_0_sentinel && !(fn##_ptr = (__typeof(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
+    if (!v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
 
 #define LIGHTUP_FUNCTION(fn) \
-    fn##_ptr = (__typeof(fn))(dlsym(libssl, #fn));
+    fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn));
 
 #define FALLBACK_FUNCTION(fn) \
-    if (!(fn##_ptr = (__typeof(fn))(dlsym(libssl, #fn)))) { fn##_ptr = (__typeof(fn))local_##fn; }
+    if (!(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fn##_ptr = (TYPEOF(fn))local_##fn; }
 
 #define RENAMED_FUNCTION(fn,oldfn) \
-    if (!v1_0_sentinel && !(fn##_ptr = (__typeof(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); } \
-    if (v1_0_sentinel && !(fn##_ptr = (__typeof(fn))(dlsym(libssl, #oldfn)))) { fprintf(stderr, "Cannot get required symbol " #oldfn " from libssl\n"); abort(); }
+    if (!v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); } \
+    if (v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #oldfn)))) { fprintf(stderr, "Cannot get required symbol " #oldfn " from libssl\n"); abort(); }
 
 #define LEGACY_FUNCTION(fn) \
-    if (v1_0_sentinel && !(fn##_ptr = (__typeof(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
+    if (v1_0_sentinel && !(fn##_ptr = (TYPEOF(fn))(dlsym(libssl, #fn)))) { fprintf(stderr, "Cannot get required symbol " #fn " from libssl\n"); abort(); }
 
     FOR_ALL_OPENSSL_FUNCTIONS
 #undef LEGACY_FUNCTION

--- a/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/libraries/Native/Unix/System.Security.Cryptography.Native/opensslshim.h
@@ -35,6 +35,7 @@
 #include <openssl/x509v3.h>
 
 #include "pal_crypto_config.h"
+#include "pal_compiler.h"
 #define OPENSSL_VERSION_1_1_1_RTM 0x10101000L
 #define OPENSSL_VERSION_1_1_0_RTM 0x10100000L
 #define OPENSSL_VERSION_1_0_2_RTM 0x10002000L
@@ -579,12 +580,12 @@ void SSL_get0_alpn_selected(const SSL* ssl, const unsigned char** protocol, unsi
     LIGHTUP_FUNCTION(EC_POINT_set_affine_coordinates_GF2m) \
 
 // Declare pointers to all the used OpenSSL functions
-#define REQUIRED_FUNCTION(fn) extern __typeof(fn)* fn##_ptr;
-#define NEW_REQUIRED_FUNCTION(fn) extern __typeof(fn)* fn##_ptr;
-#define LIGHTUP_FUNCTION(fn) extern __typeof(fn)* fn##_ptr;
-#define FALLBACK_FUNCTION(fn) extern __typeof(fn)* fn##_ptr;
-#define RENAMED_FUNCTION(fn,oldfn) extern __typeof(fn)* fn##_ptr;
-#define LEGACY_FUNCTION(fn) extern __typeof(fn)* fn##_ptr;
+#define REQUIRED_FUNCTION(fn) extern TYPEOF(fn)* fn##_ptr;
+#define NEW_REQUIRED_FUNCTION(fn) extern TYPEOF(fn)* fn##_ptr;
+#define LIGHTUP_FUNCTION(fn) extern TYPEOF(fn)* fn##_ptr;
+#define FALLBACK_FUNCTION(fn) extern TYPEOF(fn)* fn##_ptr;
+#define RENAMED_FUNCTION(fn,oldfn) extern TYPEOF(fn)* fn##_ptr;
+#define LEGACY_FUNCTION(fn) extern TYPEOF(fn)* fn##_ptr;
 FOR_ALL_OPENSSL_FUNCTIONS
 #undef LEGACY_FUNCTION
 #undef RENAMED_FUNCTION


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/40283

It seems like CMake 3.18 now builds this as C instead of C++. See: https://github.com/dotnet/runtime/issues/40283#issuecomment-668884573

Putting this up to unblock people that are using CMake 3.18.

@jkotas @janvorli do you have a better idea to fix this?

cc: @tarekgh @jkoritzinsky 