### PR TITLE
Fix StringBuilder AV

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -795,7 +795,6 @@ namespace System.Text
             }
         }
 
-
         /// <summary>
         /// Appends a string to the end of this builder.
         /// </summary>
@@ -808,9 +807,8 @@ namespace System.Text
                 char[] chunkChars = m_ChunkChars;
                 int chunkLength = m_ChunkLength;
                 int valueLen = value.Length;
-                int newCurrentIndex = chunkLength + valueLen;
 
-                if (newCurrentIndex < chunkChars.Length) // Use strictly < to avoid issues if count == 0, newIndex == length
+                if (((uint)chunkLength + (uint)valueLen) < (uint)chunkChars.Length) // Use strictly < to avoid issues if count == 0, newIndex == length
                 {
                     if (valueLen <= 2)
                     {
@@ -835,7 +833,7 @@ namespace System.Text
                         }
                     }
 
-                    m_ChunkLength = newCurrentIndex;
+                    m_ChunkLength = chunkLength + valueLen;
                 }
                 else
                 {

--- a/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -2231,12 +2231,12 @@ namespace System.Text.Tests
             Assert.True(sb1.Equals(sb2));
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static unsafe void FailureOnLargeString()
         {
             RemoteExecutor.Invoke(() => // Uses lots of memory
             {
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("valueCount", () =>
+                AssertExtensions.ThrowsAny<ArgumentOutOfRangeException, OutOfMemoryException>(() =>
                 {
                     StringBuilder sb = new StringBuilder();
                     sb.Append(new char[2_000_000_000]);

--- a/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
+++ b/src/libraries/System.Runtime/tests/System/Text/StringBuilderTests.cs
@@ -2230,5 +2230,23 @@ namespace System.Text.Tests
 
             Assert.True(sb1.Equals(sb2));
         }
+
+        [Fact]
+        public static unsafe void FailureOnLargeString()
+        {
+            RemoteExecutor.Invoke(() => // Uses lots of memory
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("valueCount", () =>
+                {
+                    StringBuilder sb = new StringBuilder();
+                    sb.Append(new char[2_000_000_000]);
+                    sb.Length--;
+                    string s = new string('x', 500_000_000);
+                    sb.Append(s); // This should throw, not AV
+                });
+
+                return RemoteExecutor.SuccessExitCode; // workaround https://github.com/dotnet/arcade/issues/5865
+            }).Dispose();
+        }
     }
 }


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/32527

Given the complexity of the code and the internal state, I don't feel particularly confident that there aren't other similar bugs. StringBuilder might be a good candidate for some smart fuzzing.