### PR TITLE
Simplify JS interop for Blazor WebAssembly

### DIFF
--- a/src/mono/wasm/runtime/dotnet_support.js
+++ b/src/mono/wasm/runtime/dotnet_support.js
@@ -29,6 +29,24 @@ var DotNetSupportLib = {
 			return MONO.string_decoder.copy (mono_obj);
 		}
 	},
+
+	mono_wasm_invoke_js_blazor: function(exceptionMessage, callInfo, arg0, arg1, arg2)	{
+		try {
+			var blazorExports = DOTNET._dotnet_get_global().Blazor;
+			if (!blazorExports) {
+				throw new Error('The blazor.webassembly.js library is not loaded.');
+			}
+
+			return blazorExports._internal.invokeJSFromDotNet(callInfo, arg0, arg1, arg2);
+		} catch (ex) {
+			var exceptionJsString = ex.message + '\n' + ex.stack;
+			var exceptionSystemString = mono_string(exceptionJsString);
+			setValue (exceptionMessage, exceptionSystemString, 'i32'); // *exceptionMessage = exceptionSystemString;
+			return 0;
+		}
+	},
+
+	// This is for back-compat only and will eventually be removed
 	mono_wasm_invoke_js_marshalled: function(exceptionMessage, asyncHandleLongPtr, functionName, argsJson, treatResultAsVoid) {
 
 		var mono_string = DOTNET._dotnet_get_global()._mono_string_cached
@@ -67,6 +85,8 @@ var DotNetSupportLib = {
 			return 0;
 		}
 	},
+
+	// This is for back-compat only and will eventually be removed
 	mono_wasm_invoke_js_unmarshalled: function(exceptionMessage, funcName, arg0, arg1, arg2)	{
 		try {
 			// Get the function you're trying to invoke

--- a/src/mono/wasm/runtime/driver.c
+++ b/src/mono/wasm/runtime/driver.c
@@ -24,6 +24,8 @@ void core_initialize_internals ();
 #endif
 
 // Blazor specific custom routines - see dotnet_support.js for backing code
+extern void* mono_wasm_invoke_js_blazor (MonoString **exceptionMessage, void *callInfo, void* arg0, void* arg1, void* arg2);
+// The following two are for back-compat and will eventually be removed
 extern void* mono_wasm_invoke_js_marshalled (MonoString **exceptionMessage, void *asyncHandleLongPtr, MonoString *funcName, MonoString *argsJson);
 extern void* mono_wasm_invoke_js_unmarshalled (MonoString **exceptionMessage, MonoString *funcName, void* arg0, void* arg1, void* arg2);
 
@@ -348,6 +350,8 @@ void mono_initialize_internals ()
 	// TODO: what happens when two types in different assemblies have the same FQN?
 
 	// Blazor specific custom routines - see dotnet_support.js for backing code
+	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJS", mono_wasm_invoke_js_blazor);
+	// The following two are for back-compat and will eventually be removed
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSMarshalled", mono_wasm_invoke_js_marshalled);
 	mono_add_internal_call ("WebAssembly.JSInterop.InternalCalls::InvokeJSUnmarshalled", mono_wasm_invoke_js_unmarshalled);
 


### PR DESCRIPTION
Previously we had two different JS interop primitives used by Blazor on WebAssembly:

 - `mono_wasm_invoke_js_marshalled`
 - `mono_wasm_invoke_js_unmarshalled`

The exact set of params and semantics was embedded in the runtime and not updatable without runtime changes.

This PR proposes a single replacement for both the above - `mono_wasm_invoke_js_blazor` - which:

 - Is not opinionated about the semantics of the call - it just passes it through to Blazor JS code. As such it doesn't have to distinguish marshalled and unmarshalled cases, unlike the previous implementation.
 - Doesn't fix a particular set of parameters up front - it just receives a `void*` and passes it through. Blazor can therefore organize whatever set of parameters it wants on some struct and pass it through. As such it doesn't have to distinguish between sync and async calls, unlike the previous implementation.

I'm suggesting we do this now so that we can implement some enhancements to JS interop on the Blazor side without needing further runtime changes.