### PR TITLE
Sign and add entitlements to createdump and host binaries

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -70,7 +70,7 @@
     <_subset>$(_subset.Replace('+mono+', '+$(DefaultMonoSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+libs+', '+$(DefaultLibrariesSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+installer+', '+$(DefaultInstallerSubsets)+'))</_subset>
-    <_subset>$(_subset.Replace('+installer.packages+', '+$(DefaultInstallerSubsets.Replace('corehost+', ''))+'))</_subset>
+    <_subset>$(_subset.Replace('+installer.nocorehost+', '+$(DefaultInstallerSubsets.Replace('corehost+', ''))+'))</_subset>
 
     <!-- Surround _subset in dashes to simplify checks below -->
     <_subset>+$(_subset.Trim('+'))+</_subset>
@@ -106,7 +106,7 @@
     <!-- Installer -->
     <SubsetName Include="Installer" Description="The .NET Core hosts, hosting libraries, bundles, and installers. Includes these projects' tests." />
     <SubsetName Include="CoreHost" Description="The .NET Core hosts." />
-    <SubsetName Include="Installer.Packages" Description="Hosting libraries, bundles, and installers. Includes these projects' tests." />
+    <SubsetName Include="Installer.NoCoreHost" Description="Hosting libraries, bundles, and installers. Includes these projects' tests." />
     <SubsetName Include="Installer.Managed" Description="The managed .NET hosting projects. This includes HostModel." />
     <SubsetName Include="Installer.DepProjs" Description="The dependency projects. These gather shared framework files and run crossgen on them to turn them into ready-to-run (R2R) assemblies for the current platform." />
     <SubsetName Include="Installer.PkgProjs" Description="The packaging projects. These produce NETCoreApp assets: NuGet packages, installers, zips, and Linux packages." />

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -70,6 +70,7 @@
     <_subset>$(_subset.Replace('+mono+', '+$(DefaultMonoSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+libs+', '+$(DefaultLibrariesSubsets)+'))</_subset>
     <_subset>$(_subset.Replace('+installer+', '+$(DefaultInstallerSubsets)+'))</_subset>
+    <_subset>$(_subset.Replace('+installer.packages+', '+$(DefaultInstallerSubsets.Replace('corehost+', ''))+'))</_subset>
 
     <!-- Surround _subset in dashes to simplify checks below -->
     <_subset>+$(_subset.Trim('+'))+</_subset>
@@ -105,6 +106,7 @@
     <!-- Installer -->
     <SubsetName Include="Installer" Description="The .NET Core hosts, hosting libraries, bundles, and installers. Includes these projects' tests." />
     <SubsetName Include="CoreHost" Description="The .NET Core hosts." />
+    <SubsetName Include="Installer.Packages" Description="Hosting libraries, bundles, and installers. Includes these projects' tests." />
     <SubsetName Include="Installer.Managed" Description="The managed .NET hosting projects. This includes HostModel." />
     <SubsetName Include="Installer.DepProjs" Description="The dependency projects. These gather shared framework files and run crossgen on them to turn them into ready-to-run (R2R) assemblies for the current platform." />
     <SubsetName Include="Installer.PkgProjs" Description="The packaging projects. These produce NETCoreApp assets: NuGet packages, installers, zips, and Linux packages." />

--- a/eng/pipelines/common/createdump-entitlements.plist
+++ b/eng/pipelines/common/createdump-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+      <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+      <true/>
+    <key>com.apple.security.cs.debugger</key>
+      <true/>
+  </dict>
+</plist>

--- a/eng/pipelines/common/entitlements.plist
+++ b/eng/pipelines/common/entitlements.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+      <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+      <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+      <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+      <true/>
+    <key>com.apple.security.cs.debugger</key>
+      <true/>
+    <key>com.apple.security.get-task-allow</key>
+      <true/>
+  </dict>
+</plist>

--- a/eng/pipelines/common/macos-sign-with-entitlements.yml
+++ b/eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -1,0 +1,52 @@
+parameters:
+  fileToSign : ''
+  fileToSignFolder: ''
+  entitlementsFile : ''
+
+steps:
+  - script: codesign -s - -f --entitlements ${{ parameters.entitlementsFile }} ${{ parameters.fileToSignFolder }}/${{ parameters.fileToSign }}
+    displayName: 'Add entitlements to ${{ parameters.fileToSign }}'
+
+  - task: ArchiveFiles@2
+    displayName: 'Zip ${{ parameters.fileToSign }} for signing'
+    inputs:
+      rootFolderOrFile:  '${{ parameters.fileToSignFolder }}/${{ parameters.fileToSign }}'
+      archiveFile:       '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_to_sign.zip'
+      archiveType:       zip
+      includeRootFolder: true
+      replaceExistingArchive: true
+
+  - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    displayName: 'ESRP CodeSigning'
+    inputs:
+      ConnectedServiceName: 'ESRP CodeSigning'
+      FolderPath: '$(Build.ArtifactStagingDirectory)/'
+      Pattern: '${{ parameters.fileToSign }}_to_sign.zip'
+      UseMinimatch: true
+      signConfigType: inlineSignParams
+      inlineOperation: |
+        [
+          {
+            "keyCode": "CP-401337-Apple",
+            "operationCode": "MacAppDeveloperSign",
+            "parameters" : {
+              "hardening": "Enable"
+            },
+            "toolName": "sign",
+            "toolVersion": "1.0"
+          }
+        ]  
+
+  - task: ExtractFiles@1
+    displayName: 'Extract ${{ parameters.fileToSign }} after signing'
+    inputs:
+      archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_to_sign.zip'
+      destinationFolder: '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_destination'
+
+  - task: CopyFiles@2
+    displayName: 'Copy ${{ parameters.fileToSign }} to destination ${{ parameters.fileToSignFolder }}'
+    inputs:
+      contents: '${{ parameters.fileToSign }}'
+      sourceFolder: '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_destination'
+      targetFolder: '${{ parameters.fileToSignFolder }}'
+      overWrite: true

--- a/eng/pipelines/common/macos-sign-with-entitlements.yml
+++ b/eng/pipelines/common/macos-sign-with-entitlements.yml
@@ -1,17 +1,29 @@
 parameters:
-  fileToSign : ''
-  fileToSignFolder: ''
-  entitlementsFile : ''
+  filesToSign: []
 
 steps:
-  - script: codesign -s - -f --entitlements ${{ parameters.entitlementsFile }} ${{ parameters.fileToSignFolder }}/${{ parameters.fileToSign }}
-    displayName: 'Add entitlements to ${{ parameters.fileToSign }}'
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK 2.1.808'
+    inputs:
+      packageType: sdk
+      version: 2.1.808
+
+  - ${{ each file in parameters.filesToSign }}:
+    - script: codesign -s - -f --entitlements ${{ file.entitlementsFile }} ${{ file.path }}/${{ file.name }}
+      displayName: 'Add entitlements to ${{ file.name }}'
+
+    - task: CopyFiles@2
+      displayName: 'Copy entitled file ${{ file.name }}'
+      inputs:
+        contents: '${{ file.path }}/${{ file.name }}'
+        targetFolder: '$(Build.ArtifactStagingDirectory)/mac_entitled'
+        overWrite: true
 
   - task: ArchiveFiles@2
-    displayName: 'Zip ${{ parameters.fileToSign }} for signing'
+    displayName: 'Zip MacOS files for signing'
     inputs:
-      rootFolderOrFile:  '${{ parameters.fileToSignFolder }}/${{ parameters.fileToSign }}'
-      archiveFile:       '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_to_sign.zip'
+      rootFolderOrFile:  '$(Build.ArtifactStagingDirectory)/mac_entitled'
+      archiveFile:       '$(Build.ArtifactStagingDirectory)/mac_entitled_to_sign.zip'
       archiveType:       zip
       includeRootFolder: true
       replaceExistingArchive: true
@@ -21,7 +33,7 @@ steps:
     inputs:
       ConnectedServiceName: 'ESRP CodeSigning'
       FolderPath: '$(Build.ArtifactStagingDirectory)/'
-      Pattern: '${{ parameters.fileToSign }}_to_sign.zip'
+      Pattern: 'mac_entitled_to_sign.zip'
       UseMinimatch: true
       signConfigType: inlineSignParams
       inlineOperation: |
@@ -38,15 +50,16 @@ steps:
         ]  
 
   - task: ExtractFiles@1
-    displayName: 'Extract ${{ parameters.fileToSign }} after signing'
+    displayName: 'Extract MacOS after signing'
     inputs:
-      archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_to_sign.zip'
-      destinationFolder: '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_destination'
+      archiveFilePatterns: '$(Build.ArtifactStagingDirectory)/mac_entitled_to_sign.zip'
+      destinationFolder: '$(Build.ArtifactStagingDirectory)/mac_entitled_signed'
 
-  - task: CopyFiles@2
-    displayName: 'Copy ${{ parameters.fileToSign }} to destination ${{ parameters.fileToSignFolder }}'
-    inputs:
-      contents: '${{ parameters.fileToSign }}'
-      sourceFolder: '$(Build.ArtifactStagingDirectory)/${{ parameters.fileToSign }}_destination'
-      targetFolder: '${{ parameters.fileToSignFolder }}'
-      overWrite: true
+  - ${{ each file in parameters.filesToSign }}:
+    - task: CopyFiles@2
+      displayName: 'Copy ${{ file.name }} to destination'
+      inputs:
+        contents: ${{ file.name }}
+        sourceFolder: '$(Build.ArtifactStagingDirectory)/mac_entitled_signed'
+        targetFolder: '${{ file.path }}'
+        overWrite: true

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -170,17 +170,16 @@ jobs:
     # Sign and add entitlements to these MacOS binaries
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
       - ${{ if eq(parameters.osGroup, 'OSX') }}:
-        - task: UseDotNet@2
-          displayName: 'Use .NET Core SDK 2.1.808'
-          inputs:
-            packageType: sdk
-            version: 2.1.808
 
         - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
           parameters:
-            fileToSign: createdump
-            fileToSignFolder: $(buildProductRootFolderPath)
-            entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/createdump-entitlements.plist
+            filesToSign: 
+            - name: createdump
+              path: $(buildProductRootFolderPath)
+              entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/createdump-entitlements.plist
+            - name: corerun
+              path: $(buildProductRootFolderPath)
+              entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
 
         - task: CopyFiles@2
           displayName: 'Copy signed createdump to sharedFramework'
@@ -189,12 +188,6 @@ jobs:
             sourceFolder: $(buildProductRootFolderPath)
             targetFolder: $(buildProductRootFolderPath)/sharedFramework
             overWrite: true
-
-        - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
-          parameters:
-            fileToSign: corerun
-            fileToSignFolder: $(buildProductRootFolderPath)
-            entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
 
     # Sign on Windows
     - ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(parameters.signBinaries, 'true'), ne(parameters.testGroup, 'clrTools')) }}:

--- a/eng/pipelines/coreclr/templates/build-job.yml
+++ b/eng/pipelines/coreclr/templates/build-job.yml
@@ -167,6 +167,35 @@ jobs:
       - script: $(coreClrRepoRootDir)build-test$(scriptExt) skipstressdependencies skipmanaged skipgeneratelayout $(buildConfig) $(archType) $(crossArg) $(osArg) $(priorityArg) $(compilerArg)
         displayName: Build native test components
 
+    # Sign and add entitlements to these MacOS binaries
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - ${{ if eq(parameters.osGroup, 'OSX') }}:
+        - task: UseDotNet@2
+          displayName: 'Use .NET Core SDK 2.1.808'
+          inputs:
+            packageType: sdk
+            version: 2.1.808
+
+        - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
+          parameters:
+            fileToSign: createdump
+            fileToSignFolder: $(buildProductRootFolderPath)
+            entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/createdump-entitlements.plist
+
+        - task: CopyFiles@2
+          displayName: 'Copy signed createdump to sharedFramework'
+          inputs:
+            contents: createdump
+            sourceFolder: $(buildProductRootFolderPath)
+            targetFolder: $(buildProductRootFolderPath)/sharedFramework
+            overWrite: true
+
+        - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
+          parameters:
+            fileToSign: corerun
+            fileToSignFolder: $(buildProductRootFolderPath)
+            entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+
     # Sign on Windows
     - ${{ if and(eq(parameters.osGroup, 'Windows_NT'), eq(parameters.signBinaries, 'true'), ne(parameters.testGroup, 'clrTools')) }}:
       - powershell: eng\common\build.ps1 -ci -sign -restore -configuration:$(buildConfig) -warnaserror:0 /p:ArcadeBuild=true /p:OfficialBuild=true /p:TargetOS=$(osGroup) /p:TargetArchitecture=$(archType) /p:Configuration=$(_BuildConfig) /p:DotNetSignType=$env:_SignType -projects $(Build.SourcesDirectory)\eng\empty.csproj

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -467,25 +467,17 @@ jobs:
       displayName: Build CoreHost
 
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-      - task: UseDotNet@2
-        displayName: 'Use .NET Core SDK 2.1.808'
-        inputs:
-          packageType: sdk
-          version: 2.1.808
-
       - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
         parameters:
-          fileToSign: dotnet
-          fileToSignFolder: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
-          entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+          filesToSign: 
+          - name: dotnet
+            path: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
+            entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+          - name: apphost
+            path: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
+            entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
 
-      - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
-        parameters:
-          fileToSign: apphost
-          fileToSignFolder: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
-          entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
-
-    - script: $(BaseJobBuildCommand) -subset installer.packages
+    - script: $(BaseJobBuildCommand) -subset installer.nocorehost
       displayName: Build and Package
 
   - ${{ if in(parameters.osGroup, 'OSX', 'iOS','tvOS') }}: 

--- a/eng/pipelines/installer/jobs/base-job.yml
+++ b/eng/pipelines/installer/jobs/base-job.yml
@@ -132,7 +132,7 @@ jobs:
 
     - name: BaseJobBuildCommand
       value: >-
-        $(Build.SourcesDirectory)/build.sh -subset installer -ci
+        $(Build.SourcesDirectory)/build.sh -ci
         $(BuildAction)
         -configuration $(_BuildConfig)
         $(LiveOverridePathArgs)
@@ -456,8 +456,37 @@ jobs:
         df -h
       displayName: Disk Usage before Build
 
-  - script: $(BaseJobBuildCommand)
-    displayName: Build
+  # Build the default subset non-MacOS platforms
+  - ${{ if ne(parameters.osGroup, 'OSX') }}:
+    - script: $(BaseJobBuildCommand)
+      displayName: Build
+
+  # Build corehost, sign and add entitlements to MacOS binaries
+  - ${{ if eq(parameters.osGroup, 'OSX') }}:
+    - script: $(BaseJobBuildCommand) -subset corehost
+      displayName: Build CoreHost
+
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+      - task: UseDotNet@2
+        displayName: 'Use .NET Core SDK 2.1.808'
+        inputs:
+          packageType: sdk
+          version: 2.1.808
+
+      - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
+        parameters:
+          fileToSign: dotnet
+          fileToSignFolder: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
+          entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+
+      - template: /eng/pipelines/common/macos-sign-with-entitlements.yml
+        parameters:
+          fileToSign: apphost
+          fileToSignFolder: $(Build.SourcesDirectory)/artifacts/bin/osx-${{ parameters.archType }}.$(_BuildConfig)/corehost
+          entitlementsFile: $(Build.SourcesDirectory)/eng/pipelines/common/entitlements.plist
+
+    - script: $(BaseJobBuildCommand) -subset installer.packages
+      displayName: Build and Package
 
   - ${{ if in(parameters.osGroup, 'OSX', 'iOS','tvOS') }}: 
     - script: |


### PR DESCRIPTION
Enables createdump on MacOS by signing and adding the necessary entitlements to createdump, corerun, dotnet, and apphost.

Part of issue #https://github.com/dotnet/runtime/issues/34916.