### PR TITLE
Update Equals method from ActivityContext

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/ActivityContext.cs
@@ -93,7 +93,7 @@ namespace System.Diagnostics
             return context;
         }
 
-        public bool Equals(ActivityContext value) =>  SpanId.Equals(value.SpanId) && TraceId.Equals(value.TraceId) && TraceFlags == value.TraceFlags && TraceState == value.TraceState;
+        public bool Equals(ActivityContext value) =>  SpanId.Equals(value.SpanId) && TraceId.Equals(value.TraceId) && TraceFlags == value.TraceFlags && TraceState == value.TraceState && IsRemote == value.IsRemote;
 
         public override bool Equals(object? obj) => (obj is ActivityContext context) ? Equals(context) : false;
         public static bool operator ==(ActivityContext left, ActivityContext right) => left.Equals(right);


### PR DESCRIPTION
Fixes: #40462

Updated Equals method from `ActivityContext` to consider `IsRemote` as well.

/cc @tarekgh @noahfalk @cijothomas @CodeBlanch