### PR TITLE
[browser] Re-enable debug_levels less than zero 

### DIFF
--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -358,7 +358,7 @@ void mono_initialize_internals ()
 }
 
 EMSCRIPTEN_KEEPALIVE void
-mono_wasm_load_runtime (const char *unused, int enable_debugging)
+mono_wasm_load_runtime (const char *unused, int debug_level)
 {
 	const char *interp_opts = "";
 
@@ -386,10 +386,18 @@ mono_wasm_load_runtime (const char *unused, int enable_debugging)
 #endif
 #else
 	mono_jit_set_aot_mode (MONO_AOT_MODE_INTERP_ONLY);
-	if (enable_debugging > 0) {
+
+	/*
+	 * debug_level > 0 enables debugging and sets the debug log level to debug_level
+	 * debug_level == 0 disables debugging and enables interpreter optimizations
+	 * debug_level < 0 enabled debugging and disables debug logging.
+	 *
+	 * Note: when debugging is enabled interpreter optimizations are disabled.
+	 */
+	if (debug_level) {
 		// Disable optimizations which interfere with debugging
 		interp_opts = "-all";
-		mono_wasm_enable_debugging (enable_debugging);
+		mono_wasm_enable_debugging (debug_level);
 	}
 #endif
 


### PR DESCRIPTION
debug_level > 0 enables debugging and sets the debug log level to debug_level
debug_level == 0 disables debugging and enables interpreter optimizations
debug_level < 0 enabled debugging and disables debug logging.

Note: when debugging is enabled interpreter optimizations are disabled.

Reverts https://github.com/dotnet/runtime/pull/40429 the proper fix for #40428 is for blazor to pass 0 in Release mode.