### PR TITLE
Remove workaround in DefaultValueAttributeCtorTest trimming test

### DIFF
--- a/src/libraries/System.Runtime/tests/TrimmingTests/DefaultValueAttributeCtorTest.cs
+++ b/src/libraries/System.Runtime/tests/TrimmingTests/DefaultValueAttributeCtorTest.cs
@@ -13,10 +13,6 @@ class Program
 {
     static int Main(string[] args)
     {
-        // workaround TypeConverterAttribute not being annotated correctly
-        // https://github.com/dotnet/runtime/issues/39125
-        var _ = new MyStringConverter();
-
         TypeDescriptor.AddAttributes(typeof(string), new TypeConverterAttribute(typeof(MyStringConverter)));
 
         var attribute = new DefaultValueAttribute(typeof(string), "Hello, world!");


### PR DESCRIPTION
This should have been removed as part of https://github.com/dotnet/runtime/pull/39144.