### PR TITLE
Add custom name binding for .Net Configuration.

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/ref/Microsoft.Extensions.Configuration.Binder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/ref/Microsoft.Extensions.Configuration.Binder.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Extensions.Configuration
     {
         public BinderOptions() { }
         public bool BindNonPublicProperties { get { throw null; } set { } }
+        public bool BindPropertyUsingAttributeNames { get { throw null; } set { } }
     }
     public static partial class ConfigurationBinder
     {

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/BinderOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/BinderOptions.cs
@@ -13,5 +13,11 @@ namespace Microsoft.Extensions.Configuration
         /// If true, the binder will attempt to set all non read-only properties.
         /// </summary>
         public bool BindNonPublicProperties { get; set; }
+
+        /// <summary>
+        /// When false (the default), the binder will only attempt to set property values by property name lookup.
+        /// If true, the binder will attempt to use the custom property attribute names available to bind property values.
+        /// </summary>
+        public bool BindPropertyUsingAttributeNames { get; set; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -199,14 +199,14 @@ namespace Microsoft.Extensions.Configuration
             object propertyValue = property.GetValue(instance);
             bool hasSetter = property.SetMethod != null && (property.SetMethod.IsPublic || options.BindNonPublicProperties);
 
-            if (propertyValue == null && !hasSetter)
+            if (!hasSetter)
             {
                 // Property doesn't have a value and we cannot set it so there is no
                 // point in going further down the graph
                 return;
             }
 
-            propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);
+            propertyValue = GetPropertyValue(property, instance, config, options);
 
             if (propertyValue != null && hasSetter)
             {
@@ -556,6 +556,26 @@ namespace Microsoft.Extensions.Configuration
             return null;
         }
 
+        private static object GetPropertyValue(PropertyInfo property, object instance, IConfiguration config, BinderOptions options)
+        {
+            var propertyValue = property.GetValue(instance);
+
+            if (!options.BindPropertyUsingAttributeNames)
+                return BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);
+
+            var propertyNames = GetPropertyAttributeNames(property);
+
+            foreach (var propertyName in propertyNames)
+            {
+                propertyValue = BindInstance(property.PropertyType, propertyValue, config.GetSection(propertyName), options);
+
+                if (propertyValue != null)
+                    return propertyValue;
+            }
+
+            return BindInstance(property.PropertyType, propertyValue, config.GetSection(property.Name), options);
+        }
+
         private static IEnumerable<PropertyInfo> GetAllProperties(TypeInfo type)
         {
             var allProperties = new List<PropertyInfo>();
@@ -568,6 +588,18 @@ namespace Microsoft.Extensions.Configuration
             while (type != typeof(object).GetTypeInfo());
 
             return allProperties;
+        }
+
+        private static IEnumerable<string> GetPropertyAttributeNames(MemberInfo property)
+        {
+            if (property == null)
+                return Enumerable.Empty<string>();
+
+            return from attributeData in property.GetCustomAttributesData()
+                   from namedArgument in attributeData?.NamedArguments
+                   where string.Equals(namedArgument.MemberName, "Name", StringComparison.InvariantCultureIgnoreCase)
+                   where namedArgument.TypedValue.ArgumentType == typeof(string)
+                   select namedArgument.TypedValue.Value.ToString();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace Microsoft.Extensions.Configuration.Binder.Test
@@ -33,6 +34,9 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             private string PrivateProperty { get; set; }
             internal string InternalProperty { get; set; }
             protected string ProtectedProperty { get; set; }
+
+            [DataMember(Name = "Named_Property")]
+            public string NamedProperty { get; set; }
 
             protected string ProtectedPrivateSet { get; private set; }
 
@@ -193,6 +197,37 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             Assert.Equal("Section", options.Section.Path);
             Assert.Equal("DerivedSection", childOptions.DerivedSection.Key);
             Assert.Equal("Section:DerivedSection", childOptions.DerivedSection.Path);
+            Assert.Null(options.Section.Value);
+        }
+
+        [Fact]
+        public void CanBindAttributesIConfigurationSection()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Section:Integer", "-2"},
+                {"Section:Boolean", "TRUe"},
+                {"Section:Nested:Integer", "11"},
+                {"Section:Virtual", "Sup"},
+                {"Section:Named_Property", "Yo"},
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var options = config.Get<ConfigurationInterfaceOptions>();
+
+            var childOptions = options.Section.Get<DerivedOptions>(binderOptions =>
+                binderOptions.BindPropertyUsingAttributeName = true);
+
+            Assert.True(childOptions.Boolean);
+            Assert.Equal(-2, childOptions.Integer);
+            Assert.Equal(11, childOptions.Nested.Integer);
+            Assert.Equal("Derived:Sup", childOptions.Virtual);
+            Assert.Equal("Yo", childOptions.NamedProperty);
+
+            Assert.Equal("Section", options.Section.Key);
+            Assert.Equal("Section", options.Section.Path);
             Assert.Null(options.Section.Value);
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/ConfigurationBinderTests.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Extensions.Configuration.Binder.Test
             var options = config.Get<ConfigurationInterfaceOptions>();
 
             var childOptions = options.Section.Get<DerivedOptions>(binderOptions =>
-                binderOptions.BindPropertyUsingAttributeName = true);
+                binderOptions.BindPropertyUsingAttributeNames = true);
 
             Assert.True(childOptions.Boolean);
             Assert.Equal(-2, childOptions.Integer);


### PR DESCRIPTION
Took a swag at addressing the gap between the Json source and the Binder projects. The Json settings I work with contain names that don't match the setting classes. Those are mapped by `JsonProperty` or `DataMember` where a name is given that can be mapped.

The binder project, rightfully, doesn't know about Json or any other formats. The one area where it could be built up more is around looking at the attributes associated with the properties of the object it's attempting to bind to the configuration dictionary. This is an attempt to try to just that.

Summary of the changes (Less than 80 chars):

- Added new BindingOption flag for binding by attribute names
- Broke out the property value lookup into a standalone function
- Added a function to return "name" values from custom attribute data from the PropertyType

Addresses issue https://github.com/dotnet/runtime/issues/36010