### PR TITLE
[mono] Allow creating `TypedReference *` and `TypedReference &` via reflection.

### DIFF
--- a/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypePropertyTests.cs
@@ -224,7 +224,6 @@ namespace System.Tests.Types
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/31713", TestRuntimes.Mono)]
         public void IsByRef_Get_ReturnsExpected()
         {
             Type t = CreateType();

--- a/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Type/TypeTests.cs
@@ -391,7 +391,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(MakeByRefType_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37489", TestRuntimes.Mono)]
         public void MakeByRefType_Invoke_ReturnsExpected(Type t)
         {
             Type tPointer = t.MakeByRefType();
@@ -474,7 +473,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(MakePointerType_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/37489", TestRuntimes.Mono)]
         public void MakePointerType_Invoke_ReturnsExpected(Type t)
         {
             Type tPointer = t.MakePointerType();

--- a/src/mono/mono/metadata/icall.c
+++ b/src/mono/mono/metadata/icall.c
@@ -7230,7 +7230,7 @@ ves_icall_System_Reflection_RuntimeModule_ResolveSignature (MonoImage *image, gu
 }
 
 static void
-check_for_invalid_type (MonoClass *klass, MonoError *error)
+check_for_invalid_array_type (MonoClass *klass, MonoError *error)
 {
 	char *name;
 
@@ -7243,13 +7243,23 @@ check_for_invalid_type (MonoClass *klass, MonoError *error)
 	mono_error_set_type_load_name (error, name, g_strdup (""), "");
 }
 
+static void
+check_for_invalid_byref_or_pointer_type (MonoClass *klass, MonoError *error)
+{
+#ifdef ENABLE_NETCORE
+	return;
+#else
+	check_for_invalid_array_type (klass, error);
+#endif
+}
+
 MonoReflectionTypeHandle
 ves_icall_RuntimeType_make_array_type (MonoReflectionTypeHandle ref_type, int rank, MonoError *error)
 {
 	MonoType *type = MONO_HANDLE_GETVAL (ref_type, type);
 
 	MonoClass *klass = mono_class_from_mono_type_internal (type);
-	check_for_invalid_type (klass, error);
+	check_for_invalid_array_type (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
 	MonoClass *aklass;
@@ -7276,7 +7286,7 @@ ves_icall_RuntimeType_make_byref_type (MonoReflectionTypeHandle ref_type, MonoEr
 	mono_class_init_checked (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
-	check_for_invalid_type (klass, error);
+	check_for_invalid_byref_or_pointer_type (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
 	MonoDomain *domain = MONO_HANDLE_DOMAIN (ref_type);
@@ -7292,7 +7302,7 @@ ves_icall_RuntimeType_MakePointerType (MonoReflectionTypeHandle ref_type, MonoEr
 	mono_class_init_checked (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
-	check_for_invalid_type (klass, error);
+	check_for_invalid_byref_or_pointer_type (klass, error);
 	return_val_if_nok (error, MONO_HANDLE_CAST (MonoReflectionType, NULL_HANDLE));
 
 	MonoClass *pklass = mono_class_create_ptr (type);


### PR DESCRIPTION
CoreCLR gained support for creating`TypedReference *` and `TypedReference &` via `MakePointerType` and `MakeByRefType` in https://github.com/dotnet/coreclr/pull/25817.

Reenable byref System.Void-related reflection tests.

Fixes https://github.com/dotnet/runtime/issues/31713.
Fixes https://github.com/dotnet/runtime/issues/37489.