### PR TITLE
Remove throw OperationCanceledException in Host.StopAsync

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Extensions.Hosting.Internal
                 {
                     foreach (IHostedService hostedService in _hostedServices.Reverse())
                     {
-                        token.ThrowIfCancellationRequested();
                         try
                         {
                             await hostedService.StopAsync(token).ConfigureAwait(false);
@@ -91,9 +90,14 @@ namespace Microsoft.Extensions.Hosting.Internal
                 // Fire IHostApplicationLifetime.Stopped
                 _applicationLifetime.NotifyStopped();
 
-                token.ThrowIfCancellationRequested();
-                await _hostLifetime.StopAsync(token).ConfigureAwait(false);
-
+                try
+                {
+                    await _hostLifetime.StopAsync(token).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    exceptions.Add(ex);
+                }
 
                 if (exceptions.Count > 0)
                 {


### PR DESCRIPTION
Removed throw `OperationCanceledExceptio`n in `Host.StopAsync`

Fixes: #40290

Please review
Thank you in advance