### PR TITLE
Remove dynamic caching from EEJitManager::ResolveEHClause

### DIFF
--- a/src/coreclr/src/vm/codeman.h
+++ b/src/coreclr/src/vm/codeman.h
@@ -1116,7 +1116,7 @@ public:
 private :
     PTR_HostCodeHeap    m_cleanupList;
     //When EH Clauses are resolved we need to atomically update the TypeHandle
-    Crst                m_EHClauseCritSec;
+    Crst                m_JitLoadCritSec;
 
 #if !defined CROSSGEN_COMPILE
     // must hold critical section to access this structure.


### PR DESCRIPTION
This caching was intended to improve performance of repeatedly catching exceptions. As it happens, the critical section that was being used to protect the cache could trigger a GC, and cause a failure under stress. However, some years ago, the eh clause as operated on by the ResolveEHClause method was changed to be a copy of the EHClause stored during the JIT operation, and thus the caching efforts done in this function did not provide value, and in fact are a minor source of multithread scaling concerns.

- Remove the dynamic caching. (Note, the TypeHandle member variable and the HasCachedTypeHandle function, are still used for LCG dynamic methods.)
- Rename the critical section used to protect the cache, as it is now only used to protect from loading multiple copies of the JIT.

Fixes #40252 