### PR TITLE
Mark System.Security.Cryptography.OpenSsl as unsupported on Windows

### DIFF
--- a/eng/versioning.targets
+++ b/eng/versioning.targets
@@ -29,6 +29,13 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <!-- Adds UnsupportedOSPlatform attribute for requested libraries -->
+  <ItemGroup Condition="'$(UnsupportedOSPlatform)' != '' and '$(IsTestProject)' != 'true'">
+    <AssemblyAttribute Include="System.Runtime.Versioning.UnsupportedOSPlatform">
+        <_Parameter1>$(UnsupportedOSPlatform)</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
   <Target Name="DecideIfWeNeedToIncludeDllSafeSearchPathAttribute"
           Condition="'$(IsDotNetFrameworkProductAssembly)' == 'true' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">
 

--- a/src/libraries/System.Security.Cryptography.OpenSsl/Directory.Build.props
+++ b/src/libraries/System.Security.Cryptography.OpenSsl/Directory.Build.props
@@ -2,5 +2,7 @@
   <Import Project="..\Directory.Build.props" />
   <PropertyGroup>
     <StrongNameKeyId>Microsoft</StrongNameKeyId>
+    <IncludePlatformAttributes>true</IncludePlatformAttributes>
+    <UnsupportedOSPlatform>windows</UnsupportedOSPlatform>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
fixes #40101

![obraz](https://user-images.githubusercontent.com/6011991/89411076-18ea6e00-d725-11ea-993c-ca58e99a0f4a.png)
