### PR TITLE
When returning single-register local variable use V0 as the candidate for source operand of GT_RETURN

### DIFF
--- a/src/coreclr/src/jit/lsrabuild.cpp
+++ b/src/coreclr/src/jit/lsrabuild.cpp
@@ -3443,10 +3443,15 @@ int LinearScan::BuildReturn(GenTree* tree)
         if (varTypeIsSIMD(tree) && !op1->IsMultiRegLclVar())
         {
             useCandidates = allSIMDRegs();
+            if (op1->OperGet() == GT_LCL_VAR)
+            {
+                assert(op1->TypeGet() != TYP_SIMD32);
+                useCandidates = RBM_DOUBLERET;
+            }
             BuildUse(op1, useCandidates);
             return 1;
         }
-#endif // !TARGET_ARM64
+#endif // TARGET_ARM64
 
         if (varTypeIsStruct(tree))
         {


### PR DESCRIPTION
@CarolEidt originally suggested this change during one of our meetings. 

Below are the collected results for framework libraries - all of the changes belong to System.Private.CoreLib.

```asm
Summary of Code Size diffs:
(Lower is better)
Total bytes of diff: -984 (-0.00% of base)
    diff is an improvement.
Top file improvements (bytes):
        -984 : System.Private.CoreLib.dasm (-0.02% of base)
1 total files with Code Size differences (1 improved, 0 regressed), 265 unchanged.
Top method improvements (bytes):
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Byte]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[SByte]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[UInt16]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Int16]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[UInt32]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Int32]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[UInt64]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Int64]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Single]
          -4 (-5.56% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Double]
          -4 (-2.27% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[UInt16],System.Numerics.Vector`1[UInt16]):System.Numerics.Vector`1[Byte]
          -4 (-2.17% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[UInt32],System.Numerics.Vector`1[UInt32]):System.Numerics.Vector`1[UInt16]
          -4 (-2.17% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[UInt64],System.Numerics.Vector`1[UInt64]):System.Numerics.Vector`1[UInt32]
          -4 (-2.27% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[Int16],System.Numerics.Vector`1[Int16]):System.Numerics.Vector`1[SByte]
          -4 (-2.17% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[Int32],System.Numerics.Vector`1[Int32]):System.Numerics.Vector`1[Int16]
          -4 (-2.17% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[Int64],System.Numerics.Vector`1[Int64]):System.Numerics.Vector`1[Int32]
          -4 (-2.08% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:Narrow(System.Numerics.Vector`1[Double],System.Numerics.Vector`1[Double]):System.Numerics.Vector`1[Single]
          -4 (-3.03% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:ConvertToSingle(System.Numerics.Vector`1[Int32]):System.Numerics.Vector`1[Single]
          -4 (-2.94% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:ConvertToSingle(System.Numerics.Vector`1[UInt32]):System.Numerics.Vector`1[Single]
          -4 (-3.03% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector:ConvertToDouble(System.Numerics.Vector`1[Int64]):System.Numerics.Vector`1[Double]
Top method improvements (percentages):
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[UInt64][System.UInt64]:get_Zero():System.Numerics.Vector`1[UInt64]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[UInt32][System.UInt32]:get_Zero():System.Numerics.Vector`1[UInt32]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[UInt16][System.UInt16]:get_Zero():System.Numerics.Vector`1[UInt16]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[SByte][System.SByte]:get_Zero():System.Numerics.Vector`1[SByte]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Single][System.Single]:get_Zero():System.Numerics.Vector`1[Single]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Byte][System.Byte]:get_Zero():System.Numerics.Vector`1[Byte]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Double][System.Double]:get_Zero():System.Numerics.Vector`1[Double]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int16][System.Int16]:get_Zero():System.Numerics.Vector`1[Int16]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int64][System.Int64]:get_Zero():System.Numerics.Vector`1[Int64]
          -4 (-16.67% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int32][System.Int32]:get_Zero():System.Numerics.Vector`1[Int32]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[UInt64][System.UInt64]:get_One():System.Numerics.Vector`1[UInt64]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[UInt32][System.UInt32]:get_One():System.Numerics.Vector`1[UInt32]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[UInt16][System.UInt16]:get_One():System.Numerics.Vector`1[UInt16]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[SByte][System.SByte]:get_One():System.Numerics.Vector`1[SByte]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Single][System.Single]:get_One():System.Numerics.Vector`1[Single]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Byte][System.Byte]:get_One():System.Numerics.Vector`1[Byte]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Double][System.Double]:get_One():System.Numerics.Vector`1[Double]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int16][System.Int16]:get_One():System.Numerics.Vector`1[Int16]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int64][System.Int64]:get_One():System.Numerics.Vector`1[Int64]
          -4 (-14.29% of base) : System.Private.CoreLib.dasm - System.Numerics.Vector`1[Int32][System.Int32]:get_One():System.Numerics.Vector`1[Int32]
246 total methods with Code Size differences (246 improved, 0 regressed), 231919 unchanged.
Completed analysis in 44.28s
```

An example of disassembly differences
```patch
diff --git a/base/System.Private.CoreLib.dasm b/diff/System.Private.CoreLib.dasm
index 541356b..f8503b8 100644
--- a/base/System.Private.CoreLib.dasm
+++ b/diff/System.Private.CoreLib.dasm
@@ -787135,15 +787135,14 @@ G_M43092_IG02:
             blr     x1
             ldp     x0, x1, [fp,#40]
             stp     x0, x1, [fp,#16]
-            ldr     q16, [fp,#16]
-            mov     v0.16b, v16.16b
-						;; bbWeight=1    PerfScore 16.50
+            ldr     q0, [fp,#16]
+						;; bbWeight=1    PerfScore 16.00
 G_M43092_IG03:
             ldp     fp, lr, [sp],#64
             ret     lr
 						;; bbWeight=1    PerfScore 2.00
 
-; Total bytes of code 72, prolog size 12, PerfScore 29.20, (MethodHash=b10d57ab) for method System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Byte]
+; Total bytes of code 68, prolog size 12, PerfScore 28.30, (MethodHash=b10d57ab) for method System.Numerics.Vector`1[__Canon][System.__Canon]:op_Explicit(System.Numerics.Vector`1[__Canon]):System.Numerics.Vector`1[Byte]
 ; ============================================================
 ```

@dotnet/jit-contrib PTAL