### PR TITLE
Fixes for QUIC and HTTP/3

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicAddressHelpers.cs
@@ -11,7 +11,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         internal const ushort IPv4 = 2;
         internal const ushort IPv6 = 23;
 
-        internal static unsafe IPEndPoint INetToIPEndPoint(SOCKADDR_INET inetAddress)
+        internal static unsafe IPEndPoint INetToIPEndPoint(ref SOCKADDR_INET inetAddress)
         {
             if (inetAddress.si_family == IPv4)
             {

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicSession.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/Internal/MsQuicSession.cs
@@ -28,7 +28,7 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
             QuicExceptionHelpers.ThrowIfFailed(MsQuicApi.Api.ConnectionOpenDelegate(
                 _nativeObjPtr,
-                MsQuicConnection.NativeCallbackHandler,
+                MsQuicConnection.s_connectionDelegate,
                 IntPtr.Zero,
                 out IntPtr connectionPtr),
                 "Could not open the connection.");
@@ -83,15 +83,15 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
 
         public void SetPeerBiDirectionalStreamCount(ushort count)
         {
-            SetUshortParamter(QUIC_PARAM_SESSION.PEER_BIDI_STREAM_COUNT, count);
+            SetUshortParameter(QUIC_PARAM_SESSION.PEER_BIDI_STREAM_COUNT, count);
         }
 
         public void SetPeerUnidirectionalStreamCount(ushort count)
         {
-            SetUshortParamter(QUIC_PARAM_SESSION.PEER_UNIDI_STREAM_COUNT, count);
+            SetUshortParameter(QUIC_PARAM_SESSION.PEER_UNIDI_STREAM_COUNT, count);
         }
 
-        private unsafe void SetUshortParamter(QUIC_PARAM_SESSION param, ushort count)
+        private unsafe void SetUshortParameter(QUIC_PARAM_SESSION param, ushort count)
         {
             var buffer = new MsQuicNativeMethods.QuicBuffer()
             {

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicListener.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicListener.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable
+using System.Diagnostics;
 using System.Net.Quic.Implementations.MsQuic.Internal;
 using System.Net.Security;
 using System.Runtime.InteropServices;
@@ -15,7 +16,7 @@ namespace System.Net.Quic.Implementations.MsQuic
     internal sealed class MsQuicListener : QuicListenerProvider, IDisposable
     {
         // Security configuration for MsQuic
-        private MsQuicSession _session;
+        private readonly MsQuicSession _session;
 
         // Pointer to the underlying listener
         // TODO replace all IntPtr with SafeHandles
@@ -25,10 +26,10 @@ namespace System.Net.Quic.Implementations.MsQuic
         private GCHandle _handle;
 
         // Delegate that wraps the static function that will be called when receiving an event.
-        private ListenerCallbackDelegate? _listenerDelegate;
+        private static readonly ListenerCallbackDelegate s_listenerDelegate = new ListenerCallbackDelegate(NativeCallbackHandler);
 
         // Ssl listening options (ALPN, cert, etc)
-        private SslServerAuthenticationOptions _sslOptions;
+        private readonly SslServerAuthenticationOptions _sslOptions;
 
         private QuicListenerOptions _options;
         private volatile bool _disposed;
@@ -142,11 +143,10 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             SOCKADDR_INET inetAddress = MsQuicParameterHelpers.GetINetParam(MsQuicApi.Api, _ptr, (uint)QUIC_PARAM_LEVEL.LISTENER, (uint)QUIC_PARAM_LISTENER.LOCAL_ADDRESS);
 
-            _listenEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(inetAddress);
+            _listenEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(ref inetAddress);
         }
 
-        internal unsafe uint ListenerCallbackHandler(
-            ref ListenerEvent evt)
+        internal unsafe uint ListenerCallbackHandler(ref ListenerEvent evt)
         {
             try
             {
@@ -154,10 +154,14 @@ namespace System.Net.Quic.Implementations.MsQuic
                 {
                     case QUIC_LISTENER_EVENT.NEW_CONNECTION:
                         {
-                            NewConnectionInfo connectionInfo = *(NewConnectionInfo*)evt.Data.NewConnection.Info;
-                            IPEndPoint localEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(*(SOCKADDR_INET*)connectionInfo.LocalAddress);
-                            IPEndPoint remoteEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(*(SOCKADDR_INET*)connectionInfo.RemoteAddress);
+                            ref NewConnectionInfo connectionInfo = ref *(NewConnectionInfo*)evt.Data.NewConnection.Info;
+
+                            IPEndPoint localEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(ref *(SOCKADDR_INET*)connectionInfo.LocalAddress);
+                            IPEndPoint remoteEndPoint = MsQuicAddressHelpers.INetToIPEndPoint(ref *(SOCKADDR_INET*)connectionInfo.RemoteAddress);
+
                             MsQuicConnection msQuicConnection = new MsQuicConnection(localEndPoint, remoteEndPoint, evt.Data.NewConnection.Connection);
+                            msQuicConnection.SetNegotiatedAlpn(connectionInfo.NegotiatedAlpn, connectionInfo.NegotiatedAlpnLength);
+
                             _acceptConnectionQueue.Writer.TryWrite(msQuicConnection);
                         }
                         // Always pend the new connection to wait for the security config to be resolved
@@ -167,8 +171,15 @@ namespace System.Net.Quic.Implementations.MsQuic
                         return MsQuicStatusCodes.InternalError;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                if (NetEventSource.Log.IsEnabled())
+                {
+                    NetEventSource.Error(this, $"Exception occurred during connection callback: {ex.Message}");
+                }
+
+                // TODO: trigger an exception on any outstanding async calls.
+
                 return MsQuicStatusCodes.InternalError;
             }
         }
@@ -191,11 +202,12 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         internal void SetCallbackHandler()
         {
+            Debug.Assert(!_handle.IsAllocated);
             _handle = GCHandle.Alloc(this);
-            _listenerDelegate = new ListenerCallbackDelegate(NativeCallbackHandler);
+
             MsQuicApi.Api.SetCallbackHandlerDelegate(
                 _ptr,
-                _listenerDelegate,
+                s_listenerDelegate,
                 GCHandle.ToIntPtr(_handle));
         }
 

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicStream.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Implementations/MsQuic/MsQuicStream.cs
@@ -23,7 +23,7 @@ namespace System.Net.Quic.Implementations.MsQuic
         private GCHandle _handle;
 
         // Delegate that wraps the static function that will be called when receiving an event.
-        private StreamCallbackDelegate? _callback;
+        internal static readonly StreamCallbackDelegate s_streamDelegate = new StreamCallbackDelegate(NativeCallbackHandler);
 
         // Backing for StreamId
         private long _streamId = -1;
@@ -62,10 +62,10 @@ namespace System.Net.Quic.Implementations.MsQuic
 
         private volatile bool _disposed;
 
-        private List<QuicBuffer> _receiveQuicBuffers = new List<QuicBuffer>();
+        private readonly List<QuicBuffer> _receiveQuicBuffers = new List<QuicBuffer>();
 
         // TODO consider using Interlocked.Exchange instead of a sync if we can avoid it.
-        private object _sync = new object();
+        private readonly object _sync = new object();
 
         // Creates a new MsQuicStream
         internal MsQuicStream(MsQuicConnection connection, QUIC_STREAM_OPEN_FLAG flags, IntPtr nativeObjPtr, bool inbound)
@@ -79,17 +79,19 @@ namespace System.Net.Quic.Implementations.MsQuic
             _shutdownWriteResettableCompletionSource = new ResettableCompletionSource<uint>();
             SetCallbackHandler();
 
+            bool isBidirectional = !flags.HasFlag(QUIC_STREAM_OPEN_FLAG.UNIDIRECTIONAL);
+
             if (inbound)
             {
-                _started = true;
-                _canWrite = !flags.HasFlag(QUIC_STREAM_OPEN_FLAG.UNIDIRECTIONAL);
                 _canRead = true;
+                _canWrite = isBidirectional;
+                _started = true;
             }
             else
             {
+                _canRead = isBidirectional;
                 _canWrite = true;
-                _canRead = !flags.HasFlag(QUIC_STREAM_OPEN_FLAG.UNIDIRECTIONAL);
-                StartWrites();
+                StartLocalStream();
             }
         }
 
@@ -715,7 +717,6 @@ namespace System.Net.Quic.Implementations.MsQuic
             CleanupSendState();
 
             // TODO throw if a write was canceled.
-            uint errorCode = evt.Data.SendComplete.Canceled;
 
             bool shouldComplete = false;
             lock (_sync)
@@ -753,10 +754,9 @@ namespace System.Net.Quic.Implementations.MsQuic
         {
             _handle = GCHandle.Alloc(this);
 
-            _callback = new StreamCallbackDelegate(NativeCallbackHandler);
             MsQuicApi.Api.SetCallbackHandlerDelegate(
                 _ptr,
-                _callback,
+                s_streamDelegate,
                 GCHandle.ToIntPtr(_handle));
         }
 
@@ -921,7 +921,10 @@ namespace System.Net.Quic.Implementations.MsQuic
             return _sendResettableCompletionSource.GetTypelessValueTask();
         }
 
-        private void StartWrites()
+        /// <summary>
+        /// Assigns a stream ID and begins process the stream.
+        /// </summary>
+        private void StartLocalStream()
         {
             Debug.Assert(!_started);
             uint status = MsQuicApi.Api.StreamStartDelegate(

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Interop/Interop.MsQuic.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Interop/Interop.MsQuic.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static class MsQuic
     {
-        [DllImport(Libraries.MsQuic)]
-        internal static unsafe extern uint MsQuicOpen(int version, out MsQuicNativeMethods.NativeApi* registration);
+        [DllImport(Libraries.MsQuic, CallingConvention = CallingConvention.Cdecl)]
+        internal static unsafe extern uint MsQuicOpen(out MsQuicNativeMethods.NativeApi* registration);
     }
 }

--- a/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Interop/MsQuicEnums.cs
+++ b/src/libraries/Common/src/System/Net/Http/aspnetcore/Quic/Interop/MsQuicEnums.cs
@@ -3,19 +3,26 @@
 
 namespace System.Net.Quic.Implementations.MsQuic.Internal
 {
+    internal enum QUIC_EXECUTION_PROFILE : uint
+    {
+        QUIC_EXECUTION_PROFILE_LOW_LATENCY,         // Default
+        QUIC_EXECUTION_PROFILE_TYPE_MAX_THROUGHPUT,
+        QUIC_EXECUTION_PROFILE_TYPE_SCAVENGER,
+        QUIC_EXECUTION_PROFILE_TYPE_REAL_TIME
+    }
+
     /// <summary>
     /// Flags to pass when creating a security config.
     /// </summary>
     [Flags]
     internal enum QUIC_SEC_CONFIG_FLAG : uint
     {
-        NONE = 0,
         CERT_HASH = 0x00000001,
         CERT_HASH_STORE = 0x00000002,
         CERT_CONTEXT = 0x00000004,
         CERT_FILE = 0x00000008,
         ENABL_OCSP = 0x00000010,
-        CERT_NULL = 0xF0000000,
+        CERT_NULL = 0xF0000000 // TODO: only valid for stub TLS.
     }
 
     [Flags]
@@ -67,22 +74,30 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         NONE = 0,
         ALLOW_0_RTT = 0x00000001,
         FIN = 0x00000002,
+        DGRAM_PRIORITY = 0x00000004
     }
 
     internal enum QUIC_PARAM_LEVEL : uint
     {
-        REGISTRATION = 0,
-        SESSION = 1,
-        LISTENER = 2,
-        CONNECTION = 3,
-        TLS = 4,
-        STREAM = 5,
+        GLOBAL,
+        REGISTRATION,
+        SESSION,
+        LISTENER,
+        CONNECTION,
+        TLS,
+        STREAM
+    }
+
+    internal enum QUIC_PARAM_GLOBAL : uint
+    {
+        RETRY_MEMORY_PERCENT = 0,
+        SUPPORTED_VERSIONS = 1,
+        LOAD_BALANCING_MODE = 2,
     }
 
     internal enum QUIC_PARAM_REGISTRATION : uint
     {
-        RETRY_MEMORY_PERCENT = 0,
-        CID_PREFIX = 1
+        CID_PREFIX = 0
     }
 
     internal enum QUIC_PARAM_SESSION : uint
@@ -92,7 +107,10 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         PEER_UNIDI_STREAM_COUNT = 2,
         IDLE_TIMEOUT = 3,
         DISCONNECT_TIMEOUT = 4,
-        MAX_BYTES_PER_KEY = 5
+        MAX_BYTES_PER_KEY = 5,
+        MIGRATION_ENABLED = 6,
+        DATAGRAM_RECEIVE_ENABLED = 7,
+        SERVER_RESUMPTION_LEVEL = 8
     }
 
     internal enum QUIC_PARAM_LISTENER : uint
@@ -122,7 +140,11 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         SEND_PACING = 16,
         SHARE_UDP_BINDING = 17,
         IDEAL_PROCESSOR = 18,
-        MAX_STREAM_IDS = 19
+        MAX_STREAM_IDS = 19,
+        STREAM_SCHEDULING_SCHEME = 20,
+        DATAGRAM_RECEIVE_ENABLED = 21,
+        DATAGRAM_SEND_ENABLED = 22,
+        DISABLE_1RTT_ENCRYPTION = 23
     }
 
     internal enum QUIC_PARAM_STREAM : uint
@@ -149,6 +171,11 @@ namespace System.Net.Quic.Implementations.MsQuic.Internal
         STREAMS_AVAILABLE = 7,
         PEER_NEEDS_STREAMS = 8,
         IDEAL_PROCESSOR_CHANGED = 9,
+        DATAGRAM_STATE_CHANGED = 10,
+        DATAGRAM_RECEIVED = 11,
+        DATAGRAM_SEND_STATE_CHANGED = 12,
+        RESUMED = 13,
+        RESUMPTION_TICKET_RECEIVED = 14
     }
 
     internal enum QUIC_STREAM_EVENT : uint

--- a/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/Http3LoopbackServer.cs
@@ -28,7 +28,7 @@ namespace System.Net.Test.Common
             var sslOpts = new SslServerAuthenticationOptions
             {
                 EnabledSslProtocols = options.SslProtocols,
-                ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http3 },
+                ApplicationProtocols = new List<SslApplicationProtocol> { new SslApplicationProtocol("h3") },
                 //ServerCertificate = _cert,
                 ClientCertificateRequired = false
             };
@@ -70,7 +70,7 @@ namespace System.Net.Test.Common
     {
         public static Http3LoopbackServerFactory Singleton { get; } = new Http3LoopbackServerFactory();
 
-        public override Version Version => HttpVersion.Version30;
+        public override Version Version { get; } = new Version(3, 0);
 
         public override GenericLoopbackServer CreateServer(GenericLoopbackOptions options = null)
         {

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTestBase.cs
@@ -20,6 +20,8 @@ namespace System.Net.Http.Functional.Tests
 
     public abstract partial class HttpClientHandlerTestBase : FileCleanupTestBase
     {
+        public static readonly Version HttpVersion30 = new Version(3, 0);
+
         public readonly ITestOutputHelper _output;
 
         protected virtual Version UseVersion => HttpVersion.Version11;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderValue.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Globalization;
+using System.Text;
+
 namespace System.Net.Http.Headers
 {
     /// <remarks>
@@ -44,5 +47,30 @@ namespace System.Net.Http.Headers
         /// </summary>
         /// <remarks>TODO: if made public, this should be made internal as Persist is left open-ended and can be non-boolean in the future.</remarks>
         public bool Persist { get; }
+
+        public override string ToString()
+        {
+            StringBuilder sb = StringBuilderCache.Acquire(capacity: AlpnProtocolName.Length + (Host?.Length ?? 0) + 64);
+
+            sb.Append(AlpnProtocolName);
+            sb.Append("=\"");
+            if (Host != null) sb.Append(Host);
+            sb.Append(':');
+            sb.Append(Port.ToString(CultureInfo.InvariantCulture));
+            sb.Append('"');
+
+            if (MaxAge != TimeSpan.FromTicks(AltSvcHeaderParser.DefaultMaxAgeTicks))
+            {
+                sb.Append("; ma=");
+                sb.Append((MaxAge.Ticks / TimeSpan.TicksPerSecond).ToString(CultureInfo.InvariantCulture));
+            }
+
+            if (Persist)
+            {
+                sb.Append("; persist=1");
+            }
+
+            return StringBuilderCache.GetStringAndRelease(sb);
+        }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -471,7 +471,7 @@ namespace System.Net.Http
                 //  - On stream 0, the origin will be specified. HTTP/2 can service multiple origins per connection, and so the server can report origins other than what our pool is using.
                 //  - Otherwise, the origin is implicitly defined by the request stream and must be of length 0.
 
-                if ((frameHeader.StreamId != 0 && originLength == 0) || (frameHeader.StreamId == 0 && span.Length >= originLength && span.Slice(originLength).SequenceEqual(_pool.Http2AltSvcOriginUri)))
+                if ((frameHeader.StreamId != 0 && originLength == 0) || (frameHeader.StreamId == 0 && span.Length >= originLength && span.Slice(0, originLength).SequenceEqual(_pool.Http2AltSvcOriginUri)))
                 {
                     span = span.Slice(originLength);
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3Connection.cs
@@ -9,11 +9,16 @@ using System.IO;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http.Headers;
+using System.Net.Security;
 
 namespace System.Net.Http
 {
     internal sealed class Http3Connection : HttpConnectionBase, IDisposable
     {
+        // TODO: once HTTP/3 is standardized, create APIs for these.
+        public static readonly Version HttpVersion30 = new Version(3, 0);
+        public static readonly SslApplicationProtocol Http3ApplicationProtocol = new SslApplicationProtocol("h3");
+
         /// <summary>
         /// If we receive a settings frame larger than this, tear down the connection with an error.
         /// </summary>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -12,8 +12,6 @@ using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Net.Http.QPack;
 using System.Runtime.ExceptionServices;
-using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Http
 {
@@ -292,11 +290,9 @@ namespace System.Net.Http
         /// <summary>
         /// Waits for the initial response headers to be completed, including e.g. Expect 100 Continue.
         /// </summary>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
         private async Task ReadResponseAsync(CancellationToken cancellationToken)
         {
-            Debug.Assert(_response != null);
+            Debug.Assert(_response == null);
             do
             {
                 _headerState = HeaderState.StatusHeader;
@@ -313,6 +309,7 @@ namespace System.Net.Http
                 }
 
                 await ReadHeadersAsync(payloadLength, cancellationToken).ConfigureAwait(false);
+                Debug.Assert(_response != null);
             }
             while ((int)_response.StatusCode < 200);
 
@@ -881,7 +878,7 @@ namespace System.Net.Http
 
                 _response = new HttpResponseMessage()
                 {
-                    Version = HttpVersion.Version30,
+                    Version = Http3Connection.HttpVersion30,
                     RequestMessage = _request,
                     Content = new HttpConnectionResponseContent(),
                     StatusCode = (HttpStatusCode)statusCode

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -31,8 +31,7 @@ namespace System.Net.Http
 
         public bool Equals(HttpAuthority? other)
         {
-            Debug.Assert(other != null);
-            return string.Equals(IdnHost, other.IdnHost) && Port == other.Port;
+            return other != null && string.Equals(IdnHost, other.IdnHost) && Port == other.Port;
         }
 
         public override bool Equals(object? obj)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPool.cs
@@ -124,7 +124,7 @@ namespace System.Net.Http
             }
 
             _http2Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version20;
-            _http3Enabled = _poolManager.Settings._maxHttpVersion >= HttpVersion.Version30;
+            _http3Enabled = _poolManager.Settings._maxHttpVersion >= Http3Connection.HttpVersion30;
 
             switch (kind)
             {
@@ -259,7 +259,7 @@ namespace System.Net.Http
             if (NetEventSource.Log.IsEnabled()) Trace($"{this}");
         }
 
-        private static readonly List<SslApplicationProtocol> s_http3ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http3 };
+        private static readonly List<SslApplicationProtocol> s_http3ApplicationProtocols = new List<SslApplicationProtocol>() { Http3Connection.Http3ApplicationProtocol };
         private static readonly List<SslApplicationProtocol> s_http2ApplicationProtocols = new List<SslApplicationProtocol>() { SslApplicationProtocol.Http2, SslApplicationProtocol.Http11 };
 
         private static SslClientAuthenticationOptions ConstructSslOptions(HttpConnectionPoolManager poolManager, string sslHostName)
@@ -883,7 +883,7 @@ namespace System.Net.Http
             {
                 int parseIdx = 0;
 
-                while (AltSvcHeaderParser.Parser.TryParseValue(altSvcHeaderValue, null, ref parseIdx, out object? parsedValue))
+                if (AltSvcHeaderParser.Parser.TryParseValue(altSvcHeaderValue, null, ref parseIdx, out object? parsedValue))
                 {
                     var value = (AltSvcHeaderValue?)parsedValue;
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionSettings.cs
@@ -66,7 +66,7 @@ namespace System.Net.Http
         {
             bool allowHttp2 = AllowHttp2;
             _maxHttpVersion =
-                AllowDraftHttp3 && allowHttp2 ? HttpVersion.Version30 :
+                AllowDraftHttp3 && allowHttp2 ? Http3Connection.HttpVersion30 :
                 allowHttp2 ? HttpVersion.Version20 :
                 HttpVersion.Version11;
             _allowUnencryptedHttp2 = allowHttp2 && AllowUnencryptedHttp2;

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http.Functional.Tests
 {
     public abstract class HttpClientHandlerTest_Http3 : HttpClientHandlerTestBase
     {
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
 
         public static bool SupportsAlpn => PlatformDetection.SupportsAlpn;
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http.Functional.Tests
                 handler.ServerCertificateCustomValidationCallback = TestHelper.AllowAllCertificates;
             }
 
-            if (useVersion == HttpVersion.Version30)
+            if (useVersion == HttpVersion30)
             {
                 SetUsePrenegotiatedHttp3(handler, usePrenegotiatedHttp3: true);
             }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientMiniStressTest.cs
@@ -35,7 +35,7 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http3 : HttpClientMiniStress
     {
         public SocketsHttpHandler_HttpClientMiniStress_Http3(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 
     public sealed class SocketsHttpHandler_HttpClientMiniStress_Http2 : HttpClientMiniStress

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -2324,7 +2324,7 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandler_HttpClientHandler_Finalization_Http3_Test : HttpClientHandler_Finalization_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Finalization_Http3_Test(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 
     [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
@@ -2337,34 +2337,34 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandlerTest_Cookies_Http3 : HttpClientHandlerTest_Cookies
     {
         public SocketsHttpHandlerTest_Cookies_Http3(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 
     [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
     public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Http3 : HttpClientHandlerTest
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Http3(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 
     [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
     public sealed class SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http3 : HttpClientHandlerTest_Headers
     {
         public SocketsHttpHandlerTest_HttpClientHandlerTest_Headers_Http3(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 
     [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3 : HttpClientHandler_Cancellation_Test
     {
         public SocketsHttpHandler_HttpClientHandler_Cancellation_Test_Http3(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 
     [ConditionalClass(typeof(QuicConnection), nameof(QuicConnection.IsQuicSupported))]
     public sealed class SocketsHttpHandler_HttpClientHandler_AltSvc_Test_Http3 : HttpClientHandler_AltSvc_Test
     {
         public SocketsHttpHandler_HttpClientHandler_AltSvc_Test_Http3(ITestOutputHelper output) : base(output) { }
-        protected override Version UseVersion => HttpVersion.Version30;
+        protected override Version UseVersion => HttpVersion30;
     }
 }

--- a/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
+++ b/src/libraries/System.Net.Primitives/ref/System.Net.Primitives.cs
@@ -208,7 +208,6 @@ namespace System.Net
         public static readonly System.Version Version10;
         public static readonly System.Version Version11;
         public static readonly System.Version Version20;
-        public static readonly System.Version Version30;
     }
     public partial interface ICredentials
     {

--- a/src/libraries/System.Net.Primitives/src/System/Net/HttpVersion.cs
+++ b/src/libraries/System.Net.Primitives/src/System/Net/HttpVersion.cs
@@ -9,6 +9,5 @@ namespace System.Net
         public static readonly Version Version10 = new Version(1, 0);
         public static readonly Version Version11 = new Version(1, 1);
         public static readonly Version Version20 = new Version(2, 0);
-        public static readonly Version Version30 = new Version(3, 0);
     }
 }

--- a/src/libraries/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/libraries/System.Net.Security/ref/System.Net.Security.cs
@@ -119,7 +119,6 @@ namespace System.Net.Security
         private readonly int _dummyPrimitive;
         public static readonly System.Net.Security.SslApplicationProtocol Http11;
         public static readonly System.Net.Security.SslApplicationProtocol Http2;
-        public static readonly System.Net.Security.SslApplicationProtocol Http3;
         public SslApplicationProtocol(byte[] protocol) { throw null; }
         public SslApplicationProtocol(string protocol) { throw null; }
         public System.ReadOnlyMemory<byte> Protocol { get { throw null; } }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslApplicationProtocol.cs
@@ -10,13 +10,10 @@ namespace System.Net.Security
     public readonly struct SslApplicationProtocol : IEquatable<SslApplicationProtocol>
     {
         private static readonly Encoding s_utf8 = Encoding.GetEncoding(Encoding.UTF8.CodePage, EncoderFallback.ExceptionFallback, DecoderFallback.ExceptionFallback);
-        private static readonly byte[] s_http3Utf8 = new byte[] { 0x68, 0x33 }; // "h3"
         private static readonly byte[] s_http2Utf8 = new byte[] { 0x68, 0x32 }; // "h2"
         private static readonly byte[] s_http11Utf8 = new byte[] { 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 }; // "http/1.1"
 
         // Refer to IANA on ApplicationProtocols: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
-        // h3
-        public static readonly SslApplicationProtocol Http3 = new SslApplicationProtocol(s_http3Utf8, copy: false);
         // h2
         public static readonly SslApplicationProtocol Http2 = new SslApplicationProtocol(s_http2Utf8, copy: false);
         // http/1.1

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -111,7 +111,6 @@ namespace System.Net.Security
             None = 0,
             Http11 = 1,
             Http2 = 2,
-            Http3 = 4,
             Other = 128
         }
 
@@ -672,10 +671,6 @@ namespace System.Net.Security
                     if (protocol.SequenceEqual(SslApplicationProtocol.Http2.Protocol.Span))
                     {
                         alpn |= ApplicationProtocolInfo.Http2;
-                    }
-                    else if (protocol.SequenceEqual(SslApplicationProtocol.Http3.Protocol.Span))
-                    {
-                        alpn |= ApplicationProtocolInfo.Http3;
                     }
                     else
                     {


### PR DESCRIPTION
Update MsQuic P/Invoke layer to latest version.
Fix a race condition in MsQuicListener setting MsQuicConnection.Connected.
Some MsQuic cleanup.
Remove (un-reviewed and not yet standard) HttpVersion.Version30 and SslApplicationProtocol.Http3 APIs.
Fix Alt-Svc support and tests.