### PR TITLE
map TcpListener APM methods to Task-based methods

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/libraries/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -80,6 +80,8 @@
              Link="Common\System\Net\SocketAddress.cs" />
     <Compile Include="$(CommonPath)System\Net\TcpValidationHelpers.cs"
              Link="Common\System\Net\TcpValidationHelpers.cs" />
+    <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
+             Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <!-- System.Net.Internals -->
     <Compile Include="$(CommonPath)System\Net\Internals\IPEndPointExtensions.cs"
              Link="Common\System\Net\Internals\IPEndPointExtensions.cs" />
@@ -215,8 +217,6 @@
              Link="Common\System\Net\SocketProtocolSupportPal.Unix" />
     <Compile Include="$(CommonPath)System\Net\Sockets\SocketErrorPal.Unix.cs"
              Link="Common\System\Net\Sockets\SocketErrorPal.Unix" />
-    <Compile Include="$(CommonPath)System\Threading\Tasks\TaskToApm.cs"
-             Link="Common\System\Threading\Tasks\TaskToApm.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Errors.cs"
              Link="Common\Interop\Unix\Interop.Errors.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -207,40 +207,17 @@ namespace System.Net.Sockets
             return new TcpClient(acceptedSocket);
         }
 
-        public IAsyncResult BeginAcceptSocket(AsyncCallback? callback, object? state)
-        {
+        public IAsyncResult BeginAcceptSocket(AsyncCallback? callback, object? state) =>
+            TaskToApm.Begin(AcceptSocketAsync(), callback, state);
 
-            if (!_active)
-            {
-                throw new InvalidOperationException(SR.net_stopped);
-            }
-
-            return _serverSocket!.BeginAccept(callback, state);
-        }
-
-        public Socket EndAcceptSocket(IAsyncResult asyncResult)
-        {
-            if (asyncResult == null)
-            {
-                throw new ArgumentNullException(nameof(asyncResult));
-            }
-
-            LazyAsyncResult? lazyResult = asyncResult as LazyAsyncResult;
-            Socket? asyncSocket = lazyResult == null ? null : lazyResult.AsyncObject as Socket;
-            if (asyncSocket == null)
-            {
-                throw new ArgumentException(SR.net_io_invalidasyncresult, nameof(asyncResult));
-            }
-
-            // This will throw ObjectDisposedException if Stop() has been called.
-            return asyncSocket.EndAccept(asyncResult);
-        }
+        public Socket EndAcceptSocket(IAsyncResult asyncResult) =>
+            TaskToApm.End<Socket>(asyncResult);
 
         public IAsyncResult BeginAcceptTcpClient(AsyncCallback? callback, object? state) =>
-            BeginAcceptSocket(callback, state);
+            TaskToApm.Begin(AcceptTcpClientAsync(), callback, state);
 
         public TcpClient EndAcceptTcpClient(IAsyncResult asyncResult) =>
-            new TcpClient(EndAcceptSocket(asyncResult));
+            TaskToApm.End<TcpClient>(asyncResult);
 
         public Task<Socket> AcceptSocketAsync()
         {


### PR DESCRIPTION
This removes the custom implementation of APM methods on TcpListener by mapping them to Task-based methods and removes the dependency on LazyAsyncResult in this code.