### PR TITLE
[JsonSerializer] Verify null can't be assigned to non-nullable structs

### DIFF
--- a/src/libraries/System.Text.Json/tests/Serialization/Array.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Array.ReadTests.cs
@@ -616,8 +616,7 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal(0, obj.MyImmutableList.Count);
             TestRoundTrip(obj);
 
-            // TODO: Skip ImmutableArray due to https://github.com/dotnet/runtime/issues/1037.
-            const string inputJsonWithNullCollections =
+            string inputJsonWithNullCollections =
                 @"{
                     ""Array"":null,
                     ""List"":null,
@@ -627,6 +626,10 @@ namespace System.Text.Json.Serialization.Tests
 
             obj = JsonSerializer.Deserialize<ClassWithNonNullEnumerableGetters>(inputJsonWithNullCollections);
             TestRoundTrip(obj);
+
+            // ImmutableArray<T> is a struct and cannot be null.
+            inputJsonWithNullCollections = @"{""MyImmutableArray"":null}";
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ClassWithNonNullEnumerableGetters>(inputJsonWithNullCollections));
         }
 
         [Fact]

--- a/src/libraries/System.Text.Json/tests/Serialization/Null.ReadTests.cs
+++ b/src/libraries/System.Text.Json/tests/Serialization/Null.ReadTests.cs
@@ -168,25 +168,33 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Equal('Y', JsonSerializer.Deserialize<char>("\"\u0059\""));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1037")]
         [Fact]
         public static void ParseNullStringToStructShouldThrowJsonException()
         {
             string nullString = "null";
-            Utf8JsonReader reader = new Utf8JsonReader(Encoding.UTF8.GetBytes(nullString));
+            byte[] nullStringAsBytes = Encoding.UTF8.GetBytes(nullString);
+
+            Utf8JsonReader reader = new Utf8JsonReader(nullStringAsBytes);
 
             JsonTestHelper.AssertThrows<JsonException>(reader, (reader) => JsonSerializer.Deserialize<SimpleStruct>(ref reader));
-            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleStruct>(Encoding.UTF8.GetBytes(nullString)));
+            Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleStruct>(nullStringAsBytes));
             Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<SimpleStruct>(nullString));
+
+            // null can be assigned to nullable structs.
+            Assert.Null(JsonSerializer.Deserialize<SimpleStruct?>(nullStringAsBytes));
+            Assert.Null(JsonSerializer.Deserialize<SimpleStruct?>(nullString));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1037")]
         [Fact]
         public static async Task ParseNullStringShouldThrowJsonExceptionAsync()
         {
             using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("null")))
             { 
                 await Assert.ThrowsAsync<JsonException>(async () => await JsonSerializer.DeserializeAsync<SimpleStruct>(stream));
+
+                // null can be assigned to nullable structs.
+                stream.Position = 0;
+                Assert.Null(await JsonSerializer.DeserializeAsync<SimpleStruct?>(stream));
             }
         }
 


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/1037. Fixed during serializer refactoring - https://github.com/dotnet/runtime/pull/2259.

We have additional tests for this scenario: https://github.com/dotnet/runtime/blob/0f7370baa68c5809f93095cbce9bf614f44cc731/src/libraries/System.Text.Json/tests/Serialization/ConstructorTests/ConstructorTests.ParameterMatching.cs#L342-L370